### PR TITLE
Short-circuit getTokenAtPositionWorker

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -649,7 +649,8 @@ namespace ts {
 
                 const start = allowPositionInLeadingTrivia ? child.getFullStart() : child.getStart(sourceFile, includeJsDocComment);
                 if (start > position) {
-                    continue;
+                    // If this child begins after position, then all subsequent children will as well.
+                    break;
                 }
 
                 const end = child.getEnd();


### PR DESCRIPTION
The children of a given node are sorted by start position so, if one of
them starts after a given position, all subsequent children all start
after that position.