### PR TITLE
Quickfix jsdoc in Typescript files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9955,6 +9955,11 @@ namespace ts {
                 neverType;
         }
 
+        /**
+         * Add undefined or null or both to a type if they are missing.
+         * @param type - type to add undefined and/or null to if not present
+         * @param flags - Either TypeFlags.Undefined or TypeFlags.Null, or both
+         */
         function getNullableType(type: Type, flags: TypeFlags): Type {
             const missing = (flags & ~type.flags) & (TypeFlags.Undefined | TypeFlags.Null);
             return missing === 0 ? type :

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -117,6 +117,7 @@ namespace ts {
             },
             getParameterType: getTypeAtPosition,
             getReturnTypeOfSignature,
+            getNullableType,
             getNonNullableType,
             typeToTypeNode: nodeBuilder.typeToTypeNode,
             indexInfoToIndexSignatureDeclaration: nodeBuilder.indexInfoToIndexSignatureDeclaration,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2520,6 +2520,7 @@ namespace ts {
          * Returns `any` if the index is not valid.
          */
         /* @internal */ getParameterType(signature: Signature, parameterIndex: number): Type;
+        getNullableType(type: Type, flags: TypeFlags): Type;
         getNonNullableType(type: Type): Type;
 
         /** Note that the resulting nodes cannot be checked. */

--- a/src/services/codefixes/disableJsDiagnostics.ts
+++ b/src/services/codefixes/disableJsDiagnostics.ts
@@ -32,7 +32,7 @@ namespace ts.codefix {
             }
         }
 
-        // If all fails, add an extra new line immediatlly before the error span.
+        // If all fails, add an extra new line immediately before the error span.
         return {
             span: { start: position, length: 0 },
             newText: `${position === startPosition ? "" : newLineCharacter}// @ts-ignore${newLineCharacter}`

--- a/src/services/codefixes/fixJSDocTypes.ts
+++ b/src/services/codefixes/fixJSDocTypes.ts
@@ -1,0 +1,52 @@
+/* @internal */
+namespace ts.codefix {
+    registerCodeFix({
+        errorCodes: [Diagnostics.JSDoc_types_can_only_be_used_inside_documentation_comments.code],
+        getCodeActions: getActionsForJSDocTypes
+    });
+
+    function getActionsForJSDocTypes(context: CodeFixContext): CodeAction[] | undefined {
+        const sourceFile = context.sourceFile;
+
+        const node = getTokenAtPosition(sourceFile, context.span.start, /*includeJsDocComment*/ false);
+        if (node.kind !== SyntaxKind.VariableDeclaration) return;
+
+        const type = (node as VariableDeclaration).type;
+        if (containsJSDocType(type)) {
+            const tsType = getTypeFromJSDocType(type);
+            return [{
+                description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Change_0_to_1), [getTextOfNode(type), tsType]),
+                changes: [{
+                    fileName: sourceFile.fileName,
+                    textChanges: [{
+                        span: { start: type.getStart(), length: type.getWidth() },
+                        newText: tsType
+                    }],
+                }],
+            }];
+        }
+    }
+
+    function containsJSDocType(type: TypeNode): boolean {
+        switch (type.kind) {
+            case SyntaxKind.JSDocUnknownType:
+            case SyntaxKind.JSDocAllType:
+            case SyntaxKind.JSDocVariadicType:
+                return true;
+            // TODO: Of course you can put JSDoc types inside normal types, like number?[] and so on
+        }
+    }
+
+    function getTypeFromJSDocType(type: TypeNode): string {
+        switch (type.kind) {
+            case SyntaxKind.JSDocUnknownType:
+            case SyntaxKind.JSDocAllType:
+                return "any";
+            case SyntaxKind.JSDocVariadicType:
+                // this will surely work!
+                return getTypeFromJSDocType((type as JSDocVariadicType).type) + "[]";
+            // TODO: Of course you can put JSDoc types inside normal types, like number?[] and so on
+        }
+        return getTextOfNode(type);
+    }
+}

--- a/src/services/codefixes/fixJSDocTypes.ts
+++ b/src/services/codefixes/fixJSDocTypes.ts
@@ -11,41 +11,64 @@ namespace ts.codefix {
         const decl = ts.findAncestor(node, n => n.kind === SyntaxKind.VariableDeclaration);
         if (!decl) return;
         const jsdocType = (decl as VariableDeclaration).type;
+        let cheesyHacks = false;
 
         // TODO: Only if get(jsdoctype) !== jsdoctype
+        // TODO: Create cheesy hacks to support | null | undefined -- just flip a boolean and rerun with that boolean set
 
         const trk = textChanges.ChangeTracker.fromCodeFixContext(context);
         trk.replaceNode(sourceFile, jsdocType, getTypeFromJSDocType(jsdocType));
-        return [{
+        const changes = [{
             // TODO: This seems like the LEAST SAFE way to get the new text
             description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Change_0_to_1), [getTextOfNode(jsdocType), trk.getChanges()[0].textChanges[0].newText]),
             changes: trk.getChanges(),
         }];
-    }
 
-    function getTypeFromJSDocType(type: TypeNode): TypeNode {
-        switch (type.kind) {
-            case SyntaxKind.JSDocUnknownType:
-            case SyntaxKind.JSDocAllType:
-                return createToken(SyntaxKind.AnyKeyword) as TypeNode;
-            case SyntaxKind.JSDocVariadicType:
-                return createArrayTypeNode(getTypeFromJSDocType((type as JSDocVariadicType).type));
-            case SyntaxKind.ArrayType:
-                // TODO: Only create an error if the get(type.type) !== type.type.
-                return createArrayTypeNode(getTypeFromJSDocType((type as ArrayTypeNode).elementType));
-            case SyntaxKind.TypeReference:
-                return getTypeReferenceFromJSDocType(type as TypeReferenceNode);
-            case SyntaxKind.Identifier:
-                return type;
+        if (cheesyHacks) {
+            const trk = textChanges.ChangeTracker.fromCodeFixContext(context);
+            trk.replaceNode(sourceFile, jsdocType, getTypeFromJSDocType(jsdocType));
+            changes.push({
+                // TODO: This seems like the LEAST SAFE way to get the new text
+                description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Change_0_to_1), [getTextOfNode(jsdocType), trk.getChanges()[0].textChanges[0].newText]),
+                changes: trk.getChanges(),
+            });
         }
-        // TODO: Need to recur on all relevant nodes. Is a call to visit enough?
-        return type;
-    }
+        return changes;
 
-    function getTypeReferenceFromJSDocType(type: TypeReferenceNode) {
-        if (type.typeArguments && type.typeName.jsdocDotPos) {
-            return createTypeReferenceNode(type.typeName, map(type.typeArguments, getTypeFromJSDocType));
+        function getTypeFromJSDocType(type: TypeNode): TypeNode {
+            switch (type.kind) {
+                case SyntaxKind.JSDocUnknownType:
+                case SyntaxKind.JSDocAllType:
+                    return createToken(SyntaxKind.AnyKeyword) as TypeNode;
+                case SyntaxKind.JSDocVariadicType:
+                    return createArrayTypeNode(getTypeFromJSDocType((type as JSDocVariadicType).type));
+                case SyntaxKind.JSDocNullableType:
+                    if (cheesyHacks) {
+                        return createUnionTypeNode([getTypeFromJSDocType((type as JSDocNullableType).type), createNull(), createToken(SyntaxKind.UndefinedKeyword) as TypeNode]);
+                    }
+                    else {
+                        cheesyHacks = true;
+                        return createUnionTypeNode([getTypeFromJSDocType((type as JSDocNullableType).type), createNull()]);
+                    }
+                case SyntaxKind.JSDocNonNullableType:
+                    return getTypeFromJSDocType((type as JSDocNullableType).type);
+                case SyntaxKind.ArrayType:
+                    // TODO: Only create an error if the get(type.type) !== type.type.
+                    return createArrayTypeNode(getTypeFromJSDocType((type as ArrayTypeNode).elementType));
+                case SyntaxKind.TypeReference:
+                    return getTypeReferenceFromJSDocType(type as TypeReferenceNode);
+                case SyntaxKind.Identifier:
+                    return type;
+            }
+            // TODO: Need to recur on all relevant nodes. Is a call to visit enough?
+            return type;
         }
-        return getTypeFromJSDocType(type);
+
+        function getTypeReferenceFromJSDocType(type: TypeReferenceNode) {
+            if (type.typeArguments && type.typeName.jsdocDotPos) {
+                return createTypeReferenceNode(type.typeName, map(type.typeArguments, getTypeFromJSDocType));
+            }
+            return getTypeFromJSDocType(type);
+        }
     }
 }

--- a/src/services/codefixes/fixJSDocTypes.ts
+++ b/src/services/codefixes/fixJSDocTypes.ts
@@ -7,13 +7,14 @@ namespace ts.codefix {
 
     function getActionsForJSDocTypes(context: CodeFixContext): CodeAction[] | undefined {
         const sourceFile = context.sourceFile;
-
         const node = getTokenAtPosition(sourceFile, context.span.start, /*includeJsDocComment*/ false);
-        if (node.kind !== SyntaxKind.VariableDeclaration) return;
+        const decl = ts.findAncestor(node, n => n.kind === SyntaxKind.VariableDeclaration);
+        if (!decl) return;
+        const jsdocType = (decl as VariableDeclaration).type;
+
+        // TODO: Only if get(jsdoctype) !== jsdoctype
 
         const trk = textChanges.ChangeTracker.fromCodeFixContext(context);
-        const jsdocType = (node as VariableDeclaration).type;
-        // TODO: Only if get(jsdoctype) !== jsdoctype
         trk.replaceNode(sourceFile, jsdocType, getTypeFromJSDocType(jsdocType));
         return [{
             // TODO: This seems like the LEAST SAFE way to get the new text

--- a/src/services/codefixes/fixJSDocTypes.ts
+++ b/src/services/codefixes/fixJSDocTypes.ts
@@ -15,11 +15,11 @@ namespace ts.codefix {
         const jsdocType = (decl as VariableDeclaration).type;
         const original = getTextOfNode(jsdocType);
         const type = checker.getTypeFromTypeNode(jsdocType);
-        const actions = [createAction(jsdocType, sourceFile.fileName, original, checker.typeToString(type))];
+        const actions = [createAction(jsdocType, sourceFile.fileName, original, checker.typeToString(type, /*enclosingDeclaration*/ undefined, TypeFormatFlags.NoTruncation))];
         if (jsdocType.kind === SyntaxKind.JSDocNullableType) {
             // for nullable types, suggest the flow-compatible `T | null | undefined`
             // in addition to the jsdoc/closure-compatible `T | null`
-            const replacementWithUndefined = checker.typeToString(checker.getNullableType(type, TypeFlags.Undefined));
+            const replacementWithUndefined = checker.typeToString(checker.getNullableType(type, TypeFlags.Undefined), /*enclosingDeclaration*/ undefined, TypeFormatFlags.NoTruncation);
             actions.push(createAction(jsdocType, sourceFile.fileName, original, replacementWithUndefined));
         }
         return actions;

--- a/src/services/codefixes/fixJSDocTypes.ts
+++ b/src/services/codefixes/fixJSDocTypes.ts
@@ -10,65 +10,31 @@ namespace ts.codefix {
         const node = getTokenAtPosition(sourceFile, context.span.start, /*includeJsDocComment*/ false);
         const decl = ts.findAncestor(node, n => n.kind === SyntaxKind.VariableDeclaration);
         if (!decl) return;
+        const checker = context.program.getTypeChecker();
+
         const jsdocType = (decl as VariableDeclaration).type;
-        let cheesyHacks = false;
-
-        // TODO: Only if get(jsdoctype) !== jsdoctype
-        // TODO: Create cheesy hacks to support | null | undefined -- just flip a boolean and rerun with that boolean set
-
-        const trk = textChanges.ChangeTracker.fromCodeFixContext(context);
-        trk.replaceNode(sourceFile, jsdocType, getTypeFromJSDocType(jsdocType));
-        const changes = [{
-            // TODO: This seems like the LEAST SAFE way to get the new text
-            description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Change_0_to_1), [getTextOfNode(jsdocType), trk.getChanges()[0].textChanges[0].newText]),
-            changes: trk.getChanges(),
-        }];
-
-        if (cheesyHacks) {
-            const trk = textChanges.ChangeTracker.fromCodeFixContext(context);
-            trk.replaceNode(sourceFile, jsdocType, getTypeFromJSDocType(jsdocType));
-            changes.push({
-                // TODO: This seems like the LEAST SAFE way to get the new text
-                description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Change_0_to_1), [getTextOfNode(jsdocType), trk.getChanges()[0].textChanges[0].newText]),
-                changes: trk.getChanges(),
-            });
+        const original = getTextOfNode(jsdocType);
+        const type = checker.getTypeFromTypeNode(jsdocType);
+        const actions = [createAction(jsdocType, sourceFile.fileName, original, checker.typeToString(type))];
+        if (jsdocType.kind === SyntaxKind.JSDocNullableType) {
+            // for nullable types, suggest the flow-compatible `T | null | undefined`
+            // in addition to the jsdoc/closure-compatible `T | null`
+            const replacementWithUndefined = checker.typeToString(checker.getNullableType(type, TypeFlags.Undefined));
+            actions.push(createAction(jsdocType, sourceFile.fileName, original, replacementWithUndefined));
         }
-        return changes;
+        return actions;
+    }
 
-        function getTypeFromJSDocType(type: TypeNode): TypeNode {
-            switch (type.kind) {
-                case SyntaxKind.JSDocUnknownType:
-                case SyntaxKind.JSDocAllType:
-                    return createToken(SyntaxKind.AnyKeyword) as TypeNode;
-                case SyntaxKind.JSDocVariadicType:
-                    return createArrayTypeNode(getTypeFromJSDocType((type as JSDocVariadicType).type));
-                case SyntaxKind.JSDocNullableType:
-                    if (cheesyHacks) {
-                        return createUnionTypeNode([getTypeFromJSDocType((type as JSDocNullableType).type), createNull(), createToken(SyntaxKind.UndefinedKeyword) as TypeNode]);
-                    }
-                    else {
-                        cheesyHacks = true;
-                        return createUnionTypeNode([getTypeFromJSDocType((type as JSDocNullableType).type), createNull()]);
-                    }
-                case SyntaxKind.JSDocNonNullableType:
-                    return getTypeFromJSDocType((type as JSDocNullableType).type);
-                case SyntaxKind.ArrayType:
-                    // TODO: Only create an error if the get(type.type) !== type.type.
-                    return createArrayTypeNode(getTypeFromJSDocType((type as ArrayTypeNode).elementType));
-                case SyntaxKind.TypeReference:
-                    return getTypeReferenceFromJSDocType(type as TypeReferenceNode);
-                case SyntaxKind.Identifier:
-                    return type;
-            }
-            // TODO: Need to recur on all relevant nodes. Is a call to visit enough?
-            return type;
-        }
-
-        function getTypeReferenceFromJSDocType(type: TypeReferenceNode) {
-            if (type.typeArguments && type.typeName.jsdocDotPos) {
-                return createTypeReferenceNode(type.typeName, map(type.typeArguments, getTypeFromJSDocType));
-            }
-            return getTypeFromJSDocType(type);
-        }
+    function createAction(declaration: TypeNode, fileName: string, original: string, replacement: string): CodeAction {
+        return {
+            description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Change_0_to_1), [original, replacement]),
+            changes: [{
+                fileName,
+                textChanges: [{
+                    span: { start: declaration.getStart(), length: declaration.getWidth() },
+                    newText: replacement
+                }]
+            }],
+        };
     }
 }

--- a/src/services/codefixes/fixes.ts
+++ b/src/services/codefixes/fixes.ts
@@ -7,6 +7,7 @@
 /// <reference path="fixExtendsInterfaceBecomesImplements.ts" />
 /// <reference path="fixForgottenThisPropertyAccess.ts" />
 /// <reference path='fixUnusedIdentifier.ts' />
+/// <reference path='fixJSDocTypes.ts' />
 /// <reference path='importFixes.ts' />
 /// <reference path='disableJsDiagnostics.ts' />
 /// <reference path='helpers.ts' />

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax1.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax1.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|?|] = 12;
+
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax2.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax2.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|*|] = 12;
+
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax3.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax3.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|...number|] = 12;
+
+verify.rangeAfterCodeFix("number[]");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax3.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax3.ts
@@ -1,4 +1,4 @@
 /// <reference path='fourslash.ts' />
-//// var x: [|...number|] = 12;
+//// var x: [|......number[][]|] = 12;
 
-verify.rangeAfterCodeFix("number[]");
+verify.rangeAfterCodeFix("number[][][][]");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax4.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax4.ts
@@ -1,4 +1,4 @@
 /// <reference path='fourslash.ts' />
 //// var x: [|Array.<number>|] = 12;
 
-verify.rangeAfterCodeFix("Array<number>");
+verify.rangeAfterCodeFix("number[]");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax4.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax4.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|Array.<number>|] = 12;
+
+verify.rangeAfterCodeFix("Array<number>");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax5.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax5.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|?number|] = 12;
+
+verify.rangeAfterCodeFix("number | null", /*includeWhiteSpace*/ false, /*errorCode*/ 8020, 0);

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax5.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax5.ts
@@ -1,3 +1,4 @@
+// @strict: true
 /// <reference path='fourslash.ts' />
 //// var x: [|?number|] = 12;
 

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax6.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax6.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|number?|] = 12;
+
+verify.rangeAfterCodeFix("number | null | undefined", /*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 1);

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax6.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax6.ts
@@ -1,3 +1,4 @@
+// @strict: true
 /// <reference path='fourslash.ts' />
 //// var x: [|number?|] = 12;
 

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax7.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax7.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|!number|] = 12;
+
+verify.rangeAfterCodeFix("number");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax8.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax8.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|function(this: number, number): string|] = 12;
+
+verify.rangeAfterCodeFix("(this: number, arg1: number) => string");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax9.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax9.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var x: [|function(new: number)|] = 12;
+
+verify.rangeAfterCodeFix("new () => number");


### PR DESCRIPTION
Add a codefix for the "JSDoc types can only be used inside documentation comments" error in .ts files. The codefix offers to convert the JSDoc-syntax type into the equivalent Typescript-syntax type.

Notes:
1. Because this error is not issued in Javascript files, it is *not* applicable to (for example) flow files that have the .js extension. Those files will continue to get the "types can only be used .ts files" error.
2. Because the codefix uses `getTypeFromTypeNode` and `typeToString`, you will only get `T | null` from `?T` for `strictNullChecks: true`. This is technically correct, but loses the intent of the JSDoc.
3. The codefix has a special case for `?T` since it is valid flow syntax as well as valid JSDoc/Closure syntax. The special case converts `?T` to `T | null | undefined`. Because of other flow and typescript differences, this is not likely to be a successful Flow &rarr; Typescript converter! 