### PR TITLE
Simplify parameters to updateProjectStructure and updateErrorCheck

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -343,7 +343,7 @@ namespace ts.server {
                 case ContextEvent:
                     const { project, fileName } = event.data;
                     this.projectService.logger.info(`got context event, updating diagnostics for ${fileName}`);
-                    this.errorCheck.startNew(next => this.updateErrorCheck(next, [{ fileName, project }], this.changeSeq, (n) => n === this.changeSeq, 100));
+                    this.errorCheck.startNew(next => this.updateErrorCheck(next, [{ fileName, project }], 100));
                     break;
                 case ConfigFileDiagEvent:
                     const { triggerFile, configFileName, diagnostics } = event.data;
@@ -459,22 +459,23 @@ namespace ts.server {
             }
         }
 
-        private updateProjectStructure(seq: number, matchSeq: (seq: number) => boolean, ms = 1500) {
+        private updateProjectStructure() {
+            const ms = 1500;
+            const seq = this.changeSeq;
             this.host.setTimeout(() => {
-                if (matchSeq(seq)) {
+                if (this.changeSeq === seq) {
                     this.projectService.refreshInferredProjects();
                 }
             }, ms);
         }
 
-        private updateErrorCheck(next: NextStep, checkList: PendingErrorCheck[], seq: number, matchSeq: (seq: number) => boolean, ms = 1500, followMs = 200, requireOpen = true) {
-            if (followMs > ms) {
-                followMs = ms;
-            }
+        private updateErrorCheck(next: NextStep, checkList: PendingErrorCheck[], ms: number, requireOpen = true) {
+            const seq = this.changeSeq;
+            const followMs = Math.min(ms, 200);
 
             let index = 0;
             const checkOne = () => {
-                if (matchSeq(seq)) {
+                if (this.changeSeq === seq) {
                     const checkSpec = checkList[index];
                     index++;
                     if (checkSpec.project.containsFile(checkSpec.fileName, requireOpen)) {
@@ -489,7 +490,7 @@ namespace ts.server {
                 }
             };
 
-            if ((checkList.length > index) && (matchSeq(seq))) {
+            if (checkList.length > index && this.changeSeq === seq) {
                 next.delay(ms, checkOne);
             }
         }
@@ -1268,14 +1269,14 @@ namespace ts.server {
         }
 
         private getDiagnostics(next: NextStep, delay: number, fileNames: string[]): void {
-            const checkList = mapDefined(fileNames, uncheckedFileName => {
+            const checkList = mapDefined<string, PendingErrorCheck>(fileNames, uncheckedFileName => {
                 const fileName = toNormalizedPath(uncheckedFileName);
                 const project = this.projectService.getDefaultProjectForFile(fileName, /*refreshInferredProjects*/ true);
                 return project && { fileName, project };
             });
 
             if (checkList.length > 0) {
-                this.updateErrorCheck(next, checkList, this.changeSeq, (n) => n === this.changeSeq, delay);
+                this.updateErrorCheck(next, checkList, delay);
             }
         }
 
@@ -1289,7 +1290,7 @@ namespace ts.server {
                     scriptInfo.editContent(start, end, args.insertString);
                     this.changeSeq++;
                 }
-                this.updateProjectStructure(this.changeSeq, n => n === this.changeSeq);
+                this.updateProjectStructure();
             }
         }
 
@@ -1644,7 +1645,7 @@ namespace ts.server {
                 const checkList = fileNamesInProject.map(fileName => ({ fileName, project }));
                 // Project level error analysis runs on background files too, therefore
                 // doesn't require the file to be opened
-                this.updateErrorCheck(next, checkList, this.changeSeq, (n) => n === this.changeSeq, delay, 200, /*requireOpen*/ false);
+                this.updateErrorCheck(next, checkList, delay, /*requireOpen*/ false);
             }
         }
 


### PR DESCRIPTION
Every call to these methods had the same parameters -- so we can just handle that inside the method and take fewer parameters.