### PR TITLE
Watch for the creation of missing files

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -138,6 +138,7 @@ var harnessSources = harnessCoreSources.concat([
     "telemetry.ts",
     "transform.ts",
     "customTransforms.ts",
+    "programMissingFiles.ts",
 ].map(function (f) {
     return path.join(unittestsDirectory, f);
 })).concat([

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1097,6 +1097,15 @@ namespace ts {
         return result;
     }
 
+    /**
+     * Creates a set from the elements of an array.
+     *
+     * @param array the array of input elements.
+     */
+    export function arrayToSet<T>(array: T[], makeKey: (value: T) => string): Map<true> {
+        return arrayToMap<T, true>(array, makeKey, () => true);
+    }
+
     export function cloneMap<T>(map: Map<T>) {
         const clone = createMap<T>();
         copyEntries(map, clone);

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -879,15 +879,15 @@ namespace ts {
                         return oldProgram.structureIsReused = StructureIsReused.SafeModules;
                     }
                 }
+
+                for (const p of oldProgram.getMissingFilePaths()) {
+                    filesByName.set(p, undefined);
+                }
             }
 
             // update fileName -> file mapping
             for (let i = 0; i < newSourceFiles.length; i++) {
                 filesByName.set(filePaths[i], newSourceFiles[i]);
-            }
-
-            for (const p of oldProgram.getMissingFilePaths()) {
-                filesByName.set(p, undefined);
             }
 
             files = newSourceFiles;

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -340,11 +340,20 @@ namespace ts {
                     }
 
                     function fileChanged(curr: any, prev: any) {
-                        if (+curr.mtime <= +prev.mtime) {
+                        const isCurrZero = +curr.mtime === 0;
+                        const isPrevZero = +prev.mtime === 0;
+                        const added = !isCurrZero && isPrevZero;
+                        const deleted = isCurrZero && !isPrevZero;
+
+                        // This value is consistent with poll() in createPollingWatchedFileSet()
+                        // and depended upon by the file watchers created in Project.updateGraphWorker.
+                        const removed = deleted ? true : (added ? false : undefined);
+
+                        if (!added && !deleted && +curr.mtime <= +prev.mtime) {
                             return;
                         }
 
-                        callback(fileName);
+                        callback(fileName, removed);
                     }
                 },
                 watchDirectory: (directoryName, callback, recursive) => {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -285,6 +285,19 @@ namespace ts {
 
             setCachedProgram(compileResult.program);
             reportWatchDiagnostic(createCompilerDiagnostic(Diagnostics.Compilation_complete_Watching_for_file_changes));
+
+            if (compileResult.program.getMissingFilePaths) {
+                const missingPaths = compileResult.program.getMissingFilePaths() || [];
+                missingPaths.forEach((path: Path): void => {
+                    const fileWatcher = sys.watchFile(path, (_fileName: string, removed?: boolean) => {
+                        // removed = deleted ? true : (added ? false : undefined)
+                        if (removed === false) {
+                            fileWatcher.close();
+                            startTimerForRecompilation();
+                        }
+                    });
+                });
+            }
         }
 
         function cachedFileExists(fileName: string): boolean {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -286,18 +286,15 @@ namespace ts {
             setCachedProgram(compileResult.program);
             reportWatchDiagnostic(createCompilerDiagnostic(Diagnostics.Compilation_complete_Watching_for_file_changes));
 
-            if (compileResult.program.getMissingFilePaths) {
-                const missingPaths = compileResult.program.getMissingFilePaths() || [];
-                missingPaths.forEach((path: Path): void => {
-                    const fileWatcher = sys.watchFile(path, (_fileName: string, removed?: boolean) => {
-                        // removed = deleted ? true : (added ? false : undefined)
-                        if (removed === false) {
-                            fileWatcher.close();
-                            startTimerForRecompilation();
-                        }
-                    });
+            const missingPaths = compileResult.program.getMissingFilePaths();
+            missingPaths.forEach(path => {
+                const fileWatcher = sys.watchFile(path, (_fileName, eventKind) => {
+                    if (eventKind === FileWatcherEventKind.Created) {
+                        fileWatcher.close();
+                        startTimerForRecompilation();
+                    }
                 });
-            }
+            });
         }
 
         function cachedFileExists(fileName: string): boolean {
@@ -321,7 +318,7 @@ namespace ts {
             const sourceFile = hostGetSourceFile(fileName, languageVersion, onError);
             if (sourceFile && isWatchSet(compilerOptions) && sys.watchFile) {
                 // Attach a file watcher
-                sourceFile.fileWatcher = sys.watchFile(sourceFile.fileName, (_fileName: string, removed?: boolean) => sourceFileChanged(sourceFile, removed));
+                sourceFile.fileWatcher = sys.watchFile(sourceFile.fileName, (_fileName, eventKind) => sourceFileChanged(sourceFile, eventKind));
             }
             return sourceFile;
         }
@@ -343,10 +340,10 @@ namespace ts {
         }
 
         // If a source file changes, mark it as unwatched and start the recompilation timer
-        function sourceFileChanged(sourceFile: SourceFile, removed?: boolean) {
+        function sourceFileChanged(sourceFile: SourceFile, eventKind: FileWatcherEventKind) {
             sourceFile.fileWatcher.close();
             sourceFile.fileWatcher = undefined;
-            if (removed) {
+            if (eventKind === FileWatcherEventKind.Deleted) {
                 unorderedRemoveItem(rootFileNames, sourceFile.fileName);
             }
             startTimerForRecompilation();

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2430,7 +2430,8 @@ namespace ts {
          * Get a list of file names that were passed to 'createProgram' or referenced in a
          * program source file but could not be located.
          */
-        getMissingFilePaths?(): Path[];
+        /* @internal */
+        getMissingFilePaths(): Path[];
 
         /**
          * Emits the JavaScript and declaration files.  If targetSourceFile is not specified, then

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2427,6 +2427,12 @@ namespace ts {
         getSourceFiles(): SourceFile[];
 
         /**
+         * Get a list of file names that were passed to 'createProgram' or referenced in a
+         * program source file but could not be located.
+         */
+        getMissingFilePaths?(): Path[];
+
+        /**
          * Emits the JavaScript and declaration files.  If targetSourceFile is not specified, then
          * the JavaScript and declaration files will be produced for all the files in this program.
          * If targetSourceFile is specified, then only the JavaScript and declaration for that

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -129,6 +129,7 @@
         "./unittests/transform.ts",
         "./unittests/customTransforms.ts",
         "./unittests/textChanges.ts",
-        "./unittests/telemetry.ts"
+        "./unittests/telemetry.ts",
+        "./unittests/programMissingFiles.ts"
     ]
 }

--- a/src/harness/unittests/cachingInServerLSHost.ts
+++ b/src/harness/unittests/cachingInServerLSHost.ts
@@ -75,7 +75,7 @@ namespace ts {
         const rootScriptInfo = projectService.getOrCreateScriptInfo(rootFile, /* openedByClient */ true, /*containingProject*/ undefined);
 
         const project = projectService.createInferredProjectWithRootFileIfNecessary(rootScriptInfo);
-        project.setCompilerOptions({ module: ts.ModuleKind.AMD } );
+        project.setCompilerOptions({ module: ts.ModuleKind.AMD, noLib: true } );
         return {
             project,
             rootScriptInfo

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -208,7 +208,7 @@ namespace ts.projectSystem {
 
                 file1Consumer1.content = `let y = 10;`;
                 host.reloadFS([moduleFile1, file1Consumer1, file1Consumer2, configFile, libFile]);
-                host.triggerFileWatcherCallback(file1Consumer1.path, /*removed*/ false);
+                host.triggerFileWatcherCallback(file1Consumer1.path, FileWatcherEventKind.Changed);
 
                 session.executeCommand(changeModuleFile1ShapeRequest1);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer2] }]);
@@ -225,7 +225,7 @@ namespace ts.projectSystem {
                 session.executeCommand(changeModuleFile1ShapeRequest1);
                 // Delete file1Consumer2
                 host.reloadFS([moduleFile1, file1Consumer1, configFile, libFile]);
-                host.triggerFileWatcherCallback(file1Consumer2.path, /*removed*/ true);
+                host.triggerFileWatcherCallback(file1Consumer2.path, FileWatcherEventKind.Deleted);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1] }]);
             });
 
@@ -475,7 +475,7 @@ namespace ts.projectSystem {
 
                 openFilesForSession([referenceFile1], session);
                 host.reloadFS([referenceFile1, configFile]);
-                host.triggerFileWatcherCallback(moduleFile1.path, /*removed*/ true);
+                host.triggerFileWatcherCallback(moduleFile1.path, FileWatcherEventKind.Deleted);
 
                 const request = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: referenceFile1.path });
                 sendAffectedFileRequestAndCheckResult(session, request, [

--- a/src/harness/unittests/programMissingFiles.ts
+++ b/src/harness/unittests/programMissingFiles.ts
@@ -41,39 +41,33 @@ namespace ts {
             const program = createProgram([emptyFileRelativePath], options, testCompilerHost);
             const missing = program.getMissingFilePaths();
             assert.isDefined(missing);
-            assert.equal(missing.length, 0);
+            assert.deepEqual(missing, []);
         });
 
         it("handles missing root file", () => {
             const program = createProgram(["./nonexistent.ts"], options, testCompilerHost);
             const missing = program.getMissingFilePaths();
             assert.isDefined(missing);
-            assert.equal(missing.length, 1);
-            assert.equal(missing[0].toString(), "d:/pretend/nonexistent.ts"); // Absolute path
+            assert.deepEqual(missing, ["d:/pretend/nonexistent.ts"]); // Absolute path
         });
 
         it("handles multiple missing root files", () => {
             const program = createProgram(["./nonexistent0.ts", "./nonexistent1.ts"], options, testCompilerHost);
             const missing = program.getMissingFilePaths().sort();
-            assert.equal(missing.length, 2);
-            assert.equal(missing[0].toString(), "d:/pretend/nonexistent0.ts");
-            assert.equal(missing[1].toString(), "d:/pretend/nonexistent1.ts");
+            assert.deepEqual(missing, ["d:/pretend/nonexistent0.ts", "d:/pretend/nonexistent1.ts"]);
         });
 
         it("handles a mix of present and missing root files", () => {
             const program = createProgram(["./nonexistent0.ts", emptyFileRelativePath, "./nonexistent1.ts"], options, testCompilerHost);
             const missing = program.getMissingFilePaths().sort();
-            assert.equal(missing.length, 2);
-            assert.equal(missing[0].toString(), "d:/pretend/nonexistent0.ts");
-            assert.equal(missing[1].toString(), "d:/pretend/nonexistent1.ts");
+            assert.deepEqual(missing, ["d:/pretend/nonexistent0.ts", "d:/pretend/nonexistent1.ts"]);
         });
 
         it("handles repeatedly specified root files", () => {
             const program = createProgram(["./nonexistent.ts", "./nonexistent.ts"], options, testCompilerHost);
             const missing = program.getMissingFilePaths();
             assert.isDefined(missing);
-            assert.equal(missing.length, 1);
-            assert.equal(missing[0].toString(), "d:/pretend/nonexistent.ts");
+            assert.deepEqual(missing, ["d:/pretend/nonexistent.ts"]);
         });
 
         it("normalizes file paths", () => {
@@ -89,21 +83,21 @@ namespace ts {
             const program = createProgram([referenceFileRelativePath], options, testCompilerHost);
             const missing = program.getMissingFilePaths().sort();
             assert.isDefined(missing);
-            assert.equal(missing.length, 6);
+            assert.deepEqual(missing, [
+                // From absolute reference
+                "d:/imaginary/nonexistent1.ts",
 
-            // From absolute reference
-            assert.equal(missing[0].toString(), "d:/imaginary/nonexistent1.ts");
+                // From relative reference
+                "d:/pretend/nonexistent2.ts",
 
-            // From relative reference
-            assert.equal(missing[1].toString(), "d:/pretend/nonexistent2.ts");
+                // From unqualified reference
+                "d:/pretend/nonexistent3.ts",
 
-            // From unqualified reference
-            assert.equal(missing[2].toString(), "d:/pretend/nonexistent3.ts");
-
-            // From no-extension reference
-            assert.equal(missing[3].toString(), "d:/pretend/nonexistent4.d.ts");
-            assert.equal(missing[4].toString(), "d:/pretend/nonexistent4.ts");
-            assert.equal(missing[5].toString(), "d:/pretend/nonexistent4.tsx");
+                // From no-extension reference
+                "d:/pretend/nonexistent4.d.ts",
+                "d:/pretend/nonexistent4.ts",
+                "d:/pretend/nonexistent4.tsx"
+            ]);
         });
     });
 }

--- a/src/harness/unittests/programMissingFiles.ts
+++ b/src/harness/unittests/programMissingFiles.ts
@@ -1,0 +1,109 @@
+/// <reference path="..\harness.ts" />
+
+namespace ts {
+    describe("Program.getMissingFilePaths", () => {
+
+        const options: CompilerOptions = {
+            noLib: true,
+        };
+
+        const emptyFileName = "empty.ts";
+        const emptyFileRelativePath = "./" + emptyFileName;
+
+        const emptyFile: Harness.Compiler.TestFile = {
+            unitName: emptyFileName,
+            content: ""
+        };
+
+        const referenceFileName = "reference.ts";
+        const referenceFileRelativePath = "./" + referenceFileName;
+
+        const referenceFile: Harness.Compiler.TestFile = {
+            unitName: referenceFileName,
+            content:
+                "/// <reference path=\"d:/imaginary/nonexistent1.ts\"/>\n" + // Absolute
+                "/// <reference path=\"./nonexistent2.ts\"/>\n" + // Relative
+                "/// <reference path=\"nonexistent3.ts\"/>\n" + // Unqualified
+                "/// <reference path=\"nonexistent4\"/>\n"   // No extension
+        };
+
+        const testCompilerHost = Harness.Compiler.createCompilerHost(
+            /*inputFiles*/ [emptyFile, referenceFile],
+            /*writeFile*/ undefined,
+            /*scriptTarget*/ undefined,
+            /*useCaseSensitiveFileNames*/ false,
+            /*currentDirectory*/ "d:\\pretend\\",
+            /*newLineKind*/ NewLineKind.LineFeed,
+            /*libFiles*/ undefined
+        );
+
+        it("handles no missing root files", () => {
+            const program = createProgram([emptyFileRelativePath], options, testCompilerHost);
+            const missing = program.getMissingFilePaths();
+            assert.isDefined(missing);
+            assert.equal(missing.length, 0);
+        });
+
+        it("handles missing root file", () => {
+            const program = createProgram(["./nonexistent.ts"], options, testCompilerHost);
+            const missing = program.getMissingFilePaths();
+            assert.isDefined(missing);
+            assert.equal(missing.length, 1);
+            assert.equal(missing[0].toString(), "d:/pretend/nonexistent.ts"); // Absolute path
+        });
+
+        it("handles multiple missing root files", () => {
+            const program = createProgram(["./nonexistent0.ts", "./nonexistent1.ts"], options, testCompilerHost);
+            const missing = program.getMissingFilePaths().sort();
+            assert.equal(missing.length, 2);
+            assert.equal(missing[0].toString(), "d:/pretend/nonexistent0.ts");
+            assert.equal(missing[1].toString(), "d:/pretend/nonexistent1.ts");
+        });
+
+        it("handles a mix of present and missing root files", () => {
+            const program = createProgram(["./nonexistent0.ts", emptyFileRelativePath, "./nonexistent1.ts"], options, testCompilerHost);
+            const missing = program.getMissingFilePaths().sort();
+            assert.equal(missing.length, 2);
+            assert.equal(missing[0].toString(), "d:/pretend/nonexistent0.ts");
+            assert.equal(missing[1].toString(), "d:/pretend/nonexistent1.ts");
+        });
+
+        it("handles repeatedly specified root files", () => {
+            const program = createProgram(["./nonexistent.ts", "./nonexistent.ts"], options, testCompilerHost);
+            const missing = program.getMissingFilePaths();
+            assert.isDefined(missing);
+            assert.equal(missing.length, 1);
+            assert.equal(missing[0].toString(), "d:/pretend/nonexistent.ts");
+        });
+
+        it("normalizes file paths", () => {
+            const program0 = createProgram(["./nonexistent.ts", "./NONEXISTENT.ts"], options, testCompilerHost);
+            const program1 = createProgram(["./NONEXISTENT.ts", "./nonexistent.ts"], options, testCompilerHost);
+            const missing0 = program0.getMissingFilePaths();
+            const missing1 = program1.getMissingFilePaths();
+            assert.equal(missing0.length, 1);
+            assert.deepEqual(missing0, missing1);
+        });
+
+        it("handles missing triple slash references", () => {
+            const program = createProgram([referenceFileRelativePath], options, testCompilerHost);
+            const missing = program.getMissingFilePaths().sort();
+            assert.isDefined(missing);
+            assert.equal(missing.length, 6);
+
+            // From absolute reference
+            assert.equal(missing[0].toString(), "d:/imaginary/nonexistent1.ts");
+
+            // From relative reference
+            assert.equal(missing[1].toString(), "d:/pretend/nonexistent2.ts");
+
+            // From unqualified reference
+            assert.equal(missing[2].toString(), "d:/pretend/nonexistent3.ts");
+
+            // From no-extension reference
+            assert.equal(missing[3].toString(), "d:/pretend/nonexistent4.d.ts");
+            assert.equal(missing[4].toString(), "d:/pretend/nonexistent4.ts");
+            assert.equal(missing[5].toString(), "d:/pretend/nonexistent4.tsx");
+        });
+    });
+}

--- a/src/harness/unittests/projectErrors.ts
+++ b/src/harness/unittests/projectErrors.ts
@@ -135,7 +135,7 @@ namespace ts.projectSystem {
             }
             // fix config and trigger watcher
             host.reloadFS([file1, file2, correctConfig]);
-            host.triggerFileWatcherCallback(correctConfig.path, /*false*/);
+            host.triggerFileWatcherCallback(correctConfig.path, FileWatcherEventKind.Changed);
             {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
@@ -177,7 +177,7 @@ namespace ts.projectSystem {
             }
             // break config and trigger watcher
             host.reloadFS([file1, file2, corruptedConfig]);
-            host.triggerFileWatcherCallback(corruptedConfig.path, /*false*/);
+            host.triggerFileWatcherCallback(corruptedConfig.path, FileWatcherEventKind.Changed);
             {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);

--- a/src/harness/unittests/reuseProgramStructure.ts
+++ b/src/harness/unittests/reuseProgramStructure.ts
@@ -316,6 +316,31 @@ namespace ts {
             assert.isTrue(program_1.structureIsReused === StructureIsReused.Not);
         });
 
+        it("succeeds if missing files remain missing", () => {
+            const options: CompilerOptions = { target, noLib: true };
+
+            const program_1 = newProgram(files, ["a.ts"], options);
+            assert.notDeepEqual(emptyArray, program_1.getMissingFilePaths());
+
+            const program_2 = updateProgram(program_1, ["a.ts"], options, noop);
+            assert.deepEqual(program_1.getMissingFilePaths(), program_2.getMissingFilePaths());
+
+            assert.equal(StructureIsReused.Completely, program_1.structureIsReused);
+        });
+
+        it("fails if missing file is created", () => {
+            const options: CompilerOptions = { target, noLib: true };
+
+            const program_1 = newProgram(files, ["a.ts"], options);
+            assert.notDeepEqual(emptyArray, program_1.getMissingFilePaths());
+
+            const newTexts: NamedSourceText[] = files.concat([{ name: "non-existing-file.ts", text: SourceText.New("", "", `var x = 1`) }]);
+            const program_2 = updateProgram(program_1, ["a.ts"], options, noop, newTexts);
+            assert.deepEqual(emptyArray, program_2.getMissingFilePaths());
+
+            assert.equal(StructureIsReused.SafeModules, program_1.structureIsReused);
+        });
+
         it("resolution cache follows imports", () => {
             (<any>Error).stackTraceLimit = Infinity;
 

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2028,7 +2028,7 @@ namespace ts.projectSystem {
             projectService.openExternalProject({ projectFileName, options: {}, rootFiles: [{ fileName: file1.path, scriptKind: ScriptKind.JS, hasMixedContent: true }] });
 
             checkNumberOfProjects(projectService, { externalProjects: 1 });
-            checkWatchedFiles(host, []);
+            checkWatchedFiles(host, [libFile.path]); // watching the "missing" lib file
 
             const project = projectService.externalProjects[0];
 

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -731,7 +731,7 @@ namespace ts.projectSystem {
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
             const p = projectService.configuredProjects[0];
             checkProjectActualFiles(p, [app.path, jsconfig.path]);
-            checkWatchedFiles(host, [jsconfig.path, "/bower_components", "/node_modules"]);
+            checkWatchedFiles(host, [jsconfig.path, "/bower_components", "/node_modules", libFile.path]);
 
             installer.installAll(/*expectedCount*/ 1);
 

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -820,7 +820,7 @@ namespace ts.projectSystem {
             installer.checkPendingCommands(/*expectedCount*/ 0);
 
             host.reloadFS([f, fixedPackageJson]);
-            host.triggerFileWatcherCallback(fixedPackageJson.path, /*removed*/ false);
+            host.triggerFileWatcherCallback(fixedPackageJson.path, FileWatcherEventKind.Changed);
             // expected install request
             installer.installAll(/*expectedCount*/ 1);
 

--- a/src/server/lsHost.ts
+++ b/src/server/lsHost.ts
@@ -210,8 +210,11 @@ namespace ts.server {
             return this.host.resolvePath(path);
         }
 
-        fileExists(path: string): boolean {
-            return this.host.fileExists(path);
+        fileExists(file: string): boolean {
+            // As an optimization, don't hit the disks for files we already know don't exist
+            // (because we're watching for their creation).
+            const path = toPath(file, this.host.getCurrentDirectory(), this.getCanonicalFileName);
+            return !this.project.isWatchedMissingFile(path) && this.host.fileExists(file);
         }
 
         readFile(fileName: string): string {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -311,6 +311,13 @@ namespace ts.server {
             this.lsHost.dispose();
             this.lsHost = undefined;
 
+            // Clean up file watchers waiting for missing files
+            for (const p of this.missingFilesMap.getKeys()) {
+                this.missingFilesMap.get(p).close();
+                this.missingFilesMap.remove(p);
+            }
+            this.missingFilesMap = undefined;
+
             // signal language service to release source files acquired from document registry
             this.languageService.dispose();
             this.languageService = undefined;

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -631,7 +631,7 @@ namespace ts.server {
                 // Missing files that are not yet watched should be added to the map.
                 missingFilePaths.forEach(p => {
                     if (!this.missingFilesMap.contains(p)) {
-                        const fileWatcher = ts.sys.watchFile(p, (_filename: string, removed?: boolean) => {
+                        const fileWatcher = this.projectService.host.watchFile(p, (_filename: string, removed?: boolean) => {
                             // removed = deleted ? true : (added ? false : undefined)
                             if (removed === false && this.missingFilesMap.contains(p)) {
                                 fileWatcher.close();

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -107,6 +107,7 @@ namespace ts.server {
         private rootFilesMap: Map<ScriptInfo> = createMap<ScriptInfo>();
         private program: ts.Program;
         private externalFiles: SortedReadonlyArray<string>;
+        private missingFilesMap: FileMap<FileWatcher> = createFileMap<FileWatcher>();
 
         private cachedUnresolvedImportsPerFile = new UnresolvedImportsMap();
         private lastCachedUnresolvedImportsList: SortedReadonlyArray<string>;
@@ -606,6 +607,39 @@ namespace ts.server {
                 }
             }
 
+            if (hasChanges && this.program.getMissingFilePaths) {
+                const missingFilePaths = this.program.getMissingFilePaths() || emptyArray;
+                const missingFilePathsSet = createMap<true>();
+                missingFilePaths.forEach(p => missingFilePathsSet.set(p, true));
+
+                // Files that are no longer missing (e.g. because they are no longer required)
+                // should no longer be watched.
+                this.missingFilesMap.getKeys().forEach(p => {
+                    if (!missingFilePathsSet.has(p)) {
+                        this.missingFilesMap.get(p).close();
+                        this.missingFilesMap.remove(p);
+                    }
+                });
+
+                // Missing files that are not yet watched should be added to the map.
+                missingFilePaths.forEach(p => {
+                    if (!this.missingFilesMap.contains(p)) {
+                        const fileWatcher = ts.sys.watchFile(p, (_filename: string, removed?: boolean) => {
+                            // removed = deleted ? true : (added ? false : undefined)
+                            if (removed === false && this.missingFilesMap.contains(p)) {
+                                fileWatcher.close();
+                                this.missingFilesMap.remove(p);
+
+                                // When a missing file is created, we should update the graph.
+                                this.markAsDirty();
+                                this.updateGraph();
+                            }
+                        });
+                        this.missingFilesMap.set(p, fileWatcher);
+                    }
+                });
+            }
+
             const oldExternalFiles = this.externalFiles || emptyArray as SortedReadonlyArray<string>;
             this.externalFiles = this.getExternalFiles();
             enumerateInsertsAndDeletes(this.externalFiles, oldExternalFiles,
@@ -624,6 +658,10 @@ namespace ts.server {
                 });
 
             return hasChanges;
+        }
+
+        isWatchedMissingFile(path: Path) {
+            return this.missingFilesMap.contains(path);
         }
 
         getScriptInfoLSHost(fileName: string) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -522,6 +522,9 @@ namespace ts.server {
                 return;
             }
 
+            // removed = deleted ? true : (added ? false : undefined)
+            // This value is consistent with sys.watchFile()
+            // and depended upon by the file watchers created in performCompilation() in tsc's executeCommandLine().
             fs.stat(watchedFile.fileName, (err: any, stats: any) => {
                 if (err) {
                     watchedFile.callback(watchedFile.fileName);
@@ -560,7 +563,9 @@ namespace ts.server {
             const file: WatchedFile = {
                 fileName,
                 callback,
-                mtime: getModifiedTime(fileName)
+                mtime: sys.fileExists(fileName)
+                    ? getModifiedTime(fileName)
+                    : new Date(0) // Any subsequent modification will occur after this time
             };
 
             watchedFiles.push(file);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -522,16 +522,16 @@ namespace ts.server {
                 return;
             }
 
-            // removed = deleted ? true : (added ? false : undefined)
-            // This value is consistent with sys.watchFile()
-            // and depended upon by the file watchers created in performCompilation() in tsc's executeCommandLine().
             fs.stat(watchedFile.fileName, (err: any, stats: any) => {
                 if (err) {
-                    watchedFile.callback(watchedFile.fileName);
+                    watchedFile.callback(watchedFile.fileName, FileWatcherEventKind.Changed);
                 }
                 else if (watchedFile.mtime.getTime() !== stats.mtime.getTime()) {
                     watchedFile.mtime = stats.mtime;
-                    watchedFile.callback(watchedFile.fileName, watchedFile.mtime.getTime() === 0);
+                    const eventKind = watchedFile.mtime.getTime() === 0
+                        ? FileWatcherEventKind.Deleted
+                        : FileWatcherEventKind.Changed;
+                    watchedFile.callback(watchedFile.fileName, eventKind);
                 }
             });
         }

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -2,7 +2,10 @@
 namespace ts.DocumentHighlights {
     export function getDocumentHighlights(program: Program, cancellationToken: CancellationToken, sourceFile: SourceFile, position: number, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] | undefined {
         const node = getTouchingWord(sourceFile, position, /*includeJsDocComment*/ true);
-        if (!node) return undefined;
+        // Note that getTouchingWord indicates failure by returning the sourceFile node.
+        if (node === sourceFile) return undefined;
+
+        Debug.assert(node.parent !== undefined);
 
         if (isJsxOpeningElement(node.parent) && node.parent.tagName === node || isJsxClosingElement(node.parent)) {
             // For a JSX element, just highlight the matching tag, not all references.


### PR DESCRIPTION
When we discover that a file is missing, call `watchFile` on its path so that we can update our state when it is created.

1) For `tsc --watch`, we schedule a new build
2) For `tsserver`, we update the containing projects

Caveat: VS will not know about the state change in tsserver until the next time it synchronizes its project list