### PR TITLE
Suppress brace completion of Quotes in Comments

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -1117,25 +1117,6 @@ namespace ts.formatting {
         }
     }
 
-    export function getRangeOfEnclosingComment(sourceFile: SourceFile, position: number, onlyMultiLine: boolean): CommentRange | undefined {
-        const precedingToken = findPrecedingToken(position, sourceFile);
-        const trailingRangesOfPreviousToken = precedingToken && getTrailingCommentRanges(sourceFile.text, precedingToken.end);
-        const leadingCommentRangesOfNextToken = getLeadingCommentRangesOfNode(getTokenAtPosition(sourceFile, position, /*includeJsDocComment*/ false), sourceFile);
-        const commentRanges = trailingRangesOfPreviousToken && leadingCommentRangesOfNextToken ?
-            trailingRangesOfPreviousToken.concat(leadingCommentRangesOfNextToken) :
-            trailingRangesOfPreviousToken || leadingCommentRangesOfNextToken;
-        if (commentRanges) {
-            for (const range of commentRanges) {
-                // We need to extend the range when in an unclosed multi-line comment.
-                if (range.pos < position && position < range.end ||
-                    position === range.end && (range.kind === SyntaxKind.SingleLineCommentTrivia || position === sourceFile.getFullWidth())) {
-                    return onlyMultiLine && range.kind !== SyntaxKind.MultiLineCommentTrivia ? undefined : range;
-                }
-            }
-        }
-        return undefined;
-    }
-
     function getOpenTokenForList(node: Node, list: Node[]) {
         switch (node.kind) {
             case SyntaxKind.Constructor:

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -1117,6 +1117,25 @@ namespace ts.formatting {
         }
     }
 
+    export function getRangeOfEnclosingComment(sourceFile: SourceFile, position: number, onlyMultiLine: boolean): CommentRange | undefined {
+        const precedingToken = findPrecedingToken(position, sourceFile);
+        const trailingRangesOfPreviousToken = precedingToken && getTrailingCommentRanges(sourceFile.text, precedingToken.end);
+        const leadingCommentRangesOfNextToken = getLeadingCommentRangesOfNode(getTokenAtPosition(sourceFile, position, /*includeJsDocComment*/ false), sourceFile);
+        const commentRanges = trailingRangesOfPreviousToken && leadingCommentRangesOfNextToken ?
+            trailingRangesOfPreviousToken.concat(leadingCommentRangesOfNextToken) :
+            trailingRangesOfPreviousToken || leadingCommentRangesOfNextToken;
+        if (commentRanges) {
+            for (const range of commentRanges) {
+                // We need to extend the range when in an unclosed multi-line comment.
+                if (range.pos < position && position < range.end ||
+                    position === range.end && (range.kind === SyntaxKind.SingleLineCommentTrivia || position === sourceFile.getFullWidth())) {
+                    return onlyMultiLine && range.kind !== SyntaxKind.MultiLineCommentTrivia ? undefined : range;
+                }
+            }
+        }
+        return undefined;
+    }
+
     function getOpenTokenForList(node: Node, list: Node[]) {
         switch (node.kind) {
             case SyntaxKind.Constructor:

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1826,7 +1826,7 @@ namespace ts {
                 case CharacterCodes.singleQuote:
                 case CharacterCodes.doubleQuote:
                 case CharacterCodes.backtick:
-                    return !ts.formatting.getRangeOfEnclosingComment(sourceFile, position, /*onlyMultiLine*/ false);
+                    return !isInComment(sourceFile, position);
             }
 
             return true;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1822,6 +1822,13 @@ namespace ts {
                 return false;
             }
 
+            switch (openingBrace) {
+                case CharacterCodes.singleQuote:
+                case CharacterCodes.doubleQuote:
+                case CharacterCodes.backtick:
+                    return !ts.formatting.getRangeOfEnclosingComment(sourceFile, position, /*onlyMultiLine*/ false);
+            }
+
             return true;
         }
 

--- a/tests/cases/fourslash/commentBraceCompletionPosition.ts
+++ b/tests/cases/fourslash/commentBraceCompletionPosition.ts
@@ -7,8 +7,8 @@
 ////     // inside regular comment /*2*/
 ////     var c = "";
 ////
-////    /* inside multi-
-////       line comment /*3*/ 
+////    /*3*//* inside /*4*/multi-
+////       line comment /*5*/ 
 ////    */
 ////    var y =12;
 //// }
@@ -24,5 +24,13 @@ verify.isValidBraceCompletionAtPosition('(');
 verify.not.isValidBraceCompletionAtPosition('"');
 
 goTo.marker('3');
+verify.isValidBraceCompletionAtPosition('(');
+verify.isValidBraceCompletionAtPosition('"');
+
+goTo.marker('4');
+verify.isValidBraceCompletionAtPosition('(');
+verify.not.isValidBraceCompletionAtPosition('"');
+
+goTo.marker('5');
 verify.isValidBraceCompletionAtPosition('(');
 verify.not.isValidBraceCompletionAtPosition('"');

--- a/tests/cases/fourslash/commentBraceCompletionPosition.ts
+++ b/tests/cases/fourslash/commentBraceCompletionPosition.ts
@@ -15,9 +15,14 @@
 
 goTo.marker('1');
 verify.isValidBraceCompletionAtPosition('(');
+verify.not.isValidBraceCompletionAtPosition('"');
+verify.not.isValidBraceCompletionAtPosition(`'`);
+verify.not.isValidBraceCompletionAtPosition('`');
 
 goTo.marker('2');
 verify.isValidBraceCompletionAtPosition('(');
+verify.not.isValidBraceCompletionAtPosition('"');
 
 goTo.marker('3');
 verify.isValidBraceCompletionAtPosition('(');
+verify.not.isValidBraceCompletionAtPosition('"');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes https://developercommunity.visualstudio.com/content/problem/16657/javascript-comment-typing-a-single-quotation-mark.html
