### PR TITLE
Allow configurable npmLocation for typingsInstaller

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -13,6 +13,7 @@ namespace ts.server {
         globalTypingsCacheLocation: string;
         logger: Logger;
         typingSafeListLocation: string;
+        npmLocation: string | undefined;
         telemetryEnabled: boolean;
         globalPlugins: string[];
         pluginProbeLocations: string[];
@@ -219,7 +220,7 @@ namespace ts.server {
         }
     }
 
-    class NodeTypingsInstaller implements ITypingsInstaller {
+    export class NodeTypingsInstaller implements ITypingsInstaller {
         private installer: NodeChildProcess;
         private installerPidReported = false;
         private socket: NodeSocket;
@@ -234,6 +235,7 @@ namespace ts.server {
             eventPort: number,
             readonly globalTypingsCacheLocation: string,
             readonly typingSafeListLocation: string,
+            private readonly npmLocation: string | undefined,
             private newLine: string) {
             this.throttledOperations = new ThrottledOperations(host);
             if (eventPort) {
@@ -278,19 +280,21 @@ namespace ts.server {
             if (this.typingSafeListLocation) {
                 args.push(Arguments.TypingSafeListLocation, this.typingSafeListLocation);
             }
+            if (this.npmLocation) {
+                args.push(Arguments.NpmLocation, this.npmLocation);
+            }
+
             const execArgv: string[] = [];
-            {
-                for (const arg of process.execArgv) {
-                    const match = /^--(debug|inspect)(=(\d+))?$/.exec(arg);
-                    if (match) {
-                        // if port is specified - use port + 1
-                        // otherwise pick a default port depending on if 'debug' or 'inspect' and use its value + 1
-                        const currentPort = match[3] !== undefined
-                            ? +match[3]
-                            : match[1] === "debug" ? 5858 : 9229;
-                        execArgv.push(`--${match[1]}=${currentPort + 1}`);
-                        break;
-                    }
+            for (const arg of process.execArgv) {
+                const match = /^--(debug|inspect)(=(\d+))?$/.exec(arg);
+                if (match) {
+                    // if port is specified - use port + 1
+                    // otherwise pick a default port depending on if 'debug' or 'inspect' and use its value + 1
+                    const currentPort = match[3] !== undefined
+                        ? +match[3]
+                        : match[1] === "debug" ? 5858 : 9229;
+                    execArgv.push(`--${match[1]}=${currentPort + 1}`);
+                    break;
                 }
             }
 
@@ -389,10 +393,10 @@ namespace ts.server {
 
     class IOSession extends Session {
         constructor(options: IOSessionOptions) {
-            const { host, installerEventPort, globalTypingsCacheLocation, typingSafeListLocation, canUseEvents } = options;
+            const { host, installerEventPort, globalTypingsCacheLocation, typingSafeListLocation, npmLocation, canUseEvents } = options;
             const typingsInstaller = disableAutomaticTypingAcquisition
                 ? undefined
-                : new NodeTypingsInstaller(telemetryEnabled, logger, host, installerEventPort, globalTypingsCacheLocation, typingSafeListLocation, host.newLine);
+                : new NodeTypingsInstaller(telemetryEnabled, logger, host, installerEventPort, globalTypingsCacheLocation, typingSafeListLocation, npmLocation, host.newLine);
 
             super({
                 host,
@@ -741,7 +745,8 @@ namespace ts.server {
         validateLocaleAndSetLanguage(localeStr, sys);
     }
 
-    const typingSafeListLocation = findArgument("--typingSafeListLocation");
+    const typingSafeListLocation = findArgument(Arguments.TypingSafeListLocation);
+    const npmLocation = findArgument(Arguments.NpmLocation);
 
     const globalPlugins = (findArgument("--globalPlugins") || "").split(",");
     const pluginProbeLocations = (findArgument("--pluginProbeLocations") || "").split(",");
@@ -760,6 +765,7 @@ namespace ts.server {
         disableAutomaticTypingAcquisition,
         globalTypingsCacheLocation: getGlobalTypingsCacheLocation(),
         typingSafeListLocation,
+        npmLocation,
         telemetryEnabled,
         logger,
         globalPlugins,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -220,7 +220,7 @@ namespace ts.server {
         }
     }
 
-    export class NodeTypingsInstaller implements ITypingsInstaller {
+    class NodeTypingsInstaller implements ITypingsInstaller {
         private installer: NodeChildProcess;
         private installerPidReported = false;
         private socket: NodeSocket;

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -12,13 +12,18 @@ namespace ts.server {
         export const LogFile = "--logFile";
         export const EnableTelemetry = "--enableTelemetry";
         export const TypingSafeListLocation = "--typingSafeListLocation";
+        /**
+         * This argument specifies the location of the NPM executable.
+         * typingsInstaller will run the command with `${npmLocation} install ...`.
+         */
+        export const NpmLocation = "--npmLocation";
     }
 
     export function hasArgument(argumentName: string) {
         return sys.args.indexOf(argumentName) >= 0;
     }
 
-    export function findArgument(argumentName: string) {
+    export function findArgument(argumentName: string): string | undefined {
         const index = sys.args.indexOf(argumentName);
         return index >= 0 && index < sys.args.length - 1
             ? sys.args[index + 1]

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -70,7 +70,7 @@ namespace ts.server.typingsInstaller {
 
     type ExecSync = (command: string, options: { cwd: string, stdio?: "ignore" }) => any;
 
-    class NodeTypingsInstaller extends TypingsInstaller {
+    export class NodeTypingsInstaller extends TypingsInstaller {
         private readonly execSync: ExecSync;
         private readonly npmPath: string;
         readonly typesRegistry: Map<void>;

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -87,7 +87,7 @@ namespace ts.server.typingsInstaller {
             this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0]);
             if (this.log.isEnabled()) {
                 this.log.writeLine(`Process id: ${process.pid}`);
-                this.log.writeLine(`NPM location: ${npmLocation}`);
+                this.log.writeLine(`NPM location: ${this.npmPath} (explicit '${Arguments.NpmLocation}' ${npmLocation === undefined ? "not " : ""} provided)`);
             }
             ({ execSync: this.execSync } = require("child_process"));
 

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -84,10 +84,11 @@ namespace ts.server.typingsInstaller {
                 typingSafeListLocation ? toPath(typingSafeListLocation, "", createGetCanonicalFileName(sys.useCaseSensitiveFileNames)) : toPath("typingSafeList.json", __dirname, createGetCanonicalFileName(sys.useCaseSensitiveFileNames)),
                 throttleLimit,
                 log);
+            this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0]);
             if (this.log.isEnabled()) {
                 this.log.writeLine(`Process id: ${process.pid}`);
+                this.log.writeLine(`NPM location: ${npmLocation}`);
             }
-            this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0]);
             ({ execSync: this.execSync } = require("child_process"));
 
             this.ensurePackageDirectoryExists(globalTypingsCacheLocation);


### PR DESCRIPTION
Fixes #15287

When `--npmLocation /foo/npm` is passed to the server, the server will pass the same argument to typingsInstaller, and typingsInstaller will use `/foo/npm install ...` in place of `npm install ...`.

(This does not include a unit test :frowning:, that would require launching new processes to ensure that the arguments get through. Our unit tests for typingsInstaller use a TestTypingsInstaller that avoids using NPM.)