### PR TITLE
Fix source map for variables in ES5/3 async funcs and generators

### DIFF
--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -239,7 +239,7 @@ namespace ts {
         function hoistVariableDeclaration(name: Identifier): void {
             Debug.assert(state > TransformationState.Uninitialized, "Cannot modify the lexical environment during initialization.");
             Debug.assert(state < TransformationState.Completed, "Cannot modify the lexical environment after transformation has completed.");
-            const decl = createVariableDeclaration(name);
+            const decl = setEmitFlags(createVariableDeclaration(name), EmitFlags.NoNestedSourceMaps);
             if (!lexicalEnvironmentVariableDeclarations) {
                 lexicalEnvironmentVariableDeclarations = [decl];
             }

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -640,10 +640,13 @@ namespace ts {
                     return undefined;
                 }
 
-                return createStatement(
-                    inlineExpressions(
-                        map(variables, transformInitializedVariable)
-                    )
+                return setSourceMapRange(
+                    createStatement(
+                        inlineExpressions(
+                            map(variables, transformInitializedVariable)
+                        )
+                    ),
+                    node
                 );
             }
         }
@@ -1281,9 +1284,12 @@ namespace ts {
         }
 
         function transformInitializedVariable(node: VariableDeclaration) {
-            return createAssignment(
-                <Identifier>getSynthesizedClone(node.name),
-                visitNode(node.initializer, visitor, isExpression)
+            return setSourceMapRange(
+                createAssignment(
+                    setSourceMapRange(<Identifier>getSynthesizedClone(node.name), node.name),
+                    visitNode(node.initializer, visitor, isExpression)
+                ),
+                node
             );
         }
 

--- a/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.js
+++ b/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.js
@@ -1,0 +1,14 @@
+//// [sourceMapValidationVarInDownLevelGenerator.ts]
+function * f() {
+    var x = 1, y;
+}
+
+//// [sourceMapValidationVarInDownLevelGenerator.js]
+function f() {
+    var x, y;
+    return __generator(this, function (_a) {
+        x = 1;
+        return [2 /*return*/];
+    });
+}
+//# sourceMappingURL=sourceMapValidationVarInDownLevelGenerator.js.map

--- a/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.js.map
+++ b/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.js.map
@@ -1,0 +1,2 @@
+//// [sourceMapValidationVarInDownLevelGenerator.js.map]
+{"version":3,"file":"sourceMapValidationVarInDownLevelGenerator.js","sourceRoot":"","sources":["sourceMapValidationVarInDownLevelGenerator.ts"],"names":[],"mappings":"AAAA;;;QACQ,CAAC,GAAG,CAAC,CAAI;;;CAChB"}

--- a/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.sourcemap.txt
+++ b/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.sourcemap.txt
@@ -1,0 +1,47 @@
+===================================================================
+JsFile: sourceMapValidationVarInDownLevelGenerator.js
+mapUrl: sourceMapValidationVarInDownLevelGenerator.js.map
+sourceRoot: 
+sources: sourceMapValidationVarInDownLevelGenerator.ts
+===================================================================
+-------------------------------------------------------------------
+emittedFile:tests/cases/compiler/sourceMapValidationVarInDownLevelGenerator.js
+sourceFile:sourceMapValidationVarInDownLevelGenerator.ts
+-------------------------------------------------------------------
+>>>function f() {
+1 >
+2 >^^^^^^^^^^^^^^->
+1 >
+1 >Emitted(1, 1) Source(1, 1) + SourceIndex(0)
+---
+>>>    var x, y;
+>>>    return __generator(this, function (_a) {
+>>>        x = 1;
+1->^^^^^^^^
+2 >        ^
+3 >         ^^^
+4 >            ^
+5 >             ^
+6 >              ^^^^^^^^^^^^^^^^^->
+1->function * f() {
+  >    var 
+2 >        x
+3 >          = 
+4 >            1
+5 >             , y;
+1->Emitted(4, 9) Source(2, 9) + SourceIndex(0)
+2 >Emitted(4, 10) Source(2, 10) + SourceIndex(0)
+3 >Emitted(4, 13) Source(2, 13) + SourceIndex(0)
+4 >Emitted(4, 14) Source(2, 14) + SourceIndex(0)
+5 >Emitted(4, 15) Source(2, 18) + SourceIndex(0)
+---
+>>>        return [2 /*return*/];
+>>>    });
+>>>}
+1->^
+2 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+1->
+  >}
+1->Emitted(7, 2) Source(3, 2) + SourceIndex(0)
+---
+>>>//# sourceMappingURL=sourceMapValidationVarInDownLevelGenerator.js.map

--- a/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.symbols
+++ b/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/sourceMapValidationVarInDownLevelGenerator.ts ===
+function * f() {
+>f : Symbol(f, Decl(sourceMapValidationVarInDownLevelGenerator.ts, 0, 0))
+
+    var x = 1, y;
+>x : Symbol(x, Decl(sourceMapValidationVarInDownLevelGenerator.ts, 1, 7))
+>y : Symbol(y, Decl(sourceMapValidationVarInDownLevelGenerator.ts, 1, 14))
+}

--- a/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.types
+++ b/tests/baselines/reference/sourceMapValidationVarInDownLevelGenerator.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/sourceMapValidationVarInDownLevelGenerator.ts ===
+function * f() {
+>f : () => IterableIterator<any>
+
+    var x = 1, y;
+>x : number
+>1 : 1
+>y : any
+}

--- a/tests/cases/compiler/sourceMapValidationVarInDownLevelGenerator.ts
+++ b/tests/cases/compiler/sourceMapValidationVarInDownLevelGenerator.ts
@@ -1,0 +1,7 @@
+// @sourcemap: true
+// @downlevelIteration: true
+// @noEmitHelpers: true
+// @lib: es2015
+function * f() {
+    var x = 1, y;
+}


### PR DESCRIPTION
This change adjusts the source map offsets for rewritten variable declarations in async functions and generators for ES5/3

Fixes #14506
