### PR TITLE
Improve return type parse error

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2,11 +2,13 @@
 /// <reference path="scanner.ts"/>
 
 namespace ts {
-    const enum SignatureContext {
+    const enum SignatureFlags {
+        None = 0,
         Yield = 1 << 0,
         Await = 1 << 1,
         Type  = 1 << 2,
         RequireCompleteParameterList = 1 << 3,
+        IgnoreMissingOpenBrace = 1 << 4,
     }
 
     let NodeConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
@@ -2225,10 +2227,10 @@ namespace ts {
 
         function fillSignature(
             returnToken: SyntaxKind.ColonToken | SyntaxKind.EqualsGreaterThanToken,
-            context: SignatureContext,
+            flags: SignatureFlags,
             signature: SignatureDeclaration): void {
             signature.typeParameters = parseTypeParameters();
-            signature.parameters = parseParameterList(context);
+            signature.parameters = parseParameterList(flags);
 
             const returnTokenRequired = returnToken === SyntaxKind.EqualsGreaterThanToken;
             if (returnTokenRequired) {
@@ -2238,7 +2240,7 @@ namespace ts {
             else if (parseOptional(returnToken)) {
                 signature.type = parseTypeOrTypePredicate();
             }
-            else if (context & SignatureContext.Type) {
+            else if (flags & SignatureFlags.Type) {
                 const start = scanner.getTokenPos();
                 const length = scanner.getTextPos() - start;
                 const backwardToken = parseOptional(returnToken === SyntaxKind.ColonToken ? SyntaxKind.EqualsGreaterThanToken : SyntaxKind.ColonToken);
@@ -2250,7 +2252,7 @@ namespace ts {
             }
         }
 
-        function parseParameterList(context: SignatureContext) {
+        function parseParameterList(flags: SignatureFlags) {
             // FormalParameters [Yield,Await]: (modified)
             //      [empty]
             //      FormalParameterList[?Yield,Await]
@@ -2268,15 +2270,15 @@ namespace ts {
                 const savedYieldContext = inYieldContext();
                 const savedAwaitContext = inAwaitContext();
 
-                setYieldContext(!!(context & SignatureContext.Yield));
-                setAwaitContext(!!(context & SignatureContext.Await));
+                setYieldContext(!!(flags & SignatureFlags.Yield));
+                setAwaitContext(!!(flags & SignatureFlags.Await));
 
                 const result = parseDelimitedList(ParsingContext.Parameters, parseParameter);
 
                 setYieldContext(savedYieldContext);
                 setAwaitContext(savedAwaitContext);
 
-                if (!parseExpected(SyntaxKind.CloseParenToken) && (context & SignatureContext.RequireCompleteParameterList)) {
+                if (!parseExpected(SyntaxKind.CloseParenToken) && (flags & SignatureFlags.RequireCompleteParameterList)) {
                     // Caller insisted that we had to end with a )   We didn't.  So just return
                     // undefined here.
                     return undefined;
@@ -2288,7 +2290,7 @@ namespace ts {
             // We didn't even have an open paren.  If the caller requires a complete parameter list,
             // we definitely can't provide that.  However, if they're ok with an incomplete one,
             // then just return an empty set of parameters.
-            return (context & SignatureContext.RequireCompleteParameterList) ? undefined : createMissingList<ParameterDeclaration>();
+            return (flags & SignatureFlags.RequireCompleteParameterList) ? undefined : createMissingList<ParameterDeclaration>();
         }
 
         function parseTypeMemberSemicolon() {
@@ -2307,7 +2309,7 @@ namespace ts {
             if (kind === SyntaxKind.ConstructSignature) {
                 parseExpected(SyntaxKind.NewKeyword);
             }
-            fillSignature(SyntaxKind.ColonToken, SignatureContext.Type, node);
+            fillSignature(SyntaxKind.ColonToken, SignatureFlags.Type, node);
             parseTypeMemberSemicolon();
             return addJSDocComment(finishNode(node));
         }
@@ -2397,7 +2399,7 @@ namespace ts {
 
                 // Method signatures don't exist in expression contexts.  So they have neither
                 // [Yield] nor [Await]
-                fillSignature(SyntaxKind.ColonToken, SignatureContext.Type, method);
+                fillSignature(SyntaxKind.ColonToken, SignatureFlags.Type, method);
                 parseTypeMemberSemicolon();
                 return addJSDocComment(finishNode(method));
             }
@@ -2541,7 +2543,7 @@ namespace ts {
             if (kind === SyntaxKind.ConstructorType) {
                 parseExpected(SyntaxKind.NewKeyword);
             }
-            fillSignature(SyntaxKind.EqualsGreaterThanToken, SignatureContext.Type, node);
+            fillSignature(SyntaxKind.EqualsGreaterThanToken, SignatureFlags.Type, node);
             return finishNode(node);
         }
 
@@ -3268,7 +3270,7 @@ namespace ts {
         function parseParenthesizedArrowFunctionExpressionHead(allowAmbiguity: boolean): ArrowFunction {
             const node = <ArrowFunction>createNode(SyntaxKind.ArrowFunction);
             node.modifiers = parseModifiersForArrowFunction();
-            const isAsync = (getModifierFlags(node) & ModifierFlags.Async) ? SignatureContext.Await : 0;
+            const isAsync = (getModifierFlags(node) & ModifierFlags.Async) ? SignatureFlags.Await : SignatureFlags.None;
 
             // Arrow functions are never generators.
             //
@@ -3277,7 +3279,7 @@ namespace ts {
             // a => (b => c)
             // And think that "(b =>" was actually a parenthesized arrow function with a missing
             // close paren.
-            fillSignature(SyntaxKind.ColonToken, isAsync | (allowAmbiguity ? 0 : SignatureContext.RequireCompleteParameterList), node);
+            fillSignature(SyntaxKind.ColonToken, isAsync | (allowAmbiguity ? SignatureFlags.None : SignatureFlags.RequireCompleteParameterList), node);
 
             // If we couldn't get parameters, we definitely could not parse out an arrow function.
             if (!node.parameters) {
@@ -3302,7 +3304,7 @@ namespace ts {
 
         function parseArrowFunctionExpressionBody(isAsync: boolean): Block | Expression {
             if (token() === SyntaxKind.OpenBraceToken) {
-                return parseFunctionBlock(/*allowYield*/ false, /*allowAwait*/ isAsync, /*ignoreMissingOpenBrace*/ false);
+                return parseFunctionBlock(isAsync ? SignatureFlags.Await : SignatureFlags.None);
             }
 
             if (token() !== SyntaxKind.SemicolonToken &&
@@ -3323,8 +3325,8 @@ namespace ts {
                 // try to recover better.  If we don't do this, then the next close curly we see may end
                 // up preemptively closing the containing construct.
                 //
-                // Note: even when 'ignoreMissingOpenBrace' is passed as true, parseBody will still error.
-                return parseFunctionBlock(/*allowYield*/ false, /*allowAwait*/ isAsync, /*ignoreMissingOpenBrace*/ true);
+                // Note: even when 'IgnoreMissingOpenBrace' is passed, parseBody will still error.
+                return parseFunctionBlock(SignatureFlags.IgnoreMissingOpenBrace | (isAsync ? SignatureFlags.Await : SignatureFlags.None));
             }
 
             return isAsync
@@ -4400,8 +4402,8 @@ namespace ts {
             parseExpected(SyntaxKind.FunctionKeyword);
             node.asteriskToken = parseOptionalToken(SyntaxKind.AsteriskToken);
 
-            const isGenerator = node.asteriskToken ? SignatureContext.Yield : 0;
-            const isAsync = (getModifierFlags(node) & ModifierFlags.Async) ? SignatureContext.Await : 0;
+            const isGenerator = node.asteriskToken ? SignatureFlags.Yield : SignatureFlags.None;
+            const isAsync = (getModifierFlags(node) & ModifierFlags.Async) ? SignatureFlags.Await : SignatureFlags.None;
             node.name =
                 isGenerator && isAsync ? doInYieldAndAwaitContext(parseOptionalIdentifier) :
                     isGenerator ? doInYieldContext(parseOptionalIdentifier) :
@@ -4409,7 +4411,7 @@ namespace ts {
                             parseOptionalIdentifier();
 
             fillSignature(SyntaxKind.ColonToken, isGenerator | isAsync, node);
-            node.body = parseFunctionBlock(/*allowYield*/ !!isGenerator, /*allowAwait*/ !!isAsync, /*ignoreMissingOpenBrace*/ false);
+            node.body = parseFunctionBlock(isGenerator | isAsync);
 
             if (saveDecoratorContext) {
                 setDecoratorContext(/*val*/ true);
@@ -4458,12 +4460,12 @@ namespace ts {
             return finishNode(node);
         }
 
-        function parseFunctionBlock(allowYield: boolean, allowAwait: boolean, ignoreMissingOpenBrace: boolean, diagnosticMessage?: DiagnosticMessage): Block {
+        function parseFunctionBlock(flags: SignatureFlags, diagnosticMessage?: DiagnosticMessage): Block {
             const savedYieldContext = inYieldContext();
-            setYieldContext(allowYield);
+            setYieldContext(!!(flags & SignatureFlags.Yield));
 
             const savedAwaitContext = inAwaitContext();
-            setAwaitContext(allowAwait);
+            setAwaitContext(!!(flags & SignatureFlags.Await));
 
             // We may be in a [Decorator] context when parsing a function expression or
             // arrow function. The body of the function is not in [Decorator] context.
@@ -4472,7 +4474,7 @@ namespace ts {
                 setDecoratorContext(/*val*/ false);
             }
 
-            const block = parseBlock(ignoreMissingOpenBrace, diagnosticMessage);
+            const block = parseBlock(!!(flags & SignatureFlags.IgnoreMissingOpenBrace), diagnosticMessage);
 
             if (saveDecoratorContext) {
                 setDecoratorContext(/*val*/ true);
@@ -5019,13 +5021,13 @@ namespace ts {
             return !scanner.hasPrecedingLineBreak() && (isIdentifier() || token() === SyntaxKind.StringLiteral);
         }
 
-        function parseFunctionBlockOrSemicolon(isGenerator: boolean, isAsync: boolean, diagnosticMessage?: DiagnosticMessage): Block {
+        function parseFunctionBlockOrSemicolon(flags: SignatureFlags, diagnosticMessage?: DiagnosticMessage): Block {
             if (token() !== SyntaxKind.OpenBraceToken && canParseSemicolon()) {
                 parseSemicolon();
                 return;
             }
 
-            return parseFunctionBlock(isGenerator, isAsync, /*ignoreMissingOpenBrace*/ false, diagnosticMessage);
+            return parseFunctionBlock(flags, diagnosticMessage);
         }
 
         // DECLARATIONS
@@ -5160,10 +5162,10 @@ namespace ts {
             parseExpected(SyntaxKind.FunctionKeyword);
             node.asteriskToken = parseOptionalToken(SyntaxKind.AsteriskToken);
             node.name = hasModifier(node, ModifierFlags.Default) ? parseOptionalIdentifier() : parseIdentifier();
-            const isGenerator = node.asteriskToken ? SignatureContext.Yield : 0;
-            const isAsync = hasModifier(node, ModifierFlags.Async) ? SignatureContext.Await : 0;
+            const isGenerator = node.asteriskToken ? SignatureFlags.Yield : SignatureFlags.None;
+            const isAsync = hasModifier(node, ModifierFlags.Async) ? SignatureFlags.Await : SignatureFlags.None;
             fillSignature(SyntaxKind.ColonToken, isGenerator | isAsync, node);
-            node.body = parseFunctionBlockOrSemicolon(!!isGenerator, !!isAsync, Diagnostics.or_expected);
+            node.body = parseFunctionBlockOrSemicolon(isGenerator | isAsync, Diagnostics.or_expected);
             return addJSDocComment(finishNode(node));
         }
 
@@ -5172,8 +5174,8 @@ namespace ts {
             node.decorators = decorators;
             node.modifiers = modifiers;
             parseExpected(SyntaxKind.ConstructorKeyword);
-            fillSignature(SyntaxKind.ColonToken, /*context*/ 0, node);
-            node.body = parseFunctionBlockOrSemicolon(/*isGenerator*/ false, /*isAsync*/ false, Diagnostics.or_expected);
+            fillSignature(SyntaxKind.ColonToken, SignatureFlags.None, node);
+            node.body = parseFunctionBlockOrSemicolon(SignatureFlags.None, Diagnostics.or_expected);
             return addJSDocComment(finishNode(node));
         }
 
@@ -5184,10 +5186,10 @@ namespace ts {
             method.asteriskToken = asteriskToken;
             method.name = name;
             method.questionToken = questionToken;
-            const isGenerator = asteriskToken ? SignatureContext.Yield : 0;
-            const isAsync = hasModifier(method, ModifierFlags.Async) ? SignatureContext.Await : 0;
+            const isGenerator = asteriskToken ? SignatureFlags.Yield : SignatureFlags.None;
+            const isAsync = hasModifier(method, ModifierFlags.Async) ? SignatureFlags.Await : SignatureFlags.None;
             fillSignature(SyntaxKind.ColonToken, isGenerator | isAsync, method);
-            method.body = parseFunctionBlockOrSemicolon(!!isGenerator, !!isAsync, diagnosticMessage);
+            method.body = parseFunctionBlockOrSemicolon(isGenerator | isAsync, diagnosticMessage);
             return addJSDocComment(finishNode(method));
         }
 
@@ -5240,8 +5242,8 @@ namespace ts {
             node.decorators = decorators;
             node.modifiers = modifiers;
             node.name = parsePropertyName();
-            fillSignature(SyntaxKind.ColonToken, /*context*/ 0, node);
-            node.body = parseFunctionBlockOrSemicolon(/*isGenerator*/ false, /*isAsync*/ false);
+            fillSignature(SyntaxKind.ColonToken, SignatureFlags.None, node);
+            node.body = parseFunctionBlockOrSemicolon(SignatureFlags.None);
             return addJSDocComment(finishNode(node));
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2231,6 +2231,16 @@ namespace ts {
             else if (parseOptional(returnToken)) {
                 signature.type = parseTypeOrTypePredicate();
             }
+            else if (context === SignatureContext.Type) {
+                const start = scanner.getTokenPos();
+                const length = scanner.getTextPos() - start;
+                const backwardToken = parseOptional(returnToken === SyntaxKind.ColonToken ? SyntaxKind.EqualsGreaterThanToken : SyntaxKind.ColonToken);
+                if (backwardToken) {
+                    // This is easy to get backward, especially in type contexts, so parse the type anyway
+                    signature.type = parseTypeOrTypePredicate();
+                    parseErrorAtPosition(start, length, Diagnostics._0_expected, tokenToString(returnToken));
+                }
+            }
         }
 
         function parseParameterList(context: SignatureContext) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2,6 +2,13 @@
 /// <reference path="scanner.ts"/>
 
 namespace ts {
+    const enum SignatureContext {
+        Yield = 1 << 0,
+        Await = 1 << 1,
+        Type  = 1 << 2,
+        RequireCompleteParameterList = 1 << 3,
+    }
+
     let NodeConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
     let TokenConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
     let IdentifierConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
@@ -2231,7 +2238,7 @@ namespace ts {
             else if (parseOptional(returnToken)) {
                 signature.type = parseTypeOrTypePredicate();
             }
-            else if (context === SignatureContext.Type) {
+            else if (context & SignatureContext.Type) {
                 const start = scanner.getTokenPos();
                 const length = scanner.getTextPos() - start;
                 const backwardToken = parseOptional(returnToken === SyntaxKind.ColonToken ? SyntaxKind.EqualsGreaterThanToken : SyntaxKind.ColonToken);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -36,6 +36,13 @@ namespace ts {
         end: number;
     }
 
+    export const enum SignatureContext {
+        Yield = 1 << 1,
+        Await = 1 << 2,
+        Type  = 1 << 3,
+        RequireCompleteParameterList = 1 << 4,
+    }
+
     // token > SyntaxKind.Identifer => token is a keyword
     // Also, If you add a new SyntaxKind be sure to keep the `Markers` section at the bottom in sync
     export const enum SyntaxKind {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -36,13 +36,6 @@ namespace ts {
         end: number;
     }
 
-    export const enum SignatureContext {
-        Yield = 1 << 1,
-        Await = 1 << 2,
-        Type  = 1 << 3,
-        RequireCompleteParameterList = 1 << 4,
-    }
-
     // token > SyntaxKind.Identifer => token is a keyword
     // Also, If you add a new SyntaxKind be sure to keep the `Markers` section at the bottom in sync
     export const enum SyntaxKind {

--- a/tests/baselines/reference/parseErrorIncorrectReturnToken.errors.txt
+++ b/tests/baselines/reference/parseErrorIncorrectReturnToken.errors.txt
@@ -1,0 +1,37 @@
+tests/cases/compiler/parseErrorIncorrectReturnToken.ts(2,17): error TS1005: ':' expected.
+tests/cases/compiler/parseErrorIncorrectReturnToken.ts(4,22): error TS1005: '=>' expected.
+tests/cases/compiler/parseErrorIncorrectReturnToken.ts(4,24): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/compiler/parseErrorIncorrectReturnToken.ts(9,18): error TS1005: '{' expected.
+tests/cases/compiler/parseErrorIncorrectReturnToken.ts(9,21): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/compiler/parseErrorIncorrectReturnToken.ts(9,28): error TS1005: ';' expected.
+tests/cases/compiler/parseErrorIncorrectReturnToken.ts(12,1): error TS1128: Declaration or statement expected.
+
+
+==== tests/cases/compiler/parseErrorIncorrectReturnToken.ts (7 errors) ====
+    type F1 = {
+        (n: number) => string; // should be : not =>
+                    ~~
+!!! error TS1005: ':' expected.
+    }
+    type F2 = (n: number): string; // should be => not :
+                         ~
+!!! error TS1005: '=>' expected.
+                           ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+    
+    // doesn't work in non-type contexts, where the return type is optional
+    let f = (n: number) => string => n.toString();
+    let o = {
+        m(n: number) => string {
+                     ~~
+!!! error TS1005: '{' expected.
+                        ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                               ~
+!!! error TS1005: ';' expected.
+            return n.toString();
+        }
+    };
+    ~
+!!! error TS1128: Declaration or statement expected.
+    

--- a/tests/baselines/reference/parseErrorIncorrectReturnToken.js
+++ b/tests/baselines/reference/parseErrorIncorrectReturnToken.js
@@ -1,0 +1,27 @@
+//// [parseErrorIncorrectReturnToken.ts]
+type F1 = {
+    (n: number) => string; // should be : not =>
+}
+type F2 = (n: number): string; // should be => not :
+
+// doesn't work in non-type contexts, where the return type is optional
+let f = (n: number) => string => n.toString();
+let o = {
+    m(n: number) => string {
+        return n.toString();
+    }
+};
+
+
+//// [parseErrorIncorrectReturnToken.js]
+string; // should be => not :
+// doesn't work in non-type contexts, where the return type is optional
+var f = function (n) { return function (string) { return n.toString(); }; };
+var o = {
+    m: function (n) { }
+};
+string;
+{
+    return n.toString();
+}
+;

--- a/tests/cases/compiler/parseErrorIncorrectReturnToken.ts
+++ b/tests/cases/compiler/parseErrorIncorrectReturnToken.ts
@@ -1,0 +1,13 @@
+
+type F1 = {
+    (n: number) => string; // should be : not =>
+}
+type F2 = (n: number): string; // should be => not :
+
+// doesn't work in non-type contexts, where the return type is optional
+let f = (n: number) => string => n.toString();
+let o = {
+    m(n: number) => string {
+        return n.toString();
+    }
+};


### PR DESCRIPTION
Better error for wrong return token (`:` vs `=>`) in types.

Who really remembers the right return token to use for `{ (): string }` vs `() => string` ? Now the compiler (1) suggests the right token (2) parses the return type as a return type. 

This is a **huge** improvement from the previous behaviour when the first example was wrongly written as `{ () => string }`. Before, `=>` was parsed sort of like `;`. `{ (); string }` gives you a type literal with a call signature and a member named `string`. Very confusing.


Note that parsing both tokens would be ambiguous in expression position, so impossible to give a better message from the parser in this context. For example:

```
let f = (x: number) => number => x + 1;
                    ~~
                    Should be ':'
```

But the parser doesn't know that 'number' isn't an argument named 'number'.