### PR TITLE
Fix parsing of globalPlugins and pluginProbeLocations: Don't include empty string

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -754,8 +754,16 @@ namespace ts.server {
     const typingSafeListLocation = findArgument(Arguments.TypingSafeListLocation);
     const npmLocation = findArgument(Arguments.NpmLocation);
 
-    const globalPlugins = (findArgument("--globalPlugins") || "").split(",");
-    const pluginProbeLocations = (findArgument("--pluginProbeLocations") || "").split(",");
+    function parseStringArray(argName: string): string[] {
+        const arg = findArgument(argName);
+        if (arg === undefined) {
+            return emptyArray as string[]; // TODO: https://github.com/Microsoft/TypeScript/issues/16312
+        }
+        return arg.split(",").filter(name => name !== "");
+    }
+
+    const globalPlugins = parseStringArray("--globalPlugins");
+    const pluginProbeLocations = parseStringArray("--pluginProbeLocations");
     const allowLocalPluginLoads = hasArgument("--allowLocalPluginLoads");
 
     const useSingleInferredProject = hasArgument("--useSingleInferredProject");


### PR DESCRIPTION
@rbuckton noticed this while looking at server logs.