### PR TITLE
Support completions in destructuring in for-of

### DIFF
--- a/tests/cases/fourslash/completionsDestructuring.ts
+++ b/tests/cases/fourslash/completionsDestructuring.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+////const points = [{ x: 1, y: 2 }];
+////points.forEach(({ /*a*/ }) => { });
+////const { /*b*/ } = points[0];
+////for (const { /*c*/ } of points) {}
+
+goTo.eachMarker(() => {
+    verify.completionListContains("x");
+    verify.completionListContains("y");
+    verify.completionListCount(2);
+});


### PR DESCRIPTION
Fixes #16452

@rbuckton I wanted to test this with `for-await-of` but couldn't seem to get it to work.
I tried:
```ts
// @lib: esnext

////...existing test...
////async function f(points: AsyncIterable<{ x: number, y: number }>) {
////    for await (const { /*d*/ } of points) {}
////}
verify.noErrors();
```

I get: `minChar: 173, limChar: 186, message: Cannot find name 'AsyncIterable'.`