### PR TITLE
Improve JavaScript type from constructor imported via require

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16090,7 +16090,7 @@ namespace ts {
         }
 
         function getJavaScriptClassType(symbol: Symbol): Type | undefined {
-            if (symbol && isDeclarationOfFunctionOrClassExpression(symbol)) {
+            if (isDeclarationOfFunctionOrClassExpression(symbol)) {
                 symbol = getSymbolOfNode((<VariableDeclaration>symbol.valueDeclaration).initializer);
             }
             if (isJavaScriptConstructor(symbol.valueDeclaration)) {

--- a/tests/baselines/reference/constructorFunctions2.symbols
+++ b/tests/baselines/reference/constructorFunctions2.symbols
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/salsa/node.d.ts ===
+declare function require(id: string): any;
+>require : Symbol(require, Decl(node.d.ts, 0, 0))
+>id : Symbol(id, Decl(node.d.ts, 0, 25))
+
+declare var module: any, exports: any;
+>module : Symbol(module, Decl(node.d.ts, 1, 11))
+>exports : Symbol(exports, Decl(node.d.ts, 1, 24))
+
+=== tests/cases/conformance/salsa/index.js ===
+const A = require("./other");
+>A : Symbol(A, Decl(index.js, 0, 5))
+>require : Symbol(require, Decl(node.d.ts, 0, 0))
+>"./other" : Symbol("tests/cases/conformance/salsa/other", Decl(other.js, 0, 0))
+
+const a = new A().id;
+>a : Symbol(a, Decl(index.js, 1, 5))
+>new A().id : Symbol(A.id, Decl(other.js, 0, 14))
+>A : Symbol(A, Decl(index.js, 0, 5))
+>id : Symbol(A.id, Decl(other.js, 0, 14))
+
+const B = function() { this.id = 1; }
+>B : Symbol(B, Decl(index.js, 3, 5))
+>id : Symbol(B.id, Decl(index.js, 3, 22))
+
+const b = new B().id;
+>b : Symbol(b, Decl(index.js, 4, 5))
+>new B().id : Symbol(B.id, Decl(index.js, 3, 22))
+>B : Symbol(B, Decl(index.js, 3, 5))
+>id : Symbol(B.id, Decl(index.js, 3, 22))
+
+=== tests/cases/conformance/salsa/other.js ===
+function A() { this.id = 1; }
+>A : Symbol(A, Decl(other.js, 0, 0))
+>id : Symbol(A.id, Decl(other.js, 0, 14))
+
+module.exports = A;
+>module : Symbol(export=, Decl(other.js, 0, 29))
+>exports : Symbol(export=, Decl(other.js, 0, 29))
+>A : Symbol(A, Decl(other.js, 0, 0))
+

--- a/tests/baselines/reference/constructorFunctions2.types
+++ b/tests/baselines/reference/constructorFunctions2.types
@@ -1,0 +1,55 @@
+=== tests/cases/conformance/salsa/node.d.ts ===
+declare function require(id: string): any;
+>require : (id: string) => any
+>id : string
+
+declare var module: any, exports: any;
+>module : any
+>exports : any
+
+=== tests/cases/conformance/salsa/index.js ===
+const A = require("./other");
+>A : () => void
+>require("./other") : () => void
+>require : (id: string) => any
+>"./other" : "./other"
+
+const a = new A().id;
+>a : number
+>new A().id : number
+>new A() : { id: number; }
+>A : () => void
+>id : number
+
+const B = function() { this.id = 1; }
+>B : () => void
+>function() { this.id = 1; } : () => void
+>this.id = 1 : 1
+>this.id : any
+>this : any
+>id : any
+>1 : 1
+
+const b = new B().id;
+>b : number
+>new B().id : number
+>new B() : { id: number; }
+>B : () => void
+>id : number
+
+=== tests/cases/conformance/salsa/other.js ===
+function A() { this.id = 1; }
+>A : () => void
+>this.id = 1 : 1
+>this.id : any
+>this : any
+>id : any
+>1 : 1
+
+module.exports = A;
+>module.exports = A : () => void
+>module.exports : any
+>module : any
+>exports : any
+>A : () => void
+

--- a/tests/cases/conformance/salsa/constructorFunctions2.ts
+++ b/tests/cases/conformance/salsa/constructorFunctions2.ts
@@ -1,0 +1,18 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @module: commonjs
+// @filename: node.d.ts
+declare function require(id: string): any;
+declare var module: any, exports: any;
+
+// @filename: index.js
+const A = require("./other");
+const a = new A().id;
+
+const B = function() { this.id = 1; }
+const b = new B().id;
+
+// @filename: other.js
+function A() { this.id = 1; }
+module.exports = A;


### PR DESCRIPTION
This improves the type we resolve for a `new` expression whose constructor was imported from a JavaScript file via a CommonJS `require` call.

Fixes #16467
