### PR TITLE
Fix bug in importTracker: `getExportNode` must verify that we are on the LHS of a VariableDeclaration

### DIFF
--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -453,7 +453,7 @@ namespace ts.FindAllReferences {
                 }
             }
             else {
-                const exportNode = getExportNode(parent);
+                const exportNode = getExportNode(parent, node);
                 if (exportNode && hasModifier(exportNode, ModifierFlags.Export)) {
                     if (isImportEqualsDeclaration(exportNode) && exportNode.moduleReference === node) {
                         // We're at `Y` in `export import X = Y`. This is not the exported symbol, the left-hand-side is. So treat this as an import statement.
@@ -558,10 +558,11 @@ namespace ts.FindAllReferences {
 
     // If a reference is a class expression, the exported node would be its parent.
     // If a reference is a variable declaration, the exported node would be the variable statement.
-    function getExportNode(parent: Node): Node | undefined {
+    function getExportNode(parent: Node, node: Node): Node | undefined {
         if (parent.kind === SyntaxKind.VariableDeclaration) {
             const p = parent as ts.VariableDeclaration;
-            return p.parent.kind === ts.SyntaxKind.CatchClause ? undefined : p.parent.parent.kind === SyntaxKind.VariableStatement ? p.parent.parent : undefined;
+            return p.name !== node ? undefined :
+                p.parent.kind === ts.SyntaxKind.CatchClause ? undefined : p.parent.parent.kind === SyntaxKind.VariableStatement ? p.parent.parent : undefined;
         }
         else {
             return parent;

--- a/tests/cases/fourslash/findAllRefsExportConstEqualToClass.ts
+++ b/tests/cases/fourslash/findAllRefsExportConstEqualToClass.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////class [|{| "isWriteAccess": true, "isDefinition": true |}C|] {}
+////export const [|{| "isWriteAccess": true, "isDefinition": true |}D|] = [|C|];
+
+// @Filename: /b.ts
+////import { [|{| "isWriteAccess": true, "isDefinition": true |}D|] } from "./a";
+
+const [C0, D0, C1, D1] = test.ranges();
+
+verify.singleReferenceGroup("class C", [C0, C1]);
+
+const d0Group = { definition: "const D: typeof C", ranges: [D0] };
+const d1Group = { definition: "import D", ranges: [D1] };
+verify.referenceGroups(D0, [d0Group, d1Group]);
+verify.referenceGroups(D1, [d1Group, d0Group]);


### PR DESCRIPTION
Previously this test would have crashed because we assume that `symbol.parent` will always be set on an exported VariableDeclaration, but weren't checking that we were at the LHS symbol.