### PR TITLE
Handle `depth` in all readDirectory implementations

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1992,7 +1992,7 @@ namespace ts {
         }
 
         if (include && include.length > 0) {
-            for (const file of host.readDirectory(basePath, supportedExtensions, exclude, include)) {
+            for (const file of host.readDirectory(basePath, supportedExtensions, exclude, include, /*depth*/ undefined)) {
                 // If we have already included a literal or wildcard path with a
                 // higher priority extension, we should skip this file.
                 //

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -33,7 +33,7 @@ namespace ts {
         getExecutingFilePath(): string;
         getCurrentDirectory(): string;
         getDirectories(path: string): string[];
-        readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[]): string[];
+        readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[], depth?: number): string[];
         getModifiedTime?(path: string): Date;
         /**
          * This should be cryptographically secure.
@@ -281,8 +281,8 @@ namespace ts {
                 }
             }
 
-            function readDirectory(path: string, extensions?: string[], excludes?: string[], includes?: string[]): string[] {
-                return matchFiles(path, extensions, excludes, includes, useCaseSensitiveFileNames, process.cwd(), getAccessibleFileSystemEntries);
+            function readDirectory(path: string, extensions?: string[], excludes?: string[], includes?: string[], depth?: number): string[] {
+                return matchFiles(path, extensions, excludes, includes, useCaseSensitiveFileNames, process.cwd(), depth, getAccessibleFileSystemEntries);
             }
 
             const enum FileSystemEntryKind {
@@ -475,7 +475,7 @@ namespace ts {
                 getCurrentDirectory: () => ChakraHost.currentDirectory,
                 getDirectories: ChakraHost.getDirectories,
                 getEnvironmentVariable: ChakraHost.getEnvironmentVariable || (() => ""),
-                readDirectory: (path: string, extensions?: string[], excludes?: string[], includes?: string[]) => {
+                readDirectory(path, extensions, excludes, includes, _depth) {
                     const pattern = getFileMatcherPatterns(path, excludes, includes, !!ChakraHost.useCaseSensitiveFileNames, ChakraHost.currentDirectory);
                     return ChakraHost.readDirectory(path, extensions, pattern.basePaths, pattern.excludePattern, pattern.includeFilePattern, pattern.includeDirectoryPattern);
                 },

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2390,7 +2390,7 @@ namespace ts {
     export interface ParseConfigHost {
         useCaseSensitiveFileNames: boolean;
 
-        readDirectory(rootDir: string, extensions: string[], excludes: string[], includes: string[]): string[];
+        readDirectory(rootDir: string, extensions: string[], excludes: string[], includes: string[], depth: number): string[];
 
         /**
          * Gets a value indicating whether the specified path exists and is a file.

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -493,7 +493,7 @@ namespace Harness {
         args(): string[];
         getExecutingFilePath(): string;
         exit(exitCode?: number): void;
-        readDirectory(path: string, extension?: string[], exclude?: string[], include?: string[]): string[];
+        readDirectory(path: string, extension?: string[], exclude?: string[], include?: string[], depth?: number): string[];
         tryEnableSourceMapsForHost?(): void;
         getEnvironmentVariable?(name: string): string;
     }
@@ -537,7 +537,7 @@ namespace Harness {
                     ts.sys.tryEnableSourceMapsForHost();
                 }
             }
-            export const readDirectory: typeof IO.readDirectory = (path, extension, exclude, include) => ts.sys.readDirectory(path, extension, exclude, include);
+            export const readDirectory: typeof IO.readDirectory = (path, extension, exclude, include, depth) => ts.sys.readDirectory(path, extension, exclude, include, depth);
 
             export function createDirectory(path: string) {
                 if (!directoryExists(path)) {
@@ -733,12 +733,12 @@ namespace Harness {
                 Http.writeToServerSync(serverRoot + path, "WRITE", contents);
             }
 
-            export function readDirectory(path: string, extension?: string[], exclude?: string[], include?: string[]) {
+            export function readDirectory(path: string, extension?: string[], exclude?: string[], include?: string[], depth?: number) {
                 const fs = new Utils.VirtualFileSystem(path, useCaseSensitiveFileNames());
                 for (const file of listFiles(path)) {
                     fs.addFile(file);
                 }
-                return ts.matchFiles(path, extension, exclude, include, useCaseSensitiveFileNames(), getCurrentDirectory(), path => {
+                return ts.matchFiles(path, extension, exclude, include, useCaseSensitiveFileNames(), getCurrentDirectory(), depth, path => {
                     const entry = fs.traversePath(path);
                     if (entry && entry.isDirectory()) {
                         const directory = <Utils.VirtualDirectory>entry;

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -208,10 +208,11 @@ namespace Harness.LanguageService {
             const script = this.getScriptSnapshot(fileName);
             return script !== undefined;
         }
-        readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[]): string[] {
+        readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[], depth?: number): string[] {
             return ts.matchFiles(path, extensions, exclude, include,
                 /*useCaseSensitiveFileNames*/ false,
                 this.getCurrentDirectory(),
+                depth,
                 (p) => this.virtualFileSystem.getAccessibleFileSystemEntries(p));
         }
         readFile(path: string): string {
@@ -312,9 +313,7 @@ namespace Harness.LanguageService {
         getScriptVersion(fileName: string): string { return this.nativeHost.getScriptVersion(fileName); }
         getLocalizedDiagnosticMessages(): string { return JSON.stringify({}); }
 
-        readDirectory(_rootDir: string, _extension: string): string {
-            return ts.notImplemented();
-        }
+        readDirectory = ts.notImplemented;
         readDirectoryNames = ts.notImplemented;
         readFileNames = ts.notImplemented;
         fileExists(fileName: string) { return this.getScriptInfo(fileName) !== undefined; }
@@ -668,9 +667,7 @@ namespace Harness.LanguageService {
             return ts.sys.getEnvironmentVariable(name);
         }
 
-        readDirectory(_path: string, _extension?: string[], _exclude?: string[], _include?: string[]): string[] {
-            return ts.notImplemented();
-        }
+        readDirectory() { return ts.notImplemented(); }
 
         watchFile(): ts.FileWatcher {
             return { close: ts.noop };

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -67,6 +67,7 @@ interface IOLog {
         extensions: string[],
         exclude: string[],
         include: string[],
+        depth: number,
         result: string[]
     }[];
 }
@@ -220,10 +221,9 @@ namespace Playback {
             memoize(path => findFileByPath(replayLog.filesRead, path, /*throwFileNotFoundError*/ true).contents));
 
         wrapper.readDirectory = recordReplay(wrapper.readDirectory, underlying)(
-            (path, extensions, exclude, include) => {
-                const result = (<ts.System>underlying).readDirectory(path, extensions, exclude, include);
-                const logEntry = { path, extensions, exclude, include, result };
-                recordLog.directoriesRead.push(logEntry);
+            (path, extensions, exclude, include, depth) => {
+                const result = (<ts.System>underlying).readDirectory(path, extensions, exclude, include, depth);
+                recordLog.directoriesRead.push({ path, extensions, exclude, include, depth, result });
                 return result;
             },
             path => {

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -275,8 +275,8 @@ class ProjectRunner extends RunnerBase {
                     : ts.normalizeSlashes(testCase.projectRoot) + "/" + ts.normalizeSlashes(fileName);
             }
 
-            function readDirectory(rootDir: string, extension: string[], exclude: string[], include: string[]): string[] {
-                const harnessReadDirectoryResult = Harness.IO.readDirectory(getFileNameInTheProjectTest(rootDir), extension, exclude, include);
+            function readDirectory(rootDir: string, extension: string[], exclude: string[], include: string[], depth: number): string[] {
+                const harnessReadDirectoryResult = Harness.IO.readDirectory(getFileNameInTheProjectTest(rootDir), extension, exclude, include, depth);
                 const result: string[] = [];
                 for (let i = 0; i < harnessReadDirectoryResult.length; i++) {
                     result[i] = ts.getRelativePathToDirectoryOrUrl(testCase.projectRoot, harnessReadDirectoryResult[i],

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -19,7 +19,7 @@ namespace ts.server {
         getExecutingFilePath(): string { return void 0; },
         getCurrentDirectory(): string { return void 0; },
         getEnvironmentVariable(): string { return ""; },
-        readDirectory(): string[] { return []; },
+        readDirectory() { return []; },
         exit: noop,
         setTimeout() { return 0; },
         clearTimeout: noop,

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -438,14 +438,13 @@ namespace ts.projectSystem {
             }
         }
 
-        readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[]): string[] {
-            const that = this;
-            return ts.matchFiles(path, extensions, exclude, include, this.useCaseSensitiveFileNames, this.getCurrentDirectory(), (dir) => {
+        readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[], depth?: number): string[] {
+            return ts.matchFiles(path, extensions, exclude, include, this.useCaseSensitiveFileNames, this.getCurrentDirectory(), depth, (dir) => {
                 const result: FileSystemEntries = {
                     directories: [],
                     files: []
                 };
-                const dirEntry = that.fs.get(that.toPath(dir));
+                const dirEntry = this.fs.get(this.toPath(dir));
                 if (isFolder(dirEntry)) {
                     dirEntry.entries.forEach((entry) => {
                         if (isFolder(entry)) {

--- a/src/harness/virtualFileSystem.ts
+++ b/src/harness/virtualFileSystem.ts
@@ -216,8 +216,8 @@ namespace Utils {
             }
         }
 
-        readDirectory(path: string, extensions: string[], excludes: string[], includes: string[]) {
-            return ts.matchFiles(path, extensions, excludes, includes, this.useCaseSensitiveFileNames, this.currentDirectory, (path: string) => this.getAccessibleFileSystemEntries(path));
+        readDirectory(path: string, extensions: string[], excludes: string[], includes: string[], depth: number) {
+            return ts.matchFiles(path, extensions, excludes, includes, this.useCaseSensitiveFileNames, this.currentDirectory, depth, (path: string) => this.getAccessibleFileSystemEntries(path));
         }
     }
 }

--- a/src/server/lsHost.ts
+++ b/src/server/lsHost.ts
@@ -222,8 +222,8 @@ namespace ts.server {
             return this.host.directoryExists(path);
         }
 
-        readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[]): string[] {
-            return this.host.readDirectory(path, extensions, exclude, include);
+        readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[], depth?: number): string[] {
+            return this.host.readDirectory(path, extensions, exclude, include, depth);
         }
 
         getDirectories(path: string): string[] {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -35,7 +35,6 @@ namespace ts.server {
     } = require("os");
 
     function getGlobalTypingsCacheLocation() {
-        const versionMajorMinor = ts.version.match(/\d+\.\d+/)[0];
         switch (process.platform) {
             case "win32": {
                 const basePath = process.env.LOCALAPPDATA ||

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -434,5 +434,4 @@ namespace ts.server.typingsInstaller {
     export function typingsName(packageName: string): string {
         return `@types/${packageName}@ts${versionMajorMinor}`;
     }
-    const versionMajorMinor = version.split(".").slice(0, 2).join(".");
 }

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -212,6 +212,7 @@ namespace ts.JsTyping {
             }
 
             const typingNames: string[] = [];
+            // depth of 2, so we access `node_modules/foo` but not `node_modules/foo/bar`
             const fileNames = host.readDirectory(packagesFolderPath, [".json"], /*excludes*/ undefined, /*includes*/ undefined, /*depth*/ 2);
             for (const fileName of fileNames) {
                 const normalizedFileName = normalizePath(fileName);

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -163,7 +163,7 @@ namespace ts {
          * LS host can optionally implement these methods to support completions for module specifiers.
          * Without these methods, only completions for ambient modules will be provided.
          */
-        readDirectory?(path: string, extensions?: string[], exclude?: string[], include?: string[]): string[];
+        readDirectory?(path: string, extensions?: string[], exclude?: string[], include?: string[], depth?: number): string[];
         readFile?(path: string, encoding?: string): string;
         fileExists?(path: string): boolean;
 


### PR DESCRIPTION
`discoverTypings` needs to pass a `depth` parameter to `readDirectory` to ensure that `node_modules` is not traversed deeply. (This may have caused the slowdown in #16203.) Unfortunately, TypeScript allowed us to write an optional `depth` parameter at the declaration, even if it doesn't appear in almost any of the implementations. This PR adds `depth` to all of our implementations.

It's possible that third party implementations still don't handle a `depth` parameter; don't think there are any third-party hosts being used for `discoverTypings` though.

It's missing support for `ChakraHost` though. @paulvanbrenk How would we add support for that?

