### PR TITLE
Remove ILineInfo type

### DIFF
--- a/src/harness/unittests/versionCache.ts
+++ b/src/harness/unittests/versionCache.ts
@@ -7,8 +7,7 @@ namespace ts {
     }
 
     function lineColToPosition(lineIndex: server.LineIndex, line: number, col: number) {
-        const lineInfo = lineIndex.lineNumberToInfo(line);
-        return (lineInfo.offset + col - 1);
+        return lineIndex.absolutePositionOfStartOfLine(line) + (col - 1);
     }
 
     function validateEdit(lineIndex: server.LineIndex, sourceText: string, position: number, deleteLength: number, insertString: string): void {
@@ -298,20 +297,17 @@ and grew 1cm per day`;
 
         it("Line/offset from pos", () => {
             for (let i = 0; i < iterationCount; i++) {
-                const lp = lineIndex.charOffsetToLineNumberAndPos(rsa[i]);
+                const lp = lineIndex.positionToLineOffset(rsa[i]);
                 const lac = ts.computeLineAndCharacterOfPosition(lineMap, rsa[i]);
                 assert.equal(lac.line + 1, lp.line, "Line number mismatch " + (lac.line + 1) + " " + lp.line + " " + i);
-                assert.equal(lac.character, (lp.offset), "Charachter offset mismatch " + lac.character + " " + lp.offset + " " + i);
+                assert.equal(lac.character, lp.offset - 1, "Character offset mismatch " + lac.character + " " + (lp.offset - 1) + " " + i);
             }
         });
 
         it("Start pos from line", () => {
             for (let i = 0; i < iterationCount; i++) {
                 for (let j = 0; j < lines.length; j++) {
-                    const lineInfo = lineIndex.lineNumberToInfo(j + 1);
-                    const lineIndexOffset = lineInfo.offset;
-                    const lineMapOffset = lineMap[j];
-                    assert.equal(lineIndexOffset, lineMapOffset);
+                    assert.equal(lineIndex.absolutePositionOfStartOfLine(j + 1), lineMap[j]);
                 }
             }
         });

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -640,7 +640,7 @@ namespace ts.server.protocol {
     }
 
     /**
-     * Location in source code expressed as (one-based) line and character offset.
+     * Location in source code expressed as (one-based) line and (one-based) column offset.
      */
     export interface Location {
         line: number;


### PR DESCRIPTION
We were using the term "offset" to mean many different things:

* Absolute position in a file
* Position relative to the start of a LineNode
* Zero-based column
* One-based column
* Accumulator for the absolute position

We were also using the `ILineInfo` type in many unrelated situations. There was no case where we needed every field.

This PR switches us to using some clearer terminology. Every time the `protocol.Location` type is used, it is assumed that we are dealing with a 1-based line and 1-based column. Elsewhere we use explicit names such as `relativeOneBasedLine`.