### PR TITLE
Type-check `sum`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -84,9 +84,9 @@ namespace ts {
         // extra cost of calling `getParseTreeNode` when calling these functions from inside the
         // checker.
         const checker: TypeChecker = {
-            getNodeCount: () => sum(host.getSourceFiles(), "nodeCount"),
-            getIdentifierCount: () => sum(host.getSourceFiles(), "identifierCount"),
-            getSymbolCount: () => sum(host.getSourceFiles(), "symbolCount") + symbolCount,
+            getNodeCount: () => sum<"nodeCount">(host.getSourceFiles(), "nodeCount"),
+            getIdentifierCount: () => sum<"identifierCount">(host.getSourceFiles(), "identifierCount"),
+            getSymbolCount: () => sum<"symbolCount">(host.getSourceFiles(), "symbolCount") + symbolCount,
             getTypeCount: () => typeCount,
             isUndefinedSymbol: symbol => symbol === undefinedSymbol,
             isArgumentsSymbol: symbol => symbol === argumentsSymbol,

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -727,7 +727,7 @@ namespace ts {
         return result;
     }
 
-    export function sum(array: any[], prop: string): number {
+    export function sum<K extends string>(array: { [x in K]: number }[], prop: K): number {
         let result = 0;
         for (const v of array) {
             result += v[prop];


### PR DESCRIPTION
It's unfortunate that we need to supply an explicit type argument here; otherwise it infers the type `keyof SourceFile`. This happens even if the string argument comes first.