### PR TITLE
Simplify isDeclarationNameOrImportPropertyName

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24818,13 +24818,9 @@ namespace ts {
         switch (name.parent.kind) {
             case SyntaxKind.ImportSpecifier:
             case SyntaxKind.ExportSpecifier:
-                if ((name.parent as ImportOrExportSpecifier).propertyName) {
-                    return true;
-                }
-                // falls through
+                return true;
             default:
                 return isDeclarationName(name);
-
         }
     }
 }


### PR DESCRIPTION
This code added in  #15741 is needlessly complicated. If our parent is an `ImportSpecifier` or `ExportSpecifier` and we're not the `propertyName`, we're the `name`, so `isDeclarationName` will always be true anyway.
