### PR TITLE
Enable debug info when running tests

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -662,6 +662,10 @@ namespace ts {
     }
 }
 
+if (ts.Debug.isDebugging) {
+    ts.Debug.enableDebugInfo();
+}
+
 if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
     ts.sys.tryEnableSourceMapsForHost();
 }

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -222,6 +222,10 @@ if (taskConfigsFolder) {
     }
 }
 else {
+    if (ts.Debug.isDebugging) {
+        ts.Debug.enableDebugInfo();
+    }
+
     runTests(runners);
 }
 if (!runUnitTests) {


### PR DESCRIPTION
In #16120 I added some additional members to `Node`, `Symbol`, and `Type` that are only available when debugging the compiler. These provide some at-a-glance information about runtime enum values. This change makes them available when debugging tests as well.