### PR TITLE
In TypeScript code, never bind JSDoc normally, just set parent pointers

### DIFF
--- a/tests/baselines/reference/jsdocInTypeScript.errors.txt
+++ b/tests/baselines/reference/jsdocInTypeScript.errors.txt
@@ -62,3 +62,9 @@ tests/cases/compiler/jsdocInTypeScript.ts(42,12): error TS2503: Cannot find name
                ~
 !!! error TS2503: Cannot find namespace 'N'.
     
+    // Not legal JSDoc, but that shouldn't matter in TypeScript.
+    /**
+     * @type {{foo: (function(string, string): string)}}
+     */
+    const obj = { foo: (a, b) => a + b };
+    

--- a/tests/baselines/reference/jsdocInTypeScript.js
+++ b/tests/baselines/reference/jsdocInTypeScript.js
@@ -42,6 +42,12 @@ let i: I; // Should succeed thanks to type parameter default
 /** @typedef {string} N.Str */
 import M = N; // Error: @typedef does not create namespaces in TypeScript code.
 
+// Not legal JSDoc, but that shouldn't matter in TypeScript.
+/**
+ * @type {{foo: (function(string, string): string)}}
+ */
+const obj = { foo: (a, b) => a + b };
+
 
 //// [jsdocInTypeScript.js]
 var T = (function () {
@@ -68,3 +74,8 @@ function tem(t) { return {}; }
 var i; // Should succeed thanks to type parameter default
 /** @typedef {string} N.Str */
 var M = N; // Error: @typedef does not create namespaces in TypeScript code.
+// Not legal JSDoc, but that shouldn't matter in TypeScript.
+/**
+ * @type {{foo: (function(string, string): string)}}
+ */
+var obj = { foo: function (a, b) { return a + b; } };

--- a/tests/cases/compiler/jsdocInTypeScript.ts
+++ b/tests/cases/compiler/jsdocInTypeScript.ts
@@ -40,3 +40,9 @@ let i: I; // Should succeed thanks to type parameter default
 
 /** @typedef {string} N.Str */
 import M = N; // Error: @typedef does not create namespaces in TypeScript code.
+
+// Not legal JSDoc, but that shouldn't matter in TypeScript.
+/**
+ * @type {{foo: (function(string, string): string)}}
+ */
+const obj = { foo: (a, b) => a + b };


### PR DESCRIPTION
Fixes #16554

The fixes to #14752 (#14997) #16358 (#16413), and #16359 (#16416) were overly complex and specialized.
The only reason we needed to bind JSDoc in TypeScript code was to set parent pointers. This adds a function to do only that. (I started binding JSDoc in #15856 and should have just done this PR in the first place.)
Since we will now never reach a JSDoc node in the normal binder in TypeScript code, we can remove a bunch of checks for `isInJavaScriptFile` (undoing the previous specialized fixes to the above issues).
