### PR TITLE
Fix the completion for parameters

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -694,7 +694,7 @@ namespace FourSlash {
 
         public verifyCompletionListItemsCountIsGreaterThan(count: number, negative: boolean) {
             const completions = this.getCompletionListAtCaret();
-            const itemsCount = completions.entries.length;
+            const itemsCount = completions ? completions.entries.length : 0;
 
             if (negative) {
                 if (itemsCount > count) {
@@ -3521,6 +3521,12 @@ namespace FourSlashInterface {
             "constructor",
             "async"
         ];
+        public allowedConstructorParameterKeywords = [
+            "public",
+            "private",
+            "protected",
+            "readonly",
+        ];
 
         constructor(protected state: FourSlash.TestState, private negative = false) {
             if (!negative) {
@@ -3559,6 +3565,12 @@ namespace FourSlashInterface {
 
         public completionListContainsClassElementKeywords() {
             for (const keyword of this.allowedClassElementKeywords) {
+                this.completionListContains(keyword, keyword, /*documentation*/ undefined, "keyword");
+            }
+        }
+
+        public completionListContainsConstructorParameterKeywords() {
+            for (const keyword of this.allowedConstructorParameterKeywords) {
                 this.completionListContains(keyword, keyword, /*documentation*/ undefined, "keyword");
             }
         }

--- a/tests/cases/fourslash/completionEntryForClassMembers.ts
+++ b/tests/cases/fourslash/completionEntryForClassMembers.ts
@@ -112,6 +112,11 @@
 ////class N extends B {
 ////    async /*classThatHasWrittenAsyncKeyword*/
 ////}
+////class O extends B {
+////    constructor(public a) {
+////    }, 
+////    /*classElementAfterConstructorSeparatedByComma*/
+////}
 
 const allowedKeywordCount = verify.allowedClassElementKeywords.length;
 type CompletionInfo = [string, string];
@@ -220,7 +225,8 @@ const classInstanceElementLocations = [
     "classThatStartedWritingIdentifierOfGetAccessor",
     "classThatStartedWritingIdentifierOfSetAccessor",
     "classThatStartedWritingIdentifierAfterModifier",
-    "classThatHasWrittenAsyncKeyword"
+    "classThatHasWrittenAsyncKeyword",
+    "classElementAfterConstructorSeparatedByComma"
 ];
 verifyClassElementLocations(instanceMemberInfo, classInstanceElementLocations);
 

--- a/tests/cases/fourslash/completionListAfterPropertyName.ts
+++ b/tests/cases/fourslash/completionListAfterPropertyName.ts
@@ -1,0 +1,88 @@
+///<reference path="fourslash.ts" />
+
+// @Filename: a.ts
+////class Test1 {
+////	public some /*afterPropertyName*/
+////}
+
+// @Filename: b.ts
+////class Test2 {
+////	public some(/*inMethodParameter*/
+////}
+
+// @Filename: c.ts
+////class Test3 {
+////	public some(a/*atMethodParameter*/
+////}
+
+// @Filename: d.ts
+////class Test4 {
+////	public some(a /*afterMethodParameter*/
+////}
+
+// @Filename: e.ts
+////class Test5 {
+////	public some(a /*afterMethodParameterBeforeComma*/,
+////}
+
+// @Filename: f.ts
+////class Test6 {
+////	public some(a, /*afterMethodParameterComma*/
+////}
+
+// @Filename: g.ts
+////class Test7 {
+////	constructor(/*inConstructorParameter*/
+////}
+
+// @Filename: h.ts
+////class Test8 {
+////	constructor(public /*inConstructorParameterAfterModifier*/
+////}
+
+// @Filename: i.ts
+////class Test9 {
+////	constructor(a/*atConstructorParameter*/
+////}
+
+// @Filename: j.ts
+////class Test10 {
+////	constructor(public/*atConstructorParameterModifier*/
+////}
+
+// @Filename: k.ts
+////class Test11 {
+////	constructor(public a/*atConstructorParameterAfterModifier*/
+////}
+
+// @Filename: l.ts
+////class Test12 {
+////	constructor(a /*afterConstructorParameter*/
+////}
+
+// @Filename: m.ts
+////class Test13 {
+////	constructor(a /*afterConstructorParameterBeforeComma*/,
+////}
+
+// @Filename: n.ts
+////class Test14 {
+////	constructor(public a, /*afterConstructorParameterComma*/
+////}
+
+for (const marker of ["afterPropertyName",
+    "inMethodParameter", "atMethodParameter", "afterMethodParameter",
+    "afterMethodParameterBeforeComma", "afterMethodParameterComma",
+    "afterConstructorParameter", "afterConstructorParameterBeforeComma"]) {
+
+    goTo.marker(marker);
+    verify.completionListIsEmpty();
+}
+
+for (const marker of ["inConstructorParameter", "inConstructorParameterAfterModifier",
+    "atConstructorParameter", "atConstructorParameterModifier", "atConstructorParameterAfterModifier",
+    "afterConstructorParameterComma"]) {
+    goTo.marker(marker);
+    verify.completionListContainsConstructorParameterKeywords();
+    verify.completionListCount(verify.allowedConstructorParameterKeywords.length);
+}

--- a/tests/cases/fourslash/completionListAtIdentifierDefinitionLocations_parameters.ts
+++ b/tests/cases/fourslash/completionListAtIdentifierDefinitionLocations_parameters.ts
@@ -22,4 +22,18 @@
 
 ////class bar10{ constructor(...a/*constructorParamter6*/
 
-goTo.eachMarker(() => verify.completionListIsEmpty());
+for (let i = 1; i <= 4; i++) {
+    goTo.marker("parameterName" + i.toString());
+    verify.completionListIsEmpty();
+}
+
+for (let i = 1; i <= 4; i++) {
+    goTo.marker("constructorParamter" + i.toString());
+    verify.completionListContainsConstructorParameterKeywords();
+    verify.completionListCount(verify.allowedConstructorParameterKeywords.length);
+}
+
+for (let i = 5; i <= 6; i++) {
+    goTo.marker("constructorParamter" + i.toString());
+    verify.completionListIsEmpty();
+}

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -134,12 +134,14 @@ declare namespace FourSlashInterface {
         private negative;
         not: verifyNegatable;
         allowedClassElementKeywords: string[];
+        allowedConstructorParameterKeywords: string[];
         constructor(negative?: boolean);
         completionListCount(expectedCount: number): void;
         completionListContains(symbol: string, text?: string, documentation?: string, kind?: string, spanIndex?: number): void;
         completionListItemsCountIsGreaterThan(count: number): void;
         completionListIsEmpty(): void;
         completionListContainsClassElementKeywords(): void;
+        completionListContainsConstructorParameterKeywords(): void;
         completionListAllowsNewIdentifier(): void;
         signatureHelpPresent(): void;
         errorExistsBetweenMarkers(startMarker: string, endMarker: string): void;

--- a/tests/cases/fourslash/globalCompletionListInsideObjectLiterals.ts
+++ b/tests/cases/fourslash/globalCompletionListInsideObjectLiterals.ts
@@ -39,7 +39,7 @@ goTo.marker("3");
 VerifyGlobalCompletionList();
 
 goTo.marker("4");
-VerifyGlobalCompletionList();
+verify.completionListIsEmpty();
 
 // Literal member completion after member name with empty member expression.
 goTo.marker("5");


### PR DESCRIPTION
Show public/private/protected/readonly when looking for constructor parameter and otherwise parameter declaration or property declaraiton should result in no completion
Fixes #15937
