### PR TITLE
Check applicable signature fix

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14894,6 +14894,20 @@ namespace ts {
                 // Type parameters from outer context referenced by source type are fixed by instantiation of the source type
                 inferTypes(context.inferences, instantiateType(source, contextualMapper), target);
             });
+            // If contextualMapper is fakeInferenceMapper we are being called by checkApplicableSignature.
+            if (contextualMapper === fakeInferenceMapper) {
+                let source, target;
+                if (contextualSignature.typePredicate && signature.typePredicate && contextualSignature.typePredicate.kind === signature.typePredicate.kind) {
+                    source = contextualSignature.typePredicate.type;
+                    target = signature.typePredicate.type;
+                }
+                else {
+                    source = getReturnTypeOfSignature(contextualSignature);
+                    target = getReturnTypeOfSignature(signature);
+                }
+                // source is already instantiated by the caller of checkApplicableSignature.
+                inferTypes(context.inferences, source, target);
+            }
             const inferred = getInferredTypes(context);
             for (let i = 0; i < inferred.length; ++i) {
                 // If inference has failed, use the first constituent type. During checking, the other

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7971,9 +7971,9 @@ namespace ts {
 
         function createFakeInferenceMapper(): TypeMapper {
             const fakeSignature = <Signature>{
-                typeParameters: []
+                 typeParameters: []
             };
-            return getInferenceMapper(createInferenceContext(fakeSignature, /*inferUnionTypes*/ false, /*useAnyForNoInferences*/ false));
+            return createInferenceContext(fakeSignature, 0);
         }
 
         function combineTypeMappers(mapper1: TypeMapper, mapper2: TypeMapper): TypeMapper {
@@ -14899,7 +14899,7 @@ namespace ts {
                 // If inference has failed, use the first constituent type. During checking, the other
                 // constituents will fail to match, resulting in a nice error message pointing it out.
                 if (inferred[i] === unknownType) {
-                    inferred[i] = getInferenceCandidates(context, i)[0] || inferred[i];
+                    inferred[i] = context.inferences[i].candidates[0] || inferred[i];
                 }
             }
             return getSignatureInstantiation(signature, inferred);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14896,6 +14896,8 @@ namespace ts {
             });
             const inferred = getInferredTypes(context);
             for (let i = 0; i < inferred.length; ++i) {
+                // If inference has failed, use the first constituent type. During checking, the other
+                // constituents will fail to match, resulting in a nice error message pointing it out.
                 if (inferred[i] === unknownType) {
                     inferred[i] = getInferenceCandidates(context, i)[0] || inferred[i];
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="moduleNameResolver.ts"/>
+/// <reference path="moduleNameResolver.ts"/>
 /// <reference path="binder.ts"/>
 
 /* @internal */
@@ -7973,7 +7973,7 @@ namespace ts {
             const fakeSignature = <Signature>{
                 typeParameters: []
             };
-            return getInferenceMapper(createInferenceContext(fakeSignature, false, false));
+            return getInferenceMapper(createInferenceContext(fakeSignature, /*inferUnionTypes*/ false, /*useAnyForNoInferences*/ false));
         }
 
         function combineTypeMappers(mapper1: TypeMapper, mapper2: TypeMapper): TypeMapper {

--- a/tests/baselines/reference/contextualSignatureInstantiation.errors.txt
+++ b/tests/baselines/reference/contextualSignatureInstantiation.errors.txt
@@ -1,0 +1,53 @@
+tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts(19,13): error TS2345: Argument of type '(x: number, y: number) => number' is not assignable to parameter of type '(x: number, y: string) => number'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts(20,23): error TS2345: Argument of type '(x: number, y: number) => number' is not assignable to parameter of type '(x: number, y: string) => number'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts(21,23): error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+
+
+==== tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts (3 errors) ====
+    // TypeScript Spec, section 4.12.2:
+    // If e is an expression of a function type that contains exactly one generic call signature and no other members,
+    // and T is a function type with exactly one non - generic call signature and no other members, then any inferences
+    // made for type parameters referenced by the parameters of T's call signature are fixed, and e's type is changed
+    // to a function type with e's call signature instantiated in the context of T's call signature (section 3.8.5).
+    
+    declare function foo<T>(cb: (x: number, y: string) => T): T;
+    declare function bar<T, U, V>(x: T, y: U, cb: (x: T, y: U) => V): V;
+    declare function baz<T, U>(x: T, y: T, cb: (x: T, y: T) => U): U;
+    
+    declare function g<T>(x: T, y: T): T;
+    declare function h<T, U>(x: T, y: U): T[] | U[];
+    
+    var a: number;
+    var a = bar(1, 1, g);      // Should be number
+    var a = baz(1, 1, g);      // Should be number
+    
+    var b: number | string;
+    var b = foo(g);            // Should error
+                ~
+!!! error TS2345: Argument of type '(x: number, y: number) => number' is not assignable to parameter of type '(x: number, y: string) => number'.
+!!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    var b = bar(1, "one", g);  // Should error
+                          ~
+!!! error TS2345: Argument of type '(x: number, y: number) => number' is not assignable to parameter of type '(x: number, y: string) => number'.
+!!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    var b = bar("one", 1, g);  // Should error
+                          ~
+!!! error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
+!!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    var b = baz(b, b, g);      // Should be number | string
+    
+    var d: number[] | string[];
+    var d = foo(h);            // Should be number[] | string[]
+    var d = bar(1, "one", h);  // Should be number[] | string[]
+    var d = bar("one", 1, h);  // Should be number[] | string[]
+    var d = baz(d, d, g);      // Should be number[] | string[]
+    

--- a/tests/baselines/reference/contextualSignatureInstantiation.js
+++ b/tests/baselines/reference/contextualSignatureInstantiation.js
@@ -17,9 +17,9 @@ var a = bar(1, 1, g);      // Should be number
 var a = baz(1, 1, g);      // Should be number
 
 var b: number | string;
-var b = foo(g);            // Should be number | string
-var b = bar(1, "one", g);  // Should be number | string
-var b = bar("one", 1, g);  // Should be number | string
+var b = foo(g);            // Should error
+var b = bar(1, "one", g);  // Should error
+var b = bar("one", 1, g);  // Should error
 var b = baz(b, b, g);      // Should be number | string
 
 var d: number[] | string[];
@@ -39,9 +39,9 @@ var a;
 var a = bar(1, 1, g); // Should be number
 var a = baz(1, 1, g); // Should be number
 var b;
-var b = foo(g); // Should be number | string
-var b = bar(1, "one", g); // Should be number | string
-var b = bar("one", 1, g); // Should be number | string
+var b = foo(g); // Should error
+var b = bar(1, "one", g); // Should error
+var b = bar("one", 1, g); // Should error
 var b = baz(b, b, g); // Should be number | string
 var d;
 var d = foo(h); // Should be number[] | string[]

--- a/tests/baselines/reference/functionConstraintSatisfaction2.errors.txt
+++ b/tests/baselines/reference/functionConstraintSatisfaction2.errors.txt
@@ -10,7 +10,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
   Type 'typeof C' provides no match for the signature '(x: string): string'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(26,15): error TS2345: Argument of type 'new (x: string) => string' is not assignable to parameter of type '(x: string) => string'.
   Type 'new (x: string) => string' provides no match for the signature '(x: string): string'.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(28,16): error TS2345: Argument of type '<U, V>(x: U, y: V) => U' is not assignable to parameter of type '(x: string) => string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(28,16): error TS2345: Argument of type '(x: string, y: {}) => string' is not assignable to parameter of type '(x: string) => string'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(29,16): error TS2345: Argument of type 'typeof C2' is not assignable to parameter of type '(x: string) => string'.
   Type 'typeof C2' provides no match for the signature '(x: string): string'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(30,16): error TS2345: Argument of type 'new <T>(x: T) => T' is not assignable to parameter of type '(x: string) => string'.
@@ -75,7 +75,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
     var r8 = foo2(<U>(x: U) => x); // no error expected
     var r11 = foo2(<U, V>(x: U, y: V) => x);
                    ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<U, V>(x: U, y: V) => U' is not assignable to parameter of type '(x: string) => string'.
+!!! error TS2345: Argument of type '(x: string, y: {}) => string' is not assignable to parameter of type '(x: string) => string'.
     var r13 = foo2(C2);
                    ~~
 !!! error TS2345: Argument of type 'typeof C2' is not assignable to parameter of type '(x: string) => string'.

--- a/tests/baselines/reference/functionConstraintSatisfaction3.errors.txt
+++ b/tests/baselines/reference/functionConstraintSatisfaction3.errors.txt
@@ -1,0 +1,103 @@
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(48,6): error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(49,7): error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(55,12): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(56,11): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(64,17): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+
+
+==== tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts (5 errors) ====
+    // satisfaction of a constraint to Function, no errors expected
+    
+    function foo<T extends (x: string) => string>(x: T): T { return x; }
+    
+    interface I {
+        (): string;
+    }
+    var i: I;
+    
+    class C {
+        foo: string;
+    }
+    
+    var a: { (): string };
+    var b: { new (): string };
+    var c: { (): string; (x): string };
+    
+    var r1 = foo((x) => x);
+    var r2 = foo((x: string) => x);
+    var r3 = foo(function (x) { return x });
+    var r4 = foo(function (x: string) { return x });
+    var r5 = foo(i);
+    var r8 = foo(c);
+    
+    interface I2<T> {
+        (x: T): T;
+    }
+    var i2: I2<string>;
+    
+    class C2<T> {
+        foo: T;
+    }
+    
+    var a2: { <T>(x: T): T };
+    var b2: { new <T>(x: T): T };
+    var c2: { <T>(x: T): T; <T>(x: T, y: T): T };
+    
+    var r9 = foo(function <U>(x: U) { return x; });
+    var r10 = foo(<U extends string>(x: U) => x);
+    var r12 = foo(i2);
+    var r15 = foo(c2);
+    
+    declare function id2<T>(x: T, y: T): T;
+    
+    declare function boom<R>(f: (x: string, y: number) => R): R;
+    declare function boom2(f: (x: string, y: number) => string): void;
+    
+    boom(id2);  // Should be an error T = [string, number]
+         ~~~
+!!! error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
+!!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    boom2(id2); // Should be an error T = [string, number]
+          ~~~
+!!! error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
+!!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    
+    declare function withNum<N extends number>(x: N): N;
+    declare function withString<S extends string>(f: (x: S) => S): void;
+    declare function useString(f: (x: string) => string): void;
+    
+    withString(withNum);  // Error
+               ~~~~~~~
+!!! error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+!!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    useString(withNum);   // Error
+              ~~~~~~~
+!!! error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+!!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    
+    declare function okay<R>(f: (x: 1, y: number) => R): R;
+    declare function transitive<T>(x: T, f: (x: T) => T): void;
+    
+    okay(id2);
+    
+    transitive(1, withNum);
+    transitive('1', withNum);
+                    ~~~~~~~
+!!! error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+!!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    

--- a/tests/baselines/reference/functionConstraintSatisfaction3.errors.txt
+++ b/tests/baselines/reference/functionConstraintSatisfaction3.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(48,6): error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(50,6): error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
   Types of parameters 'y' and 'y' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(49,7): error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(51,7): error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
   Types of parameters 'y' and 'y' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(55,12): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(59,12): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
   Types of parameters 'x' and 'x' are incompatible.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(56,11): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(60,11): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
   Types of parameters 'x' and 'x' are incompatible.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(64,17): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts(70,17): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: string) => string'.
   Types of parameters 'x' and 'x' are incompatible.
     Type 'string' is not assignable to type 'number'.
 
@@ -59,9 +59,11 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
     var r15 = foo(c2);
     
     declare function id2<T>(x: T, y: T): T;
+    declare function id3<T>(x: T, y: T, z: T): T;
     
     declare function boom<R>(f: (x: string, y: number) => R): R;
     declare function boom2(f: (x: string, y: number) => string): void;
+    declare function boom3<R>(f: (x: string, y: number, z: R) => R): R;
     
     boom(id2);  // Should be an error T = [string, number]
          ~~~
@@ -73,6 +75,8 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
 !!! error TS2345: Argument of type '(x: string, y: string) => string' is not assignable to parameter of type '(x: string, y: number) => string'.
 !!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
 !!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    boom<string|number>(id2);   // Should be OK
+    boom3<string|number>(id3);  // Should be OK
     
     declare function withNum<N extends number>(x: N): N;
     declare function withString<S extends string>(f: (x: S) => S): void;
@@ -90,9 +94,11 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
 !!! error TS2345:     Type 'string' is not assignable to type 'number'.
     
     declare function okay<R>(f: (x: 1, y: number) => R): R;
+    declare function okay2(f: (x: string, y: number) => string|number);
     declare function transitive<T>(x: T, f: (x: T) => T): void;
     
     okay(id2);
+    okay2(id2);
     
     transitive(1, withNum);
     transitive('1', withNum);

--- a/tests/baselines/reference/functionConstraintSatisfaction3.js
+++ b/tests/baselines/reference/functionConstraintSatisfaction3.js
@@ -42,12 +42,16 @@ var r12 = foo(i2);
 var r15 = foo(c2);
 
 declare function id2<T>(x: T, y: T): T;
+declare function id3<T>(x: T, y: T, z: T): T;
 
 declare function boom<R>(f: (x: string, y: number) => R): R;
 declare function boom2(f: (x: string, y: number) => string): void;
+declare function boom3<R>(f: (x: string, y: number, z: R) => R): R;
 
 boom(id2);  // Should be an error T = [string, number]
 boom2(id2); // Should be an error T = [string, number]
+boom<string|number>(id2);   // Should be OK
+boom3<string|number>(id3);  // Should be OK
 
 declare function withNum<N extends number>(x: N): N;
 declare function withString<S extends string>(f: (x: S) => S): void;
@@ -57,9 +61,11 @@ withString(withNum);  // Error
 useString(withNum);   // Error
 
 declare function okay<R>(f: (x: 1, y: number) => R): R;
+declare function okay2(f: (x: string, y: number) => string|number);
 declare function transitive<T>(x: T, f: (x: T) => T): void;
 
 okay(id2);
+okay2(id2);
 
 transitive(1, withNum);
 transitive('1', withNum);
@@ -98,8 +104,11 @@ var r12 = foo(i2);
 var r15 = foo(c2);
 boom(id2); // Should be an error T = [string, number]
 boom2(id2); // Should be an error T = [string, number]
+boom(id2); // Should be OK
+boom3(id3); // Should be OK
 withString(withNum); // Error
 useString(withNum); // Error
 okay(id2);
+okay2(id2);
 transitive(1, withNum);
 transitive('1', withNum);

--- a/tests/baselines/reference/functionConstraintSatisfaction3.js
+++ b/tests/baselines/reference/functionConstraintSatisfaction3.js
@@ -41,6 +41,30 @@ var r10 = foo(<U extends string>(x: U) => x);
 var r12 = foo(i2);
 var r15 = foo(c2);
 
+declare function id2<T>(x: T, y: T): T;
+
+declare function boom<R>(f: (x: string, y: number) => R): R;
+declare function boom2(f: (x: string, y: number) => string): void;
+
+boom(id2);  // Should be an error T = [string, number]
+boom2(id2); // Should be an error T = [string, number]
+
+declare function withNum<N extends number>(x: N): N;
+declare function withString<S extends string>(f: (x: S) => S): void;
+declare function useString(f: (x: string) => string): void;
+
+withString(withNum);  // Error
+useString(withNum);   // Error
+
+declare function okay<R>(f: (x: 1, y: number) => R): R;
+declare function transitive<T>(x: T, f: (x: T) => T): void;
+
+okay(id2);
+
+transitive(1, withNum);
+transitive('1', withNum);
+
+
 //// [functionConstraintSatisfaction3.js]
 // satisfaction of a constraint to Function, no errors expected
 function foo(x) { return x; }
@@ -72,3 +96,10 @@ var r9 = foo(function (x) { return x; });
 var r10 = foo(function (x) { return x; });
 var r12 = foo(i2);
 var r15 = foo(c2);
+boom(id2); // Should be an error T = [string, number]
+boom2(id2); // Should be an error T = [string, number]
+withString(withNum); // Error
+useString(withNum); // Error
+okay(id2);
+transitive(1, withNum);
+transitive('1', withNum);

--- a/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.errors.txt
@@ -1,0 +1,30 @@
+tests/cases/compiler/genericArgumentCallSigAssignmentCompat.ts(16,31): error TS2345: Argument of type '(value: string | number | boolean) => string | number | boolean' is not assignable to parameter of type 'Iterator<string | number | boolean, boolean>'.
+  Type 'string | number | boolean' is not assignable to type 'boolean'.
+    Type 'string' is not assignable to type 'boolean'.
+
+
+==== tests/cases/compiler/genericArgumentCallSigAssignmentCompat.ts (1 errors) ====
+    module Underscore {
+        export interface Iterator<T, U> {
+            (value: T, index: any, list: any): U;
+        }
+     
+        export interface Static {
+            all<T>(list: T[], iterator?: Iterator<T, boolean>, context?: any): boolean;
+            identity<T>(value: T): T;
+        }
+    }
+     
+    declare var _: Underscore.Static;
+     
+    // No error, Call signatures of types '<T>(value: T) => T' and 'Underscore.Iterator<{}, boolean>' are compatible when instantiated with any.
+    // Ideally, we would not have a generic signature here, because it should be instantiated with {} during inferential typing
+    _.all([true, 1, null, 'yes'], _.identity);
+                                  ~~~~~~~~~~
+!!! error TS2345: Argument of type '(value: string | number | boolean) => string | number | boolean' is not assignable to parameter of type 'Iterator<string | number | boolean, boolean>'.
+!!! error TS2345:   Type 'string | number | boolean' is not assignable to type 'boolean'.
+!!! error TS2345:     Type 'string' is not assignable to type 'boolean'.
+     
+    // Ok, because fixing makes us infer boolean for T
+    _.all([true], _.identity);
+    

--- a/tests/baselines/reference/genericCallWithFunctionTypedArguments5.errors.txt
+++ b/tests/baselines/reference/genericCallWithFunctionTypedArguments5.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts(10,14): error TS2345: Argument of type '{ cb: <T>(x: T, y: T) => string; }' is not assignable to parameter of type '{ cb: (t: {}) => string; }'.
+tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts(10,14): error TS2345: Argument of type '{ cb: (x: {}, y: {}) => string; }' is not assignable to parameter of type '{ cb: (t: {}) => string; }'.
   Types of property 'cb' are incompatible.
-    Type '<T>(x: T, y: T) => string' is not assignable to type '(t: {}) => string'.
+    Type '(x: {}, y: {}) => string' is not assignable to type '(t: {}) => string'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments5.ts(11,14): error TS2345: Argument of type '{ cb: (x: string, y: number) => string; }' is not assignable to parameter of type '{ cb: (t: string) => string; }'.
   Types of property 'cb' are incompatible.
     Type '(x: string, y: number) => string' is not assignable to type '(t: string) => string'.
@@ -18,9 +18,9 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFun
     // more args not allowed
     var r2 = foo({ cb: <T>(x: T, y: T) => '' }); // error
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ cb: <T>(x: T, y: T) => string; }' is not assignable to parameter of type '{ cb: (t: {}) => string; }'.
+!!! error TS2345: Argument of type '{ cb: (x: {}, y: {}) => string; }' is not assignable to parameter of type '{ cb: (t: {}) => string; }'.
 !!! error TS2345:   Types of property 'cb' are incompatible.
-!!! error TS2345:     Type '<T>(x: T, y: T) => string' is not assignable to type '(t: {}) => string'.
+!!! error TS2345:     Type '(x: {}, y: {}) => string' is not assignable to type '(t: {}) => string'.
     var r3 = foo({ cb: (x: string, y: number) => '' }); // error
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ cb: (x: string, y: number) => string; }' is not assignable to parameter of type '{ cb: (t: string) => string; }'.

--- a/tests/baselines/reference/genericTypeArgumentInference1.errors.txt
+++ b/tests/baselines/reference/genericTypeArgumentInference1.errors.txt
@@ -1,0 +1,26 @@
+tests/cases/compiler/genericTypeArgumentInference1.ts(12,39): error TS2345: Argument of type '(value: string | number | boolean) => string | number | boolean' is not assignable to parameter of type 'Iterator<string | number | boolean, boolean>'.
+  Type 'string | number | boolean' is not assignable to type 'boolean'.
+    Type 'string' is not assignable to type 'boolean'.
+
+
+==== tests/cases/compiler/genericTypeArgumentInference1.ts (1 errors) ====
+    module Underscore {
+        export interface Iterator<T, U> {
+            (value: T, index: any, list: any): U;
+        }
+        export interface Static {
+            all<T>(list: T[], iterator?: Iterator<T, boolean>, context?: any): T;
+            identity<T>(value: T): T;
+        }
+    }
+    declare var _: Underscore.Static;
+    
+    var r = _.all([true, 1, null, 'yes'], _.identity);
+                                          ~~~~~~~~~~
+!!! error TS2345: Argument of type '(value: string | number | boolean) => string | number | boolean' is not assignable to parameter of type 'Iterator<string | number | boolean, boolean>'.
+!!! error TS2345:   Type 'string | number | boolean' is not assignable to type 'boolean'.
+!!! error TS2345:     Type 'string' is not assignable to type 'boolean'.
+    var r2 = _.all([true], _.identity);
+    var r3 = _.all([], _.identity);
+    var r4 = _.all([<any>true], _.identity);
+    

--- a/tests/baselines/reference/promisePermutations.errors.txt
+++ b/tests/baselines/reference/promisePermutations.errors.txt
@@ -31,17 +31,17 @@ tests/cases/compiler/promisePermutations.ts(110,19): error TS2345: Argument of t
 tests/cases/compiler/promisePermutations.ts(111,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
-tests/cases/compiler/promisePermutations.ts(117,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations.ts(120,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations.ts(121,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations.ts(122,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations.ts(126,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(117,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(120,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(121,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations.ts(122,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(126,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(129,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/promisePermutations.ts(132,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations.ts(133,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations.ts(134,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(132,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(133,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations.ts(134,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(137,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(144,12): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
@@ -239,24 +239,24 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
     var nPromise: (x: any) => Promise<number>;
     var r8a = r8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
     var s8a = s8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
     var r9: IPromise<number>;
     var r9a = r9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
     var r9d = r9.then(testFunction, sIPromise, nIPromise); // ok
@@ -268,13 +268,13 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
     var s9: Promise<number>;
     var s9a = s9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok
     var s9f = s9.then(testFunction, sIPromise, nIPromise); // error

--- a/tests/baselines/reference/promisePermutations.errors.txt
+++ b/tests/baselines/reference/promisePermutations.errors.txt
@@ -31,17 +31,17 @@ tests/cases/compiler/promisePermutations.ts(110,19): error TS2345: Argument of t
 tests/cases/compiler/promisePermutations.ts(111,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
-tests/cases/compiler/promisePermutations.ts(117,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations.ts(120,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations.ts(121,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations.ts(122,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations.ts(126,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(117,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(120,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(121,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations.ts(122,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(126,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(129,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/promisePermutations.ts(132,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations.ts(133,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations.ts(134,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(132,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations.ts(133,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations.ts(134,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations.ts(137,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(144,12): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
@@ -239,24 +239,24 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
     var nPromise: (x: any) => Promise<number>;
     var r8a = r8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
     var s8a = s8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
     var r9: IPromise<number>;
     var r9a = r9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
     var r9d = r9.then(testFunction, sIPromise, nIPromise); // ok
@@ -268,13 +268,13 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
     var s9: Promise<number>;
     var s9a = s9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok
     var s9f = s9.then(testFunction, sIPromise, nIPromise); // error

--- a/tests/baselines/reference/promisePermutations2.errors.txt
+++ b/tests/baselines/reference/promisePermutations2.errors.txt
@@ -31,17 +31,17 @@ tests/cases/compiler/promisePermutations2.ts(109,19): error TS2345: Argument of 
 tests/cases/compiler/promisePermutations2.ts(110,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
-tests/cases/compiler/promisePermutations2.ts(116,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations2.ts(119,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations2.ts(120,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations2.ts(121,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations2.ts(125,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(116,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(119,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(120,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations2.ts(121,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(125,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(128,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/promisePermutations2.ts(131,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations2.ts(132,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations2.ts(133,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(131,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(132,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations2.ts(133,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(136,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(143,12): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
@@ -238,24 +238,24 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
     var nPromise: (x: any) => Promise<number>;
     var r8a = r8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
     var s8a = s8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
     var r9: IPromise<number>;
     var r9a = r9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
     var r9d = r9.then(testFunction, sIPromise, nIPromise); // error
@@ -267,13 +267,13 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
     var s9: Promise<number>;
     var s9a = s9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok
     var s9f = s9.then(testFunction, sIPromise, nIPromise); // error

--- a/tests/baselines/reference/promisePermutations2.errors.txt
+++ b/tests/baselines/reference/promisePermutations2.errors.txt
@@ -31,17 +31,17 @@ tests/cases/compiler/promisePermutations2.ts(109,19): error TS2345: Argument of 
 tests/cases/compiler/promisePermutations2.ts(110,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
-tests/cases/compiler/promisePermutations2.ts(116,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations2.ts(119,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations2.ts(120,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations2.ts(121,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations2.ts(125,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(116,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(119,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(120,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations2.ts(121,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(125,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(128,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/promisePermutations2.ts(131,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations2.ts(132,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations2.ts(133,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(131,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations2.ts(132,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations2.ts(133,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations2.ts(136,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(143,12): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
@@ -238,24 +238,24 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
     var nPromise: (x: any) => Promise<number>;
     var r8a = r8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
     var s8a = s8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
     var r9: IPromise<number>;
     var r9a = r9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
     var r9d = r9.then(testFunction, sIPromise, nIPromise); // error
@@ -267,13 +267,13 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
     var s9: Promise<number>;
     var s9a = s9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok
     var s9f = s9.then(testFunction, sIPromise, nIPromise); // error

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -34,17 +34,17 @@ tests/cases/compiler/promisePermutations3.ts(109,19): error TS2345: Argument of 
 tests/cases/compiler/promisePermutations3.ts(110,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
-tests/cases/compiler/promisePermutations3.ts(116,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations3.ts(119,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations3.ts(120,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations3.ts(121,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations3.ts(125,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(116,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(119,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(120,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations3.ts(121,19): error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(125,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(128,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/promisePermutations3.ts(131,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations3.ts(132,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations3.ts(133,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(131,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(132,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations3.ts(133,19): error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(136,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(143,12): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
@@ -250,24 +250,24 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var nPromise: (x: any) => Promise<number>;
     var r8a = r8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
     var s8a = s8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: (a: any) => any) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
     var r9: IPromise<number>;
     var r9a = r9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
     var r9d = r9.then(testFunction, sIPromise, nIPromise); // error
@@ -279,13 +279,13 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var s9: Promise<number>;
     var s9a = s9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => IPromise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: any, cb: <U>(a: U) => U) => Promise<any>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok
     var s9f = s9.then(testFunction, sIPromise, nIPromise); // error

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -34,17 +34,17 @@ tests/cases/compiler/promisePermutations3.ts(109,19): error TS2345: Argument of 
 tests/cases/compiler/promisePermutations3.ts(110,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
-tests/cases/compiler/promisePermutations3.ts(116,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations3.ts(119,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations3.ts(120,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations3.ts(121,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations3.ts(125,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(116,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(119,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(120,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations3.ts(121,19): error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(125,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(128,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/promisePermutations3.ts(131,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
-tests/cases/compiler/promisePermutations3.ts(132,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
-tests/cases/compiler/promisePermutations3.ts(133,19): error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(131,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+tests/cases/compiler/promisePermutations3.ts(132,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+tests/cases/compiler/promisePermutations3.ts(133,19): error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
 tests/cases/compiler/promisePermutations3.ts(136,11): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'IPromise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(143,12): error TS2453: The type argument for type parameter 'U' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
@@ -250,24 +250,24 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var nPromise: (x: any) => Promise<number>;
     var r8a = r8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r8b = r8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     var s8: Promise<number>;
     var s8a = s8.then(testFunction8, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8b = s8.then(testFunction8P, testFunction8P, testFunction8P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s8c = s8.then(testFunction8P, testFunction8, testFunction8); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: (a: number) => number) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s8d = s8.then(nIPromise, nIPromise, nIPromise).then(nIPromise, nIPromise, nIPromise); // ok
     
     var r9: IPromise<number>;
     var r9a = r9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var r9b = r9.then(sIPromise, sIPromise, sIPromise); // ok
     var r9c = r9.then(nIPromise, nIPromise, nIPromise); // ok
     var r9d = r9.then(testFunction, sIPromise, nIPromise); // error
@@ -279,13 +279,13 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var s9: Promise<number>;
     var s9a = s9.then(testFunction9, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => IPromise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9b = s9.then(testFunction9P, testFunction9P, testFunction9P); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => Promise<any>'.
     var s9c = s9.then(testFunction9P, testFunction9, testFunction9); // error
                       ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '<T>(x: T, cb: <U>(a: U) => U) => Promise<T>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
+!!! error TS2345: Argument of type '(x: number, cb: <U>(a: U) => U) => Promise<number>' is not assignable to parameter of type '(value: number) => IPromise<any>'.
     var s9d = s9.then(sPromise, sPromise, sPromise); // ok
     var s9e = s9.then(nPromise, nPromise, nPromise); // ok
     var s9f = s9.then(testFunction, sIPromise, nIPromise); // error

--- a/tests/baselines/reference/subtypingWithCallSignatures2.js
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.js
@@ -48,9 +48,9 @@ declare function foo13(a: any): any;
 declare function foo14(a: (x: { a: string; b: number }) => Object): typeof a;
 declare function foo14(a: any): any;
 
-declare function foo15(a: { 
+declare function foo15(a: {
     (x: number): number[];
-    (x: string): string[]; 
+    (x: string): string[];
 }): typeof a;
 declare function foo15(a: any): any;
 
@@ -80,79 +80,79 @@ declare function foo18(a: any): any;
 
 var r1arg1 = <T>(x: T) => [x];
 var r1arg2 = (x: number) => [1];
-var r1 = foo1(r1arg1); // any, return types are not subtype of first overload
+var r1 = foo1(r1arg1);
 var r1a = [r1arg2, r1arg1]; // generic signature, subtype in both directions
 var r1b = [r1arg1, r1arg2]; // generic signature, subtype in both directions
 
 var r2arg1 = <T>(x: T) => [''];
 var r2arg2 = (x: number) => [''];
-var r2 = foo2(r2arg1); 
+var r2 = foo2(r2arg1);
 var r2a = [r2arg1, r2arg2];
 var r2b = [r2arg2, r2arg1];
 
 var r3arg1 = <T>(x: T) => x;
 var r3arg2 = (x: number) => { };
-var r3 = foo3(r3arg1); 
+var r3 = foo3(r3arg1);
 var r3a = [r3arg1, r3arg2];
 var r3b = [r3arg2, r3arg1];
 
 var r4arg1 = <T, U>(x: T, y: U) => x;
 var r4arg2 = (x: string, y: number) => '';
-var r4 = foo4(r4arg1); // any
+var r4 = foo4(r4arg1);
 var r4a = [r4arg1, r4arg2];
 var r4b = [r4arg2, r4arg1];
 
 var r5arg1 = <T, U>(x: (arg: T) => U) => <T>null;
 var r5arg2 = (x: (arg: string) => number) => '';
-var r5 = foo5(r5arg1); // any
+var r5 = foo5(r5arg1);
 var r5a = [r5arg1, r5arg2];
 var r5b = [r5arg2, r5arg1];
 
 var r6arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U) => <T>null;
 var r6arg2 = (x: (arg: Base) => Derived) => <Base>null;
-var r6 = foo6(r6arg1); // any
+var r6 = foo6(r6arg1);
 var r6a = [r6arg1, r6arg2];
 var r6b = [r6arg2, r6arg1];
 
 var r7arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U) => (r: T) => <U>null;
 var r7arg2 = (x: (arg: Base) => Derived) => (r: Base) => <Derived>null;
-var r7 = foo7(r7arg1); // any
+var r7 = foo7(r7arg1);
 var r7a = [r7arg1, r7arg2];
 var r7b = [r7arg2, r7arg1];
 
 var r8arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: T) => U) => (r: T) => <U>null;
 var r8arg2 = (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => <Derived>null;
-var r8 = foo8(r8arg1); // any
+var r8 = foo8(r8arg1);
 var r8a = [r8arg1, r8arg2];
 var r8b = [r8arg2, r8arg1];
 
 var r9arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => <U>null;
 var r9arg2 = (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => <Derived>null;
-var r9 = foo9(r9arg1); // any
+var r9 = foo9(r9arg1);
 var r9a = [r9arg1, r9arg2];
 var r9b = [r9arg2, r9arg1];
 
 var r10arg1 = <T extends Derived>(...x: T[]) => x[0];
 var r10arg2 = (...x: Derived[]) => <Derived>null;
-var r10 = foo10(r10arg1); // any
+var r10 = foo10(r10arg1);
 var r10a = [r10arg1, r10arg2];
 var r10b = [r10arg2, r10arg1];
 
 var r11arg1 = <T extends Base>(x: T, y: T) => x;
 var r11arg2 = (x: { foo: string }, y: { foo: string; bar: string }) => <Base>null;
-var r11 = foo11(r11arg1); // any
+var r11 = foo11(r11arg1);
 var r11a = [r11arg1, r11arg2];
 var r11b = [r11arg2, r11arg1];
 
 var r12arg1 = <T extends Array<Base>>(x: Array<Base>, y: T) => <Array<Derived>>null;
 var r12arg2 = (x: Array<Base>, y: Array<Derived2>) => <Array<Derived>>null;
-var r12 = foo12(r12arg1); // any
+var r12 = foo12(r12arg1);
 var r12a = [r12arg1, r12arg2];
 var r12b = [r12arg2, r12arg1];
 
 var r13arg1 = <T extends Array<Derived>>(x: Array<Base>, y: T) => y;
 var r13arg2 = (x: Array<Base>, y: Array<Derived>) => <Array<Derived>>null;
-var r13 = foo13(r13arg1); // any
+var r13 = foo13(r13arg1);
 var r13a = [r13arg1, r13arg2];
 var r13b = [r13arg2, r13arg1];
 
@@ -165,11 +165,11 @@ var r14b = [r14arg2, r14arg1];
 var r15arg1 = <T>(x: T) => <T[]>null
 var r15 = foo15(r15arg1); // any
 var r16arg1 = <T extends Base>(x: T) => [1];
-var r16 = foo16(r16arg1); 
+var r16 = foo16(r16arg1);
 var r17arg1 = <T>(x: (a: T) => T) => <T[]>null;
 var r17 = foo17(r17arg1); // any
 var r18arg1 = <T>(x: (a: T) => T) => <T[]>null;
-var r18 = foo18(r18arg1); 
+var r18 = foo18(r18arg1);
 
 
 //// [subtypingWithCallSignatures2.js]
@@ -212,7 +212,7 @@ var OtherDerived = (function (_super) {
 }(Base));
 var r1arg1 = function (x) { return [x]; };
 var r1arg2 = function (x) { return [1]; };
-var r1 = foo1(r1arg1); // any, return types are not subtype of first overload
+var r1 = foo1(r1arg1);
 var r1a = [r1arg2, r1arg1]; // generic signature, subtype in both directions
 var r1b = [r1arg1, r1arg2]; // generic signature, subtype in both directions
 var r2arg1 = function (x) { return ['']; };
@@ -227,32 +227,32 @@ var r3a = [r3arg1, r3arg2];
 var r3b = [r3arg2, r3arg1];
 var r4arg1 = function (x, y) { return x; };
 var r4arg2 = function (x, y) { return ''; };
-var r4 = foo4(r4arg1); // any
+var r4 = foo4(r4arg1);
 var r4a = [r4arg1, r4arg2];
 var r4b = [r4arg2, r4arg1];
 var r5arg1 = function (x) { return null; };
 var r5arg2 = function (x) { return ''; };
-var r5 = foo5(r5arg1); // any
+var r5 = foo5(r5arg1);
 var r5a = [r5arg1, r5arg2];
 var r5b = [r5arg2, r5arg1];
 var r6arg1 = function (x) { return null; };
 var r6arg2 = function (x) { return null; };
-var r6 = foo6(r6arg1); // any
+var r6 = foo6(r6arg1);
 var r6a = [r6arg1, r6arg2];
 var r6b = [r6arg2, r6arg1];
 var r7arg1 = function (x) { return function (r) { return null; }; };
 var r7arg2 = function (x) { return function (r) { return null; }; };
-var r7 = foo7(r7arg1); // any
+var r7 = foo7(r7arg1);
 var r7a = [r7arg1, r7arg2];
 var r7b = [r7arg2, r7arg1];
 var r8arg1 = function (x, y) { return function (r) { return null; }; };
 var r8arg2 = function (x, y) { return function (r) { return null; }; };
-var r8 = foo8(r8arg1); // any
+var r8 = foo8(r8arg1);
 var r8a = [r8arg1, r8arg2];
 var r8b = [r8arg2, r8arg1];
 var r9arg1 = function (x, y) { return function (r) { return null; }; };
 var r9arg2 = function (x, y) { return function (r) { return null; }; };
-var r9 = foo9(r9arg1); // any
+var r9 = foo9(r9arg1);
 var r9a = [r9arg1, r9arg2];
 var r9b = [r9arg2, r9arg1];
 var r10arg1 = function () {
@@ -269,22 +269,22 @@ var r10arg2 = function () {
     }
     return null;
 };
-var r10 = foo10(r10arg1); // any
+var r10 = foo10(r10arg1);
 var r10a = [r10arg1, r10arg2];
 var r10b = [r10arg2, r10arg1];
 var r11arg1 = function (x, y) { return x; };
 var r11arg2 = function (x, y) { return null; };
-var r11 = foo11(r11arg1); // any
+var r11 = foo11(r11arg1);
 var r11a = [r11arg1, r11arg2];
 var r11b = [r11arg2, r11arg1];
 var r12arg1 = function (x, y) { return null; };
 var r12arg2 = function (x, y) { return null; };
-var r12 = foo12(r12arg1); // any
+var r12 = foo12(r12arg1);
 var r12a = [r12arg1, r12arg2];
 var r12b = [r12arg2, r12arg1];
 var r13arg1 = function (x, y) { return y; };
 var r13arg2 = function (x, y) { return null; };
-var r13 = foo13(r13arg1); // any
+var r13 = foo13(r13arg1);
 var r13a = [r13arg1, r13arg2];
 var r13b = [r13arg2, r13arg1];
 var r14arg1 = function (x) { return x.a; };

--- a/tests/baselines/reference/subtypingWithCallSignatures2.symbols
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.symbols
@@ -216,14 +216,14 @@ declare function foo14(a: any): any;
 >foo14 : Symbol(foo14, Decl(subtypingWithCallSignatures2.ts, 44, 36), Decl(subtypingWithCallSignatures2.ts, 46, 77))
 >a : Symbol(a, Decl(subtypingWithCallSignatures2.ts, 47, 23))
 
-declare function foo15(a: { 
+declare function foo15(a: {
 >foo15 : Symbol(foo15, Decl(subtypingWithCallSignatures2.ts, 47, 36), Decl(subtypingWithCallSignatures2.ts, 52, 13))
 >a : Symbol(a, Decl(subtypingWithCallSignatures2.ts, 49, 23))
 
     (x: number): number[];
 >x : Symbol(x, Decl(subtypingWithCallSignatures2.ts, 50, 5))
 
-    (x: string): string[]; 
+    (x: string): string[];
 >x : Symbol(x, Decl(subtypingWithCallSignatures2.ts, 51, 5))
 
 }): typeof a;
@@ -319,7 +319,7 @@ var r1arg2 = (x: number) => [1];
 >r1arg2 : Symbol(r1arg2, Decl(subtypingWithCallSignatures2.ts, 80, 3))
 >x : Symbol(x, Decl(subtypingWithCallSignatures2.ts, 80, 14))
 
-var r1 = foo1(r1arg1); // any, return types are not subtype of first overload
+var r1 = foo1(r1arg1);
 >r1 : Symbol(r1, Decl(subtypingWithCallSignatures2.ts, 81, 3))
 >foo1 : Symbol(foo1, Decl(subtypingWithCallSignatures2.ts, 5, 49), Decl(subtypingWithCallSignatures2.ts, 7, 60))
 >r1arg1 : Symbol(r1arg1, Decl(subtypingWithCallSignatures2.ts, 79, 3))
@@ -344,7 +344,7 @@ var r2arg2 = (x: number) => [''];
 >r2arg2 : Symbol(r2arg2, Decl(subtypingWithCallSignatures2.ts, 86, 3))
 >x : Symbol(x, Decl(subtypingWithCallSignatures2.ts, 86, 14))
 
-var r2 = foo2(r2arg1); 
+var r2 = foo2(r2arg1);
 >r2 : Symbol(r2, Decl(subtypingWithCallSignatures2.ts, 87, 3))
 >foo2 : Symbol(foo2, Decl(subtypingWithCallSignatures2.ts, 8, 35), Decl(subtypingWithCallSignatures2.ts, 10, 60))
 >r2arg1 : Symbol(r2arg1, Decl(subtypingWithCallSignatures2.ts, 85, 3))
@@ -370,7 +370,7 @@ var r3arg2 = (x: number) => { };
 >r3arg2 : Symbol(r3arg2, Decl(subtypingWithCallSignatures2.ts, 92, 3))
 >x : Symbol(x, Decl(subtypingWithCallSignatures2.ts, 92, 14))
 
-var r3 = foo3(r3arg1); 
+var r3 = foo3(r3arg1);
 >r3 : Symbol(r3, Decl(subtypingWithCallSignatures2.ts, 93, 3))
 >foo3 : Symbol(foo3, Decl(subtypingWithCallSignatures2.ts, 11, 35), Decl(subtypingWithCallSignatures2.ts, 13, 56))
 >r3arg1 : Symbol(r3arg1, Decl(subtypingWithCallSignatures2.ts, 91, 3))
@@ -400,7 +400,7 @@ var r4arg2 = (x: string, y: number) => '';
 >x : Symbol(x, Decl(subtypingWithCallSignatures2.ts, 98, 14))
 >y : Symbol(y, Decl(subtypingWithCallSignatures2.ts, 98, 24))
 
-var r4 = foo4(r4arg1); // any
+var r4 = foo4(r4arg1);
 >r4 : Symbol(r4, Decl(subtypingWithCallSignatures2.ts, 99, 3))
 >foo4 : Symbol(foo4, Decl(subtypingWithCallSignatures2.ts, 14, 35), Decl(subtypingWithCallSignatures2.ts, 16, 69))
 >r4arg1 : Symbol(r4arg1, Decl(subtypingWithCallSignatures2.ts, 97, 3))
@@ -430,7 +430,7 @@ var r5arg2 = (x: (arg: string) => number) => '';
 >x : Symbol(x, Decl(subtypingWithCallSignatures2.ts, 104, 14))
 >arg : Symbol(arg, Decl(subtypingWithCallSignatures2.ts, 104, 18))
 
-var r5 = foo5(r5arg1); // any
+var r5 = foo5(r5arg1);
 >r5 : Symbol(r5, Decl(subtypingWithCallSignatures2.ts, 105, 3))
 >foo5 : Symbol(foo5, Decl(subtypingWithCallSignatures2.ts, 17, 35), Decl(subtypingWithCallSignatures2.ts, 19, 75))
 >r5arg1 : Symbol(r5arg1, Decl(subtypingWithCallSignatures2.ts, 103, 3))
@@ -465,7 +465,7 @@ var r6arg2 = (x: (arg: Base) => Derived) => <Base>null;
 >Derived : Symbol(Derived, Decl(subtypingWithCallSignatures2.ts, 2, 27))
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures2.ts, 0, 0))
 
-var r6 = foo6(r6arg1); // any
+var r6 = foo6(r6arg1);
 >r6 : Symbol(r6, Decl(subtypingWithCallSignatures2.ts, 111, 3))
 >foo6 : Symbol(foo6, Decl(subtypingWithCallSignatures2.ts, 20, 35), Decl(subtypingWithCallSignatures2.ts, 22, 72))
 >r6arg1 : Symbol(r6arg1, Decl(subtypingWithCallSignatures2.ts, 109, 3))
@@ -504,7 +504,7 @@ var r7arg2 = (x: (arg: Base) => Derived) => (r: Base) => <Derived>null;
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures2.ts, 0, 0))
 >Derived : Symbol(Derived, Decl(subtypingWithCallSignatures2.ts, 2, 27))
 
-var r7 = foo7(r7arg1); // any
+var r7 = foo7(r7arg1);
 >r7 : Symbol(r7, Decl(subtypingWithCallSignatures2.ts, 117, 3))
 >foo7 : Symbol(foo7, Decl(subtypingWithCallSignatures2.ts, 23, 35), Decl(subtypingWithCallSignatures2.ts, 25, 88))
 >r7arg1 : Symbol(r7arg1, Decl(subtypingWithCallSignatures2.ts, 115, 3))
@@ -551,7 +551,7 @@ var r8arg2 = (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures2.ts, 0, 0))
 >Derived : Symbol(Derived, Decl(subtypingWithCallSignatures2.ts, 2, 27))
 
-var r8 = foo8(r8arg1); // any
+var r8 = foo8(r8arg1);
 >r8 : Symbol(r8, Decl(subtypingWithCallSignatures2.ts, 123, 3))
 >foo8 : Symbol(foo8, Decl(subtypingWithCallSignatures2.ts, 26, 35), Decl(subtypingWithCallSignatures2.ts, 28, 116))
 >r8arg1 : Symbol(r8arg1, Decl(subtypingWithCallSignatures2.ts, 121, 3))
@@ -599,7 +599,7 @@ var r9arg2 = (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures2.ts, 0, 0))
 >Derived : Symbol(Derived, Decl(subtypingWithCallSignatures2.ts, 2, 27))
 
-var r9 = foo9(r9arg1); // any
+var r9 = foo9(r9arg1);
 >r9 : Symbol(r9, Decl(subtypingWithCallSignatures2.ts, 129, 3))
 >foo9 : Symbol(foo9, Decl(subtypingWithCallSignatures2.ts, 29, 35), Decl(subtypingWithCallSignatures2.ts, 31, 116))
 >r9arg1 : Symbol(r9arg1, Decl(subtypingWithCallSignatures2.ts, 127, 3))
@@ -628,7 +628,7 @@ var r10arg2 = (...x: Derived[]) => <Derived>null;
 >Derived : Symbol(Derived, Decl(subtypingWithCallSignatures2.ts, 2, 27))
 >Derived : Symbol(Derived, Decl(subtypingWithCallSignatures2.ts, 2, 27))
 
-var r10 = foo10(r10arg1); // any
+var r10 = foo10(r10arg1);
 >r10 : Symbol(r10, Decl(subtypingWithCallSignatures2.ts, 135, 3))
 >foo10 : Symbol(foo10, Decl(subtypingWithCallSignatures2.ts, 32, 35), Decl(subtypingWithCallSignatures2.ts, 34, 66))
 >r10arg1 : Symbol(r10arg1, Decl(subtypingWithCallSignatures2.ts, 133, 3))
@@ -662,7 +662,7 @@ var r11arg2 = (x: { foo: string }, y: { foo: string; bar: string }) => <Base>nul
 >bar : Symbol(bar, Decl(subtypingWithCallSignatures2.ts, 140, 52))
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures2.ts, 0, 0))
 
-var r11 = foo11(r11arg1); // any
+var r11 = foo11(r11arg1);
 >r11 : Symbol(r11, Decl(subtypingWithCallSignatures2.ts, 141, 3))
 >foo11 : Symbol(foo11, Decl(subtypingWithCallSignatures2.ts, 35, 36), Decl(subtypingWithCallSignatures2.ts, 37, 99))
 >r11arg1 : Symbol(r11arg1, Decl(subtypingWithCallSignatures2.ts, 139, 3))
@@ -701,7 +701,7 @@ var r12arg2 = (x: Array<Base>, y: Array<Derived2>) => <Array<Derived>>null;
 >Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Derived : Symbol(Derived, Decl(subtypingWithCallSignatures2.ts, 2, 27))
 
-var r12 = foo12(r12arg1); // any
+var r12 = foo12(r12arg1);
 >r12 : Symbol(r12, Decl(subtypingWithCallSignatures2.ts, 147, 3))
 >foo12 : Symbol(foo12, Decl(subtypingWithCallSignatures2.ts, 38, 36), Decl(subtypingWithCallSignatures2.ts, 40, 92))
 >r12arg1 : Symbol(r12arg1, Decl(subtypingWithCallSignatures2.ts, 145, 3))
@@ -739,7 +739,7 @@ var r13arg2 = (x: Array<Base>, y: Array<Derived>) => <Array<Derived>>null;
 >Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Derived : Symbol(Derived, Decl(subtypingWithCallSignatures2.ts, 2, 27))
 
-var r13 = foo13(r13arg1); // any
+var r13 = foo13(r13arg1);
 >r13 : Symbol(r13, Decl(subtypingWithCallSignatures2.ts, 153, 3))
 >foo13 : Symbol(foo13, Decl(subtypingWithCallSignatures2.ts, 41, 36), Decl(subtypingWithCallSignatures2.ts, 43, 91))
 >r13arg1 : Symbol(r13arg1, Decl(subtypingWithCallSignatures2.ts, 151, 3))
@@ -807,7 +807,7 @@ var r16arg1 = <T extends Base>(x: T) => [1];
 >x : Symbol(x, Decl(subtypingWithCallSignatures2.ts, 165, 31))
 >T : Symbol(T, Decl(subtypingWithCallSignatures2.ts, 165, 15))
 
-var r16 = foo16(r16arg1); 
+var r16 = foo16(r16arg1);
 >r16 : Symbol(r16, Decl(subtypingWithCallSignatures2.ts, 166, 3))
 >foo16 : Symbol(foo16, Decl(subtypingWithCallSignatures2.ts, 53, 36), Decl(subtypingWithCallSignatures2.ts, 58, 13))
 >r16arg1 : Symbol(r16arg1, Decl(subtypingWithCallSignatures2.ts, 165, 3))
@@ -835,7 +835,7 @@ var r18arg1 = <T>(x: (a: T) => T) => <T[]>null;
 >T : Symbol(T, Decl(subtypingWithCallSignatures2.ts, 169, 15))
 >T : Symbol(T, Decl(subtypingWithCallSignatures2.ts, 169, 15))
 
-var r18 = foo18(r18arg1); 
+var r18 = foo18(r18arg1);
 >r18 : Symbol(r18, Decl(subtypingWithCallSignatures2.ts, 170, 3))
 >foo18 : Symbol(foo18, Decl(subtypingWithCallSignatures2.ts, 65, 36), Decl(subtypingWithCallSignatures2.ts, 76, 13))
 >r18arg1 : Symbol(r18arg1, Decl(subtypingWithCallSignatures2.ts, 169, 3))

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -888,8 +888,8 @@ var r14arg2 = (x: { a: string; b: number }) => <Object>null;
 >null : null
 
 var r14 = foo14(r14arg1); // any
->r14 : any
->foo14(r14arg1) : any
+>r14 : (x: { a: string; b: number; }) => Object
+>foo14(r14arg1) : (x: { a: string; b: number; }) => Object
 >foo14 : { (a: (x: { a: string; b: number; }) => Object): (x: { a: string; b: number; }) => Object; (a: any): any; }
 >r14arg1 : <T>(x: { a: T; b: T; }) => T
 

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -216,14 +216,14 @@ declare function foo14(a: any): any;
 >foo14 : { (a: (x: { a: string; b: number; }) => Object): (x: { a: string; b: number; }) => Object; (a: any): any; }
 >a : any
 
-declare function foo15(a: { 
+declare function foo15(a: {
 >foo15 : { (a: { (x: number): number[]; (x: string): string[]; }): { (x: number): number[]; (x: string): string[]; }; (a: any): any; }
 >a : { (x: number): number[]; (x: string): string[]; }
 
     (x: number): number[];
 >x : number
 
-    (x: string): string[]; 
+    (x: string): string[];
 >x : string
 
 }): typeof a;
@@ -324,9 +324,9 @@ var r1arg2 = (x: number) => [1];
 >[1] : number[]
 >1 : 1
 
-var r1 = foo1(r1arg1); // any, return types are not subtype of first overload
->r1 : any
->foo1(r1arg1) : any
+var r1 = foo1(r1arg1);
+>r1 : (x: number) => number[]
+>foo1(r1arg1) : (x: number) => number[]
 >foo1 : { (a: (x: number) => number[]): (x: number) => number[]; (a: any): any; }
 >r1arg1 : <T>(x: T) => T[]
 
@@ -358,7 +358,7 @@ var r2arg2 = (x: number) => [''];
 >[''] : string[]
 >'' : ""
 
-var r2 = foo2(r2arg1); 
+var r2 = foo2(r2arg1);
 >r2 : (x: number) => string[]
 >foo2(r2arg1) : (x: number) => string[]
 >foo2 : { (a: (x: number) => string[]): (x: number) => string[]; (a: any): any; }
@@ -389,7 +389,7 @@ var r3arg2 = (x: number) => { };
 >(x: number) => { } : (x: number) => void
 >x : number
 
-var r3 = foo3(r3arg1); 
+var r3 = foo3(r3arg1);
 >r3 : (x: number) => void
 >foo3(r3arg1) : (x: number) => void
 >foo3 : { (a: (x: number) => void): (x: number) => void; (a: any): any; }
@@ -425,9 +425,9 @@ var r4arg2 = (x: string, y: number) => '';
 >y : number
 >'' : ""
 
-var r4 = foo4(r4arg1); // any
->r4 : any
->foo4(r4arg1) : any
+var r4 = foo4(r4arg1);
+>r4 : (x: string, y: number) => string
+>foo4(r4arg1) : (x: string, y: number) => string
 >foo4 : { (a: (x: string, y: number) => string): (x: string, y: number) => string; (a: any): any; }
 >r4arg1 : <T, U>(x: T, y: U) => T
 
@@ -463,9 +463,9 @@ var r5arg2 = (x: (arg: string) => number) => '';
 >arg : string
 >'' : ""
 
-var r5 = foo5(r5arg1); // any
->r5 : any
->foo5(r5arg1) : any
+var r5 = foo5(r5arg1);
+>r5 : (x: (arg: string) => number) => string
+>foo5(r5arg1) : (x: (arg: string) => number) => string
 >foo5 : { (a: (x: (arg: string) => number) => string): (x: (arg: string) => number) => string; (a: any): any; }
 >r5arg1 : <T, U>(x: (arg: T) => U) => T
 
@@ -507,9 +507,9 @@ var r6arg2 = (x: (arg: Base) => Derived) => <Base>null;
 >Base : Base
 >null : null
 
-var r6 = foo6(r6arg1); // any
->r6 : any
->foo6(r6arg1) : any
+var r6 = foo6(r6arg1);
+>r6 : (x: (arg: Base) => Derived) => Base
+>foo6(r6arg1) : (x: (arg: Base) => Derived) => Base
 >foo6 : { (a: (x: (arg: Base) => Derived) => Base): (x: (arg: Base) => Derived) => Base; (a: any): any; }
 >r6arg1 : <T extends Base, U extends Derived>(x: (arg: T) => U) => T
 
@@ -557,9 +557,9 @@ var r7arg2 = (x: (arg: Base) => Derived) => (r: Base) => <Derived>null;
 >Derived : Derived
 >null : null
 
-var r7 = foo7(r7arg1); // any
->r7 : any
->foo7(r7arg1) : any
+var r7 = foo7(r7arg1);
+>r7 : (x: (arg: Base) => Derived) => (r: Base) => Derived
+>foo7(r7arg1) : (x: (arg: Base) => Derived) => (r: Base) => Derived
 >foo7 : { (a: (x: (arg: Base) => Derived) => (r: Base) => Derived): (x: (arg: Base) => Derived) => (r: Base) => Derived; (a: any): any; }
 >r7arg1 : <T extends Base, U extends Derived>(x: (arg: T) => U) => (r: T) => U
 
@@ -615,9 +615,9 @@ var r8arg2 = (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base
 >Derived : Derived
 >null : null
 
-var r8 = foo8(r8arg1); // any
->r8 : any
->foo8(r8arg1) : any
+var r8 = foo8(r8arg1);
+>r8 : (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived
+>foo8(r8arg1) : (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived
 >foo8 : { (a: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived): (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived; (a: any): any; }
 >r8arg1 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: T) => U) => (r: T) => U
 
@@ -674,9 +674,9 @@ var r9arg2 = (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base
 >Derived : Derived
 >null : null
 
-var r9 = foo9(r9arg1); // any
->r9 : any
->foo9(r9arg1) : any
+var r9 = foo9(r9arg1);
+>r9 : (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived
+>foo9(r9arg1) : (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived
 >foo9 : { (a: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived): (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived; (a: any): any; }
 >r9arg1 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 
@@ -712,9 +712,9 @@ var r10arg2 = (...x: Derived[]) => <Derived>null;
 >Derived : Derived
 >null : null
 
-var r10 = foo10(r10arg1); // any
->r10 : any
->foo10(r10arg1) : any
+var r10 = foo10(r10arg1);
+>r10 : (...x: Derived[]) => Derived
+>foo10(r10arg1) : (...x: Derived[]) => Derived
 >foo10 : { (a: (...x: Derived[]) => Derived): (...x: Derived[]) => Derived; (a: any): any; }
 >r10arg1 : <T extends Derived>(...x: T[]) => T
 
@@ -753,9 +753,9 @@ var r11arg2 = (x: { foo: string }, y: { foo: string; bar: string }) => <Base>nul
 >Base : Base
 >null : null
 
-var r11 = foo11(r11arg1); // any
->r11 : any
->foo11(r11arg1) : any
+var r11 = foo11(r11arg1);
+>r11 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
+>foo11(r11arg1) : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >foo11 : { (a: (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): (x: { foo: string; }, y: { foo: string; bar: string; }) => Base; (a: any): any; }
 >r11arg1 : <T extends Base>(x: T, y: T) => T
 
@@ -801,7 +801,7 @@ var r12arg2 = (x: Array<Base>, y: Array<Derived2>) => <Array<Derived>>null;
 >Derived : Derived
 >null : null
 
-var r12 = foo12(r12arg1); // any
+var r12 = foo12(r12arg1);
 >r12 : (x: Base[], y: Derived2[]) => Derived[]
 >foo12(r12arg1) : (x: Base[], y: Derived2[]) => Derived[]
 >foo12 : { (a: (x: Base[], y: Derived2[]) => Derived[]): (x: Base[], y: Derived2[]) => Derived[]; (a: any): any; }
@@ -846,9 +846,9 @@ var r13arg2 = (x: Array<Base>, y: Array<Derived>) => <Array<Derived>>null;
 >Derived : Derived
 >null : null
 
-var r13 = foo13(r13arg1); // any
->r13 : any
->foo13(r13arg1) : any
+var r13 = foo13(r13arg1);
+>r13 : (x: Base[], y: Derived[]) => Derived[]
+>foo13(r13arg1) : (x: Base[], y: Derived[]) => Derived[]
 >foo13 : { (a: (x: Base[], y: Derived[]) => Derived[]): (x: Base[], y: Derived[]) => Derived[]; (a: any): any; }
 >r13arg1 : <T extends Derived[]>(x: Base[], y: T) => T
 
@@ -931,7 +931,7 @@ var r16arg1 = <T extends Base>(x: T) => [1];
 >[1] : number[]
 >1 : 1
 
-var r16 = foo16(r16arg1); 
+var r16 = foo16(r16arg1);
 >r16 : { <T extends Derived>(x: T): number[]; <U extends Base>(x: U): number[]; }
 >foo16(r16arg1) : { <T extends Derived>(x: T): number[]; <U extends Base>(x: U): number[]; }
 >foo16 : { (a: { <T extends Derived>(x: T): number[]; <U extends Base>(x: U): number[]; }): { <T extends Derived>(x: T): number[]; <U extends Base>(x: U): number[]; }; (a: any): any; }
@@ -967,7 +967,7 @@ var r18arg1 = <T>(x: (a: T) => T) => <T[]>null;
 >T : T
 >null : null
 
-var r18 = foo18(r18arg1); 
+var r18 = foo18(r18arg1);
 >r18 : { (x: { (a: number): number; (a: string): string; }): any[]; (x: { (a: boolean): boolean; (a: Date): Date; }): any[]; }
 >foo18(r18arg1) : { (x: { (a: number): number; (a: string): string; }): any[]; (x: { (a: boolean): boolean; (a: Date): Date; }): any[]; }
 >foo18 : { (a: { (x: { (a: number): number; (a: string): string; }): any[]; (x: { (a: boolean): boolean; (a: Date): Date; }): any[]; }): { (x: { (a: number): number; (a: string): string; }): any[]; (x: { (a: boolean): boolean; (a: Date): Date; }): any[]; }; (a: any): any; }

--- a/tests/baselines/reference/subtypingWithCallSignatures3.js
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.js
@@ -60,7 +60,7 @@ module Errors {
 
     var r2arg = <T extends Base, U extends Derived, V extends Derived2>(x: (arg: T) => U) => (r: T) => <V>null;
     var r2arg2 = (x: (arg: Base) => Derived) => (r: Base) => <Derived2>null;
-    var r2 = foo7(r2arg); // any
+    var r2 = foo7(r2arg);
     var r2a = [r2arg2, r2arg];
     var r2b = [r2arg, r2arg2];
 
@@ -72,13 +72,13 @@ module Errors {
 
     var r4arg = <T extends Derived>(...x: T[]) => <T>null;
     var r4arg2 = (...x: Base[]) => <Base>null;
-    var r4 = foo10(r4arg); // any
+    var r4 = foo10(r4arg);
     var r4a = [r4arg2, r4arg];
     var r4b = [r4arg, r4arg2];
 
     var r5arg = <T extends Derived>(x: T, y: T) => <T>null;
     var r5arg2 = (x: { foo: string }, y: { foo: string; bar: string }) => <Base>null;
-    var r5 = foo11(r5arg); // any
+    var r5 = foo11(r5arg);
     var r5a = [r5arg2, r5arg];
     var r5b = [r5arg, r5arg2];
 
@@ -95,7 +95,7 @@ module Errors {
     var r7b = [r7arg, r7arg2];
 
     var r7arg3 = <T extends Base>(x: { a: T; b: T }) => 1;
-    var r7c = foo15(r7arg3); // (x: { a: string; b: number }) => number): number;
+    var r7c = foo15(r7arg3); // any
     var r7d = [r7arg2, r7arg3];
     var r7e = [r7arg3, r7arg2];
 
@@ -117,6 +117,7 @@ module WithGenericSignaturesInBaseType {
     var r3arg2 = <T>(x: T) => <T[]>null;
     var r3 = foo3(r3arg2); // any
 }
+
 
 //// [subtypingWithCallSignatures3.js]
 // checking subtype relations for function types as it relates to contextual signature instantiation
@@ -164,7 +165,7 @@ var Errors;
     var r1b = [function (x) { return null; }, function (x) { return ['']; }];
     var r2arg = function (x) { return function (r) { return null; }; };
     var r2arg2 = function (x) { return function (r) { return null; }; };
-    var r2 = foo7(r2arg); // any
+    var r2 = foo7(r2arg);
     var r2a = [r2arg2, r2arg];
     var r2b = [r2arg, r2arg2];
     var r3arg = function (x, y) { return function (r) { return null; }; };
@@ -186,12 +187,12 @@ var Errors;
         }
         return null;
     };
-    var r4 = foo10(r4arg); // any
+    var r4 = foo10(r4arg);
     var r4a = [r4arg2, r4arg];
     var r4b = [r4arg, r4arg2];
     var r5arg = function (x, y) { return null; };
     var r5arg2 = function (x, y) { return null; };
-    var r5 = foo11(r5arg); // any
+    var r5 = foo11(r5arg);
     var r5a = [r5arg2, r5arg];
     var r5b = [r5arg, r5arg2];
     var r6arg = function (x, y) { return null; };
@@ -205,7 +206,7 @@ var Errors;
     var r7a = [r7arg2, r7arg];
     var r7b = [r7arg, r7arg2];
     var r7arg3 = function (x) { return 1; };
-    var r7c = foo15(r7arg3); // (x: { a: string; b: number }) => number): number;
+    var r7c = foo15(r7arg3); // any
     var r7d = [r7arg2, r7arg3];
     var r7e = [r7arg3, r7arg2];
     var r8arg = function (x) { return null; };

--- a/tests/baselines/reference/subtypingWithCallSignatures3.symbols
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.symbols
@@ -258,7 +258,7 @@ module Errors {
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures3.ts, 3, 15))
 >Derived2 : Symbol(Derived2, Decl(subtypingWithCallSignatures3.ts, 5, 47))
 
-    var r2 = foo7(r2arg); // any
+    var r2 = foo7(r2arg);
 >r2 : Symbol(r2, Decl(subtypingWithCallSignatures3.ts, 61, 7))
 >foo7 : Symbol(foo7, Decl(subtypingWithCallSignatures3.ts, 10, 40), Decl(subtypingWithCallSignatures3.ts, 12, 95))
 >r2arg : Symbol(r2arg, Decl(subtypingWithCallSignatures3.ts, 59, 7))
@@ -334,7 +334,7 @@ module Errors {
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures3.ts, 3, 15))
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures3.ts, 3, 15))
 
-    var r4 = foo10(r4arg); // any
+    var r4 = foo10(r4arg);
 >r4 : Symbol(r4, Decl(subtypingWithCallSignatures3.ts, 73, 7))
 >foo10 : Symbol(foo10, Decl(subtypingWithCallSignatures3.ts, 16, 40), Decl(subtypingWithCallSignatures3.ts, 18, 66))
 >r4arg : Symbol(r4arg, Decl(subtypingWithCallSignatures3.ts, 71, 7))
@@ -368,7 +368,7 @@ module Errors {
 >bar : Symbol(bar, Decl(subtypingWithCallSignatures3.ts, 78, 55))
 >Base : Symbol(Base, Decl(subtypingWithCallSignatures3.ts, 3, 15))
 
-    var r5 = foo11(r5arg); // any
+    var r5 = foo11(r5arg);
 >r5 : Symbol(r5, Decl(subtypingWithCallSignatures3.ts, 79, 7))
 >foo11 : Symbol(foo11, Decl(subtypingWithCallSignatures3.ts, 19, 41), Decl(subtypingWithCallSignatures3.ts, 21, 105))
 >r5arg : Symbol(r5arg, Decl(subtypingWithCallSignatures3.ts, 77, 7))
@@ -463,7 +463,7 @@ module Errors {
 >b : Symbol(b, Decl(subtypingWithCallSignatures3.ts, 95, 44))
 >T : Symbol(T, Decl(subtypingWithCallSignatures3.ts, 95, 18))
 
-    var r7c = foo15(r7arg3); // (x: { a: string; b: number }) => number): number;
+    var r7c = foo15(r7arg3); // any
 >r7c : Symbol(r7c, Decl(subtypingWithCallSignatures3.ts, 96, 7))
 >foo15 : Symbol(foo15, Decl(subtypingWithCallSignatures3.ts, 25, 41), Decl(subtypingWithCallSignatures3.ts, 27, 83))
 >r7arg3 : Symbol(r7arg3, Decl(subtypingWithCallSignatures3.ts, 95, 7))
@@ -557,3 +557,4 @@ module WithGenericSignaturesInBaseType {
 >foo3 : Symbol(foo3, Decl(subtypingWithCallSignatures3.ts, 111, 26), Decl(subtypingWithCallSignatures3.ts, 113, 64))
 >r3arg2 : Symbol(r3arg2, Decl(subtypingWithCallSignatures3.ts, 115, 7))
 }
+

--- a/tests/baselines/reference/subtypingWithCallSignatures3.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.types
@@ -284,9 +284,9 @@ module Errors {
 >Derived2 : Derived2
 >null : null
 
-    var r2 = foo7(r2arg); // any
->r2 : any
->foo7(r2arg) : any
+    var r2 = foo7(r2arg);
+>r2 : (x: (arg: Base) => Derived) => (r: Base) => Derived2
+>foo7(r2arg) : (x: (arg: Base) => Derived) => (r: Base) => Derived2
 >foo7 : { (a2: (x: (arg: Base) => Derived) => (r: Base) => Derived2): (x: (arg: Base) => Derived) => (r: Base) => Derived2; (a2: any): any; }
 >r2arg : <T extends Base, U extends Derived, V extends Derived2>(x: (arg: T) => U) => (r: T) => V
 
@@ -380,9 +380,9 @@ module Errors {
 >Base : Base
 >null : null
 
-    var r4 = foo10(r4arg); // any
->r4 : any
->foo10(r4arg) : any
+    var r4 = foo10(r4arg);
+>r4 : (...x: Base[]) => Base
+>foo10(r4arg) : (...x: Base[]) => Base
 >foo10 : { (a2: (...x: Base[]) => Base): (...x: Base[]) => Base; (a2: any): any; }
 >r4arg : <T extends Derived>(...x: T[]) => T
 
@@ -423,9 +423,9 @@ module Errors {
 >Base : Base
 >null : null
 
-    var r5 = foo11(r5arg); // any
->r5 : any
->foo11(r5arg) : any
+    var r5 = foo11(r5arg);
+>r5 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
+>foo11(r5arg) : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >foo11 : { (a2: (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): (x: { foo: string; }, y: { foo: string; bar: string; }) => Base; (a2: any): any; }
 >r5arg : <T extends Derived>(x: T, y: T) => T
 
@@ -540,9 +540,9 @@ module Errors {
 >T : T
 >1 : 1
 
-    var r7c = foo15(r7arg3); // (x: { a: string; b: number }) => number): number;
->r7c : (x: { a: string; b: number; }) => number
->foo15(r7arg3) : (x: { a: string; b: number; }) => number
+    var r7c = foo15(r7arg3); // any
+>r7c : any
+>foo15(r7arg3) : any
 >foo15 : { (a2: (x: { a: string; b: number; }) => number): (x: { a: string; b: number; }) => number; (a2: any): any; }
 >r7arg3 : <T extends Base>(x: { a: T; b: T; }) => number
 
@@ -653,3 +653,4 @@ module WithGenericSignaturesInBaseType {
 >foo3 : { (a2: <T>(x: T) => string[]): <T>(x: T) => string[]; (a2: any): any; }
 >r3arg2 : <T>(x: T) => T[]
 }
+

--- a/tests/baselines/reference/subtypingWithCallSignatures3.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.types
@@ -206,8 +206,8 @@ module Errors {
 >a2 : any
 
     var r1 = foo2(<T, U>(x: T) => <U[]>null); // any
->r1 : any
->foo2(<T, U>(x: T) => <U[]>null) : any
+>r1 : (x: number) => string[]
+>foo2(<T, U>(x: T) => <U[]>null) : (x: number) => string[]
 >foo2 : { (a2: (x: number) => string[]): (x: number) => string[]; (a2: any): any; }
 ><T, U>(x: T) => <U[]>null : <T, U>(x: T) => U[]
 >T : T

--- a/tests/baselines/reference/underscoreTest1.errors.txt
+++ b/tests/baselines/reference/underscoreTest1.errors.txt
@@ -1,0 +1,908 @@
+tests/cases/compiler/underscoreTest1_underscoreTests.ts(26,7): error TS2345: Argument of type '(string | number | boolean)[]' is not assignable to parameter of type 'Dictionary<{}>'.
+  Index signature is missing in type '(string | number | boolean)[]'.
+
+
+==== tests/cases/compiler/underscoreTest1_underscoreTests.ts (1 errors) ====
+    /// <reference path="underscoreTest1_underscore.ts" />
+    
+    declare var $;
+    declare function alert(x: string): void;
+    
+    _.each([1, 2, 3], (num) => alert(num.toString()));
+    _.each({ one: 1, two: 2, three: 3 }, (value: number, key?: string) => alert(value.toString()));
+    
+    _.map([1, 2, 3], (num) => num * 3);
+    _.map({ one: 1, two: 2, three: 3 }, (value: number, key?: string) => value * 3);
+    
+    var sum = _.reduce([1, 2, 3], (memo, num) => memo + num, 0);
+    
+    var list = [[0, 1], [2, 3], [4, 5]];
+    var flat = _.reduceRight(list, (a, b) => a.concat(b), []);
+    
+    var even = _.find([1, 2, 3, 4, 5, 6], (num) => num % 2 == 0);
+    
+    var evens = _.filter([1, 2, 3, 4, 5, 6], (num) => num % 2 == 0);
+    
+    var listOfPlays = [{ title: "Cymbeline", author: "Shakespeare", year: 1611 }, { title: "The Tempest", author: "Shakespeare", year: 1611 }, { title: "Other", author: "Not Shakespeare", year: 2012 }];
+    _.where(listOfPlays, { author: "Shakespeare", year: 1611 });
+    
+    var odds = _.reject([1, 2, 3, 4, 5, 6], (num) => num % 2 == 0);
+    
+    _.all([true, 1, null, 'yes'], _.identity);
+          ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '(string | number | boolean)[]' is not assignable to parameter of type 'Dictionary<{}>'.
+!!! error TS2345:   Index signature is missing in type '(string | number | boolean)[]'.
+    
+    _.any([null, 0, 'yes', false]);
+    
+    _.contains([1, 2, 3], 3);
+    
+    _.invoke([[5, 1, 7], [3, 2, 1]], 'sort');
+    
+    var stooges = [{ name: 'moe', age: 40 }, { name: 'larry', age: 50 }, { name: 'curly', age: 60 }];
+    _.pluck(stooges, 'name');
+    
+    _.max(stooges, (stooge) => stooge.age);
+    
+    var numbers = [10, 5, 100, 2, 1000];
+    _.min(numbers);
+    
+    _.sortBy([1, 2, 3, 4, 5, 6], (num) => Math.sin(num));
+    
+    
+    // not sure how this is typechecking at all.. Math.floor(e) is number not string..?
+    _([1.3, 2.1, 2.4]).groupBy((e: number, i?: number, list?: number[]) => Math.floor(e));
+    _.groupBy([1.3, 2.1, 2.4], (num: number) => Math.floor(num));
+    _.groupBy(['one', 'two', 'three'], 'length');
+    
+    _.countBy([1, 2, 3, 4, 5], (num) => num % 2 == 0 ? 'even' : 'odd');
+    
+    _.shuffle([1, 2, 3, 4, 5, 6]);
+    
+    // (function(){ return _.toArray(arguments).slice(1); })(1, 2, 3, 4);
+    
+    _.size({ one: 1, two: 2, three: 3 });
+    
+    ///////////////////////////////////////////////////////////////////////////////////////
+    
+    _.first([5, 4, 3, 2, 1]);
+    _.initial([5, 4, 3, 2, 1]);
+    _.last([5, 4, 3, 2, 1]);
+    _.rest([5, 4, 3, 2, 1]);
+    _.compact([0, 1, false, 2, '', 3]);
+    
+    _.flatten([1, 2, 3, 4]);
+    _.flatten([1, [2]]);
+    
+    // typescript doesn't like the elements being different
+    _.flatten([1, [2], [3, [[4]]]]);
+    _.flatten([1, [2], [3, [[4]]]], true);
+    _.without([1, 2, 1, 0, 3, 1, 4], 0, 1);
+    _.union([1, 2, 3], [101, 2, 1, 10], [2, 1]);
+    _.intersection([1, 2, 3], [101, 2, 1, 10], [2, 1]);
+    _.difference([1, 2, 3, 4, 5], [5, 2, 10]);
+    _.uniq([1, 2, 1, 3, 1, 4]);
+    _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]);
+    _.object(['moe', 'larry', 'curly'], [30, 40, 50]);
+    _.object([['moe', 30], ['larry', 40], ['curly', 50]]);
+    _.indexOf([1, 2, 3], 2);
+    _.lastIndexOf([1, 2, 3, 1, 2, 3], 2);
+    _.sortedIndex([10, 20, 30, 40, 50], 35);
+    _.range(10);
+    _.range(1, 11);
+    _.range(0, 30, 5);
+    _.range(0, 30, 5);
+    _.range(0);
+    
+    ///////////////////////////////////////////////////////////////////////////////////////
+    
+    var func = function (greeting) { return greeting + ': ' + this.name };
+    // need a second var otherwise typescript thinks func signature is the above func type,
+    // instead of the newly returned _bind => func type.
+    var func2 = _.bind(func, { name: 'moe' }, 'hi');
+    func2();
+    
+    var buttonView = {
+        label: 'underscore',
+        onClick: function () { alert('clicked: ' + this.label); },
+        onHover: function () { alert('hovering: ' + this.label); }
+    };
+    _.bindAll(buttonView);
+    $('#underscore_button').bind('click', buttonView.onClick);
+    
+    var fibonacci = _.memoize(function (n) {
+        return n < 2 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+    });
+    
+    var log = _.bind((message?: string, ...rest: string[]) => { }, Date);
+    _.delay(log, 1000, 'logged later');
+    
+    _.defer(function () { alert('deferred'); });
+    
+    var updatePosition = () => alert('updating position...');
+    var throttled = _.throttle(updatePosition, 100);
+    $(null).scroll(throttled);
+    
+    var calculateLayout = () => alert('calculating layout...');
+    var lazyLayout = _.debounce(calculateLayout, 300);
+    $(null).resize(lazyLayout);
+    
+    var createApplication = () => alert('creating application...');
+    var initialize = _.once(createApplication);
+    initialize();
+    initialize();
+    
+    var notes: any[];
+    var render = () => alert("rendering...");
+    var renderNotes = _.after(notes.length, render);
+    _.each(notes, (note) => note.asyncSave({ success: renderNotes }));
+    
+    var hello = function (name) { return "hello: " + name; };
+    hello = _.wrap(hello, (func, arg) => { return "before, " + func(arg) + ", after"; });
+    hello("moe");
+    
+    var greet = function (name) { return "hi: " + name; };
+    var exclaim = function (statement) { return statement + "!"; };
+    var welcome = _.compose(exclaim, greet);
+    welcome('moe');
+    
+    ///////////////////////////////////////////////////////////////////////////////////////
+    
+    _.keys({ one: 1, two: 2, three: 3 });
+    _.values({ one: 1, two: 2, three: 3 });
+    _.pairs({ one: 1, two: 2, three: 3 });
+    _.invert({ Moe: "Moses", Larry: "Louis", Curly: "Jerome" });
+    _.functions(_);
+    _.extend({ name: 'moe' }, { age: 50 });
+    _.pick({ name: 'moe', age: 50, userid: 'moe1' }, 'name', 'age');
+    _.omit({ name: 'moe', age: 50, userid: 'moe1' }, 'userid');
+    
+    var iceCream = { flavor: "chocolate" };
+    _.defaults(iceCream, { flavor: "vanilla", sprinkles: "lots" });
+    
+    _.clone({ name: 'moe' });
+    
+    _.chain([1, 2, 3, 200])
+        .filter(function (num) { return num % 2 == 0; })
+        .tap(<any>alert)
+        .map(function (num) { return num * num })
+        .value();
+    
+    _.has({ a: 1, b: 2, c: 3 }, "b");
+    
+    var moe = { name: 'moe', luckyNumbers: [13, 27, 34] };
+    var clone = { name: 'moe', luckyNumbers: [13, 27, 34] };
+    moe == clone;
+    _.isEqual(moe, clone);
+    
+    _.isEmpty([1, 2, 3]);
+    _.isEmpty({});
+    
+    _.isElement($('body')[0]);
+    
+    (function () { return _.isArray(arguments); })();
+    _.isArray([1, 2, 3]);
+    
+    _.isObject({});
+    _.isObject(1);
+    
+    
+    // (() => { return _.isArguments(arguments); })(1, 2, 3);
+    _.isArguments([1, 2, 3]);
+    
+    _.isFunction(alert);
+    
+    _.isString("moe");
+    
+    _.isNumber(8.4 * 5);
+    
+    _.isFinite(-101);
+    
+    _.isFinite(-Infinity);
+    
+    _.isBoolean(null);
+    
+    _.isDate(new Date());
+    
+    _.isRegExp(/moe/);
+    
+    _.isNaN(NaN);
+    isNaN(undefined);
+    _.isNaN(undefined);
+    
+    _.isNull(null);
+    _.isNull(undefined);
+    
+    _.isUndefined((<any>null).missingVariable);
+    
+    ///////////////////////////////////////////////////////////////////////////////////////
+    
+    var underscore = _.noConflict();
+    
+    var moe2 = { name: 'moe' };
+    moe2 === _.identity(moe);
+    
+    var genie;
+    
+    _.times(3, function (n) { genie.grantWishNumber(n); });
+    
+    _.random(0, 100);
+    
+    _.mixin({
+        capitalize: function (string) {
+            return string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
+        }
+    });
+    (<any>_("fabio")).capitalize();
+    
+    _.uniqueId('contact_');
+    
+    _.escape('Curly, Larry & Moe');
+    
+    var object = { cheese: 'crumpets', stuff: function () { return 'nonsense'; } };
+    _.result(object, 'cheese');
+    
+    _.result(object, 'stuff');
+    
+    var compiled = _.template("hello: <%= name %>");
+    compiled({ name: 'moe' });
+    var list2 = "<% _.each(people, function(name) { %> <li><%= name %></li> <% }); %>";
+    _.template(list2, { people: ['moe', 'curly', 'larry'] });
+    var template = _.template("<b><%- value %></b>");
+    template({ value: '<script>' });
+    var compiled2 = _.template("<% print('Hello ' + epithet); %>");
+    compiled2({ epithet: "stooge" });
+    _.templateSettings = {
+        interpolate: /\{\{(.+?)\}\}/g
+    };
+    var template2 = _.template("Hello {{ name }}!");
+    template2({ name: "Mustache" });
+    _.template("Using 'with': <%= data.answer %>", { answer: 'no' }, { variable: 'data' });
+==== tests/cases/compiler/underscoreTest1_underscore.ts (0 errors) ====
+    interface Dictionary<T> {
+        [x: string]: T;
+    }
+    
+    interface Iterator_<T, U> {
+        (value: T, index: any, list: any): U;
+    }
+    
+    interface Reducer<T, U> {
+        (accumulator: U, value: T, index: any, list: any): U;
+    }
+    
+    interface Tuple2<T0, T1> extends Array<any> {
+        0: T0;
+        1: T1;
+    }
+    
+    interface Tuple3<T0, T1, T2> extends Array<any> {
+        0: T0;
+        1: T1;
+        2: T2;
+    }
+    
+    interface Tuple4<T0, T1, T2, T3> extends Array<any> {
+        0: T0;
+        1: T1;
+        2: T2;
+        3: T3;
+    }
+    
+    module Underscore {
+        export interface WrappedObject<T> {
+            keys(): string[];
+            values(): any[];
+            pairs(): any[][];
+            invert(): any;
+            functions(): string[];
+            methods(): string[];
+            extend(...sources: any[]): T;
+            pick(...keys: string[]): T;
+            omit(...keys: string[]): T;
+            defaults(...defaults: any[]): T;
+            clone(): T;
+            tap(interceptor: (object: T) => void): T;
+            has(key: string): boolean;
+            isEqual(other: T): boolean;
+            isEmpty(): boolean;
+            isElement(): boolean;
+            isArray(): boolean;
+            isObject(): boolean;
+            isArguments(): boolean;
+            isFunction(): boolean;
+            isString(): boolean;
+            isNumber(): boolean;
+            isFinite(): boolean;
+            isBoolean(): boolean;
+            isDate(): boolean;
+            isRegExp(): boolean;
+            isNaN(): boolean;
+            isNull(): boolean;
+            isUndefined(): boolean;
+            value(): T;
+        }
+    
+        export interface WrappedFunction<T extends Function> extends WrappedObject<T> {
+            bind(object: any): T;
+            bind(object: any, ...args: any[]): Function;
+            bindAll(...methodNames: string[]): T;
+            partial(...args: any[]): Function;
+            memoize(hashFunction?: Function): T;
+            delay(wait: number, ...args: any[]): number;
+            defer(...args: any[]): number;
+            throttle(wait: number): T;
+            debounce(wait: number, immediate?: boolean): T;
+            once(): T;
+            wrap(wrapper: (func: T, ...args: any[]) => any): T;
+            compose(...funcs: Function[]): Function;
+        }
+    
+        export interface WrappedArray<T> extends WrappedObject<Array<T>> {
+            each(iterator: Iterator_<T, void>, context?: any): void;
+            forEach(iterator: Iterator_<T, void>, context?: any): void;
+            map<U>(iterator: Iterator_<T, U>, context?: any): U[];
+            collect<U>(iterator: Iterator_<T, U>, context?: any): U[];
+            reduce(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            reduce<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            foldl(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            foldl<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            inject(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            inject<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            reduceRight(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            reduceRight<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            foldr(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            foldr<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            find(iterator: Iterator_<T, boolean>, context?: any): T;
+            detect(iterator: Iterator_<T, boolean>, context?: any): T;
+            filter(iterator: Iterator_<T, boolean>, context?: any): T[];
+            select(iterator: Iterator_<T, boolean>, context?: any): T[];
+            where(properties: Object): T[];
+            findWhere(properties: Object): T;
+            reject(iterator: Iterator_<T, boolean>, context?: any): T[];
+            every(iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            all(iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            some(iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            any(iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            contains(value: T): boolean;
+            include(value: T): boolean;
+            invoke(methodName: string, ...args: any[]): any[];
+            pluck(propertyName: string): any[];
+            max(iterator?: Iterator_<T, any>, context?: any): T;
+            min(iterator?: Iterator_<T, any>, context?: any): T;
+            sortBy(iterator: Iterator_<T, any>, context?: any): T[];
+            sortBy(propertyName: string): T[];
+            groupBy(iterator?: Iterator_<T, any>, context?: any): Dictionary<T[]>;
+            groupBy(propertyName: string): Dictionary<T[]>;
+            countBy(iterator?: Iterator_<T, any>, context?: any): Dictionary<number>;
+            countBy(propertyName: string): Dictionary<number>;
+            shuffle(): T[];
+            toArray(): T[];
+            size(): number;
+            first(): T;
+            first(count: number): T[];
+            head(): T;
+            head(count: number): T[];
+            take(): T;
+            take(count: number): T[];
+            initial(): T;
+            initial(count: number): T[];
+            last(): T;
+            last(count: number): T[];
+            rest(index?: number): T[];
+            compact(): T[];
+            flatten<U>(shallow?: boolean): U[];
+            without(...values: T[]): T[];
+            union(...arrays: T[][]): T[];
+            intersection(...arrays: T[][]): T[];
+            difference(...others: T[][]): T[];
+            uniq(isSorted?: boolean): T[];
+            uniq<U>(isSorted: boolean, iterator: Iterator_<T, U>, context?: any): U[];
+            unique(isSorted?: boolean): T[];
+            unique<U>(isSorted: boolean, iterator: Iterator_<T, U>, context?: any): U[];
+            zip(...arrays: any[][]): any[][];
+            object(): any;
+            object(values: any[]): any;
+            indexOf(value: T, isSorted?: boolean): number;
+            lastIndexOf(value: T, fromIndex?: number): number;
+            sortedIndex(obj: T, propertyName: string): number;
+            sortedIndex(obj: T, iterator?: Iterator_<T, any>, context?: any): number;
+            // Methods from Array
+            concat(...items: T[]): T[];
+            join(separator?: string): string;
+            pop(): T;
+            push(...items: T[]): number;
+            reverse(): T[];
+            shift(): T;
+            slice(start: number, end?: number): T[];
+            sort(compareFn?: (a: T, b: T) => number): T[];
+            splice(start: number): T[];
+            splice(start: number, deleteCount: number, ...items: T[]): T[];
+            unshift(...items: T[]): number;
+        }
+    
+        export interface WrappedDictionary<T> extends WrappedObject<Dictionary<T>> {
+            each(iterator: Iterator_<T, void>, context?: any): void;
+            forEach(iterator: Iterator_<T, void>, context?: any): void;
+            map<U>(iterator: Iterator_<T, U>, context?: any): U[];
+            collect<U>(iterator: Iterator_<T, U>, context?: any): U[];
+            reduce(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            reduce<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            foldl(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            foldl<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            inject(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            inject<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            reduceRight(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            reduceRight<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            foldr(iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            foldr<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            find(iterator: Iterator_<T, boolean>, context?: any): T;
+            detect(iterator: Iterator_<T, boolean>, context?: any): T;
+            filter(iterator: Iterator_<T, boolean>, context?: any): T[];
+            select(iterator: Iterator_<T, boolean>, context?: any): T[];
+            where(properties: Object): T[];
+            findWhere(properties: Object): T;
+            reject(iterator: Iterator_<T, boolean>, context?: any): T[];
+            every(iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            all(iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            some(iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            any(iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            contains(value: T): boolean;
+            include(value: T): boolean;
+            invoke(methodName: string, ...args: any[]): any[];
+            pluck(propertyName: string): any[];
+            max(iterator?: Iterator_<T, any>, context?: any): T;
+            min(iterator?: Iterator_<T, any>, context?: any): T;
+            sortBy(iterator: Iterator_<T, any>, context?: any): T[];
+            sortBy(propertyName: string): T[];
+            groupBy(iterator?: Iterator_<T, any>, context?: any): Dictionary<T[]>;
+            groupBy(propertyName: string): Dictionary<T[]>;
+            countBy(iterator?: Iterator_<T, any>, context?: any): Dictionary<number>;
+            countBy(propertyName: string): Dictionary<number>;
+            shuffle(): T[];
+            toArray(): T[];
+            size(): number;
+        }
+    
+        export interface ChainedObject<T> {
+            keys(): ChainedArray<string>;
+            values(): ChainedArray<any>;
+            pairs(): ChainedArray<any[]>;
+            invert(): ChainedObject<any>;
+            functions(): ChainedArray<string>;
+            methods(): ChainedArray<string>;
+            extend(...sources: any[]): ChainedObject<T>;
+            pick(...keys: string[]): ChainedObject<T>;
+            omit(...keys: string[]): ChainedObject<T>;
+            defaults(...defaults: any[]): ChainedObject<T>;
+            clone(): ChainedObject<T>;
+            tap(interceptor: (object: T) => void): ChainedObject<T>;
+            has(key: string): ChainedObject<boolean>;
+            isEqual(other: T): ChainedObject<boolean>;
+            isEmpty(): ChainedObject<boolean>;
+            isElement(): ChainedObject<boolean>;
+            isArray(): ChainedObject<boolean>;
+            isObject(): ChainedObject<boolean>;
+            isArguments(): ChainedObject<boolean>;
+            isFunction(): ChainedObject<boolean>;
+            isString(): ChainedObject<boolean>;
+            isNumber(): ChainedObject<boolean>;
+            isFinite(): ChainedObject<boolean>;
+            isBoolean(): ChainedObject<boolean>;
+            isDate(): ChainedObject<boolean>;
+            isRegExp(): ChainedObject<boolean>;
+            isNaN(): ChainedObject<boolean>;
+            isNull(): ChainedObject<boolean>;
+            isUndefined(): ChainedObject<boolean>;
+            value(): T;
+        }
+    
+        export interface ChainedArray<T> extends ChainedObject<Array<T>> {
+            each(iterator: Iterator_<T, void>, context?: any): ChainedObject<void>;
+            forEach(iterator: Iterator_<T, void>, context?: any): ChainedObject<void>;
+            map<U>(iterator: Iterator_<T, U>, context?: any): ChainedArray<U>;
+            collect<U>(iterator: Iterator_<T, U>, context?: any): ChainedArray<U>;
+            reduce(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            reduce<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            foldl(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            foldl<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            inject(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            inject<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            reduceRight(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            reduceRight<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            foldr(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            foldr<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            find(iterator: Iterator_<T, boolean>, context?: any): ChainedObject<T>;
+            detect(iterator: Iterator_<T, boolean>, context?: any): ChainedObject<T>;
+            filter(iterator: Iterator_<T, boolean>, context?: any): ChainedArray<T>;
+            select(iterator: Iterator_<T, boolean>, context?: any): ChainedArray<T>;
+            where(properties: Object): ChainedArray<T>;
+            findWhere(properties: Object): ChainedObject<T>;
+            reject(iterator: Iterator_<T, boolean>, context?: any): ChainedArray<T>;
+            every(iterator?: Iterator_<T, boolean>, context?: any): ChainedObject<boolean>;
+            all(iterator?: Iterator_<T, boolean>, context?: any): ChainedObject<boolean>;
+            some(iterator?: Iterator_<T, boolean>, context?: any): ChainedObject<boolean>;
+            any(iterator?: Iterator_<T, boolean>, context?: any): ChainedObject<boolean>;
+            contains(value: T): ChainedObject<boolean>;
+            include(value: T): ChainedObject<boolean>;
+            invoke(methodName: string, ...args: any[]): ChainedArray<any>;
+            pluck(propertyName: string): ChainedArray<any>;
+            max(iterator?: Iterator_<T, any>, context?: any): ChainedObject<T>;
+            min(iterator?: Iterator_<T, any>, context?: any): ChainedObject<T>;
+            sortBy(iterator: Iterator_<T, any>, context?: any): ChainedArray<T>;
+            sortBy(propertyName: string): ChainedArray<T>;
+            // Should return ChainedDictionary<T[]>, but expansive recursion not allowed
+            groupBy(iterator?: Iterator_<T, any>, context?: any): ChainedDictionary<any[]>;
+            groupBy(propertyName: string): ChainedDictionary<any[]>;
+            countBy(iterator?: Iterator_<T, any>, context?: any): ChainedDictionary<number>;
+            countBy(propertyName: string): ChainedDictionary<number>;
+            shuffle(): ChainedArray<T>;
+            toArray(): ChainedArray<T>;
+            size(): ChainedObject<number>;
+            first(): ChainedObject<T>;
+            first(count: number): ChainedArray<T>;
+            head(): ChainedObject<T>;
+            head(count: number): ChainedArray<T>;
+            take(): ChainedObject<T>;
+            take(count: number): ChainedArray<T>;
+            initial(): ChainedObject<T>;
+            initial(count: number): ChainedArray<T>;
+            last(): ChainedObject<T>;
+            last(count: number): ChainedArray<T>;
+            rest(index?: number): ChainedArray<T>;
+            compact(): ChainedArray<T>;
+            flatten<U>(shallow?: boolean): ChainedArray<U>;
+            without(...values: T[]): ChainedArray<T>;
+            union(...arrays: T[][]): ChainedArray<T>;
+            intersection(...arrays: T[][]): ChainedArray<T>;
+            difference(...others: T[][]): ChainedArray<T>;
+            uniq(isSorted?: boolean): ChainedArray<T>;
+            uniq<U>(isSorted: boolean, iterator: Iterator_<T, U>, context?: any): ChainedArray<U>;
+            unique(isSorted?: boolean): ChainedArray<T>;
+            unique<U>(isSorted: boolean, iterator: Iterator_<T, U>, context?: any): ChainedArray<U>;
+            zip(...arrays: any[][]): ChainedArray<any[]>;
+            object(): ChainedObject<any>;
+            object(values: any[]): ChainedObject<any>;
+            indexOf(value: T, isSorted?: boolean): ChainedObject<number>;
+            lastIndexOf(value: T, fromIndex?: number): ChainedObject<number>;
+            sortedIndex(obj: T, propertyName: string): ChainedObject<number>;
+            sortedIndex(obj: T, iterator?: Iterator_<T, any>, context?: any): ChainedObject<number>;
+            // Methods from Array
+            concat(...items: T[]): ChainedArray<T>;
+            join(separator?: string): ChainedObject<string>;
+            pop(): ChainedObject<T>;
+            push(...items: T[]): ChainedObject<number>;
+            reverse(): ChainedArray<T>;
+            shift(): ChainedObject<T>;
+            slice(start: number, end?: number): ChainedArray<T>;
+            sort(compareFn?: (a: T, b: T) => number): ChainedArray<T>;
+            splice(start: number): ChainedArray<T>;
+            splice(start: number, deleteCount: number, ...items: T[]): ChainedArray<T>;
+            unshift(...items: T[]): ChainedObject<number>;
+            // Methods from ChainedObject with promoted return types
+            extend(...sources: any[]): ChainedArray<T>;
+            pick(...keys: string[]): ChainedArray<T>;
+            omit(...keys: string[]): ChainedArray<T>;
+            defaults(...defaults: any[]): ChainedArray<T>;
+            clone(): ChainedArray<T>;
+            tap(interceptor: (object: T[]) => void): ChainedArray<T>;
+        }
+    
+        export interface ChainedDictionary<T> extends ChainedObject<Dictionary<T>> {
+            each(iterator: Iterator_<T, void>, context?: any): ChainedObject<void>;
+            forEach(iterator: Iterator_<T, void>, context?: any): ChainedObject<void>;
+            map<U>(iterator: Iterator_<T, U>, context?: any): ChainedArray<U>;
+            collect<U>(iterator: Iterator_<T, U>, context?: any): ChainedArray<U>;
+            reduce(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            reduce<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            foldl(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            foldl<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            inject(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            inject<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            reduceRight(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            reduceRight<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            foldr(iterator: Reducer<T, T>, initialValue?: T, context?: any): ChainedObject<T>;
+            foldr<U>(iterator: Reducer<T, U>, initialValue: U, context?: any): ChainedObject<U>;
+            find(iterator: Iterator_<T, boolean>, context?: any): ChainedObject<T>;
+            detect(iterator: Iterator_<T, boolean>, context?: any): ChainedObject<T>;
+            filter(iterator: Iterator_<T, boolean>, context?: any): ChainedArray<T>;
+            select(iterator: Iterator_<T, boolean>, context?: any): ChainedArray<T>;
+            where(properties: Object): ChainedArray<T>;
+            findWhere(properties: Object): ChainedObject<T>;
+            reject(iterator: Iterator_<T, boolean>, context?: any): ChainedArray<T>;
+            every(iterator?: Iterator_<T, boolean>, context?: any): ChainedObject<boolean>;
+            all(iterator?: Iterator_<T, boolean>, context?: any): ChainedObject<boolean>;
+            some(iterator?: Iterator_<T, boolean>, context?: any): ChainedObject<boolean>;
+            any(iterator?: Iterator_<T, boolean>, context?: any): ChainedObject<boolean>;
+            contains(value: T): ChainedObject<boolean>;
+            include(value: T): ChainedObject<boolean>;
+            invoke(methodName: string, ...args: any[]): ChainedArray<any>;
+            pluck(propertyName: string): ChainedArray<any>;
+            max(iterator?: Iterator_<T, any>, context?: any): ChainedObject<T>;
+            min(iterator?: Iterator_<T, any>, context?: any): ChainedObject<T>;
+            sortBy(iterator: Iterator_<T, any>, context?: any): ChainedArray<T>;
+            sortBy(propertyName: string): ChainedArray<T>;
+            // Should return ChainedDictionary<T[]>, but expansive recursion not allowed
+            groupBy(iterator?: Iterator_<T, any>, context?: any): ChainedDictionary<any[]>;
+            groupBy(propertyName: string): ChainedDictionary<any[]>;
+            countBy(iterator?: Iterator_<T, any>, context?: any): ChainedDictionary<number>;
+            countBy(propertyName: string): ChainedDictionary<number>;
+            shuffle(): ChainedArray<T>;
+            toArray(): ChainedArray<T>;
+            size(): ChainedObject<number>;
+            // Methods from ChainedObject with promoted return types
+            extend(...sources: any[]): ChainedDictionary<T>;
+            pick(...keys: string[]): ChainedDictionary<T>;
+            omit(...keys: string[]): ChainedDictionary<T>;
+            defaults(...defaults: any[]): ChainedDictionary<T>;
+            clone(): ChainedDictionary<T>;
+            tap(interceptor: (object: Dictionary<T>) => void): ChainedDictionary<T>;
+        }
+    
+        export interface TemplateSettings {
+            evaluate?: RegExp;
+            interpolate?: RegExp;
+            escape?: RegExp;
+            variable?: string;
+        }
+    
+        export interface Static {
+            <T>(list: T[]): WrappedArray<T>;
+            <T>(list: Dictionary<T>): WrappedDictionary<T>;
+            <T extends Function>(func: T): WrappedFunction<T>;
+            <T>(obj: T): WrappedObject<T>;
+    
+            chain<T>(list: T[]): ChainedArray<T>;
+            chain<T>(list: Dictionary<T>): ChainedDictionary<T>;
+            chain<T>(obj: T): ChainedObject<T>;
+    
+            each<T>(list: T[], iterator: Iterator_<T, void>, context?: any): void;
+            each<T>(list: Dictionary<T>, iterator: Iterator_<T, void>, context?: any): void;
+            forEach<T>(list: T[], iterator: Iterator_<T, void>, context?: any): void;
+            forEach<T>(list: Dictionary<T>, iterator: Iterator_<T, void>, context?: any): void;
+    
+            map<T, U>(list: T[], iterator: Iterator_<T, U>, context?: any): U[];
+            map<T, U>(list: Dictionary<T>, iterator: Iterator_<T, U>, context?: any): U[];
+            collect<T, U>(list: T[], iterator: Iterator_<T, U>, context?: any): U[];
+            collect<T, U>(list: Dictionary<T>, iterator: Iterator_<T, U>, context?: any): U[];
+    
+            reduce<T>(list: T[], iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            reduce<T, U>(list: T[], iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            reduce<T>(list: Dictionary<T>, iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            reduce<T, U>(list: Dictionary<T>, iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            foldl<T>(list: T[], iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            foldl<T, U>(list: T[], iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            foldl<T>(list: Dictionary<T>, iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            foldl<T, U>(list: Dictionary<T>, iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            inject<T>(list: T[], iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            inject<T, U>(list: T[], iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            inject<T>(list: Dictionary<T>, iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            inject<T, U>(list: Dictionary<T>, iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+    
+            reduceRight<T>(list: T[], iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            reduceRight<T, U>(list: T[], iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            reduceRight<T>(list: Dictionary<T>, iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            reduceRight<T, U>(list: Dictionary<T>, iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            foldr<T>(list: T[], iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            foldr<T, U>(list: T[], iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+            foldr<T>(list: Dictionary<T>, iterator: Reducer<T, T>, initialValue?: T, context?: any): T;
+            foldr<T, U>(list: Dictionary<T>, iterator: Reducer<T, U>, initialValue: U, context?: any): U;
+    
+            find<T>(list: T[], iterator: Iterator_<T, boolean>, context?: any): T;
+            find<T>(list: Dictionary<T>, iterator: Iterator_<T, boolean>, context?: any): T;
+            detect<T>(list: T[], iterator: Iterator_<T, boolean>, context?: any): T;
+            detect<T>(list: Dictionary<T>, iterator: Iterator_<T, boolean>, context?: any): T;
+    
+            filter<T>(list: T[], iterator: Iterator_<T, boolean>, context?: any): T[];
+            filter<T>(list: Dictionary<T>, iterator: Iterator_<T, boolean>, context?: any): T[];
+            select<T>(list: T[], iterator: Iterator_<T, boolean>, context?: any): T[];
+            select<T>(list: Dictionary<T>, iterator: Iterator_<T, boolean>, context?: any): T[];
+    
+            where<T>(list: T[], properties: Object): T[];
+            where<T>(list: Dictionary<T>, properties: Object): T[];
+    
+            findWhere<T>(list: T[], properties: Object): T;
+            findWhere<T>(list: Dictionary<T>, properties: Object): T;
+    
+            reject<T>(list: T[], iterator: Iterator_<T, boolean>, context?: any): T[];
+            reject<T>(list: Dictionary<T>, iterator: Iterator_<T, boolean>, context?: any): T[];
+    
+            every<T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            every<T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            all<T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            all<T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean;
+    
+            some<T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            some<T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            any<T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean;
+            any<T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean;
+    
+            contains<T>(list: T[], value: T): boolean;
+            contains<T>(list: Dictionary<T>, value: T): boolean;
+            include<T>(list: T[], value: T): boolean;
+            include<T>(list: Dictionary<T>, value: T): boolean;
+    
+            invoke(list: any[], methodName: string, ...args: any[]): any[];
+            invoke(list: Dictionary<any>, methodName: string, ...args: any[]): any[];
+    
+            pluck(list: any[], propertyName: string): any[];
+            pluck(list: Dictionary<any>, propertyName: string): any[];
+    
+            max<T>(list: T[], iterator?: Iterator_<T, any>, context?: any): T;
+            max<T>(list: Dictionary<T>, iterator?: Iterator_<T, any>, context?: any): T;
+    
+            min<T>(list: T[], iterator?: Iterator_<T, any>, context?: any): T;
+            min<T>(list: Dictionary<T>, iterator?: Iterator_<T, any>, context?: any): T;
+    
+            sortBy<T>(list: T[], iterator: Iterator_<T, any>, context?: any): T[];
+            sortBy<T>(list: Dictionary<T>, iterator: Iterator_<T, any>, context?: any): T[];
+            sortBy<T>(list: T[], propertyName: string): T[];
+            sortBy<T>(list: Dictionary<T>, propertyName: string): T[];
+    
+            groupBy<T>(list: T[], iterator?: Iterator_<T, any>, context?: any): Dictionary<T[]>;
+            groupBy<T>(list: Dictionary<T>, iterator?: Iterator_<T, any>, context?: any): Dictionary<T[]>;
+            groupBy<T>(list: T[], propertyName: string): Dictionary<T[]>;
+            groupBy<T>(list: Dictionary<T>, propertyName: string): Dictionary<T[]>;
+    
+            countBy<T>(list: T[], iterator?: Iterator_<T, any>, context?: any): Dictionary<number>;
+            countBy<T>(list: Dictionary<T>, iterator?: Iterator_<T, any>, context?: any): Dictionary<number>;
+            countBy<T>(list: T[], propertyName: string): Dictionary<number>;
+            countBy<T>(list: Dictionary<T>, propertyName: string): Dictionary<number>;
+    
+            shuffle<T>(list: T[]): T[];
+            shuffle<T>(list: Dictionary<T>): T[];
+    
+            toArray<T>(list: T[]): T[];
+            toArray<T>(list: Dictionary<T>): T[];
+    
+            size<T>(list: T[]): number;
+            size<T>(list: Dictionary<T>): number;
+    
+            first<T>(list: T[]): T;
+            first<T>(list: T[], count: number): T[];
+            head<T>(list: T[]): T;
+            head<T>(list: T[], count: number): T[];
+            take<T>(list: T[]): T;
+            take<T>(list: T[], count: number): T[];
+    
+            initial<T>(list: T[]): T;
+            initial<T>(list: T[], count: number): T[];
+    
+            last<T>(list: T[]): T;
+            last<T>(list: T[], count: number): T[];
+    
+            rest<T>(list: T[], index?: number): T[];
+    
+            compact<T>(list: T[]): T[];
+    
+            flatten<T>(list: T[][]): T[];
+            flatten<T>(array: any[], shallow?: boolean): T[];
+    
+            without<T>(list: T[], ...values: T[]): T[];
+    
+            union<T>(...arrays: T[][]): T[];
+    
+            intersection<T>(...arrays: T[][]): T[];
+    
+            difference<T>(list: T[], ...others: T[][]): T[];
+    
+            uniq<T>(list: T[], isSorted?: boolean): T[];
+            uniq<T, U>(list: T[], isSorted: boolean, iterator: Iterator_<T, U>, context?: any): U[];
+            unique<T>(list: T[], isSorted?: boolean): T[];
+            unique<T, U>(list: T[], isSorted: boolean, iterator: Iterator_<T, U>, context?: any): U[];
+    
+            zip<T0, T1>(a0: T0[], a1: T1[]): Tuple2<T0, T1>[];
+            zip<T0, T1, T2>(a0: T0[], a1: T1[], a2: T2[]): Tuple3<T0, T1, T2>[];
+            zip<T0, T1, T2, T3>(a0: T0[], a1: T1[], a2: T2[], a3: T3[]): Tuple4<T0, T1, T2, T3>[];
+            zip(...arrays: any[][]): any[][];
+    
+            object(list: any[][]): any;
+            object(keys: string[], values: any[]): any;
+    
+            indexOf<T>(list: T[], value: T, isSorted?: boolean): number;
+    
+            lastIndexOf<T>(list: T[], value: T, fromIndex?: number): number;
+    
+            sortedIndex<T>(list: T[], obj: T, propertyName: string): number;
+            sortedIndex<T>(list: T[], obj: T, iterator?: Iterator_<T, any>, context?: any): number;
+    
+            range(stop: number): number[];
+            range(start: number, stop: number, step?: number): number[];
+    
+            bind<T extends Function>(func: T, object: any): T;
+            bind(func: Function, object: any, ...args: any[]): Function;
+    
+            bindAll<T>(object: T, ...methodNames: string[]): T;
+    
+            partial(func: Function, ...args: any[]): Function;
+    
+            memoize<T extends Function>(func: T, hashFunction?: Function): T;
+    
+            delay(func: Function, wait: number, ...args: any[]): number;
+    
+            defer(func: Function, ...args: any[]): number;
+    
+            throttle<T extends Function>(func: T, wait: number): T;
+    
+            debounce<T extends Function>(func: T, wait: number, immediate?: boolean): T;
+    
+            once<T extends Function>(func: T): T;
+    
+            after<T extends Function>(count: number, func: T): T;
+    
+            wrap<T extends Function>(func: T, wrapper: (func: T, ...args: any[]) => any): T;
+    
+            compose(...funcs: Function[]): Function;
+    
+            keys(object: any): string[];
+    
+            values(object: any): any[];
+    
+            pairs(object: any): any[][];
+    
+            invert(object: any): any;
+    
+            functions(object: any): string[];
+            methods(object: any): string[];
+    
+            extend<T>(destination: T, ...sources: any[]): T;
+    
+            pick<T>(object: T, ...keys: string[]): T;
+    
+            omit<T>(object: T, ...keys: string[]): T;
+    
+            defaults<T>(object: T, ...defaults: any[]): T;
+    
+            clone<T>(object: T): T;
+    
+            tap<T>(object: T, interceptor: (object: T) => void): T;
+    
+            has(object: any, key: string): boolean;
+    
+            isEqual<T>(object: T, other: T): boolean;
+    
+            isEmpty(object: any): boolean;
+            isElement(object: any): boolean;
+            isArray(object: any): boolean;
+            isObject(value: any): boolean;
+            isArguments(object: any): boolean;
+            isFunction(object: any): boolean;
+            isString(object: any): boolean;
+            isNumber(object: any): boolean;
+            isFinite(object: any): boolean;
+            isBoolean(object: any): boolean;
+            isDate(object: any): boolean;
+            isRegExp(object: any): boolean;
+            isNaN(object: any): boolean;
+            isNull(object: any): boolean;
+            isUndefined(value: any): boolean;
+    
+            noConflict(): Static;
+    
+            identity<T>(value: T): T;
+    
+            times<U>(n: number, iterator: Iterator_<number, U>, context?: any): U[];
+    
+            random(max: number): number;
+            random(min: number, max: number): number;
+    
+            mixin(object: any): void;
+    
+            uniqueId(): number;
+            uniqueId(prefix: string): string;
+    
+            escape(s: string): string;
+    
+            unescape(s: string): string;
+    
+            result(object: any, property: string): any;
+    
+            templateSettings: TemplateSettings;
+    
+            template(templateString: string): (data: any) => string;
+            template(templateString: string, data: any, settings?: TemplateSettings): string;
+        }
+    }
+    
+    declare var _: Underscore.Static;
+    

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts
@@ -39,3 +39,26 @@ var r9 = foo(function <U>(x: U) { return x; });
 var r10 = foo(<U extends string>(x: U) => x);
 var r12 = foo(i2);
 var r15 = foo(c2);
+
+declare function id2<T>(x: T, y: T): T;
+
+declare function boom<R>(f: (x: string, y: number) => R): R;
+declare function boom2(f: (x: string, y: number) => string): void;
+
+boom(id2);  // Should be an error T = [string, number]
+boom2(id2); // Should be an error T = [string, number]
+
+declare function withNum<N extends number>(x: N): N;
+declare function withString<S extends string>(f: (x: S) => S): void;
+declare function useString(f: (x: string) => string): void;
+
+withString(withNum);  // Error
+useString(withNum);   // Error
+
+declare function okay<R>(f: (x: 1, y: number) => R): R;
+declare function transitive<T>(x: T, f: (x: T) => T): void;
+
+okay(id2);
+
+transitive(1, withNum);
+transitive('1', withNum);

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts
@@ -41,12 +41,16 @@ var r12 = foo(i2);
 var r15 = foo(c2);
 
 declare function id2<T>(x: T, y: T): T;
+declare function id3<T>(x: T, y: T, z: T): T;
 
 declare function boom<R>(f: (x: string, y: number) => R): R;
 declare function boom2(f: (x: string, y: number) => string): void;
+declare function boom3<R>(f: (x: string, y: number, z: R) => R): R;
 
 boom(id2);  // Should be an error T = [string, number]
 boom2(id2); // Should be an error T = [string, number]
+boom<string|number>(id2);   // Should be OK
+boom3<string|number>(id3);  // Should be OK
 
 declare function withNum<N extends number>(x: N): N;
 declare function withString<S extends string>(f: (x: S) => S): void;
@@ -56,9 +60,11 @@ withString(withNum);  // Error
 useString(withNum);   // Error
 
 declare function okay<R>(f: (x: 1, y: number) => R): R;
+declare function okay2(f: (x: string, y: number) => string|number);
 declare function transitive<T>(x: T, f: (x: T) => T): void;
 
 okay(id2);
+okay2(id2);
 
 transitive(1, withNum);
 transitive('1', withNum);

--- a/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2.ts
+++ b/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2.ts
@@ -47,9 +47,9 @@ declare function foo13(a: any): any;
 declare function foo14(a: (x: { a: string; b: number }) => Object): typeof a;
 declare function foo14(a: any): any;
 
-declare function foo15(a: { 
+declare function foo15(a: {
     (x: number): number[];
-    (x: string): string[]; 
+    (x: string): string[];
 }): typeof a;
 declare function foo15(a: any): any;
 
@@ -79,79 +79,79 @@ declare function foo18(a: any): any;
 
 var r1arg1 = <T>(x: T) => [x];
 var r1arg2 = (x: number) => [1];
-var r1 = foo1(r1arg1); // any, return types are not subtype of first overload
+var r1 = foo1(r1arg1);
 var r1a = [r1arg2, r1arg1]; // generic signature, subtype in both directions
 var r1b = [r1arg1, r1arg2]; // generic signature, subtype in both directions
 
 var r2arg1 = <T>(x: T) => [''];
 var r2arg2 = (x: number) => [''];
-var r2 = foo2(r2arg1); 
+var r2 = foo2(r2arg1);
 var r2a = [r2arg1, r2arg2];
 var r2b = [r2arg2, r2arg1];
 
 var r3arg1 = <T>(x: T) => x;
 var r3arg2 = (x: number) => { };
-var r3 = foo3(r3arg1); 
+var r3 = foo3(r3arg1);
 var r3a = [r3arg1, r3arg2];
 var r3b = [r3arg2, r3arg1];
 
 var r4arg1 = <T, U>(x: T, y: U) => x;
 var r4arg2 = (x: string, y: number) => '';
-var r4 = foo4(r4arg1); // any
+var r4 = foo4(r4arg1);
 var r4a = [r4arg1, r4arg2];
 var r4b = [r4arg2, r4arg1];
 
 var r5arg1 = <T, U>(x: (arg: T) => U) => <T>null;
 var r5arg2 = (x: (arg: string) => number) => '';
-var r5 = foo5(r5arg1); // any
+var r5 = foo5(r5arg1);
 var r5a = [r5arg1, r5arg2];
 var r5b = [r5arg2, r5arg1];
 
 var r6arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U) => <T>null;
 var r6arg2 = (x: (arg: Base) => Derived) => <Base>null;
-var r6 = foo6(r6arg1); // any
+var r6 = foo6(r6arg1);
 var r6a = [r6arg1, r6arg2];
 var r6b = [r6arg2, r6arg1];
 
 var r7arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U) => (r: T) => <U>null;
 var r7arg2 = (x: (arg: Base) => Derived) => (r: Base) => <Derived>null;
-var r7 = foo7(r7arg1); // any
+var r7 = foo7(r7arg1);
 var r7a = [r7arg1, r7arg2];
 var r7b = [r7arg2, r7arg1];
 
 var r8arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: T) => U) => (r: T) => <U>null;
 var r8arg2 = (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => <Derived>null;
-var r8 = foo8(r8arg1); // any
+var r8 = foo8(r8arg1);
 var r8a = [r8arg1, r8arg2];
 var r8b = [r8arg2, r8arg1];
 
 var r9arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => <U>null;
 var r9arg2 = (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => <Derived>null;
-var r9 = foo9(r9arg1); // any
+var r9 = foo9(r9arg1);
 var r9a = [r9arg1, r9arg2];
 var r9b = [r9arg2, r9arg1];
 
 var r10arg1 = <T extends Derived>(...x: T[]) => x[0];
 var r10arg2 = (...x: Derived[]) => <Derived>null;
-var r10 = foo10(r10arg1); // any
+var r10 = foo10(r10arg1);
 var r10a = [r10arg1, r10arg2];
 var r10b = [r10arg2, r10arg1];
 
 var r11arg1 = <T extends Base>(x: T, y: T) => x;
 var r11arg2 = (x: { foo: string }, y: { foo: string; bar: string }) => <Base>null;
-var r11 = foo11(r11arg1); // any
+var r11 = foo11(r11arg1);
 var r11a = [r11arg1, r11arg2];
 var r11b = [r11arg2, r11arg1];
 
 var r12arg1 = <T extends Array<Base>>(x: Array<Base>, y: T) => <Array<Derived>>null;
 var r12arg2 = (x: Array<Base>, y: Array<Derived2>) => <Array<Derived>>null;
-var r12 = foo12(r12arg1); // any
+var r12 = foo12(r12arg1);
 var r12a = [r12arg1, r12arg2];
 var r12b = [r12arg2, r12arg1];
 
 var r13arg1 = <T extends Array<Derived>>(x: Array<Base>, y: T) => y;
 var r13arg2 = (x: Array<Base>, y: Array<Derived>) => <Array<Derived>>null;
-var r13 = foo13(r13arg1); // any
+var r13 = foo13(r13arg1);
 var r13a = [r13arg1, r13arg2];
 var r13b = [r13arg2, r13arg1];
 
@@ -164,8 +164,8 @@ var r14b = [r14arg2, r14arg1];
 var r15arg1 = <T>(x: T) => <T[]>null
 var r15 = foo15(r15arg1); // any
 var r16arg1 = <T extends Base>(x: T) => [1];
-var r16 = foo16(r16arg1); 
+var r16 = foo16(r16arg1);
 var r17arg1 = <T>(x: (a: T) => T) => <T[]>null;
 var r17 = foo17(r17arg1); // any
 var r18arg1 = <T>(x: (a: T) => T) => <T[]>null;
-var r18 = foo18(r18arg1); 
+var r18 = foo18(r18arg1);

--- a/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3.ts
+++ b/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3.ts
@@ -59,7 +59,7 @@ module Errors {
 
     var r2arg = <T extends Base, U extends Derived, V extends Derived2>(x: (arg: T) => U) => (r: T) => <V>null;
     var r2arg2 = (x: (arg: Base) => Derived) => (r: Base) => <Derived2>null;
-    var r2 = foo7(r2arg); // any
+    var r2 = foo7(r2arg);
     var r2a = [r2arg2, r2arg];
     var r2b = [r2arg, r2arg2];
 
@@ -71,13 +71,13 @@ module Errors {
 
     var r4arg = <T extends Derived>(...x: T[]) => <T>null;
     var r4arg2 = (...x: Base[]) => <Base>null;
-    var r4 = foo10(r4arg); // any
+    var r4 = foo10(r4arg);
     var r4a = [r4arg2, r4arg];
     var r4b = [r4arg, r4arg2];
 
     var r5arg = <T extends Derived>(x: T, y: T) => <T>null;
     var r5arg2 = (x: { foo: string }, y: { foo: string; bar: string }) => <Base>null;
-    var r5 = foo11(r5arg); // any
+    var r5 = foo11(r5arg);
     var r5a = [r5arg2, r5arg];
     var r5b = [r5arg, r5arg2];
 
@@ -94,7 +94,7 @@ module Errors {
     var r7b = [r7arg, r7arg2];
 
     var r7arg3 = <T extends Base>(x: { a: T; b: T }) => 1;
-    var r7c = foo15(r7arg3); // (x: { a: string; b: number }) => number): number;
+    var r7c = foo15(r7arg3); // any
     var r7d = [r7arg2, r7arg3];
     var r7e = [r7arg3, r7arg2];
 

--- a/tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts
@@ -16,9 +16,9 @@ var a = bar(1, 1, g);      // Should be number
 var a = baz(1, 1, g);      // Should be number
 
 var b: number | string;
-var b = foo(g);            // Should be number | string
-var b = bar(1, "one", g);  // Should be number | string
-var b = bar("one", 1, g);  // Should be number | string
+var b = foo(g);            // Should error
+var b = bar(1, "one", g);  // Should error
+var b = bar("one", 1, g);  // Should error
 var b = baz(b, b, g);      // Should be number | string
 
 var d: number[] | string[];

--- a/tests/cases/fourslash/genericTypeArgumentInference2.ts
+++ b/tests/cases/fourslash/genericTypeArgumentInference2.ts
@@ -18,8 +18,8 @@
 ////var /*4*/r4 = _./*41*/all([<any>true], _.identity);
 
 verify.quickInfos({
-    1: "var r: string | number | boolean",
-    11: "(method) Underscore.Static.all<string | number | boolean>(list: (string | number | boolean)[], iterator?: Underscore.Iterator<string | number | boolean, boolean>, context?: any): string | number | boolean",
+    1: "var r: T",
+    11: "(method) Underscore.Static.all<T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any): T",
 
     2: "var r2: boolean",
     21: "(method) Underscore.Static.all<boolean>(list: boolean[], iterator?: Underscore.Iterator<boolean, boolean>, context?: any): boolean",
@@ -30,4 +30,4 @@ verify.quickInfos({
     4: "var r4: any",
     41: "(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any"
 });
-verify.noErrors();
+verify.numberOfErrorsInCurrentFile(1);


### PR DESCRIPTION
Use parameter inference when checking whether the provided arguments are applicable on the (inferred) signature.

Fixes #3410, #14766, #16107