### PR TITLE
Remove duplicate switch cases

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1137,7 +1137,6 @@ namespace ts {
                         case SyntaxKind.FunctionExpression:
                         case SyntaxKind.FunctionDeclaration:
                         case SyntaxKind.ArrowFunction:
-                        case SyntaxKind.FunctionDeclaration:
                         case SyntaxKind.VariableDeclaration:
                             // type annotation
                             if ((<FunctionLikeDeclaration | VariableDeclaration | ParameterDeclaration | PropertyDeclaration>parent).type === node) {
@@ -1202,7 +1201,6 @@ namespace ts {
                         case SyntaxKind.FunctionExpression:
                         case SyntaxKind.FunctionDeclaration:
                         case SyntaxKind.ArrowFunction:
-                        case SyntaxKind.FunctionDeclaration:
                             // Check type parameters
                             if (nodes === (<ClassDeclaration | FunctionLikeDeclaration>parent).typeParameters) {
                                 diagnostics.push(createDiagnosticForNodeArray(nodes, Diagnostics.type_parameter_declarations_can_only_be_used_in_a_ts_file));

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1155,7 +1155,6 @@ namespace ts {
 
     export function isPartOfExpression(node: Node): boolean {
         switch (node.kind) {
-            case SyntaxKind.ThisKeyword:
             case SyntaxKind.SuperKeyword:
             case SyntaxKind.NullKeyword:
             case SyntaxKind.TrueKeyword:
@@ -1224,7 +1223,6 @@ namespace ts {
                     case SyntaxKind.SwitchStatement:
                     case SyntaxKind.CaseClause:
                     case SyntaxKind.ThrowStatement:
-                    case SyntaxKind.SwitchStatement:
                         return (<ExpressionStatement>parent).expression === node;
                     case SyntaxKind.ForStatement:
                         const forStatement = <ForStatement>parent;

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -1148,10 +1148,6 @@ namespace ts {
                 result = reduceNode((<AsExpression>node).type, cbNode, result);
                 break;
 
-            case SyntaxKind.NonNullExpression:
-                result = reduceNode((<NonNullExpression>node).expression, cbNode, result);
-                break;
-
             // Misc
             case SyntaxKind.TemplateSpan:
                 result = reduceNode((<TemplateSpan>node).expression, cbNode, result);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -657,7 +657,6 @@ namespace ts {
                     case SyntaxKind.ImportEqualsDeclaration:
                     case SyntaxKind.ExportSpecifier:
                     case SyntaxKind.ImportSpecifier:
-                    case SyntaxKind.ImportEqualsDeclaration:
                     case SyntaxKind.ImportClause:
                     case SyntaxKind.NamespaceImport:
                     case SyntaxKind.GetAccessor:


### PR DESCRIPTION
Fixes #16243
These are pretty straightforward; the only change in behavior here is that we will no longer consider `ThisKeyword` to be part of an expression if it appears as a type.