### PR TITLE
Fix #17023

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2061,8 +2061,10 @@ namespace ts {
                 case SyntaxKind.Parameter:
                     return bindParameter(<ParameterDeclaration>node);
                 case SyntaxKind.VariableDeclaration:
+                    return bindVariableDeclarationOrBindingElement(<VariableDeclaration>node);
                 case SyntaxKind.BindingElement:
-                    return bindVariableDeclarationOrBindingElement(<VariableDeclaration | BindingElement>node);
+                    node.flowNode = currentFlow;
+                    return bindVariableDeclarationOrBindingElement(<BindingElement>node);
                 case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.PropertySignature:
                     return bindPropertyWorker(node as PropertyDeclaration | PropertySignature);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10670,7 +10670,7 @@ namespace ts {
                 return key && key + "." + (<PropertyAccessExpression>node).name.text;
             }
             if (node.kind === SyntaxKind.BindingElement) {
-                const key = node.parent.parent.kind === SyntaxKind.BindingElement ? getFlowCacheKey(node.parent.parent) : isApparentTypePosition(node.parent.parent) ? "@<initializer>" : "<initializer>";
+                const key = node.parent.parent.kind === SyntaxKind.VariableDeclaration ? getFlowCacheKey((node.parent.parent as VariableDeclaration).initializer) : getFlowCacheKey(node.parent.parent);
                 const text = getBindingElementNameText(node as BindingElement);
                 return key && text && key + "." + text;
             }
@@ -10691,11 +10691,11 @@ namespace ts {
         function getBindingElementNameText(element: BindingElement): string | undefined {
             if (element.parent.kind === SyntaxKind.ObjectBindingPattern) {
                 const name = element.propertyName || element.name;
-                if (isComputedNonLiteralName(name as PropertyName)) return undefined;
                 switch (name.kind) {
                     case SyntaxKind.Identifier:
                         return unescapeLeadingUnderscores(name.text);
                     case SyntaxKind.ComputedPropertyName:
+                        if (isComputedNonLiteralName(name as PropertyName)) return undefined;
                         return (name.expression as LiteralExpression).text;
                     case SyntaxKind.StringLiteral:
                     case SyntaxKind.NumericLiteral:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10727,7 +10727,14 @@ namespace ts {
                 case SyntaxKind.BindingElement:
                     if (target.kind !== SyntaxKind.PropertyAccessExpression) return false;
                     const t = target as PropertyAccessExpression;
-                    return t.name.text === getBindingElementNameText(source as BindingElement) && source.parent.parent.kind === SyntaxKind.BindingElement ? isMatchingReference(source.parent.parent, t.expression) : true;
+                    if (t.name.text !== getBindingElementNameText(source as BindingElement)) return false;
+                    if (source.parent.parent.kind === SyntaxKind.BindingElement && isMatchingReference(source.parent.parent, t.expression)) {
+                            return true;
+                    }
+                    if (source.parent.parent.kind === SyntaxKind.VariableDeclaration) {
+                        const maybeId = (source.parent.parent as VariableDeclaration).initializer;
+                        return maybeId && isMatchingReference(maybeId, t.expression);
+                    }
             }
             return false;
         }

--- a/tests/baselines/reference/destructuringTypeGuardFlow.js
+++ b/tests/baselines/reference/destructuringTypeGuardFlow.js
@@ -19,11 +19,37 @@ if (aFoo.bar && aFoo.nested.b) {
   const bAgain: string = text;
 }
 
+type bar = {
+  elem1: number | null;
+  elem2: foo | null;
+};
+
+const bBar = { elem1: 7, elem2: aFoo };
+
+if (bBar.elem2 && bBar.elem2.bar && bBar.elem2.nested.b) {
+  const { bar, baz, nested: {a, b: text} } = bBar.elem2;
+  const right: number = bBar.elem2.bar;
+  const wrong: number = bar;
+  const another: string = baz;
+  const aAgain: number = a;
+  const bAgain: string = text;
+}
+
+
 //// [destructuringTypeGuardFlow.js]
 var aFoo = { bar: 3, baz: "b", nested: { a: 1, b: "y" } };
 if (aFoo.bar && aFoo.nested.b) {
     var bar = aFoo.bar, baz = aFoo.baz, _a = aFoo.nested, a = _a.a, text = _a.b;
     var right = aFoo.bar;
+    var wrong = bar;
+    var another = baz;
+    var aAgain = a;
+    var bAgain = text;
+}
+var bBar = { elem1: 7, elem2: aFoo };
+if (bBar.elem2 && bBar.elem2.bar && bBar.elem2.nested.b) {
+    var _b = bBar.elem2, bar = _b.bar, baz = _b.baz, _c = _b.nested, a = _c.a, text = _c.b;
+    var right = bBar.elem2.bar;
     var wrong = bar;
     var another = baz;
     var aAgain = a;

--- a/tests/baselines/reference/destructuringTypeGuardFlow.js
+++ b/tests/baselines/reference/destructuringTypeGuardFlow.js
@@ -1,0 +1,31 @@
+//// [destructuringTypeGuardFlow.ts]
+type foo = {
+  bar: number | null;
+  baz: string;
+  nested: {
+    a: number;
+    b: string | null;
+  }
+};
+
+const aFoo: foo = { bar: 3, baz: "b", nested: { a: 1, b: "y" } };
+
+if (aFoo.bar && aFoo.nested.b) {
+  const { bar, baz, nested: {a, b: text} } = aFoo;
+  const right: number = aFoo.bar;
+  const wrong: number = bar;
+  const another: string = baz;
+  const aAgain: number = a;
+  const bAgain: string = text;
+}
+
+//// [destructuringTypeGuardFlow.js]
+var aFoo = { bar: 3, baz: "b", nested: { a: 1, b: "y" } };
+if (aFoo.bar && aFoo.nested.b) {
+    var bar = aFoo.bar, baz = aFoo.baz, _a = aFoo.nested, a = _a.a, text = _a.b;
+    var right = aFoo.bar;
+    var wrong = bar;
+    var another = baz;
+    var aAgain = a;
+    var bAgain = text;
+}

--- a/tests/baselines/reference/destructuringTypeGuardFlow.symbols
+++ b/tests/baselines/reference/destructuringTypeGuardFlow.symbols
@@ -69,3 +69,75 @@ if (aFoo.bar && aFoo.nested.b) {
 >bAgain : Symbol(bAgain, Decl(destructuringTypeGuardFlow.ts, 17, 7))
 >text : Symbol(text, Decl(destructuringTypeGuardFlow.ts, 12, 31))
 }
+
+type bar = {
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 18, 1))
+
+  elem1: number | null;
+>elem1 : Symbol(elem1, Decl(destructuringTypeGuardFlow.ts, 20, 12))
+
+  elem2: foo | null;
+>elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 21, 23))
+>foo : Symbol(foo, Decl(destructuringTypeGuardFlow.ts, 0, 0))
+
+};
+
+const bBar = { elem1: 7, elem2: aFoo };
+>bBar : Symbol(bBar, Decl(destructuringTypeGuardFlow.ts, 25, 5))
+>elem1 : Symbol(elem1, Decl(destructuringTypeGuardFlow.ts, 25, 14))
+>elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>aFoo : Symbol(aFoo, Decl(destructuringTypeGuardFlow.ts, 9, 5))
+
+if (bBar.elem2 && bBar.elem2.bar && bBar.elem2.nested.b) {
+>bBar.elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>bBar : Symbol(bBar, Decl(destructuringTypeGuardFlow.ts, 25, 5))
+>elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>bBar.elem2.bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+>bBar.elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>bBar : Symbol(bBar, Decl(destructuringTypeGuardFlow.ts, 25, 5))
+>elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+>bBar.elem2.nested.b : Symbol(b, Decl(destructuringTypeGuardFlow.ts, 4, 14))
+>bBar.elem2.nested : Symbol(nested, Decl(destructuringTypeGuardFlow.ts, 2, 14))
+>bBar.elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>bBar : Symbol(bBar, Decl(destructuringTypeGuardFlow.ts, 25, 5))
+>elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>nested : Symbol(nested, Decl(destructuringTypeGuardFlow.ts, 2, 14))
+>b : Symbol(b, Decl(destructuringTypeGuardFlow.ts, 4, 14))
+
+  const { bar, baz, nested: {a, b: text} } = bBar.elem2;
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 28, 9))
+>baz : Symbol(baz, Decl(destructuringTypeGuardFlow.ts, 28, 14))
+>nested : Symbol(nested, Decl(destructuringTypeGuardFlow.ts, 2, 14))
+>a : Symbol(a, Decl(destructuringTypeGuardFlow.ts, 28, 29))
+>b : Symbol(b, Decl(destructuringTypeGuardFlow.ts, 4, 14))
+>text : Symbol(text, Decl(destructuringTypeGuardFlow.ts, 28, 31))
+>bBar.elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>bBar : Symbol(bBar, Decl(destructuringTypeGuardFlow.ts, 25, 5))
+>elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+
+  const right: number = bBar.elem2.bar;
+>right : Symbol(right, Decl(destructuringTypeGuardFlow.ts, 29, 7))
+>bBar.elem2.bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+>bBar.elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>bBar : Symbol(bBar, Decl(destructuringTypeGuardFlow.ts, 25, 5))
+>elem2 : Symbol(elem2, Decl(destructuringTypeGuardFlow.ts, 25, 24))
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+
+  const wrong: number = bar;
+>wrong : Symbol(wrong, Decl(destructuringTypeGuardFlow.ts, 30, 7))
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 28, 9))
+
+  const another: string = baz;
+>another : Symbol(another, Decl(destructuringTypeGuardFlow.ts, 31, 7))
+>baz : Symbol(baz, Decl(destructuringTypeGuardFlow.ts, 28, 14))
+
+  const aAgain: number = a;
+>aAgain : Symbol(aAgain, Decl(destructuringTypeGuardFlow.ts, 32, 7))
+>a : Symbol(a, Decl(destructuringTypeGuardFlow.ts, 28, 29))
+
+  const bAgain: string = text;
+>bAgain : Symbol(bAgain, Decl(destructuringTypeGuardFlow.ts, 33, 7))
+>text : Symbol(text, Decl(destructuringTypeGuardFlow.ts, 28, 31))
+}
+

--- a/tests/baselines/reference/destructuringTypeGuardFlow.symbols
+++ b/tests/baselines/reference/destructuringTypeGuardFlow.symbols
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/destructuringTypeGuardFlow.ts ===
+type foo = {
+>foo : Symbol(foo, Decl(destructuringTypeGuardFlow.ts, 0, 0))
+
+  bar: number | null;
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+
+  baz: string;
+>baz : Symbol(baz, Decl(destructuringTypeGuardFlow.ts, 1, 21))
+
+  nested: {
+>nested : Symbol(nested, Decl(destructuringTypeGuardFlow.ts, 2, 14))
+
+    a: number;
+>a : Symbol(a, Decl(destructuringTypeGuardFlow.ts, 3, 11))
+
+    b: string | null;
+>b : Symbol(b, Decl(destructuringTypeGuardFlow.ts, 4, 14))
+  }
+};
+
+const aFoo: foo = { bar: 3, baz: "b", nested: { a: 1, b: "y" } };
+>aFoo : Symbol(aFoo, Decl(destructuringTypeGuardFlow.ts, 9, 5))
+>foo : Symbol(foo, Decl(destructuringTypeGuardFlow.ts, 0, 0))
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 9, 19))
+>baz : Symbol(baz, Decl(destructuringTypeGuardFlow.ts, 9, 27))
+>nested : Symbol(nested, Decl(destructuringTypeGuardFlow.ts, 9, 37))
+>a : Symbol(a, Decl(destructuringTypeGuardFlow.ts, 9, 47))
+>b : Symbol(b, Decl(destructuringTypeGuardFlow.ts, 9, 53))
+
+if (aFoo.bar && aFoo.nested.b) {
+>aFoo.bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+>aFoo : Symbol(aFoo, Decl(destructuringTypeGuardFlow.ts, 9, 5))
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+>aFoo.nested.b : Symbol(b, Decl(destructuringTypeGuardFlow.ts, 4, 14))
+>aFoo.nested : Symbol(nested, Decl(destructuringTypeGuardFlow.ts, 2, 14))
+>aFoo : Symbol(aFoo, Decl(destructuringTypeGuardFlow.ts, 9, 5))
+>nested : Symbol(nested, Decl(destructuringTypeGuardFlow.ts, 2, 14))
+>b : Symbol(b, Decl(destructuringTypeGuardFlow.ts, 4, 14))
+
+  const { bar, baz, nested: {a, b: text} } = aFoo;
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 12, 9))
+>baz : Symbol(baz, Decl(destructuringTypeGuardFlow.ts, 12, 14))
+>nested : Symbol(nested, Decl(destructuringTypeGuardFlow.ts, 2, 14))
+>a : Symbol(a, Decl(destructuringTypeGuardFlow.ts, 12, 29))
+>b : Symbol(b, Decl(destructuringTypeGuardFlow.ts, 4, 14))
+>text : Symbol(text, Decl(destructuringTypeGuardFlow.ts, 12, 31))
+>aFoo : Symbol(aFoo, Decl(destructuringTypeGuardFlow.ts, 9, 5))
+
+  const right: number = aFoo.bar;
+>right : Symbol(right, Decl(destructuringTypeGuardFlow.ts, 13, 7))
+>aFoo.bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+>aFoo : Symbol(aFoo, Decl(destructuringTypeGuardFlow.ts, 9, 5))
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 0, 12))
+
+  const wrong: number = bar;
+>wrong : Symbol(wrong, Decl(destructuringTypeGuardFlow.ts, 14, 7))
+>bar : Symbol(bar, Decl(destructuringTypeGuardFlow.ts, 12, 9))
+
+  const another: string = baz;
+>another : Symbol(another, Decl(destructuringTypeGuardFlow.ts, 15, 7))
+>baz : Symbol(baz, Decl(destructuringTypeGuardFlow.ts, 12, 14))
+
+  const aAgain: number = a;
+>aAgain : Symbol(aAgain, Decl(destructuringTypeGuardFlow.ts, 16, 7))
+>a : Symbol(a, Decl(destructuringTypeGuardFlow.ts, 12, 29))
+
+  const bAgain: string = text;
+>bAgain : Symbol(bAgain, Decl(destructuringTypeGuardFlow.ts, 17, 7))
+>text : Symbol(text, Decl(destructuringTypeGuardFlow.ts, 12, 31))
+}

--- a/tests/baselines/reference/destructuringTypeGuardFlow.types
+++ b/tests/baselines/reference/destructuringTypeGuardFlow.types
@@ -78,3 +78,81 @@ if (aFoo.bar && aFoo.nested.b) {
 >bAgain : string
 >text : string
 }
+
+type bar = {
+>bar : bar
+
+  elem1: number | null;
+>elem1 : number | null
+>null : null
+
+  elem2: foo | null;
+>elem2 : foo | null
+>foo : foo
+>null : null
+
+};
+
+const bBar = { elem1: 7, elem2: aFoo };
+>bBar : { elem1: number; elem2: foo; }
+>{ elem1: 7, elem2: aFoo } : { elem1: number; elem2: foo; }
+>elem1 : number
+>7 : 7
+>elem2 : foo
+>aFoo : foo
+
+if (bBar.elem2 && bBar.elem2.bar && bBar.elem2.nested.b) {
+>bBar.elem2 && bBar.elem2.bar && bBar.elem2.nested.b : string | 0 | null
+>bBar.elem2 && bBar.elem2.bar : number | null
+>bBar.elem2 : foo
+>bBar : { elem1: number; elem2: foo; }
+>elem2 : foo
+>bBar.elem2.bar : number | null
+>bBar.elem2 : foo
+>bBar : { elem1: number; elem2: foo; }
+>elem2 : foo
+>bar : number | null
+>bBar.elem2.nested.b : string | null
+>bBar.elem2.nested : { a: number; b: string | null; }
+>bBar.elem2 : foo
+>bBar : { elem1: number; elem2: foo; }
+>elem2 : foo
+>nested : { a: number; b: string | null; }
+>b : string | null
+
+  const { bar, baz, nested: {a, b: text} } = bBar.elem2;
+>bar : number
+>baz : string
+>nested : any
+>a : number
+>b : any
+>text : string
+>bBar.elem2 : foo
+>bBar : { elem1: number; elem2: foo; }
+>elem2 : foo
+
+  const right: number = bBar.elem2.bar;
+>right : number
+>bBar.elem2.bar : number
+>bBar.elem2 : foo
+>bBar : { elem1: number; elem2: foo; }
+>elem2 : foo
+>bar : number
+
+  const wrong: number = bar;
+>wrong : number
+>bar : number
+
+  const another: string = baz;
+>another : string
+>baz : string
+
+  const aAgain: number = a;
+>aAgain : number
+>a : number
+
+  const bAgain: string = text;
+>bAgain : string
+>text : string
+}
+

--- a/tests/baselines/reference/destructuringTypeGuardFlow.types
+++ b/tests/baselines/reference/destructuringTypeGuardFlow.types
@@ -1,0 +1,80 @@
+=== tests/cases/compiler/destructuringTypeGuardFlow.ts ===
+type foo = {
+>foo : foo
+
+  bar: number | null;
+>bar : number | null
+>null : null
+
+  baz: string;
+>baz : string
+
+  nested: {
+>nested : { a: number; b: string | null; }
+
+    a: number;
+>a : number
+
+    b: string | null;
+>b : string | null
+>null : null
+  }
+};
+
+const aFoo: foo = { bar: 3, baz: "b", nested: { a: 1, b: "y" } };
+>aFoo : foo
+>foo : foo
+>{ bar: 3, baz: "b", nested: { a: 1, b: "y" } } : { bar: number; baz: string; nested: { a: number; b: string; }; }
+>bar : number
+>3 : 3
+>baz : string
+>"b" : "b"
+>nested : { a: number; b: string; }
+>{ a: 1, b: "y" } : { a: number; b: string; }
+>a : number
+>1 : 1
+>b : string
+>"y" : "y"
+
+if (aFoo.bar && aFoo.nested.b) {
+>aFoo.bar && aFoo.nested.b : string | 0 | null
+>aFoo.bar : number | null
+>aFoo : foo
+>bar : number | null
+>aFoo.nested.b : string | null
+>aFoo.nested : { a: number; b: string | null; }
+>aFoo : foo
+>nested : { a: number; b: string | null; }
+>b : string | null
+
+  const { bar, baz, nested: {a, b: text} } = aFoo;
+>bar : number
+>baz : string
+>nested : any
+>a : number
+>b : any
+>text : string
+>aFoo : foo
+
+  const right: number = aFoo.bar;
+>right : number
+>aFoo.bar : number
+>aFoo : foo
+>bar : number
+
+  const wrong: number = bar;
+>wrong : number
+>bar : number
+
+  const another: string = baz;
+>another : string
+>baz : string
+
+  const aAgain: number = a;
+>aAgain : number
+>a : number
+
+  const bAgain: string = text;
+>bAgain : string
+>text : string
+}

--- a/tests/baselines/reference/sourceMapValidationDestructuringForOfObjectBindingPattern.symbols
+++ b/tests/baselines/reference/sourceMapValidationDestructuringForOfObjectBindingPattern.symbols
@@ -136,9 +136,9 @@ for (let { skills: { primary: primaryA, secondary: secondaryA } } of getMultiRob
 }
 for (let { skills: { primary: primaryA, secondary: secondaryA } } of [{ name: "mower", skills: { primary: "mowing", secondary: "none" } },
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 86))
->primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 10, 13))
+>primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 96))
 >primaryA : Symbol(primaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 20))
->secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 11, 24))
+>secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 115))
 >secondaryA : Symbol(secondaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 39))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 71))
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 86))
@@ -236,9 +236,9 @@ for (let {name: nameA, skills: { primary: primaryA, secondary: secondaryA } } of
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 83))
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 10))
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 98))
->primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 10, 13))
+>primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 108))
 >primaryA : Symbol(primaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 32))
->secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 11, 24))
+>secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 127))
 >secondaryA : Symbol(secondaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 51))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 83))
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 98))

--- a/tests/baselines/reference/sourceMapValidationDestructuringForOfObjectBindingPattern.symbols
+++ b/tests/baselines/reference/sourceMapValidationDestructuringForOfObjectBindingPattern.symbols
@@ -136,9 +136,9 @@ for (let { skills: { primary: primaryA, secondary: secondaryA } } of getMultiRob
 }
 for (let { skills: { primary: primaryA, secondary: secondaryA } } of [{ name: "mower", skills: { primary: "mowing", secondary: "none" } },
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 86))
->primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 96))
+>primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 10, 13))
 >primaryA : Symbol(primaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 20))
->secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 115))
+>secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 11, 24))
 >secondaryA : Symbol(secondaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 39))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 71))
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 86))
@@ -236,9 +236,9 @@ for (let {name: nameA, skills: { primary: primaryA, secondary: secondaryA } } of
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 83))
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 10))
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 98))
->primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 108))
+>primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 10, 13))
 >primaryA : Symbol(primaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 32))
->secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 127))
+>secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 11, 24))
 >secondaryA : Symbol(secondaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 51))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 83))
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 98))

--- a/tests/cases/compiler/destructuringTypeGuardFlow.ts
+++ b/tests/cases/compiler/destructuringTypeGuardFlow.ts
@@ -18,3 +18,19 @@ if (aFoo.bar && aFoo.nested.b) {
   const aAgain: number = a;
   const bAgain: string = text;
 }
+
+type bar = {
+  elem1: number | null;
+  elem2: foo | null;
+};
+
+const bBar = { elem1: 7, elem2: aFoo };
+
+if (bBar.elem2 && bBar.elem2.bar && bBar.elem2.nested.b) {
+  const { bar, baz, nested: {a, b: text} } = bBar.elem2;
+  const right: number = bBar.elem2.bar;
+  const wrong: number = bar;
+  const another: string = baz;
+  const aAgain: number = a;
+  const bAgain: string = text;
+}

--- a/tests/cases/compiler/destructuringTypeGuardFlow.ts
+++ b/tests/cases/compiler/destructuringTypeGuardFlow.ts
@@ -1,0 +1,20 @@
+// @strictNullChecks: true
+type foo = {
+  bar: number | null;
+  baz: string;
+  nested: {
+    a: number;
+    b: string | null;
+  }
+};
+
+const aFoo: foo = { bar: 3, baz: "b", nested: { a: 1, b: "y" } };
+
+if (aFoo.bar && aFoo.nested.b) {
+  const { bar, baz, nested: {a, b: text} } = aFoo;
+  const right: number = aFoo.bar;
+  const wrong: number = bar;
+  const another: string = baz;
+  const aAgain: number = a;
+  const bAgain: string = text;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #17023 - binding patterns correctly have their initial type bound to the narrowed type of the narrowed property indicated by the binding pattern. Previously, we were not getting their flow type when looking for their initial type (and the flow logic wasn't setup to look for references equivalent to a nested binding element).
