### PR TITLE
getApplicableRefactors: Don't return undefined response

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -494,6 +494,17 @@ namespace ts {
         return result;
     }
 
+    export function flatMapIter<T, U>(iter: Iterator<T>, mapfn: (x: T) => U[] | undefined): U[] {
+        const result: U[] = [];
+        while (true) {
+            const { value, done } = iter.next();
+            if (done) break;
+            const res = mapfn(value);
+            if (res) result.push(...res);
+        }
+        return result;
+    }
+
     /**
      * Maps an array. If the mapped value is an array, it is spread into the result.
      * Avoids allocation if all elements map to themselves.

--- a/src/services/refactorProvider.ts
+++ b/src/services/refactorProvider.ts
@@ -33,22 +33,9 @@ namespace ts {
             refactors.set(refactor.name, refactor);
         }
 
-        export function getApplicableRefactors(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
-            let results: ApplicableRefactorInfo[];
-            const refactorList: Refactor[] = [];
-            refactors.forEach(refactor => {
-                refactorList.push(refactor);
-            });
-            for (const refactor of refactorList) {
-                if (context.cancellationToken && context.cancellationToken.isCancellationRequested()) {
-                    return results;
-                }
-                const infos = refactor.getAvailableActions(context);
-                if (infos && infos.length) {
-                    (results || (results = [])).push(...infos);
-                }
-            }
-            return results;
+        export function getApplicableRefactors(context: RefactorContext): ApplicableRefactorInfo[] {
+            return flatMapIter(refactors.values(), refactor =>
+                context.cancellationToken && context.cancellationToken.isCancellationRequested() ? [] : refactor.getAvailableActions(context));
         }
 
         export function getEditsForRefactor(context: RefactorContext, refactorName: string, actionName: string): RefactorEditInfo | undefined {


### PR DESCRIPTION
In `session.ts`:

```ts
[CommandNames.GetApplicableRefactors]: (request: protocol.GetApplicableRefactorsRequest) => {
    return this.requiredResponse(this.getApplicableRefactors(request.arguments));
},
```
If we return `undefined` for something with a required response, this will cause an error later on. (The error message is simply `"No content available."`.)

There is probably a similar error for `getEditsForRefactor`.