### PR TITLE
Delay signature return type instantiation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8038,7 +8038,7 @@ namespace ts {
             const result = createSignature(signature.declaration, freshTypeParameters,
                 signature.thisParameter && instantiateSymbol(signature.thisParameter, mapper),
                 instantiateList(signature.parameters, mapper, instantiateSymbol),
-                instantiateType(signature.resolvedReturnType, mapper),
+                /*resolvedReturnType*/ undefined,
                 freshTypePredicate,
                 signature.minArgumentCount, signature.hasRestParameter, signature.hasLiteralTypes);
             result.target = signature;

--- a/tests/baselines/reference/returnInfiniteIntersection.js
+++ b/tests/baselines/reference/returnInfiniteIntersection.js
@@ -1,0 +1,15 @@
+//// [returnInfiniteIntersection.ts]
+function recursive() {
+    let x = <T>(subkey: T) => recursive();
+    return x as typeof x & { p };
+}
+
+let result = recursive()(1)
+
+
+//// [returnInfiniteIntersection.js]
+function recursive() {
+    var x = function (subkey) { return recursive(); };
+    return x;
+}
+var result = recursive()(1);

--- a/tests/baselines/reference/returnInfiniteIntersection.symbols
+++ b/tests/baselines/reference/returnInfiniteIntersection.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/returnInfiniteIntersection.ts ===
+function recursive() {
+>recursive : Symbol(recursive, Decl(returnInfiniteIntersection.ts, 0, 0))
+
+    let x = <T>(subkey: T) => recursive();
+>x : Symbol(x, Decl(returnInfiniteIntersection.ts, 1, 7))
+>T : Symbol(T, Decl(returnInfiniteIntersection.ts, 1, 13))
+>subkey : Symbol(subkey, Decl(returnInfiniteIntersection.ts, 1, 16))
+>T : Symbol(T, Decl(returnInfiniteIntersection.ts, 1, 13))
+>recursive : Symbol(recursive, Decl(returnInfiniteIntersection.ts, 0, 0))
+
+    return x as typeof x & { p };
+>x : Symbol(x, Decl(returnInfiniteIntersection.ts, 1, 7))
+>x : Symbol(x, Decl(returnInfiniteIntersection.ts, 1, 7))
+>p : Symbol(p, Decl(returnInfiniteIntersection.ts, 2, 28))
+}
+
+let result = recursive()(1)
+>result : Symbol(result, Decl(returnInfiniteIntersection.ts, 5, 3))
+>recursive : Symbol(recursive, Decl(returnInfiniteIntersection.ts, 0, 0))
+

--- a/tests/baselines/reference/returnInfiniteIntersection.types
+++ b/tests/baselines/reference/returnInfiniteIntersection.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/returnInfiniteIntersection.ts ===
+function recursive() {
+>recursive : () => (<T>(subkey: T) => any & { p: any; }) & { p: any; }
+
+    let x = <T>(subkey: T) => recursive();
+>x : <T>(subkey: T) => any & { p: any; }
+><T>(subkey: T) => recursive() : <T>(subkey: T) => any & { p: any; }
+>T : T
+>subkey : T
+>T : T
+>recursive() : (<T>(subkey: T) => any & { p: any; }) & { p: any; }
+>recursive : () => (<T>(subkey: T) => any & { p: any; }) & { p: any; }
+
+    return x as typeof x & { p };
+>x as typeof x & { p } : (<T>(subkey: T) => any & { p: any; }) & { p: any; }
+>x : <T>(subkey: T) => any & { p: any; }
+>x : <T>(subkey: T) => any & { p: any; }
+>p : any
+}
+
+let result = recursive()(1)
+>result : (<T>(subkey: T) => any & { p: any; }) & { p: any; }
+>recursive()(1) : (<T>(subkey: T) => any & { p: any; }) & { p: any; }
+>recursive() : (<T>(subkey: T) => any & { p: any; }) & { p: any; }
+>recursive : () => (<T>(subkey: T) => any & { p: any; }) & { p: any; }
+>1 : 1
+

--- a/tests/cases/compiler/returnInfiniteIntersection.ts
+++ b/tests/cases/compiler/returnInfiniteIntersection.ts
@@ -1,0 +1,6 @@
+function recursive() {
+    let x = <T>(subkey: T) => recursive();
+    return x as typeof x & { p };
+}
+
+let result = recursive()(1)


### PR DESCRIPTION
Delay instantiation of signature return type `getReturnTypeOfSignature` correctly handles an un-instantiated signature, but `instantiateSignature` used to eagerly instantiate the return type. This caused an infinite recursion in #16233.

Now `instantiateSignature` doesn't instantiate the return type, but relies on `getReturnTypeOfSignature` to do it.

Fixes #16233