### PR TITLE
Adds tracking for failed tests, re-running failed tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ internal/
 !tests/baselines/reference/project/nodeModules*/**/*
 .idea
 yarn.lock
+.failed-tests

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -811,6 +811,8 @@ function runConsoleTests(defaultReporter, runInParallel) {
     var inspect = process.env.inspect || process.env["inspect-brk"] || process.env.i;
     var testTimeout = process.env.timeout || defaultTestTimeout;
     var tests = process.env.test || process.env.tests || process.env.t;
+    var failed = process.env.failed || false;
+    var keepFailed = process.env.keepFailed || process.env["keep-failed"] || false;
     var light = process.env.light || false;
     var stackTraceLimit = process.env.stackTraceLimit;
     var testConfigFile = 'test.config';
@@ -849,9 +851,13 @@ function runConsoleTests(defaultReporter, runInParallel) {
     if (!runInParallel) {
         var startTime = mark();
         var args = [];
-        args.push("-R", reporter);
+        args.push("-R", "scripts/mocha-file-reporter");
+        args.push("-O", '"reporter=' + reporter + (keepFailed ? ",keepFailed=true" : "") + '"');
         if (tests) {
             args.push("-g", `"${tests}"`);
+        }
+        else if (failed) {
+            args.push("--opts", ".failed-tests");
         }
         if (colors) {
             args.push("--colors");
@@ -894,7 +900,7 @@ function runConsoleTests(defaultReporter, runInParallel) {
         var savedNodeEnv = process.env.NODE_ENV;
         process.env.NODE_ENV = "development";
         var startTime = mark();
-        runTestsInParallel(taskConfigsFolder, run, { testTimeout: testTimeout, noColors: !colors }, function (err) {
+        runTestsInParallel(taskConfigsFolder, run, { testTimeout: testTimeout, noColors: !colors, keepFailed }, function (err) {
             process.env.NODE_ENV = savedNodeEnv;
             measure(startTime);
             // last worker clean everything and runs linter in case if there were no errors

--- a/scripts/mocha-file-reporter.js
+++ b/scripts/mocha-file-reporter.js
@@ -11,8 +11,6 @@ function FileReporter(runner, options) {
     var reporterOptions = this.reporterOptions = options.reporterOptions || {};
     reporterOptions.file = reporterOptions.file || ".failed-tests";
     reporterOptions.keepFailed = reporterOptions.keepFailed || false;
-    reporterOptions.reporter = reporterOptions.reporter;
-    reporterOptions.reporterOptions = reporterOptions.reporterOptions || {};
     if (reporterOptions.reporter) {
         var _reporter;
         if (typeof reporterOptions.reporter === "function") {
@@ -32,7 +30,7 @@ function FileReporter(runner, options) {
 
         var newOptions = {};
         for (var p in options) newOptions[p] = options[p];
-        newOptions.reporterOptions = reporterOptions.reporterOptions;
+        newOptions.reporterOptions = reporterOptions.reporterOptions || {};
         this.reporter = new _reporter(runner, newOptions);
     }
 

--- a/scripts/mocha-file-reporter.js
+++ b/scripts/mocha-file-reporter.js
@@ -1,0 +1,77 @@
+var Mocha = require('mocha');
+var path = require('path');
+var fs = require('fs');
+
+exports = module.exports = FileReporter;
+
+function FileReporter(runner, options) {
+    if (!runner) return;
+    options = options || {};
+
+    var reporterOptions = this.reporterOptions = options.reporterOptions || {};
+    reporterOptions.file = reporterOptions.file || ".failed-tests";
+    reporterOptions.keepFailed = reporterOptions.keepFailed || false;
+    reporterOptions.reporter = reporterOptions.reporter;
+    reporterOptions.reporterOptions = reporterOptions.reporterOptions || {};
+    if (reporterOptions.reporter) {
+        var _reporter;
+        if (typeof reporterOptions.reporter === "function") {
+            _reporter = reporterOptions.reporter;
+        }
+        else if (Mocha.reporters[reporterOptions.reporter]) {
+            _reporter = Mocha.reporters[reporterOptions.reporter];
+        }
+        else {
+            try {
+                _reporter = require(reporterOptions.reporter);
+            }
+            catch (err) {
+                _reporter = require(path.resolve(process.cwd(), reporterOptions.reporter));
+            }
+        }
+
+        var newOptions = {};
+        for (var p in options) newOptions[p] = options[p];
+        newOptions.reporterOptions = reporterOptions.reporterOptions;
+        this.reporter = new _reporter(runner, newOptions);
+    }
+
+    var failures = this.failures = [];
+    runner.on('fail', function (test, err) {
+        failures.push(test);
+    });
+}
+
+FileReporter.prototype.done = function (numFailures, fn) {
+    FileReporter.writeFailures(this.reporterOptions.file, this.failures, this.reporterOptions.keepFailed, done);
+
+    function done(err) {
+        var reporter = this.reporter;
+        if (reporter && reporter.done) {
+            reporter.done(numFailures, fn);
+        }
+        else {
+            if (fn) fn(numFailures);
+        }
+
+        if (err) console.error(err);
+    }
+}
+
+FileReporter.writeFailures = function (fileName, failures, keepFailed, fn) {
+    if (failures.length) {
+        var failed = failures.map(function (test) { return escapeRegExp(test.fullTitle()); }).join("|");
+        fs.writeFile(fileName, "--grep " + failed, "utf8", fn);
+    }
+    else if (!keepFailed) {
+        fs.unlink(fileName, function () { fn(); });
+    }
+    else {
+        fn();
+    }
+};
+
+var reservedCharacterRegExp = /[^\w]/g;
+function escapeRegExp(pattern) {
+    return pattern.replace(reservedCharacterRegExp, function (match) { return "\\" + match; });
+}

--- a/scripts/mocha-file-reporter.js
+++ b/scripts/mocha-file-reporter.js
@@ -37,13 +37,17 @@ function FileReporter(runner, options) {
     }
 
     var failures = this.failures = [];
+    var tests = this.tests = [];
+    runner.on('test end', function (test) {
+        tests.push(test);
+    })
     runner.on('fail', function (test, err) {
         failures.push(test);
     });
 }
 
 FileReporter.prototype.done = function (numFailures, fn) {
-    FileReporter.writeFailures(this.reporterOptions.file, this.failures, this.reporterOptions.keepFailed, done);
+    FileReporter.writeFailures(this.reporterOptions.file, this.failures, this.reporterOptions.keepFailed || this.tests.length === 0, done);
 
     function done(err) {
         var reporter = this.reporter;


### PR DESCRIPTION
This change adds the following capabilities:
* After running tests (either via `runtests` or `runtests-parallel`), any failing tests will be written to a _.failed-tests_ file.
  * This file is in a response-file format understood by mocha's `--opts` option.
  * The names of failing tests are escaped and combined to be used with mocha's `--grep` option.
* Running either `jake runtests failed=true` or `gulp runtests --failed` will run only the failing tests from the last test run.
  * The `failed` option will be superseded by the `tests` option, if both are provided.
  * The `failed` option is not currently supported on the `runtests-parallel` task.
* When a test run completes successfully, the _.failed-tests_ file is removed unless you also pass `keepFailed=true` to **jake** or `--keepFailed` to **gulp**.

**Examples (jake)**
```
# Run tests with test failure tracking
jake runtests
jake runtests-parallel

# Run failed tests (remove .failed-tests file on success)
jake runtests failed=true

# Run failed tests (do not remove .failed-tests file on success)
jake runtests failed=true keepFailed=true
```

**Examples (gulp)**
```
# Run tests with test failure tracking
gulp runtests
gulp runtests-parallel

# Run failed tests (remove .failed-tests file on success)
gulp runtests --failed

# Run failed tests (do not remove .failed-tests file on success)
gulp runtests --failed --keepFailed
```