### PR TITLE
Fix tslint=5.3.2 until --exclude is fixed in 5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "through2": "latest",
         "travis-fold": "latest",
         "ts-node": "latest",
-        "tslint": "latest",
+        "tslint": "5.3.2",
         "typescript": "next"
     },
     "scripts": {


### PR DESCRIPTION
Fixes the build break. Multiple --excludes are ignored in tslint 5.4. Tracked by palantir/tslint#2855
