### PR TITLE
getResolvedModule: Don't need to call hasResolvedModule

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -3910,7 +3910,8 @@ namespace ts {
     export function getExternalModuleNameLiteral(importNode: ImportDeclaration | ExportDeclaration | ImportEqualsDeclaration, sourceFile: SourceFile, host: EmitHost, resolver: EmitResolver, compilerOptions: CompilerOptions) {
         const moduleName = getExternalModuleName(importNode);
         if (moduleName.kind === SyntaxKind.StringLiteral) {
-            return tryGetModuleNameFromDeclaration(importNode, host, resolver, compilerOptions)
+            // Can't get module name from declaration if importNode is synthesized.
+            return importNode.parent && tryGetModuleNameFromDeclaration(importNode, host, resolver, compilerOptions)
                 || tryRenameExternalModule(<StringLiteral>moduleName, sourceFile)
                 || getSynthesizedClone(<StringLiteral>moduleName);
         }

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -3910,8 +3910,7 @@ namespace ts {
     export function getExternalModuleNameLiteral(importNode: ImportDeclaration | ExportDeclaration | ImportEqualsDeclaration, sourceFile: SourceFile, host: EmitHost, resolver: EmitResolver, compilerOptions: CompilerOptions) {
         const moduleName = getExternalModuleName(importNode);
         if (moduleName.kind === SyntaxKind.StringLiteral) {
-            // Can't get module name from declaration if importNode is synthesized.
-            return importNode.parent && tryGetModuleNameFromDeclaration(importNode, host, resolver, compilerOptions)
+            return tryGetModuleNameFromDeclaration(importNode, host, resolver, compilerOptions)
                 || tryRenameExternalModule(<StringLiteral>moduleName, sourceFile)
                 || getSynthesizedClone(<StringLiteral>moduleName);
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -84,12 +84,8 @@ namespace ts {
         return node.end - node.pos;
     }
 
-    export function hasResolvedModule(sourceFile: SourceFile, moduleNameText: string): boolean {
-        return !!(sourceFile && sourceFile.resolvedModules && sourceFile.resolvedModules.get(moduleNameText));
-    }
-
-    export function getResolvedModule(sourceFile: SourceFile, moduleNameText: string): ResolvedModuleFull {
-        return hasResolvedModule(sourceFile, moduleNameText) ? sourceFile.resolvedModules.get(moduleNameText) : undefined;
+    export function getResolvedModule(sourceFile: SourceFile, moduleNameText: string): ResolvedModuleFull | undefined {
+        return sourceFile.resolvedModules && sourceFile.resolvedModules.get(moduleNameText);
     }
 
     export function setResolvedModule(sourceFile: SourceFile, moduleNameText: string, resolvedModule: ResolvedModuleFull): void {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -85,7 +85,7 @@ namespace ts {
     }
 
     export function getResolvedModule(sourceFile: SourceFile, moduleNameText: string): ResolvedModuleFull | undefined {
-        return sourceFile.resolvedModules && sourceFile.resolvedModules.get(moduleNameText);
+        return sourceFile && sourceFile.resolvedModules && sourceFile.resolvedModules.get(moduleNameText);
     }
 
     export function setResolvedModule(sourceFile: SourceFile, moduleNameText: string, resolvedModule: ResolvedModuleFull): void {


### PR DESCRIPTION
Wise men say: Don't ask to ask, just ask.
`hasResolvedModule` is internal and unused.
This doesn't seem to be called with potentially undefined inputs anywhere.