### PR TITLE
Cast identifier names to string in lint rule

### DIFF
--- a/scripts/tslint/booleanTriviaRule.ts
+++ b/scripts/tslint/booleanTriviaRule.ts
@@ -27,7 +27,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
     /** Skip certain function/method names whose parameter names are not informative. */
     function shouldIgnoreCalledExpression(expression: ts.Expression): boolean {
         if (expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
-            const methodName = (expression as ts.PropertyAccessExpression).name.text;
+            const methodName = (expression as ts.PropertyAccessExpression).name.text as string;
             if (methodName.indexOf("set") === 0) {
                 return true;
             }
@@ -44,7 +44,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
             }
         }
         else if (expression.kind === ts.SyntaxKind.Identifier) {
-            const functionName = (expression as ts.Identifier).text;
+            const functionName = (expression as ts.Identifier).text as string;
             if (functionName.indexOf("set") === 0) {
                 return true;
             }


### PR DESCRIPTION
To be compatible with both the current version of the compiler and the nightly (which uses a branded string for the text member).

The lint doesn't care about leading underscores in the strings its searching, so it doesn't need to escape anything anyway.

Fixes #17020.
