### PR TITLE
No weak type checks with comparable relation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8815,7 +8815,8 @@ namespace ts {
                     }
                 }
 
-                if (!(source.flags & TypeFlags.UnionOrIntersection) &&
+                if (relation !== comparableRelation &&
+                    !(source.flags & TypeFlags.UnionOrIntersection) &&
                     !(target.flags & TypeFlags.Union) &&
                     !isIntersectionConstituent &&
                     source !== globalObjectType &&


### PR DESCRIPTION
Don't do weak type checks when checking whether two types are comparable.