### PR TITLE
Fix typo in typescript.d.ts comments

### DIFF
--- a/lib/typescript.d.ts
+++ b/lib/typescript.d.ts
@@ -1987,7 +1987,7 @@ declare namespace ts {
     interface ObjectType extends Type {
         objectFlags: ObjectFlags;
     }
-    /** Class and interface types (TypeFlags.Class and TypeFlags.Interface). */
+    /** Class and interface types (ObjectFlags.Class and ObjectFlags.Interface). */
     interface InterfaceType extends ObjectType {
         typeParameters: TypeParameter[];
         outerTypeParameters: TypeParameter[];
@@ -2003,7 +2003,7 @@ declare namespace ts {
         declaredNumberIndexInfo: IndexInfo;
     }
     /**
-     * Type references (TypeFlags.Reference). When a class or interface has type parameters or
+     * Type references (ObjectFlags.Reference). When a class or interface has type parameters or
      * a "this" type, references to the class or interface are made using type references. The
      * typeArguments property specifies the types to substitute for the type parameters of the
      * class or interface and optionally includes an extra element that specifies the type to


### PR DESCRIPTION
Comments incorrectly read 'TypeFlags' instead of 'ObjectFlags' at some places.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[V ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ V] Code is up-to-date with the `master` branch
[ V] You've successfully run `jake runtests` locally
[ V] You've signed the CLA
[V ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #16800
