### PR TITLE
Fixes the memory leak because of project and its corresponding script info even after project is removed

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2204,10 +2204,10 @@ namespace ts.projectSystem {
             projectService.closeClientFile(f1.path);
             projectService.checkNumberOfProjects({});
 
-            for (const f of [f2, f3]) {
+            for (const f of [f1, f2, f3]) {
                 // There shouldnt be any script info as we closed the file that resulted in creation of it
                 const scriptInfo = projectService.getScriptInfoForNormalizedPath(server.toNormalizedPath(f.path));
-                assert.equal(scriptInfo, undefined, `expected script info to be closed: '${f.path}'`);
+                assert.equal(scriptInfo.containingProjects.length, 0, `expect 0 containing projects for '${f.path}'`);
             }
         });
 

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2205,8 +2205,9 @@ namespace ts.projectSystem {
             projectService.checkNumberOfProjects({});
 
             for (const f of [f2, f3]) {
+                // There shouldnt be any script info as we closed the file that resulted in creation of it
                 const scriptInfo = projectService.getScriptInfoForNormalizedPath(server.toNormalizedPath(f.path));
-                assert.equal(scriptInfo.containingProjects.length, 0, `expect 0 containing projects for '${f.path}'`);
+                assert.equal(scriptInfo, undefined, `expected script info to be closed: '${f.path}'`);
             }
         });
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -827,10 +827,20 @@ namespace ts.server {
                         this.assignScriptInfoToInferredProjectIfNecessary(f, /*addToListOfOpenFiles*/ false);
                     }
                 }
+
+                // Cleanup script infos that are not open and not part of any project
+                this.deleteOrphanScriptInfoNotInAnyProject();
             }
-            if (info.containingProjects.length === 0) {
-                // if there are not projects that include this script info - delete it
-                this.filenameToScriptInfo.remove(info.path);
+        }
+
+        private deleteOrphanScriptInfoNotInAnyProject() {
+            for (const path of this.filenameToScriptInfo.getKeys()) {
+                const info = this.filenameToScriptInfo.get(path);
+                if (!info.isScriptOpen() && info.containingProjects.length === 0) {
+                    // if there are not projects that include this script info - delete it
+                    info.stopWatcher();
+                    this.filenameToScriptInfo.remove(info.path);
+                }
             }
         }
 
@@ -1418,6 +1428,8 @@ namespace ts.server {
             for (const p of this.inferredProjects) {
                 p.updateGraph();
             }
+
+            this.deleteOrphanScriptInfoNotInAnyProject();
             this.printProjects();
         }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1484,6 +1484,10 @@ namespace ts.server {
             // at this point if file is the part of some configured/external project then this project should be created
             const info = this.getOrCreateScriptInfoForNormalizedPath(fileName, /*openedByClient*/ true, fileContent, scriptKind, hasMixedContent);
             this.assignScriptInfoToInferredProjectIfNecessary(info, /*addToListOfOpenFiles*/ true);
+            // Delete the orphan files here because there might be orphan script infos (which are not part of project)
+            // when some file/s were closed which resulted in project removal.
+            // It was then postponed to cleanup these script infos so that they can be reused if
+            // the file from that old project is reopened because of opening file from here.
             this.deleteOrphanScriptInfoNotInAnyProject();
             this.printProjects();
             return { configFileName, configFileErrors };

--- a/src/server/lsHost.ts
+++ b/src/server/lsHost.ts
@@ -11,11 +11,11 @@ namespace ts.server {
 
         private filesWithChangedSetOfUnresolvedImports: Path[];
 
-        private readonly resolveModuleName: typeof resolveModuleName;
+        private resolveModuleName: typeof resolveModuleName;
         readonly trace: (s: string) => void;
         readonly realpath?: (path: string) => string;
 
-        constructor(private readonly host: ServerHost, private readonly project: Project, private readonly cancellationToken: HostCancellationToken) {
+        constructor(private readonly host: ServerHost, private project: Project, private readonly cancellationToken: HostCancellationToken) {
             this.cancellationToken = new ThrottledCancellationToken(cancellationToken, project.projectService.throttleWaitMilliseconds);
             this.getCanonicalFileName = ts.createGetCanonicalFileName(this.host.useCaseSensitiveFileNames);
 
@@ -45,6 +45,11 @@ namespace ts.server {
             if (this.host.realpath) {
                 this.realpath = path => this.host.realpath(path);
             }
+        }
+
+        dispose() {
+            this.project = undefined;
+            this.resolveModuleName = undefined;
         }
 
         public startRecordingFilesWithChangedResolutions() {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -116,7 +116,7 @@ namespace ts.server {
 
         public languageServiceEnabled = true;
 
-        protected readonly lsHost: LSHost;
+        protected lsHost: LSHost;
 
         builder: Builder;
         /**
@@ -297,9 +297,15 @@ namespace ts.server {
             this.rootFiles = undefined;
             this.rootFilesMap = undefined;
             this.program = undefined;
+            this.builder = undefined;
+            this.cachedUnresolvedImportsPerFile = undefined;
+            this.projectErrors = undefined;
+            this.lsHost.dispose();
+            this.lsHost = undefined;
 
             // signal language service to release source files acquired from document registry
             this.languageService.dispose();
+            this.languageService = undefined;
         }
 
         getCompilerOptions() {
@@ -1043,6 +1049,7 @@ namespace ts.server {
 
             if (this.projectFileWatcher) {
                 this.projectFileWatcher.close();
+                this.projectFileWatcher = undefined;
             }
 
             if (this.typeRootsWatchers) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1311,7 +1311,9 @@ namespace ts {
             if (program) {
                 forEach(program.getSourceFiles(), f =>
                     documentRegistry.releaseDocument(f.fileName, program.getCompilerOptions()));
+                program = undefined;
             }
+            host = undefined;
         }
 
         /// Diagnostics

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -815,7 +815,7 @@ namespace ts {
         private _compilationSettings: CompilerOptions;
         private currentDirectory: string;
 
-        constructor(private host: LanguageServiceHost, private getCanonicalFileName: (fileName: string) => string) {
+        constructor(private host: LanguageServiceHost, getCanonicalFileName: (fileName: string) => string) {
             // script id => script index
             this.currentDirectory = host.getCurrentDirectory();
             this.fileNameToEntry = createFileMap<HostFileInformation>();
@@ -850,22 +850,17 @@ namespace ts {
             return entry;
         }
 
-        private getEntry(path: Path): HostFileInformation {
+        public getEntryByPath(path: Path): HostFileInformation {
             return this.fileNameToEntry.get(path);
         }
 
-        private contains(path: Path): boolean {
+        public containsEntryByPath(path: Path): boolean {
             return this.fileNameToEntry.contains(path);
         }
 
-        public getOrCreateEntry(fileName: string): HostFileInformation {
-            const path = toPath(fileName, this.currentDirectory, this.getCanonicalFileName);
-            return this.getOrCreateEntryByPath(fileName, path);
-        }
-
         public getOrCreateEntryByPath(fileName: string, path: Path): HostFileInformation {
-            return this.contains(path)
-                ? this.getEntry(path)
+            return this.containsEntryByPath(path)
+                ? this.getEntryByPath(path)
                 : this.createEntry(fileName, path);
         }
 
@@ -882,12 +877,12 @@ namespace ts {
         }
 
         public getVersion(path: Path): string {
-            const file = this.getEntry(path);
+            const file = this.getEntryByPath(path);
             return file && file.version;
         }
 
         public getScriptSnapshot(path: Path): IScriptSnapshot {
-            const file = this.getEntry(path);
+            const file = this.getEntryByPath(path);
             return file && file.scriptSnapshot;
         }
     }
@@ -1152,12 +1147,19 @@ namespace ts {
                 getCurrentDirectory: () => currentDirectory,
                 fileExists: (fileName): boolean => {
                     // stub missing host functionality
-                    return hostCache.getOrCreateEntry(fileName) !== undefined;
+                    const path = toPath(fileName, currentDirectory, getCanonicalFileName);
+                    return hostCache.containsEntryByPath(path) ?
+                        !!hostCache.getEntryByPath(path) :
+                        (host.fileExists && host.fileExists(fileName));
                 },
                 readFile: (fileName): string => {
                     // stub missing host functionality
-                    const entry = hostCache.getOrCreateEntry(fileName);
-                    return entry && entry.scriptSnapshot.getText(0, entry.scriptSnapshot.getLength());
+                    const path = toPath(fileName, currentDirectory, getCanonicalFileName);
+                    if (hostCache.containsEntryByPath(path)) {
+                        const entry = hostCache.getEntryByPath(path);
+                        return entry && entry.scriptSnapshot.getText(0, entry.scriptSnapshot.getLength());
+                    }
+                    return host.readFile && host.readFile(fileName);
                 },
                 directoryExists: directoryName => {
                     return directoryProbablyExists(directoryName, host);


### PR DESCRIPTION
- fileExists and readFile of the CompilerHost created by Language service created script infos but it shouldn't because the getSourceFile is the correct api to get those since the script infos (scriptsnapshot and watcher for the file) are always associated to the project they are requested from. The issue here was that the script infos created by fileExists and readFile would get the project assigned but never removed because they weren't part of project's source file. 1bf1209   fixes this by directing those call to host instead.
- When project is removed it removed the script shot of open file/s from that project but it never use to remove it for files are not open. For big projects that meant huge strings and rest of the stuff still in memory. 2ec92b9 cleans up the ScriptInfos not associated with any project to reduce footprint left behind by closing files. This change also cleans up few pointers to make sure project, LShost, LS and other structures that are related to the project are cleaned up
- 98cb0ce  moves the cleanup of orphan script infos to after next open file so that we can reuse the script infos if the file from the previously closed project is opened right after that.

Fixes https://github.com/Microsoft/vscode/issues/28112 and #16329