### PR TITLE
fix #15447: `object` is empty object type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8599,6 +8599,7 @@ namespace ts {
 
         function isEmptyObjectType(type: Type): boolean {
             return type.flags & TypeFlags.Object ? isEmptyResolvedType(resolveStructuredTypeMembers(<ObjectType>type)) :
+                type.flags & TypeFlags.NonPrimitive ? true :
                 type.flags & TypeFlags.Union ? forEach((<UnionType>type).types, isEmptyObjectType) :
                 type.flags & TypeFlags.Intersection ? !forEach((<UnionType>type).types, t => !isEmptyObjectType(t)) :
                 false;

--- a/tests/baselines/reference/nonPrimitiveUnionIntersection.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveUnionIntersection.errors.txt
@@ -1,18 +1,32 @@
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(1,5): error TS2322: Type '""' is not assignable to type 'object & string'.
   Type '""' is not assignable to type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(3,1): error TS2322: Type 'string' is not assignable to type 'object & string'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(3,5): error TS2322: Type '123' is not assignable to type 'object & {}'.
+  Type '123' is not assignable to type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(4,1): error TS2322: Type 'string' is not assignable to type 'object & string'.
   Type 'string' is not assignable to type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(8,38): error TS2322: Type '{ bar: string; }' is not assignable to type 'object & { err: string; }'.
+  Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
 
 
-==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts (2 errors) ====
+==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts (4 errors) ====
     var a: object & string = ""; // error
         ~
 !!! error TS2322: Type '""' is not assignable to type 'object & string'.
 !!! error TS2322:   Type '""' is not assignable to type 'object'.
     var b: object | string = ""; // ok
+    var c: object & {} = 123; // error
+        ~
+!!! error TS2322: Type '123' is not assignable to type 'object & {}'.
+!!! error TS2322:   Type '123' is not assignable to type 'object'.
     a = b; // error
     ~
 !!! error TS2322: Type 'string' is not assignable to type 'object & string'.
 !!! error TS2322:   Type 'string' is not assignable to type 'object'.
     b = a; // ok
+    
+    const foo: object & {} = {bar: 'bar'}; // ok
+    const bar: object & {err: string} = {bar: 'bar'}; // error
+                                         ~~~~~~~~~~
+!!! error TS2322: Type '{ bar: string; }' is not assignable to type 'object & { err: string; }'.
+!!! error TS2322:   Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
     

--- a/tests/baselines/reference/nonPrimitiveUnionIntersection.js
+++ b/tests/baselines/reference/nonPrimitiveUnionIntersection.js
@@ -1,17 +1,29 @@
 //// [nonPrimitiveUnionIntersection.ts]
 var a: object & string = ""; // error
 var b: object | string = ""; // ok
+var c: object & {} = 123; // error
 a = b; // error
 b = a; // ok
+
+const foo: object & {} = {bar: 'bar'}; // ok
+const bar: object & {err: string} = {bar: 'bar'}; // error
 
 
 //// [nonPrimitiveUnionIntersection.js]
 var a = ""; // error
 var b = ""; // ok
+var c = 123; // error
 a = b; // error
 b = a; // ok
+var foo = { bar: 'bar' }; // ok
+var bar = { bar: 'bar' }; // error
 
 
 //// [nonPrimitiveUnionIntersection.d.ts]
 declare var a: object & string;
 declare var b: object | string;
+declare var c: object & {};
+declare const foo: object & {};
+declare const bar: object & {
+    err: string;
+};

--- a/tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts
+++ b/tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts
@@ -1,5 +1,9 @@
 // @declaration: true
 var a: object & string = ""; // error
 var b: object | string = ""; // ok
+var c: object & {} = 123; // error
 a = b; // error
 b = a; // ok
+
+const foo: object & {} = {bar: 'bar'}; // ok
+const bar: object & {err: string} = {bar: 'bar'}; // error


### PR DESCRIPTION
Fixes #15447
