### PR TITLE
Use correct source root for tests

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -561,7 +561,7 @@ gulp.task(run, /*help*/ false, [servicesFile], () => {
         .pipe(newer(run))
         .pipe(sourcemaps.init())
         .pipe(testProject())
-        .pipe(sourcemaps.write(".", { includeContent: false, sourceRoot: "../../" }))
+        .pipe(sourcemaps.write(".", { includeContent: false, sourceRoot: "." }))
         .pipe(gulp.dest("src/harness"));
 });
 


### PR DESCRIPTION
I noticed my error messages while testing were names like `"E:\Github\compiler\binder.ts"` - with this change, they originate from the correct location (are are thus clickable links in the console). The previous path may have been required as a workaround for some old version of the tools we use, but is apparently no longer needed.
