### PR TITLE
discoverTypings should look at typingSafelist.json values

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -13,7 +13,8 @@ namespace ts.projectSystem {
             express: "express",
             jquery: "jquery",
             lodash: "lodash",
-            moment: "moment"
+            moment: "moment",
+            chroma: "chroma-js"
         })
     };
 
@@ -61,7 +62,6 @@ namespace ts.projectSystem {
             super(installTypingHost, globalTypingsCacheLocation, safeList.path, throttleLimit, log);
         }
 
-        safeFileList = safeList.path;
         protected postExecActions: PostExecAction[] = [];
 
         executePendingCommands() {

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1009,6 +1009,26 @@ namespace ts.projectSystem {
     });
 
     describe("discover typings", () => {
+        it("should use mappings from safe list", () => {
+            const app = {
+                path: "/a/b/app.js",
+                content: ""
+            };
+            const jquery = {
+                path: "/a/b/jquery.js",
+                content: ""
+            };
+            const chroma = {
+                path: "/a/b/chroma.min.js",
+                content: ""
+            };
+            const cache = createMap<string>();
+
+            const host = createServerHost([app, jquery, chroma]);
+            const result = JsTyping.discoverTypings(host, [app.path, jquery.path, chroma.path], getDirectoryPath(<Path>app.path), /*safeListPath*/ undefined, cache, { enable: true }, []);
+            assert.deepEqual(result.newTypingNames, ["jquery", "chroma-js"]);
+        });
+
         it("should return node for core modules", () => {
             const f = {
                 path: "/a/b/app.js",
@@ -1016,6 +1036,7 @@ namespace ts.projectSystem {
             };
             const host = createServerHost([f]);
             const cache = createMap<string>();
+
             for (const name of JsTyping.nodeCoreModuleList) {
                 const result = JsTyping.discoverTypings(host, [f.path], getDirectoryPath(<Path>f.path), /*safeListPath*/ undefined, cache, { enable: true }, [name, "somename"]);
                 assert.deepEqual(result.newTypingNames.sort(), ["node", "somename"]);
@@ -1040,7 +1061,7 @@ namespace ts.projectSystem {
     });
 
     describe("telemetry events", () => {
-        it ("should be received", () => {
+        it("should be received", () => {
             const f1 = {
                 path: "/a/app.js",
                 content: ""
@@ -1089,7 +1110,7 @@ namespace ts.projectSystem {
     });
 
     describe("progress notifications", () => {
-        it ("should be sent for success", () => {
+        it("should be sent for success", () => {
             const f1 = {
                 path: "/a/app.js",
                 content: ""
@@ -1140,7 +1161,7 @@ namespace ts.projectSystem {
             checkProjectActualFiles(projectService.inferredProjects[0], [f1.path, commander.path]);
         });
 
-        it ("should be sent for error", () => {
+        it("should be sent for error", () => {
             const f1 = {
                 path: "/a/app.js",
                 content: ""

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -143,7 +143,7 @@ namespace ts.JsTyping {
         /**
          * Merge a given list of typingNames to the inferredTypings map
          */
-        function mergeTypings(typingNames: string[]) {
+        function mergeTypings(typingNames: ReadonlyArray<string>) {
             if (!typingNames) {
                 return;
             }
@@ -192,7 +192,7 @@ namespace ts.JsTyping {
             const cleanedTypingNames = map(inferredTypingNames, f => f.replace(/((?:\.|-)min(?=\.|$))|((?:-|\.)\d+)/g, ""));
 
             if (safeList !== EmptySafeList) {
-                mergeTypings(map(filter(cleanedTypingNames, f => safeList.has(f)), (f => safeList.get(f))));
+                mergeTypings(ts.mapDefined(cleanedTypingNames, f => safeList.get(f)));
             }
 
             const hasJsxFile = forEach(fileNames, f => ensureScriptKind(f, getScriptKindFromFileName(f)) === ScriptKind.JSX);

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -192,7 +192,7 @@ namespace ts.JsTyping {
             const cleanedTypingNames = map(inferredTypingNames, f => f.replace(/((?:\.|-)min(?=\.|$))|((?:-|\.)\d+)/g, ""));
 
             if (safeList !== EmptySafeList) {
-                mergeTypings(filter(cleanedTypingNames, f => safeList.has(f)));
+                mergeTypings(map(filter(cleanedTypingNames, f => safeList.has(f)), (f => safeList.get(f))));
             }
 
             const hasJsxFile = forEach(fileNames, f => ensureScriptKind(f, getScriptKindFromFileName(f)) === ScriptKind.JSX);


### PR DESCRIPTION
The npm package names in typingSafeList.json were getting ignored, breaking type acquisition for packages where file name != package name