### PR TITLE
Declare 'sum' so that it doesn't require type arguments.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -83,9 +83,9 @@ namespace ts {
         // extra cost of calling `getParseTreeNode` when calling these functions from inside the
         // checker.
         const checker: TypeChecker = {
-            getNodeCount: () => sum<"nodeCount">(host.getSourceFiles(), "nodeCount"),
-            getIdentifierCount: () => sum<"identifierCount">(host.getSourceFiles(), "identifierCount"),
-            getSymbolCount: () => sum<"symbolCount">(host.getSourceFiles(), "symbolCount") + symbolCount,
+            getNodeCount: () => sum(host.getSourceFiles(), "nodeCount"),
+            getIdentifierCount: () => sum(host.getSourceFiles(), "identifierCount"),
+            getSymbolCount: () => sum(host.getSourceFiles(), "symbolCount") + symbolCount,
             getTypeCount: () => typeCount,
             isUndefinedSymbol: symbol => symbol === undefinedSymbol,
             isArgumentsSymbol: symbol => symbol === argumentsSymbol,

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -703,7 +703,8 @@ namespace ts {
     export function sum<T extends Record<K, number>, K extends string>(array: T[], prop: K): number {
         let result = 0;
         for (const v of array) {
-            result += (v[prop] as number);
+            // Note: we need the following type assertion because of GH #17069
+            result += v[prop] as number;
         }
         return result;
     }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -700,10 +700,10 @@ namespace ts {
         return result;
     }
 
-    export function sum<K extends string>(array: { [x in K]: number }[], prop: K): number {
+    export function sum<T extends Record<K, number>, K extends string>(array: T[], prop: K): number {
         let result = 0;
         for (const v of array) {
-            result += v[prop];
+            result += (v[prop] as number);
         }
         return result;
     }


### PR DESCRIPTION
Addresses concerns raised in #16823.