### PR TITLE
Remove duplicate entries from tsconfig files

### DIFF
--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -26,7 +26,6 @@
         "transformers/es2015.ts",
         "transformers/es5.ts",
         "transformers/generators.ts",
-        "transformers/es5.ts",
         "transformers/destructuring.ts",
         "transformers/module/module.ts",
         "transformers/module/system.ts",

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -26,7 +26,6 @@
         "../compiler/transformers/es2015.ts",
         "../compiler/transformers/es5.ts",
         "../compiler/transformers/generators.ts",
-        "../compiler/transformers/generators.ts",
         "../compiler/transformers/destructuring.ts",
         "../compiler/transformers/module/module.ts",
         "../compiler/transformers/module/system.ts",


### PR DESCRIPTION
We had duplicate file entries in our tsconfig files. Do we not issue an error for this? Or do we just not use these tsconfigs for non-editor things?