### PR TITLE
Remove nonpublic members from destructuring completion lists

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1002,7 +1002,7 @@ namespace ts.Completions {
                     const typeForObject = typeChecker.getTypeAtLocation(objectLikeContainer);
                     if (!typeForObject) return false;
                     // In a binding pattern, get only known properties. Everywhere else we will get all possible properties.
-                    typeMembers = typeChecker.getPropertiesOfType(typeForObject);
+                    typeMembers = typeChecker.getPropertiesOfType(typeForObject).filter((symbol) => !(getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.NonPublicAccessibilityModifier));
                     existingMembers = (<ObjectBindingPattern>objectLikeContainer).elements;
                 }
             }

--- a/tests/cases/fourslash/completionListInObjectBindingPattern14.ts
+++ b/tests/cases/fourslash/completionListInObjectBindingPattern14.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts"/>
+
+////const { b/**/ } = new class {
+////    private ab;
+////    protected bc;
+////}
+
+goTo.marker();
+verify.completionListIsEmpty();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15214

Filter out nonpublic properties from the list of "known" properties when doing an object binding.
