### PR TITLE
Type `emptyArray` as `never[]`

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2,7 +2,7 @@
 /* @internal */
 namespace ts {
     export const scanner: Scanner = createScanner(ScriptTarget.Latest, /*skipTrivia*/ true);
-    export const emptyArray: any[] = [];
+    export const emptyArray: never[] = [] as never[];
 
     export const enum SemanticMeaning {
         None = 0x0,


### PR DESCRIPTION
If this is an `any[]` then any value that's possibly an `emptyArray` will also be considered an `any[]`.
This should actually be a `ReadonlyArray<never>` but see #16716.
