### PR TITLE
Enable "object-literal-shorthand" lint rule

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -675,7 +675,7 @@ function runConsoleTests(defaultReporter: string, runInParallel: boolean, done: 
             }
             args.push(run);
             setNodeEnvToDevelopment();
-            runTestsInParallel(taskConfigsFolder, run, { testTimeout: testTimeout, noColors: colors === " --no-colors " }, function(err) {
+            runTestsInParallel(taskConfigsFolder, run, { testTimeout, noColors: colors === " --no-colors " }, function(err) {
                 // last worker clean everything and runs linter in case if there were no errors
                 del(taskConfigsFolder).then(() => {
                     if (!err) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21181,7 +21181,7 @@ namespace ts {
                 for (const prop of properties) {
                     const existing = seen.get(prop.name);
                     if (!existing) {
-                        seen.set(prop.name, { prop: prop, containingType: base });
+                        seen.set(prop.name, { prop, containingType: base });
                     }
                     else {
                         const isInheritedProperty = existing.containingType !== type;

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -151,11 +151,7 @@ namespace ts {
      */
     export function resolveTypeReferenceDirective(typeReferenceDirectiveName: string, containingFile: string | undefined, options: CompilerOptions, host: ModuleResolutionHost): ResolvedTypeReferenceDirectiveWithFailedLookupLocations {
         const traceEnabled = isTraceEnabled(options, host);
-        const moduleResolutionState: ModuleResolutionState = {
-            compilerOptions: options,
-            host: host,
-            traceEnabled
-        };
+        const moduleResolutionState: ModuleResolutionState = { compilerOptions: options, host, traceEnabled };
 
         const typeRoots = getEffectiveTypeRoots(options, host);
         if (traceEnabled) {

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -145,7 +145,7 @@ namespace ts {
 
             // Initialize source map data
             sourceMapData = {
-                sourceMapFilePath: sourceMapFilePath,
+                sourceMapFilePath,
                 jsSourceMappingURL: !compilerOptions.inlineSourceMap ? getBaseFileName(normalizeSlashes(sourceMapFilePath)) : undefined,
                 sourceMapFile: getBaseFileName(normalizeSlashes(filePath)),
                 sourceMapSourceRoot: compilerOptions.sourceRoot || "",
@@ -292,8 +292,8 @@ namespace ts {
 
                 // New span
                 lastRecordedSourceMapSpan = {
-                    emittedLine: emittedLine,
-                    emittedColumn: emittedColumn,
+                    emittedLine,
+                    emittedColumn,
                     sourceLine: sourceLinePos.line,
                     sourceColumn: sourceLinePos.character,
                     sourceIndex: sourceMapSourceIndex

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -325,7 +325,7 @@ namespace ts {
             const nodeSystem: System = {
                 args: process.argv.slice(2),
                 newLine: _os.EOL,
-                useCaseSensitiveFileNames: useCaseSensitiveFileNames,
+                useCaseSensitiveFileNames,
                 write(s: string): void {
                     process.stdout.write(s);
                 },
@@ -394,9 +394,7 @@ namespace ts {
                         }
                     );
                 },
-                resolvePath: function(path: string): string {
-                    return _path.resolve(path);
-                },
+                resolvePath: path => _path.resolve(path),
                 fileExists,
                 directoryExists,
                 createDirectory(directoryName: string) {

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -2220,8 +2220,8 @@ namespace ts {
             beginBlock(<LoopBlock>{
                 kind: CodeBlockKind.Loop,
                 isScript: false,
-                breakLabel: breakLabel,
-                continueLabel: continueLabel
+                breakLabel,
+                continueLabel,
             });
             return breakLabel;
         }
@@ -2262,7 +2262,7 @@ namespace ts {
             beginBlock(<SwitchBlock>{
                 kind: CodeBlockKind.Switch,
                 isScript: false,
-                breakLabel: breakLabel
+                breakLabel,
             });
             return breakLabel;
         }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2569,7 +2569,7 @@ namespace FourSlash {
 
             // if there was an explicit match kind specified, then it should be validated.
             if (matchKind !== undefined) {
-                const missingItem = { name: name, kind: kind, searchValue: searchValue, matchKind: matchKind, fileName: fileName, parentName: parentName };
+                const missingItem = { name, kind, searchValue, matchKind, fileName, parentName };
                 this.raiseError(`verifyNavigationItemsListContains failed - could not find the item: ${stringify(missingItem)} in the returned list: (${stringify(items)})`);
             }
         }
@@ -2643,7 +2643,7 @@ namespace FourSlash {
                 }
             }
 
-            const missingItem = { fileName: fileName, start: start, end: end, isWriteAccess: isWriteAccess };
+            const missingItem = { fileName, start, end, isWriteAccess };
             this.raiseError(`verifyOccurrencesAtPositionListContains failed - could not find the item: ${stringify(missingItem)} in the returned list: (${stringify(occurrences)})`);
         }
 
@@ -3265,7 +3265,7 @@ ${code}
                             }
 
                             const range: Range = {
-                                fileName: fileName,
+                                fileName,
                                 start: rangeStart.position,
                                 end: (i - 1) - difference,
                                 marker: rangeStart.marker
@@ -3393,7 +3393,7 @@ ${code}
             content: output,
             fileOptions: {},
             version: 0,
-            fileName: fileName
+            fileName,
         };
     }
 
@@ -4224,11 +4224,8 @@ namespace FourSlashInterface {
         }
 
         function getClassification(classificationType: ts.ClassificationTypeNames, text: string, position?: number): Classification {
-            return {
-                classificationType,
-                text: text,
-                textSpan: position === undefined ? undefined : { start: position, end: position + text.length }
-            };
+            const textSpan = position === undefined ? undefined : { start: position, end: position + text.length };
+            return { classificationType, text, textSpan };
         }
     }
 }

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -354,7 +354,7 @@ class ProjectRunner extends RunnerBase {
                 ensureDirectoryStructure(ts.getDirectoryPath(ts.normalizePath(outputFilePath)));
                 Harness.IO.writeFile(outputFilePath, data);
 
-                outputFiles.push({ emittedFileName: fileName, code: data, fileName: diskRelativeName, writeByteOrderMark: writeByteOrderMark });
+                outputFiles.push({ emittedFileName: fileName, code: data, fileName: diskRelativeName, writeByteOrderMark });
             }
         }
 

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -259,7 +259,7 @@ namespace Harness.SourceMapRecorder {
         export function recordSourceMapSpan(sourceMapSpan: ts.SourceMapSpan) {
             // verify the decoded span is same as the new span
             const decodeResult = SourceMapDecoder.decodeNextEncodedSourceMapSpan();
-            let decodedErrors: string[];
+            let decodeErrors: string[];
             if (decodeResult.error
                 || decodeResult.sourceMapSpan.emittedLine   !== sourceMapSpan.emittedLine
                 || decodeResult.sourceMapSpan.emittedColumn !== sourceMapSpan.emittedColumn
@@ -268,22 +268,20 @@ namespace Harness.SourceMapRecorder {
                 || decodeResult.sourceMapSpan.sourceIndex   !== sourceMapSpan.sourceIndex
                 || decodeResult.sourceMapSpan.nameIndex     !== sourceMapSpan.nameIndex) {
                 if (decodeResult.error) {
-                    decodedErrors = ["!!^^ !!^^ There was decoding error in the sourcemap at this location: " + decodeResult.error];
+                    decodeErrors = ["!!^^ !!^^ There was decoding error in the sourcemap at this location: " + decodeResult.error];
                 }
                 else {
-                    decodedErrors = ["!!^^ !!^^ The decoded span from sourcemap's mapping entry does not match what was encoded for this span:"];
+                    decodeErrors = ["!!^^ !!^^ The decoded span from sourcemap's mapping entry does not match what was encoded for this span:"];
                 }
-                decodedErrors.push("!!^^ !!^^ Decoded span from sourcemap's mappings entry: " + getSourceMapSpanString(decodeResult.sourceMapSpan, /*getAbsentNameIndex*/ true) + " Span encoded by the emitter:" + getSourceMapSpanString(sourceMapSpan, /*getAbsentNameIndex*/ true));
+                decodeErrors.push("!!^^ !!^^ Decoded span from sourcemap's mappings entry: " + getSourceMapSpanString(decodeResult.sourceMapSpan, /*getAbsentNameIndex*/ true) + " Span encoded by the emitter:" + getSourceMapSpanString(sourceMapSpan, /*getAbsentNameIndex*/ true));
             }
 
             if (spansOnSingleLine.length && spansOnSingleLine[0].sourceMapSpan.emittedLine !== sourceMapSpan.emittedLine) {
                 // On different line from the one that we have been recording till now,
                 writeRecordedSpans();
-                spansOnSingleLine = [{ sourceMapSpan: sourceMapSpan, decodeErrors: decodedErrors }];
+                spansOnSingleLine = [];
             }
-            else {
-                spansOnSingleLine.push({ sourceMapSpan: sourceMapSpan, decodeErrors: decodedErrors });
-            }
+            spansOnSingleLine.push({ sourceMapSpan, decodeErrors });
         }
 
         export function recordNewSourceFileSpan(sourceMapSpan: ts.SourceMapSpan, newSourceFileCode: string) {

--- a/src/harness/test262Runner.ts
+++ b/src/harness/test262Runner.ts
@@ -48,7 +48,7 @@ class Test262BaselineRunner extends RunnerBase {
                 // Emit the results
                 testState = {
                     filename: testFilename,
-                    inputFiles: inputFiles,
+                    inputFiles,
                     compilerResult: undefined,
                 };
 

--- a/src/harness/typeWriter.ts
+++ b/src/harness/typeWriter.ts
@@ -68,7 +68,7 @@ class TypeWriterWalker {
         this.results.push({
             line: lineAndCharacter.line,
             syntaxKind: node.kind,
-            sourceText: sourceText,
+            sourceText,
             type: typeString,
             symbol: symbolString
         });

--- a/src/harness/unittests/services/colorization.ts
+++ b/src/harness/unittests/services/colorization.ts
@@ -30,13 +30,9 @@ describe("Colorization", function () {
     function identifier(text: string, position?: number) { return createClassification(text, ts.TokenClass.Identifier, position); }
     function numberLiteral(text: string, position?: number) { return createClassification(text, ts.TokenClass.NumberLiteral, position); }
     function stringLiteral(text: string, position?: number) { return createClassification(text, ts.TokenClass.StringLiteral, position); }
-    function finalEndOfLineState(value: number): ClassificationEntry { return { value: value, classification: undefined, position: 0 }; }
-    function createClassification(text: string, tokenClass: ts.TokenClass, position?: number): ClassificationEntry {
-        return {
-            value: text,
-            classification: tokenClass,
-            position: position,
-        };
+    function finalEndOfLineState(value: number): ClassificationEntry { return { value, classification: undefined, position: 0 }; }
+    function createClassification(value: string, classification: ts.TokenClass, position?: number): ClassificationEntry {
+        return { value, classification, position };
     }
 
     function testLexicalClassification(text: string, initialEndOfLineState: ts.EndOfLineState, ...expectedEntries: ClassificationEntry[]): void {

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -389,7 +389,7 @@ namespace ts.server {
                     request_seq: 0,
                     type: "response",
                     command,
-                    body: body,
+                    body,
                     success: true
                 });
             });
@@ -436,7 +436,7 @@ namespace ts.server {
                 request_seq: 0,
                 type: "response",
                 command,
-                body: body,
+                body,
                 success: true
             });
         });

--- a/src/harness/unittests/telemetry.ts
+++ b/src/harness/unittests/telemetry.ts
@@ -77,7 +77,7 @@ namespace ts.projectSystem {
                 et.service.openExternalProject({
                     rootFiles: toExternalFiles([file1.path]),
                     options: compilerOptions,
-                    projectFileName: projectFileName,
+                    projectFileName,
                 });
                 checkNumberOfProjects(et.service, { externalProjects: 1 });
             }

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -115,7 +115,7 @@ namespace ts.projectSystem {
         for (const typing of installedTypings) {
             dependencies[typing] = "1.0.0";
         }
-        return JSON.stringify({ dependencies: dependencies });
+        return JSON.stringify({ dependencies });
     }
 
     export function getExecutingFilePathFromLibFile(): string {

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -184,10 +184,7 @@ namespace ts.server {
         }
 
         getProjectInfo(fileName: string, needFileNameList: boolean): protocol.ProjectInfo {
-            const args: protocol.ProjectInfoRequestArgs = {
-                file: fileName,
-                needFileNameList: needFileNameList
-            };
+            const args: protocol.ProjectInfoRequestArgs = { file: fileName, needFileNameList };
 
             const request = this.processRequest<protocol.ProjectInfoRequest>(CommandNames.ProjectInfo, args);
             const response = this.processResponse<protocol.ProjectInfoResponse>(request);
@@ -270,7 +267,7 @@ namespace ts.server {
                     kindModifiers: entry.kindModifiers,
                     matchKind: entry.matchKind,
                     isCaseSensitive: entry.isCaseSensitive,
-                    fileName: fileName,
+                    fileName,
                     textSpan: ts.createTextSpanFromBounds(start, end)
                 };
             });
@@ -304,7 +301,7 @@ namespace ts.server {
                 file: fileName,
                 line: lineOffset.line,
                 offset: lineOffset.offset,
-                key: key
+                key,
             };
 
             // TODO: handle FormatCodeOptions
@@ -332,7 +329,7 @@ namespace ts.server {
                 return {
                     containerKind: ScriptElementKind.unknown,
                     containerName: "",
-                    fileName: fileName,
+                    fileName,
                     textSpan: ts.createTextSpanFromBounds(start, end),
                     kind: ScriptElementKind.unknown,
                     name: ""
@@ -358,7 +355,7 @@ namespace ts.server {
                 return {
                     containerKind: ScriptElementKind.unknown,
                     containerName: "",
-                    fileName: fileName,
+                    fileName,
                     textSpan: ts.createTextSpanFromBounds(start, end),
                     kind: ScriptElementKind.unknown,
                     name: ""
@@ -411,7 +408,7 @@ namespace ts.server {
                 const start = this.lineOffsetToPosition(fileName, entry.start);
                 const end = this.lineOffsetToPosition(fileName, entry.end);
                 return {
-                    fileName: fileName,
+                    fileName,
                     textSpan: ts.createTextSpanFromBounds(start, end),
                     isWriteAccess: entry.isWriteAccess,
                     isDefinition: entry.isDefinition,
@@ -456,7 +453,7 @@ namespace ts.server {
                 start: entry.start,
                 length: entry.length,
                 messageText: entry.message,
-                category: category,
+                category,
                 code: entry.code
             };
         }
@@ -483,10 +480,7 @@ namespace ts.server {
                 entry.locs.map((loc: protocol.TextSpan) => {
                     const start = this.lineOffsetToPosition(fileName, loc.start);
                     const end = this.lineOffsetToPosition(fileName, loc.end);
-                    locations.push({
-                        textSpan: ts.createTextSpanFromBounds(start, end),
-                        fileName: fileName
-                    });
+                    locations.push({ textSpan: ts.createTextSpanFromBounds(start, end), fileName, });
                 });
             });
             return this.lastRenameEntry = {
@@ -497,11 +491,11 @@ namespace ts.server {
                 kindModifiers: response.body.info.kindModifiers,
                 localizedErrorMessage: response.body.info.localizedErrorMessage,
                 triggerSpan: ts.createTextSpanFromBounds(position, position),
-                fileName: fileName,
-                position: position,
-                findInStrings: findInStrings,
-                findInComments: findInComments,
-                locations: locations
+                fileName,
+                position,
+                findInStrings,
+                findInComments,
+                locations,
             };
         }
 
@@ -596,10 +590,7 @@ namespace ts.server {
 
             const result: SignatureHelpItems = {
                 items: helpItems.items,
-                applicableSpan: {
-                    start: start,
-                    length: end - start
-                },
+                applicableSpan: { start, length: end - start },
                 selectedItemIndex: helpItems.selectedItemIndex,
                 argumentIndex: helpItems.argumentIndex,
                 argumentCount: helpItems.argumentCount,
@@ -686,7 +677,7 @@ namespace ts.server {
                 startOffset: startLineOffset.offset,
                 endLine: endLineOffset.line,
                 endOffset: endLineOffset.offset,
-                errorCodes: errorCodes,
+                errorCodes,
             };
 
             const request = this.processRequest<protocol.CodeFixRequest>(CommandNames.GetCodeFixes, args);
@@ -779,10 +770,7 @@ namespace ts.server {
             const end = this.lineOffsetToPosition(fileName, change.end);
 
             return {
-                span: {
-                    start: start,
-                    length: end - start
-                },
+                span: { start, length: end - start },
                 newText: change.newText ? change.newText : ""
             };
         }
@@ -801,10 +789,7 @@ namespace ts.server {
             return response.body.map(entry => {
                 const start = this.lineOffsetToPosition(fileName, entry.start);
                 const end = this.lineOffsetToPosition(fileName, entry.end);
-                return {
-                    start: start,
-                    length: end - start,
-                };
+                return { start, length: end - start };
             });
         }
 

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -508,7 +508,7 @@ namespace ts.server {
             const walkFns = {
                 goSubtree: true,
                 done: false,
-                leaf: function (this: ILineIndexWalker, relativeStart: number, relativeLength: number, ll: LineLeaf) {
+                leaf(this: ILineIndexWalker, relativeStart: number, relativeLength: number, ll: LineLeaf) {
                     if (!f(ll, relativeStart, relativeLength)) {
                         this.done = true;
                     }
@@ -607,25 +607,25 @@ namespace ts.server {
         }
 
         static linesFromText(text: string) {
-            const lineStarts = ts.computeLineStarts(text);
+            const lineMap = ts.computeLineStarts(text);
 
-            if (lineStarts.length === 0) {
-                return { lines: <string[]>[], lineMap: lineStarts };
+            if (lineMap.length === 0) {
+                return { lines: <string[]>[], lineMap };
             }
-            const lines = <string[]>new Array(lineStarts.length);
-            const lc = lineStarts.length - 1;
+            const lines = <string[]>new Array(lineMap.length);
+            const lc = lineMap.length - 1;
             for (let lmi = 0; lmi < lc; lmi++) {
-                lines[lmi] = text.substring(lineStarts[lmi], lineStarts[lmi + 1]);
+                lines[lmi] = text.substring(lineMap[lmi], lineMap[lmi + 1]);
             }
 
-            const endText = text.substring(lineStarts[lc]);
+            const endText = text.substring(lineMap[lc]);
             if (endText.length > 0) {
                 lines[lc] = endText;
             }
             else {
                 lines.length--;
             }
-            return { lines: lines, lineMap: lineStarts };
+            return { lines, lineMap };
         }
     }
 
@@ -791,12 +791,7 @@ namespace ts.server {
                     charOffset += child.charCount();
                 }
             }
-            return {
-                child: child,
-                childIndex: i,
-                relativeLineNumber: relativeLineNumber,
-                charOffset: charOffset
-            };
+            return { child, childIndex: i, relativeLineNumber, charOffset };
         }
 
         childFromCharOffset(lineNumber: number, charOffset: number) {
@@ -813,12 +808,7 @@ namespace ts.server {
                     lineNumber += child.lineCount();
                 }
             }
-            return {
-                child: child,
-                childIndex: i,
-                charOffset: charOffset,
-                lineNumber: lineNumber
-            };
+            return { child, childIndex: i, charOffset, lineNumber };
         }
 
         splitAfter(childIndex: number) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -510,6 +510,7 @@ namespace ts.server {
         const watchedFiles: WatchedFile[] = [];
         let nextFileToCheck = 0;
         let watchTimer: any;
+        return { getModifiedTime, poll, startWatchTimer, addFile, removeFile };
 
         function getModifiedTime(fileName: string): Date {
             return fs.statSync(fileName).mtime;
@@ -577,14 +578,6 @@ namespace ts.server {
         function removeFile(file: WatchedFile) {
             unorderedRemoveItem(watchedFiles, file);
         }
-
-        return {
-            getModifiedTime: getModifiedTime,
-            poll: poll,
-            startWatchTimer: startWatchTimer,
-            addFile: addFile,
-            removeFile: removeFile
-        };
     }
 
     // REVIEW: for now this implementation uses polling.

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -439,7 +439,7 @@ namespace ts.server {
                 }
 
                 const bakedDiags = diags.map((diag) => formatDiag(file, project, diag));
-                this.event<protocol.DiagnosticEventBody>({ file: file, diagnostics: bakedDiags }, "semanticDiag");
+                this.event<protocol.DiagnosticEventBody>({ file, diagnostics: bakedDiags }, "semanticDiag");
             }
             catch (err) {
                 this.logError(err, "semantic check");
@@ -451,7 +451,7 @@ namespace ts.server {
                 const diags = project.getLanguageService().getSyntacticDiagnostics(file);
                 if (diags) {
                     const bakedDiags = diags.map((diag) => formatDiag(file, project, diag));
-                    this.event<protocol.DiagnosticEventBody>({ file: file, diagnostics: bakedDiags }, "syntaxDiag");
+                    this.event<protocol.DiagnosticEventBody>({ file, diagnostics: bakedDiags }, "syntaxDiag");
                 }
             }
             catch (err) {
@@ -939,8 +939,8 @@ namespace ts.server {
                             const lineText = refScriptInfo.getSnapshot().getText(refLineSpan.start, ts.textSpanEnd(refLineSpan)).replace(/\r|\n/g, "");
                             return {
                                 file: ref.fileName,
-                                start: start,
-                                lineText: lineText,
+                                start,
+                                lineText,
                                 end: refScriptInfo.positionToLineOffset(ts.textSpanEnd(ref.textSpan)),
                                 isWriteAccess: ref.isWriteAccess,
                                 isDefinition: ref.isDefinition
@@ -1072,7 +1072,7 @@ namespace ts.server {
                     kindModifiers: quickInfo.kindModifiers,
                     start: scriptInfo.positionToLineOffset(quickInfo.textSpan.start),
                     end: scriptInfo.positionToLineOffset(ts.textSpanEnd(quickInfo.textSpan)),
-                    displayString: displayString,
+                    displayString,
                     documentation: docString,
                     tags: quickInfo.tags || []
                 };
@@ -1402,8 +1402,8 @@ namespace ts.server {
                                 name: navItem.name,
                                 kind: navItem.kind,
                                 file: navItem.fileName,
-                                start: start,
-                                end: end,
+                                start,
+                                end,
                             };
                             if (navItem.kindModifiers && (navItem.kindModifiers !== "")) {
                                 bakedItem.kindModifiers = navItem.kindModifiers;

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -389,7 +389,7 @@ namespace ts.server.typingsInstaller {
                         this.log.writeLine(`Got FS notification for ${f}, handler is already invoked '${isInvoked}'`);
                     }
                     if (!isInvoked) {
-                        this.sendResponse({ projectName: projectName, kind: server.ActionInvalidate });
+                        this.sendResponse({ projectName, kind: server.ActionInvalidate });
                         isInvoked = true;
                     }
                 }, /*pollingInterval*/ 2000);

--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -58,11 +58,7 @@ namespace ts.codefix {
         }
 
         function pushAction(result: CodeAction[], newNodes: Node[], description: string): void {
-            const newAction: CodeAction = {
-                description: description,
-                changes: newNodesToChanges(newNodes, openBrace, context)
-            };
-            result.push(newAction);
+            result.push({ description, changes: newNodesToChanges(newNodes, openBrace, context) });
         }
     }
 }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -76,7 +76,7 @@ namespace ts.Completions {
             addRange(entries, getKeywordCompletions(keywordFilters));
         }
 
-        return { isGlobalCompletion, isMemberCompletion, isNewIdentifierLocation: isNewIdentifierLocation, entries };
+        return { isGlobalCompletion, isMemberCompletion, isNewIdentifierLocation, entries };
     }
 
     function getJavaScriptCompletionEntries(sourceFile: SourceFile, position: number, uniqueNames: Map<string>, target: ScriptTarget): CompletionEntry[] {

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -179,7 +179,7 @@ namespace ts {
                 const sourceFile = createLanguageServiceSourceFile(fileName, scriptSnapshot, compilationSettings.target, version, /*setNodeParents*/ false, scriptKind);
 
                 entry = {
-                    sourceFile: sourceFile,
+                    sourceFile,
                     languageServiceRefCount: 0,
                     owners: []
                 };

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -146,7 +146,7 @@ namespace ts.formatting {
         // format from the beginning of the line
         const span = {
             pos: getLineStartPositionForPosition(start, sourceFile),
-            end: end
+            end,
         };
         return formatSpan(span, sourceFile, options, rulesProvider, FormattingRequestKind.FormatSelection);
     }

--- a/src/services/formatting/formattingScanner.ts
+++ b/src/services/formatting/formattingScanner.ts
@@ -96,7 +96,7 @@ namespace ts.formatting {
                 // consume leading trivia
                 scanner.scan();
                 const item = {
-                    pos: pos,
+                    pos,
                     end: scanner.getStartPos(),
                     kind: t
                 };
@@ -264,11 +264,7 @@ namespace ts.formatting {
                 }
             }
 
-            lastTokenInfo = {
-                leadingTrivia: leadingTrivia,
-                trailingTrivia: trailingTrivia,
-                token: token
-            };
+            lastTokenInfo = { leadingTrivia, trailingTrivia, token };
 
             return fixTokenKind(lastTokenInfo, n);
         }

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -271,7 +271,7 @@ namespace ts.GoToDefinition {
             fileName: targetFileName,
             textSpan: createTextSpanFromBounds(0, 0),
             kind: ScriptElementKind.scriptElement,
-            name: name,
+            name,
             containerName: undefined,
             containerKind: undefined
         };

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -10,7 +10,7 @@ namespace ts.OutliningElementsCollector {
                     textSpan: createTextSpanFromBounds(startElement.pos, endElement.end),
                     hintSpan: createTextSpanFromNode(hintSpanNode, sourceFile),
                     bannerText: collapseText,
-                    autoCollapse: autoCollapse
+                    autoCollapse,
                 };
                 elements.push(span);
             }
@@ -22,7 +22,7 @@ namespace ts.OutliningElementsCollector {
                     textSpan: createTextSpanFromBounds(commentSpan.pos, commentSpan.end),
                     hintSpan: createTextSpanFromBounds(commentSpan.pos, commentSpan.end),
                     bannerText: collapseText,
-                    autoCollapse: autoCollapse
+                    autoCollapse,
                 };
                 elements.push(span);
             }
@@ -71,7 +71,7 @@ namespace ts.OutliningElementsCollector {
                 const multipleSingleLineComments: CommentRange = {
                     kind: SyntaxKind.SingleLineCommentTrivia,
                     pos: start,
-                    end: end,
+                    end,
                 };
 
                 addOutliningSpanComments(multipleSingleLineComments, /*autoCollapse*/ false);

--- a/src/services/preProcess.ts
+++ b/src/services/preProcess.ts
@@ -41,13 +41,9 @@ namespace ts {
         }
 
         function getFileReference() {
-            const file = scanner.getTokenValue();
+            const fileName = scanner.getTokenValue();
             const pos = scanner.getTokenPos();
-            return {
-                fileName: file,
-                pos: pos,
-                end: pos + file.length
-            };
+            return { fileName, pos, end: pos + fileName.length };
         }
 
         function recordAmbientExternalModule(): void {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -847,7 +847,7 @@ namespace ts {
                 entry = {
                     hostFileName: fileName,
                     version: this.host.getScriptVersion(fileName),
-                    scriptSnapshot: scriptSnapshot,
+                    scriptSnapshot,
                     scriptKind: getScriptKind(fileName, this.host)
                 };
             }
@@ -1533,12 +1533,8 @@ namespace ts {
             const sourceFile = getValidSourceFile(fileName);
             const outputFiles: OutputFile[] = [];
 
-            function writeFile(fileName: string, data: string, writeByteOrderMark: boolean) {
-                outputFiles.push({
-                    name: fileName,
-                    writeByteOrderMark: writeByteOrderMark,
-                    text: data
-                });
+            function writeFile(fileName: string, text: string, writeByteOrderMark: boolean) {
+                outputFiles.push({ name: fileName, writeByteOrderMark, text });
             }
 
             const customTransformers = host.getCustomTransformers && host.getCustomTransformers();
@@ -1782,25 +1778,14 @@ namespace ts {
             synchronizeHostData();
             const sourceFile = getValidSourceFile(fileName);
             const span = { start, length: end - start };
-            const newLineChar = getNewLineOrDefaultFromHost(host);
+            const newLineCharacter = getNewLineOrDefaultFromHost(host);
 
             let allFixes: CodeAction[] = [];
 
-            forEach(deduplicate(errorCodes), error => {
+            forEach(deduplicate(errorCodes), errorCode => {
                 cancellationToken.throwIfCancellationRequested();
-
-                const context = {
-                    errorCode: error,
-                    sourceFile: sourceFile,
-                    span: span,
-                    program: program,
-                    newLineCharacter: newLineChar,
-                    host: host,
-                    cancellationToken: cancellationToken,
-                    rulesProvider: getRuleProvider(formatOptions)
-                };
-
-                const fixes = codefix.getFixes(context);
+                const rulesProvider = getRuleProvider(formatOptions);
+                const fixes = codefix.getFixes({ errorCode, sourceFile, span, program, newLineCharacter, host, cancellationToken, rulesProvider });
                 if (fixes) {
                     allFixes = allFixes.concat(fixes);
                 }
@@ -1916,11 +1901,7 @@ namespace ts {
                     }
 
                     const message = matchArray[2];
-                    result.push({
-                        descriptor: descriptor,
-                        message: message,
-                        position: matchPosition
-                    });
+                    result.push({ descriptor, message, position: matchPosition });
                 }
             }
 

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -242,7 +242,7 @@ namespace ts.textChanges {
         }
 
         public insertNodeAt(sourceFile: SourceFile, pos: number, newNode: Node, options: InsertNodeOptions = {}) {
-            this.changes.push({ sourceFile, options, node: newNode, range: { pos: pos, end: pos } });
+            this.changes.push({ sourceFile, options, node: newNode, range: { pos, end: pos } });
             return this;
         }
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1198,10 +1198,7 @@ namespace ts {
     }
 
     export function displayPart(text: string, kind: SymbolDisplayPartKind): SymbolDisplayPart {
-        return <SymbolDisplayPart>{
-            text: text,
-            kind: SymbolDisplayPartKind[kind]
-        };
+        return { text, kind: SymbolDisplayPartKind[kind] };
     }
 
     export function spacePart() {

--- a/tslint.json
+++ b/tslint.json
@@ -26,6 +26,7 @@
         "no-trailing-whitespace": [true, "ignore-template-strings"],
         "no-type-assertion-whitespace": true,
         "no-var-keyword": true,
+        "object-literal-shorthand": true,
         "object-literal-surrounding-space": true,
         "one-line": [true,
             "check-open-brace",
@@ -63,6 +64,6 @@
             "check-module",
             "check-separator",
             "check-type"
-        ]	
+        ]
 	}
 }


### PR DESCRIPTION
Replace `{ foo: foo }` with `{ foo }` and `{ foo: function() {} }` with `{ foo() {} }`.