### PR TITLE
Add parentheses around keyof in declaration emit when needed

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3233,9 +3233,15 @@ namespace ts {
                         writer.writeStringLiteral(literalTypeToString(<LiteralType>type));
                     }
                     else if (type.flags & TypeFlags.Index) {
+                        if (flags & TypeFormatFlags.InElementType) {
+                            writePunctuation(writer, SyntaxKind.OpenParenToken);
+                        }
                         writer.writeKeyword("keyof");
                         writeSpace(writer);
                         writeType((<IndexType>type).type, TypeFormatFlags.InElementType);
+                        if (flags & TypeFormatFlags.InElementType) {
+                            writePunctuation(writer, SyntaxKind.CloseParenToken);
+                        }
                     }
                     else if (type.flags & TypeFlags.IndexedAccess) {
                         writeType((<IndexedAccessType>type).objectType, TypeFormatFlags.InElementType);

--- a/tests/baselines/reference/declarationEmitIndexTypeArray.js
+++ b/tests/baselines/reference/declarationEmitIndexTypeArray.js
@@ -1,0 +1,25 @@
+//// [declarationEmitIndexTypeArray.ts]
+function doSomethingWithKeys<T>(...keys: (keyof T)[]) { }
+
+const utilityFunctions = {
+  doSomethingWithKeys
+};
+
+
+//// [declarationEmitIndexTypeArray.js]
+function doSomethingWithKeys() {
+    var keys = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        keys[_i] = arguments[_i];
+    }
+}
+var utilityFunctions = {
+    doSomethingWithKeys: doSomethingWithKeys
+};
+
+
+//// [declarationEmitIndexTypeArray.d.ts]
+declare function doSomethingWithKeys<T>(...keys: (keyof T)[]): void;
+declare const utilityFunctions: {
+    doSomethingWithKeys: <T>(...keys: (keyof T)[]) => void;
+};

--- a/tests/baselines/reference/declarationEmitIndexTypeArray.symbols
+++ b/tests/baselines/reference/declarationEmitIndexTypeArray.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/declarationEmitIndexTypeArray.ts ===
+function doSomethingWithKeys<T>(...keys: (keyof T)[]) { }
+>doSomethingWithKeys : Symbol(doSomethingWithKeys, Decl(declarationEmitIndexTypeArray.ts, 0, 0))
+>T : Symbol(T, Decl(declarationEmitIndexTypeArray.ts, 0, 29))
+>keys : Symbol(keys, Decl(declarationEmitIndexTypeArray.ts, 0, 32))
+>T : Symbol(T, Decl(declarationEmitIndexTypeArray.ts, 0, 29))
+
+const utilityFunctions = {
+>utilityFunctions : Symbol(utilityFunctions, Decl(declarationEmitIndexTypeArray.ts, 2, 5))
+
+  doSomethingWithKeys
+>doSomethingWithKeys : Symbol(doSomethingWithKeys, Decl(declarationEmitIndexTypeArray.ts, 2, 26))
+
+};
+

--- a/tests/baselines/reference/declarationEmitIndexTypeArray.types
+++ b/tests/baselines/reference/declarationEmitIndexTypeArray.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/declarationEmitIndexTypeArray.ts ===
+function doSomethingWithKeys<T>(...keys: (keyof T)[]) { }
+>doSomethingWithKeys : <T>(...keys: keyof T[]) => void
+>T : T
+>keys : keyof T[]
+>T : T
+
+const utilityFunctions = {
+>utilityFunctions : { doSomethingWithKeys: <T>(...keys: keyof T[]) => void; }
+>{  doSomethingWithKeys} : { doSomethingWithKeys: <T>(...keys: keyof T[]) => void; }
+
+  doSomethingWithKeys
+>doSomethingWithKeys : <T>(...keys: keyof T[]) => void
+
+};
+

--- a/tests/cases/compiler/declarationEmitIndexTypeArray.ts
+++ b/tests/cases/compiler/declarationEmitIndexTypeArray.ts
@@ -1,0 +1,6 @@
+// @declaration: true
+function doSomethingWithKeys<T>(...keys: (keyof T)[]) { }
+
+const utilityFunctions = {
+  doSomethingWithKeys
+};


### PR DESCRIPTION
Fixes #15886 

Note @weswigham I know you will probably get rid of this code soon, but there should seriously be a utility for adding parentheses around things.
