### PR TITLE
Fix synthetic properties in hasExcessProperties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8977,7 +8977,9 @@ namespace ts {
                                     reportError(Diagnostics.Property_0_does_not_exist_on_type_1, symbolToString(prop), typeToString(target));
                                 }
                                 else {
-                                    errorNode = prop.valueDeclaration;
+                                    if (prop.valueDeclaration) {
+                                        errorNode = prop.valueDeclaration;
+                                    }
                                     reportError(Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
                                         symbolToString(prop), typeToString(target));
                                 }

--- a/tests/baselines/reference/excessPropertyCheckWithSpread.errors.txt
+++ b/tests/baselines/reference/excessPropertyCheckWithSpread.errors.txt
@@ -1,0 +1,30 @@
+tests/cases/compiler/excessPropertyCheckWithSpread.ts(6,3): error TS2345: Argument of type '{ n: number; a: number; }' is not assignable to parameter of type '{ a: any; }'.
+  Object literal may only specify known properties, and 'n' does not exist in type '{ a: any; }'.
+tests/cases/compiler/excessPropertyCheckWithSpread.ts(16,3): error TS2345: Argument of type '{ opt: string | number; a: number; }' is not assignable to parameter of type '{ a: any; }'.
+  Object literal may only specify known properties, and 'opt' does not exist in type '{ a: any; }'.
+
+
+==== tests/cases/compiler/excessPropertyCheckWithSpread.ts (2 errors) ====
+    declare function f({ a: number }): void
+    interface I {
+        readonly n: number;
+    }
+    declare let i: I;
+    f({ a: 1, ...i });
+      ~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ n: number; a: number; }' is not assignable to parameter of type '{ a: any; }'.
+!!! error TS2345:   Object literal may only specify known properties, and 'n' does not exist in type '{ a: any; }'.
+    
+    interface R {
+        opt?: number
+    }
+    interface L {
+        opt: string
+    }
+    declare let l: L;
+    declare let r: R;
+    f({ a: 1, ...l, ...r });
+      ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ opt: string | number; a: number; }' is not assignable to parameter of type '{ a: any; }'.
+!!! error TS2345:   Object literal may only specify known properties, and 'opt' does not exist in type '{ a: any; }'.
+    

--- a/tests/baselines/reference/excessPropertyCheckWithSpread.js
+++ b/tests/baselines/reference/excessPropertyCheckWithSpread.js
@@ -1,0 +1,30 @@
+//// [excessPropertyCheckWithSpread.ts]
+declare function f({ a: number }): void
+interface I {
+    readonly n: number;
+}
+declare let i: I;
+f({ a: 1, ...i });
+
+interface R {
+    opt?: number
+}
+interface L {
+    opt: string
+}
+declare let l: L;
+declare let r: R;
+f({ a: 1, ...l, ...r });
+
+
+//// [excessPropertyCheckWithSpread.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+f(__assign({ a: 1 }, i));
+f(__assign({ a: 1 }, l, r));

--- a/tests/cases/compiler/excessPropertyCheckWithSpread.ts
+++ b/tests/cases/compiler/excessPropertyCheckWithSpread.ts
@@ -1,0 +1,16 @@
+declare function f({ a: number }): void
+interface I {
+    readonly n: number;
+}
+declare let i: I;
+f({ a: 1, ...i });
+
+interface R {
+    opt?: number
+}
+interface L {
+    opt: string
+}
+declare let l: L;
+declare let r: R;
+f({ a: 1, ...l, ...r });


### PR DESCRIPTION
`hasExcessProperty` now only uses `valueDeclaration` for error reporting if available. Previously it would crash if `valueDeclaration` was not set; this happened with synthetic property symbols, specifically those created by `getSpreadType`. `getSpreadType` creates synthetic properties to remove `readonly` and to create union types when spreading an optional property into another property.

Fixes #16292