### PR TITLE
Simplify calculation of `excludedMeanings`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21658,10 +21658,8 @@ namespace ts {
                 // Based on symbol.flags we can compute a set of excluded meanings (meaning that resolved alias should not have,
                 // otherwise it will conflict with some local declaration). Note that in addition to normal flags we include matching SymbolFlags.Export*
                 // in order to prevent collisions with declarations that were exported from the current module (they still contribute to local names).
-                const excludedMeanings =
-                    (symbol.flags & (SymbolFlags.Value | SymbolFlags.ExportValue) ? SymbolFlags.Value : 0) |
-                    (symbol.flags & SymbolFlags.Type ? SymbolFlags.Type : 0) |
-                    (symbol.flags & SymbolFlags.Namespace ? SymbolFlags.Namespace : 0);
+                const excludedMeanings = symbol.flags & (SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace)
+                    | (symbol.flags & SymbolFlags.ExportValue ? SymbolFlags.Value : SymbolFlags.None);
                 if (target.flags & excludedMeanings) {
                     const message = node.kind === SyntaxKind.ExportSpecifier ?
                         Diagnostics.Export_declaration_conflicts_with_exported_declaration_of_0 :


### PR DESCRIPTION
No need to do each component of `SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace` individually, we can just do them all at once.
