### PR TITLE
Typeof can refer to a class in a previous file with --out

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -735,6 +735,7 @@ namespace ts {
             if (declarationFile !== useFile) {
                 if ((modulekind && (declarationFile.externalModuleIndicator || useFile.externalModuleIndicator)) ||
                     (!compilerOptions.outFile && !compilerOptions.out) ||
+                    isInTypeQuery(usage) ||
                     isInAmbientContext(declaration)) {
                     // nodes are in different files and order cannot be determined
                     return true;

--- a/tests/baselines/reference/blockScopedClassDeclarationAcrossFiles.js
+++ b/tests/baselines/reference/blockScopedClassDeclarationAcrossFiles.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts] ////
+
+//// [c.ts]
+let foo: typeof C;
+//// [b.ts]
+class C { }
+
+
+//// [foo.js]
+var foo;
+var C = (function () {
+    function C() {
+    }
+    return C;
+}());

--- a/tests/baselines/reference/blockScopedClassDeclarationAcrossFiles.symbols
+++ b/tests/baselines/reference/blockScopedClassDeclarationAcrossFiles.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/c.ts ===
+let foo: typeof C;
+>foo : Symbol(foo, Decl(c.ts, 0, 3))
+>C : Symbol(C, Decl(b.ts, 0, 0))
+
+=== tests/cases/compiler/b.ts ===
+class C { }
+>C : Symbol(C, Decl(b.ts, 0, 0))
+

--- a/tests/baselines/reference/blockScopedClassDeclarationAcrossFiles.types
+++ b/tests/baselines/reference/blockScopedClassDeclarationAcrossFiles.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/c.ts ===
+let foo: typeof C;
+>foo : typeof C
+>C : typeof C
+
+=== tests/cases/compiler/b.ts ===
+class C { }
+>C : C
+

--- a/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
+++ b/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
@@ -1,0 +1,5 @@
+// @outFile: foo.js
+// @Filename: c.ts
+let foo: typeof C;
+// @Filename: b.ts
+class C { }


### PR DESCRIPTION
Fixes #15998 in the same way as #15239

`typeof C` can now refer to block-scoped values in a preceding file when used with --out or --outFile. Previously this was not allowed with --out or --outFile since they depend on file order for their emit.