### PR TITLE
Remove `createFileMap`

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -145,50 +145,6 @@ namespace ts {
         };
     }
 
-    export function createFileMap<T>(keyMapper: (key: string) => string): FileMap<T> {
-        const files = createMap<T>();
-        return {
-            get,
-            set,
-            contains,
-            remove,
-            forEachValue: forEachValueInMap,
-            getKeys,
-            clear,
-        };
-
-        function forEachValueInMap(f: (key: Path, value: T) => void) {
-            files.forEach((file, key) => {
-                f(<Path>key, file);
-            });
-        }
-
-        function getKeys() {
-            return arrayFrom(files.keys()) as Path[];
-        }
-
-        // path should already be well-formed so it does not need to be normalized
-        function get(path: Path): T {
-            return files.get(keyMapper(path));
-        }
-
-        function set(path: Path, value: T) {
-            files.set(keyMapper(path), value);
-        }
-
-        function contains(path: Path) {
-            return files.has(keyMapper(path));
-        }
-
-        function remove(path: Path) {
-            files.delete(keyMapper(path));
-        }
-
-        function clear() {
-            files.clear();
-        }
-    }
-
     export function toPath(fileName: string, basePath: string, getCanonicalFileName: (path: string) => string): Path {
         const nonCanonicalizedPath = isRootedDiskPath(fileName)
             ? normalizePath(fileName)

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -916,7 +916,7 @@ namespace ts {
         }
 
         function isEmitBlocked(emitFileName: string): boolean {
-            return hasEmitBlockingDiagnostics.contains(toPath(emitFileName, currentDirectory, getCanonicalFileName));
+            return hasEmitBlockingDiagnostics.has(toPath(emitFileName, currentDirectory, getCanonicalFileName));
         }
 
         function emitWorker(program: Program, sourceFile: SourceFile, writeFileCallback: WriteFileCallback, cancellationToken: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult {
@@ -1974,7 +1974,7 @@ namespace ts {
                     }
 
                     // Report error if multiple files write into same file
-                    if (emitFilesSeen.contains(emitFilePath)) {
+                    if (emitFilesSeen.has(emitFilePath)) {
                         // Already seen the same emit file - report error
                         blockEmittingOfFile(emitFileName, createCompilerDiagnostic(Diagnostics.Cannot_write_file_0_because_it_would_be_overwritten_by_multiple_input_files, emitFileName));
                     }
@@ -2101,6 +2101,30 @@ namespace ts {
         }
         function needAllowJs() {
             return options.allowJs ? undefined : Diagnostics.Module_0_was_resolved_to_1_but_allowJs_is_not_set;
+        }
+    }
+
+    interface FileMap<T> {
+        get(fileName: Path): T;
+        set(fileName: Path, value: T): void;
+        has(fileName: Path): boolean;
+    }
+
+    function createFileMap<T>(keyMapper: (key: string) => string): FileMap<T> {
+        const files = createMap<T>();
+        return { get, set, has };
+
+        // path should already be well-formed so it does not need to be normalized
+        function get(path: Path): T {
+            return files.get(keyMapper(path));
+        }
+
+        function set(path: Path, value: T) {
+            files.set(keyMapper(path), value);
+        }
+
+        function has(path: Path) {
+            return files.has(keyMapper(path));
         }
     }
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -553,6 +553,10 @@ namespace ts {
 
         return program;
 
+        function toPath(fileName: string): Path {
+            return ts.toPath(fileName, currentDirectory, getCanonicalFileName);
+        }
+
         function getCommonSourceDirectory() {
             if (commonSourceDirectory === undefined) {
                 const emittedFiles = filter(files, file => sourceFileMayBeEmitted(file, options, isSourceFileFromExternalLibrary));
@@ -916,7 +920,7 @@ namespace ts {
         }
 
         function isEmitBlocked(emitFileName: string): boolean {
-            return hasEmitBlockingDiagnostics.has(toPath(emitFileName, currentDirectory, getCanonicalFileName));
+            return hasEmitBlockingDiagnostics.has(toPath(emitFileName));
         }
 
         function emitWorker(program: Program, sourceFile: SourceFile, writeFileCallback: WriteFileCallback, cancellationToken: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult {
@@ -975,7 +979,7 @@ namespace ts {
         }
 
         function getSourceFile(fileName: string): SourceFile {
-            return getSourceFileByPath(toPath(fileName, currentDirectory, getCanonicalFileName));
+            return getSourceFileByPath(toPath(fileName));
         }
 
         function getSourceFileByPath(path: Path): SourceFile {
@@ -1466,7 +1470,7 @@ namespace ts {
 
         /** This should have similar behavior to 'processSourceFile' without diagnostics or mutation. */
         function getSourceFileFromReference(referencingFile: SourceFile, ref: FileReference): SourceFile | undefined {
-            return getSourceFileFromReferenceWorker(resolveTripleslashReference(ref.fileName, referencingFile.fileName), fileName => filesByName.get(toPath(fileName, currentDirectory, getCanonicalFileName)));
+            return getSourceFileFromReferenceWorker(resolveTripleslashReference(ref.fileName, referencingFile.fileName), fileName => filesByName.get(toPath(fileName)));
         }
 
         function getSourceFileFromReferenceWorker(
@@ -1510,7 +1514,7 @@ namespace ts {
         /** This has side effects through `findSourceFile`. */
         function processSourceFile(fileName: string, isDefaultLib: boolean, refFile?: SourceFile, refPos?: number, refEnd?: number): void {
             getSourceFileFromReferenceWorker(fileName,
-                fileName => findSourceFile(fileName, toPath(fileName, currentDirectory, getCanonicalFileName), isDefaultLib, refFile, refPos, refEnd),
+                fileName => findSourceFile(fileName, toPath(fileName), isDefaultLib, refFile, refPos, refEnd),
                 (diagnostic, ...args) => {
                     fileProcessingDiagnostics.add(refFile !== undefined && refEnd !== undefined && refPos !== undefined
                         ? createFileDiagnostic(refFile, refPos, refEnd - refPos, diagnostic, ...args)
@@ -1733,7 +1737,7 @@ namespace ts {
                         modulesWithElidedImports.set(file.path, true);
                     }
                     else if (shouldAddFile) {
-                        const path = toPath(resolvedFileName, currentDirectory, getCanonicalFileName);
+                        const path = toPath(resolvedFileName);
                         const pos = skipTrivia(file.text, file.imports[i].pos);
                         findSourceFile(resolvedFileName, path, /*isDefaultLib*/ false, file, pos, file.imports[i].end);
                     }
@@ -1962,7 +1966,7 @@ namespace ts {
             // Verify that all the emit files are unique and don't overwrite input files
             function verifyEmitFilePath(emitFileName: string, emitFilesSeen: Map<true>) {
                 if (emitFileName) {
-                    const emitFilePath = toPath(emitFileName, currentDirectory, getCanonicalFileName);
+                    const emitFilePath = toPath(emitFileName);
                     // Report error if the output overwrites input file
                     if (filesByName.has(emitFilePath)) {
                         let chain: DiagnosticMessageChain;
@@ -2073,7 +2077,7 @@ namespace ts {
         }
 
         function blockEmittingOfFile(emitFileName: string, diag: Diagnostic) {
-            hasEmitBlockingDiagnostics.set(toPath(emitFileName, currentDirectory, getCanonicalFileName), true);
+            hasEmitBlockingDiagnostics.set(toPath(emitFileName), true);
             programDiagnostics.add(diag);
         }
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -31,17 +31,6 @@ namespace ts {
     // arbitrary file name can be converted to Path via toPath function
     export type Path = string & { __pathBrand: any };
 
-    export interface FileMap<T> {
-        get(fileName: Path): T;
-        set(fileName: Path, value: T): void;
-        contains(fileName: Path): boolean;
-        remove(fileName: Path): void;
-
-        forEachValue(f: (key: Path, v: T) => void): void;
-        getKeys(): Path[];
-        clear(): void;
-    }
-
     export interface TextRange {
         pos: number;
         end: number;


### PR DESCRIPTION
After #16724, `createFileMap` is now only used in `program.ts`.
We had publicly exposed the `FileMap` type before, but we weren't exposing any values of that type. So we can make it internal to `program.ts`. Also removed all unused methods and renamed others to resemble those in `Map`.
