### PR TITLE
gulp-typescript does handles config extension correctly now

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -256,14 +256,8 @@ function needsUpdate(source: string | string[], dest: string | string[]): boolea
     return true;
 }
 
-// Doing tsconfig inheritance manually. https://github.com/ivogabe/gulp-typescript/issues/459
-const tsconfigBase = JSON.parse(fs.readFileSync("src/tsconfig-base.json", "utf-8")).compilerOptions;
-
 function getCompilerSettings(base: tsc.Settings, useBuiltCompiler?: boolean): tsc.Settings {
     const copy: tsc.Settings = {};
-    for (const key in tsconfigBase) {
-        copy[key] = tsconfigBase[key];
-    }
     for (const key in base) {
         copy[key] = base[key];
     }


### PR DESCRIPTION
As of about half an hour ago. The new release, however, breaks out build config since we were doing extension ourselves (and thereby including the same compiler option multiple times or something like that). By letting it do its job, we fix `gulp local`.