### PR TITLE
Never return undefined from `getExportsOfModule`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1782,7 +1782,7 @@ namespace ts {
 
         function getExportsOfModule(moduleSymbol: Symbol): SymbolTable {
             const links = getSymbolLinks(moduleSymbol);
-            return links.resolvedExports || (links.resolvedExports = getExportsForModule(moduleSymbol));
+            return links.resolvedExports || (links.resolvedExports = getExportsOfModuleWorker(moduleSymbol));
         }
 
         interface ExportCollisionTracker {
@@ -1821,13 +1821,13 @@ namespace ts {
             });
         }
 
-        function getExportsForModule(moduleSymbol: Symbol): SymbolTable {
+        function getExportsOfModuleWorker(moduleSymbol: Symbol): SymbolTable {
             const visitedSymbols: Symbol[] = [];
 
             // A module defined by an 'export=' consists on one export that needs to be resolved
             moduleSymbol = resolveExternalModuleSymbol(moduleSymbol);
 
-            return visit(moduleSymbol) || moduleSymbol.exports;
+            return visit(moduleSymbol) || emptySymbols;
 
             // The ES6 spec permits export * declarations in a module to circularly reference the module itself. For example,
             // module 'a' can 'export * from "b"' and 'b' can 'export * from "a"' without error.

--- a/tests/cases/fourslash/completionList_getExportsOfModule.ts
+++ b/tests/cases/fourslash/completionList_getExportsOfModule.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts'/>
+
+// This used to cause a crash because we would ask for exports on `"x"`,
+// which would return undefined and cause a NPE. Now we return emptySymbol instead.
+// See GH#16610.
+
+////declare module "x" {
+////    declare var x: number;
+////    export = x;
+////}
+////
+////let y: /**/
+
+goTo.marker();
+// This is just a dummy test to cause `getCompletionsAtPosition` to be called.
+verify.not.completionListContains("x");


### PR DESCRIPTION
Fixes #16537 and #16610 

Turns out the error also requires `@types/node` to be installed to reproduce. The problem was with an ambiently declared module having `export =` of a value with no exports, this the result of `getExportsOfModule` was unexpectedly undefined.