### PR TITLE
Weak types for primitives

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9427,7 +9427,7 @@ namespace ts {
             function hasCommonProperties(source: Type, target: Type) {
                 const isComparingJsxAttributes = !!(source.flags & TypeFlags.JsxAttributes);
                 for (const prop of getPropertiesOfType(source)) {
-                    if (isKnownProperty(target, prop.name, isComparingJsxAttributes)) {
+                    if (isKnownProperty(target, prop.name, isComparingJsxAttributes, /*skipGlobalObject*/ true)) {
                         return true;
                     }
                 }
@@ -14221,12 +14221,12 @@ namespace ts {
          * @param name a property name to search
          * @param isComparingJsxAttributes a boolean flag indicating whether we are searching in JsxAttributesType
          */
-        function isKnownProperty(targetType: Type, name: string, isComparingJsxAttributes: boolean): boolean {
+        function isKnownProperty(targetType: Type, name: string, isComparingJsxAttributes: boolean, skipGlobalObject?: boolean): boolean {
             if (targetType.flags & TypeFlags.Object) {
                 const resolved = resolveStructuredTypeMembers(<ObjectType>targetType);
                 if (resolved.stringIndexInfo ||
                     resolved.numberIndexInfo && isNumericLiteralName(name) ||
-                    getPropertyOfType(targetType, name) ||
+                    (skipGlobalObject ? getPropertyOfObjectType(targetType, name) : getPropertyOfType(targetType, name)) ||
                     isComparingJsxAttributes && !isUnhyphenatedJsxName(name)) {
                     // For JSXAttributes, if the attribute has a hyphenated name, consider that the attribute to be known.
                     return true;

--- a/tests/baselines/reference/generatorTypeCheck63.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck63.errors.txt
@@ -1,11 +1,12 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(24,14): error TS2322: Type '(a: State | 1) => IterableIterator<State | 1>' is not assignable to type 'Strategy<State>'.
-  Type 'IterableIterator<State | 1>' is not assignable to type 'IterableIterator<State>'.
-    Type 'State | 1' is not assignable to type 'State'.
-      Type '1' is not assignable to type 'State'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(24,61): error TS2345: Argument of type '(state: State) => IterableIterator<State | 1>' is not assignable to parameter of type '(a: StrategicState) => IterableIterator<StrategicState>'.
+  Type 'IterableIterator<State | 1>' is not assignable to type 'IterableIterator<StrategicState>'.
+    Type 'State | 1' is not assignable to type 'StrategicState'.
+      Type '1' has no properties in common with type 'StrategicState'.
 tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(29,70): error TS7025: Generator implicitly has type 'IterableIterator<any>' because it does not yield any values. Consider supplying a return type.
 tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(32,42): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'State' is not a valid type argument because it is not a supertype of candidate '1'.
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(36,14): error TS2322: Type '(a: State | 1) => IterableIterator<State | 1>' is not assignable to type 'Strategy<State>'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(36,62): error TS2345: Argument of type '(state: State) => IterableIterator<State | 1>' is not assignable to parameter of type '(a: StrategicState) => IterableIterator<StrategicState>'.
+  Type 'IterableIterator<State | 1>' is not assignable to type 'IterableIterator<StrategicState>'.
 
 
 ==== tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts (4 errors) ====
@@ -33,11 +34,11 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(36,14): err
     }
     
     export const Nothing: Strategy<State> = strategy("Nothing", function* (state: State) {
-                 ~~~~~~~
-!!! error TS2322: Type '(a: State | 1) => IterableIterator<State | 1>' is not assignable to type 'Strategy<State>'.
-!!! error TS2322:   Type 'IterableIterator<State | 1>' is not assignable to type 'IterableIterator<State>'.
-!!! error TS2322:     Type 'State | 1' is not assignable to type 'State'.
-!!! error TS2322:       Type '1' is not assignable to type 'State'.
+                                                                ~~~~~~~~
+!!! error TS2345: Argument of type '(state: State) => IterableIterator<State | 1>' is not assignable to parameter of type '(a: StrategicState) => IterableIterator<StrategicState>'.
+!!! error TS2345:   Type 'IterableIterator<State | 1>' is not assignable to type 'IterableIterator<StrategicState>'.
+!!! error TS2345:     Type 'State | 1' is not assignable to type 'StrategicState'.
+!!! error TS2345:       Type '1' has no properties in common with type 'StrategicState'.
         yield 1;
         return state;
     });
@@ -55,8 +56,9 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(36,14): err
     });
     
     export const Nothing3: Strategy<State> = strategy("Nothing", function* (state: State) {
-                 ~~~~~~~~
-!!! error TS2322: Type '(a: State | 1) => IterableIterator<State | 1>' is not assignable to type 'Strategy<State>'.
+                                                                 ~~~~~~~~
+!!! error TS2345: Argument of type '(state: State) => IterableIterator<State | 1>' is not assignable to parameter of type '(a: StrategicState) => IterableIterator<StrategicState>'.
+!!! error TS2345:   Type 'IterableIterator<State | 1>' is not assignable to type 'IterableIterator<StrategicState>'.
         yield state;
         return 1;
     });

--- a/tests/baselines/reference/weakType.errors.txt
+++ b/tests/baselines/reference/weakType.errors.txt
@@ -1,11 +1,14 @@
-tests/cases/compiler/weakType.ts(31,18): error TS2559: Type '{ error?: number; }' has no properties in common with type 'ChangeOptions'.
-tests/cases/compiler/weakType.ts(56,5): error TS2322: Type '{ properties: { wrong: string; }; }' is not assignable to type 'Weak & Spoiler'.
+tests/cases/compiler/weakType.ts(16,13): error TS2559: Type '12' has no properties in common with type 'Settings'.
+tests/cases/compiler/weakType.ts(17,13): error TS2559: Type '"completely wrong"' has no properties in common with type 'Settings'.
+tests/cases/compiler/weakType.ts(18,13): error TS2559: Type 'false' has no properties in common with type 'Settings'.
+tests/cases/compiler/weakType.ts(35,18): error TS2559: Type '{ error?: number; }' has no properties in common with type 'ChangeOptions'.
+tests/cases/compiler/weakType.ts(60,5): error TS2322: Type '{ properties: { wrong: string; }; }' is not assignable to type 'Weak & Spoiler'.
   Type '{ properties: { wrong: string; }; }' is not assignable to type 'Weak'.
     Types of property 'properties' are incompatible.
       Type '{ wrong: string; }' has no properties in common with type '{ b?: number; }'.
 
 
-==== tests/cases/compiler/weakType.ts (2 errors) ====
+==== tests/cases/compiler/weakType.ts (5 errors) ====
     interface Settings {
         timeout?: number;
         onError?(): void;
@@ -16,10 +19,20 @@ tests/cases/compiler/weakType.ts(56,5): error TS2322: Type '{ properties: { wron
     }
     
     function doSomething(settings: Settings) { /* ... */ }
-    
     // forgot to call `getDefaultSettings`
     // but it is not caught because we don't check for call signatures
     doSomething(getDefaultSettings);
+    // same for arrow expressions:
+    doSomething(() => { });
+    doSomething(12);
+                ~~
+!!! error TS2559: Type '12' has no properties in common with type 'Settings'.
+    doSomething('completely wrong');
+                ~~~~~~~~~~~~~~~~~~
+!!! error TS2559: Type '"completely wrong"' has no properties in common with type 'Settings'.
+    doSomething(false);
+                ~~~~~
+!!! error TS2559: Type 'false' has no properties in common with type 'Settings'.
     
     // this is an oddly popular way of defining settings
     // this example is from services/textChanges.ts

--- a/tests/baselines/reference/weakType.js
+++ b/tests/baselines/reference/weakType.js
@@ -9,10 +9,14 @@ function getDefaultSettings() {
 }
 
 function doSomething(settings: Settings) { /* ... */ }
-
 // forgot to call `getDefaultSettings`
 // but it is not caught because we don't check for call signatures
 doSomething(getDefaultSettings);
+// same for arrow expressions:
+doSomething(() => { });
+doSomething(12);
+doSomething('completely wrong');
+doSomething(false);
 
 // this is an oddly popular way of defining settings
 // this example is from services/textChanges.ts
@@ -65,6 +69,11 @@ function doSomething(settings) { }
 // forgot to call `getDefaultSettings`
 // but it is not caught because we don't check for call signatures
 doSomething(getDefaultSettings);
+// same for arrow expressions:
+doSomething(function () { });
+doSomething(12);
+doSomething('completely wrong');
+doSomething(false);
 function del(options, error) {
     if (options === void 0) { options = {}; }
     if (error === void 0) { error = {}; }

--- a/tests/cases/compiler/weakType.ts
+++ b/tests/cases/compiler/weakType.ts
@@ -8,10 +8,14 @@ function getDefaultSettings() {
 }
 
 function doSomething(settings: Settings) { /* ... */ }
-
 // forgot to call `getDefaultSettings`
 // but it is not caught because we don't check for call signatures
 doSomething(getDefaultSettings);
+// same for arrow expressions:
+doSomething(() => { });
+doSomething(12);
+doSomething('completely wrong');
+doSomething(false);
 
 // this is an oddly popular way of defining settings
 // this example is from services/textChanges.ts


### PR DESCRIPTION
Fixes #16333 

Previously, weak type errors didn't occur with primitive sources because the apparent type of primitives all include `toString`. `isKnownProperty` reports that `toString` is known for *all* types because it falls back to `globalObjectType` when it can't find the property on the given type.

To avoid making other errors worse, specifically excess object literal property errors and JSX errors, `isKnownProperty` adds a flag that controls whether to include the Object properties. This is clunky but works. If you have a better idea, please suggest it.