### PR TITLE
Jsdoc @template in scope as type parameter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6178,19 +6178,11 @@ namespace ts {
             return undefined;
         }
 
-        function getTypeParametersFromJSDocTemplate(declaration: DeclarationWithTypeParameters): TypeParameterDeclaration[] {
-            if (declaration.flags & NodeFlags.JavaScriptFile) {
-                const templateTag = getJSDocTemplateTag(declaration);
-                return templateTag && templateTag.typeParameters;
-            }
-            return undefined;
-        }
-
         // Return list of type parameters with duplicates removed (duplicate identifier errors are generated in the actual
         // type checking functions).
         function getTypeParametersFromDeclaration(declaration: DeclarationWithTypeParameters): TypeParameter[] {
             let result: TypeParameter[];
-            forEach(declaration.typeParameters || getTypeParametersFromJSDocTemplate(declaration), node => {
+            forEach(getEffectiveTypeParameterDeclarations(declaration), node => {
                 const tp = getDeclaredTypeOfTypeParameter(node.symbol);
                 if (!contains(result, tp)) {
                     if (!result) {
@@ -8165,8 +8157,7 @@ namespace ts {
                     case SyntaxKind.ClassExpression:
                     case SyntaxKind.InterfaceDeclaration:
                     case SyntaxKind.TypeAliasDeclaration:
-                        const declaration = node as DeclarationWithTypeParameters;
-                        const typeParameters = declaration.typeParameters || getTypeParametersFromJSDocTemplate(declaration);
+                        const typeParameters = getEffectiveTypeParameterDeclarations(node as DeclarationWithTypeParameters);
                         if (typeParameters) {
                             for (const d of typeParameters) {
                                 if (contains(mappedTypes, getDeclaredTypeOfTypeParameter(getSymbolOfNode(d)))) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2744,8 +2744,8 @@ namespace ts {
     }
 
     /**
-     * Gets the effective return type annotation of a signature. If the node was parsed in a
-     * JavaScript file, gets the return type annotation from JSDoc.
+     * Gets the effective type parameters. If the node was parsed in a
+     * JavaScript file, gets the type parameters from the `@template` tag from JSDoc.
      */
     export function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeParameters): TypeParameterDeclaration[] {
         if (node.typeParameters) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1448,7 +1448,7 @@ namespace ts {
         return node && firstOrUndefined(getJSDocTags(node, kind));
     }
 
-   export function getJSDocs(node: Node): (JSDoc | JSDocTag)[] {
+    export function getJSDocs(node: Node): (JSDoc | JSDocTag)[] {
         if (isJSDocTypedefTag(node)) {
             return [node.parent];
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2744,6 +2744,20 @@ namespace ts {
     }
 
     /**
+     * Gets the effective return type annotation of a signature. If the node was parsed in a
+     * JavaScript file, gets the return type annotation from JSDoc.
+     */
+    export function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeParameters): TypeParameterDeclaration[] {
+        if (node.typeParameters) {
+            return node.typeParameters;
+        }
+        if (node.flags & NodeFlags.JavaScriptFile) {
+            const templateTag = getJSDocTemplateTag(node);
+            return templateTag && templateTag.typeParameters;
+        }
+    }
+
+    /**
      * Gets the effective type annotation of the value parameter of a set accessor. If the node
      * was parsed in a JavaScript file, gets the type annotation from JSDoc.
      */

--- a/tests/baselines/reference/jsdocTemplateTag.symbols
+++ b/tests/baselines/reference/jsdocTemplateTag.symbols
@@ -1,0 +1,36 @@
+=== tests/cases/conformance/jsdoc/jsdocTemplateTag.ts ===
+/**
+ * @param {T} a
+ * @template T
+ */
+function f<T>(a: T) {
+>f : Symbol(f, Decl(jsdocTemplateTag.ts, 0, 0))
+>T : Symbol(T, Decl(jsdocTemplateTag.ts, 4, 11))
+>a : Symbol(a, Decl(jsdocTemplateTag.ts, 4, 14))
+>T : Symbol(T, Decl(jsdocTemplateTag.ts, 4, 11))
+
+    return () => a
+>a : Symbol(a, Decl(jsdocTemplateTag.ts, 4, 14))
+}
+let n = f(1)()
+>n : Symbol(n, Decl(jsdocTemplateTag.ts, 7, 3))
+>f : Symbol(f, Decl(jsdocTemplateTag.ts, 0, 0))
+
+/**
+ * @param {T} a
+ * @template T
+ * @returns {function(): T}
+ */
+function g<T>(a: T) {
+>g : Symbol(g, Decl(jsdocTemplateTag.ts, 7, 14))
+>T : Symbol(T, Decl(jsdocTemplateTag.ts, 14, 11))
+>a : Symbol(a, Decl(jsdocTemplateTag.ts, 14, 14))
+>T : Symbol(T, Decl(jsdocTemplateTag.ts, 14, 11))
+
+    return () => a
+>a : Symbol(a, Decl(jsdocTemplateTag.ts, 14, 14))
+}
+let s = g('hi')()
+>s : Symbol(s, Decl(jsdocTemplateTag.ts, 17, 3))
+>g : Symbol(g, Decl(jsdocTemplateTag.ts, 7, 14))
+

--- a/tests/baselines/reference/jsdocTemplateTag.types
+++ b/tests/baselines/reference/jsdocTemplateTag.types
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/jsdoc/jsdocTemplateTag.ts ===
+/**
+ * @param {T} a
+ * @template T
+ */
+function f<T>(a: T) {
+>f : <T>(a: T) => () => T
+>T : T
+>a : T
+>T : T
+
+    return () => a
+>() => a : () => T
+>a : T
+}
+let n = f(1)()
+>n : number
+>f(1)() : number
+>f(1) : () => number
+>f : <T>(a: T) => () => T
+>1 : 1
+
+/**
+ * @param {T} a
+ * @template T
+ * @returns {function(): T}
+ */
+function g<T>(a: T) {
+>g : <T>(a: T) => () => T
+>T : T
+>a : T
+>T : T
+
+    return () => a
+>() => a : () => T
+>a : T
+}
+let s = g('hi')()
+>s : string
+>g('hi')() : string
+>g('hi') : () => string
+>g : <T>(a: T) => () => T
+>'hi' : "hi"
+

--- a/tests/cases/conformance/jsdoc/jsdocTemplateTag.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTemplateTag.ts
@@ -1,0 +1,21 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+/**
+ * @param {T} a
+ * @template T
+ */
+function f<T>(a: T) {
+    return () => a
+}
+let n = f(1)()
+
+/**
+ * @param {T} a
+ * @template T
+ * @returns {function(): T}
+ */
+function g<T>(a: T) {
+    return () => a
+}
+let s = g('hi')()


### PR DESCRIPTION
The code to make sure that type parameters are in scope for instantiation previously ignored type parameters created by `@template`.  Now it correctly says that they are in scope.

Fixes #15177, which showed that functions returned from a generic function were not instantiated. Turns out this was because the type parameters were not recognised as in scope, so the instantiation algorithm skipped them.
