### PR TITLE
Use unix cache location on the major BSDs

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -45,6 +45,8 @@ namespace ts.server {
                     os.tmpdir();
                 return combinePaths(normalizeSlashes(basePath), "Microsoft/TypeScript");
             }
+            case "openbsd":
+            case "freebsd":
             case "darwin":
             case "linux":
             case "android": {


### PR DESCRIPTION
`XDG_CACHE_HOME` and `~/.cache` are both fine for caching data. Without this, `tsserver` fails to run at all on BSDs.