### PR TITLE
Fix parameter emit for synthetic function types

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -228,7 +228,7 @@ namespace ts {
 
     // Signature elements
 
-    export function createTypeParameterDeclaration(name: string | Identifier, constraint: TypeNode | undefined, defaultType: TypeNode | undefined) {
+    export function createTypeParameterDeclaration(name: string | Identifier, constraint?: TypeNode, defaultType?: TypeNode) {
         const node = createSynthesizedNode(SyntaxKind.TypeParameter) as TypeParameterDeclaration;
         node.name = asName(name);
         node.constraint = constraint;

--- a/src/harness/unittests/printer.ts
+++ b/src/harness/unittests/printer.ts
@@ -81,63 +81,136 @@ namespace ts {
 
         describe("printNode", () => {
             const printsCorrectly = makePrintsCorrectly("printsNodeCorrectly");
-            let sourceFile: SourceFile;
-            before(() => sourceFile = createSourceFile("source.ts", "", ScriptTarget.ES2015));
-            // tslint:disable boolean-trivia
-            const syntheticNode = createClassDeclaration(
-                undefined,
-                undefined,
-                /*name*/ createIdentifier("C"),
-                undefined,
-                undefined,
-                createNodeArray([
-                    createProperty(
-                        undefined,
+            printsCorrectly("class", {}, printer => printer.printNode(
+                EmitHint.Unspecified,
+                createClassDeclaration(
+                    /*decorators*/ undefined,
+                    /*modifiers*/ undefined,
+                    /*name*/ createIdentifier("C"),
+                    /*typeParameters*/ undefined,
+                    /*heritageClauses*/ undefined,
+                    [createProperty(
+                        /*decorators*/ undefined,
                         createNodeArray([createToken(SyntaxKind.PublicKeyword)]),
                         createIdentifier("prop"),
-                        undefined,
-                        undefined,
-                        undefined
-                    )
-                ])
-            );
+                        /*questionToken*/ undefined,
+                        /*type*/ undefined,
+                        /*initializer*/ undefined
+                    )]
+                ),
+                createSourceFile("source.ts", "", ScriptTarget.ES2015)
+            ));
+
+            printsCorrectly("namespaceExportDeclaration", {}, printer => printer.printNode(
+                EmitHint.Unspecified,
+                createNamespaceExportDeclaration("B"),
+                createSourceFile("source.ts", "", ScriptTarget.ES2015)
+            ));
 
             // https://github.com/Microsoft/TypeScript/issues/15971
-            const classWithOptionalMethodAndProperty = createClassDeclaration(
-                undefined,
-                /* modifiers */ createNodeArray([createToken(SyntaxKind.DeclareKeyword)]),
-                /* name      */ createIdentifier("X"),
-                undefined,
-                undefined,
-                createNodeArray([
-                    createMethod(
-                        undefined,
-                        undefined,
-                        undefined,
-                        /* name          */ createIdentifier("method"),
-                        /* questionToken */ createToken(SyntaxKind.QuestionToken),
-                        undefined,
-                        undefined,
-                        /* type          */ createKeywordTypeNode(SyntaxKind.VoidKeyword),
-                        undefined
+            printsCorrectly("classWithOptionalMethodAndProperty", {}, printer => printer.printNode(
+                EmitHint.Unspecified,
+                createClassDeclaration(
+                    /*decorators*/ undefined,
+                    /*modifiers*/ [createToken(SyntaxKind.DeclareKeyword)],
+                    /*name*/ createIdentifier("X"),
+                    /*typeParameters*/ undefined,
+                    /*heritageClauses*/ undefined,
+                    [
+                        createMethod(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            /*asteriskToken*/ undefined,
+                            /*name*/ createIdentifier("method"),
+                            /*questionToken*/ createToken(SyntaxKind.QuestionToken),
+                            /*typeParameters*/ undefined,
+                            [],
+                            /*type*/ createKeywordTypeNode(SyntaxKind.VoidKeyword),
+                            /*body*/ undefined
+                        ),
+                        createProperty(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            /*name*/ createIdentifier("property"),
+                            /*questionToken*/ createToken(SyntaxKind.QuestionToken),
+                            /*type*/ createKeywordTypeNode(SyntaxKind.StringKeyword),
+                            /*initializer*/ undefined
+                        ),
+                    ]
+                ),
+                createSourceFile("source.ts", "", ScriptTarget.ES2015)
+            ));
+
+            // https://github.com/Microsoft/TypeScript/issues/15651
+            printsCorrectly("functionTypes", {}, printer => printer.printNode(
+                EmitHint.Unspecified,
+                createTupleTypeNode([
+                    createFunctionTypeNode(
+                        /*typeArguments*/ undefined,
+                        [createParameter(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            /*dotDotDotToken*/ undefined,
+                            createIdentifier("args")
+                        )],
+                        createKeywordTypeNode(SyntaxKind.AnyKeyword)
                     ),
-                    createProperty(
-                        undefined,
-                        undefined,
-                        /* name          */ createIdentifier("property"),
-                        /* questionToken */ createToken(SyntaxKind.QuestionToken),
-                        /* type          */ createKeywordTypeNode(SyntaxKind.StringKeyword),
-                        undefined
+                    createFunctionTypeNode(
+                        [createTypeParameterDeclaration("T")],
+                        [createParameter(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            /*dotDotDotToken*/ undefined,
+                            createIdentifier("args")
+                        )],
+                        createKeywordTypeNode(SyntaxKind.AnyKeyword)
                     ),
-                ])
-            );
-
-            // tslint:enable boolean-trivia
-            printsCorrectly("class", {}, printer => printer.printNode(EmitHint.Unspecified, syntheticNode, sourceFile));
-
-            printsCorrectly("namespaceExportDeclaration", {}, printer => printer.printNode(EmitHint.Unspecified, createNamespaceExportDeclaration("B"), sourceFile));
-
-            printsCorrectly("classWithOptionalMethodAndProperty", {}, printer => printer.printNode(EmitHint.Unspecified, classWithOptionalMethodAndProperty, sourceFile));
+                    createFunctionTypeNode(
+                        /*typeArguments*/ undefined,
+                        [createParameter(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            createToken(SyntaxKind.DotDotDotToken),
+                            createIdentifier("args")
+                        )],
+                        createKeywordTypeNode(SyntaxKind.AnyKeyword)
+                    ),
+                    createFunctionTypeNode(
+                        /*typeArguments*/ undefined,
+                        [createParameter(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            /*dotDotDotToken*/ undefined,
+                            createIdentifier("args"),
+                            createToken(SyntaxKind.QuestionToken)
+                        )],
+                        createKeywordTypeNode(SyntaxKind.AnyKeyword)
+                    ),
+                    createFunctionTypeNode(
+                        /*typeArguments*/ undefined,
+                        [createParameter(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            /*dotDotDotToken*/ undefined,
+                            createIdentifier("args"),
+                            /*questionToken*/ undefined,
+                            createKeywordTypeNode(SyntaxKind.AnyKeyword)
+                        )],
+                        createKeywordTypeNode(SyntaxKind.AnyKeyword)
+                    ),
+                    createFunctionTypeNode(
+                        /*typeArguments*/ undefined,
+                        [createParameter(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            /*dotDotDotToken*/ undefined,
+                            createObjectBindingPattern([])
+                        )],
+                        createKeywordTypeNode(SyntaxKind.AnyKeyword)
+                    ),
+                ]),
+                createSourceFile("source.ts", "", ScriptTarget.ES2015)
+            ));
         });
     });
 }

--- a/tests/baselines/reference/printerApi/printsNodeCorrectly.functionTypes.js
+++ b/tests/baselines/reference/printerApi/printsNodeCorrectly.functionTypes.js
@@ -1,0 +1,1 @@
+[args => any, <T>(args) => any, (...args) => any, (args?) => any, (args: any) => any, ({}) => any]


### PR DESCRIPTION
Currently, the emitter determines whether to emit parentheses around the parameter purely based on the number of parameters and whether there are any parsed tokens between the parent node and the first parameter.  However, this logic is invalid if both the parent node and the parameter are both synthesized.

This change adds a few more additional tests to ensure its valid to emit the parameter list of an arrow function or function type.

Fixes #15651
