### PR TITLE
Stop spelling suggestions after 10 name-not-found errors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1095,13 +1095,13 @@ namespace ts {
                         if (suggestedNameNotFoundMessage && suggestionCount < maximumSuggestionCount) {
                             suggestion = getSuggestionForNonexistentSymbol(originalLocation, name, meaning);
                             if (suggestion) {
-                                suggestionCount++;
                                 error(errorLocation, suggestedNameNotFoundMessage, typeof nameArg === "string" ? nameArg : declarationNameToString(nameArg), suggestion);
                             }
                         }
                         if (!suggestion) {
                             error(errorLocation, nameNotFoundMessage, typeof nameArg === "string" ? nameArg : declarationNameToString(nameArg));
                         }
+                        suggestionCount++;
                     }
                 }
                 return undefined;

--- a/tests/baselines/reference/parserRealSource11.errors.txt
+++ b/tests/baselines/reference/parserRealSource11.errors.txt
@@ -46,7 +46,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(199,42): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(219,33): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(231,30): error TS2304: Cannot find name 'Emitter'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(231,48): error TS2304: Cannot find name 'TokenID'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(233,52): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(233,52): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(237,36): error TS2304: Cannot find name 'TypeFlow'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(251,21): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(268,19): error TS2304: Cannot find name 'NodeType'.
@@ -85,27 +85,27 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(427,22): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(441,30): error TS2304: Cannot find name 'Emitter'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(441,48): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(445,22): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(446,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(446,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(449,22): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(451,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(451,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(453,22): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(454,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(454,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(457,22): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(460,22): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(463,22): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(465,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(465,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(467,22): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(469,50): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(472,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(472,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(474,22): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(476,50): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(479,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(479,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(481,22): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(483,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(483,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(485,22): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(487,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(487,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(489,22): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(491,58): error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(491,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(494,22): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(496,58): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(498,22): error TS2304: Cannot find name 'NodeType'.
@@ -848,7 +848,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                 emitter.recordSourceMappingStart(this);
                 emitter.emitJavascriptList(this, null, TokenID.Semicolon, startLine, false, false);
                                                        ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                 emitter.recordSourceMappingEnd(this);
             }
     
@@ -1139,7 +1139,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
 !!! error TS2304: Cannot find name 'NodeType'.
                         emitter.emitJavascript(this.operand, TokenID.PlusPlus, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         emitter.writeToOutput("++");
                         break;
                     case NodeType.LogNot:
@@ -1148,14 +1148,14 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                         emitter.writeToOutput("!");
                         emitter.emitJavascript(this.operand, TokenID.Exclamation, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         break;
                     case NodeType.DecPost:
                          ~~~~~~~~
 !!! error TS2304: Cannot find name 'NodeType'.
                         emitter.emitJavascript(this.operand, TokenID.MinusMinus, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         emitter.writeToOutput("--");
                         break;
                     case NodeType.ObjectLit:
@@ -1174,7 +1174,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                         emitter.writeToOutput("~");
                         emitter.emitJavascript(this.operand, TokenID.Tilde, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         break;
                     case NodeType.Neg:
                          ~~~~~~~~
@@ -1187,7 +1187,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                         }
                         emitter.emitJavascript(this.operand, TokenID.Minus, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         break;
                     case NodeType.Pos:
                          ~~~~~~~~
@@ -1200,7 +1200,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                         }
                         emitter.emitJavascript(this.operand, TokenID.Plus, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         break;
                     case NodeType.IncPre:
                          ~~~~~~~~
@@ -1208,7 +1208,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                         emitter.writeToOutput("++");
                         emitter.emitJavascript(this.operand, TokenID.PlusPlus, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         break;
                     case NodeType.DecPre:
                          ~~~~~~~~
@@ -1216,7 +1216,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                         emitter.writeToOutput("--");
                         emitter.emitJavascript(this.operand, TokenID.MinusMinus, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         break;
                     case NodeType.Throw:
                          ~~~~~~~~
@@ -1224,7 +1224,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                         emitter.writeToOutput("throw ");
                         emitter.emitJavascript(this.operand, TokenID.Tilde, false);
                                                              ~~~~~~~
-!!! error TS2552: Cannot find name 'TokenID'. Did you mean 'tokenId'?
+!!! error TS2304: Cannot find name 'TokenID'.
                         emitter.writeToOutput(";");
                         break;
                     case NodeType.Typeof:

--- a/tests/baselines/reference/parserRealSource13.errors.txt
+++ b/tests/baselines/reference/parserRealSource13.errors.txt
@@ -113,7 +113,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(123,26): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(123,39): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(128,33): error TS2339: Property 'getAstWalkerFactory' does not exist on type 'typeof TypeScript'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(132,51): error TS2304: Cannot find name 'AST'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(135,36): error TS2552: Cannot find name 'NodeType'. Did you mean 'nodeType'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(135,36): error TS2304: Cannot find name 'NodeType'.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts (116 errors) ====
@@ -483,7 +483,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(135,36): error 
             var nodeType = ast.nodeType;
             var callbackString = (<any>NodeType)._map[nodeType] + "Callback";
                                        ~~~~~~~~
-!!! error TS2552: Cannot find name 'NodeType'. Did you mean 'nodeType'?
+!!! error TS2304: Cannot find name 'NodeType'.
             if (callback[callbackString]) {
                 return callback[callbackString](pre, ast);
             }

--- a/tests/baselines/reference/parserRealSource7.errors.txt
+++ b/tests/baselines/reference/parserRealSource7.errors.txt
@@ -11,11 +11,11 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(34,54): error TS
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(34,68): error TS2304: Cannot find name 'TypeCollectionContext'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(35,25): error TS2304: Cannot find name 'ValueLocation'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(36,30): error TS2304: Cannot find name 'TypeLink'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(41,17): error TS2552: Cannot find name 'FieldSymbol'. Did you mean 'fieldSymbol'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(41,17): error TS2304: Cannot find name 'FieldSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(43,31): error TS2304: Cannot find name 'SymbolFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(43,54): error TS2304: Cannot find name 'SymbolFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(49,58): error TS2304: Cannot find name 'Type'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(50,29): error TS2552: Cannot find name 'Signature'. Did you mean 'signature'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(50,29): error TS2304: Cannot find name 'Signature'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(51,36): error TS2304: Cannot find name 'TypeLink'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(55,30): error TS2304: Cannot find name 'SignatureGroup'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(59,66): error TS2304: Cannot find name 'Type'.
@@ -46,7 +46,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(154,27): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(155,26): error TS2304: Cannot find name 'hasFlag'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(155,55): error TS2304: Cannot find name 'VarFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(165,28): error TS2304: Cannot find name 'ModuleType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(169,26): error TS2552: Cannot find name 'TypeSymbol'. Did you mean 'typeSymbol'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(169,26): error TS2304: Cannot find name 'TypeSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(186,48): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(186,61): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(186,75): error TS2304: Cannot find name 'TypeCollectionContext'.
@@ -81,8 +81,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(212,46): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(212,64): error TS2304: Cannot find name 'DualStringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(212,88): error TS2304: Cannot find name 'StringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(212,111): error TS2304: Cannot find name 'StringHashTable'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(216,30): error TS2552: Cannot find name 'TypeSymbol'. Did you mean 'typeSymbol'?
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(231,72): error TS2552: Cannot find name 'NodeType'. Did you mean 'modType'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(216,30): error TS2304: Cannot find name 'TypeSymbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(231,72): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(234,27): error TS2304: Cannot find name 'TypeSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(238,80): error TS2304: Cannot find name 'StringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(239,37): error TS2304: Cannot find name 'ScopedMembers'.
@@ -142,7 +142,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(349,47): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(349,65): error TS2304: Cannot find name 'DualStringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(349,89): error TS2304: Cannot find name 'StringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(349,112): error TS2304: Cannot find name 'StringHashTable'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(350,30): error TS2552: Cannot find name 'TypeSymbol'. Did you mean 'typeSymbol'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(350,30): error TS2304: Cannot find name 'TypeSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(360,37): error TS2304: Cannot find name 'SymbolFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(364,37): error TS2304: Cannot find name 'SymbolFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(368,37): error TS2304: Cannot find name 'SymbolFlags'.
@@ -196,7 +196,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(476,57): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(477,29): error TS2304: Cannot find name 'ValueLocation'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(478,29): error TS2304: Cannot find name 'hasFlag'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(478,55): error TS2304: Cannot find name 'VarFlags'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(480,21): error TS2552: Cannot find name 'FieldSymbol'. Did you mean 'fieldSymbol'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(480,21): error TS2304: Cannot find name 'FieldSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(482,34): error TS2304: Cannot find name 'hasFlag'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(482,60): error TS2304: Cannot find name 'VarFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(492,30): error TS2304: Cannot find name 'getTypeLink'.
@@ -218,7 +218,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(507,26): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(507,52): error TS2304: Cannot find name 'ASTFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(518,22): error TS2304: Cannot find name 'FieldSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(531,29): error TS2304: Cannot find name 'ValueLocation'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(533,21): error TS2552: Cannot find name 'FieldSymbol'. Did you mean 'fieldSymbol'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(533,21): error TS2304: Cannot find name 'FieldSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(535,53): error TS2304: Cannot find name 'VarFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(535,75): error TS2304: Cannot find name 'VarFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(539,38): error TS2304: Cannot find name 'SymbolFlags'.
@@ -372,7 +372,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
             var fieldSymbol =
                 new FieldSymbol("prototype", ast.minChar,
                     ~~~~~~~~~~~
-!!! error TS2552: Cannot find name 'FieldSymbol'. Did you mean 'fieldSymbol'?
+!!! error TS2304: Cannot find name 'FieldSymbol'.
                                 context.checker.locationInfo.unitIndex, true, field);
             fieldSymbol.flags |= (SymbolFlags.Property | SymbolFlags.BuiltIn);
                                   ~~~~~~~~~~~
@@ -389,7 +389,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
 !!! error TS2304: Cannot find name 'Type'.
             var signature = new Signature();
                                 ~~~~~~~~~
-!!! error TS2552: Cannot find name 'Signature'. Did you mean 'signature'?
+!!! error TS2304: Cannot find name 'Signature'.
             signature.returnType = new TypeLink();
                                        ~~~~~~~~
 !!! error TS2304: Cannot find name 'TypeLink'.
@@ -570,7 +570,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
     
             typeSymbol = new TypeSymbol(importDecl.id.text, importDecl.minChar,
                              ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeSymbol'. Did you mean 'typeSymbol'?
+!!! error TS2304: Cannot find name 'TypeSymbol'.
                                         context.checker.locationInfo.unitIndex, modType);
     
             typeSymbol.aliasLink = importDecl;
@@ -687,7 +687,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
     
                 typeSymbol = new TypeSymbol(modName, moduleDecl.minChar,
                                  ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeSymbol'. Did you mean 'typeSymbol'?
+!!! error TS2304: Cannot find name 'TypeSymbol'.
                                             context.checker.locationInfo.unitIndex, modType);
     
                 if (context.scopeChain.moduleDecl) {
@@ -704,7 +704,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
             else {
                 if (symbol && symbol.declAST && symbol.declAST.nodeType != NodeType.ModuleDeclaration) {
                                                                            ~~~~~~~~
-!!! error TS2552: Cannot find name 'NodeType'. Did you mean 'modType'?
+!!! error TS2304: Cannot find name 'NodeType'.
                     context.checker.errorReporter.simpleError(moduleDecl, "Conflicting symbol name for module '" + modName + "'");
                 }
                 typeSymbol = <TypeSymbol>symbol;
@@ -943,7 +943,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
 !!! error TS2304: Cannot find name 'StringHashTable'.
                 typeSymbol = new TypeSymbol(className, classDecl.minChar,
                                  ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeSymbol'. Did you mean 'typeSymbol'?
+!!! error TS2304: Cannot find name 'TypeSymbol'.
                                             context.checker.locationInfo.unitIndex, classType);
                 typeSymbol.declAST = classDecl;
                 typeSymbol.instanceType = instanceType;
@@ -1181,7 +1181,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
                 var fieldSymbol =
                     new FieldSymbol(argDecl.id.text, argDecl.minChar,
                         ~~~~~~~~~~~
-!!! error TS2552: Cannot find name 'FieldSymbol'. Did you mean 'fieldSymbol'?
+!!! error TS2304: Cannot find name 'FieldSymbol'.
                                     context.checker.locationInfo.unitIndex,
                                     !hasFlag(argDecl.varFlags, VarFlags.Readonly),
                                      ~~~~~~~
@@ -1278,7 +1278,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
                 var fieldSymbol =
                     new FieldSymbol(varDecl.id.text, varDecl.minChar,
                         ~~~~~~~~~~~
-!!! error TS2552: Cannot find name 'FieldSymbol'. Did you mean 'fieldSymbol'?
+!!! error TS2304: Cannot find name 'FieldSymbol'.
                                     context.checker.locationInfo.unitIndex,
                                     (varDecl.varFlags & VarFlags.Readonly) == VarFlags.None,
                                                         ~~~~~~~~

--- a/tests/baselines/reference/parserRealSource8.errors.txt
+++ b/tests/baselines/reference/parserRealSource8.errors.txt
@@ -47,7 +47,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(160,52): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(160,76): error TS2304: Cannot find name 'StringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(160,99): error TS2304: Cannot find name 'StringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(162,28): error TS2304: Cannot find name 'Type'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(163,30): error TS2552: Cannot find name 'WithSymbol'. Did you mean 'withSymbol'?
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(163,30): error TS2304: Cannot find name 'WithSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(170,40): error TS2339: Property 'SymbolScopeBuilder' does not exist on type 'typeof TypeScript'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(176,50): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(177,25): error TS2304: Cannot find name 'FuncDecl'.
@@ -397,7 +397,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error T
 !!! error TS2304: Cannot find name 'Type'.
             var withSymbol = new WithSymbol(withStmt.minChar, context.typeFlow.checker.locationInfo.unitIndex, withType);
                                  ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'WithSymbol'. Did you mean 'withSymbol'?
+!!! error TS2304: Cannot find name 'WithSymbol'.
             withType.members = members;
             withType.ambientMembers = ambientMembers;
             withType.symbol = withSymbol;

--- a/tests/baselines/reference/parserharness.errors.txt
+++ b/tests/baselines/reference/parserharness.errors.txt
@@ -18,17 +18,17 @@ tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(721,62): e
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(724,29): error TS2304: Cannot find name 'ITextWriter'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(754,53): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(764,56): error TS2503: Cannot find namespace 'TypeScript'.
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(765,37): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(767,47): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(776,13): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(776,42): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(765,37): error TS2304: Cannot find name 'TypeScript'.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(767,47): error TS2304: Cannot find name 'TypeScript'.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(776,13): error TS2304: Cannot find name 'TypeScript'.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(776,42): error TS2304: Cannot find name 'TypeScript'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(781,23): error TS2503: Cannot find namespace 'TypeScript'.
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(794,49): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(795,49): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(987,53): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(987,89): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(794,49): error TS2304: Cannot find name 'TypeScript'.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(795,49): error TS2304: Cannot find name 'TypeScript'.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(987,53): error TS2304: Cannot find name 'TypeScript'.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(987,89): error TS2304: Cannot find name 'TypeScript'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(987,115): error TS2503: Cannot find namespace 'TypeScript'.
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(987,145): error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(987,145): error TS2304: Cannot find name 'TypeScript'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(988,43): error TS2304: Cannot find name 'TypeScript'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(999,40): error TS2503: Cannot find namespace 'TypeScript'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(1041,43): error TS2503: Cannot find namespace 'TypeScript'.
@@ -917,11 +917,11 @@ tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(2030,32): 
 !!! error TS2503: Cannot find namespace 'TypeScript'.
                 var compiler = c || new TypeScript.TypeScriptCompiler(stderr);
                                         ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                 compiler.parser.errorRecovery = true;
                 compiler.settings.codeGenTarget = TypeScript.CodeGenTarget.ES5;
                                                   ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                 compiler.settings.controlFlow = true;
                 compiler.settings.controlFlowUseDef = true;
                 if (Harness.usePull) {
@@ -932,9 +932,9 @@ tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(2030,32): 
                 compiler.parseEmitOption(stdout);
                 TypeScript.moduleGenTarget = TypeScript.ModuleGenTarget.Synchronous;
                 ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                                              ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                 compiler.addUnit(Harness.Compiler.libText, "lib.d.ts", true);
                 return compiler;
             }
@@ -956,10 +956,10 @@ tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(2030,32): 
                         // requires unit to already exist in the compiler
                         compiler.pullUpdateUnit(new TypeScript.StringSourceText(""), filename, true);
                                                     ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                         compiler.pullUpdateUnit(new TypeScript.StringSourceText(code), filename, true);
                                                     ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                     }
                 }
                 else {
@@ -1153,13 +1153,13 @@ tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(2030,32): 
                             var script = compiler.scripts.members[m];
                             var enclosingScopeContext = TypeScript.findEnclosingScopeAt(new TypeScript.NullLogger(), <TypeScript.Script>script, new TypeScript.StringSourceText(code), 0, false);
                                                         ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                                                                                             ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                                                                                                                       ~~~~~~~~~~
 !!! error TS2503: Cannot find namespace 'TypeScript'.
                                                                                                                                                     ~~~~~~~~~~
-!!! error TS2552: Cannot find name 'TypeScript'. Did you mean 'TypeScriptLS'?
+!!! error TS2304: Cannot find name 'TypeScript'.
                             var entries = new TypeScript.ScopeTraversal(compiler).getScopeEntries(enclosingScopeContext);
                                               ~~~~~~~~~~
 !!! error TS2304: Cannot find name 'TypeScript'.


### PR DESCRIPTION
Spelling suggestions now stop after the tenth name-not-found error, which is better for performance.

Previously, spelling suggestions stopped after name-not-found errors led to 10 *suggestions*. This may never happen for a failed import, which is the most common case for lots of name-not-found errors. In that worst case, we would continue to search for spelling suggestions for every name-not-found error but never find any.