### PR TITLE
Fix16211

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4821,7 +4821,7 @@ namespace ts {
 
         function getInstantiatedConstructorsForTypeArguments(type: Type, typeArgumentNodes: TypeNode[], location: Node): Signature[] {
             let signatures = getConstructorsForTypeArguments(type, typeArgumentNodes, location);
-            if (typeArgumentNodes) {
+            if (some(typeArgumentNodes)) {
                 const typeArguments = map(typeArgumentNodes, getTypeFromTypeNode);
                 signatures = map(signatures, sig => getSignatureInstantiation(sig, typeArguments));
             }
@@ -20921,7 +20921,7 @@ namespace ts {
                     const staticBaseType = getApparentType(baseConstructorType);
                     checkBaseTypeAccessibility(staticBaseType, baseTypeNode);
                     checkSourceElement(baseTypeNode.expression);
-                    if (baseTypeNode.typeArguments) {
+                    if (some(baseTypeNode.typeArguments)) {
                         forEach(baseTypeNode.typeArguments, checkSourceElement);
                         for (const constructor of getConstructorsForTypeArguments(staticBaseType, baseTypeNode.typeArguments, baseTypeNode)) {
                             if (!checkTypeArgumentConstraints(constructor.typeParameters, baseTypeNode.typeArguments)) {
@@ -23896,6 +23896,11 @@ namespace ts {
                 const sourceFile = getSourceFileOfNode(node);
                 return grammarErrorAtPos(sourceFile, types.pos, 0, Diagnostics._0_list_cannot_be_empty, listType);
             }
+            return forEach(types, checkGrammarExpressionWithTypeArguments);
+        }
+
+        function checkGrammarExpressionWithTypeArguments(node: ExpressionWithTypeArguments) {
+            return checkGrammarTypeArguments(node, node.typeArguments);
         }
 
         function checkGrammarClassDeclarationHeritageClauses(node: ClassLikeDeclaration) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4820,12 +4820,21 @@ namespace ts {
         }
 
         function getInstantiatedConstructorsForTypeArguments(type: Type, typeArgumentNodes: TypeNode[], location: Node): Signature[] {
-            let signatures = getConstructorsForTypeArguments(type, typeArgumentNodes, location);
-            if (some(typeArgumentNodes)) {
+            const signatures = getConstructorsForTypeArguments(type, typeArgumentNodes, location);
+            if (some(signatures)) {
+                const result: Signature[] = [];
                 const typeArguments = map(typeArgumentNodes, getTypeFromTypeNode);
-                signatures = map(signatures, sig => getSignatureInstantiation(sig, typeArguments));
+                for (const sig of signatures) {
+                    if (some(sig.typeParameters)) {
+                        result.push(getSignatureInstantiation(sig, typeArguments));
+                    }
+                    else {
+                        result.push(sig);
+                    }
+                }
+                return result;
             }
-            return signatures;
+            return emptyArray;
         }
 
         /**

--- a/tests/baselines/reference/genericDefaults.js
+++ b/tests/baselines/reference/genericDefaults.js
@@ -458,6 +458,15 @@ const Derived02c01 = new Derived02(1);
 const Derived02c02 = new Derived02<number>();
 const Derived02c03 = new Derived02<number>(1);
 
+// https://github.com/Microsoft/TypeScript/issues/16211
+interface Base02 {}
+interface Base02Constructor { new <T = A>(a: T): Base02 & T; }
+declare const Base02: Base02Constructor;
+declare class Derived03 extends Base02 {}
+const Derived03c00 = new Derived03(ab);
+const Derived03c01 = Derived03c00.a;
+type DerivedProps = keyof Derived03;
+
 type t00<T = number> = { a: T; }
 const t00c00 = (<t00>x).a;
 const t00c01 = (<t00<number>>x).a;
@@ -479,7 +488,6 @@ const t03c01 = (<t03<1>>x).a;
 const t03c02 = (<t03<number, number>>x).a;
 const t03c03 = (<t03<1, 1>>x).a;
 const t03c04 = (<t03<number, 1>>x).a;
-
 
 //// [genericDefaults.js]
 // no inference
@@ -834,6 +842,8 @@ var Derived02c00 = new Derived02();
 var Derived02c01 = new Derived02(1);
 var Derived02c02 = new Derived02();
 var Derived02c03 = new Derived02(1);
+var Derived03c00 = new Derived03(ab);
+var Derived03c01 = Derived03c00.a;
 var t00c00 = x.a;
 var t00c01 = x.a;
 var t01c00 = x.a;
@@ -977,6 +987,17 @@ declare const Derived02c00: Derived02<string>;
 declare const Derived02c01: Derived02<number>;
 declare const Derived02c02: Derived02<number>;
 declare const Derived02c03: Derived02<number>;
+interface Base02 {
+}
+interface Base02Constructor {
+    new <T = A>(a: T): Base02 & T;
+}
+declare const Base02: Base02Constructor;
+declare class Derived03 extends Base02 {
+}
+declare const Derived03c00: Derived03;
+declare const Derived03c01: number;
+declare type DerivedProps = keyof Derived03;
 declare type t00<T = number> = {
     a: T;
 };

--- a/tests/baselines/reference/genericDefaults.symbols
+++ b/tests/baselines/reference/genericDefaults.symbols
@@ -2123,135 +2123,171 @@ const Derived02c03 = new Derived02<number>(1);
 >Derived02c03 : Symbol(Derived02c03, Decl(genericDefaults.ts, 457, 5))
 >Derived02 : Symbol(Derived02, Decl(genericDefaults.ts, 451, 46))
 
+// https://github.com/Microsoft/TypeScript/issues/16211
+interface Base02 {}
+>Base02 : Symbol(Base02, Decl(genericDefaults.ts, 457, 46), Decl(genericDefaults.ts, 462, 13))
+
+interface Base02Constructor { new <T = A>(a: T): Base02 & T; }
+>Base02Constructor : Symbol(Base02Constructor, Decl(genericDefaults.ts, 460, 19))
+>T : Symbol(T, Decl(genericDefaults.ts, 461, 35))
+>A : Symbol(A, Decl(genericDefaults.ts, 0, 0))
+>a : Symbol(a, Decl(genericDefaults.ts, 461, 42))
+>T : Symbol(T, Decl(genericDefaults.ts, 461, 35))
+>Base02 : Symbol(Base02, Decl(genericDefaults.ts, 457, 46), Decl(genericDefaults.ts, 462, 13))
+>T : Symbol(T, Decl(genericDefaults.ts, 461, 35))
+
+declare const Base02: Base02Constructor;
+>Base02 : Symbol(Base02, Decl(genericDefaults.ts, 457, 46), Decl(genericDefaults.ts, 462, 13))
+>Base02Constructor : Symbol(Base02Constructor, Decl(genericDefaults.ts, 460, 19))
+
+declare class Derived03 extends Base02 {}
+>Derived03 : Symbol(Derived03, Decl(genericDefaults.ts, 462, 40))
+>Base02 : Symbol(Base02, Decl(genericDefaults.ts, 457, 46), Decl(genericDefaults.ts, 462, 13))
+
+const Derived03c00 = new Derived03(ab);
+>Derived03c00 : Symbol(Derived03c00, Decl(genericDefaults.ts, 464, 5))
+>Derived03 : Symbol(Derived03, Decl(genericDefaults.ts, 462, 40))
+>ab : Symbol(ab, Decl(genericDefaults.ts, 11, 13))
+
+const Derived03c01 = Derived03c00.a;
+>Derived03c01 : Symbol(Derived03c01, Decl(genericDefaults.ts, 465, 5))
+>Derived03c00.a : Symbol(A.a, Decl(genericDefaults.ts, 0, 13))
+>Derived03c00 : Symbol(Derived03c00, Decl(genericDefaults.ts, 464, 5))
+>a : Symbol(A.a, Decl(genericDefaults.ts, 0, 13))
+
+type DerivedProps = keyof Derived03;
+>DerivedProps : Symbol(DerivedProps, Decl(genericDefaults.ts, 465, 36))
+>Derived03 : Symbol(Derived03, Decl(genericDefaults.ts, 462, 40))
+
 type t00<T = number> = { a: T; }
->t00 : Symbol(t00, Decl(genericDefaults.ts, 457, 46))
->T : Symbol(T, Decl(genericDefaults.ts, 459, 9))
->a : Symbol(a, Decl(genericDefaults.ts, 459, 24))
->T : Symbol(T, Decl(genericDefaults.ts, 459, 9))
+>t00 : Symbol(t00, Decl(genericDefaults.ts, 466, 36))
+>T : Symbol(T, Decl(genericDefaults.ts, 468, 9))
+>a : Symbol(a, Decl(genericDefaults.ts, 468, 24))
+>T : Symbol(T, Decl(genericDefaults.ts, 468, 9))
 
 const t00c00 = (<t00>x).a;
->t00c00 : Symbol(t00c00, Decl(genericDefaults.ts, 460, 5))
->(<t00>x).a : Symbol(a, Decl(genericDefaults.ts, 459, 24))
->t00 : Symbol(t00, Decl(genericDefaults.ts, 457, 46))
+>t00c00 : Symbol(t00c00, Decl(genericDefaults.ts, 469, 5))
+>(<t00>x).a : Symbol(a, Decl(genericDefaults.ts, 468, 24))
+>t00 : Symbol(t00, Decl(genericDefaults.ts, 466, 36))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 459, 24))
+>a : Symbol(a, Decl(genericDefaults.ts, 468, 24))
 
 const t00c01 = (<t00<number>>x).a;
->t00c01 : Symbol(t00c01, Decl(genericDefaults.ts, 461, 5))
->(<t00<number>>x).a : Symbol(a, Decl(genericDefaults.ts, 459, 24))
->t00 : Symbol(t00, Decl(genericDefaults.ts, 457, 46))
+>t00c01 : Symbol(t00c01, Decl(genericDefaults.ts, 470, 5))
+>(<t00<number>>x).a : Symbol(a, Decl(genericDefaults.ts, 468, 24))
+>t00 : Symbol(t00, Decl(genericDefaults.ts, 466, 36))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 459, 24))
+>a : Symbol(a, Decl(genericDefaults.ts, 468, 24))
 
 type t01<T, U = T> = { a: [T, U]; }
->t01 : Symbol(t01, Decl(genericDefaults.ts, 461, 34))
->T : Symbol(T, Decl(genericDefaults.ts, 463, 9))
->U : Symbol(U, Decl(genericDefaults.ts, 463, 11))
->T : Symbol(T, Decl(genericDefaults.ts, 463, 9))
->a : Symbol(a, Decl(genericDefaults.ts, 463, 22))
->T : Symbol(T, Decl(genericDefaults.ts, 463, 9))
->U : Symbol(U, Decl(genericDefaults.ts, 463, 11))
+>t01 : Symbol(t01, Decl(genericDefaults.ts, 470, 34))
+>T : Symbol(T, Decl(genericDefaults.ts, 472, 9))
+>U : Symbol(U, Decl(genericDefaults.ts, 472, 11))
+>T : Symbol(T, Decl(genericDefaults.ts, 472, 9))
+>a : Symbol(a, Decl(genericDefaults.ts, 472, 22))
+>T : Symbol(T, Decl(genericDefaults.ts, 472, 9))
+>U : Symbol(U, Decl(genericDefaults.ts, 472, 11))
 
 const t01c00 = (<t01<number>>x).a;
->t01c00 : Symbol(t01c00, Decl(genericDefaults.ts, 464, 5))
->(<t01<number>>x).a : Symbol(a, Decl(genericDefaults.ts, 463, 22))
->t01 : Symbol(t01, Decl(genericDefaults.ts, 461, 34))
+>t01c00 : Symbol(t01c00, Decl(genericDefaults.ts, 473, 5))
+>(<t01<number>>x).a : Symbol(a, Decl(genericDefaults.ts, 472, 22))
+>t01 : Symbol(t01, Decl(genericDefaults.ts, 470, 34))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 463, 22))
+>a : Symbol(a, Decl(genericDefaults.ts, 472, 22))
 
 const t01c01 = (<t01<number, string>>x).a;
->t01c01 : Symbol(t01c01, Decl(genericDefaults.ts, 465, 5))
->(<t01<number, string>>x).a : Symbol(a, Decl(genericDefaults.ts, 463, 22))
->t01 : Symbol(t01, Decl(genericDefaults.ts, 461, 34))
+>t01c01 : Symbol(t01c01, Decl(genericDefaults.ts, 474, 5))
+>(<t01<number, string>>x).a : Symbol(a, Decl(genericDefaults.ts, 472, 22))
+>t01 : Symbol(t01, Decl(genericDefaults.ts, 470, 34))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 463, 22))
+>a : Symbol(a, Decl(genericDefaults.ts, 472, 22))
 
 type t02<T extends number, U = T> = { a: [T, U]; }
->t02 : Symbol(t02, Decl(genericDefaults.ts, 465, 42))
->T : Symbol(T, Decl(genericDefaults.ts, 467, 9))
->U : Symbol(U, Decl(genericDefaults.ts, 467, 26))
->T : Symbol(T, Decl(genericDefaults.ts, 467, 9))
->a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
->T : Symbol(T, Decl(genericDefaults.ts, 467, 9))
->U : Symbol(U, Decl(genericDefaults.ts, 467, 26))
+>t02 : Symbol(t02, Decl(genericDefaults.ts, 474, 42))
+>T : Symbol(T, Decl(genericDefaults.ts, 476, 9))
+>U : Symbol(U, Decl(genericDefaults.ts, 476, 26))
+>T : Symbol(T, Decl(genericDefaults.ts, 476, 9))
+>a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
+>T : Symbol(T, Decl(genericDefaults.ts, 476, 9))
+>U : Symbol(U, Decl(genericDefaults.ts, 476, 26))
 
 const t02c00 = (<t02<number>>x).a;
->t02c00 : Symbol(t02c00, Decl(genericDefaults.ts, 468, 5))
->(<t02<number>>x).a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
->t02 : Symbol(t02, Decl(genericDefaults.ts, 465, 42))
+>t02c00 : Symbol(t02c00, Decl(genericDefaults.ts, 477, 5))
+>(<t02<number>>x).a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
+>t02 : Symbol(t02, Decl(genericDefaults.ts, 474, 42))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
+>a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
 
 const t02c01 = (<t02<1>>x).a;
->t02c01 : Symbol(t02c01, Decl(genericDefaults.ts, 469, 5))
->(<t02<1>>x).a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
->t02 : Symbol(t02, Decl(genericDefaults.ts, 465, 42))
+>t02c01 : Symbol(t02c01, Decl(genericDefaults.ts, 478, 5))
+>(<t02<1>>x).a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
+>t02 : Symbol(t02, Decl(genericDefaults.ts, 474, 42))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
+>a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
 
 const t02c02 = (<t02<number, number>>x).a;
->t02c02 : Symbol(t02c02, Decl(genericDefaults.ts, 470, 5))
->(<t02<number, number>>x).a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
->t02 : Symbol(t02, Decl(genericDefaults.ts, 465, 42))
+>t02c02 : Symbol(t02c02, Decl(genericDefaults.ts, 479, 5))
+>(<t02<number, number>>x).a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
+>t02 : Symbol(t02, Decl(genericDefaults.ts, 474, 42))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
+>a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
 
 const t02c03 = (<t02<1, number>>x).a;
->t02c03 : Symbol(t02c03, Decl(genericDefaults.ts, 471, 5))
->(<t02<1, number>>x).a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
->t02 : Symbol(t02, Decl(genericDefaults.ts, 465, 42))
+>t02c03 : Symbol(t02c03, Decl(genericDefaults.ts, 480, 5))
+>(<t02<1, number>>x).a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
+>t02 : Symbol(t02, Decl(genericDefaults.ts, 474, 42))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
+>a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
 
 const t02c04 = (<t02<number, 1>>x).a;
->t02c04 : Symbol(t02c04, Decl(genericDefaults.ts, 472, 5))
->(<t02<number, 1>>x).a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
->t02 : Symbol(t02, Decl(genericDefaults.ts, 465, 42))
+>t02c04 : Symbol(t02c04, Decl(genericDefaults.ts, 481, 5))
+>(<t02<number, 1>>x).a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
+>t02 : Symbol(t02, Decl(genericDefaults.ts, 474, 42))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 467, 37))
+>a : Symbol(a, Decl(genericDefaults.ts, 476, 37))
 
 type t03<T extends number, U extends T = T> = { a: [T, U]; }
->t03 : Symbol(t03, Decl(genericDefaults.ts, 472, 37))
->T : Symbol(T, Decl(genericDefaults.ts, 474, 9))
->U : Symbol(U, Decl(genericDefaults.ts, 474, 26))
->T : Symbol(T, Decl(genericDefaults.ts, 474, 9))
->T : Symbol(T, Decl(genericDefaults.ts, 474, 9))
->a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
->T : Symbol(T, Decl(genericDefaults.ts, 474, 9))
->U : Symbol(U, Decl(genericDefaults.ts, 474, 26))
+>t03 : Symbol(t03, Decl(genericDefaults.ts, 481, 37))
+>T : Symbol(T, Decl(genericDefaults.ts, 483, 9))
+>U : Symbol(U, Decl(genericDefaults.ts, 483, 26))
+>T : Symbol(T, Decl(genericDefaults.ts, 483, 9))
+>T : Symbol(T, Decl(genericDefaults.ts, 483, 9))
+>a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
+>T : Symbol(T, Decl(genericDefaults.ts, 483, 9))
+>U : Symbol(U, Decl(genericDefaults.ts, 483, 26))
 
 const t03c00 = (<t03<number>>x).a;
->t03c00 : Symbol(t03c00, Decl(genericDefaults.ts, 475, 5))
->(<t03<number>>x).a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
->t03 : Symbol(t03, Decl(genericDefaults.ts, 472, 37))
+>t03c00 : Symbol(t03c00, Decl(genericDefaults.ts, 484, 5))
+>(<t03<number>>x).a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
+>t03 : Symbol(t03, Decl(genericDefaults.ts, 481, 37))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
+>a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
 
 const t03c01 = (<t03<1>>x).a;
->t03c01 : Symbol(t03c01, Decl(genericDefaults.ts, 476, 5))
->(<t03<1>>x).a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
->t03 : Symbol(t03, Decl(genericDefaults.ts, 472, 37))
+>t03c01 : Symbol(t03c01, Decl(genericDefaults.ts, 485, 5))
+>(<t03<1>>x).a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
+>t03 : Symbol(t03, Decl(genericDefaults.ts, 481, 37))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
+>a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
 
 const t03c02 = (<t03<number, number>>x).a;
->t03c02 : Symbol(t03c02, Decl(genericDefaults.ts, 477, 5))
->(<t03<number, number>>x).a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
->t03 : Symbol(t03, Decl(genericDefaults.ts, 472, 37))
+>t03c02 : Symbol(t03c02, Decl(genericDefaults.ts, 486, 5))
+>(<t03<number, number>>x).a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
+>t03 : Symbol(t03, Decl(genericDefaults.ts, 481, 37))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
+>a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
 
 const t03c03 = (<t03<1, 1>>x).a;
->t03c03 : Symbol(t03c03, Decl(genericDefaults.ts, 478, 5))
->(<t03<1, 1>>x).a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
->t03 : Symbol(t03, Decl(genericDefaults.ts, 472, 37))
+>t03c03 : Symbol(t03c03, Decl(genericDefaults.ts, 487, 5))
+>(<t03<1, 1>>x).a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
+>t03 : Symbol(t03, Decl(genericDefaults.ts, 481, 37))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
+>a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
 
 const t03c04 = (<t03<number, 1>>x).a;
->t03c04 : Symbol(t03c04, Decl(genericDefaults.ts, 479, 5))
->(<t03<number, 1>>x).a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
->t03 : Symbol(t03, Decl(genericDefaults.ts, 472, 37))
+>t03c04 : Symbol(t03c04, Decl(genericDefaults.ts, 488, 5))
+>(<t03<number, 1>>x).a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
+>t03 : Symbol(t03, Decl(genericDefaults.ts, 481, 37))
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
->a : Symbol(a, Decl(genericDefaults.ts, 474, 47))
+>a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
 

--- a/tests/baselines/reference/genericDefaults.types
+++ b/tests/baselines/reference/genericDefaults.types
@@ -2446,6 +2446,43 @@ const Derived02c03 = new Derived02<number>(1);
 >Derived02 : typeof Derived02
 >1 : 1
 
+// https://github.com/Microsoft/TypeScript/issues/16211
+interface Base02 {}
+>Base02 : Base02
+
+interface Base02Constructor { new <T = A>(a: T): Base02 & T; }
+>Base02Constructor : Base02Constructor
+>T : T
+>A : A
+>a : T
+>T : T
+>Base02 : Base02
+>T : T
+
+declare const Base02: Base02Constructor;
+>Base02 : Base02Constructor
+>Base02Constructor : Base02Constructor
+
+declare class Derived03 extends Base02 {}
+>Derived03 : Derived03
+>Base02 : Base02 & A
+
+const Derived03c00 = new Derived03(ab);
+>Derived03c00 : Derived03
+>new Derived03(ab) : Derived03
+>Derived03 : typeof Derived03
+>ab : AB
+
+const Derived03c01 = Derived03c00.a;
+>Derived03c01 : number
+>Derived03c00.a : number
+>Derived03c00 : Derived03
+>a : number
+
+type DerivedProps = keyof Derived03;
+>DerivedProps : "a"
+>Derived03 : Derived03
+
 type t00<T = number> = { a: T; }
 >t00 : t00<T>
 >T : T

--- a/tests/cases/compiler/genericDefaults.ts
+++ b/tests/cases/compiler/genericDefaults.ts
@@ -458,6 +458,15 @@ const Derived02c01 = new Derived02(1);
 const Derived02c02 = new Derived02<number>();
 const Derived02c03 = new Derived02<number>(1);
 
+// https://github.com/Microsoft/TypeScript/issues/16211
+interface Base02 {}
+interface Base02Constructor { new <T = A>(a: T): Base02 & T; }
+declare const Base02: Base02Constructor;
+declare class Derived03 extends Base02 {}
+const Derived03c00 = new Derived03(ab);
+const Derived03c01 = Derived03c00.a;
+type DerivedProps = keyof Derived03;
+
 type t00<T = number> = { a: T; }
 const t00c00 = (<t00>x).a;
 const t00c01 = (<t00<number>>x).a;


### PR DESCRIPTION
This fixes an issue with `extends` where the instantiation of a class-like "constructor" function used as a base class fails when the construct signature returns a type parameter default.

This also fixes an issue where we were not reporting a grammar error for an empty type argument list in a heritage clause.

Fixes #16211
