### PR TITLE
LineNode.add: return value never used

### DIFF
--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -851,9 +851,9 @@ namespace ts.server {
         }
 
         // assume there is room for the item; return true if more room
-        add(collection: LineCollection) {
+        add(collection: LineCollection): void {
             this.children.push(collection);
-            return (this.children.length < lineCollectionCapacity);
+            Debug.assert(this.children.length <= lineCollectionCapacity);
         }
 
         charCount() {


### PR DESCRIPTION
This was returning an unobserved value. Used an assert instead.