### PR TITLE
Indent filesToString

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -690,7 +690,7 @@ namespace ts.server {
             }
             let strBuilder = "";
             for (const file of this.program.getSourceFiles()) {
-                strBuilder += `${file.fileName}\n`;
+                strBuilder += `\t${file.fileName}\n`;
             }
             return strBuilder;
         }


### PR DESCRIPTION
When reading tsserver logs, it's annoying to have large file lists displayed on the top level -- this should make them collapsible in most text editors.