### PR TITLE
Update build scripts for npm5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ branches:
   - release-2.3
 
 install:
-  - npm uninstall typescript
-  - npm uninstall tslint
+  - npm uninstall typescript --no-save
+  - npm uninstall tslint --no-save
   - npm install
 
 cache:

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,12 +2,12 @@
 
 # Set up NVM
 export NVM_DIR="/home/dotnet-bot/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" 
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
 nvm install $1
 
-npm uninstall typescript
-npm uninstall tslint
+npm uninstall typescript --no-save
+npm uninstall tslint --no-save
 npm install
 npm update
 npm test


### PR DESCRIPTION
As of npm 5.0.0, npm will `--save` by default. Our build scripts for Travis and Jenkins both include the following steps:

```
npm uninstall typescript
npm uninstall tslint
npm install
```

Since since npm now saves changes to package.json by default, the `npm install` above *will not* reinstall the packages.

This change tells npm not to save changes during `uninstall`.