### PR TITLE
Add jsdoc to EOF token to catch missed `@typedef`s

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -685,7 +685,7 @@ namespace ts {
 
             sourceFile.statements = parseList(ParsingContext.SourceElements, parseStatement);
             Debug.assert(token() === SyntaxKind.EndOfFileToken);
-            sourceFile.endOfFileToken = <EndOfFileToken>parseTokenNode();
+            sourceFile.endOfFileToken = addJSDocComment(parseTokenNode() as EndOfFileToken);
 
             setExternalModuleIndicator(sourceFile);
 

--- a/tests/baselines/reference/jsdocTypeDefAtStartOfFile.symbols
+++ b/tests/baselines/reference/jsdocTypeDefAtStartOfFile.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/dtsEquivalent.js ===
+/** @typedef {{[k: string]: any}} AnyEffect */
+No type information for this code./** @typedef {number} Third */
+No type information for this code.=== tests/cases/conformance/jsdoc/index.js ===
+/** @type {AnyEffect} */
+let b;
+>b : Symbol(b, Decl(index.js, 1, 3))
+
+/** @type {Third} */
+let c;
+>c : Symbol(c, Decl(index.js, 3, 3))
+

--- a/tests/baselines/reference/jsdocTypeDefAtStartOfFile.types
+++ b/tests/baselines/reference/jsdocTypeDefAtStartOfFile.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/dtsEquivalent.js ===
+/** @typedef {{[k: string]: any}} AnyEffect */
+No type information for this code./** @typedef {number} Third */
+No type information for this code.=== tests/cases/conformance/jsdoc/index.js ===
+/** @type {AnyEffect} */
+let b;
+>b : { [k: string]: any; }
+
+/** @type {Third} */
+let c;
+>c : number
+

--- a/tests/cases/conformance/jsdoc/jsdocTypeDefAtStartOfFile.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeDefAtStartOfFile.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: dtsEquivalent.js
+/** @typedef {{[k: string]: any}} AnyEffect */
+/** @typedef {number} Third */
+// @Filename: index.js
+/** @type {AnyEffect} */
+let b;
+/** @type {Third} */
+let c;


### PR DESCRIPTION
In JS files that consist only of `@typedef`s, the doc comments were not parsed because there was nothing for them to attach to. Now we call `addJSDocComment` on the EOF token, so they attach there.

Fixes #15901 

