### PR TITLE
Add missing visitNode call to object literal members

### DIFF
--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -158,8 +158,8 @@ namespace ts {
             return visitEachChild(node, visitor, context);
         }
 
-        function chunkObjectLiteralElements(elements: ReadonlyArray<ObjectLiteralElement>): Expression[] {
-            let chunkObject: (ShorthandPropertyAssignment | PropertyAssignment)[];
+        function chunkObjectLiteralElements(elements: ReadonlyArray<ObjectLiteralElementLike>): Expression[] {
+            let chunkObject: ObjectLiteralElementLike[];
             const objects: Expression[] = [];
             for (const e of elements) {
                 if (e.kind === SyntaxKind.SpreadAssignment) {
@@ -179,7 +179,7 @@ namespace ts {
                         chunkObject.push(createPropertyAssignment(p.name, visitNode(p.initializer, visitor, isExpression)));
                     }
                     else {
-                        chunkObject.push(e as ShorthandPropertyAssignment);
+                        chunkObject.push(visitNode(e, visitor, isObjectLiteralElementLike));
                     }
                 }
             }

--- a/tests/baselines/reference/objectSpreadWithinMethodWithinObjectWithSpread.js
+++ b/tests/baselines/reference/objectSpreadWithinMethodWithinObjectWithSpread.js
@@ -1,0 +1,26 @@
+//// [objectSpreadWithinMethodWithinObjectWithSpread.ts]
+const obj = {};
+const a = {
+    ...obj,
+    prop() {
+        return {
+            ...obj,
+            metadata: 213
+        };
+    }
+};
+
+
+//// [objectSpreadWithinMethodWithinObjectWithSpread.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+var obj = {};
+var a = __assign({}, obj, { prop: function () {
+        return __assign({}, obj, { metadata: 213 });
+    } });

--- a/tests/baselines/reference/objectSpreadWithinMethodWithinObjectWithSpread.symbols
+++ b/tests/baselines/reference/objectSpreadWithinMethodWithinObjectWithSpread.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/objectSpreadWithinMethodWithinObjectWithSpread.ts ===
+const obj = {};
+>obj : Symbol(obj, Decl(objectSpreadWithinMethodWithinObjectWithSpread.ts, 0, 5))
+
+const a = {
+>a : Symbol(a, Decl(objectSpreadWithinMethodWithinObjectWithSpread.ts, 1, 5))
+
+    ...obj,
+>obj : Symbol(obj, Decl(objectSpreadWithinMethodWithinObjectWithSpread.ts, 0, 5))
+
+    prop() {
+>prop : Symbol(prop, Decl(objectSpreadWithinMethodWithinObjectWithSpread.ts, 2, 11))
+
+        return {
+            ...obj,
+>obj : Symbol(obj, Decl(objectSpreadWithinMethodWithinObjectWithSpread.ts, 0, 5))
+
+            metadata: 213
+>metadata : Symbol(metadata, Decl(objectSpreadWithinMethodWithinObjectWithSpread.ts, 5, 19))
+
+        };
+    }
+};
+

--- a/tests/baselines/reference/objectSpreadWithinMethodWithinObjectWithSpread.types
+++ b/tests/baselines/reference/objectSpreadWithinMethodWithinObjectWithSpread.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/objectSpreadWithinMethodWithinObjectWithSpread.ts ===
+const obj = {};
+>obj : {}
+>{} : {}
+
+const a = {
+>a : { prop(): { metadata: number; }; }
+>{    ...obj,    prop() {        return {            ...obj,            metadata: 213        };    }} : { prop(): { metadata: number; }; }
+
+    ...obj,
+>obj : {}
+
+    prop() {
+>prop : () => { metadata: number; }
+
+        return {
+>{            ...obj,            metadata: 213        } : { metadata: number; }
+
+            ...obj,
+>obj : {}
+
+            metadata: 213
+>metadata : number
+>213 : 213
+
+        };
+    }
+};
+

--- a/tests/cases/compiler/objectSpreadWithinMethodWithinObjectWithSpread.ts
+++ b/tests/cases/compiler/objectSpreadWithinMethodWithinObjectWithSpread.ts
@@ -1,0 +1,10 @@
+const obj = {};
+const a = {
+    ...obj,
+    prop() {
+        return {
+            ...obj,
+            metadata: 213
+        };
+    }
+};


### PR DESCRIPTION
Object literal elements that are neither spread elements, nor property assignments would not have visitNode called on them. Therefore, the esnext transformer would not be called on them and their children.

Fixes #16765.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->