### PR TITLE
Comments incorrectly read 'TypeFlags' instead of 'ObjectFlags' at some places

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3179,7 +3179,7 @@ namespace ts {
         objectFlags: ObjectFlags;
     }
 
-    /** Class and interface types (TypeFlags.Class and TypeFlags.Interface). */
+    /** Class and interface types (ObjectFlags.Class and ObjectFlags.Interface). */
     export interface InterfaceType extends ObjectType {
         typeParameters: TypeParameter[];           // Type parameters (undefined if non-generic)
         outerTypeParameters: TypeParameter[];      // Outer type parameters (undefined if none)
@@ -3203,7 +3203,7 @@ namespace ts {
     }
 
     /**
-     * Type references (TypeFlags.Reference). When a class or interface has type parameters or
+     * Type references (ObjectFlags.Reference). When a class or interface has type parameters or
      * a "this" type, references to the class or interface are made using type references. The
      * typeArguments property specifies the types to substitute for the type parameters of the
      * class or interface and optionally includes an extra element that specifies the type to


### PR DESCRIPTION
Comments incorrectly read 'TypeFlags' instead of 'ObjectFlags' at some places

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ v] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ v] Code is up-to-date with the `master` branch
[ v] You've successfully run `jake runtests` locally
[ v] You've signed the CLA
[ v] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #16800 
