### PR TITLE
Convert Extension to a string enum

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2131,13 +2131,13 @@ namespace ts {
     export function getScriptKindFromFileName(fileName: string): ScriptKind {
         const ext = fileName.substr(fileName.lastIndexOf("."));
         switch (ext.toLowerCase()) {
-            case ".js":
+            case Extension.Js:
                 return ScriptKind.JS;
-            case ".jsx":
+            case Extension.Jsx:
                 return ScriptKind.JSX;
-            case ".ts":
+            case Extension.Ts:
                 return ScriptKind.TS;
-            case ".tsx":
+            case Extension.Tsx:
                 return ScriptKind.TSX;
             default:
                 return ScriptKind.Unknown;
@@ -2147,10 +2147,10 @@ namespace ts {
     /**
      *  List of supported extensions in order of file resolution precedence.
      */
-    export const supportedTypeScriptExtensions = [".ts", ".tsx", ".d.ts"];
+    export const supportedTypeScriptExtensions = [Extension.Ts, Extension.Tsx, Extension.Dts];
     /** Must have ".d.ts" first because if ".ts" goes first, that will be detected as the extension instead of ".d.ts". */
-    export const supportedTypescriptExtensionsForExtractExtension = [".d.ts", ".ts", ".tsx"];
-    export const supportedJavascriptExtensions = [".js", ".jsx"];
+    export const supportedTypescriptExtensionsForExtractExtension = [Extension.Dts, Extension.Ts, Extension.Tsx];
+    export const supportedJavascriptExtensions = [Extension.Js, Extension.Jsx];
     const allSupportedExtensions = supportedTypeScriptExtensions.concat(supportedJavascriptExtensions);
 
     export function getSupportedExtensions(options?: CompilerOptions, extraFileExtensions?: JsFileExtensionInfo[]): string[] {
@@ -2158,7 +2158,7 @@ namespace ts {
         if (!extraFileExtensions || extraFileExtensions.length === 0 || !needAllExtensions) {
             return needAllExtensions ? allSupportedExtensions : supportedTypeScriptExtensions;
         }
-        const extensions = allSupportedExtensions.slice(0);
+        const extensions: string[] = allSupportedExtensions.slice(0);
         for (const extInfo of extraFileExtensions) {
             if (extensions.indexOf(extInfo.extension) === -1) {
                 extensions.push(extInfo.extension);
@@ -2237,7 +2237,7 @@ namespace ts {
         }
     }
 
-    const extensionsToRemove = [".d.ts", ".ts", ".js", ".tsx", ".jsx"];
+    const extensionsToRemove = [Extension.Dts, Extension.Ts, Extension.Js, Extension.Tsx, Extension.Jsx];
     export function removeFileExtension(path: string): string {
         for (const ext of extensionsToRemove) {
             const extensionless = tryRemoveExtension(path, ext);
@@ -2491,7 +2491,7 @@ namespace ts {
 
     /** True if an extension is one of the supported TypeScript extensions. */
     export function extensionIsTypeScript(ext: Extension): boolean {
-        return ext <= Extension.LastTypeScriptExtension;
+        return ext === Extension.Ts || ext === Extension.Tsx || ext === Extension.Dts;
     }
 
     /**
@@ -2506,21 +2506,7 @@ namespace ts {
         Debug.fail(`File ${path} has unknown extension.`);
     }
     export function tryGetExtensionFromPath(path: string): Extension | undefined {
-        if (fileExtensionIs(path, ".d.ts")) {
-            return Extension.Dts;
-        }
-        if (fileExtensionIs(path, ".ts")) {
-            return Extension.Ts;
-        }
-        if (fileExtensionIs(path, ".tsx")) {
-            return Extension.Tsx;
-        }
-        if (fileExtensionIs(path, ".js")) {
-            return Extension.Js;
-        }
-        if (fileExtensionIs(path, ".jsx")) {
-            return Extension.Jsx;
-        }
+        return find(supportedTypescriptExtensionsForExtractExtension, e => fileExtensionIs(path, e)) || find(supportedJavascriptExtensions, e => fileExtensionIs(path, e));
     }
 
     export function isCheckJsEnabledForFile(sourceFile: SourceFile, compilerOptions: CompilerOptions) {

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -815,15 +815,15 @@ namespace ts {
 
         switch (extensions) {
             case Extensions.DtsOnly:
-                return tryExtension(".d.ts", Extension.Dts);
+                return tryExtension(Extension.Dts);
             case Extensions.TypeScript:
-                return tryExtension(".ts", Extension.Ts) || tryExtension(".tsx", Extension.Tsx) || tryExtension(".d.ts", Extension.Dts);
+                return tryExtension(Extension.Ts) || tryExtension(Extension.Tsx) || tryExtension(Extension.Dts);
             case Extensions.JavaScript:
-                return tryExtension(".js", Extension.Js) || tryExtension(".jsx", Extension.Jsx);
+                return tryExtension(Extension.Js) || tryExtension(Extension.Jsx);
         }
 
-        function tryExtension(ext: string, extension: Extension): Resolved | undefined {
-            const path = tryFile(candidate + ext, failedLookupLocations, onlyRecordFailures, state);
+        function tryExtension(extension: Extension): Resolved | undefined {
+            const path = tryFile(candidate + extension, failedLookupLocations, onlyRecordFailures, state);
             return path && { path, extension };
         }
     }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -764,7 +764,7 @@ namespace ts {
             sourceFile.languageVersion = languageVersion;
             sourceFile.fileName = normalizePath(fileName);
             sourceFile.languageVariant = getLanguageVariant(scriptKind);
-            sourceFile.isDeclarationFile = fileExtensionIs(sourceFile.fileName, ".d.ts");
+            sourceFile.isDeclarationFile = fileExtensionIs(sourceFile.fileName, Extension.Dts);
             sourceFile.scriptKind = scriptKind;
 
             return sourceFile;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1495,7 +1495,7 @@ namespace ts {
                 }
 
                 const sourceFileWithAddedExtension = forEach(supportedExtensions, extension => getSourceFile(fileName + extension));
-                if (fail && !sourceFileWithAddedExtension) fail(Diagnostics.File_0_not_found, fileName + ".ts");
+                if (fail && !sourceFileWithAddedExtension) fail(Diagnostics.File_0_not_found, fileName + Extension.Ts);
                 return sourceFileWithAddedExtension;
             }
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3881,13 +3881,12 @@ namespace ts {
         extension: Extension;
     }
 
-    export enum Extension {
-        Ts,
-        Tsx,
-        Dts,
-        Js,
-        Jsx,
-        LastTypeScriptExtension = Dts
+    export const enum Extension {
+        Ts = ".ts",
+        Tsx = ".tsx",
+        Dts = ".d.ts",
+        Js = ".js",
+        Jsx = ".jsx"
     }
 
     export interface ResolvedModuleWithFailedLookupLocations {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2495,7 +2495,7 @@ namespace ts {
         const path = outputDir
             ? getSourceFilePathInNewDir(sourceFile, host, outputDir)
             : sourceFile.fileName;
-        return removeFileExtension(path) + ".d.ts";
+        return removeFileExtension(path) + Extension.Dts;
     }
 
     export interface EmitFileNames {
@@ -2554,7 +2554,7 @@ namespace ts {
             if (sourceFiles.length) {
                 const jsFilePath = options.outFile || options.out;
                 const sourceMapFilePath = getSourceMapFilePath(jsFilePath, options);
-                const declarationFilePath = options.declaration ? removeFileExtension(jsFilePath) + ".d.ts" : "";
+                const declarationFilePath = options.declaration ? removeFileExtension(jsFilePath) + Extension.Dts : "";
                 action({ jsFilePath, sourceMapFilePath, declarationFilePath }, createBundle(sourceFiles), emitOnlyDtsFiles);
             }
         }
@@ -2575,19 +2575,19 @@ namespace ts {
     // JavaScript files are always LanguageVariant.JSX, as JSX syntax is allowed in .js files also.
     // So for JavaScript files, '.jsx' is only emitted if the input was '.jsx', and JsxEmit.Preserve.
     // For TypeScript, the only time to emit with a '.jsx' extension, is on JSX input, and JsxEmit.Preserve
-    function getOutputExtension(sourceFile: SourceFile, options: CompilerOptions): string {
+    function getOutputExtension(sourceFile: SourceFile, options: CompilerOptions): Extension {
         if (options.jsx === JsxEmit.Preserve) {
             if (isSourceFileJavaScript(sourceFile)) {
-                if (fileExtensionIs(sourceFile.fileName, ".jsx")) {
-                    return ".jsx";
+                if (fileExtensionIs(sourceFile.fileName, Extension.Jsx)) {
+                    return Extension.Jsx;
                 }
             }
             else if (sourceFile.languageVariant === LanguageVariant.JSX) {
                 // TypeScript source file preserving JSX syntax
-                return ".jsx";
+                return Extension.Jsx;
             }
         }
-        return ".js";
+        return Extension.Js;
     }
 
     export function getSourceFilePathInNewDir(sourceFile: SourceFile, host: EmitHost, newDirPath: string) {

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -90,7 +90,7 @@ class CompilerBaselineRunner extends RunnerBase {
                 }
 
                 lastUnit = units[units.length - 1];
-                hasNonDtsFiles = ts.forEach(units, unit => !ts.fileExtensionIs(unit.name, ".d.ts"));
+                hasNonDtsFiles = ts.forEach(units, unit => !ts.fileExtensionIs(unit.name, ts.Extension.Dts));
                 // We need to assemble the list of input files for the compiler and other related files on the 'filesystem' (ie in a multi-file test)
                 // If the last file in a test uses require or a triple slash reference we'll assume all other files will be brought in via references,
                 // otherwise, assume all files are just meant to be in the same compilation session without explicit references to one another.

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1459,7 +1459,7 @@ namespace FourSlash {
             let baselineFile = this.testData.globalOptions[metadataOptionNames.baselineFile];
             if (!baselineFile) {
                 baselineFile = this.activeFile.fileName.replace(this.basePath + "/breakpointValidation", "bpSpan");
-                baselineFile = baselineFile.replace(".ts", ".baseline");
+                baselineFile = baselineFile.replace(ts.Extension.Ts, ".baseline");
 
             }
             Harness.Baseline.runBaseline(
@@ -1529,7 +1529,7 @@ namespace FourSlash {
         public baselineQuickInfo() {
             let baselineFile = this.testData.globalOptions[metadataOptionNames.baselineFile];
             if (!baselineFile) {
-                baselineFile = ts.getBaseFileName(this.activeFile.fileName).replace(".ts", ".baseline");
+                baselineFile = ts.getBaseFileName(this.activeFile.fileName).replace(ts.Extension.Ts, ".baseline");
             }
 
             Harness.Baseline.runBaseline(

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1249,7 +1249,7 @@ namespace Harness {
                     sourceFileName = outFile;
                 }
 
-                const dTsFileName = ts.removeFileExtension(sourceFileName) + ".d.ts";
+                const dTsFileName = ts.removeFileExtension(sourceFileName) + ts.Extension.Dts;
 
                 return ts.forEach(result.declFilesCode, declFile => declFile.fileName === dTsFileName ? declFile : undefined);
             }
@@ -1465,7 +1465,7 @@ namespace Harness {
                 // When calling this function from rwc-runner, the baselinePath will have no extension.
                 // As rwc test- file is stored in json which ".json" will get stripped off.
                 // When calling this function from compiler-runner, the baselinePath will then has either ".ts" or ".tsx" extension
-                const outputFileName = ts.endsWith(baselinePath, ".ts") || ts.endsWith(baselinePath, ".tsx") ?
+                const outputFileName = ts.endsWith(baselinePath, ts.Extension.Ts) || ts.endsWith(baselinePath, ts.Extension.Tsx) ?
                     baselinePath.replace(/\.tsx?/, fullExtension) : baselinePath.concat(fullExtension);
                 Harness.Baseline.runBaseline(outputFileName, () => fullBaseLine, opts);
             }
@@ -1563,7 +1563,7 @@ namespace Harness {
             }
 
             // check js output
-            Harness.Baseline.runBaseline(baselinePath.replace(/\.tsx?/, ".js"), () => {
+            Harness.Baseline.runBaseline(baselinePath.replace(/\.tsx?/, ts.Extension.Js), () => {
                 let tsCode = "";
                 const tsSources = otherFiles.concat(toBeCompiled);
                 if (tsSources.length > 1) {
@@ -1651,22 +1651,22 @@ namespace Harness {
         }
 
         export function isTS(fileName: string) {
-            return ts.endsWith(fileName, ".ts");
+            return ts.endsWith(fileName, ts.Extension.Ts);
         }
 
         export function isTSX(fileName: string) {
-            return ts.endsWith(fileName, ".tsx");
+            return ts.endsWith(fileName, ts.Extension.Tsx);
         }
 
         export function isDTS(fileName: string) {
-            return ts.endsWith(fileName, ".d.ts");
+            return ts.endsWith(fileName, ts.Extension.Dts);
         }
 
         export function isJS(fileName: string) {
-            return ts.endsWith(fileName, ".js");
+            return ts.endsWith(fileName, ts.Extension.Js);
         }
         export function isJSX(fileName: string) {
-            return ts.endsWith(fileName, ".jsx");
+            return ts.endsWith(fileName, ts.Extension.Jsx);
         }
 
         export function isJSMap(fileName: string) {
@@ -1973,7 +1973,7 @@ namespace Harness {
     export function isDefaultLibraryFile(filePath: string): boolean {
         // We need to make sure that the filePath is prefixed with "lib." not just containing "lib." and end with ".d.ts"
         const fileName = ts.getBaseFileName(ts.normalizeSlashes(filePath));
-        return ts.startsWith(fileName, "lib.") && ts.endsWith(fileName, ".d.ts");
+        return ts.startsWith(fileName, "lib.") && ts.endsWith(fileName, ts.Extension.Dts);
     }
 
     export function isBuiltFile(filePath: string): boolean {

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -325,8 +325,8 @@ class ProjectRunner extends RunnerBase {
                     // we need to instead create files that can live in the project reference folder
                     // but make sure extension of these files matches with the fileName the compiler asked to write
                     diskRelativeName = "diskFile" + nonSubfolderDiskFiles +
-                    (Harness.Compiler.isDTS(fileName) ? ".d.ts" :
-                    Harness.Compiler.isJS(fileName) ? ".js" : ".js.map");
+                    (Harness.Compiler.isDTS(fileName) ? ts.Extension.Dts :
+                    Harness.Compiler.isJS(fileName) ? ts.Extension.Js : ".js.map");
                     nonSubfolderDiskFiles++;
                 }
 
@@ -386,14 +386,14 @@ class ProjectRunner extends RunnerBase {
                         emitOutputFilePathWithoutExtension = ts.removeFileExtension(sourceFile.fileName);
                     }
 
-                    const outputDtsFileName = emitOutputFilePathWithoutExtension + ".d.ts";
+                    const outputDtsFileName = emitOutputFilePathWithoutExtension + ts.Extension.Dts;
                     const file = findOutputDtsFile(outputDtsFileName);
                     if (file) {
                         allInputFiles.unshift(file);
                     }
                 }
                 else {
-                    const outputDtsFileName = ts.removeFileExtension(compilerOptions.outFile || compilerOptions.out) + ".d.ts";
+                    const outputDtsFileName = ts.removeFileExtension(compilerOptions.outFile || compilerOptions.out) + ts.Extension.Dts;
                     const outputDtsFile = findOutputDtsFile(outputDtsFileName);
                     if (!ts.contains(allInputFiles, outputDtsFile)) {
                         allInputFiles.unshift(outputDtsFile);

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -513,7 +513,7 @@ namespace ts.projectSystem {
                 const lines = ["var x = 1;", "var y = 2;"];
                 const path = "/a/app";
                 const f = {
-                    path: path + ".ts",
+                    path: path + ts.Extension.Ts,
                     content: lines.join(newLine)
                 };
                 const host = createServerHost([f], { newLine });
@@ -530,7 +530,7 @@ namespace ts.projectSystem {
                     command: "compileOnSaveEmitFile",
                     arguments: { file: f.path }
                 });
-                const emitOutput = host.readFile(path + ".js");
+                const emitOutput = host.readFile(path + ts.Extension.Js);
                 assert.equal(emitOutput, f.content + newLine, "content of emit output should be identical with the input + newline");
             }
         });

--- a/src/harness/unittests/moduleResolution.ts
+++ b/src/harness/unittests/moduleResolution.ts
@@ -5,7 +5,7 @@ namespace ts {
         if (!expected === !actual) {
             if (expected) {
                 assert.isTrue(expected.resolvedFileName === actual.resolvedFileName, `'resolvedFileName': expected '${expected.resolvedFileName}' to be equal to '${actual.resolvedFileName}'`);
-                assert.isTrue(expected.extension === actual.extension, `'ext': expected '${Extension[expected.extension]}' to be equal to '${Extension[actual.extension]}'`);
+                assert.isTrue(expected.extension === actual.extension, `'ext': expected '${expected.extension}' to be equal to '${actual.extension}'`);
                 assert.isTrue(expected.isExternalLibraryImport === actual.isExternalLibraryImport, `'isExternalLibraryImport': expected '${expected.isExternalLibraryImport}' to be equal to '${actual.isExternalLibraryImport}'`);
             }
             return true;

--- a/src/harness/unittests/transpile.ts
+++ b/src/harness/unittests/transpile.ts
@@ -36,7 +36,7 @@ namespace ts {
 
                     transpileOptions.reportDiagnostics = true;
 
-                    justName = "transpile/" + name.replace(/[^a-z0-9\-. ]/ig, "") + (transpileOptions.compilerOptions.jsx ? ".tsx" : ".ts");
+                    justName = "transpile/" + name.replace(/[^a-z0-9\-. ]/ig, "") + (transpileOptions.compilerOptions.jsx ? Extension.Tsx : Extension.Ts);
                     toBeCompiled = [{
                         unitName: transpileOptions.fileName,
                         content: input
@@ -88,7 +88,7 @@ namespace ts {
                 }
 
                 it("Correct output for " + justName, () => {
-                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".js"), () => {
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ts.Extension.Js), () => {
                         if (transpileResult.outputText) {
                             return transpileResult.outputText;
                         }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -25,7 +25,7 @@ namespace ts.server {
                     result.jsx += 1;
                     break;
                 case ScriptKind.TS:
-                    fileExtensionIs(info.fileName, ".d.ts")
+                    fileExtensionIs(info.fileName, Extension.Dts)
                         ? result.dts += 1
                         : result.ts += 1;
                     break;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1569,7 +1569,7 @@ namespace ts.server {
                 else {
                     const info = this.projectService.getScriptInfo(fileNameInProject);
                     if (!info.isScriptOpen()) {
-                        if (fileNameInProject.indexOf(".d.ts") > 0) {
+                        if (fileNameInProject.indexOf(Extension.Dts) > 0) {
                             veryLowPriorityFiles.push(fileNameInProject);
                         }
                         else {

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -10,7 +10,7 @@ namespace ts.NavigateTo {
         for (const sourceFile of sourceFiles) {
             cancellationToken.throwIfCancellationRequested();
 
-            if (excludeDtsFiles && fileExtensionIs(sourceFile.fileName, ".d.ts")) {
+            if (excludeDtsFiles && fileExtensionIs(sourceFile.fileName, Extension.Dts)) {
                 continue;
             }
 


### PR DESCRIPTION
This should be backwards-compatible so long as people are accessing it as `Extension.Ts` and not `0`.