### PR TITLE
Allow running in strict mode

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24692,15 +24692,15 @@ namespace ts {
                 return grammarErrorOnNode(node, Diagnostics.Dynamic_import_cannot_have_type_arguments);
             }
 
-            const arguments = node.arguments;
-            if (arguments.length !== 1) {
+            const nodeArguments = node.arguments;
+            if (nodeArguments.length !== 1) {
                 return grammarErrorOnNode(node, Diagnostics.Dynamic_import_must_have_one_specifier_as_an_argument);
             }
 
             // see: parseArgumentOrArrayLiteralElement...we use this function which parse arguments of callExpression to parse specifier for dynamic import.
             // parseArgumentOrArrayLiteralElement allows spread element to be in an argument list which is not allowed as specifier in dynamic import.
-            if (isSpreadElement(arguments[0])) {
-                return grammarErrorOnNode(arguments[0], Diagnostics.Specifier_of_dynamic_import_cannot_be_spread_element);
+            if (isSpreadElement(nodeArguments[0])) {
+                return grammarErrorOnNode(nodeArguments[0], Diagnostics.Specifier_of_dynamic_import_cannot_be_spread_element);
             }
         }
     }


### PR DESCRIPTION
`arguments` can't be assigned in strict mode.

Fixes #16531
