### PR TITLE
Add missing newline in --pretty diagnostics formatter

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -332,6 +332,7 @@ namespace ts {
             const categoryColor = getCategoryFormat(diagnostic.category);
             const category = DiagnosticCategory[diagnostic.category].toLowerCase();
             output += `${ formatAndReset(category, categoryColor) } TS${ diagnostic.code }: ${ flattenDiagnosticMessageText(diagnostic.messageText, sys.newLine) }`;
+            output += sys.newLine;
         }
         return output;
     }

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -61,7 +61,7 @@ namespace ts {
     }
 
     function reportDiagnosticWithColorAndContext(diagnostic: Diagnostic, host: FormatDiagnosticsHost): void {
-        sys.write(ts.formatDiagnosticsWithColorAndContext([diagnostic], host) + sys.newLine + sys.newLine);
+        sys.write(ts.formatDiagnosticsWithColorAndContext([diagnostic], host) + sys.newLine);
     }
 
     function reportWatchDiagnostic(diagnostic: Diagnostic) {


### PR DESCRIPTION
It was compensated in tsc.ts, but then other compilers are missing a newline.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

See #16583