### PR TITLE
Document highlights for a JSX tag should just be the matching tag, not all references

### DIFF
--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -1,17 +1,23 @@
 /* @internal */
 namespace ts.DocumentHighlights {
-    export function getDocumentHighlights(program: Program, cancellationToken: CancellationToken, sourceFile: SourceFile, position: number, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] {
+    export function getDocumentHighlights(program: Program, cancellationToken: CancellationToken, sourceFile: SourceFile, position: number, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] | undefined {
         const node = getTouchingWord(sourceFile, position, /*includeJsDocComment*/ true);
-        return node && (getSemanticDocumentHighlights(node, program, cancellationToken, sourceFilesToSearch) || getSyntacticDocumentHighlights(node, sourceFile));
+        if (!node) return undefined;
+
+        if (isJsxOpeningElement(node.parent) && node.parent.tagName === node || isJsxClosingElement(node.parent)) {
+            // For a JSX element, just highlight the matching tag, not all references.
+            const { openingElement, closingElement } = node.parent.parent;
+            const highlightSpans = [openingElement, closingElement].map(({ tagName }) => getHighlightSpanForNode(tagName, sourceFile));
+            return [{ fileName: sourceFile.fileName, highlightSpans }];
+        }
+
+        return getSemanticDocumentHighlights(node, program, cancellationToken, sourceFilesToSearch) || getSyntacticDocumentHighlights(node, sourceFile);
     }
 
     function getHighlightSpanForNode(node: Node, sourceFile: SourceFile): HighlightSpan {
-        const start = node.getStart(sourceFile);
-        const end = node.getEnd();
-
         return {
             fileName: sourceFile.fileName,
-            textSpan: createTextSpanFromBounds(start, end),
+            textSpan: createTextSpanFromNode(node, sourceFile),
             kind: HighlightSpanKind.none
         };
     }

--- a/tests/cases/fourslash/findReferencesJSXTagName.ts
+++ b/tests/cases/fourslash/findReferencesJSXTagName.ts
@@ -11,8 +11,7 @@
 ////export const [|{| "isWriteAccess": true, "isDefinition": true |}SubmissionComp|] = (submission: SubmissionProps) =>
 ////    <div style={{ fontFamily: "sans-serif" }}></div>;
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
+const [r0, r1, r2] = test.ranges();
 const imports = { definition: "import SubmissionComp", ranges: [r0, r1] };
 const def = { definition: "const SubmissionComp: (submission: any) => any", ranges: [r2] };
 verify.referenceGroups([r0, r1], [imports, def]);

--- a/tests/cases/fourslash/findReferencesJSXTagName3.ts
+++ b/tests/cases/fourslash/findReferencesJSXTagName3.ts
@@ -1,0 +1,38 @@
+/// <reference path='fourslash.ts'/>
+
+// @jsx: preserve
+
+// @Filename: /a.tsx
+////namespace JSX {
+////    export interface Element { }
+////    export interface IntrinsicElements {
+////        [|{| "isWriteAccess": true, "isDefinition": true |}div|]: any;
+////    }
+////}
+////
+////const [|{| "isWriteAccess": true, "isDefinition": true |}Comp|] = () =>
+////    <[|div|]>
+////        Some content
+////        <[|div|]>More content</[|div|]>
+////    </[|div|]>;
+////
+////const x = <[|Comp|]>
+////    Content
+////</[|Comp|]>;
+
+const ranges = test.ranges();
+const [d0, c0, d1, d2, d3, d4, c1, c2] = test.ranges();
+
+const allD = [d0, d1, d2, d3, d4];
+const allC = [c0, c1, c2];
+
+verify.singleReferenceGroup("(property) JSX.IntrinsicElements.div: any", allD);
+verify.singleReferenceGroup("const Comp: () => JSX.Element", allC);
+
+// For document highlights, we will just do tag matching if on a tag. Otherwise we find-all-references.
+verify.documentHighlightsOf(d0, [d0, d1, d2, d3, d4]);
+verify.rangesAreDocumentHighlights([d1, d4]);
+verify.rangesAreDocumentHighlights([d2, d3]);
+
+verify.documentHighlightsOf(c0, [c0, c1, c2]);
+verify.rangesAreDocumentHighlights([c1, c2]);

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -250,6 +250,7 @@ declare namespace FourSlashInterface {
         occurrencesAtPositionCount(expectedCount: number): void;
         rangesAreDocumentHighlights(ranges?: Range[]): void;
         rangesWithSameTextAreDocumentHighlights(): void;
+        documentHighlightsOf(startRange: Range, ranges: Range[]): void;
         completionEntryDetailIs(entryName: string, text: string, documentation?: string, kind?: string): void;
         /**
          * This method *requires* a contiguous, complete, and ordered stream of classifications for a file.


### PR DESCRIPTION
Fixes #10138

This only changes the behavior of document highlights, not find-all-references.