### PR TITLE
In getDeclarationSpaces, treat a type alias as a SymbolFlags.Type, not a SymbolFlags.Value

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18802,6 +18802,7 @@ namespace ts {
             function getDeclarationSpaces(d: Declaration): SymbolFlags {
                 switch (d.kind) {
                     case SyntaxKind.InterfaceDeclaration:
+                    case SyntaxKind.TypeAliasDeclaration:
                         return SymbolFlags.ExportType;
                     case SyntaxKind.ModuleDeclaration:
                         return isAmbientModule(d) || getModuleInstanceState(d) !== ModuleInstanceState.NonInstantiated
@@ -18811,12 +18812,17 @@ namespace ts {
                     case SyntaxKind.EnumDeclaration:
                         return SymbolFlags.ExportType | SymbolFlags.ExportValue;
                     case SyntaxKind.ImportEqualsDeclaration:
-                        let result: SymbolFlags = 0;
+                        let result = SymbolFlags.None;
                         const target = resolveAlias(getSymbolOfNode(d));
                         forEach(target.declarations, d => { result |= getDeclarationSpaces(d); });
                         return result;
-                    default:
+                    case SyntaxKind.VariableDeclaration:
+                    case SyntaxKind.BindingElement:
+                    case SyntaxKind.FunctionDeclaration:
+                    case SyntaxKind.ImportSpecifier: // https://github.com/Microsoft/TypeScript/pull/7591
                         return SymbolFlags.ExportValue;
+                    default:
+                        Debug.fail((ts as any).SyntaxKind[d.kind]);
                 }
             }
         }

--- a/tests/baselines/reference/mergedDeclarationExports.errors.txt
+++ b/tests/baselines/reference/mergedDeclarationExports.errors.txt
@@ -1,0 +1,44 @@
+tests/cases/compiler/mergedDeclarationExports.ts(13,11): error TS2395: Individual declarations in merged declaration 'c' must be all exported or all local.
+tests/cases/compiler/mergedDeclarationExports.ts(14,18): error TS2395: Individual declarations in merged declaration 'c' must be all exported or all local.
+tests/cases/compiler/mergedDeclarationExports.ts(17,11): error TS2395: Individual declarations in merged declaration 'd' must be all exported or all local.
+tests/cases/compiler/mergedDeclarationExports.ts(18,14): error TS2395: Individual declarations in merged declaration 'd' must be all exported or all local.
+tests/cases/compiler/mergedDeclarationExports.ts(21,11): error TS2395: Individual declarations in merged declaration 'N' must be all exported or all local.
+tests/cases/compiler/mergedDeclarationExports.ts(22,18): error TS2395: Individual declarations in merged declaration 'N' must be all exported or all local.
+
+
+==== tests/cases/compiler/mergedDeclarationExports.ts (6 errors) ====
+    // OK -- one is type, one is value
+    interface b {}
+    export const b = 1;
+    
+    // OK -- one is a type, one is a namespace, one is a value.
+    type t = 0;
+    namespace t { interface I {} }
+    export const t = 0;
+    
+    // Should get errors if they have some meaning in common.
+    
+    // both types
+    interface c {}
+              ~
+!!! error TS2395: Individual declarations in merged declaration 'c' must be all exported or all local.
+    export interface c {}
+                     ~
+!!! error TS2395: Individual declarations in merged declaration 'c' must be all exported or all local.
+    
+    // both types (class is also value, but that doesn't matter)
+    interface d {}
+              ~
+!!! error TS2395: Individual declarations in merged declaration 'd' must be all exported or all local.
+    export class d {}
+                 ~
+!!! error TS2395: Individual declarations in merged declaration 'd' must be all exported or all local.
+    
+    // both namespaces
+    namespace N { }
+              ~
+!!! error TS2395: Individual declarations in merged declaration 'N' must be all exported or all local.
+    export namespace N {}
+                     ~
+!!! error TS2395: Individual declarations in merged declaration 'N' must be all exported or all local.
+    

--- a/tests/baselines/reference/mergedDeclarationExports.js
+++ b/tests/baselines/reference/mergedDeclarationExports.js
@@ -1,0 +1,36 @@
+//// [mergedDeclarationExports.ts]
+// OK -- one is type, one is value
+interface b {}
+export const b = 1;
+
+// OK -- one is a type, one is a namespace, one is a value.
+type t = 0;
+namespace t { interface I {} }
+export const t = 0;
+
+// Should get errors if they have some meaning in common.
+
+// both types
+interface c {}
+export interface c {}
+
+// both types (class is also value, but that doesn't matter)
+interface d {}
+export class d {}
+
+// both namespaces
+namespace N { }
+export namespace N {}
+
+
+//// [mergedDeclarationExports.js]
+"use strict";
+exports.__esModule = true;
+exports.b = 1;
+exports.t = 0;
+var d = (function () {
+    function d() {
+    }
+    return d;
+}());
+exports.d = d;

--- a/tests/cases/compiler/mergedDeclarationExports.ts
+++ b/tests/cases/compiler/mergedDeclarationExports.ts
@@ -1,0 +1,22 @@
+// OK -- one is type, one is value
+interface b {}
+export const b = 1;
+
+// OK -- one is a type, one is a namespace, one is a value.
+type t = 0;
+namespace t { interface I {} }
+export const t = 0;
+
+// Should get errors if they have some meaning in common.
+
+// both types
+interface c {}
+export interface c {}
+
+// both types (class is also value, but that doesn't matter)
+interface d {}
+export class d {}
+
+// both namespaces
+namespace N { }
+export namespace N {}


### PR DESCRIPTION
Fixes #16596
We will no longer produce an error message for:
```ts
type t = number;
export const t = 0;
```
Previously we had an error in this case but not for `interface`.
