### PR TITLE
Support completions for enums in switch cases

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -227,6 +227,7 @@ namespace ts {
                 location = getParseTreeNode(location);
                 return resolveName(location, name, meaning, /*nameNotFoundMessage*/ undefined, name);
             },
+            getRemainingSwitchCaseTypes,
         };
 
         const tupleTypes: GenericType[] = [];
@@ -11075,6 +11076,15 @@ namespace ts {
                 links.switchTypes = !contains(types, undefined) ? types : emptyArray;
             }
             return links.switchTypes;
+        }
+
+        function getRemainingSwitchCaseTypes(node: SwitchStatement): Type[] | undefined {
+            const type = getTypeOfExpression(node.expression);
+            if (!isLiteralType(type)) return undefined;
+
+            const types = type.flags & TypeFlags.Union ? (type as ts.UnionType).types : [type];
+            const switchTypes = mapDefined(node.caseBlock.clauses, getTypeOfSwitchClause);
+            return types.filter(t => !contains(switchTypes, t));
         }
 
         function eachTypeContainedIn(source: Type, types: Type[]) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2648,6 +2648,9 @@ namespace ts {
 
         /* @internal */ getJsxNamespace(): string;
         /* @internal */ resolveNameAtLocation(location: Node, name: string, meaning: SymbolFlags): Symbol | undefined;
+
+        /** Types that are not already covered by some switch case. */
+        /* @internal */ getRemainingSwitchCaseTypes(node: SwitchStatement): Type[] | undefined;
     }
 
     export enum NodeBuilderFlags {

--- a/tests/cases/fourslash/completionsSwitchCase.ts
+++ b/tests/cases/fourslash/completionsSwitchCase.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts'/>
+
+////enum E { A, B }
+////declare const e: E;
+////switch (e) {
+////    case /*1*/
+////}
+////switch (e) {
+////    case E.B:
+////    case /*2*/:
+////    default:
+////    case nonsense:
+////}
+
+verify.completionsAt("1", ["E.A", "E.B"]);
+verify.completionsAt("2", ["E.A"]);


### PR DESCRIPTION
Support getting completions to the right of the `case` keyword.
Doesn't include already-covered cases.
Does not address #13711 as that scenario is if you just typed `E.`. That will require a lot more refactoring (which should be done anyway).