### PR TITLE
Clean up uses of ensureScriptKind

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2125,7 +2125,7 @@ namespace ts {
         // If the 'scriptKind' is 'undefined' or 'Unknown' then we attempt
         // to get the ScriptKind from the file name. If it cannot be resolved
         // from the file name then the default 'TS' script kind is returned.
-        return (scriptKind || getScriptKindFromFileName(fileName)) || ScriptKind.TS;
+        return scriptKind || getScriptKindFromFileName(fileName) || ScriptKind.TS;
     }
 
     export function getScriptKindFromFileName(fileName: string): ScriptKind {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2118,7 +2118,7 @@ namespace ts {
         return absolute.substring(0, absolute.lastIndexOf(directorySeparator, wildcardOffset));
     }
 
-    export function ensureScriptKind(fileName: string, scriptKind?: ScriptKind): ScriptKind {
+    export function ensureScriptKind(fileName: string, scriptKind: ScriptKind | undefined): ScriptKind {
         // Using scriptKind as a condition handles both:
         // - 'scriptKind' is unspecified and thus it is `undefined`
         // - 'scriptKind' is set and it is `Unknown` (0)

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -71,8 +71,7 @@ namespace ts.JsTyping {
         // Only infer typings for .js and .jsx files
         fileNames = mapDefined(fileNames, fileName => {
             const path = normalizePath(fileName);
-            const kind = ensureScriptKind(path, getScriptKindFromFileName(path));
-            if (kind === ScriptKind.JS || kind === ScriptKind.JSX) {
+            if (hasJavaScriptFileExtension(path)) {
                 return path;
             }
         });
@@ -191,7 +190,7 @@ namespace ts.JsTyping {
                 }
             }
 
-            const hasJsxFile = forEach(fileNames, f => ensureScriptKind(f, getScriptKindFromFileName(f)) === ScriptKind.JSX);
+            const hasJsxFile = some(fileNames, f => fileExtensionIs(f, Extension.Jsx));
             if (hasJsxFile) {
                 addInferredTyping("react");
             }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1303,14 +1303,7 @@ namespace ts {
     export function getScriptKind(fileName: string, host?: LanguageServiceHost): ScriptKind {
         // First check to see if the script kind was specified by the host. Chances are the host
         // may override the default script kind for the file extension.
-        let scriptKind: ScriptKind;
-        if (host && host.getScriptKind) {
-            scriptKind = host.getScriptKind(fileName);
-        }
-        if (!scriptKind) {
-            scriptKind = getScriptKindFromFileName(fileName);
-        }
-        return ensureScriptKind(fileName, scriptKind);
+        return ensureScriptKind(fileName, host && host.getScriptKind && host.getScriptKind(fileName));
     }
 
     export function getFirstNonSpaceCharacterPosition(text: string, position: number) {


### PR DESCRIPTION
Some uses of this function were overly complicated or unnecessary.