### PR TITLE
Add missing undefined type for createProperty initializer

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -303,7 +303,7 @@ namespace ts {
             : node;
     }
 
-    export function createProperty(decorators: Decorator[] | undefined, modifiers: Modifier[] | undefined, name: string | PropertyName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression) {
+    export function createProperty(decorators: Decorator[] | undefined, modifiers: Modifier[] | undefined, name: string | PropertyName, questionToken: QuestionToken | undefined, type: TypeNode | undefined, initializer: Expression | undefined) {
         const node = <PropertyDeclaration>createSynthesizedNode(SyntaxKind.PropertyDeclaration);
         node.decorators = asNodeArray(decorators);
         node.modifiers = asNodeArray(modifiers);
@@ -314,7 +314,7 @@ namespace ts {
         return node;
     }
 
-    export function updateProperty(node: PropertyDeclaration, decorators: Decorator[] | undefined, modifiers: Modifier[] | undefined, name: PropertyName, type: TypeNode | undefined, initializer: Expression) {
+    export function updateProperty(node: PropertyDeclaration, decorators: Decorator[] | undefined, modifiers: Modifier[] | undefined, name: PropertyName, type: TypeNode | undefined, initializer: Expression | undefined) {
         return node.decorators !== decorators
             || node.modifiers !== modifiers
             || node.name !== name


### PR DESCRIPTION
base on `PropertyDeclaration`

(types.ts)

```ts
export interface PropertyDeclaration extends ClassElement {
    kind: SyntaxKind.PropertyDeclaration;
    questionToken?: QuestionToken;      // Present for use with reporting a grammar error
    name: PropertyName;
    type?: TypeNode;
    initializer?: Expression;           // Optional initializer
}
```