### PR TITLE
contain -> Contains, mark as internal

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -484,7 +484,7 @@ namespace ts {
         const newSourceFile = IncrementalParser.updateSourceFile(sourceFile, newText, textChangeRange, aggressiveChecks);
         // Because new source file node is created, it may not have the flag PossiblyContainDynamicImport. This is the case if there is no new edit to add dynamic import.
         // We will manually port the flag to the new source file.
-        newSourceFile.flags |= (sourceFile.flags & NodeFlags.PossiblyContainDynamicImport);
+        newSourceFile.flags |= (sourceFile.flags & NodeFlags.PossiblyContainsDynamicImport);
         return newSourceFile;
     }
 
@@ -3705,7 +3705,7 @@ namespace ts {
                 // For example:
                 //      var foo3 = require("subfolder
                 //      import * as foo1 from "module-from-node  -> we want this import to be a statement rather than import call expression
-                sourceFile.flags |= NodeFlags.PossiblyContainDynamicImport;
+                sourceFile.flags |= NodeFlags.PossiblyContainsDynamicImport;
                 expression = parseTokenNode<PrimaryExpression>();
             }
             else {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1379,7 +1379,7 @@ namespace ts {
 
             for (const node of file.statements) {
                 collectModuleReferences(node, /*inAmbientModule*/ false);
-                if ((file.flags & NodeFlags.PossiblyContainDynamicImport) || isJavaScriptFile) {
+                if ((file.flags & NodeFlags.PossiblyContainsDynamicImport) || isJavaScriptFile) {
                     collectDynamicImportOrRequireCalls(node);
                 }
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -451,13 +451,14 @@ namespace ts {
         ThisNodeOrAnySubNodesHasError = 1 << 17, // If this node or any of its children had an error
         HasAggregatedChildData = 1 << 18, // If we've computed data from children and cached it in this node
 
-        // This flag will be set to true when the parse encounter dynamic import so that post-parsing process of module resolution
-        // will not walk the tree if the flag is not set. However, this flag is just a approximation because once it is set, the flag never get reset.
-        // (hence it is named "possiblyContainDynamicImport").
+        // This flag will be set to true when the parser encounters a dynamic import expression so that post-parsing process of module resolution
+        // will not walk the tree if the flag is not set. However, this flag is just a approximation because once it is set, the flag never gets reset.
+        // (hence it is named "PossiblyContainsDynamicImport").
         // During editing, if dynamic import is remove, incremental parsing will *NOT* update this flag. This will then causes walking of the tree during module resolution.
         // However, the removal operation should not occur often and in the case of the removal, it is likely that users will add back the import anyway.
         // The advantage of this approach is its simplicity. For the case of batch compilation, we garuntee that users won't have to pay the price of walking the tree if dynamic import isn't used.
-        PossiblyContainDynamicImport = 1 << 19,
+        /* @internal */
+        PossiblyContainsDynamicImport = 1 << 19,
 
         BlockScoped = Let | Const,
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -451,12 +451,14 @@ namespace ts {
         ThisNodeOrAnySubNodesHasError = 1 << 17, // If this node or any of its children had an error
         HasAggregatedChildData = 1 << 18, // If we've computed data from children and cached it in this node
 
-        // This flag will be set to true when the parser encounters a dynamic import expression so that post-parsing process of module resolution
-        // will not walk the tree if the flag is not set. However, this flag is just a approximation because once it is set, the flag never gets reset.
-        // (hence it is named "PossiblyContainsDynamicImport").
-        // During editing, if dynamic import is remove, incremental parsing will *NOT* update this flag. This will then causes walking of the tree during module resolution.
-        // However, the removal operation should not occur often and in the case of the removal, it is likely that users will add back the import anyway.
-        // The advantage of this approach is its simplicity. For the case of batch compilation, we garuntee that users won't have to pay the price of walking the tree if dynamic import isn't used.
+        // This flag will be set when the parser encounters a dynamic import expression so that module resolution
+        // will not have to walk the tree if the flag is not set. However, this flag is just a approximation because
+        // once it is set, the flag never gets cleared (hence why it's named "PossiblyContainsDynamicImport").
+        // During editing, if dynamic import is removed, incremental parsing will *NOT* update this flag. This means that the tree will always be traversed
+        // during module resolution. However, the removal operation should not occur often and in the case of the
+        // removal, it is likely that users will add the import anyway.
+        // The advantage of this approach is its simplicity. For the case of batch compilation,
+        // we guarantee that users won't have to pay the price of walking the tree if a dynamic import isn't used.
         /* @internal */
         PossiblyContainsDynamicImport = 1 << 19,
 


### PR DESCRIPTION
I think the bigger thing here is that I don't think this NodeFlag should be public. It's not something API consumers should depend on.