### PR TITLE
In a namespace exported classes, functions, enums, and nested namespaces should be readonly

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14452,7 +14452,7 @@ namespace ts {
             const assignmentKind = getAssignmentTargetKind(node);
 
             if (assignmentKind) {
-                if (isReferenceToReadonlyEntity(<Expression>node, prop) || isReferenceThroughNamespaceImport(<Expression>node)) { //!
+                if (isReferenceToReadonlyEntity(<Expression>node, prop) || isReferenceThroughNamespaceImport(<Expression>node)) {
                     error(right, Diagnostics.Cannot_assign_to_0_because_it_is_a_constant_or_a_read_only_property, right.text);
                     return unknownType;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14452,7 +14452,7 @@ namespace ts {
             const assignmentKind = getAssignmentTargetKind(node);
 
             if (assignmentKind) {
-                if (isReferenceToReadonlyEntity(<Expression>node, prop) || isReferenceThroughNamespaceImport(<Expression>node)) {
+                if (isReferenceToReadonlyEntity(<Expression>node, prop) || isReferenceThroughNamespaceImport(<Expression>node)) { //!
                     error(right, Diagnostics.Cannot_assign_to_0_because_it_is_a_constant_or_a_read_only_property, right.text);
                     return unknownType;
                 }
@@ -16724,12 +16724,13 @@ namespace ts {
             // Variables declared with 'const'
             // Get accessors without matching set accessors
             // Enum members
+            // Classes, functions, enums, and nested namespaces (these are properties if defined in a namespace)
             // Unions and intersections of the above (unions and intersections eagerly set isReadonly on creation)
             return !!(getCheckFlags(symbol) & CheckFlags.Readonly ||
                 symbol.flags & SymbolFlags.Property && getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.Readonly ||
                 symbol.flags & SymbolFlags.Variable && getDeclarationNodeFlagsFromSymbol(symbol) & NodeFlags.Const ||
                 symbol.flags & SymbolFlags.Accessor && !(symbol.flags & SymbolFlags.SetAccessor) ||
-                symbol.flags & SymbolFlags.EnumMember);
+                symbol.flags & (SymbolFlags.EnumMember | SymbolFlags.Class | SymbolFlags.Function | SymbolFlags.Enum | SymbolFlags.Namespace));
         }
 
         function isReferenceToReadonlyEntity(expr: Expression, symbol: Symbol): boolean {

--- a/tests/baselines/reference/assignmentToParenthesizedIdentifiers.errors.txt
+++ b/tests/baselines/reference/assignmentToParenthesizedIdentifiers.errors.txt
@@ -5,32 +5,22 @@ tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesize
 tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(15,1): error TS2322: Type '""' is not assignable to type 'number'.
 tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(17,1): error TS2539: Cannot assign to 'M' because it is not a variable.
 tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(18,2): error TS2539: Cannot assign to 'M' because it is not a variable.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(25,5): error TS2539: Cannot assign to 'M3' because it is not a variable.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(31,1): error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(32,1): error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(33,1): error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(37,1): error TS2539: Cannot assign to 'fn' because it is not a variable.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(38,2): error TS2539: Cannot assign to 'fn' because it is not a variable.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(43,5): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(44,5): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(48,5): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(49,5): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(54,5): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(55,5): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(56,5): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(62,1): error TS2539: Cannot assign to 'E' because it is not a variable.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(63,2): error TS2539: Cannot assign to 'E' because it is not a variable.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(69,1): error TS2539: Cannot assign to 'C' because it is not a variable.
-tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(70,2): error TS2539: Cannot assign to 'C' because it is not a variable.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(21,1): error TS2539: Cannot assign to 'fn' because it is not a variable.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(22,2): error TS2539: Cannot assign to 'fn' because it is not a variable.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(27,5): error TS2322: Type '""' is not assignable to type 'number'.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(28,5): error TS2322: Type '""' is not assignable to type 'number'.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(32,5): error TS2322: Type '""' is not assignable to type 'number'.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(33,5): error TS2322: Type '""' is not assignable to type 'number'.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(38,5): error TS2322: Type '""' is not assignable to type 'number'.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(39,5): error TS2322: Type '""' is not assignable to type 'number'.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(40,5): error TS2322: Type '""' is not assignable to type 'number'.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(46,1): error TS2539: Cannot assign to 'E' because it is not a variable.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(47,2): error TS2539: Cannot assign to 'E' because it is not a variable.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(53,1): error TS2539: Cannot assign to 'C' because it is not a variable.
+tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(54,2): error TS2539: Cannot assign to 'C' because it is not a variable.
 
 
-==== tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts (24 errors) ====
+==== tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts (20 errors) ====
     var x: number;
     x = 3; // OK
     (x) = 3; // OK
@@ -63,36 +53,6 @@ tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesize
     (M) = { y: 3 }; // Error
      ~
 !!! error TS2539: Cannot assign to 'M' because it is not a variable.
-    
-    module M2 {
-        export module M3 {
-            export var x: number;
-        }
-    
-        M3 = { x: 3 }; // Error
-        ~~
-!!! error TS2539: Cannot assign to 'M3' because it is not a variable.
-    }
-    M2.M3 = { x: 3 }; // OK
-    (M2).M3 = { x: 3 }; // OK
-    (M2.M3) = { x: 3 }; // OK
-    
-    M2.M3 = { x: '' }; // Error
-    ~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
-    (M2).M3 = { x: '' }; // Error
-    ~~~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
-    (M2.M3) = { x: '' }; // Error
-    ~~~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
-    
     
     function fn() { }
     fn = () => 3; // Bug 823548: Should be error (fn is not a reference)

--- a/tests/baselines/reference/assignmentToParenthesizedIdentifiers.js
+++ b/tests/baselines/reference/assignmentToParenthesizedIdentifiers.js
@@ -18,22 +18,6 @@ M.y = ''; // Error
 M = { y: 3 }; // Error
 (M) = { y: 3 }; // Error
 
-module M2 {
-    export module M3 {
-        export var x: number;
-    }
-
-    M3 = { x: 3 }; // Error
-}
-M2.M3 = { x: 3 }; // OK
-(M2).M3 = { x: 3 }; // OK
-(M2.M3) = { x: 3 }; // OK
-
-M2.M3 = { x: '' }; // Error
-(M2).M3 = { x: '' }; // Error
-(M2.M3) = { x: '' }; // Error
-
-
 function fn() { }
 fn = () => 3; // Bug 823548: Should be error (fn is not a reference)
 (fn) = () => 3; // Should be error
@@ -88,19 +72,6 @@ M.y = ''; // Error
 (M.y) = ''; // Error
 M = { y: 3 }; // Error
 (M) = { y: 3 }; // Error
-var M2;
-(function (M2) {
-    var M3;
-    (function (M3) {
-    })(M3 = M2.M3 || (M2.M3 = {}));
-    M3 = { x: 3 }; // Error
-})(M2 || (M2 = {}));
-M2.M3 = { x: 3 }; // OK
-(M2).M3 = { x: 3 }; // OK
-(M2.M3) = { x: 3 }; // OK
-M2.M3 = { x: '' }; // Error
-(M2).M3 = { x: '' }; // Error
-(M2.M3) = { x: '' }; // Error
 function fn() { }
 fn = function () { return 3; }; // Bug 823548: Should be error (fn is not a reference)
 (fn) = function () { return 3; }; // Should be error

--- a/tests/baselines/reference/namespaceExportsAreReadonly.errors.txt
+++ b/tests/baselines/reference/namespaceExportsAreReadonly.errors.txt
@@ -1,0 +1,59 @@
+tests/cases/compiler/namespaceExportsAreReadonly.ts(19,3): error TS2540: Cannot assign to 'x' because it is a constant or a read-only property.
+tests/cases/compiler/namespaceExportsAreReadonly.ts(21,3): error TS2540: Cannot assign to 'C' because it is a constant or a read-only property.
+tests/cases/compiler/namespaceExportsAreReadonly.ts(24,3): error TS2540: Cannot assign to 'f' because it is a constant or a read-only property.
+tests/cases/compiler/namespaceExportsAreReadonly.ts(28,3): error TS2540: Cannot assign to 'E' because it is a constant or a read-only property.
+tests/cases/compiler/namespaceExportsAreReadonly.ts(33,3): error TS2540: Cannot assign to 'M' because it is a constant or a read-only property.
+
+
+==== tests/cases/compiler/namespaceExportsAreReadonly.ts (5 errors) ====
+    namespace N {
+        export const x = 0;
+    
+        export class C {}
+        export let D = class {}
+    
+        export function f() {}
+        export let g = function() {}
+    
+        export enum E {}
+        enum Ff {}
+        export let F = Ff;
+    
+        export namespace M { export const y = 0; }
+        namespace Oo { export const y = 0; }
+        export let O = Oo;
+    }
+    
+    N.x = 1; // Error
+      ~
+!!! error TS2540: Cannot assign to 'x' because it is a constant or a read-only property.
+    
+    N.C = class {}; // Error
+      ~
+!!! error TS2540: Cannot assign to 'C' because it is a constant or a read-only property.
+    N.D = class {}; // OK
+    
+    N.f = function() {} // Error
+      ~
+!!! error TS2540: Cannot assign to 'f' because it is a constant or a read-only property.
+    N.g = function() {} // OK
+    
+    enum Ee {}
+    N.E = Ee; // Error
+      ~
+!!! error TS2540: Cannot assign to 'E' because it is a constant or a read-only property.
+    enum Ff {}
+    N.F = Ff; // OK
+    
+    namespace Mm { export const y = 0; }
+    N.M = Mm; // Error
+      ~
+!!! error TS2540: Cannot assign to 'M' because it is a constant or a read-only property.
+    namespace Oo { export const y = 0; }
+    N.O = Oo; // OK
+    
+    class K {
+        m() {}
+    }
+    new K().m = () => {}; // OK
+    

--- a/tests/baselines/reference/namespaceExportsAreReadonly.js
+++ b/tests/baselines/reference/namespaceExportsAreReadonly.js
@@ -1,0 +1,116 @@
+//// [namespaceExportsAreReadonly.ts]
+namespace N {
+    export const x = 0;
+
+    export class C {}
+    export let D = class {}
+
+    export function f() {}
+    export let g = function() {}
+
+    export enum E {}
+    enum Ff {}
+    export let F = Ff;
+
+    export namespace M { export const y = 0; }
+    namespace Oo { export const y = 0; }
+    export let O = Oo;
+}
+
+N.x = 1; // Error
+
+N.C = class {}; // Error
+N.D = class {}; // OK
+
+N.f = function() {} // Error
+N.g = function() {} // OK
+
+enum Ee {}
+N.E = Ee; // Error
+enum Ff {}
+N.F = Ff; // OK
+
+namespace Mm { export const y = 0; }
+N.M = Mm; // Error
+namespace Oo { export const y = 0; }
+N.O = Oo; // OK
+
+class K {
+    m() {}
+}
+new K().m = () => {}; // OK
+
+
+//// [namespaceExportsAreReadonly.js]
+var N;
+(function (N) {
+    N.x = 0;
+    var C = (function () {
+        function C() {
+        }
+        return C;
+    }());
+    N.C = C;
+    N.D = (function () {
+        function class_1() {
+        }
+        return class_1;
+    }());
+    function f() { }
+    N.f = f;
+    N.g = function () { };
+    var E;
+    (function (E) {
+    })(E = N.E || (N.E = {}));
+    var Ff;
+    (function (Ff) {
+    })(Ff || (Ff = {}));
+    N.F = Ff;
+    var M;
+    (function (M) {
+        M.y = 0;
+    })(M = N.M || (N.M = {}));
+    var Oo;
+    (function (Oo) {
+        Oo.y = 0;
+    })(Oo || (Oo = {}));
+    N.O = Oo;
+})(N || (N = {}));
+N.x = 1; // Error
+N.C = (function () {
+    function class_2() {
+    }
+    return class_2;
+}()); // Error
+N.D = (function () {
+    function class_3() {
+    }
+    return class_3;
+}()); // OK
+N.f = function () { }; // Error
+N.g = function () { }; // OK
+var Ee;
+(function (Ee) {
+})(Ee || (Ee = {}));
+N.E = Ee; // Error
+var Ff;
+(function (Ff) {
+})(Ff || (Ff = {}));
+N.F = Ff; // OK
+var Mm;
+(function (Mm) {
+    Mm.y = 0;
+})(Mm || (Mm = {}));
+N.M = Mm; // Error
+var Oo;
+(function (Oo) {
+    Oo.y = 0;
+})(Oo || (Oo = {}));
+N.O = Oo; // OK
+var K = (function () {
+    function K() {
+    }
+    K.prototype.m = function () { };
+    return K;
+}());
+new K().m = function () { }; // OK

--- a/tests/baselines/reference/nonInstantiatedModule.js
+++ b/tests/baselines/reference/nonInstantiatedModule.js
@@ -30,7 +30,7 @@ module M2 {
 var p: { x: number; y: number; };
 var p: M2.Point;
 
-var p2: { Origin() : { x: number; y: number; } };
+var p2: { readonly Origin: () => { x: number; y: number; } };
 var p2: typeof M2.Point;
 
 module M3 {

--- a/tests/baselines/reference/nonInstantiatedModule.symbols
+++ b/tests/baselines/reference/nonInstantiatedModule.symbols
@@ -75,11 +75,11 @@ var p: M2.Point;
 >M2 : Symbol(M2, Decl(nonInstantiatedModule.ts, 13, 13))
 >Point : Symbol(M2.Point, Decl(nonInstantiatedModule.ts, 15, 11), Decl(nonInstantiatedModule.ts, 20, 5))
 
-var p2: { Origin() : { x: number; y: number; } };
+var p2: { readonly Origin: () => { x: number; y: number; } };
 >p2 : Symbol(p2, Decl(nonInstantiatedModule.ts, 31, 3), Decl(nonInstantiatedModule.ts, 32, 3))
 >Origin : Symbol(Origin, Decl(nonInstantiatedModule.ts, 31, 9))
->x : Symbol(x, Decl(nonInstantiatedModule.ts, 31, 22))
->y : Symbol(y, Decl(nonInstantiatedModule.ts, 31, 33))
+>x : Symbol(x, Decl(nonInstantiatedModule.ts, 31, 34))
+>y : Symbol(y, Decl(nonInstantiatedModule.ts, 31, 45))
 
 var p2: typeof M2.Point;
 >p2 : Symbol(p2, Decl(nonInstantiatedModule.ts, 31, 3), Decl(nonInstantiatedModule.ts, 32, 3))

--- a/tests/baselines/reference/nonInstantiatedModule.types
+++ b/tests/baselines/reference/nonInstantiatedModule.types
@@ -79,14 +79,14 @@ var p: M2.Point;
 >M2 : any
 >Point : M2.Point
 
-var p2: { Origin() : { x: number; y: number; } };
->p2 : { Origin(): { x: number; y: number; }; }
+var p2: { readonly Origin: () => { x: number; y: number; } };
+>p2 : { readonly Origin: () => { x: number; y: number; }; }
 >Origin : () => { x: number; y: number; }
 >x : number
 >y : number
 
 var p2: typeof M2.Point;
->p2 : { Origin(): { x: number; y: number; }; }
+>p2 : { readonly Origin: () => { x: number; y: number; }; }
 >M2.Point : typeof M2.Point
 >M2 : typeof M2
 >Point : typeof M2.Point

--- a/tests/cases/compiler/namespaceExportsAreReadonly.ts
+++ b/tests/cases/compiler/namespaceExportsAreReadonly.ts
@@ -1,0 +1,40 @@
+namespace N {
+    export const x = 0;
+
+    export class C {}
+    export let D = class {}
+
+    export function f() {}
+    export let g = function() {}
+
+    export enum E {}
+    enum Ff {}
+    export let F = Ff;
+
+    export namespace M { export const y = 0; }
+    namespace Oo { export const y = 0; }
+    export let O = Oo;
+}
+
+N.x = 1; // Error
+
+N.C = class {}; // Error
+N.D = class {}; // OK
+
+N.f = function() {} // Error
+N.g = function() {} // OK
+
+enum Ee {}
+N.E = Ee; // Error
+enum Ff {}
+N.F = Ff; // OK
+
+namespace Mm { export const y = 0; }
+N.M = Mm; // Error
+namespace Oo { export const y = 0; }
+N.O = Oo; // OK
+
+class K {
+    m() {}
+}
+new K().m = () => {}; // OK

--- a/tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts
+++ b/tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts
@@ -17,22 +17,6 @@ M.y = ''; // Error
 M = { y: 3 }; // Error
 (M) = { y: 3 }; // Error
 
-module M2 {
-    export module M3 {
-        export var x: number;
-    }
-
-    M3 = { x: 3 }; // Error
-}
-M2.M3 = { x: 3 }; // OK
-(M2).M3 = { x: 3 }; // OK
-(M2.M3) = { x: 3 }; // OK
-
-M2.M3 = { x: '' }; // Error
-(M2).M3 = { x: '' }; // Error
-(M2.M3) = { x: '' }; // Error
-
-
 function fn() { }
 fn = () => 3; // Bug 823548: Should be error (fn is not a reference)
 (fn) = () => 3; // Should be error

--- a/tests/cases/conformance/internalModules/moduleDeclarations/nonInstantiatedModule.ts
+++ b/tests/cases/conformance/internalModules/moduleDeclarations/nonInstantiatedModule.ts
@@ -29,7 +29,7 @@ module M2 {
 var p: { x: number; y: number; };
 var p: M2.Point;
 
-var p2: { Origin() : { x: number; y: number; } };
+var p2: { readonly Origin: () => { x: number; y: number; } };
 var p2: typeof M2.Point;
 
 module M3 {


### PR DESCRIPTION
Fixes #16579