### PR TITLE
scriptVersionCache: Export less

### DIFF
--- a/src/harness/unittests/versionCache.ts
+++ b/src/harness/unittests/versionCache.ts
@@ -6,11 +6,11 @@ namespace ts {
         return source.substring(0, position) + newText + source.substring(position + deletedLength, source.length);
     }
 
-    function lineColToPosition(lineIndex: server.LineIndexForTest, line: number, col: number) {
+    function lineColToPosition(lineIndex: server.LineIndex, line: number, col: number) {
         return lineIndex.absolutePositionOfStartOfLine(line) + (col - 1);
     }
 
-    function validateEdit(lineIndex: server.LineIndexForTest, sourceText: string, position: number, deleteLength: number, insertString: string): void {
+    function validateEdit(lineIndex: server.LineIndex, sourceText: string, position: number, deleteLength: number, insertString: string): void {
         const checkText = editFlat(position, deleteLength, insertString, sourceText);
         const snapshot = lineIndex.edit(position, deleteLength, insertString);
         const editedText = snapshot.getText(0, snapshot.getLength());
@@ -33,10 +33,10 @@ k=y;
 var p:Point=new Point();
 var q:Point=<Point>p;`;
 
-            const { lines } = server.LineIndexForTest.linesFromText(testContent);
+            const { lines } = server.LineIndex.linesFromText(testContent);
             assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
-            const lineIndex = new server.LineIndexForTest();
+            const lineIndex = new server.LineIndex();
             lineIndex.load(lines);
 
             validateEditAtLineCharIndex = (line: number, char: number, deleteLength: number, insertString: string) => {
@@ -87,10 +87,10 @@ that ate the grass
 that was purple at the tips
 and grew 1cm per day`;
 
-            ({ lines, lineMap } = server.LineIndexForTest.linesFromText(testContent));
+            ({ lines, lineMap } = server.LineIndex.linesFromText(testContent));
             assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
-            const lineIndex = new server.LineIndexForTest();
+            const lineIndex = new server.LineIndex();
             lineIndex.load(lines);
 
             validateEditAtPosition = (position: number, deleteLength: number, insertString: string) => {
@@ -189,7 +189,7 @@ and grew 1cm per day`;
         // const iterationCount = 20000; // uncomment for testing
         let lines: string[];
         let lineMap: number[];
-        let lineIndex: server.LineIndexForTest;
+        let lineIndex: server.LineIndex;
         let testContent: string;
 
         before(() => {
@@ -199,10 +199,10 @@ and grew 1cm per day`;
             const totalChars = testContent.length;
             assert.isTrue(totalChars > 0, "Failed to read test file.");
 
-            ({ lines, lineMap } = server.LineIndexForTest.linesFromText(testContent));
+            ({ lines, lineMap } = server.LineIndex.linesFromText(testContent));
             assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
-            lineIndex = new server.LineIndexForTest();
+            lineIndex = new server.LineIndex();
             lineIndex.load(lines);
 
             let etotalChars = totalChars;

--- a/src/harness/unittests/versionCache.ts
+++ b/src/harness/unittests/versionCache.ts
@@ -6,11 +6,11 @@ namespace ts {
         return source.substring(0, position) + newText + source.substring(position + deletedLength, source.length);
     }
 
-    function lineColToPosition(lineIndex: server.LineIndex, line: number, col: number) {
+    function lineColToPosition(lineIndex: server.LineIndexForTest, line: number, col: number) {
         return lineIndex.absolutePositionOfStartOfLine(line) + (col - 1);
     }
 
-    function validateEdit(lineIndex: server.LineIndex, sourceText: string, position: number, deleteLength: number, insertString: string): void {
+    function validateEdit(lineIndex: server.LineIndexForTest, sourceText: string, position: number, deleteLength: number, insertString: string): void {
         const checkText = editFlat(position, deleteLength, insertString, sourceText);
         const snapshot = lineIndex.edit(position, deleteLength, insertString);
         const editedText = snapshot.getText(0, snapshot.getLength());
@@ -33,10 +33,10 @@ k=y;
 var p:Point=new Point();
 var q:Point=<Point>p;`;
 
-            const { lines } = server.LineIndex.linesFromText(testContent);
+            const { lines } = server.LineIndexForTest.linesFromText(testContent);
             assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
-            const lineIndex = new server.LineIndex();
+            const lineIndex = new server.LineIndexForTest();
             lineIndex.load(lines);
 
             validateEditAtLineCharIndex = (line: number, char: number, deleteLength: number, insertString: string) => {
@@ -87,10 +87,10 @@ that ate the grass
 that was purple at the tips
 and grew 1cm per day`;
 
-            ({ lines, lineMap } = server.LineIndex.linesFromText(testContent));
+            ({ lines, lineMap } = server.LineIndexForTest.linesFromText(testContent));
             assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
-            const lineIndex = new server.LineIndex();
+            const lineIndex = new server.LineIndexForTest();
             lineIndex.load(lines);
 
             validateEditAtPosition = (position: number, deleteLength: number, insertString: string) => {
@@ -189,7 +189,7 @@ and grew 1cm per day`;
         // const iterationCount = 20000; // uncomment for testing
         let lines: string[];
         let lineMap: number[];
-        let lineIndex: server.LineIndex;
+        let lineIndex: server.LineIndexForTest;
         let testContent: string;
 
         before(() => {
@@ -199,10 +199,10 @@ and grew 1cm per day`;
             const totalChars = testContent.length;
             assert.isTrue(totalChars > 0, "Failed to read test file.");
 
-            ({ lines, lineMap } = server.LineIndex.linesFromText(testContent));
+            ({ lines, lineMap } = server.LineIndexForTest.linesFromText(testContent));
             assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
-            lineIndex = new server.LineIndex();
+            lineIndex = new server.LineIndexForTest();
             lineIndex.load(lines);
 
             let etotalChars = totalChars;

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -16,7 +16,7 @@ namespace ts.server {
 
         public getVersion() {
             return this.svc
-                ? `SVC-${this.svcVersion}-${this.svc.getSnapshot().version}`
+                ? `SVC-${this.svcVersion}-${this.svc.getSnapshotVersion()}`
                 : `Text-${this.textVersion}`;
         }
 
@@ -62,22 +62,19 @@ namespace ts.server {
         }
 
         public getLineInfo(line: number): AbsolutePositionAndLineText {
-            return this.switchToScriptVersionCache().getSnapshot().index.lineNumberToInfo(line);
+            return this.switchToScriptVersionCache().getLineInfo(line);
         }
         /**
          *  @param line 0 based index
          */
-        lineToTextSpan(line: number) {
+        lineToTextSpan(line: number): TextSpan {
             if (!this.svc) {
                 const lineMap = this.getLineMap();
                 const start = lineMap[line]; // -1 since line is 1-based
                 const end = line + 1 < lineMap.length ? lineMap[line + 1] : this.text.length;
                 return createTextSpanFromBounds(start, end);
             }
-            const index = this.svc.getSnapshot().index;
-            const { lineText, absolutePosition } = index.lineNumberToInfo(line + 1);
-            const len = lineText !== undefined ? lineText.length : index.absolutePositionOfStartOfLine(line + 2) - absolutePosition;
-            return createTextSpan(absolutePosition, len);
+            return this.svc.lineToTextSpan(line);
         }
 
         /**
@@ -90,7 +87,7 @@ namespace ts.server {
             }
 
             // TODO: assert this offset is actually on the line
-            return this.svc.getSnapshot().index.absolutePositionOfStartOfLine(line) + (offset - 1);
+            return this.svc.lineOffsetToPosition(line, offset);
         }
 
         positionToLineOffset(position: number): protocol.Location {
@@ -98,7 +95,7 @@ namespace ts.server {
                 const { line, character } = computeLineAndCharacterOfPosition(this.getLineMap(), position);
                 return { line: line + 1, offset: character + 1 };
             }
-            return this.svc.getSnapshot().index.positionToLineOffset(position);
+            return this.svc.positionToLineOffset(position);
         }
 
         private getFileText(tempFileName?: string) {

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -403,7 +403,7 @@ namespace ts.server {
         }
     }
 
-    class LineIndex implements LineIndexForTest {
+    export class LineIndex {
         root: LineNode;
         // set this to true to check each edit for accuracy
         checkEdits = false;
@@ -574,20 +574,6 @@ namespace ts.server {
             return { lines, lineMap };
         }
     }
-
-    export interface LineIndexForTestStatic {
-        linesFromText(text: string): { lines: string[], lineMap: number[] };
-        new(): LineIndexForTest;
-    }
-    export interface LineIndexForTest {
-        absolutePositionOfStartOfLine(line: number): number;
-        positionToLineOffset(position: number): protocol.Location;
-        edit(pos: number, deleteLength: number, newText: string): LineIndexForTest;
-        getText(rangeStart: number, rangeLength: number): string;
-        getLength(): number;
-        load(lines: string[]): void;
-    }
-    export const LineIndexForTest: LineIndexForTestStatic = LineIndex;
 
     class LineNode implements LineCollection {
         totalChars = 0;

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -403,6 +403,7 @@ namespace ts.server {
         }
     }
 
+    /* @internal */
     export class LineIndex {
         root: LineNode;
         // set this to true to check each edit for accuracy

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -17,7 +17,7 @@ namespace ts.server {
         lineText: string | undefined;
     }
 
-    enum CharRangeSection {
+    const enum CharRangeSection {
         PreStart,
         Start,
         Entire,

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -5,7 +5,7 @@
 namespace ts.server {
     const lineCollectionCapacity = 4;
 
-    export interface LineCollection {
+    interface LineCollection {
         charCount(): number;
         lineCount(): number;
         isLeaf(): this is LineLeaf;
@@ -17,7 +17,7 @@ namespace ts.server {
         lineText: string | undefined;
     }
 
-    export enum CharRangeSection {
+    enum CharRangeSection {
         PreStart,
         Start,
         Entire,
@@ -26,7 +26,7 @@ namespace ts.server {
         PostEnd
     }
 
-    export interface ILineIndexWalker {
+    interface ILineIndexWalker {
         goSubtree: boolean;
         done: boolean;
         leaf(relativeStart: number, relativeLength: number, lineCollection: LineLeaf): void;
@@ -243,7 +243,7 @@ namespace ts.server {
     }
 
     // text change information
-    export class TextChange {
+    class TextChange {
         constructor(public pos: number, public deleteLen: number, public insertedText?: string) {
         }
 
@@ -285,17 +285,6 @@ namespace ts.server {
             }
         }
 
-        latest() {
-            return this.versions[this.currentVersionToIndex()];
-        }
-
-        latestVersion() {
-            if (this.changes.length > 0) {
-                this.getSnapshot();
-            }
-            return this.currentVersion;
-        }
-
         // reload whole script, leaving no change history behind reload
         reload(script: string) {
             this.currentVersion++;
@@ -314,7 +303,9 @@ namespace ts.server {
             this.minVersion = this.currentVersion;
         }
 
-        getSnapshot() {
+        getSnapshot(): IScriptSnapshot { return this._getSnapshot(); }
+
+        private _getSnapshot(): LineIndexSnapshot {
             let snap = this.versions[this.currentVersionToIndex()];
             if (this.changes.length > 0) {
                 let snapIndex = snap.index;
@@ -332,6 +323,29 @@ namespace ts.server {
                 }
             }
             return snap;
+        }
+
+        getSnapshotVersion(): number {
+            return this._getSnapshot().version;
+        }
+
+        getLineInfo(line: number): AbsolutePositionAndLineText {
+            return this._getSnapshot().index.lineNumberToInfo(line);
+        }
+
+        lineOffsetToPosition(line: number, column: number): number {
+            return this._getSnapshot().index.absolutePositionOfStartOfLine(line) + (column - 1);
+        }
+
+        positionToLineOffset(position: number): protocol.Location {
+            return this._getSnapshot().index.positionToLineOffset(position);
+        }
+
+        lineToTextSpan(line: number): TextSpan {
+            const index = this._getSnapshot().index;
+            const { lineText, absolutePosition } = index.lineNumberToInfo(line + 1);
+            const len = lineText !== undefined ? lineText.length : index.absolutePositionOfStartOfLine(line + 2) - absolutePosition;
+            return createTextSpan(absolutePosition, len);
         }
 
         getTextChangesBetweenVersions(oldVersion: number, newVersion: number) {
@@ -365,7 +379,7 @@ namespace ts.server {
         }
     }
 
-    export class LineIndexSnapshot implements IScriptSnapshot {
+    class LineIndexSnapshot implements IScriptSnapshot {
         constructor(readonly version: number, readonly cache: ScriptVersionCache, readonly index: LineIndex, readonly changesSincePreviousVersion: ReadonlyArray<TextChange> = emptyArray) {
         }
 
@@ -389,7 +403,7 @@ namespace ts.server {
         }
     }
 
-    export class LineIndex {
+    class LineIndex implements LineIndexForTest {
         root: LineNode;
         // set this to true to check each edit for accuracy
         checkEdits = false;
@@ -561,7 +575,21 @@ namespace ts.server {
         }
     }
 
-    export class LineNode implements LineCollection {
+    export interface LineIndexForTestStatic {
+        linesFromText(text: string): { lines: string[], lineMap: number[] };
+        new(): LineIndexForTest;
+    }
+    export interface LineIndexForTest {
+        absolutePositionOfStartOfLine(line: number): number;
+        positionToLineOffset(position: number): protocol.Location;
+        edit(pos: number, deleteLength: number, newText: string): LineIndexForTest;
+        getText(rangeStart: number, rangeLength: number): string;
+        getLength(): number;
+        load(lines: string[]): void;
+    }
+    export const LineIndexForTest: LineIndexForTestStatic = LineIndex;
+
+    class LineNode implements LineCollection {
         totalChars = 0;
         totalLines = 0;
 
@@ -844,7 +872,7 @@ namespace ts.server {
         }
     }
 
-    export class LineLeaf implements LineCollection {
+    class LineLeaf implements LineCollection {
         constructor(public text: string) {
         }
 


### PR DESCRIPTION
We can avoid exporting anything besides the `ScriptVerisonCache` class, and `LineIndex` which is used by whitebox tests.