### PR TITLE
Fix decorated class with extends in new class emit

### DIFF
--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -3401,28 +3401,19 @@ namespace ts {
                     classBodyStart++;
                 }
 
-                // We reuse the comment and source-map positions from the original variable statement
-                // and class alias, while converting the function declaration for the class constructor
-                // into an expression.
+                // The next statement is the function declaration.
+                statements.push(funcStatements[classBodyStart]);
+                classBodyStart++;
+
+                // Add the class alias following the declaration.
                 statements.push(
-                    updateVariableStatement(
-                        varStatement,
-                        /*modifiers*/ undefined,
-                        updateVariableDeclarationList(varStatement.declarationList, [
-                            updateVariableDeclaration(variable,
-                                variable.name,
-                                /*type*/ undefined,
-                                updateBinary(aliasAssignment,
-                                    aliasAssignment.left,
-                                    convertFunctionDeclarationToExpression(
-                                        cast(funcStatements[classBodyStart], isFunctionDeclaration)
-                                    )
-                                )
-                            )
-                        ])
+                    createStatement(
+                        createAssignment(
+                            aliasAssignment.left,
+                            cast(variable.name, isIdentifier)
+                        )
                     )
                 );
-                classBodyStart++;
             }
 
             // Find the trailing 'return' statement (4)

--- a/tests/baselines/reference/decoratorOnClass9.js
+++ b/tests/baselines/reference/decoratorOnClass9.js
@@ -1,0 +1,55 @@
+//// [decoratorOnClass9.ts]
+declare var dec: any;
+
+class A {}
+
+// https://github.com/Microsoft/TypeScript/issues/16417
+@dec
+class B extends A {
+    static x = 1;
+    static y = B.x;
+    m() {
+        return B.x;
+    }
+}
+
+//// [decoratorOnClass9.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var A = (function () {
+    function A() {
+    }
+    return A;
+}());
+// https://github.com/Microsoft/TypeScript/issues/16417
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    B_1 = B;
+    B.prototype.m = function () {
+        return B_1.x;
+    };
+    B.x = 1;
+    B.y = B_1.x;
+    B = B_1 = __decorate([
+        dec
+    ], B);
+    return B;
+    var B_1;
+}(A));

--- a/tests/baselines/reference/decoratorOnClass9.symbols
+++ b/tests/baselines/reference/decoratorOnClass9.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/conformance/decorators/class/decoratorOnClass9.ts ===
+declare var dec: any;
+>dec : Symbol(dec, Decl(decoratorOnClass9.ts, 0, 11))
+
+class A {}
+>A : Symbol(A, Decl(decoratorOnClass9.ts, 0, 21))
+
+// https://github.com/Microsoft/TypeScript/issues/16417
+@dec
+>dec : Symbol(dec, Decl(decoratorOnClass9.ts, 0, 11))
+
+class B extends A {
+>B : Symbol(B, Decl(decoratorOnClass9.ts, 2, 10))
+>A : Symbol(A, Decl(decoratorOnClass9.ts, 0, 21))
+
+    static x = 1;
+>x : Symbol(B.x, Decl(decoratorOnClass9.ts, 6, 19))
+
+    static y = B.x;
+>y : Symbol(B.y, Decl(decoratorOnClass9.ts, 7, 17))
+>B.x : Symbol(B.x, Decl(decoratorOnClass9.ts, 6, 19))
+>B : Symbol(B, Decl(decoratorOnClass9.ts, 2, 10))
+>x : Symbol(B.x, Decl(decoratorOnClass9.ts, 6, 19))
+
+    m() {
+>m : Symbol(B.m, Decl(decoratorOnClass9.ts, 8, 19))
+
+        return B.x;
+>B.x : Symbol(B.x, Decl(decoratorOnClass9.ts, 6, 19))
+>B : Symbol(B, Decl(decoratorOnClass9.ts, 2, 10))
+>x : Symbol(B.x, Decl(decoratorOnClass9.ts, 6, 19))
+    }
+}

--- a/tests/baselines/reference/decoratorOnClass9.types
+++ b/tests/baselines/reference/decoratorOnClass9.types
@@ -1,0 +1,34 @@
+=== tests/cases/conformance/decorators/class/decoratorOnClass9.ts ===
+declare var dec: any;
+>dec : any
+
+class A {}
+>A : A
+
+// https://github.com/Microsoft/TypeScript/issues/16417
+@dec
+>dec : any
+
+class B extends A {
+>B : B
+>A : A
+
+    static x = 1;
+>x : number
+>1 : 1
+
+    static y = B.x;
+>y : number
+>B.x : number
+>B : typeof B
+>x : number
+
+    m() {
+>m : () => number
+
+        return B.x;
+>B.x : number
+>B : typeof B
+>x : number
+    }
+}

--- a/tests/baselines/reference/es6modulekindWithES5Target11.js
+++ b/tests/baselines/reference/es6modulekindWithES5Target11.js
@@ -16,9 +16,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 var C = (function () {
-    var C = C_1 = function C() {
+    function C() {
         this.p = 1;
-    };
+    }
+    C_1 = C;
     C.x = function () { return C_1.y; };
     C.prototype.method = function () { };
     C.y = 1;

--- a/tests/cases/conformance/decorators/class/decoratorOnClass9.ts
+++ b/tests/cases/conformance/decorators/class/decoratorOnClass9.ts
@@ -1,0 +1,15 @@
+// @target:es5
+// @experimentaldecorators: true
+declare var dec: any;
+
+class A {}
+
+// https://github.com/Microsoft/TypeScript/issues/16417
+@dec
+class B extends A {
+    static x = 1;
+    static y = B.x;
+    m() {
+        return B.x;
+    }
+}


### PR DESCRIPTION
This fixes an issue with the emit for subclasses with class decorators when targeting ES5.

Fixes #16417
