### PR TITLE
Diagnostics for default class / function export in namespace

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23624,7 +23624,14 @@ namespace ts {
                         }
                         flags |= ModifierFlags.Export;
                         break;
+                    case SyntaxKind.DefaultKeyword:
+                        const container = node.parent.kind === SyntaxKind.SourceFile ? node.parent : node.parent.parent;
+                        if (container.kind === SyntaxKind.ModuleDeclaration && !isAmbientModule(container)) {
+                            return grammarErrorOnNode(modifier, Diagnostics.A_default_export_can_only_be_used_in_an_ECMAScript_style_module);
+                        }
 
+                        flags |= ModifierFlags.Default;
+                        break;
                     case SyntaxKind.DeclareKeyword:
                         if (flags & ModifierFlags.Ambient) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_already_seen, "declare");

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -3158,7 +3158,7 @@ namespace ts {
                 getExternalModuleOrNamespaceExportName(currentNamespaceContainerName, node, /*allowComments*/ false, /*allowSourceMaps*/ true),
                 getLocalName(node)
             );
-            setSourceMapRange(expression, createRange(node.name.pos, node.end));
+            setSourceMapRange(expression, createRange(node.name ? node.name.pos: node.pos, node.end));
 
             const statement = createStatement(expression);
             setSourceMapRange(statement, createRange(-1, node.end));

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -3158,7 +3158,7 @@ namespace ts {
                 getExternalModuleOrNamespaceExportName(currentNamespaceContainerName, node, /*allowComments*/ false, /*allowSourceMaps*/ true),
                 getLocalName(node)
             );
-            setSourceMapRange(expression, createRange(node.name ? node.name.pos: node.pos, node.end));
+            setSourceMapRange(expression, createRange(node.name ? node.name.pos : node.pos, node.end));
 
             const statement = createStatement(expression);
             setSourceMapRange(statement, createRange(-1, node.end));

--- a/tests/baselines/reference/exportDefaultClassInNamespace.errors.txt
+++ b/tests/baselines/reference/exportDefaultClassInNamespace.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/exportDefaultClassInNamespace.ts(2,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+tests/cases/compiler/exportDefaultClassInNamespace.ts(6,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+
+
+==== tests/cases/compiler/exportDefaultClassInNamespace.ts (2 errors) ====
+    namespace ns_class {
+        export default class {}
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
+    }
+    
+    namespace ns_abstract_class {
+        export default abstract class {}
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
+    }
+    

--- a/tests/baselines/reference/exportDefaultClassInNamespace.js
+++ b/tests/baselines/reference/exportDefaultClassInNamespace.js
@@ -1,0 +1,29 @@
+//// [exportDefaultClassInNamespace.ts]
+namespace ns_class {
+    export default class {}
+}
+
+namespace ns_abstract_class {
+    export default abstract class {}
+}
+
+
+//// [exportDefaultClassInNamespace.js]
+var ns_class;
+(function (ns_class) {
+    var default_1 = (function () {
+        function default_1() {
+        }
+        return default_1;
+    }());
+    ns_class.default_1 = default_1;
+})(ns_class || (ns_class = {}));
+var ns_abstract_class;
+(function (ns_abstract_class) {
+    var default_2 = (function () {
+        function default_2() {
+        }
+        return default_2;
+    }());
+    ns_abstract_class.default_2 = default_2;
+})(ns_abstract_class || (ns_abstract_class = {}));

--- a/tests/baselines/reference/exportDefaultClassInNamespace.symbols
+++ b/tests/baselines/reference/exportDefaultClassInNamespace.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/exportDefaultClassInNamespace.ts ===
+namespace ns_class {
+>ns_class : Symbol(ns_class, Decl(exportDefaultClassInNamespace.ts, 0, 0))
+
+    export default class {}
+}
+
+namespace ns_abstract_class {
+>ns_abstract_class : Symbol(ns_abstract_class, Decl(exportDefaultClassInNamespace.ts, 2, 1))
+
+    export default abstract class {}
+}
+

--- a/tests/baselines/reference/exportDefaultClassInNamespace.types
+++ b/tests/baselines/reference/exportDefaultClassInNamespace.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/exportDefaultClassInNamespace.ts ===
+namespace ns_class {
+>ns_class : typeof ns_class
+
+    export default class {}
+}
+
+namespace ns_abstract_class {
+>ns_abstract_class : typeof ns_abstract_class
+
+    export default abstract class {}
+}
+

--- a/tests/baselines/reference/exportDefaultFunctionInNamespace.errors.txt
+++ b/tests/baselines/reference/exportDefaultFunctionInNamespace.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/exportDefaultFunctionInNamespace.ts(2,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+tests/cases/compiler/exportDefaultFunctionInNamespace.ts(6,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+
+
+==== tests/cases/compiler/exportDefaultFunctionInNamespace.ts (2 errors) ====
+    namespace ns_function {
+        export default function () {}
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
+    }
+    
+    namespace ns_async_function {
+        export default async function () {}
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
+    }
+    

--- a/tests/baselines/reference/exportDefaultFunctionInNamespace.js
+++ b/tests/baselines/reference/exportDefaultFunctionInNamespace.js
@@ -1,0 +1,60 @@
+//// [exportDefaultFunctionInNamespace.ts]
+namespace ns_function {
+    export default function () {}
+}
+
+namespace ns_async_function {
+    export default async function () {}
+}
+
+
+//// [exportDefaultFunctionInNamespace.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var ns_function;
+(function (ns_function) {
+    default function () { }
+    ns_function.default_1 = default_1;
+})(ns_function || (ns_function = {}));
+var ns_async_function;
+(function (ns_async_function) {
+    default function () {
+        return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
+            return [2 /*return*/];
+        }); });
+    }
+    ns_async_function.default_2 = default_2;
+})(ns_async_function || (ns_async_function = {}));

--- a/tests/baselines/reference/exportDefaultFunctionInNamespace.symbols
+++ b/tests/baselines/reference/exportDefaultFunctionInNamespace.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/exportDefaultFunctionInNamespace.ts ===
+namespace ns_function {
+>ns_function : Symbol(ns_function, Decl(exportDefaultFunctionInNamespace.ts, 0, 0))
+
+    export default function () {}
+}
+
+namespace ns_async_function {
+>ns_async_function : Symbol(ns_async_function, Decl(exportDefaultFunctionInNamespace.ts, 2, 1))
+
+    export default async function () {}
+}
+

--- a/tests/baselines/reference/exportDefaultFunctionInNamespace.types
+++ b/tests/baselines/reference/exportDefaultFunctionInNamespace.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/exportDefaultFunctionInNamespace.ts ===
+namespace ns_function {
+>ns_function : typeof ns_function
+
+    export default function () {}
+}
+
+namespace ns_async_function {
+>ns_async_function : typeof ns_async_function
+
+    export default async function () {}
+}
+

--- a/tests/baselines/reference/staticPropertyNameConflicts.errors.txt
+++ b/tests/baselines/reference/staticPropertyNameConflicts.errors.txt
@@ -22,18 +22,26 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(111,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn_Anonymous'.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(121,16): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName'.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(128,16): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn'.
+tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(135,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(136,16): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength'.
+tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(142,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(143,16): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn'.
+tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(150,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(151,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
+tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(157,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(158,16): error TS2300: Duplicate identifier 'prototype'.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(158,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
+tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(165,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(166,16): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller'.
+tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(172,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(173,16): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn'.
+tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(180,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(181,16): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments'.
+tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn'.
 
 
-==== tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts (33 errors) ====
+==== tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts (41 errors) ====
     // name
     class StaticName {
         static name: number; // error
@@ -217,6 +225,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
     // length
     module TestOnDefaultExportedClass_3 {
         export default class StaticLength {
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
             static length: number; // error
                    ~~~~~~
 !!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength'.
@@ -226,6 +236,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
     
     module TestOnDefaultExportedClass_4 {
         export default class StaticLengthFn {
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
             static length() {} // error
                    ~~~~~~
 !!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn'.
@@ -236,6 +248,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
     // prototype
     module TestOnDefaultExportedClass_5 {    
         export default class StaticPrototype {
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
             static prototype: number; // error
                    ~~~~~~~~~
 !!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
@@ -245,6 +259,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
     
     module TestOnDefaultExportedClass_6 {
         export default class StaticPrototypeFn {
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
             static prototype() {} // error
                    ~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'prototype'.
@@ -257,6 +273,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
     // caller
     module TestOnDefaultExportedClass_7 {
         export default class StaticCaller {
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
             static caller: number; // error
                    ~~~~~~
 !!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller'.
@@ -266,6 +284,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
     
     module TestOnDefaultExportedClass_8 {
         export default class StaticCallerFn {
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
             static caller() {} // error
                    ~~~~~~
 !!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn'.
@@ -276,6 +296,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
     // arguments
     module TestOnDefaultExportedClass_9 {
         export default class StaticArguments {
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
             static arguments: number; // error
                    ~~~~~~~~~
 !!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments'.
@@ -285,6 +307,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameCon
     
     module TestOnDefaultExportedClass_10 {
         export default class StaticArgumentsFn {
+               ~~~~~~~
+!!! error TS1319: A default export can only be used in an ECMAScript-style module.
             static arguments() {} // error
                    ~~~~~~~~~
 !!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn'.

--- a/tests/cases/compiler/exportDefaultClassInNamespace.ts
+++ b/tests/cases/compiler/exportDefaultClassInNamespace.ts
@@ -1,0 +1,7 @@
+namespace ns_class {
+    export default class {}
+}
+
+namespace ns_abstract_class {
+    export default abstract class {}
+}

--- a/tests/cases/compiler/exportDefaultFunctionInNamespace.ts
+++ b/tests/cases/compiler/exportDefaultFunctionInNamespace.ts
@@ -1,0 +1,7 @@
+namespace ns_function {
+    export default function () {}
+}
+
+namespace ns_async_function {
+    export default async function () {}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #16300 & #16301

Since default function / class exports are parsed differently from other default exports, there were no diagnostic messages for when they were included in namespaces. Additionally, attempting to compile a default class export within a namespace was causing the compiler to crash as it assumed the class had a name when it actually didn't.

Updated the checker to also check for the default modifier and added a guard when transforming class declarations to handle when there is no name.
