### PR TITLE
Issue template: Recommend to run `tsc` directly

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -8,7 +8,7 @@
 
 ```ts
 // A *self-contained* demonstration of the problem follows...
-// Test this by running `tsc` on the command-line, rather than through another build tool.
+// Test this by running `tsc` on the command-line, rather than through another build tool such as Gulp, Webpack, etc.
 ```
 
 **Expected behavior:**

--- a/issue_template.md
+++ b/issue_template.md
@@ -8,7 +8,7 @@
 
 ```ts
 // A *self-contained* demonstration of the problem follows...
-
+// Test this by running `tsc` on the command-line, rather than through another build tool.
 ```
 
 **Expected behavior:**


### PR DESCRIPTION
Sometimes we see issues that only reproduce in a certain build environment, such as webpack or visual studio. This leads to confusion when we can't reproduce the user's issue. This would ask people to try reproducing the issue with `tsc`.