### PR TITLE
Fix reexported missing alias

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1364,6 +1364,9 @@ namespace ts {
         // An 'import { Point } from "graphics"' needs to create a symbol that combines the value side 'Point'
         // property with the type/namespace side interface 'Point'.
         function combineValueAndTypeSymbols(valueSymbol: Symbol, typeSymbol: Symbol): Symbol {
+            if (valueSymbol === unknownSymbol && typeSymbol === unknownSymbol) {
+                return unknownSymbol;
+            }
             if (valueSymbol.flags & (SymbolFlags.Type | SymbolFlags.Namespace)) {
                 return valueSymbol;
             }

--- a/tests/baselines/reference/reexportedMissingAlias.errors.txt
+++ b/tests/baselines/reference/reexportedMissingAlias.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/compiler/second.d.ts(2,27): error TS2304: Cannot find name 'CompletelyMissing'.
+tests/cases/compiler/second.d.ts(2,27): error TS2503: Cannot find namespace 'CompletelyMissing'.
+
+
+==== tests/cases/compiler/second.d.ts (2 errors) ====
+    // Fixes #15094
+    export import Component = CompletelyMissing;
+                              ~~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'CompletelyMissing'.
+                              ~~~~~~~~~~~~~~~~~
+!!! error TS2503: Cannot find namespace 'CompletelyMissing'.
+==== tests/cases/compiler/first.d.ts (0 errors) ====
+    import * as Second from './second';
+    export = Second;
+==== tests/cases/compiler/crash.ts (0 errors) ====
+    import { Component } from './first';
+    class C extends Component { }
+    

--- a/tests/baselines/reference/reexportedMissingAlias.js
+++ b/tests/baselines/reference/reexportedMissingAlias.js
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/reexportedMissingAlias.ts] ////
+
+//// [second.d.ts]
+// Fixes #15094
+export import Component = CompletelyMissing;
+//// [first.d.ts]
+import * as Second from './second';
+export = Second;
+//// [crash.ts]
+import { Component } from './first';
+class C extends Component { }
+
+
+//// [crash.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+var first_1 = require("./first");
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(first_1.Component));

--- a/tests/cases/compiler/reexportedMissingAlias.ts
+++ b/tests/cases/compiler/reexportedMissingAlias.ts
@@ -1,0 +1,9 @@
+// Fixes #15094
+// @Filename: second.d.ts
+export import Component = CompletelyMissing;
+// @Filename: first.d.ts
+import * as Second from './second';
+export = Second;
+// @Filename: crash.ts
+import { Component } from './first';
+class C extends Component { }


### PR DESCRIPTION
Previously, when getExternalModuleMember tried to combine unknownSymbol from a type and unknownSymbol from a value, combineValueAndTypeSymbol would create a new franken-symbol that was no longer equal to unknownSymbol. Now combineValueAndTypeSymbol just returns unknownSymbol.

Fixes #15094