### PR TITLE
getPossibleSymbolReferencePositions: Always use full start

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -678,9 +678,7 @@ namespace ts.FindAllReferences.Core {
         return parent ? scope.getSourceFile() : scope;
     }
 
-    function getPossibleSymbolReferencePositions(sourceFile: SourceFile, symbolName: string, container: Node = sourceFile, fullStart = false): number[] {
-        const start = fullStart ? container.getFullStart() : container.getStart(sourceFile);
-        const end = container.getEnd();
+    function getPossibleSymbolReferencePositions(sourceFile: SourceFile, symbolName: string, container: Node = sourceFile): number[] {
         const positions: number[] = [];
 
         /// TODO: Cache symbol existence for files to save text search
@@ -695,10 +693,10 @@ namespace ts.FindAllReferences.Core {
         const sourceLength = text.length;
         const symbolNameLength = symbolName.length;
 
-        let position = text.indexOf(symbolName, start);
+        let position = text.indexOf(symbolName, container.pos);
         while (position >= 0) {
             // If we are past the end, stop looking
-            if (position > end) break;
+            if (position > container.end) break;
 
             // We found a match.  Make sure it's not part of a larger word (i.e. the char
             // before and after it have to be a non-identifier char).
@@ -759,8 +757,7 @@ namespace ts.FindAllReferences.Core {
     }
 
     function addReferencesForKeywordInFile(sourceFile: SourceFile, kind: SyntaxKind, searchText: string, references: Push<NodeEntry>): void {
-        // Want fullStart so we can find the symbol in JSDoc comments
-        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, searchText, sourceFile, /*fullStart*/ true);
+        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, searchText, sourceFile);
         for (const position of possiblePositions) {
             const referenceLocation = getTouchingPropertyName(sourceFile, position, /*includeJsDocComment*/ true);
             if (referenceLocation.kind === kind) {
@@ -784,8 +781,7 @@ namespace ts.FindAllReferences.Core {
             return;
         }
 
-        // Need to search in the full start of the node in case there is a reference inside JSDoc.
-        for (const position of getPossibleSymbolReferencePositions(sourceFile, search.text, container, /*fullStart*/ true)) {
+        for (const position of getPossibleSymbolReferencePositions(sourceFile, search.text, container)) {
             getReferencesAtLocation(sourceFile, position, search, state);
         }
     }


### PR DESCRIPTION
Now that we usually have to look through jsdoc for references, I don't think the extra code for getting the proper start is getting us any value. Any place where we don't remember to pass `fullStart` is an obscure bug waiting to happen.