### PR TITLE
Fix ObjectConstructor.defineProperty

### DIFF
--- a/lib/lib.es6.d.ts
+++ b/lib/lib.es6.d.ts
@@ -172,10 +172,10 @@ interface ObjectConstructor {
     /**
       * Adds a property to an object, or modifies attributes of an existing property.
       * @param o Object on which to add or modify the property. This can be a native JavaScript object (that is, a user-defined object or a built in object) or a DOM object.
-      * @param p The property name.
+      * @param propertyKey The property name.
       * @param attributes Descriptor for the property. It can be for a data property or an accessor property.
       */
-    defineProperty(o: any, p: string, attributes: PropertyDescriptor & ThisType<any>): any;
+    defineProperty(o: any, propertyKey: PropertyKey, attributes: PropertyDescriptor & ThisType<any>): any;
 
     /**
       * Adds one or more properties to an object, and/or modifies attributes of existing properties.
@@ -4635,7 +4635,7 @@ interface ObjectConstructor {
      * Adds a property to an object, or modifies attributes of an existing property.
      * @param o Object on which to add or modify the property. This can be a native JavaScript
      * object (that is, a user-defined object or a built in object) or a DOM object.
-     * @param p The property name.
+     * @param propertyKey The property name.
      * @param attributes Descriptor for the property. It can be for a data property or an accessor
      *  property.
      */


### PR DESCRIPTION
I think the definition of ObjectConstructor.defineProperty() has not been updated correctly, the second parameter should accept not only strings but a PropertyKey type. Similiar to #10949.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
