### PR TITLE
Add missing null check

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -646,7 +646,7 @@ namespace ts.server {
 
                 const added: string[] = [];
                 const removed: string[] = [];
-                const updated: string[] = arrayFrom(updatedFileNames.keys());
+                const updated: string[] = updatedFileNames ? arrayFrom(updatedFileNames.keys()) : [];
 
                 forEachKey(currentFiles, id => {
                     if (!lastReportedFileNames.has(id)) {


### PR DESCRIPTION
I stumbled upon this while debugging.  If `getChangesSinceVersion` is called twice in a row, without a change occurring in between, `updatedFileNames` will be undefined the second time.

Reviewed offline by @mhegazy.