### PR TITLE
Allow visitors to return undefined

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4350,7 +4350,7 @@ namespace ts {
      */
     export type Visitor = (node: Node) => VisitResult<Node>;
 
-    export type VisitResult<T extends Node> = T | T[];
+    export type VisitResult<T extends Node> = T | T[] | undefined;
 
     export interface Printer {
         /**


### PR DESCRIPTION
While implementing `ts.Visitor`, it is possible to return `undefined` in order to drop a node. However, the typings do not reflect this and only allow to return `Node | Node []`.

This PR extends the typings to allow `undefined` as well.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

/cc @mhegazy @rbuckton 
