### PR TITLE
Ignore jsdoc when inferring rest args in JavaScript

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6391,7 +6391,7 @@ namespace ts {
                     undefined;
                 // JS functions get a free rest parameter if they reference `arguments`
                 let hasRestLikeParameter = hasRestParameter(declaration);
-                if (!hasRestLikeParameter && isInJavaScriptFile(declaration) && !hasJSDocParameterTags(declaration) && containsArgumentsReference(declaration)) {
+                if (!hasRestLikeParameter && isInJavaScriptFile(declaration) && containsArgumentsReference(declaration)) {
                     hasRestLikeParameter = true;
                     const syntheticArgsSymbol = createSymbol(SymbolFlags.Variable, "args");
                     syntheticArgsSymbol.type = anyArrayType;

--- a/tests/baselines/reference/argumentsObjectCreatesRestForJs.types
+++ b/tests/baselines/reference/argumentsObjectCreatesRestForJs.types
@@ -35,13 +35,13 @@ someRest(1, 2, 3);
  * @param {number} x - a thing
  */
 function jsdocced(x) { arguments; }
->jsdocced : (x: number) => void
+>jsdocced : (x: number, ...args: any[]) => void
 >x : number
 >arguments : IArguments
 
 jsdocced(1);
 >jsdocced(1) : void
->jsdocced : (x: number) => void
+>jsdocced : (x: number, ...args: any[]) => void
 >1 : 1
 
 function dontDoubleRest(x, ...y) { arguments; }


### PR DESCRIPTION
When inferring a rest argument for a JavaScript function signature that does not already define one, ignore whether the function has existing JSDoc `@param` tags.

Fixes #15663
