### PR TITLE
Report JSDoc syntax errors

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6322,6 +6322,12 @@ namespace ts {
                     comment.parent = parent;
                 }
 
+                if (isInJavaScriptFile(parent)) {
+                    if (!sourceFile.jsDocDiagnostics) {
+                        sourceFile.jsDocDiagnostics = [];
+                    }
+                    sourceFile.jsDocDiagnostics.push(...parseDiagnostics);
+                }
                 currentToken = saveToken;
                 parseDiagnostics.length = saveParseDiagnosticsLength;
                 parseErrorBeforeNextFinishedNode = saveParseErrorBeforeNextFinishedNode;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1021,6 +1021,9 @@ namespace ts {
             if (isSourceFileJavaScript(sourceFile)) {
                 if (!sourceFile.additionalSyntacticDiagnostics) {
                     sourceFile.additionalSyntacticDiagnostics = getJavaScriptSyntacticDiagnosticsForFile(sourceFile);
+                    if (isCheckJsEnabledForFile(sourceFile, options)) {
+                        sourceFile.additionalSyntacticDiagnostics = concatenate(sourceFile.additionalSyntacticDiagnostics, sourceFile.jsDocDiagnostics);
+                    }
                 }
                 return concatenate(sourceFile.additionalSyntacticDiagnostics, sourceFile.parseDiagnostics);
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2312,15 +2312,18 @@ namespace ts {
         /* @internal */ identifierCount: number;
         /* @internal */ symbolCount: number;
 
-        // File level diagnostics reported by the parser (includes diagnostics about /// references
+        // File-level diagnostics reported by the parser (includes diagnostics about /// references
         // as well as code diagnostics).
         /* @internal */ parseDiagnostics: Diagnostic[];
 
-        // Stores additional file level diagnostics reported by the program
-        /* @internal */ additionalSyntacticDiagnostics?: Diagnostic[];
-
-        // File level diagnostics reported by the binder.
+        // File-level diagnostics reported by the binder.
         /* @internal */ bindDiagnostics: Diagnostic[];
+
+        // File-level JSDoc diagnostics reported by the JSDoc parser
+        /* @internal */ jsDocDiagnostics?: Diagnostic[];
+
+        // Stores additional file-level diagnostics reported by the program
+        /* @internal */ additionalSyntacticDiagnostics?: Diagnostic[];
 
         // Stores a line map for the file.
         // This field should never be used directly to obtain line map, use getLineMap function instead.

--- a/tests/baselines/reference/syntaxErrors.errors.txt
+++ b/tests/baselines/reference/syntaxErrors.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/conformance/jsdoc/foo.js(2,15): error TS1005: '}' expected.
+tests/cases/conformance/jsdoc/foo.js(3,19): error TS1005: '}' expected.
+tests/cases/conformance/jsdoc/foo.js(4,18): error TS1003: Identifier expected.
+tests/cases/conformance/jsdoc/foo.js(4,19): error TS1005: '}' expected.
+
+
+==== tests/cases/conformance/jsdoc/foo.js (4 errors) ====
+    /**
+     * @param {(x)=>void} x
+                  ~~
+!!! error TS1005: '}' expected.
+     * @param {typeof String} y
+                      ~~~~~~
+!!! error TS1005: '}' expected.
+     * @param {string & number} z
+                     
+!!! error TS1003: Identifier expected.
+                      ~
+!!! error TS1005: '}' expected.
+     **/
+    function foo(x, y, z) { }
+    
+==== tests/cases/conformance/jsdoc/skipped.js (0 errors) ====
+    // @ts-nocheck
+    /**
+     * @param {(x)=>void} x
+     * @param {typeof String} y
+     * @param {string & number} z
+     **/
+    function bar(x, y, z) { }
+    

--- a/tests/cases/conformance/jsdoc/syntaxErrors.ts
+++ b/tests/cases/conformance/jsdoc/syntaxErrors.ts
@@ -1,0 +1,20 @@
+// @checkJs: true
+// @allowJs: true
+// @noEmit: true
+
+// @Filename: foo.js
+/**
+ * @param {(x)=>void} x
+ * @param {typeof String} y
+ * @param {string & number} z
+ **/
+function foo(x, y, z) { }
+
+// @Filename: skipped.js
+// @ts-nocheck
+/**
+ * @param {(x)=>void} x
+ * @param {typeof String} y
+ * @param {string & number} z
+ **/
+function bar(x, y, z) { }


### PR DESCRIPTION
Note that JSDoc syntax errors are only reported for javascript files with `// @ts-check` turned on. Typescript files don't report these errors because Typescript only uses Jsdoc for documentation &mdash; it seems wrong to report syntax errors on parts of Jsdoc that aren't also being checked.

Fixes #13371