### PR TITLE
Update special cases for await / yield expression parsing

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2960,7 +2960,7 @@ namespace ts {
                 // for now we just check if the next token is an identifier.  More heuristics
                 // can be added here later as necessary.  We just need to make sure that we
                 // don't accidentally consume something legal.
-                return lookAhead(nextTokenIsIdentifierOrKeywordOrNumberOnSameLine);
+                return lookAhead(nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine);
             }
 
             return false;
@@ -3478,7 +3478,7 @@ namespace ts {
                 }
 
                 // here we are using similar heuristics as 'isYieldExpression'
-                return lookAhead(nextTokenIsIdentifierOnSameLine);
+                return lookAhead(nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine);
             }
 
             return false;
@@ -4677,9 +4677,9 @@ namespace ts {
             return token() === SyntaxKind.FunctionKeyword && !scanner.hasPrecedingLineBreak();
         }
 
-        function nextTokenIsIdentifierOrKeywordOrNumberOnSameLine() {
+        function nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine() {
             nextToken();
-            return (tokenIsIdentifierOrKeyword(token()) || token() === SyntaxKind.NumericLiteral) && !scanner.hasPrecedingLineBreak();
+            return (tokenIsIdentifierOrKeyword(token()) || token() === SyntaxKind.NumericLiteral || token() === SyntaxKind.StringLiteral) && !scanner.hasPrecedingLineBreak();
         }
 
         function isDeclaration(): boolean {

--- a/tests/baselines/reference/awaitLiteralValues.errors.txt
+++ b/tests/baselines/reference/awaitLiteralValues.errors.txt
@@ -1,0 +1,45 @@
+tests/cases/compiler/awaitLiteralValues.ts(2,5): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitLiteralValues.ts(6,5): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitLiteralValues.ts(10,5): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitLiteralValues.ts(14,5): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitLiteralValues.ts(18,5): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitLiteralValues.ts(22,5): error TS1308: 'await' expression is only allowed within an async function.
+
+
+==== tests/cases/compiler/awaitLiteralValues.ts (6 errors) ====
+    function awaitString() {
+        await 'literal';
+        ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+    }
+    
+    function awaitNumber() {
+        await 1;
+        ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+    }
+    
+    function awaitTrue() {
+        await true;
+        ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+    }
+    
+    function awaitFalse() {
+        await false;
+        ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+    }
+    
+    function awaitNull() {
+        await null;
+        ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+    }
+    
+    function awaitUndefined() {
+        await undefined;
+        ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+    }
+    

--- a/tests/baselines/reference/awaitLiteralValues.js
+++ b/tests/baselines/reference/awaitLiteralValues.js
@@ -1,0 +1,45 @@
+//// [awaitLiteralValues.ts]
+function awaitString() {
+    await 'literal';
+}
+
+function awaitNumber() {
+    await 1;
+}
+
+function awaitTrue() {
+    await true;
+}
+
+function awaitFalse() {
+    await false;
+}
+
+function awaitNull() {
+    await null;
+}
+
+function awaitUndefined() {
+    await undefined;
+}
+
+
+//// [awaitLiteralValues.js]
+function awaitString() {
+    yield 'literal';
+}
+function awaitNumber() {
+    yield 1;
+}
+function awaitTrue() {
+    yield true;
+}
+function awaitFalse() {
+    yield false;
+}
+function awaitNull() {
+    yield null;
+}
+function awaitUndefined() {
+    yield undefined;
+}

--- a/tests/baselines/reference/yieldStringLiteral.errors.txt
+++ b/tests/baselines/reference/yieldStringLiteral.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/yieldStringLiteral.ts(2,5): error TS1163: A 'yield' expression is only allowed in a generator body.
+
+
+==== tests/cases/compiler/yieldStringLiteral.ts (1 errors) ====
+    function yieldString() {
+        yield 'literal';
+        ~~~~~
+!!! error TS1163: A 'yield' expression is only allowed in a generator body.
+    }
+    

--- a/tests/baselines/reference/yieldStringLiteral.js
+++ b/tests/baselines/reference/yieldStringLiteral.js
@@ -1,0 +1,10 @@
+//// [yieldStringLiteral.ts]
+function yieldString() {
+    yield 'literal';
+}
+
+
+//// [yieldStringLiteral.js]
+function yieldString() {
+    yield 'literal';
+}

--- a/tests/cases/compiler/awaitLiteralValues.ts
+++ b/tests/cases/compiler/awaitLiteralValues.ts
@@ -1,0 +1,23 @@
+function awaitString() {
+    await 'literal';
+}
+
+function awaitNumber() {
+    await 1;
+}
+
+function awaitTrue() {
+    await true;
+}
+
+function awaitFalse() {
+    await false;
+}
+
+function awaitNull() {
+    await null;
+}
+
+function awaitUndefined() {
+    await undefined;
+}

--- a/tests/cases/compiler/yieldStringLiteral.ts
+++ b/tests/cases/compiler/yieldStringLiteral.ts
@@ -1,0 +1,3 @@
+function yieldString() {
+    yield 'literal';
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15943 and #15981 

Updated special-case handling for `yield` expressions outside of generators to parse string literals as yield expressions as well, allowing the type checker to produce a more useful error message in that case. Additionally, updated the special-case handling for `await` expressions to use the same heuristics as `yield` expressions.