### PR TITLE
simplify isFileSystemCaseSensitive test

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -196,9 +196,16 @@ namespace ts {
                 if (platform === "win32" || platform === "win64") {
                     return false;
                 }
-                // convert current file name to upper case / lower case and check if file exists
-                // (guards against cases when name is already all uppercase or lowercase)
-                return !fileExists(__filename.toUpperCase()) || !fileExists(__filename.toLowerCase());
+                // If this file exists under a different case, we must be case-insensitve.
+                return !fileExists(swapCase(__filename));
+            }
+
+            /** Convert all lowercase chars to uppercase, and vice-versa */
+            function swapCase(s: string): string {
+                return s.replace(/\w/g, (ch) => {
+                    const up = ch.toUpperCase();
+                    return ch === up ? ch.toLowerCase() : up;
+                });
             }
 
             const platform: string = _os.platform();


### PR DESCRIPTION
Only need to call `fileExists` once, if we ensure that case is changed.