### PR TITLE
Without strictNullChecks, undefined narrows entire union

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11639,7 +11639,8 @@ namespace ts {
                 const valueType = getTypeOfExpression(value);
                 if (valueType.flags & TypeFlags.Nullable) {
                     if (!strictNullChecks) {
-                        return type;
+                        // === undefined/null gets rid of the entire union without strict null checks
+                        return assumeTrue ? valueType : type;
                     }
                     const doubleEquals = operator === SyntaxKind.EqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsToken;
                     const facts = doubleEquals ?

--- a/tests/baselines/reference/nonstrictUndefinedNarrowsEntireUnion.js
+++ b/tests/baselines/reference/nonstrictUndefinedNarrowsEntireUnion.js
@@ -1,0 +1,44 @@
+//// [nonstrictUndefinedNarrowsEntireUnion.ts]
+// === undefined / null should remove the entire union, including number
+function tripleEqualsDisjuct(x: string | number): string {
+    return typeof x === 'string' || x === undefined ? x : "";
+}
+function tripleEquals(x: string | number): string {
+    return x === undefined ? x : "";
+}
+
+function doubleEqualsDisjunct(x: string | number): string {
+    return typeof x === 'string' || x == undefined ? x : "";
+}
+function doubleEquals(x: string | number): string {
+    return x == undefined ? x : "";
+}
+
+function doubleEqualsNullDisjunct(x: string | number): string {
+    return typeof x === 'string' || x == null ? x : "";
+}
+function doubleEqualsNull(x: string | number): string {
+    return x == null ? x : "";
+}
+
+
+//// [nonstrictUndefinedNarrowsEntireUnion.js]
+// === undefined / null should remove the entire union, including number
+function tripleEqualsDisjuct(x) {
+    return typeof x === 'string' || x === undefined ? x : "";
+}
+function tripleEquals(x) {
+    return x === undefined ? x : "";
+}
+function doubleEqualsDisjunct(x) {
+    return typeof x === 'string' || x == undefined ? x : "";
+}
+function doubleEquals(x) {
+    return x == undefined ? x : "";
+}
+function doubleEqualsNullDisjunct(x) {
+    return typeof x === 'string' || x == null ? x : "";
+}
+function doubleEqualsNull(x) {
+    return x == null ? x : "";
+}

--- a/tests/baselines/reference/nonstrictUndefinedNarrowsEntireUnion.symbols
+++ b/tests/baselines/reference/nonstrictUndefinedNarrowsEntireUnion.symbols
@@ -1,0 +1,60 @@
+=== tests/cases/compiler/nonstrictUndefinedNarrowsEntireUnion.ts ===
+// === undefined / null should remove the entire union, including number
+function tripleEqualsDisjuct(x: string | number): string {
+>tripleEqualsDisjuct : Symbol(tripleEqualsDisjuct, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 0, 0))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 1, 29))
+
+    return typeof x === 'string' || x === undefined ? x : "";
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 1, 29))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 1, 29))
+>undefined : Symbol(undefined)
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 1, 29))
+}
+function tripleEquals(x: string | number): string {
+>tripleEquals : Symbol(tripleEquals, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 3, 1))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 4, 22))
+
+    return x === undefined ? x : "";
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 4, 22))
+>undefined : Symbol(undefined)
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 4, 22))
+}
+
+function doubleEqualsDisjunct(x: string | number): string {
+>doubleEqualsDisjunct : Symbol(doubleEqualsDisjunct, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 6, 1))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 8, 30))
+
+    return typeof x === 'string' || x == undefined ? x : "";
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 8, 30))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 8, 30))
+>undefined : Symbol(undefined)
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 8, 30))
+}
+function doubleEquals(x: string | number): string {
+>doubleEquals : Symbol(doubleEquals, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 10, 1))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 11, 22))
+
+    return x == undefined ? x : "";
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 11, 22))
+>undefined : Symbol(undefined)
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 11, 22))
+}
+
+function doubleEqualsNullDisjunct(x: string | number): string {
+>doubleEqualsNullDisjunct : Symbol(doubleEqualsNullDisjunct, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 13, 1))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 15, 34))
+
+    return typeof x === 'string' || x == null ? x : "";
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 15, 34))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 15, 34))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 15, 34))
+}
+function doubleEqualsNull(x: string | number): string {
+>doubleEqualsNull : Symbol(doubleEqualsNull, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 17, 1))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 18, 26))
+
+    return x == null ? x : "";
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 18, 26))
+>x : Symbol(x, Decl(nonstrictUndefinedNarrowsEntireUnion.ts, 18, 26))
+}
+

--- a/tests/baselines/reference/nonstrictUndefinedNarrowsEntireUnion.types
+++ b/tests/baselines/reference/nonstrictUndefinedNarrowsEntireUnion.types
@@ -1,0 +1,92 @@
+=== tests/cases/compiler/nonstrictUndefinedNarrowsEntireUnion.ts ===
+// === undefined / null should remove the entire union, including number
+function tripleEqualsDisjuct(x: string | number): string {
+>tripleEqualsDisjuct : (x: string | number) => string
+>x : string | number
+
+    return typeof x === 'string' || x === undefined ? x : "";
+>typeof x === 'string' || x === undefined ? x : "" : string
+>typeof x === 'string' || x === undefined : boolean
+>typeof x === 'string' : boolean
+>typeof x : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : string | number
+>'string' : "string"
+>x === undefined : boolean
+>x : number
+>undefined : undefined
+>x : string
+>"" : ""
+}
+function tripleEquals(x: string | number): string {
+>tripleEquals : (x: string | number) => string
+>x : string | number
+
+    return x === undefined ? x : "";
+>x === undefined ? x : "" : ""
+>x === undefined : boolean
+>x : string | number
+>undefined : undefined
+>x : undefined
+>"" : ""
+}
+
+function doubleEqualsDisjunct(x: string | number): string {
+>doubleEqualsDisjunct : (x: string | number) => string
+>x : string | number
+
+    return typeof x === 'string' || x == undefined ? x : "";
+>typeof x === 'string' || x == undefined ? x : "" : string
+>typeof x === 'string' || x == undefined : boolean
+>typeof x === 'string' : boolean
+>typeof x : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : string | number
+>'string' : "string"
+>x == undefined : boolean
+>x : number
+>undefined : undefined
+>x : string
+>"" : ""
+}
+function doubleEquals(x: string | number): string {
+>doubleEquals : (x: string | number) => string
+>x : string | number
+
+    return x == undefined ? x : "";
+>x == undefined ? x : "" : ""
+>x == undefined : boolean
+>x : string | number
+>undefined : undefined
+>x : undefined
+>"" : ""
+}
+
+function doubleEqualsNullDisjunct(x: string | number): string {
+>doubleEqualsNullDisjunct : (x: string | number) => string
+>x : string | number
+
+    return typeof x === 'string' || x == null ? x : "";
+>typeof x === 'string' || x == null ? x : "" : string
+>typeof x === 'string' || x == null : boolean
+>typeof x === 'string' : boolean
+>typeof x : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : string | number
+>'string' : "string"
+>x == null : boolean
+>x : number
+>null : null
+>x : string
+>"" : ""
+}
+function doubleEqualsNull(x: string | number): string {
+>doubleEqualsNull : (x: string | number) => string
+>x : string | number
+
+    return x == null ? x : "";
+>x == null ? x : "" : ""
+>x == null : boolean
+>x : string | number
+>null : null
+>x : null
+>"" : ""
+}
+

--- a/tests/cases/compiler/nonstrictUndefinedNarrowsEntireUnion.ts
+++ b/tests/cases/compiler/nonstrictUndefinedNarrowsEntireUnion.ts
@@ -1,0 +1,21 @@
+// === undefined / null should remove the entire union, including number
+function tripleEqualsDisjuct(x: string | number): string {
+    return typeof x === 'string' || x === undefined ? x : "";
+}
+function tripleEquals(x: string | number): string {
+    return x === undefined ? x : "";
+}
+
+function doubleEqualsDisjunct(x: string | number): string {
+    return typeof x === 'string' || x == undefined ? x : "";
+}
+function doubleEquals(x: string | number): string {
+    return x == undefined ? x : "";
+}
+
+function doubleEqualsNullDisjunct(x: string | number): string {
+    return typeof x === 'string' || x == null ? x : "";
+}
+function doubleEqualsNull(x: string | number): string {
+    return x == null ? x : "";
+}


### PR DESCRIPTION
I think this is technically incorrect, but there's nothing useful you can do
with `x` after being narrowed by `x===undefined` anyway. It's much more
useful to narrow the entire union and produce `x: undefined`:

```ts
function f(x: string | number} {
  if (x === undefined) {
    x.toString() // (!) this makes no sense
  }
}
function g(x: string | number): string {
  // x should narrow to string here
  return typeof x === 'string' || x === undefined ? x : "";
}
```

@andy-ms came up with the idea and I implemented it, so I'll let him provide further explanation and examples.