### PR TITLE
Fix JS-inferred rest parameters

### DIFF
--- a/tests/baselines/reference/argumentsObjectCreatesRestForJs.symbols
+++ b/tests/baselines/reference/argumentsObjectCreatesRestForJs.symbols
@@ -1,0 +1,44 @@
+=== tests/cases/compiler/main.js ===
+function allRest() { arguments; }
+>allRest : Symbol(allRest, Decl(main.js, 0, 0))
+>arguments : Symbol(arguments)
+
+allRest();
+>allRest : Symbol(allRest, Decl(main.js, 0, 0))
+
+allRest(1, 2, 3);
+>allRest : Symbol(allRest, Decl(main.js, 0, 0))
+
+function someRest(x, y) { arguments; }
+>someRest : Symbol(someRest, Decl(main.js, 2, 17))
+>x : Symbol(x, Decl(main.js, 3, 18))
+>y : Symbol(y, Decl(main.js, 3, 20))
+>arguments : Symbol(arguments)
+
+someRest(); // x and y are still optional because they are in a JS file
+>someRest : Symbol(someRest, Decl(main.js, 2, 17))
+
+someRest(1, 2, 3);
+>someRest : Symbol(someRest, Decl(main.js, 2, 17))
+
+/**
+ * @param {number} x - a thing
+ */
+function jsdocced(x) { arguments; }
+>jsdocced : Symbol(jsdocced, Decl(main.js, 5, 18))
+>x : Symbol(x, Decl(main.js, 10, 18))
+>arguments : Symbol(arguments)
+
+jsdocced(1);
+>jsdocced : Symbol(jsdocced, Decl(main.js, 5, 18))
+
+function dontDoubleRest(x, ...y) { arguments; }
+>dontDoubleRest : Symbol(dontDoubleRest, Decl(main.js, 11, 12))
+>x : Symbol(x, Decl(main.js, 13, 24))
+>y : Symbol(y, Decl(main.js, 13, 26))
+>arguments : Symbol(arguments)
+
+dontDoubleRest(1, 2, 3);
+>dontDoubleRest : Symbol(dontDoubleRest, Decl(main.js, 11, 12))
+
+

--- a/tests/baselines/reference/argumentsObjectCreatesRestForJs.types
+++ b/tests/baselines/reference/argumentsObjectCreatesRestForJs.types
@@ -1,0 +1,60 @@
+=== tests/cases/compiler/main.js ===
+function allRest() { arguments; }
+>allRest : (...args: any[]) => void
+>arguments : IArguments
+
+allRest();
+>allRest() : void
+>allRest : (...args: any[]) => void
+
+allRest(1, 2, 3);
+>allRest(1, 2, 3) : void
+>allRest : (...args: any[]) => void
+>1 : 1
+>2 : 2
+>3 : 3
+
+function someRest(x, y) { arguments; }
+>someRest : (x: any, y: any, ...args: any[]) => void
+>x : any
+>y : any
+>arguments : IArguments
+
+someRest(); // x and y are still optional because they are in a JS file
+>someRest() : void
+>someRest : (x: any, y: any, ...args: any[]) => void
+
+someRest(1, 2, 3);
+>someRest(1, 2, 3) : void
+>someRest : (x: any, y: any, ...args: any[]) => void
+>1 : 1
+>2 : 2
+>3 : 3
+
+/**
+ * @param {number} x - a thing
+ */
+function jsdocced(x) { arguments; }
+>jsdocced : (x: number) => void
+>x : number
+>arguments : IArguments
+
+jsdocced(1);
+>jsdocced(1) : void
+>jsdocced : (x: number) => void
+>1 : 1
+
+function dontDoubleRest(x, ...y) { arguments; }
+>dontDoubleRest : (x: any, ...y: any[]) => void
+>x : any
+>y : any[]
+>arguments : IArguments
+
+dontDoubleRest(1, 2, 3);
+>dontDoubleRest(1, 2, 3) : void
+>dontDoubleRest : (x: any, ...y: any[]) => void
+>1 : 1
+>2 : 2
+>3 : 3
+
+

--- a/tests/baselines/reference/jsSelfReferencingArgumentsFunction.symbols
+++ b/tests/baselines/reference/jsSelfReferencingArgumentsFunction.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/foo.js ===
+// Test #16139
+function Foo() {
+>Foo : Symbol(Foo, Decl(foo.js, 0, 0))
+
+    arguments;
+>arguments : Symbol(arguments)
+
+    return new Foo();
+>Foo : Symbol(Foo, Decl(foo.js, 0, 0))
+}
+

--- a/tests/baselines/reference/jsSelfReferencingArgumentsFunction.types
+++ b/tests/baselines/reference/jsSelfReferencingArgumentsFunction.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/foo.js ===
+// Test #16139
+function Foo() {
+>Foo : (...args: any[]) => any
+
+    arguments;
+>arguments : IArguments
+
+    return new Foo();
+>new Foo() : any
+>Foo : (...args: any[]) => any
+}
+

--- a/tests/cases/compiler/argumentsObjectCreatesRestForJs.ts
+++ b/tests/cases/compiler/argumentsObjectCreatesRestForJs.ts
@@ -1,0 +1,20 @@
+// @checkJs: true
+// @allowJs: true
+// @Filename: main.js
+// @noemit: true
+function allRest() { arguments; }
+allRest();
+allRest(1, 2, 3);
+function someRest(x, y) { arguments; }
+someRest(); // x and y are still optional because they are in a JS file
+someRest(1, 2, 3);
+
+/**
+ * @param {number} x - a thing
+ */
+function jsdocced(x) { arguments; }
+jsdocced(1);
+
+function dontDoubleRest(x, ...y) { arguments; }
+dontDoubleRest(1, 2, 3);
+

--- a/tests/cases/compiler/jsSelfReferencingArgumentsFunction.ts
+++ b/tests/cases/compiler/jsSelfReferencingArgumentsFunction.ts
@@ -1,0 +1,8 @@
+// @Filename: foo.js
+// @noEmit: true
+// @allowJs: true
+// Test #16139
+function Foo() {
+    arguments;
+    return new Foo();
+}

--- a/tests/cases/fourslash/signatureHelpCallExpressionJs.ts
+++ b/tests/cases/fourslash/signatureHelpCallExpressionJs.ts
@@ -4,14 +4,25 @@
 // @allowJs: true
 
 // @Filename: main.js
-////function fnTest() { arguments; }
-////fnTest(/*1*/);
-////fnTest(1, 2, 3);
+////function allOptional() { arguments; }
+////allOptional(/*1*/);
+////allOptional(1, 2, 3);
+////function someOptional(x, y) { arguments; }
+////someOptional(/*2*/);
+////someOptional(1, 2, 3);
+////someOptional(); // no error here; x and y are optional in JS
 
 goTo.marker('1');
 verify.signatureHelpCountIs(1);
 verify.currentSignatureParameterCountIs(1);
-verify.currentSignatureHelpIs('fnTest(...args: any[]): void');
+verify.currentSignatureHelpIs('allOptional(...args: any[]): void');
 verify.currentParameterHelpArgumentNameIs('args');
 verify.currentParameterSpanIs("...args: any[]");
+
+goTo.marker('2');
+verify.signatureHelpCountIs(1);
+verify.currentSignatureParameterCountIs(3);
+verify.currentSignatureHelpIs('someOptional(x: any, y: any, ...args: any[]): void');
+verify.currentParameterHelpArgumentNameIs('x');
+verify.currentParameterSpanIs("x: any");
 verify.numberOfErrorsInCurrentFile(0);


### PR DESCRIPTION
Create js-inferred rest parameters in `getSignatureOfDeclaration`. Previously they were created too late, in `resolveCall`, via mutation. The mutation of the signature caused bug #16139 because recursion detection in type checking didn't work.

The earlier addition of the synthetic rest parameters means that it gets used even more places, so I had to add another special case, in `symbolToParameterDeclaration`.

Fixes #16139