### PR TITLE
Rename `isTypeParameter` to `isTypeParameterDeclaration`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5981,7 +5981,7 @@ namespace ts {
                     typeParameter.default = targetDefault ? instantiateType(targetDefault, typeParameter.mapper) : noConstraintType;
                 }
                 else {
-                    const defaultDeclaration = typeParameter.symbol && forEach(typeParameter.symbol.declarations, decl => isTypeParameter(decl) && decl.default);
+                    const defaultDeclaration = typeParameter.symbol && forEach(typeParameter.symbol.declarations, decl => isTypeParameterDeclaration(decl) && decl.default);
                     typeParameter.default = defaultDeclaration ? getTypeFromTypeNode(defaultDeclaration) : noConstraintType;
                 }
             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4092,7 +4092,7 @@ namespace ts {
 
     // Signature elements
 
-    export function isTypeParameter(node: Node): node is TypeParameterDeclaration {
+    export function isTypeParameterDeclaration(node: Node): node is TypeParameterDeclaration {
         return node.kind === SyntaxKind.TypeParameter;
     }
 

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -275,7 +275,7 @@ namespace ts {
 
             case SyntaxKind.MethodSignature:
                 return updateMethodSignature(<MethodSignature>node,
-                    nodesVisitor((<MethodSignature>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<MethodSignature>node).typeParameters, visitor, isTypeParameterDeclaration),
                     nodesVisitor((<MethodSignature>node).parameters, visitor, isParameterDeclaration),
                     visitNode((<MethodSignature>node).type, visitor, isTypeNode),
                     visitNode((<MethodSignature>node).name, visitor, isPropertyName),
@@ -288,7 +288,7 @@ namespace ts {
                     visitNode((<MethodDeclaration>node).asteriskToken, tokenVisitor, isToken),
                     visitNode((<MethodDeclaration>node).name, visitor, isPropertyName),
                     visitNode((<MethodDeclaration>node).questionToken, tokenVisitor, isToken),
-                    nodesVisitor((<MethodDeclaration>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<MethodDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
                     visitParameterList((<MethodDeclaration>node).parameters, visitor, context, nodesVisitor),
                     visitNode((<MethodDeclaration>node).type, visitor, isTypeNode),
                     visitFunctionBody((<MethodDeclaration>node).body, visitor, context));
@@ -319,13 +319,13 @@ namespace ts {
 
             case SyntaxKind.CallSignature:
                 return updateCallSignature(<CallSignatureDeclaration>node,
-                    nodesVisitor((<CallSignatureDeclaration>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<CallSignatureDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
                     nodesVisitor((<CallSignatureDeclaration>node).parameters, visitor, isParameterDeclaration),
                     visitNode((<CallSignatureDeclaration>node).type, visitor, isTypeNode));
 
             case SyntaxKind.ConstructSignature:
                 return updateConstructSignature(<ConstructSignatureDeclaration>node,
-                    nodesVisitor((<ConstructSignatureDeclaration>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<ConstructSignatureDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
                     nodesVisitor((<ConstructSignatureDeclaration>node).parameters, visitor, isParameterDeclaration),
                     visitNode((<ConstructSignatureDeclaration>node).type, visitor, isTypeNode));
 
@@ -350,13 +350,13 @@ namespace ts {
 
             case SyntaxKind.FunctionType:
                 return updateFunctionTypeNode(<FunctionTypeNode>node,
-                    nodesVisitor((<FunctionTypeNode>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<FunctionTypeNode>node).typeParameters, visitor, isTypeParameterDeclaration),
                     nodesVisitor((<FunctionTypeNode>node).parameters, visitor, isParameterDeclaration),
                     visitNode((<FunctionTypeNode>node).type, visitor, isTypeNode));
 
             case SyntaxKind.ConstructorType:
                 return updateConstructorTypeNode(<ConstructorTypeNode>node,
-                    nodesVisitor((<ConstructorTypeNode>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<ConstructorTypeNode>node).typeParameters, visitor, isTypeParameterDeclaration),
                     nodesVisitor((<ConstructorTypeNode>node).parameters, visitor, isParameterDeclaration),
                     visitNode((<ConstructorTypeNode>node).type, visitor, isTypeNode));
 
@@ -400,7 +400,7 @@ namespace ts {
             case SyntaxKind.MappedType:
                 return updateMappedTypeNode((<MappedTypeNode>node),
                     visitNode((<MappedTypeNode>node).readonlyToken, tokenVisitor, isToken),
-                    visitNode((<MappedTypeNode>node).typeParameter, visitor, isTypeParameter),
+                    visitNode((<MappedTypeNode>node).typeParameter, visitor, isTypeParameterDeclaration),
                     visitNode((<MappedTypeNode>node).questionToken, tokenVisitor, isToken),
                     visitNode((<MappedTypeNode>node).type, visitor, isTypeNode));
 
@@ -476,7 +476,7 @@ namespace ts {
                     nodesVisitor((<FunctionExpression>node).modifiers, visitor, isModifier),
                     visitNode((<FunctionExpression>node).asteriskToken, tokenVisitor, isToken),
                     visitNode((<FunctionExpression>node).name, visitor, isIdentifier),
-                    nodesVisitor((<FunctionExpression>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<FunctionExpression>node).typeParameters, visitor, isTypeParameterDeclaration),
                     visitParameterList((<FunctionExpression>node).parameters, visitor, context, nodesVisitor),
                     visitNode((<FunctionExpression>node).type, visitor, isTypeNode),
                     visitFunctionBody((<FunctionExpression>node).body, visitor, context));
@@ -484,7 +484,7 @@ namespace ts {
             case SyntaxKind.ArrowFunction:
                 return updateArrowFunction(<ArrowFunction>node,
                     nodesVisitor((<ArrowFunction>node).modifiers, visitor, isModifier),
-                    nodesVisitor((<ArrowFunction>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<ArrowFunction>node).typeParameters, visitor, isTypeParameterDeclaration),
                     visitParameterList((<ArrowFunction>node).parameters, visitor, context, nodesVisitor),
                     visitNode((<ArrowFunction>node).type, visitor, isTypeNode),
                     visitFunctionBody((<ArrowFunction>node).body, visitor, context));
@@ -543,7 +543,7 @@ namespace ts {
                 return updateClassExpression(<ClassExpression>node,
                     nodesVisitor((<ClassExpression>node).modifiers, visitor, isModifier),
                     visitNode((<ClassExpression>node).name, visitor, isIdentifier),
-                    nodesVisitor((<ClassExpression>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<ClassExpression>node).typeParameters, visitor, isTypeParameterDeclaration),
                     nodesVisitor((<ClassExpression>node).heritageClauses, visitor, isHeritageClause),
                     nodesVisitor((<ClassExpression>node).members, visitor, isClassElement));
 
@@ -676,7 +676,7 @@ namespace ts {
                     nodesVisitor((<FunctionDeclaration>node).modifiers, visitor, isModifier),
                     visitNode((<FunctionDeclaration>node).asteriskToken, tokenVisitor, isToken),
                     visitNode((<FunctionDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<FunctionDeclaration>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<FunctionDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
                     visitParameterList((<FunctionDeclaration>node).parameters, visitor, context, nodesVisitor),
                     visitNode((<FunctionDeclaration>node).type, visitor, isTypeNode),
                     visitFunctionBody((<FunctionExpression>node).body, visitor, context));
@@ -686,7 +686,7 @@ namespace ts {
                     nodesVisitor((<ClassDeclaration>node).decorators, visitor, isDecorator),
                     nodesVisitor((<ClassDeclaration>node).modifiers, visitor, isModifier),
                     visitNode((<ClassDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<ClassDeclaration>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<ClassDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
                     nodesVisitor((<ClassDeclaration>node).heritageClauses, visitor, isHeritageClause),
                     nodesVisitor((<ClassDeclaration>node).members, visitor, isClassElement));
 
@@ -695,7 +695,7 @@ namespace ts {
                     nodesVisitor((<InterfaceDeclaration>node).decorators, visitor, isDecorator),
                     nodesVisitor((<InterfaceDeclaration>node).modifiers, visitor, isModifier),
                     visitNode((<InterfaceDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<InterfaceDeclaration>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<InterfaceDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
                     nodesVisitor((<InterfaceDeclaration>node).heritageClauses, visitor, isHeritageClause),
                     nodesVisitor((<InterfaceDeclaration>node).members, visitor, isTypeElement));
 
@@ -704,7 +704,7 @@ namespace ts {
                     nodesVisitor((<TypeAliasDeclaration>node).decorators, visitor, isDecorator),
                     nodesVisitor((<TypeAliasDeclaration>node).modifiers, visitor, isModifier),
                     visitNode((<TypeAliasDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<TypeAliasDeclaration>node).typeParameters, visitor, isTypeParameter),
+                    nodesVisitor((<TypeAliasDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
                     visitNode((<TypeAliasDeclaration>node).type, visitor, isTypeNode));
 
             case SyntaxKind.EnumDeclaration:


### PR DESCRIPTION
This is technically a public API breaking change, but it's only been there since #16121.
This makes the function more in line with `isConstructorDeclaration`, `isTypePredicateNode`, and others. We should use the name of the *type*, not the name of the syntax kind.
@mhegazy I'd like to get this in for ts2.4.1.