### PR TITLE
getJSDocParameterTags: no need to handle JSDocFunctionType, just return undefined

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1532,7 +1532,7 @@ namespace ts {
     export function getJSDocParameterTags(param: ParameterDeclaration): JSDocParameterTag[] | undefined {
         if (param.name && isIdentifier(param.name)) {
             const name = param.name.text;
-            return getJSDocTags(param.parent).filter((tag): tag is JSDocParameterTag => isJSDocParameterTag(tag) && tag.name.text === name);
+            return getJSDocTags(param.parent).filter((tag): tag is JSDocParameterTag => isJSDocParameterTag(tag) && tag.name.text === name) as JSDocParameterTag[];
         }
         else {
             // TODO: it's a destructured parameter, so it should look up an "object type" series of multiple lines

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1530,27 +1530,9 @@ namespace ts {
     }
 
     export function getJSDocParameterTags(param: ParameterDeclaration): JSDocParameterTag[] | undefined {
-        const func = param.parent;
-        const tags = getJSDocTags(func);
-        if (!tags) return undefined;
-
-        if (!param.name) {
-            // this is an anonymous jsdoc param from a `function(type1, type2): type3` specification
-            const paramIndex = func.parameters.indexOf(param);
-            Debug.assert(paramIndex !== -1);
-            let curParamIndex = 0;
-            for (const tag of tags) {
-                if (isJSDocParameterTag(tag)) {
-                    if (curParamIndex === paramIndex) {
-                        return [tag];
-                    }
-                    curParamIndex++;
-                }
-            }
-        }
-        else if (param.name.kind === SyntaxKind.Identifier) {
-            const name = (param.name as Identifier).text;
-            return tags.filter((tag): tag is JSDocParameterTag => isJSDocParameterTag(tag) && tag.name.text === name) as JSDocParameterTag[];
+        if (param.name && isIdentifier(param.name)) {
+            const name = param.name.text;
+            return getJSDocTags(param.parent).filter((tag): tag is JSDocParameterTag => isJSDocParameterTag(tag) && tag.name.text === name);
         }
         else {
             // TODO: it's a destructured parameter, so it should look up an "object type" series of multiple lines


### PR DESCRIPTION
This was effectively dead code as `getJSDocTags` would never return a defined result if we were already in a JSDocFunctionType (which is the only time `param.name` would be undefined).