### PR TITLE
Split import into var and type to avoid breaking backword compatability of tsserverlibrary

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -112,7 +112,13 @@ namespace ts.server {
         return true;
     }
 
-    export import CommandNames = protocol.CommandTypes;
+    // CommandNames used to be exposed before TS 2.4 as a namespace
+    // In TS 2.4 we switched to an enum, keep this for backward compatibility
+    // The var assignment ensures that even though CommandTypes are a const enum
+    // we want to ensure the value is maintained in the out since the file is
+    // built using --preseveConstEnum.
+    export type CommandNames = protocol.CommandTypes;
+    export const CommandNames = (<any>protocol).CommandTypes;
 
     export function formatMessage<T extends protocol.Message>(msg: T, logger: server.Logger, byteLength: (s: string, encoding: string) => number, newLine: string): string {
         const verboseLogging = logger.hasLevel(LogLevel.verbose);


### PR DESCRIPTION
We switched `CommandNames` from a namespace to a `const enum`. we have added an `import` alias declaration to cover that, but since it is a `const enum`, the import will be elided from the .js file. in https://github.com/Microsoft/TypeScript/pull/16381 I have removed the const label, this now uncovers the fact that `CommandNames` do not exisit in the generated JS. 

this change switches to use a type/var aliases to ensure it gets emitted in the .js file.

Fix #16393 