### PR TITLE
Add assertion to computePositionOfLineAndCharacter

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -326,13 +326,20 @@ namespace ts {
     }
 
     export function getPositionOfLineAndCharacter(sourceFile: SourceFile, line: number, character: number): number {
-        return computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character);
+        return computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text);
     }
 
     /* @internal */
-    export function computePositionOfLineAndCharacter(lineStarts: number[], line: number, character: number): number {
+    export function computePositionOfLineAndCharacter(lineStarts: number[], line: number, character: number, debugText?: string): number {
         Debug.assert(line >= 0 && line < lineStarts.length);
-        return lineStarts[line] + character;
+        const res = lineStarts[line] + character;
+        if (line < lineStarts.length - 1) {
+            Debug.assert(res < lineStarts[line + 1]);
+        }
+        else if (debugText !== undefined) {
+            Debug.assert(res < debugText.length);
+        }
+        return res;
     }
 
     /* @internal */

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -86,7 +86,7 @@ namespace ts.server {
          */
         lineOffsetToPosition(line: number, offset: number): number {
             if (!this.svc) {
-                return computePositionOfLineAndCharacter(this.getLineMap(), line - 1, offset - 1);
+                return computePositionOfLineAndCharacter(this.getLineMap(), line - 1, offset - 1, this.text);
             }
 
             // TODO: assert this offset is actually on the line


### PR DESCRIPTION
Should catch errors earlier if we are asking for a character past the end of a line.