### PR TITLE
Add package lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ internal/
 !tests/baselines/reference/project/nodeModules*/**/*
 .idea
 yarn.lock
+package-lock.json


### PR DESCRIPTION
This package lock file is autogenerated by npm v5+. Unless we adopt a policy to commit it and manually unlock/update versions, we should add it to our .gitignore.
