### PR TITLE
Apply --checkjs to bind diagnostics as well as check diagnostics

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1071,8 +1071,8 @@ namespace ts {
                 Debug.assert(!!sourceFile.bindDiagnostics);
                 // For JavaScript files, we don't want to report semantic errors unless explicitly requested.
                 const includeBindAndCheckDiagnostics = !isSourceFileJavaScript(sourceFile) || isCheckJsEnabledForFile(sourceFile, options);
-                const bindDiagnostics = includeBindAndCheckDiagnostics ? sourceFile.bindDiagnostics : [];
-                const checkDiagnostics = includeBindAndCheckDiagnostics ? typeChecker.getDiagnostics(sourceFile, cancellationToken) : [];
+                const bindDiagnostics = includeBindAndCheckDiagnostics ? sourceFile.bindDiagnostics : emptyArray;
+                const checkDiagnostics = includeBindAndCheckDiagnostics ? typeChecker.getDiagnostics(sourceFile, cancellationToken) : emptyArray;
                 const fileProcessingDiagnosticsInFile = fileProcessingDiagnostics.getDiagnostics(sourceFile.fileName);
                 const programDiagnosticsInFile = programDiagnostics.getDiagnostics(sourceFile.fileName);
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1069,10 +1069,10 @@ namespace ts {
                 const typeChecker = getDiagnosticsProducingTypeChecker();
 
                 Debug.assert(!!sourceFile.bindDiagnostics);
-                const bindDiagnostics = sourceFile.bindDiagnostics;
                 // For JavaScript files, we don't want to report semantic errors unless explicitly requested.
-                const includeCheckDiagnostics = !isSourceFileJavaScript(sourceFile) || isCheckJsEnabledForFile(sourceFile, options);
-                const checkDiagnostics = includeCheckDiagnostics ? typeChecker.getDiagnostics(sourceFile, cancellationToken) : [];
+                const includeBindAndCheckDiagnostics = !isSourceFileJavaScript(sourceFile) || isCheckJsEnabledForFile(sourceFile, options);
+                const bindDiagnostics = includeBindAndCheckDiagnostics ? sourceFile.bindDiagnostics : [];
+                const checkDiagnostics = includeBindAndCheckDiagnostics ? typeChecker.getDiagnostics(sourceFile, cancellationToken) : [];
                 const fileProcessingDiagnosticsInFile = fileProcessingDiagnostics.getDiagnostics(sourceFile.fileName);
                 const programDiagnosticsInFile = programDiagnostics.getDiagnostics(sourceFile.fileName);
 

--- a/tests/baselines/reference/jsFileCompilationBindMultipleDefaultExports.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationBindMultipleDefaultExports.errors.txt
@@ -1,15 +1,21 @@
 tests/cases/compiler/a.js(1,22): error TS2528: A module cannot have multiple default exports.
+tests/cases/compiler/a.js(1,22): error TS2652: Merged declaration 'a' cannot include a default export declaration. Consider adding a separate 'export default a' declaration instead.
 tests/cases/compiler/a.js(3,1): error TS2528: A module cannot have multiple default exports.
 tests/cases/compiler/a.js(3,16): error TS1109: Expression expected.
+tests/cases/compiler/a.js(3,20): error TS2652: Merged declaration 'a' cannot include a default export declaration. Consider adding a separate 'export default a' declaration instead.
 
 
-==== tests/cases/compiler/a.js (3 errors) ====
+==== tests/cases/compiler/a.js (5 errors) ====
     export default class a {
                          ~
 !!! error TS2528: A module cannot have multiple default exports.
+                         ~
+!!! error TS2652: Merged declaration 'a' cannot include a default export declaration. Consider adding a separate 'export default a' declaration instead.
     }
     export default var a = 10;
     ~~~~~~~~~~~~~~
 !!! error TS2528: A module cannot have multiple default exports.
                    ~~~
 !!! error TS1109: Expression expected.
+                       ~
+!!! error TS2652: Merged declaration 'a' cannot include a default export declaration. Consider adding a separate 'export default a' declaration instead.

--- a/tests/baselines/reference/jsFileCompilationBindStrictModeErrors.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationBindStrictModeErrors.errors.txt
@@ -1,9 +1,12 @@
 tests/cases/compiler/a.js(5,5): error TS1117: An object literal cannot have multiple properties with the same name in strict mode.
+tests/cases/compiler/a.js(5,5): error TS2300: Duplicate identifier 'a'.
 tests/cases/compiler/a.js(7,5): error TS1212: Identifier expected. 'let' is a reserved word in strict mode.
 tests/cases/compiler/a.js(8,8): error TS1102: 'delete' cannot be called on an identifier in strict mode.
+tests/cases/compiler/a.js(8,8): error TS2703: The operand of a delete operator must be a property reference.
 tests/cases/compiler/a.js(10,10): error TS1100: Invalid use of 'eval' in strict mode.
 tests/cases/compiler/a.js(12,10): error TS1100: Invalid use of 'arguments' in strict mode.
 tests/cases/compiler/a.js(15,1): error TS1101: 'with' statements are not allowed in strict mode.
+tests/cases/compiler/a.js(15,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/compiler/b.js(3,7): error TS1210: Invalid use of 'eval'. Class definitions are automatically in strict mode.
 tests/cases/compiler/b.js(6,13): error TS1213: Identifier expected. 'let' is a reserved word in strict mode. Class definitions are automatically in strict mode.
 tests/cases/compiler/c.js(1,12): error TS1214: Identifier expected. 'let' is a reserved word in strict mode. Modules are automatically in strict mode.
@@ -12,7 +15,7 @@ tests/cases/compiler/d.js(2,9): error TS1121: Octal literals are not allowed in 
 tests/cases/compiler/d.js(2,11): error TS1005: ',' expected.
 
 
-==== tests/cases/compiler/a.js (6 errors) ====
+==== tests/cases/compiler/a.js (9 errors) ====
     "use strict";
     var a = {
         a: "hello", // error
@@ -20,6 +23,8 @@ tests/cases/compiler/d.js(2,11): error TS1005: ',' expected.
         a: 10 // error
         ~
 !!! error TS1117: An object literal cannot have multiple properties with the same name in strict mode.
+        ~
+!!! error TS2300: Duplicate identifier 'a'.
     };
     var let = 10; // error
         ~~~
@@ -27,6 +32,8 @@ tests/cases/compiler/d.js(2,11): error TS1005: ',' expected.
     delete a; // error
            ~
 !!! error TS1102: 'delete' cannot be called on an identifier in strict mode.
+           ~
+!!! error TS2703: The operand of a delete operator must be a property reference.
     try {
     } catch (eval) { // error
              ~~~~
@@ -40,6 +47,8 @@ tests/cases/compiler/d.js(2,11): error TS1005: ',' expected.
     with (a) {
     ~~~~
 !!! error TS1101: 'with' statements are not allowed in strict mode.
+    ~~~~~~~~
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         b = 10;
     }
     

--- a/tests/baselines/reference/unreachableJavascriptChecked.errors.txt
+++ b/tests/baselines/reference/unreachableJavascriptChecked.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/unreachable.js(3,5): error TS7027: Unreachable code detected.
+
+
+==== tests/cases/compiler/unreachable.js (1 errors) ====
+    function unreachable() {
+        return 1;
+        return 2;
+        ~~~~~~
+!!! error TS7027: Unreachable code detected.
+    }

--- a/tests/baselines/reference/unreachableJavascriptChecked.js
+++ b/tests/baselines/reference/unreachableJavascriptChecked.js
@@ -1,0 +1,11 @@
+//// [unreachable.js]
+function unreachable() {
+    return 1;
+    return 2;
+}
+
+//// [unreachable.js]
+function unreachable() {
+    return 1;
+    return 2;
+}

--- a/tests/baselines/reference/unreachableJavascriptUnchecked.js
+++ b/tests/baselines/reference/unreachableJavascriptUnchecked.js
@@ -1,0 +1,11 @@
+//// [unreachable.js]
+function unreachable() {
+    return 1;
+    return 2;
+}
+
+//// [unreachable.js]
+function unreachable() {
+    return 1;
+    return 2;
+}

--- a/tests/baselines/reference/unreachableJavascriptUnchecked.symbols
+++ b/tests/baselines/reference/unreachableJavascriptUnchecked.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/unreachable.js ===
+function unreachable() {
+>unreachable : Symbol(unreachable, Decl(unreachable.js, 0, 0))
+
+    return 1;
+    return 2;
+}

--- a/tests/baselines/reference/unreachableJavascriptUnchecked.types
+++ b/tests/baselines/reference/unreachableJavascriptUnchecked.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/unreachable.js ===
+function unreachable() {
+>unreachable : () => 1 | 2
+
+    return 1;
+>1 : 1
+
+    return 2;
+>2 : 2
+}

--- a/tests/cases/compiler/jsFileCompilationBindDuplicateIdentifier.ts
+++ b/tests/cases/compiler/jsFileCompilationBindDuplicateIdentifier.ts
@@ -1,4 +1,5 @@
 // @allowJs: true
+// @checkJs: true
 // @noEmit: true
 // @filename: a.js
 var a = 10;

--- a/tests/cases/compiler/jsFileCompilationBindErrors.ts
+++ b/tests/cases/compiler/jsFileCompilationBindErrors.ts
@@ -1,4 +1,5 @@
 // @allowJs: true
+// @checkJs: true
 // @noEmit: true
 // @filename: a.js
 let C = "sss";

--- a/tests/cases/compiler/jsFileCompilationBindMultipleDefaultExports.ts
+++ b/tests/cases/compiler/jsFileCompilationBindMultipleDefaultExports.ts
@@ -1,4 +1,5 @@
 // @allowJs: true
+// @checkJs: true
 // @noEmit: true
 // @filename: a.js
 // @target: es6

--- a/tests/cases/compiler/jsFileCompilationBindReachabilityErrors.ts
+++ b/tests/cases/compiler/jsFileCompilationBindReachabilityErrors.ts
@@ -1,4 +1,5 @@
 // @allowJs: true
+// @checkJs: true
 // @noEmit: true
 // @filename: a.js
 // @noFallthroughCasesInSwitch: true

--- a/tests/cases/compiler/jsFileCompilationBindStrictModeErrors.ts
+++ b/tests/cases/compiler/jsFileCompilationBindStrictModeErrors.ts
@@ -1,4 +1,5 @@
 // @allowJs: true
+// @checkJs: true
 // @noEmit: true
 // @filename: a.js
 // @target: es6

--- a/tests/cases/compiler/unreachableJavascriptChecked.ts
+++ b/tests/cases/compiler/unreachableJavascriptChecked.ts
@@ -1,0 +1,8 @@
+// @Filename: unreachable.js
+// @allowJs: true
+// @checkJs: true
+// @outDir: out
+function unreachable() {
+    return 1;
+    return 2;
+}

--- a/tests/cases/compiler/unreachableJavascriptUnchecked.ts
+++ b/tests/cases/compiler/unreachableJavascriptUnchecked.ts
@@ -1,0 +1,8 @@
+// @Filename: unreachable.js
+// @allowJs: true
+// @checkJs: false
+// @outDir: out
+function unreachable() {
+    return 1;
+    return 2;
+}


### PR DESCRIPTION
For example, do not report unreachable code in JS files unless --checkjs is passed.