### PR TITLE
`hasProperty` doesn't need to be generic

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -955,7 +955,7 @@ namespace ts {
      * @param map A map-like.
      * @param key A property key.
      */
-    export function hasProperty<T>(map: MapLike<T>, key: string): boolean {
+    export function hasProperty(map: MapLike<any>, key: string): boolean {
         return hasOwnProperty.call(map, key);
     }
 


### PR DESCRIPTION
This function doesn't actually look at the values, so no need to give them a type.