### PR TITLE
Fix scope of @typedef references

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -275,6 +275,13 @@ namespace ts {
     }
 
     export function getContainerNode(node: Node): Declaration {
+        if (node.kind === SyntaxKind.JSDocTypedefTag) {
+            // This doesn't just apply to the node immediately under the comment, but to everything in its parent's scope.
+            // node.parent = the JSDoc comment, node.parent.parent = the node having the comment.
+            // Then we get parent again in the loop.
+            node = node.parent.parent;
+        }
+
         while (true) {
             node = node.parent;
             if (!node) {

--- a/tests/cases/fourslash/findAllRefsJsDocTypeDef_js.ts
+++ b/tests/cases/fourslash/findAllRefsJsDocTypeDef_js.ts
@@ -17,5 +17,4 @@
 //// */
 ////function f2(obj) { return 0; }
 
-const [r0, r1, r2] = test.ranges();
 verify.singleReferenceGroup("type T = number");

--- a/tests/cases/fourslash/findAllRefsJsDocTypeDef_js.ts
+++ b/tests/cases/fourslash/findAllRefsJsDocTypeDef_js.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts'/>
+
+// Tests that the scope of @typedef is not just the node immediately below it.
+
+// @allowJs: true
+
+// @Filename: /a.js
+/////** @typedef {number} [|{| "isWriteAccess": true, "isDefinition": true |}T|] */
+////
+/////**
+//// * @return {[|T|]}
+//// */
+////function f(obj) { return 0; }
+////
+/////**
+//// * @return {[|T|]}
+//// */
+////function f2(obj) { return 0; }
+
+const [r0, r1, r2] = test.ranges();
+verify.singleReferenceGroup("type T = number");


### PR DESCRIPTION
Previously, if a `@typedef` comment was attached to a function, we considered that function to be its container. Now we make sure to go to the function's *parent* before looking for a container.