### PR TITLE
convertFunctionToEs6Class: Bail if this is not a JavaScript file

### DIFF
--- a/src/services/refactors/convertFunctionToEs6Class.ts
+++ b/src/services/refactors/convertFunctionToEs6Class.ts
@@ -12,7 +12,11 @@ namespace ts.refactor {
 
     registerRefactor(convertFunctionToES6Class);
 
-    function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] {
+    function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
+        if (!isInJavaScriptFile(context.file)) {
+            return undefined;
+        }
+
         const start = context.startPosition;
         const node = getTokenAtPosition(context.file, start, /*includeJsDocComment*/ false);
         const checker = context.program.getTypeChecker();


### PR DESCRIPTION
This might "fix" #17133 (for TS users anyway), but I suspect it won't and the problem is elsewhere. But it's still a useful optimization.