### PR TITLE
buildSymbolDisplay: Handle alias parentSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3087,7 +3087,7 @@ namespace ts {
                         // Write type arguments of instantiated class/interface here
                         if (flags & SymbolFormatFlags.WriteTypeParametersOrArguments) {
                             if (getCheckFlags(symbol) & CheckFlags.Instantiated) {
-                                const params = getTypeParametersOfClassOrInterface(symbol.flags & SymbolFlags.Alias ? resolveAlias(symbol) : symbol);
+                                const params = getTypeParametersOfClassOrInterface(parentSymbol.flags & SymbolFlags.Alias ? resolveAlias(parentSymbol) : parentSymbol);
                                 buildDisplayForTypeArgumentsAndDelimiters(params, (<TransientSymbol>symbol).mapper, writer, enclosingDeclaration);
                             }
                             else {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2027,7 +2027,7 @@ namespace ts {
                                 ts.forEach(symbolFromSymbolTable.declarations, isExternalModuleImportEqualsDeclaration)) {
 
                                 const resolvedImportedSymbol = resolveAlias(symbolFromSymbolTable);
-                                if (isAccessible(symbolFromSymbolTable, resolveAlias(symbolFromSymbolTable))) {
+                                if (isAccessible(symbolFromSymbolTable, resolvedImportedSymbol)) {
                                     return [symbolFromSymbolTable];
                                 }
 
@@ -3087,8 +3087,8 @@ namespace ts {
                         // Write type arguments of instantiated class/interface here
                         if (flags & SymbolFormatFlags.WriteTypeParametersOrArguments) {
                             if (getCheckFlags(symbol) & CheckFlags.Instantiated) {
-                                buildDisplayForTypeArgumentsAndDelimiters(getTypeParametersOfClassOrInterface(parentSymbol),
-                                    (<TransientSymbol>symbol).mapper, writer, enclosingDeclaration);
+                                const params = getTypeParametersOfClassOrInterface(symbol.flags & SymbolFlags.Alias ? resolveAlias(symbol) : symbol);
+                                buildDisplayForTypeArgumentsAndDelimiters(params, (<TransientSymbol>symbol).mapper, writer, enclosingDeclaration);
                             }
                             else {
                                 buildTypeParameterDisplayFromSymbol(parentSymbol, writer, enclosingDeclaration);

--- a/tests/cases/fourslash/quickInfoOnMethodOfImportEquals.ts
+++ b/tests/cases/fourslash/quickInfoOnMethodOfImportEquals.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// Test for https://github.com/Microsoft/TypeScript/issues/15931
+
+// @Filename: /a.d.ts
+////declare class C<T> {
+////    m(): void;
+////}
+////export = C;
+
+// @Filename: /b.ts
+////import C = require("./a");
+////declare var x: C<number>;
+////x./**/m;
+
+verify.quickInfoAt("", "(method) C<number>.m(): void", undefined);


### PR DESCRIPTION
Fixes #15931
This bug only happens in quickInfo and not in the declaration emitter, because if you have `const y = x.m` in a declaration file it will just display the *type* of `x.m`, not the symbol for it.