### PR TITLE
Flag bool in less/greater than comparison as error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17414,7 +17414,7 @@ namespace ts {
                     if (checkForDisallowedESSymbolOperand(operator)) {
                         leftType = getBaseTypeOfLiteralType(checkNonNullType(leftType, left));
                         rightType = getBaseTypeOfLiteralType(checkNonNullType(rightType, right));
-                        if (!isTypeComparableTo(leftType, rightType) && !isTypeComparableTo(rightType, leftType)) {
+                        if (!checkTypeComparableWithLessOrGreaterThanOperator(leftType) || !checkTypeComparableWithLessOrGreaterThanOperator(rightType) || (!isTypeComparableTo(leftType, rightType) && !isTypeComparableTo(rightType, leftType))) {
                             reportOperatorError();
                         }
                     }
@@ -17502,6 +17502,10 @@ namespace ts {
                         checkTypeAssignableTo(valueType, leftType, left, /*headMessage*/ undefined);
                     }
                 }
+            }
+
+            function checkTypeComparableWithLessOrGreaterThanOperator(valueType: Type): boolean {
+                return !(valueType.flags & TypeFlags.BooleanLike) && !(valueType.flags & TypeFlags.DefinitelyFalsy);
             }
 
             function reportOperatorError() {

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es2017.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es2017.errors.txt
@@ -4,11 +4,12 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,33): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,38): error TS1005: ';' expected.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,39): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,41): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,49): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts (8 errors) ====
+==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts (9 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
@@ -22,8 +23,11 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 !!! error TS1005: ';' expected.
                                           ~
 !!! error TS1128: Declaration or statement expected.
+                                            ~~~~~~~~~~~~~~~
                                                     ~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                                         ~
 !!! error TS1109: Expression expected.
     }
+    ~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es5.errors.txt
@@ -4,11 +4,12 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,33): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,38): error TS1005: ';' expected.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,39): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,41): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,49): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts (8 errors) ====
+==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts (9 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
@@ -22,8 +23,11 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1
 !!! error TS1005: ';' expected.
                                           ~
 !!! error TS1128: Declaration or statement expected.
+                                            ~~~~~~~~~~~~~~~
                                                     ~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                                         ~
 !!! error TS1109: Expression expected.
     }
+    ~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es6.errors.txt
@@ -4,11 +4,12 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,33): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,38): error TS1005: ';' expected.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,39): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,41): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,49): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts (8 errors) ====
+==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts (9 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
@@ -22,8 +23,11 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
 !!! error TS1005: ';' expected.
                                           ~
 !!! error TS1128: Declaration or statement expected.
+                                            ~~~~~~~~~~~~~~~
                                                     ~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                                         ~
 !!! error TS1109: Expression expected.
     }
+    ~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es2017.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es2017.errors.txt
@@ -2,11 +2,12 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,20): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,25): error TS1005: ';' expected.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,26): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,28): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,36): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,40): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts (6 errors) ====
+==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts (7 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
 !!! error TS1138: Parameter declaration expected.
@@ -16,8 +17,11 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 !!! error TS1005: ';' expected.
                              ~
 !!! error TS1128: Declaration or statement expected.
+                               ~~~~~~~~~~~~~~~
                                        ~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                            ~
 !!! error TS1109: Expression expected.
     }
+    ~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es5.errors.txt
@@ -2,11 +2,12 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,20): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,25): error TS1005: ';' expected.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,26): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,28): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,36): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,40): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts (6 errors) ====
+==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts (7 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
 !!! error TS1138: Parameter declaration expected.
@@ -16,8 +17,11 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5
 !!! error TS1005: ';' expected.
                              ~
 !!! error TS1128: Declaration or statement expected.
+                               ~~~~~~~~~~~~~~~
                                        ~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                            ~
 !!! error TS1109: Expression expected.
     }
+    ~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es6.errors.txt
@@ -2,11 +2,12 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,20): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,25): error TS1005: ';' expected.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,26): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,28): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,36): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,40): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts (6 errors) ====
+==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts (7 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
 !!! error TS1138: Parameter declaration expected.
@@ -16,8 +17,11 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5
 !!! error TS1005: ';' expected.
                              ~
 !!! error TS1128: Declaration or statement expected.
+                               ~~~~~~~~~~~~~~~
                                        ~~~~
 !!! error TS2532: Object is possibly 'undefined'.
                                            ~
 !!! error TS1109: Expression expected.
     }
+    ~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
@@ -1,22 +1,30 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(11,11): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(13,11): error TS2365: Operator '<' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(15,11): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(15,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(16,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(16,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(20,11): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(22,11): error TS2365: Operator '>' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(24,11): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(24,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(25,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(25,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(29,11): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(31,11): error TS2365: Operator '<=' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(33,11): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(33,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(34,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(34,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(38,11): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(40,11): error TS2365: Operator '>=' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(42,11): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(42,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(43,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts (16 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts (24 errors) ====
     enum E { a, b, c }
     
     var a: number;
@@ -28,8 +36,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator <
     var ra1 = a < a;
     var ra2 = b < b;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
     var ra3 = c < c;
     var ra4 = d < d;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'void'.
     var ra5 = e < e;
     var ra6 = null < null;
               ~~~~
@@ -45,8 +57,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator >
     var rb1 = a > a;
     var rb2 = b > b;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
     var rb3 = c > c;
     var rb4 = d > d;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'void'.
     var rb5 = e > e;
     var rb6 = null > null;
               ~~~~
@@ -62,8 +78,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator <=
     var rc1 = a <= a;
     var rc2 = b <= b;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
     var rc3 = c <= c;
     var rc4 = d <= d;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'void'.
     var rc5 = e <= e;
     var rc6 = null <= null;
               ~~~~
@@ -79,8 +99,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator >=
     var rd1 = a >= a;
     var rd2 = b >= b;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
     var rd3 = c >= c;
     var rd4 = d >= d;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'void'.
     var rd5 = e >= e;
     var rd6 = null >= null;
               ~~~~

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.errors.txt
@@ -1,0 +1,235 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(35,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(38,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(47,12): error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(63,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(66,12): error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(76,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(82,12): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(85,12): error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(92,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(95,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(101,12): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts(104,12): error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts (16 errors) ====
+    var x: any;
+    
+    enum E { a, b, c }
+    
+    function foo<T>(t: T) {
+        var foo_r1 = t < x;
+        var foo_r2 = t > x;
+        var foo_r3 = t <= x;
+        var foo_r4 = t >= x;
+        var foo_r5 = t == x;
+        var foo_r6 = t != x;
+        var foo_r7 = t === x;
+        var foo_r8 = t !== x;
+    
+        var foo_r1 = x < t;
+        var foo_r2 = x > t;
+        var foo_r3 = x <= t;
+        var foo_r4 = x >= t;
+        var foo_r5 = x == t;
+        var foo_r6 = x != t;
+        var foo_r7 = x === t;
+        var foo_r8 = x !== t;
+    }
+    
+    var a: boolean;
+    var b: number;
+    var c: string;
+    var d: void;
+    var e: E;
+    var f: {};
+    var g: string[];
+    var h: Date;
+    
+    // operator <
+    var r1a1 = x < a;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
+    var r1a2 = x < b;
+    var r1a3 = x < c;
+    var r1a4 = x < d;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
+    var r1a5 = x < e;
+    var r1a6 = x < f;
+    var r1a7 = x < g;
+    var r1a7 = x < h;
+    
+    var r1b1 = a < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+    var r1b2 = b < x;
+    var r1b3 = c < x;
+    var r1b4 = d < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
+    var r1b5 = e < x;
+    var r1b6 = f < x;
+    var r1b7 = g < x;
+    var r1b7 = h < x;
+    
+    // operator >
+    var r2a1 = x > a;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
+    var r2a2 = x > b;
+    var r2a3 = x > c;
+    var r2a4 = x > d;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
+    var r2a5 = x > e;
+    var r2a6 = x > f;
+    var r2a7 = x > g;
+    var r2a7 = x > h;
+    
+    var r2b1 = a > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+    var r2b2 = b > x;
+    var r2b3 = c > x;
+    var r2b4 = d > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
+    var r2b5 = e > x;
+    var r2b6 = f > x;
+    var r2b7 = g > x;
+    var r2b7 = h > x;
+    
+    // operator <=
+    var r3a1 = x <= a;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
+    var r3a2 = x <= b;
+    var r3a3 = x <= c;
+    var r3a4 = x <= d;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
+    var r3a5 = x <= e;
+    var r3a6 = x <= f;
+    var r3a7 = x <= g;
+    var r3a7 = x <= h;
+    
+    var r3b1 = a <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+    var r3b2 = b <= x;
+    var r3b3 = c <= x;
+    var r3b4 = d <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
+    var r3b5 = e <= x;
+    var r3b6 = f <= x;
+    var r3b7 = g <= x;
+    var r3b7 = h <= x;
+    
+    // operator >=
+    var r4a1 = x >= a;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
+    var r4a2 = x >= b;
+    var r4a3 = x >= c;
+    var r4a4 = x >= d;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
+    var r4a5 = x >= e;
+    var r4a6 = x >= f;
+    var r4a7 = x >= g;
+    var r4a7 = x >= h;
+    
+    var r4b1 = a >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+    var r4b2 = b >= x;
+    var r4b3 = c >= x;
+    var r4b4 = d >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
+    var r4b5 = e >= x;
+    var r4b6 = f >= x;
+    var r4b7 = g >= x;
+    var r4b7 = h >= x;
+    
+    // operator ==
+    var r5a1 = x == a;
+    var r5a2 = x == b;
+    var r5a3 = x == c;
+    var r5a4 = x == d;
+    var r5a5 = x == e;
+    var r5a6 = x == f;
+    var r5a7 = x == g;
+    var r5a7 = x == h;
+    
+    var r5b1 = a == x;
+    var r5b2 = b == x;
+    var r5b3 = c == x;
+    var r5b4 = d == x;
+    var r5b5 = e == x;
+    var r5b6 = f == x;
+    var r5b7 = g == x;
+    var r5b7 = h == x;
+    
+    // operator !=
+    var r6a1 = x != a;
+    var r6a2 = x != b;
+    var r6a3 = x != c;
+    var r6a4 = x != d;
+    var r6a5 = x != e;
+    var r6a6 = x != f;
+    var r6a7 = x != g;
+    var r6a7 = x != h;
+    
+    var r6b1 = a != x;
+    var r6b2 = b != x;
+    var r6b3 = c != x;
+    var r6b4 = d != x;
+    var r6b5 = e != x;
+    var r6b6 = f != x;
+    var r6b7 = g != x;
+    var r6b7 = h != x;
+    
+    // operator ===
+    var r7a1 = x === a;
+    var r7a2 = x === b;
+    var r7a3 = x === c;
+    var r7a4 = x === d;
+    var r7a5 = x === e;
+    var r7a6 = x === f;
+    var r7a7 = x === g;
+    var r7a7 = x === h;
+    
+    var r7b1 = a === x;
+    var r7b2 = b === x;
+    var r7b3 = c === x;
+    var r7b4 = d === x;
+    var r7b5 = e === x;
+    var r7b6 = f === x;
+    var r7b7 = g === x;
+    var r7b7 = h === x;
+    
+    // operator !==
+    var r8a1 = x !== a;
+    var r8a2 = x !== b;
+    var r8a3 = x !== c;
+    var r8a4 = x !== d;
+    var r8a5 = x !== e;
+    var r8a6 = x !== f;
+    var r8a7 = x !== g;
+    var r8a7 = x !== h;
+    
+    var r8b1 = a !== x;
+    var r8b2 = b !== x;
+    var r8b3 = c !== x;
+    var r8b4 = d !== x;
+    var r8b5 = e !== x;
+    var r8b6 = f !== x;
+    var r8b7 = g !== x;
+    var r8b7 = h !== x;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.js
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.js
@@ -30,6 +30,7 @@ var d: void;
 var e: E;
 var f: {};
 var g: string[];
+var h: Date;
 
 // operator <
 var r1a1 = x < a;
@@ -39,6 +40,7 @@ var r1a4 = x < d;
 var r1a5 = x < e;
 var r1a6 = x < f;
 var r1a7 = x < g;
+var r1a7 = x < h;
 
 var r1b1 = a < x;
 var r1b2 = b < x;
@@ -47,6 +49,7 @@ var r1b4 = d < x;
 var r1b5 = e < x;
 var r1b6 = f < x;
 var r1b7 = g < x;
+var r1b7 = h < x;
 
 // operator >
 var r2a1 = x > a;
@@ -56,6 +59,7 @@ var r2a4 = x > d;
 var r2a5 = x > e;
 var r2a6 = x > f;
 var r2a7 = x > g;
+var r2a7 = x > h;
 
 var r2b1 = a > x;
 var r2b2 = b > x;
@@ -64,6 +68,7 @@ var r2b4 = d > x;
 var r2b5 = e > x;
 var r2b6 = f > x;
 var r2b7 = g > x;
+var r2b7 = h > x;
 
 // operator <=
 var r3a1 = x <= a;
@@ -73,6 +78,7 @@ var r3a4 = x <= d;
 var r3a5 = x <= e;
 var r3a6 = x <= f;
 var r3a7 = x <= g;
+var r3a7 = x <= h;
 
 var r3b1 = a <= x;
 var r3b2 = b <= x;
@@ -81,6 +87,7 @@ var r3b4 = d <= x;
 var r3b5 = e <= x;
 var r3b6 = f <= x;
 var r3b7 = g <= x;
+var r3b7 = h <= x;
 
 // operator >=
 var r4a1 = x >= a;
@@ -90,6 +97,7 @@ var r4a4 = x >= d;
 var r4a5 = x >= e;
 var r4a6 = x >= f;
 var r4a7 = x >= g;
+var r4a7 = x >= h;
 
 var r4b1 = a >= x;
 var r4b2 = b >= x;
@@ -98,6 +106,7 @@ var r4b4 = d >= x;
 var r4b5 = e >= x;
 var r4b6 = f >= x;
 var r4b7 = g >= x;
+var r4b7 = h >= x;
 
 // operator ==
 var r5a1 = x == a;
@@ -107,6 +116,7 @@ var r5a4 = x == d;
 var r5a5 = x == e;
 var r5a6 = x == f;
 var r5a7 = x == g;
+var r5a7 = x == h;
 
 var r5b1 = a == x;
 var r5b2 = b == x;
@@ -115,6 +125,7 @@ var r5b4 = d == x;
 var r5b5 = e == x;
 var r5b6 = f == x;
 var r5b7 = g == x;
+var r5b7 = h == x;
 
 // operator !=
 var r6a1 = x != a;
@@ -124,6 +135,7 @@ var r6a4 = x != d;
 var r6a5 = x != e;
 var r6a6 = x != f;
 var r6a7 = x != g;
+var r6a7 = x != h;
 
 var r6b1 = a != x;
 var r6b2 = b != x;
@@ -132,6 +144,7 @@ var r6b4 = d != x;
 var r6b5 = e != x;
 var r6b6 = f != x;
 var r6b7 = g != x;
+var r6b7 = h != x;
 
 // operator ===
 var r7a1 = x === a;
@@ -141,6 +154,7 @@ var r7a4 = x === d;
 var r7a5 = x === e;
 var r7a6 = x === f;
 var r7a7 = x === g;
+var r7a7 = x === h;
 
 var r7b1 = a === x;
 var r7b2 = b === x;
@@ -149,6 +163,7 @@ var r7b4 = d === x;
 var r7b5 = e === x;
 var r7b6 = f === x;
 var r7b7 = g === x;
+var r7b7 = h === x;
 
 // operator !==
 var r8a1 = x !== a;
@@ -158,6 +173,7 @@ var r8a4 = x !== d;
 var r8a5 = x !== e;
 var r8a6 = x !== f;
 var r8a7 = x !== g;
+var r8a7 = x !== h;
 
 var r8b1 = a !== x;
 var r8b2 = b !== x;
@@ -166,6 +182,7 @@ var r8b4 = d !== x;
 var r8b5 = e !== x;
 var r8b6 = f !== x;
 var r8b7 = g !== x;
+var r8b7 = h !== x;
 
 //// [comparisonOperatorWithOneOperandIsAny.js]
 var x;
@@ -200,6 +217,7 @@ var d;
 var e;
 var f;
 var g;
+var h;
 // operator <
 var r1a1 = x < a;
 var r1a2 = x < b;
@@ -208,6 +226,7 @@ var r1a4 = x < d;
 var r1a5 = x < e;
 var r1a6 = x < f;
 var r1a7 = x < g;
+var r1a7 = x < h;
 var r1b1 = a < x;
 var r1b2 = b < x;
 var r1b3 = c < x;
@@ -215,6 +234,7 @@ var r1b4 = d < x;
 var r1b5 = e < x;
 var r1b6 = f < x;
 var r1b7 = g < x;
+var r1b7 = h < x;
 // operator >
 var r2a1 = x > a;
 var r2a2 = x > b;
@@ -223,6 +243,7 @@ var r2a4 = x > d;
 var r2a5 = x > e;
 var r2a6 = x > f;
 var r2a7 = x > g;
+var r2a7 = x > h;
 var r2b1 = a > x;
 var r2b2 = b > x;
 var r2b3 = c > x;
@@ -230,6 +251,7 @@ var r2b4 = d > x;
 var r2b5 = e > x;
 var r2b6 = f > x;
 var r2b7 = g > x;
+var r2b7 = h > x;
 // operator <=
 var r3a1 = x <= a;
 var r3a2 = x <= b;
@@ -238,6 +260,7 @@ var r3a4 = x <= d;
 var r3a5 = x <= e;
 var r3a6 = x <= f;
 var r3a7 = x <= g;
+var r3a7 = x <= h;
 var r3b1 = a <= x;
 var r3b2 = b <= x;
 var r3b3 = c <= x;
@@ -245,6 +268,7 @@ var r3b4 = d <= x;
 var r3b5 = e <= x;
 var r3b6 = f <= x;
 var r3b7 = g <= x;
+var r3b7 = h <= x;
 // operator >=
 var r4a1 = x >= a;
 var r4a2 = x >= b;
@@ -253,6 +277,7 @@ var r4a4 = x >= d;
 var r4a5 = x >= e;
 var r4a6 = x >= f;
 var r4a7 = x >= g;
+var r4a7 = x >= h;
 var r4b1 = a >= x;
 var r4b2 = b >= x;
 var r4b3 = c >= x;
@@ -260,6 +285,7 @@ var r4b4 = d >= x;
 var r4b5 = e >= x;
 var r4b6 = f >= x;
 var r4b7 = g >= x;
+var r4b7 = h >= x;
 // operator ==
 var r5a1 = x == a;
 var r5a2 = x == b;
@@ -268,6 +294,7 @@ var r5a4 = x == d;
 var r5a5 = x == e;
 var r5a6 = x == f;
 var r5a7 = x == g;
+var r5a7 = x == h;
 var r5b1 = a == x;
 var r5b2 = b == x;
 var r5b3 = c == x;
@@ -275,6 +302,7 @@ var r5b4 = d == x;
 var r5b5 = e == x;
 var r5b6 = f == x;
 var r5b7 = g == x;
+var r5b7 = h == x;
 // operator !=
 var r6a1 = x != a;
 var r6a2 = x != b;
@@ -283,6 +311,7 @@ var r6a4 = x != d;
 var r6a5 = x != e;
 var r6a6 = x != f;
 var r6a7 = x != g;
+var r6a7 = x != h;
 var r6b1 = a != x;
 var r6b2 = b != x;
 var r6b3 = c != x;
@@ -290,6 +319,7 @@ var r6b4 = d != x;
 var r6b5 = e != x;
 var r6b6 = f != x;
 var r6b7 = g != x;
+var r6b7 = h != x;
 // operator ===
 var r7a1 = x === a;
 var r7a2 = x === b;
@@ -298,6 +328,7 @@ var r7a4 = x === d;
 var r7a5 = x === e;
 var r7a6 = x === f;
 var r7a7 = x === g;
+var r7a7 = x === h;
 var r7b1 = a === x;
 var r7b2 = b === x;
 var r7b3 = c === x;
@@ -305,6 +336,7 @@ var r7b4 = d === x;
 var r7b5 = e === x;
 var r7b6 = f === x;
 var r7b7 = g === x;
+var r7b7 = h === x;
 // operator !==
 var r8a1 = x !== a;
 var r8a2 = x !== b;
@@ -313,6 +345,7 @@ var r8a4 = x !== d;
 var r8a5 = x !== e;
 var r8a6 = x !== f;
 var r8a7 = x !== g;
+var r8a7 = x !== h;
 var r8b1 = a !== x;
 var r8b2 = b !== x;
 var r8b3 = c !== x;
@@ -320,3 +353,4 @@ var r8b4 = d !== x;
 var r8b5 = e !== x;
 var r8b6 = f !== x;
 var r8b7 = g !== x;
+var r8b7 = h !== x;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.symbols
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.symbols
@@ -117,571 +117,655 @@ var f: {};
 var g: string[];
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var h: Date;
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+>Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
 // operator <
 var r1a1 = x < a;
->r1a1 : Symbol(r1a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 33, 3))
+>r1a1 : Symbol(r1a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 34, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 
 var r1a2 = x < b;
->r1a2 : Symbol(r1a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 34, 3))
+>r1a2 : Symbol(r1a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 35, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 
 var r1a3 = x < c;
->r1a3 : Symbol(r1a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 35, 3))
+>r1a3 : Symbol(r1a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 36, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 
 var r1a4 = x < d;
->r1a4 : Symbol(r1a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 36, 3))
+>r1a4 : Symbol(r1a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 37, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 
 var r1a5 = x < e;
->r1a5 : Symbol(r1a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 37, 3))
+>r1a5 : Symbol(r1a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 38, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 
 var r1a6 = x < f;
->r1a6 : Symbol(r1a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 38, 3))
+>r1a6 : Symbol(r1a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 39, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 
 var r1a7 = x < g;
->r1a7 : Symbol(r1a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 39, 3))
+>r1a7 : Symbol(r1a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 40, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 41, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var r1a7 = x < h;
+>r1a7 : Symbol(r1a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 40, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 41, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+
 var r1b1 = a < x;
->r1b1 : Symbol(r1b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 41, 3))
+>r1b1 : Symbol(r1b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 43, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r1b2 = b < x;
->r1b2 : Symbol(r1b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 42, 3))
+>r1b2 : Symbol(r1b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 44, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r1b3 = c < x;
->r1b3 : Symbol(r1b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 43, 3))
+>r1b3 : Symbol(r1b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 45, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r1b4 = d < x;
->r1b4 : Symbol(r1b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 44, 3))
+>r1b4 : Symbol(r1b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 46, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r1b5 = e < x;
->r1b5 : Symbol(r1b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 45, 3))
+>r1b5 : Symbol(r1b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 47, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r1b6 = f < x;
->r1b6 : Symbol(r1b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 46, 3))
+>r1b6 : Symbol(r1b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 48, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r1b7 = g < x;
->r1b7 : Symbol(r1b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 47, 3))
+>r1b7 : Symbol(r1b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 49, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 50, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+
+var r1b7 = h < x;
+>r1b7 : Symbol(r1b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 49, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 50, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 // operator >
 var r2a1 = x > a;
->r2a1 : Symbol(r2a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 50, 3))
+>r2a1 : Symbol(r2a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 53, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 
 var r2a2 = x > b;
->r2a2 : Symbol(r2a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 51, 3))
+>r2a2 : Symbol(r2a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 54, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 
 var r2a3 = x > c;
->r2a3 : Symbol(r2a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 52, 3))
+>r2a3 : Symbol(r2a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 55, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 
 var r2a4 = x > d;
->r2a4 : Symbol(r2a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 53, 3))
+>r2a4 : Symbol(r2a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 56, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 
 var r2a5 = x > e;
->r2a5 : Symbol(r2a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 54, 3))
+>r2a5 : Symbol(r2a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 57, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 
 var r2a6 = x > f;
->r2a6 : Symbol(r2a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 55, 3))
+>r2a6 : Symbol(r2a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 58, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 
 var r2a7 = x > g;
->r2a7 : Symbol(r2a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 56, 3))
+>r2a7 : Symbol(r2a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 59, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 60, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var r2a7 = x > h;
+>r2a7 : Symbol(r2a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 59, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 60, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+
 var r2b1 = a > x;
->r2b1 : Symbol(r2b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 58, 3))
+>r2b1 : Symbol(r2b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 62, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r2b2 = b > x;
->r2b2 : Symbol(r2b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 59, 3))
+>r2b2 : Symbol(r2b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 63, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r2b3 = c > x;
->r2b3 : Symbol(r2b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 60, 3))
+>r2b3 : Symbol(r2b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 64, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r2b4 = d > x;
->r2b4 : Symbol(r2b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 61, 3))
+>r2b4 : Symbol(r2b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 65, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r2b5 = e > x;
->r2b5 : Symbol(r2b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 62, 3))
+>r2b5 : Symbol(r2b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 66, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r2b6 = f > x;
->r2b6 : Symbol(r2b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 63, 3))
+>r2b6 : Symbol(r2b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 67, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r2b7 = g > x;
->r2b7 : Symbol(r2b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 64, 3))
+>r2b7 : Symbol(r2b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 68, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 69, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+
+var r2b7 = h > x;
+>r2b7 : Symbol(r2b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 68, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 69, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 // operator <=
 var r3a1 = x <= a;
->r3a1 : Symbol(r3a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 67, 3))
+>r3a1 : Symbol(r3a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 72, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 
 var r3a2 = x <= b;
->r3a2 : Symbol(r3a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 68, 3))
+>r3a2 : Symbol(r3a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 73, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 
 var r3a3 = x <= c;
->r3a3 : Symbol(r3a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 69, 3))
+>r3a3 : Symbol(r3a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 74, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 
 var r3a4 = x <= d;
->r3a4 : Symbol(r3a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 70, 3))
+>r3a4 : Symbol(r3a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 75, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 
 var r3a5 = x <= e;
->r3a5 : Symbol(r3a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 71, 3))
+>r3a5 : Symbol(r3a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 76, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 
 var r3a6 = x <= f;
->r3a6 : Symbol(r3a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 72, 3))
+>r3a6 : Symbol(r3a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 77, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 
 var r3a7 = x <= g;
->r3a7 : Symbol(r3a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 73, 3))
+>r3a7 : Symbol(r3a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 78, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 79, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var r3a7 = x <= h;
+>r3a7 : Symbol(r3a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 78, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 79, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+
 var r3b1 = a <= x;
->r3b1 : Symbol(r3b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 75, 3))
+>r3b1 : Symbol(r3b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 81, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r3b2 = b <= x;
->r3b2 : Symbol(r3b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 76, 3))
+>r3b2 : Symbol(r3b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 82, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r3b3 = c <= x;
->r3b3 : Symbol(r3b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 77, 3))
+>r3b3 : Symbol(r3b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 83, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r3b4 = d <= x;
->r3b4 : Symbol(r3b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 78, 3))
+>r3b4 : Symbol(r3b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 84, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r3b5 = e <= x;
->r3b5 : Symbol(r3b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 79, 3))
+>r3b5 : Symbol(r3b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 85, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r3b6 = f <= x;
->r3b6 : Symbol(r3b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 80, 3))
+>r3b6 : Symbol(r3b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 86, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r3b7 = g <= x;
->r3b7 : Symbol(r3b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 81, 3))
+>r3b7 : Symbol(r3b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 87, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 88, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+
+var r3b7 = h <= x;
+>r3b7 : Symbol(r3b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 87, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 88, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 // operator >=
 var r4a1 = x >= a;
->r4a1 : Symbol(r4a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 84, 3))
+>r4a1 : Symbol(r4a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 91, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 
 var r4a2 = x >= b;
->r4a2 : Symbol(r4a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 85, 3))
+>r4a2 : Symbol(r4a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 92, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 
 var r4a3 = x >= c;
->r4a3 : Symbol(r4a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 86, 3))
+>r4a3 : Symbol(r4a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 93, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 
 var r4a4 = x >= d;
->r4a4 : Symbol(r4a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 87, 3))
+>r4a4 : Symbol(r4a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 94, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 
 var r4a5 = x >= e;
->r4a5 : Symbol(r4a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 88, 3))
+>r4a5 : Symbol(r4a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 95, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 
 var r4a6 = x >= f;
->r4a6 : Symbol(r4a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 89, 3))
+>r4a6 : Symbol(r4a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 96, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 
 var r4a7 = x >= g;
->r4a7 : Symbol(r4a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 90, 3))
+>r4a7 : Symbol(r4a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 97, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 98, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var r4a7 = x >= h;
+>r4a7 : Symbol(r4a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 97, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 98, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+
 var r4b1 = a >= x;
->r4b1 : Symbol(r4b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 92, 3))
+>r4b1 : Symbol(r4b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 100, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r4b2 = b >= x;
->r4b2 : Symbol(r4b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 93, 3))
+>r4b2 : Symbol(r4b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 101, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r4b3 = c >= x;
->r4b3 : Symbol(r4b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 94, 3))
+>r4b3 : Symbol(r4b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 102, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r4b4 = d >= x;
->r4b4 : Symbol(r4b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 95, 3))
+>r4b4 : Symbol(r4b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 103, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r4b5 = e >= x;
->r4b5 : Symbol(r4b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 96, 3))
+>r4b5 : Symbol(r4b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 104, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r4b6 = f >= x;
->r4b6 : Symbol(r4b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 97, 3))
+>r4b6 : Symbol(r4b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 105, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r4b7 = g >= x;
->r4b7 : Symbol(r4b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 98, 3))
+>r4b7 : Symbol(r4b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 106, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 107, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+
+var r4b7 = h >= x;
+>r4b7 : Symbol(r4b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 106, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 107, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 // operator ==
 var r5a1 = x == a;
->r5a1 : Symbol(r5a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 101, 3))
+>r5a1 : Symbol(r5a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 110, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 
 var r5a2 = x == b;
->r5a2 : Symbol(r5a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 102, 3))
+>r5a2 : Symbol(r5a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 111, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 
 var r5a3 = x == c;
->r5a3 : Symbol(r5a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 103, 3))
+>r5a3 : Symbol(r5a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 112, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 
 var r5a4 = x == d;
->r5a4 : Symbol(r5a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 104, 3))
+>r5a4 : Symbol(r5a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 113, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 
 var r5a5 = x == e;
->r5a5 : Symbol(r5a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 105, 3))
+>r5a5 : Symbol(r5a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 114, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 
 var r5a6 = x == f;
->r5a6 : Symbol(r5a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 106, 3))
+>r5a6 : Symbol(r5a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 115, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 
 var r5a7 = x == g;
->r5a7 : Symbol(r5a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 107, 3))
+>r5a7 : Symbol(r5a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 116, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 117, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var r5a7 = x == h;
+>r5a7 : Symbol(r5a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 116, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 117, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+
 var r5b1 = a == x;
->r5b1 : Symbol(r5b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 109, 3))
+>r5b1 : Symbol(r5b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 119, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r5b2 = b == x;
->r5b2 : Symbol(r5b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 110, 3))
+>r5b2 : Symbol(r5b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 120, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r5b3 = c == x;
->r5b3 : Symbol(r5b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 111, 3))
+>r5b3 : Symbol(r5b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 121, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r5b4 = d == x;
->r5b4 : Symbol(r5b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 112, 3))
+>r5b4 : Symbol(r5b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 122, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r5b5 = e == x;
->r5b5 : Symbol(r5b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 113, 3))
+>r5b5 : Symbol(r5b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 123, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r5b6 = f == x;
->r5b6 : Symbol(r5b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 114, 3))
+>r5b6 : Symbol(r5b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 124, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r5b7 = g == x;
->r5b7 : Symbol(r5b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 115, 3))
+>r5b7 : Symbol(r5b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 125, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 126, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+
+var r5b7 = h == x;
+>r5b7 : Symbol(r5b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 125, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 126, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 // operator !=
 var r6a1 = x != a;
->r6a1 : Symbol(r6a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 118, 3))
+>r6a1 : Symbol(r6a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 129, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 
 var r6a2 = x != b;
->r6a2 : Symbol(r6a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 119, 3))
+>r6a2 : Symbol(r6a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 130, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 
 var r6a3 = x != c;
->r6a3 : Symbol(r6a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 120, 3))
+>r6a3 : Symbol(r6a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 131, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 
 var r6a4 = x != d;
->r6a4 : Symbol(r6a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 121, 3))
+>r6a4 : Symbol(r6a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 132, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 
 var r6a5 = x != e;
->r6a5 : Symbol(r6a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 122, 3))
+>r6a5 : Symbol(r6a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 133, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 
 var r6a6 = x != f;
->r6a6 : Symbol(r6a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 123, 3))
+>r6a6 : Symbol(r6a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 134, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 
 var r6a7 = x != g;
->r6a7 : Symbol(r6a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 124, 3))
+>r6a7 : Symbol(r6a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 135, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 136, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var r6a7 = x != h;
+>r6a7 : Symbol(r6a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 135, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 136, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+
 var r6b1 = a != x;
->r6b1 : Symbol(r6b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 126, 3))
+>r6b1 : Symbol(r6b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 138, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r6b2 = b != x;
->r6b2 : Symbol(r6b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 127, 3))
+>r6b2 : Symbol(r6b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 139, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r6b3 = c != x;
->r6b3 : Symbol(r6b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 128, 3))
+>r6b3 : Symbol(r6b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 140, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r6b4 = d != x;
->r6b4 : Symbol(r6b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 129, 3))
+>r6b4 : Symbol(r6b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 141, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r6b5 = e != x;
->r6b5 : Symbol(r6b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 130, 3))
+>r6b5 : Symbol(r6b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 142, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r6b6 = f != x;
->r6b6 : Symbol(r6b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 131, 3))
+>r6b6 : Symbol(r6b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 143, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r6b7 = g != x;
->r6b7 : Symbol(r6b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 132, 3))
+>r6b7 : Symbol(r6b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 144, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 145, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+
+var r6b7 = h != x;
+>r6b7 : Symbol(r6b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 144, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 145, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 // operator ===
 var r7a1 = x === a;
->r7a1 : Symbol(r7a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 135, 3))
+>r7a1 : Symbol(r7a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 148, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 
 var r7a2 = x === b;
->r7a2 : Symbol(r7a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 136, 3))
+>r7a2 : Symbol(r7a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 149, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 
 var r7a3 = x === c;
->r7a3 : Symbol(r7a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 137, 3))
+>r7a3 : Symbol(r7a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 150, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 
 var r7a4 = x === d;
->r7a4 : Symbol(r7a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 138, 3))
+>r7a4 : Symbol(r7a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 151, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 
 var r7a5 = x === e;
->r7a5 : Symbol(r7a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 139, 3))
+>r7a5 : Symbol(r7a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 152, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 
 var r7a6 = x === f;
->r7a6 : Symbol(r7a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 140, 3))
+>r7a6 : Symbol(r7a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 153, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 
 var r7a7 = x === g;
->r7a7 : Symbol(r7a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 141, 3))
+>r7a7 : Symbol(r7a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 154, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 155, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var r7a7 = x === h;
+>r7a7 : Symbol(r7a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 154, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 155, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+
 var r7b1 = a === x;
->r7b1 : Symbol(r7b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 143, 3))
+>r7b1 : Symbol(r7b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 157, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r7b2 = b === x;
->r7b2 : Symbol(r7b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 144, 3))
+>r7b2 : Symbol(r7b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 158, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r7b3 = c === x;
->r7b3 : Symbol(r7b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 145, 3))
+>r7b3 : Symbol(r7b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 159, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r7b4 = d === x;
->r7b4 : Symbol(r7b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 146, 3))
+>r7b4 : Symbol(r7b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 160, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r7b5 = e === x;
->r7b5 : Symbol(r7b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 147, 3))
+>r7b5 : Symbol(r7b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 161, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r7b6 = f === x;
->r7b6 : Symbol(r7b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 148, 3))
+>r7b6 : Symbol(r7b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 162, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r7b7 = g === x;
->r7b7 : Symbol(r7b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 149, 3))
+>r7b7 : Symbol(r7b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 163, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 164, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+
+var r7b7 = h === x;
+>r7b7 : Symbol(r7b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 163, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 164, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 // operator !==
 var r8a1 = x !== a;
->r8a1 : Symbol(r8a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 152, 3))
+>r8a1 : Symbol(r8a1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 167, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 
 var r8a2 = x !== b;
->r8a2 : Symbol(r8a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 153, 3))
+>r8a2 : Symbol(r8a2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 168, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 
 var r8a3 = x !== c;
->r8a3 : Symbol(r8a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 154, 3))
+>r8a3 : Symbol(r8a3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 169, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 
 var r8a4 = x !== d;
->r8a4 : Symbol(r8a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 155, 3))
+>r8a4 : Symbol(r8a4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 170, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 
 var r8a5 = x !== e;
->r8a5 : Symbol(r8a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 156, 3))
+>r8a5 : Symbol(r8a5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 171, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 
 var r8a6 = x !== f;
->r8a6 : Symbol(r8a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 157, 3))
+>r8a6 : Symbol(r8a6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 172, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 
 var r8a7 = x !== g;
->r8a7 : Symbol(r8a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 158, 3))
+>r8a7 : Symbol(r8a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 173, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 174, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
 
+var r8a7 = x !== h;
+>r8a7 : Symbol(r8a7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 173, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 174, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
+
 var r8b1 = a !== x;
->r8b1 : Symbol(r8b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 160, 3))
+>r8b1 : Symbol(r8b1, Decl(comparisonOperatorWithOneOperandIsAny.ts, 176, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsAny.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r8b2 = b !== x;
->r8b2 : Symbol(r8b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 161, 3))
+>r8b2 : Symbol(r8b2, Decl(comparisonOperatorWithOneOperandIsAny.ts, 177, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsAny.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r8b3 = c !== x;
->r8b3 : Symbol(r8b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 162, 3))
+>r8b3 : Symbol(r8b3, Decl(comparisonOperatorWithOneOperandIsAny.ts, 178, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsAny.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r8b4 = d !== x;
->r8b4 : Symbol(r8b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 163, 3))
+>r8b4 : Symbol(r8b4, Decl(comparisonOperatorWithOneOperandIsAny.ts, 179, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsAny.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r8b5 = e !== x;
->r8b5 : Symbol(r8b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 164, 3))
+>r8b5 : Symbol(r8b5, Decl(comparisonOperatorWithOneOperandIsAny.ts, 180, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsAny.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r8b6 = f !== x;
->r8b6 : Symbol(r8b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 165, 3))
+>r8b6 : Symbol(r8b6, Decl(comparisonOperatorWithOneOperandIsAny.ts, 181, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsAny.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 
 var r8b7 = g !== x;
->r8b7 : Symbol(r8b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 166, 3))
+>r8b7 : Symbol(r8b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 182, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 183, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsAny.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
+
+var r8b7 = h !== x;
+>r8b7 : Symbol(r8b7, Decl(comparisonOperatorWithOneOperandIsAny.ts, 182, 3), Decl(comparisonOperatorWithOneOperandIsAny.ts, 183, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsAny.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsAny.ts, 0, 3))
 

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.types
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.types
@@ -133,6 +133,10 @@ var f: {};
 var g: string[];
 >g : string[]
 
+var h: Date;
+>h : Date
+>Date : Date
+
 // operator <
 var r1a1 = x < a;
 >r1a1 : boolean
@@ -176,6 +180,12 @@ var r1a7 = x < g;
 >x : any
 >g : string[]
 
+var r1a7 = x < h;
+>r1a7 : boolean
+>x < h : boolean
+>x : any
+>h : Date
+
 var r1b1 = a < x;
 >r1b1 : boolean
 >a < x : boolean
@@ -216,6 +226,12 @@ var r1b7 = g < x;
 >r1b7 : boolean
 >g < x : boolean
 >g : string[]
+>x : any
+
+var r1b7 = h < x;
+>r1b7 : boolean
+>h < x : boolean
+>h : Date
 >x : any
 
 // operator >
@@ -261,6 +277,12 @@ var r2a7 = x > g;
 >x : any
 >g : string[]
 
+var r2a7 = x > h;
+>r2a7 : boolean
+>x > h : boolean
+>x : any
+>h : Date
+
 var r2b1 = a > x;
 >r2b1 : boolean
 >a > x : boolean
@@ -301,6 +323,12 @@ var r2b7 = g > x;
 >r2b7 : boolean
 >g > x : boolean
 >g : string[]
+>x : any
+
+var r2b7 = h > x;
+>r2b7 : boolean
+>h > x : boolean
+>h : Date
 >x : any
 
 // operator <=
@@ -346,6 +374,12 @@ var r3a7 = x <= g;
 >x : any
 >g : string[]
 
+var r3a7 = x <= h;
+>r3a7 : boolean
+>x <= h : boolean
+>x : any
+>h : Date
+
 var r3b1 = a <= x;
 >r3b1 : boolean
 >a <= x : boolean
@@ -386,6 +420,12 @@ var r3b7 = g <= x;
 >r3b7 : boolean
 >g <= x : boolean
 >g : string[]
+>x : any
+
+var r3b7 = h <= x;
+>r3b7 : boolean
+>h <= x : boolean
+>h : Date
 >x : any
 
 // operator >=
@@ -431,6 +471,12 @@ var r4a7 = x >= g;
 >x : any
 >g : string[]
 
+var r4a7 = x >= h;
+>r4a7 : boolean
+>x >= h : boolean
+>x : any
+>h : Date
+
 var r4b1 = a >= x;
 >r4b1 : boolean
 >a >= x : boolean
@@ -471,6 +517,12 @@ var r4b7 = g >= x;
 >r4b7 : boolean
 >g >= x : boolean
 >g : string[]
+>x : any
+
+var r4b7 = h >= x;
+>r4b7 : boolean
+>h >= x : boolean
+>h : Date
 >x : any
 
 // operator ==
@@ -516,6 +568,12 @@ var r5a7 = x == g;
 >x : any
 >g : string[]
 
+var r5a7 = x == h;
+>r5a7 : boolean
+>x == h : boolean
+>x : any
+>h : Date
+
 var r5b1 = a == x;
 >r5b1 : boolean
 >a == x : boolean
@@ -556,6 +614,12 @@ var r5b7 = g == x;
 >r5b7 : boolean
 >g == x : boolean
 >g : string[]
+>x : any
+
+var r5b7 = h == x;
+>r5b7 : boolean
+>h == x : boolean
+>h : Date
 >x : any
 
 // operator !=
@@ -601,6 +665,12 @@ var r6a7 = x != g;
 >x : any
 >g : string[]
 
+var r6a7 = x != h;
+>r6a7 : boolean
+>x != h : boolean
+>x : any
+>h : Date
+
 var r6b1 = a != x;
 >r6b1 : boolean
 >a != x : boolean
@@ -641,6 +711,12 @@ var r6b7 = g != x;
 >r6b7 : boolean
 >g != x : boolean
 >g : string[]
+>x : any
+
+var r6b7 = h != x;
+>r6b7 : boolean
+>h != x : boolean
+>h : Date
 >x : any
 
 // operator ===
@@ -686,6 +762,12 @@ var r7a7 = x === g;
 >x : any
 >g : string[]
 
+var r7a7 = x === h;
+>r7a7 : boolean
+>x === h : boolean
+>x : any
+>h : Date
+
 var r7b1 = a === x;
 >r7b1 : boolean
 >a === x : boolean
@@ -726,6 +808,12 @@ var r7b7 = g === x;
 >r7b7 : boolean
 >g === x : boolean
 >g : string[]
+>x : any
+
+var r7b7 = h === x;
+>r7b7 : boolean
+>h === x : boolean
+>h : Date
 >x : any
 
 // operator !==
@@ -771,6 +859,12 @@ var r8a7 = x !== g;
 >x : any
 >g : string[]
 
+var r8a7 = x !== h;
+>r8a7 : boolean
+>x !== h : boolean
+>x : any
+>h : Date
+
 var r8b1 = a !== x;
 >r8b1 : boolean
 >a !== x : boolean
@@ -811,5 +905,11 @@ var r8b7 = g !== x;
 >r8b7 : boolean
 >g !== x : boolean
 >g : string[]
+>x : any
+
+var r8b7 = h !== x;
+>r8b7 : boolean
+>h !== x : boolean
+>h : Date
 >x : any
 

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.errors.txt
@@ -7,64 +7,80 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(15,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(16,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(33,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(33,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(34,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(35,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(36,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(36,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(37,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(38,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(39,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(40,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(42,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(43,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(44,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(45,12): error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(45,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(46,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(47,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(48,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(49,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(52,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(52,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(53,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(54,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(55,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(55,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(56,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(57,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(58,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(59,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(61,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(61,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(62,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(63,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(64,12): error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(64,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(65,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(66,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(67,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(68,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(71,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(71,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(72,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(73,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(74,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(75,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(76,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(77,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(78,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(80,12): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(80,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(81,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(82,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(83,12): error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(83,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(84,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(85,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(86,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(87,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(90,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(90,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(91,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(92,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(93,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(93,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(94,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(95,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(96,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(97,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(99,12): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(99,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(100,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(101,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(102,12): error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(102,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(103,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(104,17): error TS2531: Object is possibly 'null'.
@@ -72,7 +88,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(106,17): error TS2531: Object is possibly 'null'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts (72 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts (88 errors) ====
     enum E { a, b, c }
     
     function foo<T>(t: T) {
@@ -124,6 +140,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r1a1 = null < a;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
     var r1a2 = null < b;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
@@ -133,6 +151,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r1a4 = null < d;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
     var r1a5 = null < e;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
@@ -147,6 +167,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 !!! error TS2531: Object is possibly 'null'.
     
     var r1b1 = a < null;
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r1b2 = b < null;
@@ -156,6 +178,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r1b4 = d < null;
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r1b5 = e < null;
@@ -175,6 +199,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r2a1 = null > a;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
     var r2a2 = null > b;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
@@ -184,6 +210,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r2a4 = null > d;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
     var r2a5 = null > e;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
@@ -198,6 +226,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 !!! error TS2531: Object is possibly 'null'.
     
     var r2b1 = a > null;
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r2b2 = b > null;
@@ -207,6 +237,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r2b4 = d > null;
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r2b5 = e > null;
@@ -226,6 +258,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r3a1 = null <= a;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
     var r3a2 = null <= b;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
@@ -235,6 +269,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r3a4 = null <= d;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
     var r3a5 = null <= e;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
@@ -249,6 +285,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 !!! error TS2531: Object is possibly 'null'.
     
     var r3b1 = a <= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r3b2 = b <= null;
@@ -258,6 +296,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r3b4 = d <= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r3b5 = e <= null;
@@ -277,6 +317,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r4a1 = null >= a;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
     var r4a2 = null >= b;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
@@ -286,6 +328,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r4a4 = null >= d;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
     var r4a5 = null >= e;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
@@ -300,6 +344,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 !!! error TS2531: Object is possibly 'null'.
     
     var r4b1 = a >= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r4b2 = b >= null;
@@ -309,6 +355,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r4b4 = d >= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r4b5 = e >= null;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.errors.txt
@@ -6,65 +6,73 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(14,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(15,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(16,18): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(32,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(33,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(34,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(35,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(36,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(37,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(38,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(40,16): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(41,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(39,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(40,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(42,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(43,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(44,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(45,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(46,16): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(49,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(50,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(51,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(47,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(48,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(49,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(52,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(53,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(54,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(55,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(57,16): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(58,16): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(59,16): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(60,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(56,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(57,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(58,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(59,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(61,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(62,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(63,16): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(66,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(67,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(68,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(69,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(70,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(64,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(65,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(66,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(67,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(68,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(71,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(72,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(74,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(75,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(76,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(77,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(78,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(79,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(73,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(74,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(75,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(76,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(77,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(78,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(80,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(83,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(84,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(85,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(86,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(87,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(88,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(89,12): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(91,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(92,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(93,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(94,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(95,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(96,17): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(81,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(82,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(83,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(84,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(85,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(86,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(87,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(90,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(91,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(92,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(93,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(94,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(95,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(96,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(97,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(99,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(100,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(101,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(102,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(103,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(104,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(105,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(106,17): error TS2531: Object is possibly 'null'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts (64 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts (72 errors) ====
     enum E { a, b, c }
     
     function foo<T>(t: T) {
@@ -110,6 +118,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var e: E;
     var f: {};
     var g: string[];
+    var h: Date;
     
     // operator <
     var r1a1 = null < a;
@@ -133,6 +142,9 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r1a7 = null < g;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+    var r1a7 = null < h;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     var r1b1 = a < null;
                    ~~~~
@@ -153,6 +165,9 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r1b7 = g < null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1b7 = h < null;
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     
@@ -178,6 +193,9 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r2a7 = null > g;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+    var r2a7 = null > h;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     var r2b1 = a > null;
                    ~~~~
@@ -198,6 +216,9 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r2b7 = g > null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2b7 = h > null;
                    ~~~~
 !!! error TS2531: Object is possibly 'null'.
     
@@ -223,6 +244,9 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r3a7 = null <= g;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+    var r3a7 = null <= h;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     var r3b1 = a <= null;
                     ~~~~
@@ -243,6 +267,9 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
     var r3b7 = g <= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3b7 = h <= null;
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
     
@@ -268,6 +295,9 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r4a7 = null >= g;
                ~~~~
 !!! error TS2531: Object is possibly 'null'.
+    var r4a7 = null >= h;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     var r4b1 = a >= null;
                     ~~~~
@@ -290,6 +320,9 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r4b7 = g >= null;
                     ~~~~
 !!! error TS2531: Object is possibly 'null'.
+    var r4b7 = h >= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     // operator ==
     var r5a1 = null == a;
@@ -299,6 +332,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r5a5 = null == e;
     var r5a6 = null == f;
     var r5a7 = null == g;
+    var r5a7 = null == h;
     
     var r5b1 = a == null;
     var r5b2 = b == null;
@@ -307,6 +341,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r5b5 = e == null;
     var r5b6 = f == null;
     var r5b7 = g == null;
+    var r5b7 = h == null;
     
     // operator !=
     var r6a1 = null != a;
@@ -316,6 +351,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r6a5 = null != e;
     var r6a6 = null != f;
     var r6a7 = null != g;
+    var r6a7 = null != h;
     
     var r6b1 = a != null;
     var r6b2 = b != null;
@@ -324,6 +360,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r6b5 = e != null;
     var r6b6 = f != null;
     var r6b7 = g != null;
+    var r6b7 = h != null;
     
     // operator ===
     var r7a1 = null === a;
@@ -333,6 +370,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r7a5 = null === e;
     var r7a6 = null === f;
     var r7a7 = null === g;
+    var r7a7 = null === h;
     
     var r7b1 = a === null;
     var r7b2 = b === null;
@@ -341,6 +379,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r7b5 = e === null;
     var r7b6 = f === null;
     var r7b7 = g === null;
+    var r7b7 = h === null;
     
     // operator !==
     var r8a1 = null !== a;
@@ -350,6 +389,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r8a5 = null !== e;
     var r8a6 = null !== f;
     var r8a7 = null !== g;
+    var r8a7 = null !== h;
     
     var r8b1 = a !== null;
     var r8b2 = b !== null;
@@ -358,3 +398,4 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     var r8b5 = e !== null;
     var r8b6 = f !== null;
     var r8b7 = g !== null;
+    var r8b7 = h !== null;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.js
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.js
@@ -28,6 +28,7 @@ var d: void;
 var e: E;
 var f: {};
 var g: string[];
+var h: Date;
 
 // operator <
 var r1a1 = null < a;
@@ -37,6 +38,7 @@ var r1a4 = null < d;
 var r1a5 = null < e;
 var r1a6 = null < f;
 var r1a7 = null < g;
+var r1a7 = null < h;
 
 var r1b1 = a < null;
 var r1b2 = b < null;
@@ -45,6 +47,7 @@ var r1b4 = d < null;
 var r1b5 = e < null;
 var r1b6 = f < null;
 var r1b7 = g < null;
+var r1b7 = h < null;
 
 // operator >
 var r2a1 = null > a;
@@ -54,6 +57,7 @@ var r2a4 = null > d;
 var r2a5 = null > e;
 var r2a6 = null > f;
 var r2a7 = null > g;
+var r2a7 = null > h;
 
 var r2b1 = a > null;
 var r2b2 = b > null;
@@ -62,6 +66,7 @@ var r2b4 = d > null;
 var r2b5 = e > null;
 var r2b6 = f > null;
 var r2b7 = g > null;
+var r2b7 = h > null;
 
 // operator <=
 var r3a1 = null <= a;
@@ -71,6 +76,7 @@ var r3a4 = null <= d;
 var r3a5 = null <= e;
 var r3a6 = null <= f;
 var r3a7 = null <= g;
+var r3a7 = null <= h;
 
 var r3b1 = a <= null;
 var r3b2 = b <= null;
@@ -79,6 +85,7 @@ var r3b4 = d <= null;
 var r3b5 = e <= null;
 var r3b6 = f <= null;
 var r3b7 = g <= null;
+var r3b7 = h <= null;
 
 // operator >=
 var r4a1 = null >= a;
@@ -88,6 +95,7 @@ var r4a4 = null >= d;
 var r4a5 = null >= e;
 var r4a6 = null >= f;
 var r4a7 = null >= g;
+var r4a7 = null >= h;
 
 var r4b1 = a >= null;
 var r4b2 = b >= null;
@@ -96,6 +104,7 @@ var r4b4 = d >= null;
 var r4b5 = e >= null;
 var r4b6 = f >= null;
 var r4b7 = g >= null;
+var r4b7 = h >= null;
 
 // operator ==
 var r5a1 = null == a;
@@ -105,6 +114,7 @@ var r5a4 = null == d;
 var r5a5 = null == e;
 var r5a6 = null == f;
 var r5a7 = null == g;
+var r5a7 = null == h;
 
 var r5b1 = a == null;
 var r5b2 = b == null;
@@ -113,6 +123,7 @@ var r5b4 = d == null;
 var r5b5 = e == null;
 var r5b6 = f == null;
 var r5b7 = g == null;
+var r5b7 = h == null;
 
 // operator !=
 var r6a1 = null != a;
@@ -122,6 +133,7 @@ var r6a4 = null != d;
 var r6a5 = null != e;
 var r6a6 = null != f;
 var r6a7 = null != g;
+var r6a7 = null != h;
 
 var r6b1 = a != null;
 var r6b2 = b != null;
@@ -130,6 +142,7 @@ var r6b4 = d != null;
 var r6b5 = e != null;
 var r6b6 = f != null;
 var r6b7 = g != null;
+var r6b7 = h != null;
 
 // operator ===
 var r7a1 = null === a;
@@ -139,6 +152,7 @@ var r7a4 = null === d;
 var r7a5 = null === e;
 var r7a6 = null === f;
 var r7a7 = null === g;
+var r7a7 = null === h;
 
 var r7b1 = a === null;
 var r7b2 = b === null;
@@ -147,6 +161,7 @@ var r7b4 = d === null;
 var r7b5 = e === null;
 var r7b6 = f === null;
 var r7b7 = g === null;
+var r7b7 = h === null;
 
 // operator !==
 var r8a1 = null !== a;
@@ -156,6 +171,7 @@ var r8a4 = null !== d;
 var r8a5 = null !== e;
 var r8a6 = null !== f;
 var r8a7 = null !== g;
+var r8a7 = null !== h;
 
 var r8b1 = a !== null;
 var r8b2 = b !== null;
@@ -164,6 +180,7 @@ var r8b4 = d !== null;
 var r8b5 = e !== null;
 var r8b6 = f !== null;
 var r8b7 = g !== null;
+var r8b7 = h !== null;
 
 //// [comparisonOperatorWithOneOperandIsNull.js]
 var E;
@@ -197,6 +214,7 @@ var d;
 var e;
 var f;
 var g;
+var h;
 // operator <
 var r1a1 = null < a;
 var r1a2 = null < b;
@@ -205,6 +223,7 @@ var r1a4 = null < d;
 var r1a5 = null < e;
 var r1a6 = null < f;
 var r1a7 = null < g;
+var r1a7 = null < h;
 var r1b1 = a < null;
 var r1b2 = b < null;
 var r1b3 = c < null;
@@ -212,6 +231,7 @@ var r1b4 = d < null;
 var r1b5 = e < null;
 var r1b6 = f < null;
 var r1b7 = g < null;
+var r1b7 = h < null;
 // operator >
 var r2a1 = null > a;
 var r2a2 = null > b;
@@ -220,6 +240,7 @@ var r2a4 = null > d;
 var r2a5 = null > e;
 var r2a6 = null > f;
 var r2a7 = null > g;
+var r2a7 = null > h;
 var r2b1 = a > null;
 var r2b2 = b > null;
 var r2b3 = c > null;
@@ -227,6 +248,7 @@ var r2b4 = d > null;
 var r2b5 = e > null;
 var r2b6 = f > null;
 var r2b7 = g > null;
+var r2b7 = h > null;
 // operator <=
 var r3a1 = null <= a;
 var r3a2 = null <= b;
@@ -235,6 +257,7 @@ var r3a4 = null <= d;
 var r3a5 = null <= e;
 var r3a6 = null <= f;
 var r3a7 = null <= g;
+var r3a7 = null <= h;
 var r3b1 = a <= null;
 var r3b2 = b <= null;
 var r3b3 = c <= null;
@@ -242,6 +265,7 @@ var r3b4 = d <= null;
 var r3b5 = e <= null;
 var r3b6 = f <= null;
 var r3b7 = g <= null;
+var r3b7 = h <= null;
 // operator >=
 var r4a1 = null >= a;
 var r4a2 = null >= b;
@@ -250,6 +274,7 @@ var r4a4 = null >= d;
 var r4a5 = null >= e;
 var r4a6 = null >= f;
 var r4a7 = null >= g;
+var r4a7 = null >= h;
 var r4b1 = a >= null;
 var r4b2 = b >= null;
 var r4b3 = c >= null;
@@ -257,6 +282,7 @@ var r4b4 = d >= null;
 var r4b5 = e >= null;
 var r4b6 = f >= null;
 var r4b7 = g >= null;
+var r4b7 = h >= null;
 // operator ==
 var r5a1 = null == a;
 var r5a2 = null == b;
@@ -265,6 +291,7 @@ var r5a4 = null == d;
 var r5a5 = null == e;
 var r5a6 = null == f;
 var r5a7 = null == g;
+var r5a7 = null == h;
 var r5b1 = a == null;
 var r5b2 = b == null;
 var r5b3 = c == null;
@@ -272,6 +299,7 @@ var r5b4 = d == null;
 var r5b5 = e == null;
 var r5b6 = f == null;
 var r5b7 = g == null;
+var r5b7 = h == null;
 // operator !=
 var r6a1 = null != a;
 var r6a2 = null != b;
@@ -280,6 +308,7 @@ var r6a4 = null != d;
 var r6a5 = null != e;
 var r6a6 = null != f;
 var r6a7 = null != g;
+var r6a7 = null != h;
 var r6b1 = a != null;
 var r6b2 = b != null;
 var r6b3 = c != null;
@@ -287,6 +316,7 @@ var r6b4 = d != null;
 var r6b5 = e != null;
 var r6b6 = f != null;
 var r6b7 = g != null;
+var r6b7 = h != null;
 // operator ===
 var r7a1 = null === a;
 var r7a2 = null === b;
@@ -295,6 +325,7 @@ var r7a4 = null === d;
 var r7a5 = null === e;
 var r7a6 = null === f;
 var r7a7 = null === g;
+var r7a7 = null === h;
 var r7b1 = a === null;
 var r7b2 = b === null;
 var r7b3 = c === null;
@@ -302,6 +333,7 @@ var r7b4 = d === null;
 var r7b5 = e === null;
 var r7b6 = f === null;
 var r7b7 = g === null;
+var r7b7 = h === null;
 // operator !==
 var r8a1 = null !== a;
 var r8a2 = null !== b;
@@ -310,6 +342,7 @@ var r8a4 = null !== d;
 var r8a5 = null !== e;
 var r8a6 = null !== f;
 var r8a7 = null !== g;
+var r8a7 = null !== h;
 var r8b1 = a !== null;
 var r8b2 = b !== null;
 var r8b3 = c !== null;
@@ -317,3 +350,4 @@ var r8b4 = d !== null;
 var r8b5 = e !== null;
 var r8b6 = f !== null;
 var r8b7 = g !== null;
+var r8b7 = h !== null;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.errors.txt
@@ -1,0 +1,235 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(35,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(38,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(47,12): error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(63,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(66,12): error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(76,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(82,12): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(85,12): error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(92,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(95,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(101,12): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts(104,12): error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts (16 errors) ====
+    var x: typeof undefined;
+    
+    enum E { a, b, c }
+    
+    function foo<T>(t: T) {
+        var foo_r1 = t < x;
+        var foo_r2 = t > x;
+        var foo_r3 = t <= x;
+        var foo_r4 = t >= x;
+        var foo_r5 = t == x;
+        var foo_r6 = t != x;
+        var foo_r7 = t === x;
+        var foo_r8 = t !== x;
+    
+        var foo_r1 = x < t;
+        var foo_r2 = x > t;
+        var foo_r3 = x <= t;
+        var foo_r4 = x >= t;
+        var foo_r5 = x == t;
+        var foo_r6 = x != t;
+        var foo_r7 = x === t;
+        var foo_r8 = x !== t;
+    }
+    
+    var a: boolean;
+    var b: number;
+    var c: string;
+    var d: void;
+    var e: E;
+    var f: {};
+    var g: string[];
+    var h: Date;
+    
+    // operator <
+    var r1a1 = x < a;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
+    var r1a2 = x < b;
+    var r1a3 = x < c;
+    var r1a4 = x < d;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
+    var r1a5 = x < e;
+    var r1a6 = x < f;
+    var r1a7 = x < g;
+    var r1a7 = x < h;
+    
+    var r1b1 = a < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+    var r1b2 = b < x;
+    var r1b3 = c < x;
+    var r1b4 = d < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
+    var r1b5 = e < x;
+    var r1b6 = f < x;
+    var r1b7 = g < x;
+    var r1b7 = h < x;
+    
+    // operator >
+    var r2a1 = x > a;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
+    var r2a2 = x > b;
+    var r2a3 = x > c;
+    var r2a4 = x > d;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
+    var r2a5 = x > e;
+    var r2a6 = x > f;
+    var r2a7 = x > g;
+    var r2a7 = x > h;
+    
+    var r2b1 = a > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+    var r2b2 = b > x;
+    var r2b3 = c > x;
+    var r2b4 = d > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
+    var r2b5 = e > x;
+    var r2b6 = f > x;
+    var r2b7 = g > x;
+    var r2b7 = h > x;
+    
+    // operator <=
+    var r3a1 = x <= a;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
+    var r3a2 = x <= b;
+    var r3a3 = x <= c;
+    var r3a4 = x <= d;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
+    var r3a5 = x <= e;
+    var r3a6 = x <= f;
+    var r3a7 = x <= g;
+    var r3a7 = x <= h;
+    
+    var r3b1 = a <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+    var r3b2 = b <= x;
+    var r3b3 = c <= x;
+    var r3b4 = d <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
+    var r3b5 = e <= x;
+    var r3b6 = f <= x;
+    var r3b7 = g <= x;
+    var r3b7 = h <= x;
+    
+    // operator >=
+    var r4a1 = x >= a;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
+    var r4a2 = x >= b;
+    var r4a3 = x >= c;
+    var r4a4 = x >= d;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
+    var r4a5 = x >= e;
+    var r4a6 = x >= f;
+    var r4a7 = x >= g;
+    var r4a7 = x >= h;
+    
+    var r4b1 = a >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+    var r4b2 = b >= x;
+    var r4b3 = c >= x;
+    var r4b4 = d >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
+    var r4b5 = e >= x;
+    var r4b6 = f >= x;
+    var r4b7 = g >= x;
+    var r4b7 = h >= x;
+    
+    // operator ==
+    var r5a1 = x == a;
+    var r5a2 = x == b;
+    var r5a3 = x == c;
+    var r5a4 = x == d;
+    var r5a5 = x == e;
+    var r5a6 = x == f;
+    var r5a7 = x == g;
+    var r5a7 = x == h;
+    
+    var r5b1 = a == x;
+    var r5b2 = b == x;
+    var r5b3 = c == x;
+    var r5b4 = d == x;
+    var r5b5 = e == x;
+    var r5b6 = f == x;
+    var r5b7 = g == x;
+    var r5b7 = h == x;
+    
+    // operator !=
+    var r6a1 = x != a;
+    var r6a2 = x != b;
+    var r6a3 = x != c;
+    var r6a4 = x != d;
+    var r6a5 = x != e;
+    var r6a6 = x != f;
+    var r6a7 = x != g;
+    var r6a7 = x != h;
+    
+    var r6b1 = a != x;
+    var r6b2 = b != x;
+    var r6b3 = c != x;
+    var r6b4 = d != x;
+    var r6b5 = e != x;
+    var r6b6 = f != x;
+    var r6b7 = g != x;
+    var r6b7 = h != x;
+    
+    // operator ===
+    var r7a1 = x === a;
+    var r7a2 = x === b;
+    var r7a3 = x === c;
+    var r7a4 = x === d;
+    var r7a5 = x === e;
+    var r7a6 = x === f;
+    var r7a7 = x === g;
+    var r7a7 = x === h;
+    
+    var r7b1 = a === x;
+    var r7b2 = b === x;
+    var r7b3 = c === x;
+    var r7b4 = d === x;
+    var r7b5 = e === x;
+    var r7b6 = f === x;
+    var r7b7 = g === x;
+    var r7b7 = h === x;
+    
+    // operator !==
+    var r8a1 = x !== a;
+    var r8a2 = x !== b;
+    var r8a3 = x !== c;
+    var r8a4 = x !== d;
+    var r8a5 = x !== e;
+    var r8a6 = x !== f;
+    var r8a7 = x !== g;
+    var r8a7 = x !== h;
+    
+    var r8b1 = a !== x;
+    var r8b2 = b !== x;
+    var r8b3 = c !== x;
+    var r8b4 = d !== x;
+    var r8b5 = e !== x;
+    var r8b6 = f !== x;
+    var r8b7 = g !== x;
+    var r8b7 = h !== x;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.js
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.js
@@ -30,6 +30,7 @@ var d: void;
 var e: E;
 var f: {};
 var g: string[];
+var h: Date;
 
 // operator <
 var r1a1 = x < a;
@@ -39,6 +40,7 @@ var r1a4 = x < d;
 var r1a5 = x < e;
 var r1a6 = x < f;
 var r1a7 = x < g;
+var r1a7 = x < h;
 
 var r1b1 = a < x;
 var r1b2 = b < x;
@@ -47,6 +49,7 @@ var r1b4 = d < x;
 var r1b5 = e < x;
 var r1b6 = f < x;
 var r1b7 = g < x;
+var r1b7 = h < x;
 
 // operator >
 var r2a1 = x > a;
@@ -56,6 +59,7 @@ var r2a4 = x > d;
 var r2a5 = x > e;
 var r2a6 = x > f;
 var r2a7 = x > g;
+var r2a7 = x > h;
 
 var r2b1 = a > x;
 var r2b2 = b > x;
@@ -64,6 +68,7 @@ var r2b4 = d > x;
 var r2b5 = e > x;
 var r2b6 = f > x;
 var r2b7 = g > x;
+var r2b7 = h > x;
 
 // operator <=
 var r3a1 = x <= a;
@@ -73,6 +78,7 @@ var r3a4 = x <= d;
 var r3a5 = x <= e;
 var r3a6 = x <= f;
 var r3a7 = x <= g;
+var r3a7 = x <= h;
 
 var r3b1 = a <= x;
 var r3b2 = b <= x;
@@ -81,6 +87,7 @@ var r3b4 = d <= x;
 var r3b5 = e <= x;
 var r3b6 = f <= x;
 var r3b7 = g <= x;
+var r3b7 = h <= x;
 
 // operator >=
 var r4a1 = x >= a;
@@ -90,6 +97,7 @@ var r4a4 = x >= d;
 var r4a5 = x >= e;
 var r4a6 = x >= f;
 var r4a7 = x >= g;
+var r4a7 = x >= h;
 
 var r4b1 = a >= x;
 var r4b2 = b >= x;
@@ -98,6 +106,7 @@ var r4b4 = d >= x;
 var r4b5 = e >= x;
 var r4b6 = f >= x;
 var r4b7 = g >= x;
+var r4b7 = h >= x;
 
 // operator ==
 var r5a1 = x == a;
@@ -107,6 +116,7 @@ var r5a4 = x == d;
 var r5a5 = x == e;
 var r5a6 = x == f;
 var r5a7 = x == g;
+var r5a7 = x == h;
 
 var r5b1 = a == x;
 var r5b2 = b == x;
@@ -115,6 +125,7 @@ var r5b4 = d == x;
 var r5b5 = e == x;
 var r5b6 = f == x;
 var r5b7 = g == x;
+var r5b7 = h == x;
 
 // operator !=
 var r6a1 = x != a;
@@ -124,6 +135,7 @@ var r6a4 = x != d;
 var r6a5 = x != e;
 var r6a6 = x != f;
 var r6a7 = x != g;
+var r6a7 = x != h;
 
 var r6b1 = a != x;
 var r6b2 = b != x;
@@ -132,6 +144,7 @@ var r6b4 = d != x;
 var r6b5 = e != x;
 var r6b6 = f != x;
 var r6b7 = g != x;
+var r6b7 = h != x;
 
 // operator ===
 var r7a1 = x === a;
@@ -141,6 +154,7 @@ var r7a4 = x === d;
 var r7a5 = x === e;
 var r7a6 = x === f;
 var r7a7 = x === g;
+var r7a7 = x === h;
 
 var r7b1 = a === x;
 var r7b2 = b === x;
@@ -149,6 +163,7 @@ var r7b4 = d === x;
 var r7b5 = e === x;
 var r7b6 = f === x;
 var r7b7 = g === x;
+var r7b7 = h === x;
 
 // operator !==
 var r8a1 = x !== a;
@@ -158,6 +173,7 @@ var r8a4 = x !== d;
 var r8a5 = x !== e;
 var r8a6 = x !== f;
 var r8a7 = x !== g;
+var r8a7 = x !== h;
 
 var r8b1 = a !== x;
 var r8b2 = b !== x;
@@ -166,6 +182,7 @@ var r8b4 = d !== x;
 var r8b5 = e !== x;
 var r8b6 = f !== x;
 var r8b7 = g !== x;
+var r8b7 = h !== x;
 
 //// [comparisonOperatorWithOneOperandIsUndefined.js]
 var x;
@@ -200,6 +217,7 @@ var d;
 var e;
 var f;
 var g;
+var h;
 // operator <
 var r1a1 = x < a;
 var r1a2 = x < b;
@@ -208,6 +226,7 @@ var r1a4 = x < d;
 var r1a5 = x < e;
 var r1a6 = x < f;
 var r1a7 = x < g;
+var r1a7 = x < h;
 var r1b1 = a < x;
 var r1b2 = b < x;
 var r1b3 = c < x;
@@ -215,6 +234,7 @@ var r1b4 = d < x;
 var r1b5 = e < x;
 var r1b6 = f < x;
 var r1b7 = g < x;
+var r1b7 = h < x;
 // operator >
 var r2a1 = x > a;
 var r2a2 = x > b;
@@ -223,6 +243,7 @@ var r2a4 = x > d;
 var r2a5 = x > e;
 var r2a6 = x > f;
 var r2a7 = x > g;
+var r2a7 = x > h;
 var r2b1 = a > x;
 var r2b2 = b > x;
 var r2b3 = c > x;
@@ -230,6 +251,7 @@ var r2b4 = d > x;
 var r2b5 = e > x;
 var r2b6 = f > x;
 var r2b7 = g > x;
+var r2b7 = h > x;
 // operator <=
 var r3a1 = x <= a;
 var r3a2 = x <= b;
@@ -238,6 +260,7 @@ var r3a4 = x <= d;
 var r3a5 = x <= e;
 var r3a6 = x <= f;
 var r3a7 = x <= g;
+var r3a7 = x <= h;
 var r3b1 = a <= x;
 var r3b2 = b <= x;
 var r3b3 = c <= x;
@@ -245,6 +268,7 @@ var r3b4 = d <= x;
 var r3b5 = e <= x;
 var r3b6 = f <= x;
 var r3b7 = g <= x;
+var r3b7 = h <= x;
 // operator >=
 var r4a1 = x >= a;
 var r4a2 = x >= b;
@@ -253,6 +277,7 @@ var r4a4 = x >= d;
 var r4a5 = x >= e;
 var r4a6 = x >= f;
 var r4a7 = x >= g;
+var r4a7 = x >= h;
 var r4b1 = a >= x;
 var r4b2 = b >= x;
 var r4b3 = c >= x;
@@ -260,6 +285,7 @@ var r4b4 = d >= x;
 var r4b5 = e >= x;
 var r4b6 = f >= x;
 var r4b7 = g >= x;
+var r4b7 = h >= x;
 // operator ==
 var r5a1 = x == a;
 var r5a2 = x == b;
@@ -268,6 +294,7 @@ var r5a4 = x == d;
 var r5a5 = x == e;
 var r5a6 = x == f;
 var r5a7 = x == g;
+var r5a7 = x == h;
 var r5b1 = a == x;
 var r5b2 = b == x;
 var r5b3 = c == x;
@@ -275,6 +302,7 @@ var r5b4 = d == x;
 var r5b5 = e == x;
 var r5b6 = f == x;
 var r5b7 = g == x;
+var r5b7 = h == x;
 // operator !=
 var r6a1 = x != a;
 var r6a2 = x != b;
@@ -283,6 +311,7 @@ var r6a4 = x != d;
 var r6a5 = x != e;
 var r6a6 = x != f;
 var r6a7 = x != g;
+var r6a7 = x != h;
 var r6b1 = a != x;
 var r6b2 = b != x;
 var r6b3 = c != x;
@@ -290,6 +319,7 @@ var r6b4 = d != x;
 var r6b5 = e != x;
 var r6b6 = f != x;
 var r6b7 = g != x;
+var r6b7 = h != x;
 // operator ===
 var r7a1 = x === a;
 var r7a2 = x === b;
@@ -298,6 +328,7 @@ var r7a4 = x === d;
 var r7a5 = x === e;
 var r7a6 = x === f;
 var r7a7 = x === g;
+var r7a7 = x === h;
 var r7b1 = a === x;
 var r7b2 = b === x;
 var r7b3 = c === x;
@@ -305,6 +336,7 @@ var r7b4 = d === x;
 var r7b5 = e === x;
 var r7b6 = f === x;
 var r7b7 = g === x;
+var r7b7 = h === x;
 // operator !==
 var r8a1 = x !== a;
 var r8a2 = x !== b;
@@ -313,6 +345,7 @@ var r8a4 = x !== d;
 var r8a5 = x !== e;
 var r8a6 = x !== f;
 var r8a7 = x !== g;
+var r8a7 = x !== h;
 var r8b1 = a !== x;
 var r8b2 = b !== x;
 var r8b3 = c !== x;
@@ -320,3 +353,4 @@ var r8b4 = d !== x;
 var r8b5 = e !== x;
 var r8b6 = f !== x;
 var r8b7 = g !== x;
+var r8b7 = h !== x;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.symbols
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.symbols
@@ -118,571 +118,655 @@ var f: {};
 var g: string[];
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var h: Date;
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+>Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
 // operator <
 var r1a1 = x < a;
->r1a1 : Symbol(r1a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 33, 3))
+>r1a1 : Symbol(r1a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 34, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 
 var r1a2 = x < b;
->r1a2 : Symbol(r1a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 34, 3))
+>r1a2 : Symbol(r1a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 35, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 
 var r1a3 = x < c;
->r1a3 : Symbol(r1a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 35, 3))
+>r1a3 : Symbol(r1a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 36, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 
 var r1a4 = x < d;
->r1a4 : Symbol(r1a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 36, 3))
+>r1a4 : Symbol(r1a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 37, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 
 var r1a5 = x < e;
->r1a5 : Symbol(r1a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 37, 3))
+>r1a5 : Symbol(r1a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 38, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 
 var r1a6 = x < f;
->r1a6 : Symbol(r1a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 38, 3))
+>r1a6 : Symbol(r1a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 39, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 
 var r1a7 = x < g;
->r1a7 : Symbol(r1a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 39, 3))
+>r1a7 : Symbol(r1a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 40, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 41, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var r1a7 = x < h;
+>r1a7 : Symbol(r1a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 40, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 41, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+
 var r1b1 = a < x;
->r1b1 : Symbol(r1b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 41, 3))
+>r1b1 : Symbol(r1b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 43, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r1b2 = b < x;
->r1b2 : Symbol(r1b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 42, 3))
+>r1b2 : Symbol(r1b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 44, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r1b3 = c < x;
->r1b3 : Symbol(r1b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 43, 3))
+>r1b3 : Symbol(r1b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 45, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r1b4 = d < x;
->r1b4 : Symbol(r1b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 44, 3))
+>r1b4 : Symbol(r1b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 46, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r1b5 = e < x;
->r1b5 : Symbol(r1b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 45, 3))
+>r1b5 : Symbol(r1b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 47, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r1b6 = f < x;
->r1b6 : Symbol(r1b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 46, 3))
+>r1b6 : Symbol(r1b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 48, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r1b7 = g < x;
->r1b7 : Symbol(r1b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 47, 3))
+>r1b7 : Symbol(r1b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 49, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 50, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+
+var r1b7 = h < x;
+>r1b7 : Symbol(r1b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 49, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 50, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 // operator >
 var r2a1 = x > a;
->r2a1 : Symbol(r2a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 50, 3))
+>r2a1 : Symbol(r2a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 53, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 
 var r2a2 = x > b;
->r2a2 : Symbol(r2a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 51, 3))
+>r2a2 : Symbol(r2a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 54, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 
 var r2a3 = x > c;
->r2a3 : Symbol(r2a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 52, 3))
+>r2a3 : Symbol(r2a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 55, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 
 var r2a4 = x > d;
->r2a4 : Symbol(r2a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 53, 3))
+>r2a4 : Symbol(r2a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 56, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 
 var r2a5 = x > e;
->r2a5 : Symbol(r2a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 54, 3))
+>r2a5 : Symbol(r2a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 57, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 
 var r2a6 = x > f;
->r2a6 : Symbol(r2a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 55, 3))
+>r2a6 : Symbol(r2a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 58, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 
 var r2a7 = x > g;
->r2a7 : Symbol(r2a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 56, 3))
+>r2a7 : Symbol(r2a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 59, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 60, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var r2a7 = x > h;
+>r2a7 : Symbol(r2a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 59, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 60, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+
 var r2b1 = a > x;
->r2b1 : Symbol(r2b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 58, 3))
+>r2b1 : Symbol(r2b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 62, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r2b2 = b > x;
->r2b2 : Symbol(r2b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 59, 3))
+>r2b2 : Symbol(r2b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 63, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r2b3 = c > x;
->r2b3 : Symbol(r2b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 60, 3))
+>r2b3 : Symbol(r2b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 64, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r2b4 = d > x;
->r2b4 : Symbol(r2b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 61, 3))
+>r2b4 : Symbol(r2b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 65, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r2b5 = e > x;
->r2b5 : Symbol(r2b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 62, 3))
+>r2b5 : Symbol(r2b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 66, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r2b6 = f > x;
->r2b6 : Symbol(r2b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 63, 3))
+>r2b6 : Symbol(r2b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 67, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r2b7 = g > x;
->r2b7 : Symbol(r2b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 64, 3))
+>r2b7 : Symbol(r2b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 68, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 69, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+
+var r2b7 = h > x;
+>r2b7 : Symbol(r2b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 68, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 69, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 // operator <=
 var r3a1 = x <= a;
->r3a1 : Symbol(r3a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 67, 3))
+>r3a1 : Symbol(r3a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 72, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 
 var r3a2 = x <= b;
->r3a2 : Symbol(r3a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 68, 3))
+>r3a2 : Symbol(r3a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 73, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 
 var r3a3 = x <= c;
->r3a3 : Symbol(r3a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 69, 3))
+>r3a3 : Symbol(r3a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 74, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 
 var r3a4 = x <= d;
->r3a4 : Symbol(r3a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 70, 3))
+>r3a4 : Symbol(r3a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 75, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 
 var r3a5 = x <= e;
->r3a5 : Symbol(r3a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 71, 3))
+>r3a5 : Symbol(r3a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 76, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 
 var r3a6 = x <= f;
->r3a6 : Symbol(r3a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 72, 3))
+>r3a6 : Symbol(r3a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 77, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 
 var r3a7 = x <= g;
->r3a7 : Symbol(r3a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 73, 3))
+>r3a7 : Symbol(r3a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 78, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 79, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var r3a7 = x <= h;
+>r3a7 : Symbol(r3a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 78, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 79, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+
 var r3b1 = a <= x;
->r3b1 : Symbol(r3b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 75, 3))
+>r3b1 : Symbol(r3b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 81, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r3b2 = b <= x;
->r3b2 : Symbol(r3b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 76, 3))
+>r3b2 : Symbol(r3b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 82, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r3b3 = c <= x;
->r3b3 : Symbol(r3b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 77, 3))
+>r3b3 : Symbol(r3b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 83, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r3b4 = d <= x;
->r3b4 : Symbol(r3b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 78, 3))
+>r3b4 : Symbol(r3b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 84, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r3b5 = e <= x;
->r3b5 : Symbol(r3b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 79, 3))
+>r3b5 : Symbol(r3b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 85, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r3b6 = f <= x;
->r3b6 : Symbol(r3b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 80, 3))
+>r3b6 : Symbol(r3b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 86, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r3b7 = g <= x;
->r3b7 : Symbol(r3b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 81, 3))
+>r3b7 : Symbol(r3b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 87, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 88, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+
+var r3b7 = h <= x;
+>r3b7 : Symbol(r3b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 87, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 88, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 // operator >=
 var r4a1 = x >= a;
->r4a1 : Symbol(r4a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 84, 3))
+>r4a1 : Symbol(r4a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 91, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 
 var r4a2 = x >= b;
->r4a2 : Symbol(r4a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 85, 3))
+>r4a2 : Symbol(r4a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 92, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 
 var r4a3 = x >= c;
->r4a3 : Symbol(r4a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 86, 3))
+>r4a3 : Symbol(r4a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 93, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 
 var r4a4 = x >= d;
->r4a4 : Symbol(r4a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 87, 3))
+>r4a4 : Symbol(r4a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 94, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 
 var r4a5 = x >= e;
->r4a5 : Symbol(r4a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 88, 3))
+>r4a5 : Symbol(r4a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 95, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 
 var r4a6 = x >= f;
->r4a6 : Symbol(r4a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 89, 3))
+>r4a6 : Symbol(r4a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 96, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 
 var r4a7 = x >= g;
->r4a7 : Symbol(r4a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 90, 3))
+>r4a7 : Symbol(r4a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 97, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 98, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var r4a7 = x >= h;
+>r4a7 : Symbol(r4a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 97, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 98, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+
 var r4b1 = a >= x;
->r4b1 : Symbol(r4b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 92, 3))
+>r4b1 : Symbol(r4b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 100, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r4b2 = b >= x;
->r4b2 : Symbol(r4b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 93, 3))
+>r4b2 : Symbol(r4b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 101, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r4b3 = c >= x;
->r4b3 : Symbol(r4b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 94, 3))
+>r4b3 : Symbol(r4b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 102, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r4b4 = d >= x;
->r4b4 : Symbol(r4b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 95, 3))
+>r4b4 : Symbol(r4b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 103, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r4b5 = e >= x;
->r4b5 : Symbol(r4b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 96, 3))
+>r4b5 : Symbol(r4b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 104, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r4b6 = f >= x;
->r4b6 : Symbol(r4b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 97, 3))
+>r4b6 : Symbol(r4b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 105, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r4b7 = g >= x;
->r4b7 : Symbol(r4b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 98, 3))
+>r4b7 : Symbol(r4b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 106, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 107, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+
+var r4b7 = h >= x;
+>r4b7 : Symbol(r4b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 106, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 107, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 // operator ==
 var r5a1 = x == a;
->r5a1 : Symbol(r5a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 101, 3))
+>r5a1 : Symbol(r5a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 110, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 
 var r5a2 = x == b;
->r5a2 : Symbol(r5a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 102, 3))
+>r5a2 : Symbol(r5a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 111, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 
 var r5a3 = x == c;
->r5a3 : Symbol(r5a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 103, 3))
+>r5a3 : Symbol(r5a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 112, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 
 var r5a4 = x == d;
->r5a4 : Symbol(r5a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 104, 3))
+>r5a4 : Symbol(r5a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 113, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 
 var r5a5 = x == e;
->r5a5 : Symbol(r5a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 105, 3))
+>r5a5 : Symbol(r5a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 114, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 
 var r5a6 = x == f;
->r5a6 : Symbol(r5a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 106, 3))
+>r5a6 : Symbol(r5a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 115, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 
 var r5a7 = x == g;
->r5a7 : Symbol(r5a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 107, 3))
+>r5a7 : Symbol(r5a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 116, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 117, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var r5a7 = x == h;
+>r5a7 : Symbol(r5a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 116, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 117, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+
 var r5b1 = a == x;
->r5b1 : Symbol(r5b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 109, 3))
+>r5b1 : Symbol(r5b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 119, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r5b2 = b == x;
->r5b2 : Symbol(r5b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 110, 3))
+>r5b2 : Symbol(r5b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 120, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r5b3 = c == x;
->r5b3 : Symbol(r5b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 111, 3))
+>r5b3 : Symbol(r5b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 121, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r5b4 = d == x;
->r5b4 : Symbol(r5b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 112, 3))
+>r5b4 : Symbol(r5b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 122, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r5b5 = e == x;
->r5b5 : Symbol(r5b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 113, 3))
+>r5b5 : Symbol(r5b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 123, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r5b6 = f == x;
->r5b6 : Symbol(r5b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 114, 3))
+>r5b6 : Symbol(r5b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 124, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r5b7 = g == x;
->r5b7 : Symbol(r5b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 115, 3))
+>r5b7 : Symbol(r5b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 125, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 126, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+
+var r5b7 = h == x;
+>r5b7 : Symbol(r5b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 125, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 126, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 // operator !=
 var r6a1 = x != a;
->r6a1 : Symbol(r6a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 118, 3))
+>r6a1 : Symbol(r6a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 129, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 
 var r6a2 = x != b;
->r6a2 : Symbol(r6a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 119, 3))
+>r6a2 : Symbol(r6a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 130, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 
 var r6a3 = x != c;
->r6a3 : Symbol(r6a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 120, 3))
+>r6a3 : Symbol(r6a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 131, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 
 var r6a4 = x != d;
->r6a4 : Symbol(r6a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 121, 3))
+>r6a4 : Symbol(r6a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 132, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 
 var r6a5 = x != e;
->r6a5 : Symbol(r6a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 122, 3))
+>r6a5 : Symbol(r6a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 133, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 
 var r6a6 = x != f;
->r6a6 : Symbol(r6a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 123, 3))
+>r6a6 : Symbol(r6a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 134, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 
 var r6a7 = x != g;
->r6a7 : Symbol(r6a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 124, 3))
+>r6a7 : Symbol(r6a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 135, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 136, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var r6a7 = x != h;
+>r6a7 : Symbol(r6a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 135, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 136, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+
 var r6b1 = a != x;
->r6b1 : Symbol(r6b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 126, 3))
+>r6b1 : Symbol(r6b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 138, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r6b2 = b != x;
->r6b2 : Symbol(r6b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 127, 3))
+>r6b2 : Symbol(r6b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 139, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r6b3 = c != x;
->r6b3 : Symbol(r6b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 128, 3))
+>r6b3 : Symbol(r6b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 140, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r6b4 = d != x;
->r6b4 : Symbol(r6b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 129, 3))
+>r6b4 : Symbol(r6b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 141, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r6b5 = e != x;
->r6b5 : Symbol(r6b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 130, 3))
+>r6b5 : Symbol(r6b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 142, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r6b6 = f != x;
->r6b6 : Symbol(r6b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 131, 3))
+>r6b6 : Symbol(r6b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 143, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r6b7 = g != x;
->r6b7 : Symbol(r6b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 132, 3))
+>r6b7 : Symbol(r6b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 144, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 145, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+
+var r6b7 = h != x;
+>r6b7 : Symbol(r6b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 144, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 145, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 // operator ===
 var r7a1 = x === a;
->r7a1 : Symbol(r7a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 135, 3))
+>r7a1 : Symbol(r7a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 148, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 
 var r7a2 = x === b;
->r7a2 : Symbol(r7a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 136, 3))
+>r7a2 : Symbol(r7a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 149, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 
 var r7a3 = x === c;
->r7a3 : Symbol(r7a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 137, 3))
+>r7a3 : Symbol(r7a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 150, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 
 var r7a4 = x === d;
->r7a4 : Symbol(r7a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 138, 3))
+>r7a4 : Symbol(r7a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 151, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 
 var r7a5 = x === e;
->r7a5 : Symbol(r7a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 139, 3))
+>r7a5 : Symbol(r7a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 152, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 
 var r7a6 = x === f;
->r7a6 : Symbol(r7a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 140, 3))
+>r7a6 : Symbol(r7a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 153, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 
 var r7a7 = x === g;
->r7a7 : Symbol(r7a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 141, 3))
+>r7a7 : Symbol(r7a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 154, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 155, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var r7a7 = x === h;
+>r7a7 : Symbol(r7a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 154, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 155, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+
 var r7b1 = a === x;
->r7b1 : Symbol(r7b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 143, 3))
+>r7b1 : Symbol(r7b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 157, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r7b2 = b === x;
->r7b2 : Symbol(r7b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 144, 3))
+>r7b2 : Symbol(r7b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 158, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r7b3 = c === x;
->r7b3 : Symbol(r7b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 145, 3))
+>r7b3 : Symbol(r7b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 159, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r7b4 = d === x;
->r7b4 : Symbol(r7b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 146, 3))
+>r7b4 : Symbol(r7b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 160, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r7b5 = e === x;
->r7b5 : Symbol(r7b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 147, 3))
+>r7b5 : Symbol(r7b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 161, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r7b6 = f === x;
->r7b6 : Symbol(r7b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 148, 3))
+>r7b6 : Symbol(r7b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 162, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r7b7 = g === x;
->r7b7 : Symbol(r7b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 149, 3))
+>r7b7 : Symbol(r7b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 163, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 164, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+
+var r7b7 = h === x;
+>r7b7 : Symbol(r7b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 163, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 164, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 // operator !==
 var r8a1 = x !== a;
->r8a1 : Symbol(r8a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 152, 3))
+>r8a1 : Symbol(r8a1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 167, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 
 var r8a2 = x !== b;
->r8a2 : Symbol(r8a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 153, 3))
+>r8a2 : Symbol(r8a2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 168, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 
 var r8a3 = x !== c;
->r8a3 : Symbol(r8a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 154, 3))
+>r8a3 : Symbol(r8a3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 169, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 
 var r8a4 = x !== d;
->r8a4 : Symbol(r8a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 155, 3))
+>r8a4 : Symbol(r8a4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 170, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 
 var r8a5 = x !== e;
->r8a5 : Symbol(r8a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 156, 3))
+>r8a5 : Symbol(r8a5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 171, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 
 var r8a6 = x !== f;
->r8a6 : Symbol(r8a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 157, 3))
+>r8a6 : Symbol(r8a6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 172, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 
 var r8a7 = x !== g;
->r8a7 : Symbol(r8a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 158, 3))
+>r8a7 : Symbol(r8a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 173, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 174, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
 
+var r8a7 = x !== h;
+>r8a7 : Symbol(r8a7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 173, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 174, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
+
 var r8b1 = a !== x;
->r8b1 : Symbol(r8b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 160, 3))
+>r8b1 : Symbol(r8b1, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 176, 3))
 >a : Symbol(a, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 24, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r8b2 = b !== x;
->r8b2 : Symbol(r8b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 161, 3))
+>r8b2 : Symbol(r8b2, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 177, 3))
 >b : Symbol(b, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 25, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r8b3 = c !== x;
->r8b3 : Symbol(r8b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 162, 3))
+>r8b3 : Symbol(r8b3, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 178, 3))
 >c : Symbol(c, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 26, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r8b4 = d !== x;
->r8b4 : Symbol(r8b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 163, 3))
+>r8b4 : Symbol(r8b4, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 179, 3))
 >d : Symbol(d, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 27, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r8b5 = e !== x;
->r8b5 : Symbol(r8b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 164, 3))
+>r8b5 : Symbol(r8b5, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 180, 3))
 >e : Symbol(e, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 28, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r8b6 = f !== x;
->r8b6 : Symbol(r8b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 165, 3))
+>r8b6 : Symbol(r8b6, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 181, 3))
 >f : Symbol(f, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 29, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 
 var r8b7 = g !== x;
->r8b7 : Symbol(r8b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 166, 3))
+>r8b7 : Symbol(r8b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 182, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 183, 3))
 >g : Symbol(g, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 30, 3))
+>x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
+
+var r8b7 = h !== x;
+>r8b7 : Symbol(r8b7, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 182, 3), Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 183, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 31, 3))
 >x : Symbol(x, Decl(comparisonOperatorWithOneOperandIsUndefined.ts, 0, 3))
 

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.types
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.types
@@ -134,6 +134,10 @@ var f: {};
 var g: string[];
 >g : string[]
 
+var h: Date;
+>h : Date
+>Date : Date
+
 // operator <
 var r1a1 = x < a;
 >r1a1 : boolean
@@ -177,6 +181,12 @@ var r1a7 = x < g;
 >x : any
 >g : string[]
 
+var r1a7 = x < h;
+>r1a7 : boolean
+>x < h : boolean
+>x : any
+>h : Date
+
 var r1b1 = a < x;
 >r1b1 : boolean
 >a < x : boolean
@@ -217,6 +227,12 @@ var r1b7 = g < x;
 >r1b7 : boolean
 >g < x : boolean
 >g : string[]
+>x : any
+
+var r1b7 = h < x;
+>r1b7 : boolean
+>h < x : boolean
+>h : Date
 >x : any
 
 // operator >
@@ -262,6 +278,12 @@ var r2a7 = x > g;
 >x : any
 >g : string[]
 
+var r2a7 = x > h;
+>r2a7 : boolean
+>x > h : boolean
+>x : any
+>h : Date
+
 var r2b1 = a > x;
 >r2b1 : boolean
 >a > x : boolean
@@ -302,6 +324,12 @@ var r2b7 = g > x;
 >r2b7 : boolean
 >g > x : boolean
 >g : string[]
+>x : any
+
+var r2b7 = h > x;
+>r2b7 : boolean
+>h > x : boolean
+>h : Date
 >x : any
 
 // operator <=
@@ -347,6 +375,12 @@ var r3a7 = x <= g;
 >x : any
 >g : string[]
 
+var r3a7 = x <= h;
+>r3a7 : boolean
+>x <= h : boolean
+>x : any
+>h : Date
+
 var r3b1 = a <= x;
 >r3b1 : boolean
 >a <= x : boolean
@@ -387,6 +421,12 @@ var r3b7 = g <= x;
 >r3b7 : boolean
 >g <= x : boolean
 >g : string[]
+>x : any
+
+var r3b7 = h <= x;
+>r3b7 : boolean
+>h <= x : boolean
+>h : Date
 >x : any
 
 // operator >=
@@ -432,6 +472,12 @@ var r4a7 = x >= g;
 >x : any
 >g : string[]
 
+var r4a7 = x >= h;
+>r4a7 : boolean
+>x >= h : boolean
+>x : any
+>h : Date
+
 var r4b1 = a >= x;
 >r4b1 : boolean
 >a >= x : boolean
@@ -472,6 +518,12 @@ var r4b7 = g >= x;
 >r4b7 : boolean
 >g >= x : boolean
 >g : string[]
+>x : any
+
+var r4b7 = h >= x;
+>r4b7 : boolean
+>h >= x : boolean
+>h : Date
 >x : any
 
 // operator ==
@@ -517,6 +569,12 @@ var r5a7 = x == g;
 >x : any
 >g : string[]
 
+var r5a7 = x == h;
+>r5a7 : boolean
+>x == h : boolean
+>x : any
+>h : Date
+
 var r5b1 = a == x;
 >r5b1 : boolean
 >a == x : boolean
@@ -557,6 +615,12 @@ var r5b7 = g == x;
 >r5b7 : boolean
 >g == x : boolean
 >g : string[]
+>x : any
+
+var r5b7 = h == x;
+>r5b7 : boolean
+>h == x : boolean
+>h : Date
 >x : any
 
 // operator !=
@@ -602,6 +666,12 @@ var r6a7 = x != g;
 >x : any
 >g : string[]
 
+var r6a7 = x != h;
+>r6a7 : boolean
+>x != h : boolean
+>x : any
+>h : Date
+
 var r6b1 = a != x;
 >r6b1 : boolean
 >a != x : boolean
@@ -642,6 +712,12 @@ var r6b7 = g != x;
 >r6b7 : boolean
 >g != x : boolean
 >g : string[]
+>x : any
+
+var r6b7 = h != x;
+>r6b7 : boolean
+>h != x : boolean
+>h : Date
 >x : any
 
 // operator ===
@@ -687,6 +763,12 @@ var r7a7 = x === g;
 >x : any
 >g : string[]
 
+var r7a7 = x === h;
+>r7a7 : boolean
+>x === h : boolean
+>x : any
+>h : Date
+
 var r7b1 = a === x;
 >r7b1 : boolean
 >a === x : boolean
@@ -727,6 +809,12 @@ var r7b7 = g === x;
 >r7b7 : boolean
 >g === x : boolean
 >g : string[]
+>x : any
+
+var r7b7 = h === x;
+>r7b7 : boolean
+>h === x : boolean
+>h : Date
 >x : any
 
 // operator !==
@@ -772,6 +860,12 @@ var r8a7 = x !== g;
 >x : any
 >g : string[]
 
+var r8a7 = x !== h;
+>r8a7 : boolean
+>x !== h : boolean
+>x : any
+>h : Date
+
 var r8b1 = a !== x;
 >r8b1 : boolean
 >a !== x : boolean
@@ -812,5 +906,11 @@ var r8b7 = g !== x;
 >r8b7 : boolean
 >g !== x : boolean
 >g : string[]
+>x : any
+
+var r8b7 = h !== x;
+>r8b7 : boolean
+>h !== x : boolean
+>h : Date
 >x : any
 

--- a/tests/baselines/reference/intTypeCheck.errors.txt
+++ b/tests/baselines/reference/intTypeCheck.errors.txt
@@ -10,6 +10,7 @@ tests/cases/compiler/intTypeCheck.ts(101,5): error TS2322: Type 'Base' is not as
 tests/cases/compiler/intTypeCheck.ts(103,5): error TS2322: Type '() => void' is not assignable to type 'i1'.
   Property 'p' is missing in type '() => void'.
 tests/cases/compiler/intTypeCheck.ts(106,5): error TS2322: Type 'boolean' is not assignable to type 'i1'.
+tests/cases/compiler/intTypeCheck.ts(106,16): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/compiler/intTypeCheck.ts(106,20): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(106,21): error TS2693: 'i1' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(107,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
@@ -22,6 +23,7 @@ tests/cases/compiler/intTypeCheck.ts(114,17): error TS2350: Only a void function
 tests/cases/compiler/intTypeCheck.ts(115,5): error TS2322: Type 'Base' is not assignable to type 'i2'.
   Type 'Base' provides no match for the signature '(): any'.
 tests/cases/compiler/intTypeCheck.ts(120,5): error TS2322: Type 'boolean' is not assignable to type 'i2'.
+tests/cases/compiler/intTypeCheck.ts(120,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/compiler/intTypeCheck.ts(120,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(120,22): error TS2693: 'i2' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(121,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
@@ -35,11 +37,13 @@ tests/cases/compiler/intTypeCheck.ts(129,5): error TS2322: Type 'Base' is not as
 tests/cases/compiler/intTypeCheck.ts(131,5): error TS2322: Type '() => void' is not assignable to type 'i3'.
   Type '() => void' provides no match for the signature 'new (): any'.
 tests/cases/compiler/intTypeCheck.ts(134,5): error TS2322: Type 'boolean' is not assignable to type 'i3'.
+tests/cases/compiler/intTypeCheck.ts(134,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/compiler/intTypeCheck.ts(134,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(134,22): error TS2693: 'i3' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(135,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/compiler/intTypeCheck.ts(142,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/compiler/intTypeCheck.ts(148,5): error TS2322: Type 'boolean' is not assignable to type 'i4'.
+tests/cases/compiler/intTypeCheck.ts(148,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/compiler/intTypeCheck.ts(148,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(148,22): error TS2693: 'i4' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(149,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
@@ -54,6 +58,7 @@ tests/cases/compiler/intTypeCheck.ts(157,5): error TS2322: Type 'Base' is not as
 tests/cases/compiler/intTypeCheck.ts(159,5): error TS2322: Type '() => void' is not assignable to type 'i5'.
   Property 'p' is missing in type '() => void'.
 tests/cases/compiler/intTypeCheck.ts(162,5): error TS2322: Type 'boolean' is not assignable to type 'i5'.
+tests/cases/compiler/intTypeCheck.ts(162,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/compiler/intTypeCheck.ts(162,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(162,22): error TS2693: 'i5' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(163,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
@@ -68,6 +73,7 @@ tests/cases/compiler/intTypeCheck.ts(171,5): error TS2322: Type 'Base' is not as
 tests/cases/compiler/intTypeCheck.ts(173,5): error TS2322: Type '() => void' is not assignable to type 'i6'.
   Type 'void' is not assignable to type 'number'.
 tests/cases/compiler/intTypeCheck.ts(176,5): error TS2322: Type 'boolean' is not assignable to type 'i6'.
+tests/cases/compiler/intTypeCheck.ts(176,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/compiler/intTypeCheck.ts(176,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(176,22): error TS2693: 'i6' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(177,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
@@ -81,17 +87,19 @@ tests/cases/compiler/intTypeCheck.ts(185,17): error TS2352: Type 'Base' cannot b
 tests/cases/compiler/intTypeCheck.ts(187,5): error TS2322: Type '() => void' is not assignable to type 'i7'.
   Type '() => void' provides no match for the signature 'new (): any'.
 tests/cases/compiler/intTypeCheck.ts(190,5): error TS2322: Type 'boolean' is not assignable to type 'i7'.
+tests/cases/compiler/intTypeCheck.ts(190,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/compiler/intTypeCheck.ts(190,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(190,22): error TS2693: 'i7' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(191,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/compiler/intTypeCheck.ts(198,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/compiler/intTypeCheck.ts(204,5): error TS2322: Type 'boolean' is not assignable to type 'i8'.
+tests/cases/compiler/intTypeCheck.ts(204,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/compiler/intTypeCheck.ts(204,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(204,22): error TS2693: 'i8' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 
 
-==== tests/cases/compiler/intTypeCheck.ts (63 errors) ====
+==== tests/cases/compiler/intTypeCheck.ts (71 errors) ====
     interface i1 {
         //Property Signatures
         p;
@@ -218,6 +226,8 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj9: i1 = new <i1> anyVar;
         ~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i1'.
+                   ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                        ~
 !!! error TS1109: Expression expected.
                         ~~
@@ -252,6 +262,8 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj20: i2 = new <i2> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i2'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -287,6 +299,8 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj31: i3 = new <i3> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i3'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -311,6 +325,8 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj42: i4 = new <i4> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i4'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -348,6 +364,8 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj53: i5 = new <i5> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i5'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -385,6 +403,8 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj64: i6 = new <i6> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i6'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -420,6 +440,8 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj75: i7 = new <i7> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i7'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -444,6 +466,8 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj86: i8 = new <i8> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i8'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
@@ -32,6 +32,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,16): error TS1109:
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(13,2): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(13,8): error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,1): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,2): error TS1109: Expression expected.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,5): error TS1109: Expression expected.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,7): error TS1128: Declaration or statement expected.
@@ -70,7 +71,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,4): error TS1003: 
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005: '</' expected.
 
 
-==== tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx (70 errors) ====
+==== tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx (71 errors) ====
     declare var React: any;
     
     </>;
@@ -153,6 +154,8 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
     <.a></.a>;
     ~
 !!! error TS1109: Expression expected.
+    ~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
      ~
 !!! error TS1109: Expression expected.
         ~~

--- a/tests/baselines/reference/parserTypeAssertionInObjectCreationExpression1.errors.txt
+++ b/tests/baselines/reference/parserTypeAssertionInObjectCreationExpression1.errors.txt
@@ -1,10 +1,13 @@
+tests/cases/conformance/parser/ecmascript5/Expressions/parserTypeAssertionInObjectCreationExpression1.ts(1,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 tests/cases/conformance/parser/ecmascript5/Expressions/parserTypeAssertionInObjectCreationExpression1.ts(1,5): error TS1109: Expression expected.
 tests/cases/conformance/parser/ecmascript5/Expressions/parserTypeAssertionInObjectCreationExpression1.ts(1,6): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Expressions/parserTypeAssertionInObjectCreationExpression1.ts(1,8): error TS2304: Cannot find name 'Foo'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Expressions/parserTypeAssertionInObjectCreationExpression1.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Expressions/parserTypeAssertionInObjectCreationExpression1.ts (4 errors) ====
     new <T>Foo()
+    ~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
         ~
 !!! error TS1109: Expression expected.
          ~

--- a/tests/baselines/reference/typeAssertions.errors.txt
+++ b/tests/baselines/reference/typeAssertions.errors.txt
@@ -12,6 +12,7 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,14): err
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,14): error TS2304: Cannot find name 'is'.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,17): error TS1005: ')' expected.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,17): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,17): error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,48): error TS1005: ';' expected.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(45,2): error TS2322: Type 'string | number' is not assignable to type 'string'.
   Type 'number' is not assignable to type 'string'.
@@ -23,7 +24,7 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,44): err
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,50): error TS1005: ';' expected.
 
 
-==== tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts (18 errors) ====
+==== tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts (19 errors) ====
     // Function call whose argument is a 1 arg generic function call with explicit type arguments
     function fn1<T>(t: T) { }
     function fn2(t: any) { }
@@ -92,6 +93,8 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,50): err
 !!! error TS1005: ')' expected.
                     ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
                                                    ~
 !!! error TS1005: ';' expected.
     	str = numOrStr; // Error, no narrowing occurred

--- a/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts
+++ b/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts
@@ -29,6 +29,7 @@ var d: void;
 var e: E;
 var f: {};
 var g: string[];
+var h: Date;
 
 // operator <
 var r1a1 = x < a;
@@ -38,6 +39,7 @@ var r1a4 = x < d;
 var r1a5 = x < e;
 var r1a6 = x < f;
 var r1a7 = x < g;
+var r1a7 = x < h;
 
 var r1b1 = a < x;
 var r1b2 = b < x;
@@ -46,6 +48,7 @@ var r1b4 = d < x;
 var r1b5 = e < x;
 var r1b6 = f < x;
 var r1b7 = g < x;
+var r1b7 = h < x;
 
 // operator >
 var r2a1 = x > a;
@@ -55,6 +58,7 @@ var r2a4 = x > d;
 var r2a5 = x > e;
 var r2a6 = x > f;
 var r2a7 = x > g;
+var r2a7 = x > h;
 
 var r2b1 = a > x;
 var r2b2 = b > x;
@@ -63,6 +67,7 @@ var r2b4 = d > x;
 var r2b5 = e > x;
 var r2b6 = f > x;
 var r2b7 = g > x;
+var r2b7 = h > x;
 
 // operator <=
 var r3a1 = x <= a;
@@ -72,6 +77,7 @@ var r3a4 = x <= d;
 var r3a5 = x <= e;
 var r3a6 = x <= f;
 var r3a7 = x <= g;
+var r3a7 = x <= h;
 
 var r3b1 = a <= x;
 var r3b2 = b <= x;
@@ -80,6 +86,7 @@ var r3b4 = d <= x;
 var r3b5 = e <= x;
 var r3b6 = f <= x;
 var r3b7 = g <= x;
+var r3b7 = h <= x;
 
 // operator >=
 var r4a1 = x >= a;
@@ -89,6 +96,7 @@ var r4a4 = x >= d;
 var r4a5 = x >= e;
 var r4a6 = x >= f;
 var r4a7 = x >= g;
+var r4a7 = x >= h;
 
 var r4b1 = a >= x;
 var r4b2 = b >= x;
@@ -97,6 +105,7 @@ var r4b4 = d >= x;
 var r4b5 = e >= x;
 var r4b6 = f >= x;
 var r4b7 = g >= x;
+var r4b7 = h >= x;
 
 // operator ==
 var r5a1 = x == a;
@@ -106,6 +115,7 @@ var r5a4 = x == d;
 var r5a5 = x == e;
 var r5a6 = x == f;
 var r5a7 = x == g;
+var r5a7 = x == h;
 
 var r5b1 = a == x;
 var r5b2 = b == x;
@@ -114,6 +124,7 @@ var r5b4 = d == x;
 var r5b5 = e == x;
 var r5b6 = f == x;
 var r5b7 = g == x;
+var r5b7 = h == x;
 
 // operator !=
 var r6a1 = x != a;
@@ -123,6 +134,7 @@ var r6a4 = x != d;
 var r6a5 = x != e;
 var r6a6 = x != f;
 var r6a7 = x != g;
+var r6a7 = x != h;
 
 var r6b1 = a != x;
 var r6b2 = b != x;
@@ -131,6 +143,7 @@ var r6b4 = d != x;
 var r6b5 = e != x;
 var r6b6 = f != x;
 var r6b7 = g != x;
+var r6b7 = h != x;
 
 // operator ===
 var r7a1 = x === a;
@@ -140,6 +153,7 @@ var r7a4 = x === d;
 var r7a5 = x === e;
 var r7a6 = x === f;
 var r7a7 = x === g;
+var r7a7 = x === h;
 
 var r7b1 = a === x;
 var r7b2 = b === x;
@@ -148,6 +162,7 @@ var r7b4 = d === x;
 var r7b5 = e === x;
 var r7b6 = f === x;
 var r7b7 = g === x;
+var r7b7 = h === x;
 
 // operator !==
 var r8a1 = x !== a;
@@ -157,6 +172,7 @@ var r8a4 = x !== d;
 var r8a5 = x !== e;
 var r8a6 = x !== f;
 var r8a7 = x !== g;
+var r8a7 = x !== h;
 
 var r8b1 = a !== x;
 var r8b2 = b !== x;
@@ -165,3 +181,4 @@ var r8b4 = d !== x;
 var r8b5 = e !== x;
 var r8b6 = f !== x;
 var r8b7 = g !== x;
+var r8b7 = h !== x;

--- a/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts
+++ b/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts
@@ -27,6 +27,7 @@ var d: void;
 var e: E;
 var f: {};
 var g: string[];
+var h: Date;
 
 // operator <
 var r1a1 = null < a;
@@ -36,6 +37,7 @@ var r1a4 = null < d;
 var r1a5 = null < e;
 var r1a6 = null < f;
 var r1a7 = null < g;
+var r1a7 = null < h;
 
 var r1b1 = a < null;
 var r1b2 = b < null;
@@ -44,6 +46,7 @@ var r1b4 = d < null;
 var r1b5 = e < null;
 var r1b6 = f < null;
 var r1b7 = g < null;
+var r1b7 = h < null;
 
 // operator >
 var r2a1 = null > a;
@@ -53,6 +56,7 @@ var r2a4 = null > d;
 var r2a5 = null > e;
 var r2a6 = null > f;
 var r2a7 = null > g;
+var r2a7 = null > h;
 
 var r2b1 = a > null;
 var r2b2 = b > null;
@@ -61,6 +65,7 @@ var r2b4 = d > null;
 var r2b5 = e > null;
 var r2b6 = f > null;
 var r2b7 = g > null;
+var r2b7 = h > null;
 
 // operator <=
 var r3a1 = null <= a;
@@ -70,6 +75,7 @@ var r3a4 = null <= d;
 var r3a5 = null <= e;
 var r3a6 = null <= f;
 var r3a7 = null <= g;
+var r3a7 = null <= h;
 
 var r3b1 = a <= null;
 var r3b2 = b <= null;
@@ -78,6 +84,7 @@ var r3b4 = d <= null;
 var r3b5 = e <= null;
 var r3b6 = f <= null;
 var r3b7 = g <= null;
+var r3b7 = h <= null;
 
 // operator >=
 var r4a1 = null >= a;
@@ -87,6 +94,7 @@ var r4a4 = null >= d;
 var r4a5 = null >= e;
 var r4a6 = null >= f;
 var r4a7 = null >= g;
+var r4a7 = null >= h;
 
 var r4b1 = a >= null;
 var r4b2 = b >= null;
@@ -95,6 +103,7 @@ var r4b4 = d >= null;
 var r4b5 = e >= null;
 var r4b6 = f >= null;
 var r4b7 = g >= null;
+var r4b7 = h >= null;
 
 // operator ==
 var r5a1 = null == a;
@@ -104,6 +113,7 @@ var r5a4 = null == d;
 var r5a5 = null == e;
 var r5a6 = null == f;
 var r5a7 = null == g;
+var r5a7 = null == h;
 
 var r5b1 = a == null;
 var r5b2 = b == null;
@@ -112,6 +122,7 @@ var r5b4 = d == null;
 var r5b5 = e == null;
 var r5b6 = f == null;
 var r5b7 = g == null;
+var r5b7 = h == null;
 
 // operator !=
 var r6a1 = null != a;
@@ -121,6 +132,7 @@ var r6a4 = null != d;
 var r6a5 = null != e;
 var r6a6 = null != f;
 var r6a7 = null != g;
+var r6a7 = null != h;
 
 var r6b1 = a != null;
 var r6b2 = b != null;
@@ -129,6 +141,7 @@ var r6b4 = d != null;
 var r6b5 = e != null;
 var r6b6 = f != null;
 var r6b7 = g != null;
+var r6b7 = h != null;
 
 // operator ===
 var r7a1 = null === a;
@@ -138,6 +151,7 @@ var r7a4 = null === d;
 var r7a5 = null === e;
 var r7a6 = null === f;
 var r7a7 = null === g;
+var r7a7 = null === h;
 
 var r7b1 = a === null;
 var r7b2 = b === null;
@@ -146,6 +160,7 @@ var r7b4 = d === null;
 var r7b5 = e === null;
 var r7b6 = f === null;
 var r7b7 = g === null;
+var r7b7 = h === null;
 
 // operator !==
 var r8a1 = null !== a;
@@ -155,6 +170,7 @@ var r8a4 = null !== d;
 var r8a5 = null !== e;
 var r8a6 = null !== f;
 var r8a7 = null !== g;
+var r8a7 = null !== h;
 
 var r8b1 = a !== null;
 var r8b2 = b !== null;
@@ -163,3 +179,4 @@ var r8b4 = d !== null;
 var r8b5 = e !== null;
 var r8b6 = f !== null;
 var r8b7 = g !== null;
+var r8b7 = h !== null;

--- a/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts
+++ b/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts
@@ -29,6 +29,7 @@ var d: void;
 var e: E;
 var f: {};
 var g: string[];
+var h: Date;
 
 // operator <
 var r1a1 = x < a;
@@ -38,6 +39,7 @@ var r1a4 = x < d;
 var r1a5 = x < e;
 var r1a6 = x < f;
 var r1a7 = x < g;
+var r1a7 = x < h;
 
 var r1b1 = a < x;
 var r1b2 = b < x;
@@ -46,6 +48,7 @@ var r1b4 = d < x;
 var r1b5 = e < x;
 var r1b6 = f < x;
 var r1b7 = g < x;
+var r1b7 = h < x;
 
 // operator >
 var r2a1 = x > a;
@@ -55,6 +58,7 @@ var r2a4 = x > d;
 var r2a5 = x > e;
 var r2a6 = x > f;
 var r2a7 = x > g;
+var r2a7 = x > h;
 
 var r2b1 = a > x;
 var r2b2 = b > x;
@@ -63,6 +67,7 @@ var r2b4 = d > x;
 var r2b5 = e > x;
 var r2b6 = f > x;
 var r2b7 = g > x;
+var r2b7 = h > x;
 
 // operator <=
 var r3a1 = x <= a;
@@ -72,6 +77,7 @@ var r3a4 = x <= d;
 var r3a5 = x <= e;
 var r3a6 = x <= f;
 var r3a7 = x <= g;
+var r3a7 = x <= h;
 
 var r3b1 = a <= x;
 var r3b2 = b <= x;
@@ -80,6 +86,7 @@ var r3b4 = d <= x;
 var r3b5 = e <= x;
 var r3b6 = f <= x;
 var r3b7 = g <= x;
+var r3b7 = h <= x;
 
 // operator >=
 var r4a1 = x >= a;
@@ -89,6 +96,7 @@ var r4a4 = x >= d;
 var r4a5 = x >= e;
 var r4a6 = x >= f;
 var r4a7 = x >= g;
+var r4a7 = x >= h;
 
 var r4b1 = a >= x;
 var r4b2 = b >= x;
@@ -97,6 +105,7 @@ var r4b4 = d >= x;
 var r4b5 = e >= x;
 var r4b6 = f >= x;
 var r4b7 = g >= x;
+var r4b7 = h >= x;
 
 // operator ==
 var r5a1 = x == a;
@@ -106,6 +115,7 @@ var r5a4 = x == d;
 var r5a5 = x == e;
 var r5a6 = x == f;
 var r5a7 = x == g;
+var r5a7 = x == h;
 
 var r5b1 = a == x;
 var r5b2 = b == x;
@@ -114,6 +124,7 @@ var r5b4 = d == x;
 var r5b5 = e == x;
 var r5b6 = f == x;
 var r5b7 = g == x;
+var r5b7 = h == x;
 
 // operator !=
 var r6a1 = x != a;
@@ -123,6 +134,7 @@ var r6a4 = x != d;
 var r6a5 = x != e;
 var r6a6 = x != f;
 var r6a7 = x != g;
+var r6a7 = x != h;
 
 var r6b1 = a != x;
 var r6b2 = b != x;
@@ -131,6 +143,7 @@ var r6b4 = d != x;
 var r6b5 = e != x;
 var r6b6 = f != x;
 var r6b7 = g != x;
+var r6b7 = h != x;
 
 // operator ===
 var r7a1 = x === a;
@@ -140,6 +153,7 @@ var r7a4 = x === d;
 var r7a5 = x === e;
 var r7a6 = x === f;
 var r7a7 = x === g;
+var r7a7 = x === h;
 
 var r7b1 = a === x;
 var r7b2 = b === x;
@@ -148,6 +162,7 @@ var r7b4 = d === x;
 var r7b5 = e === x;
 var r7b6 = f === x;
 var r7b7 = g === x;
+var r7b7 = h === x;
 
 // operator !==
 var r8a1 = x !== a;
@@ -157,6 +172,7 @@ var r8a4 = x !== d;
 var r8a5 = x !== e;
 var r8a6 = x !== f;
 var r8a7 = x !== g;
+var r8a7 = x !== h;
 
 var r8b1 = a !== x;
 var r8b2 = b !== x;
@@ -165,3 +181,4 @@ var r8b4 = d !== x;
 var r8b5 = e !== x;
 var r8b6 = f !== x;
 var r8b7 = g !== x;
+var r8b7 = h !== x;


### PR DESCRIPTION
Fixes #15506.

This PR flags boolean operands in comparisons with `<`, `>`, `<=` and `>=` as errors, for example:

```TypeScript
var a = true;
var b = 123;
var c = a > b;
        ~~~~~
> error TS2365: Operator '<' cannot be applied to types 'bool' and 'number'.
```

Some baselines have changed that I didn't expect to, but mhegazy confirmed that they're due to graceful parsing ([see issue](https://github.com/Microsoft/TypeScript/issues/15506#issuecomment-307878005)).

Hope I didn't miss too much. Feedback is very welcome 😃 

