### PR TITLE
Remove unnecessary 'ts.' qualifications

### DIFF
--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -227,7 +227,7 @@ namespace ts.server {
             }));
         }
 
-        getFormattingEditsForRange(file: string, start: number, end: number, _options: ts.FormatCodeOptions): ts.TextChange[] {
+        getFormattingEditsForRange(file: string, start: number, end: number, _options: FormatCodeOptions): ts.TextChange[] {
             const args: protocol.FormatRequestArgs = this.createFileLocationRequestArgsWithEndLineAndOffset(file, start, end);
 
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -45,7 +45,7 @@ namespace ts.server {
          * Any compiler options that might contain paths will be taken out.
          * Enum compiler options will be converted to strings.
          */
-        readonly compilerOptions: ts.CompilerOptions;
+        readonly compilerOptions: CompilerOptions;
         // "extends", "files", "include", or "exclude" will be undefined if an external config is used.
         // Otherwise, we will use "true" if the property is present and "false" if it is missing.
         readonly extends: boolean | undefined;
@@ -201,7 +201,7 @@ namespace ts.server {
      * This helper function processes a list of projects and return the concatenated, sortd and deduplicated output of processing each project.
      */
     export function combineProjectOutput<T>(projects: Project[], action: (project: Project) => T[], comparer?: (a: T, b: T) => number, areEqual?: (a: T, b: T) => boolean) {
-        const result = ts.flatMap(projects, action).sort(comparer);
+        const result = flatMap(projects, action).sort(comparer);
         return projects.length > 1 ? deduplicate(result, areEqual) : result;
     }
 
@@ -240,7 +240,7 @@ namespace ts.server {
         getFileName: x => x,
         getScriptKind: _ => undefined,
         hasMixedContent: (fileName, extraFileExtensions) => {
-            const mixedContentExtensions = ts.map(ts.filter(extraFileExtensions, item => item.isMixedContent), item => item.extension);
+            const mixedContentExtensions = map(filter(extraFileExtensions, item => item.isMixedContent), item => item.extension);
             return forEach(mixedContentExtensions, extension => fileExtensionIs(fileName, extension));
         }
     };
@@ -633,7 +633,7 @@ namespace ts.server {
             // If a change was made inside "folder/file", node will trigger the callback twice:
             // one with the fileName being "folder/file", and the other one with "folder".
             // We don't respond to the second one.
-            if (fileName && !ts.isSupportedSourceFileName(fileName, project.getCompilerOptions(), this.hostConfiguration.extraFileExtensions)) {
+            if (fileName && !isSupportedSourceFileName(fileName, project.getCompilerOptions(), this.hostConfiguration.extraFileExtensions)) {
                 return;
             }
 
@@ -1082,7 +1082,7 @@ namespace ts.server {
                 configFileName: configFileName(),
                 projectType: project instanceof server.ExternalProject ? "external" : "configured",
                 languageServiceEnabled: project.languageServiceEnabled,
-                version: ts.version,
+                version,
             };
             this.eventHandler({ eventName: ProjectInfoTelemetryEvent, data });
 
@@ -1092,7 +1092,7 @@ namespace ts.server {
                 }
 
                 const configFilePath = project instanceof server.ConfiguredProject && project.getConfigFilePath();
-                const base = ts.getBaseFileName(configFilePath);
+                const base = getBaseFileName(configFilePath);
                 return base === "tsconfig.json" || base === "jsconfig.json" ? base : "other";
             }
 

--- a/src/server/lsHost.ts
+++ b/src/server/lsHost.ts
@@ -3,8 +3,8 @@
 /// <reference path="scriptInfo.ts" />
 
 namespace ts.server {
-    export class LSHost implements ts.LanguageServiceHost, ModuleResolutionHost {
-        private compilationSettings: ts.CompilerOptions;
+    export class LSHost implements LanguageServiceHost, ModuleResolutionHost {
+        private compilationSettings: CompilerOptions;
         private readonly resolvedModuleNames = createMap<Map<ResolvedModuleWithFailedLookupLocations>>();
         private readonly resolvedTypeReferenceDirectives = createMap<Map<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>>();
         private readonly getCanonicalFileName: (fileName: string) => string;
@@ -17,7 +17,7 @@ namespace ts.server {
 
         constructor(private readonly host: ServerHost, private project: Project, private readonly cancellationToken: HostCancellationToken) {
             this.cancellationToken = new ThrottledCancellationToken(cancellationToken, project.projectService.throttleWaitMilliseconds);
-            this.getCanonicalFileName = ts.createGetCanonicalFileName(this.host.useCaseSensitiveFileNames);
+            this.getCanonicalFileName = createGetCanonicalFileName(this.host.useCaseSensitiveFileNames);
 
             if (host.trace) {
                 this.trace = s => host.trace(s);
@@ -99,7 +99,7 @@ namespace ts.server {
                     }
                 }
 
-                ts.Debug.assert(resolution !== undefined);
+                Debug.assert(resolution !== undefined);
 
                 resolvedModules.push(getResult(resolution));
             }
@@ -177,7 +177,7 @@ namespace ts.server {
             return combinePaths(nodeModuleBinDir, getDefaultLibFileName(this.compilationSettings));
         }
 
-        getScriptSnapshot(filename: string): ts.IScriptSnapshot {
+        getScriptSnapshot(filename: string): IScriptSnapshot {
             const scriptInfo = this.project.getScriptInfoLSHost(filename);
             if (scriptInfo) {
                 return scriptInfo.getSnapshot();
@@ -238,7 +238,7 @@ namespace ts.server {
             this.resolvedTypeReferenceDirectives.delete(info.path);
         }
 
-        setCompilationSettings(opt: ts.CompilerOptions) {
+        setCompilationSettings(opt: CompilerOptions) {
             if (changesAffectModuleResolution(this.compilationSettings, opt)) {
                 this.resolvedModuleNames.clear();
                 this.resolvedTypeReferenceDirectives.clear();

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -105,7 +105,7 @@ namespace ts.server {
     export abstract class Project {
         private rootFiles: ScriptInfo[] = [];
         private rootFilesMap: Map<ScriptInfo> = createMap<ScriptInfo>();
-        private program: ts.Program;
+        private program: Program;
         private externalFiles: SortedReadonlyArray<string>;
         private missingFilesMap: Map<FileWatcher> = createMap<FileWatcher>();
 
@@ -180,14 +180,14 @@ namespace ts.server {
             private readonly projectName: string,
             readonly projectKind: ProjectKind,
             readonly projectService: ProjectService,
-            private documentRegistry: ts.DocumentRegistry,
+            private documentRegistry: DocumentRegistry,
             hasExplicitListOfFiles: boolean,
             languageServiceEnabled: boolean,
             private compilerOptions: CompilerOptions,
             public compileOnSaveEnabled: boolean) {
 
             if (!this.compilerOptions) {
-                this.compilerOptions = ts.getDefaultCompilerOptions();
+                this.compilerOptions = getDefaultCompilerOptions();
                 this.compilerOptions.allowNonTsExtensions = true;
                 this.compilerOptions.allowJs = true;
             }
@@ -201,7 +201,7 @@ namespace ts.server {
             this.lsHost = new LSHost(this.projectService.host, this, this.projectService.cancellationToken);
             this.lsHost.setCompilationSettings(this.compilerOptions);
 
-            this.languageService = ts.createLanguageService(this.lsHost, this.documentRegistry);
+            this.languageService = createLanguageService(this.lsHost, this.documentRegistry);
 
             if (!languageServiceEnabled) {
                 this.disableLanguageService();
@@ -875,7 +875,7 @@ namespace ts.server {
         // Used to keep track of what directories are watched for this project
         directoriesWatchedForTsconfig: string[] = [];
 
-        constructor(projectService: ProjectService, documentRegistry: ts.DocumentRegistry, compilerOptions: CompilerOptions) {
+        constructor(projectService: ProjectService, documentRegistry: DocumentRegistry, compilerOptions: CompilerOptions) {
             super(InferredProject.newName(),
                 ProjectKind.Inferred,
                 projectService,
@@ -948,7 +948,7 @@ namespace ts.server {
 
         constructor(configFileName: NormalizedPath,
             projectService: ProjectService,
-            documentRegistry: ts.DocumentRegistry,
+            documentRegistry: DocumentRegistry,
             hasExplicitListOfFiles: boolean,
             compilerOptions: CompilerOptions,
             private wildcardDirectories: Map<WatchDirectoryFlags>,
@@ -1152,7 +1152,7 @@ namespace ts.server {
         }
 
         getEffectiveTypeRoots() {
-            return ts.getEffectiveTypeRoots(this.getCompilerOptions(), this.projectService.host) || [];
+            return getEffectiveTypeRoots(this.getCompilerOptions(), this.projectService.host) || [];
         }
     }
 
@@ -1164,7 +1164,7 @@ namespace ts.server {
         private typeAcquisition: TypeAcquisition;
         constructor(public externalProjectName: string,
             projectService: ProjectService,
-            documentRegistry: ts.DocumentRegistry,
+            documentRegistry: DocumentRegistry,
             compilerOptions: CompilerOptions,
             languageServiceEnabled: boolean,
             public compileOnSaveEnabled: boolean,

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -72,12 +72,12 @@ namespace ts.server {
                 const lineMap = this.getLineMap();
                 const start = lineMap[line]; // -1 since line is 1-based
                 const end = line + 1 < lineMap.length ? lineMap[line + 1] : this.text.length;
-                return ts.createTextSpanFromBounds(start, end);
+                return createTextSpanFromBounds(start, end);
             }
             const index = this.svc.getSnapshot().index;
             const { lineText, absolutePosition } = index.lineNumberToInfo(line + 1);
             const len = lineText !== undefined ? lineText.length : index.absolutePositionOfStartOfLine(line + 2) - absolutePosition;
-            return ts.createTextSpan(absolutePosition, len);
+            return createTextSpan(absolutePosition, len);
         }
 
         /**
@@ -147,7 +147,7 @@ namespace ts.server {
          * All projects that include this file
          */
         readonly containingProjects: Project[] = [];
-        private formatCodeSettings: ts.FormatCodeSettings;
+        private formatCodeSettings: FormatCodeSettings;
         readonly path: Path;
 
         private fileWatcher: FileWatcher;

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -248,7 +248,7 @@ namespace ts.server {
         }
 
         getTextChangeRange() {
-            return ts.createTextChangeRange(ts.createTextSpan(this.pos, this.deleteLen),
+            return createTextChangeRange(createTextSpan(this.pos, this.deleteLen),
                 this.insertedText ? this.insertedText.length : 0);
         }
     }
@@ -337,21 +337,21 @@ namespace ts.server {
         getTextChangesBetweenVersions(oldVersion: number, newVersion: number) {
             if (oldVersion < newVersion) {
                 if (oldVersion >= this.minVersion) {
-                    const textChangeRanges: ts.TextChangeRange[] = [];
+                    const textChangeRanges: TextChangeRange[] = [];
                     for (let i = oldVersion + 1; i <= newVersion; i++) {
                         const snap = this.versions[this.versionToIndex(i)];
                         for (const textChange of snap.changesSincePreviousVersion) {
                             textChangeRanges.push(textChange.getTextChangeRange());
                         }
                     }
-                    return ts.collapseTextChangeRangesAcrossMultipleVersions(textChangeRanges);
+                    return collapseTextChangeRangesAcrossMultipleVersions(textChangeRanges);
                 }
                 else {
                     return undefined;
                 }
             }
             else {
-                return ts.unchangedTextChangeRange;
+                return unchangedTextChangeRange;
             }
         }
 
@@ -365,7 +365,7 @@ namespace ts.server {
         }
     }
 
-    export class LineIndexSnapshot implements ts.IScriptSnapshot {
+    export class LineIndexSnapshot implements IScriptSnapshot {
         constructor(readonly version: number, readonly cache: ScriptVersionCache, readonly index: LineIndex, readonly changesSincePreviousVersion: ReadonlyArray<TextChange> = emptyArray) {
         }
 
@@ -377,10 +377,10 @@ namespace ts.server {
             return this.index.root.charCount();
         }
 
-        getChangeRange(oldSnapshot: ts.IScriptSnapshot): ts.TextChangeRange {
+        getChangeRange(oldSnapshot: IScriptSnapshot): TextChangeRange {
             if (oldSnapshot instanceof LineIndexSnapshot && this.cache === oldSnapshot.cache) {
                 if (this.version <= oldSnapshot.version) {
-                    return ts.unchangedTextChangeRange;
+                    return unchangedTextChangeRange;
                 }
                 else {
                     return this.cache.getTextChangesBetweenVersions(oldSnapshot.version, this.version);
@@ -539,7 +539,7 @@ namespace ts.server {
         }
 
         static linesFromText(text: string) {
-            const lineMap = ts.computeLineStarts(text);
+            const lineMap = computeLineStarts(text);
 
             if (lineMap.length === 0) {
                 return { lines: <string[]>[], lineMap };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -138,7 +138,7 @@ namespace ts.server {
         terminal: false,
     });
 
-    class Logger implements ts.server.Logger {
+    class Logger implements server.Logger {
         private fd = -1;
         private seq = 0;
         private inGroup = false;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -72,12 +72,12 @@ namespace ts.server {
         }
     }
 
-    function formatDiag(fileName: NormalizedPath, project: Project, diag: ts.Diagnostic): protocol.Diagnostic {
+    function formatDiag(fileName: NormalizedPath, project: Project, diag: Diagnostic): protocol.Diagnostic {
         const scriptInfo = project.getScriptInfoForNormalizedPath(fileName);
         return {
             start: scriptInfo.positionToLineOffset(diag.start),
             end: scriptInfo.positionToLineOffset(diag.start + diag.length),
-            text: ts.flattenDiagnosticMessageText(diag.messageText, "\n"),
+            text: flattenDiagnosticMessageText(diag.messageText, "\n"),
             code: diag.code,
             category: DiagnosticCategory[diag.category].toLowerCase(),
             source: diag.source
@@ -88,12 +88,12 @@ namespace ts.server {
         return { line: lineAndCharacter.line + 1, offset: lineAndCharacter.character + 1 };
     }
 
-    function formatConfigFileDiag(diag: ts.Diagnostic, includeFileName: true): protocol.DiagnosticWithFileName;
-    function formatConfigFileDiag(diag: ts.Diagnostic, includeFileName: false): protocol.Diagnostic;
-    function formatConfigFileDiag(diag: ts.Diagnostic, includeFileName: boolean): protocol.Diagnostic | protocol.DiagnosticWithFileName {
+    function formatConfigFileDiag(diag: Diagnostic, includeFileName: true): protocol.DiagnosticWithFileName;
+    function formatConfigFileDiag(diag: Diagnostic, includeFileName: false): protocol.Diagnostic;
+    function formatConfigFileDiag(diag: Diagnostic, includeFileName: boolean): protocol.Diagnostic | protocol.DiagnosticWithFileName {
         const start = diag.file && convertToLocation(getLineAndCharacterOfPosition(diag.file, diag.start));
         const end = diag.file && convertToLocation(getLineAndCharacterOfPosition(diag.file, diag.start + diag.length));
-        const text = ts.flattenDiagnosticMessageText(diag.messageText, "\n");
+        const text = flattenDiagnosticMessageText(diag.messageText, "\n");
         const { code, source } = diag;
         const category = DiagnosticCategory[diag.category].toLowerCase();
         return includeFileName ? { start, end, text, code, category, source, fileName: diag.file && diag.file.fileName } :
@@ -389,8 +389,8 @@ namespace ts.server {
             this.host.write(formatMessage(msg, this.logger, this.byteLength, this.host.newLine));
         }
 
-        public configFileDiagnosticEvent(triggerFile: string, configFile: string, diagnostics: ts.Diagnostic[]) {
-            const bakedDiags = ts.map(diagnostics, diagnostic => formatConfigFileDiag(diagnostic, /*includeFileName*/ true));
+        public configFileDiagnosticEvent(triggerFile: string, configFile: string, diagnostics: Diagnostic[]) {
+            const bakedDiags = map(diagnostics, diagnostic => formatConfigFileDiag(diagnostic, /*includeFileName*/ true));
             const ev: protocol.ConfigFileDiagnosticEvent = {
                 seq: 0,
                 type: "event",
@@ -615,7 +615,7 @@ namespace ts.server {
                     return {
                         file: def.fileName,
                         start: defScriptInfo.positionToLineOffset(def.textSpan.start),
-                        end: defScriptInfo.positionToLineOffset(ts.textSpanEnd(def.textSpan))
+                        end: defScriptInfo.positionToLineOffset(textSpanEnd(def.textSpan))
                     };
                 });
             }
@@ -639,7 +639,7 @@ namespace ts.server {
                 return {
                     file: def.fileName,
                     start: defScriptInfo.positionToLineOffset(def.textSpan.start),
-                    end: defScriptInfo.positionToLineOffset(ts.textSpanEnd(def.textSpan))
+                    end: defScriptInfo.positionToLineOffset(textSpanEnd(def.textSpan))
                 };
             });
         }
@@ -657,7 +657,7 @@ namespace ts.server {
                     return {
                         file: fileName,
                         start: scriptInfo.positionToLineOffset(textSpan.start),
-                        end: scriptInfo.positionToLineOffset(ts.textSpanEnd(textSpan))
+                        end: scriptInfo.positionToLineOffset(textSpanEnd(textSpan))
                     };
                 });
             }
@@ -681,7 +681,7 @@ namespace ts.server {
                 const { fileName, isWriteAccess, textSpan, isInString } = occurrence;
                 const scriptInfo = project.getScriptInfo(fileName);
                 const start = scriptInfo.positionToLineOffset(textSpan.start);
-                const end = scriptInfo.positionToLineOffset(ts.textSpanEnd(textSpan));
+                const end = scriptInfo.positionToLineOffset(textSpanEnd(textSpan));
                 const result: protocol.OccurrencesResponseItem = {
                     start,
                     end,
@@ -731,7 +731,7 @@ namespace ts.server {
                 return documentHighlights;
             }
 
-            function convertToDocumentHighlightsItem(documentHighlights: ts.DocumentHighlights): ts.server.protocol.DocumentHighlightsItem {
+            function convertToDocumentHighlightsItem(documentHighlights: DocumentHighlights): protocol.DocumentHighlightsItem {
                 const { fileName, highlightSpans } = documentHighlights;
 
                 const scriptInfo = project.getScriptInfo(fileName);
@@ -740,10 +740,10 @@ namespace ts.server {
                     highlightSpans: highlightSpans.map(convertHighlightSpan)
                 };
 
-                function convertHighlightSpan(highlightSpan: ts.HighlightSpan): ts.server.protocol.HighlightSpan {
+                function convertHighlightSpan(highlightSpan: HighlightSpan): protocol.HighlightSpan {
                     const { textSpan, kind } = highlightSpan;
                     const start = scriptInfo.positionToLineOffset(textSpan.start);
-                    const end = scriptInfo.positionToLineOffset(ts.textSpanEnd(textSpan));
+                    const end = scriptInfo.positionToLineOffset(textSpanEnd(textSpan));
                     return { start, end, kind };
                 }
             }
@@ -786,7 +786,7 @@ namespace ts.server {
                 const scriptInfo = this.projectService.getScriptInfo(args.file);
                 projects = scriptInfo.containingProjects;
             }
-            // ts.filter handles case when 'projects' is undefined
+            // filter handles case when 'projects' is undefined
             projects = filter(projects, p => p.languageServiceEnabled);
             if (!projects || !projects.length) {
                 return Errors.ThrowNoProject();
@@ -839,7 +839,7 @@ namespace ts.server {
                             return <protocol.FileSpan>{
                                 file: location.fileName,
                                 start: locationScriptInfo.positionToLineOffset(location.textSpan.start),
-                                end: locationScriptInfo.positionToLineOffset(ts.textSpanEnd(location.textSpan)),
+                                end: locationScriptInfo.positionToLineOffset(textSpanEnd(location.textSpan)),
                             };
                         });
                     },
@@ -921,10 +921,10 @@ namespace ts.server {
                     return undefined;
                 }
 
-                const displayString = ts.displayPartsToString(nameInfo.displayParts);
+                const displayString = displayPartsToString(nameInfo.displayParts);
                 const nameSpan = nameInfo.textSpan;
                 const nameColStart = scriptInfo.positionToLineOffset(nameSpan.start).offset;
-                const nameText = scriptInfo.getSnapshot().getText(nameSpan.start, ts.textSpanEnd(nameSpan));
+                const nameText = scriptInfo.getSnapshot().getText(nameSpan.start, textSpanEnd(nameSpan));
                 const refs = combineProjectOutput<protocol.ReferencesResponseItem>(
                     projects,
                     (project: Project) => {
@@ -937,12 +937,12 @@ namespace ts.server {
                             const refScriptInfo = project.getScriptInfo(ref.fileName);
                             const start = refScriptInfo.positionToLineOffset(ref.textSpan.start);
                             const refLineSpan = refScriptInfo.lineToTextSpan(start.line - 1);
-                            const lineText = refScriptInfo.getSnapshot().getText(refLineSpan.start, ts.textSpanEnd(refLineSpan)).replace(/\r|\n/g, "");
+                            const lineText = refScriptInfo.getSnapshot().getText(refLineSpan.start, textSpanEnd(refLineSpan)).replace(/\r|\n/g, "");
                             return {
                                 file: ref.fileName,
                                 start,
                                 lineText,
-                                end: refScriptInfo.positionToLineOffset(ts.textSpanEnd(ref.textSpan)),
+                                end: refScriptInfo.positionToLineOffset(textSpanEnd(ref.textSpan)),
                                 isWriteAccess: ref.isWriteAccess,
                                 isDefinition: ref.isDefinition
                             };
@@ -1065,14 +1065,14 @@ namespace ts.server {
             }
 
             if (simplifiedResult) {
-                const displayString = ts.displayPartsToString(quickInfo.displayParts);
-                const docString = ts.displayPartsToString(quickInfo.documentation);
+                const displayString = displayPartsToString(quickInfo.displayParts);
+                const docString = displayPartsToString(quickInfo.documentation);
 
                 return {
                     kind: quickInfo.kind,
                     kindModifiers: quickInfo.kindModifiers,
                     start: scriptInfo.positionToLineOffset(quickInfo.textSpan.start),
-                    end: scriptInfo.positionToLineOffset(ts.textSpanEnd(quickInfo.textSpan)),
+                    end: scriptInfo.positionToLineOffset(textSpanEnd(quickInfo.textSpan)),
                     displayString,
                     documentation: docString,
                     tags: quickInfo.tags || []
@@ -1152,7 +1152,7 @@ namespace ts.server {
                     if (preferredIndent !== hasIndent) {
                         const firstNoWhiteSpacePosition = absolutePosition + i;
                         edits.push({
-                            span: ts.createTextSpanFromBounds(absolutePosition, firstNoWhiteSpacePosition),
+                            span: createTextSpanFromBounds(absolutePosition, firstNoWhiteSpacePosition),
                             newText: formatting.getIndentationString(preferredIndent, formatOptions)
                         });
                     }
@@ -1166,7 +1166,7 @@ namespace ts.server {
             return edits.map((edit) => {
                 return {
                     start: scriptInfo.positionToLineOffset(edit.span.start),
-                    end: scriptInfo.positionToLineOffset(ts.textSpanEnd(edit.span)),
+                    end: scriptInfo.positionToLineOffset(textSpanEnd(edit.span)),
                     newText: edit.newText ? edit.newText : ""
                 };
             });
@@ -1190,7 +1190,7 @@ namespace ts.server {
                         const convertedSpan = replacementSpan ? this.decorateSpan(replacementSpan, scriptInfo) : undefined;
                         return { name, kind, kindModifiers, sortText, replacementSpan: convertedSpan };
                     }
-                }).sort((a, b) => ts.compareStrings(a.name, b.name));
+                }).sort((a, b) => compareStrings(a.name, b.name));
             }
             else {
                 return completions;
@@ -1317,11 +1317,11 @@ namespace ts.server {
             if (!fileName) {
                 return;
             }
-            const file = ts.normalizePath(fileName);
+            const file = normalizePath(fileName);
             this.projectService.closeClientFile(file);
         }
 
-        private decorateNavigationBarItems(items: ts.NavigationBarItem[], scriptInfo: ScriptInfo): protocol.NavigationBarItem[] {
+        private decorateNavigationBarItems(items: NavigationBarItem[], scriptInfo: ScriptInfo): protocol.NavigationBarItem[] {
             return map(items, item => ({
                 text: item.text,
                 kind: item.kind,
@@ -1342,7 +1342,7 @@ namespace ts.server {
                     : items;
         }
 
-        private decorateNavigationTree(tree: ts.NavigationTree, scriptInfo: ScriptInfo): protocol.NavigationTree {
+        private decorateNavigationTree(tree: NavigationTree, scriptInfo: ScriptInfo): protocol.NavigationTree {
             return {
                 text: tree.text,
                 kind: tree.kind,
@@ -1355,7 +1355,7 @@ namespace ts.server {
         private decorateSpan(span: TextSpan, scriptInfo: ScriptInfo): protocol.TextSpan {
             return {
                 start: scriptInfo.positionToLineOffset(span.start),
-                end: scriptInfo.positionToLineOffset(ts.textSpanEnd(span))
+                end: scriptInfo.positionToLineOffset(textSpanEnd(span))
             };
         }
 
@@ -1385,7 +1385,7 @@ namespace ts.server {
                         return navItems.map((navItem) => {
                             const scriptInfo = project.getScriptInfo(navItem.fileName);
                             const start = scriptInfo.positionToLineOffset(navItem.textSpan.start);
-                            const end = scriptInfo.positionToLineOffset(ts.textSpanEnd(navItem.textSpan));
+                            const end = scriptInfo.positionToLineOffset(textSpanEnd(navItem.textSpan));
                             const bakedItem: protocol.NavtoItem = {
                                 name: navItem.name,
                                 kind: navItem.kind,
@@ -1450,7 +1450,7 @@ namespace ts.server {
         }
 
         private getSupportedCodeFixes(): string[] {
-            return ts.getSupportedCodeFixes();
+            return getSupportedCodeFixes();
         }
 
         private isLocation(locationOrSpan: protocol.FileLocationOrRangeRequestArgs): locationOrSpan is protocol.FileLocationRequestArgs {
@@ -1481,7 +1481,7 @@ namespace ts.server {
             return project.getLanguageService().getApplicableRefactors(file, position || textRange);
         }
 
-        private getEditsForRefactor(args: protocol.GetEditsForRefactorRequestArgs, simplifiedResult: boolean): ts.RefactorEditInfo | protocol.RefactorEditInfo {
+        private getEditsForRefactor(args: protocol.GetEditsForRefactorRequestArgs, simplifiedResult: boolean): RefactorEditInfo | protocol.RefactorEditInfo {
             const { file, project } = this.getFileAndProjectWithoutRefreshingInferredProjects(args);
             const scriptInfo = project.getScriptInfoForNormalizedPath(file);
             const { position, textRange } = this.extractPositionAndRange(args, scriptInfo);
@@ -1650,7 +1650,7 @@ namespace ts.server {
 
         getCanonicalFileName(fileName: string) {
             const name = this.host.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
-            return ts.normalizePath(name);
+            return normalizePath(name);
         }
 
         exit() {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -31,9 +31,9 @@ declare namespace ts.server {
 
     export interface DiscoverTypings extends TypingInstallerRequest {
         readonly fileNames: string[];
-        readonly projectRootPath: ts.Path;
-        readonly compilerOptions: ts.CompilerOptions;
-        readonly typeAcquisition: ts.TypeAcquisition;
+        readonly projectRootPath: Path;
+        readonly compilerOptions: CompilerOptions;
+        readonly typeAcquisition: TypeAcquisition;
         readonly unresolvedImports: SortedReadonlyArray<string>;
         readonly cachePath?: string;
         readonly kind: "discover";
@@ -63,8 +63,8 @@ declare namespace ts.server {
     }
 
     export interface SetTypings extends ProjectResponse {
-        readonly typeAcquisition: ts.TypeAcquisition;
-        readonly compilerOptions: ts.CompilerOptions;
+        readonly typeAcquisition: TypeAcquisition;
+        readonly compilerOptions: CompilerOptions;
         readonly typings: string[];
         readonly unresolvedImports: SortedReadonlyArray<string>;
         readonly kind: ActionSet;

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -77,7 +77,7 @@ namespace ts.server {
             tabSize: 4,
             newLineCharacter: host.newLine || "\n",
             convertTabsToSpaces: true,
-            indentStyle: ts.IndentStyle.Smart,
+            indentStyle: IndentStyle.Smart,
             insertSpaceAfterConstructor: false,
             insertSpaceAfterCommaDelimiter: true,
             insertSpaceAfterSemicolonInForStatements: true,
@@ -196,7 +196,7 @@ namespace ts.server {
     }
 
     export function enumerateInsertsAndDeletes<T>(a: SortedReadonlyArray<T>, b: SortedReadonlyArray<T>, inserted: (item: T) => void, deleted: (item: T) => void, compare?: (a: T, b: T) => Comparison) {
-        compare = compare || ts.compareValues;
+        compare = compare || compareValues;
         let aIndex = 0;
         let bIndex = 0;
         const aLen = a.length;


### PR DESCRIPTION
I often write `ts.` just so that I can get autocompletion, but it's unnecessary to have the qualifier when already in the `ts` namespace.
