### PR TITLE
Wrap npmLocation if needed

### DIFF
--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -85,6 +85,11 @@ namespace ts.server.typingsInstaller {
                 throttleLimit,
                 log);
             this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0]);
+
+            // If the NPM path contains spaces and isn't wrapped in quotes, do so.
+            if (this.npmPath.indexOf(" ") !== -1 && this.npmPath[0] != `"`) {
+                this.npmPath = `"${this.npmPath}"`;
+            }
             if (this.log.isEnabled()) {
                 this.log.writeLine(`Process id: ${process.pid}`);
                 this.log.writeLine(`NPM location: ${this.npmPath} (explicit '${Arguments.NpmLocation}' ${npmLocation === undefined ? "not " : ""} provided)`);

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -87,7 +87,7 @@ namespace ts.server.typingsInstaller {
             this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0]);
 
             // If the NPM path contains spaces and isn't wrapped in quotes, do so.
-            if (this.npmPath.indexOf(" ") !== -1 && this.npmPath[0] != `"`) {
+            if (this.npmPath.indexOf(" ") !== -1 && this.npmPath[0] !== `"`) {
                 this.npmPath = `"${this.npmPath}"`;
             }
             if (this.log.isEnabled()) {


### PR DESCRIPTION
If you pass an argument such as `--npmLocation "C:\Program Files\..."` the argument internally is represented without the quotes. When `this.npmPath` is then used just concated with other strings, e.g.

```typescript
this.execSync(`${this.npmPath} install ${TypesRegistryPackageName}`
```

..this fails. This checks to see if the argument has spaces and isn't already wrapped, and wraps it if need be.

CC @andy-ms and @mhegazy 