### PR TITLE
Always suggest spelling candidate that differs only by case if one exists

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14522,6 +14522,7 @@ namespace ts {
             const maximumLengthDifference = Math.min(3, name.length * 0.34);
             let bestDistance = Number.MAX_VALUE;
             let bestCandidate = undefined;
+            let justCheckExactMatches = false;
             if (name.length > 30) {
                 return undefined;
             }
@@ -14533,6 +14534,9 @@ namespace ts {
                     const candidateName = candidate.name.toLowerCase();
                     if (candidateName === name) {
                         return candidate;
+                    }
+                    if (justCheckExactMatches) {
+                        continue;
                     }
                     if (candidateName.length < 3 ||
                         name.length < 3 ||
@@ -14549,7 +14553,8 @@ namespace ts {
                         continue;
                     }
                     if (distance < 3) {
-                        return candidate;
+                        justCheckExactMatches = true;
+                        bestCandidate = candidate;
                     }
                     else if (distance < bestDistance) {
                         bestDistance = distance;

--- a/tests/baselines/reference/exactSpellingSuggestion.errors.txt
+++ b/tests/baselines/reference/exactSpellingSuggestion.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/compiler/exactSpellingSuggestion.ts(9,4): error TS2551: Property 'bit_2' does not exist on type 'typeof U8'. Did you mean 'BIT_2'?
+
+
+==== tests/cases/compiler/exactSpellingSuggestion.ts (1 errors) ====
+    // Fixes #16245 -- always suggest the exact match, even when
+    // other options are very close
+    enum U8 {
+        BIT_0 = 1 << 0,
+        BIT_1 = 1 << 1,
+        BIT_2 = 1 << 2
+    }
+    
+    U8.bit_2
+       ~~~~~
+!!! error TS2551: Property 'bit_2' does not exist on type 'typeof U8'. Did you mean 'BIT_2'?
+    

--- a/tests/baselines/reference/exactSpellingSuggestion.js
+++ b/tests/baselines/reference/exactSpellingSuggestion.js
@@ -1,0 +1,22 @@
+//// [exactSpellingSuggestion.ts]
+// Fixes #16245 -- always suggest the exact match, even when
+// other options are very close
+enum U8 {
+    BIT_0 = 1 << 0,
+    BIT_1 = 1 << 1,
+    BIT_2 = 1 << 2
+}
+
+U8.bit_2
+
+
+//// [exactSpellingSuggestion.js]
+// Fixes #16245 -- always suggest the exact match, even when
+// other options are very close
+var U8;
+(function (U8) {
+    U8[U8["BIT_0"] = 1] = "BIT_0";
+    U8[U8["BIT_1"] = 2] = "BIT_1";
+    U8[U8["BIT_2"] = 4] = "BIT_2";
+})(U8 || (U8 = {}));
+U8.bit_2;

--- a/tests/cases/compiler/exactSpellingSuggestion.ts
+++ b/tests/cases/compiler/exactSpellingSuggestion.ts
@@ -1,0 +1,9 @@
+// Fixes #16245 -- always suggest the exact match, even when
+// other options are very close
+enum U8 {
+    BIT_0 = 1 << 0,
+    BIT_1 = 1 << 1,
+    BIT_2 = 1 << 2
+}
+
+U8.bit_2


### PR DESCRIPTION
Previously, the first match that was close enough was returned as the spelling suggestion. Now, if there is a candidate that differs only by case, it will always be the suggestion.


Fixes #16245 
