### PR TITLE
Refresh typings cache if language service version changes

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -96,7 +96,7 @@ namespace ts.projectSystem {
         }
 
         enqueueInstallTypingsRequest(project: server.Project, typeAcquisition: TypeAcquisition, unresolvedImports: server.SortedReadonlyArray<string>) {
-            const request = server.createInstallTypingsRequest(project, typeAcquisition, unresolvedImports, this.globalTypingsCacheLocation);
+            const request = server.createInstallTypingsRequest(project, typeAcquisition, unresolvedImports);
             this.install(request);
         }
 

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -973,9 +973,9 @@ namespace ts.projectSystem {
                     typeScriptVersion: ts.version,
                     devDependencies: { "@types/jquery": "^2.0.46" }
                 })
-            }
+            };
             const host = createServerHost([jquery, packageJson, jqueryDTS, jqueryPackageJson]);
-            let testTypingsInstaller = (class extends Installer {
+            const testTypingsInstaller = (class extends Installer {
                 constructor() {
                     super(host, { globalTypingsCacheLocation: "/cache", typesRegistry: createTypesRegistry("jquery") });
                 }
@@ -985,9 +985,9 @@ namespace ts.projectSystem {
             projectService.openClientFile(jquery.path);
             installer.installAll(/*expectedCount*/ 0);
 
-            // Update the typescript version in the root package.json to something outdated, 
+            // Update the typescript version in the root package.json to something outdated,
             // then test again with a new instance of the typings installer
-            let newPackageJson = <any>JSON.parse(host.readFile(packageJson.path));
+            const newPackageJson = <any>JSON.parse(host.readFile(packageJson.path));
             newPackageJson.typeScriptVersion = "1.1";
             host.writeFile(packageJson.path, JSON.stringify(newPackageJson));
 

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -950,6 +950,52 @@ namespace ts.projectSystem {
             const version2 = proj.getCachedUnresolvedImportsPerFile_TestOnly().getVersion();
             assert.equal(version1, version2, "set of unresolved imports should not change");
         });
+
+        it("typings cache is used only if versions match", () => {
+            const jquery = {
+                path: "/a/jquery.js",
+                content: ""
+            };
+            const jqueryDTS = {
+                path: "/cache/node_modules/@types/jquery/index.d.ts",
+                content: ""
+            };
+            const jqueryPackageJson = {
+                path: "/cache/node_modules/@types/jquery/package.json",
+                content: JSON.stringify({
+                    typeScriptVersion: "1.1",
+                    typings: "index.d.ts"
+                })
+            };
+            const packageJson = {
+                path: "/cache/package.json",
+                content: JSON.stringify({
+                    typeScriptVersion: ts.version,
+                    devDependencies: { "@types/jquery": "^2.0.46" }
+                })
+            }
+            const host = createServerHost([jquery, packageJson, jqueryDTS, jqueryPackageJson]);
+            let testTypingsInstaller = (class extends Installer {
+                constructor() {
+                    super(host, { globalTypingsCacheLocation: "/cache", typesRegistry: createTypesRegistry("jquery") });
+                }
+            });
+            let installer = new testTypingsInstaller();
+            let projectService = createProjectService(host, { useSingleInferredProject: true, typingsInstaller: installer });
+            projectService.openClientFile(jquery.path);
+            installer.installAll(/*expectedCount*/ 0);
+
+            // Update the typescript version in the root package.json to something outdated, 
+            // then test again with a new instance of the typings installer
+            let newPackageJson = <any>JSON.parse(host.readFile(packageJson.path));
+            newPackageJson.typeScriptVersion = "1.1";
+            host.writeFile(packageJson.path, JSON.stringify(newPackageJson));
+
+            installer = new testTypingsInstaller();
+            projectService = createProjectService(host, { useSingleInferredProject: true, typingsInstaller: installer });
+            projectService.openClientFile(jquery.path);
+            installer.installAll(/*expectedCount*/ 1);
+        });
     });
 
     describe("Validate package name:", () => {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -35,7 +35,6 @@ declare namespace ts.server {
         readonly compilerOptions: ts.CompilerOptions;
         readonly typeAcquisition: ts.TypeAcquisition;
         readonly unresolvedImports: SortedReadonlyArray<string>;
-        readonly cachePath?: string;
         readonly kind: "discover";
     }
 

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -203,7 +203,7 @@ namespace ts.server.typingsInstaller {
                             // If typeScriptVersion field doesn't match the current version, don't add the package to cache
                             const typingPackageJson = combinePaths(getDirectoryPath(typingFile), "package.json");
                             const typingTypeScriptVersion = (<NpmConfig>JSON.parse(this.installTypingHost.readFile(typingPackageJson))).typeScriptVersion;
-                            if(!this.areVersionsEqualMajorMinor(typingTypeScriptVersion, ts.version)) {
+                            if (!this.areVersionsEqualMajorMinor(typingTypeScriptVersion, ts.version)) {
                                 if (this.log.isEnabled()) {
                                     this.log.writeLine(`Not adding ${typingFile} to cache because of typeScriptVersion mismatch`);
                                 }

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -136,14 +136,6 @@ namespace ts.server.typingsInstaller {
                 this.log.writeLine(`Got install request ${JSON.stringify(req)}`);
             }
 
-            // load existing typing information from the cache
-            if (req.cachePath) {
-                if (this.log.isEnabled()) {
-                    this.log.writeLine(`Request specifies cache path '${req.cachePath}', loading cached information...`);
-                }
-                this.processCacheLocation(req.cachePath);
-            }
-
             const discoverTypingsResult = JsTyping.discoverTypings(
                 this.installTypingHost,
                 req.fileNames,
@@ -165,7 +157,7 @@ namespace ts.server.typingsInstaller {
 
             // install typings
             if (discoverTypingsResult.newTypingNames.length) {
-                this.installTypings(req, req.cachePath || this.globalCachePath, discoverTypingsResult.cachedTypingPaths, discoverTypingsResult.newTypingNames);
+                this.installTypings(req, this.globalCachePath, discoverTypingsResult.cachedTypingPaths, discoverTypingsResult.newTypingNames);
             }
             else {
                 if (this.log.isEnabled()) {

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -46,7 +46,7 @@ namespace ts.server {
         }
     }
 
-    export function createInstallTypingsRequest(project: Project, typeAcquisition: TypeAcquisition, unresolvedImports: SortedReadonlyArray<string>, cachePath?: string): DiscoverTypings {
+    export function createInstallTypingsRequest(project: Project, typeAcquisition: TypeAcquisition, unresolvedImports: SortedReadonlyArray<string>): DiscoverTypings {
         return {
             projectName: project.getProjectName(),
             fileNames: project.getFileNames(/*excludeFilesFromExternalLibraries*/ true),
@@ -54,7 +54,6 @@ namespace ts.server {
             typeAcquisition,
             unresolvedImports,
             projectRootPath: getProjectRootPath(project),
-            cachePath,
             kind: "discover"
         };
     }


### PR DESCRIPTION
The on-disk typings cache should be (selectively) refreshed if the language service version changes.

- Add a new ```typeScriptVersion``` field to the package.json in the typings global cache root. This contains the value of the last typingsInstaller version that updated the cache.

- If the ```typeScriptVersion``` in the cache root doesn't match the currently running typings installer version, check the ```typeScriptVersion``` fields in the the individual typing packages. If the ```typeScriptVersion``` for the typing doesn't match the current TypeScript version, exclude the package from the in-memory cache so that it will be fetched again from npm.