### PR TITLE
Contextually type this in object literals in JS

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12602,7 +12602,7 @@ namespace ts {
                     }
                 }
             }
-            if (noImplicitThis) {
+            if (noImplicitThis || isInJavaScriptFile(func)) {
                 const containingLiteral = getContainingObjectLiteral(func);
                 if (containingLiteral) {
                     // We have an object literal method. Check if the containing object literal has a contextual type

--- a/tests/baselines/reference/contextualThisTypeInJavascript.symbols
+++ b/tests/baselines/reference/contextualThisTypeInJavascript.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/types/thisType/context.js ===
+const obj = {
+>obj : Symbol(obj, Decl(context.js, 0, 5))
+
+    prop: 2,
+>prop : Symbol(prop, Decl(context.js, 0, 13))
+
+    method() {
+>method : Symbol(method, Decl(context.js, 1, 12))
+
+        this;
+>this : Symbol(obj, Decl(context.js, 0, 11))
+
+        this.prop;
+>this.prop : Symbol(prop, Decl(context.js, 0, 13))
+>this : Symbol(obj, Decl(context.js, 0, 11))
+>prop : Symbol(prop, Decl(context.js, 0, 13))
+
+        this.method;
+>this.method : Symbol(method, Decl(context.js, 1, 12))
+>this : Symbol(obj, Decl(context.js, 0, 11))
+>method : Symbol(method, Decl(context.js, 1, 12))
+    }
+}
+

--- a/tests/baselines/reference/contextualThisTypeInJavascript.symbols
+++ b/tests/baselines/reference/contextualThisTypeInJavascript.symbols
@@ -20,6 +20,9 @@ const obj = {
 >this.method : Symbol(method, Decl(context.js, 1, 12))
 >this : Symbol(obj, Decl(context.js, 0, 11))
 >method : Symbol(method, Decl(context.js, 1, 12))
+
+        this.unknown; // ok, obj has a string indexer
+>this : Symbol(obj, Decl(context.js, 0, 11))
     }
 }
 

--- a/tests/baselines/reference/contextualThisTypeInJavascript.types
+++ b/tests/baselines/reference/contextualThisTypeInJavascript.types
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/types/thisType/context.js ===
+const obj = {
+>obj : { [x: string]: any; prop: number; method(): void; }
+>{    prop: 2,    method() {        this;        this.prop;        this.method;    }} : { [x: string]: any; prop: number; method(): void; }
+
+    prop: 2,
+>prop : number
+>2 : 2
+
+    method() {
+>method : () => void
+
+        this;
+>this : { [x: string]: any; prop: number; method(): void; }
+
+        this.prop;
+>this.prop : number
+>this : { [x: string]: any; prop: number; method(): void; }
+>prop : number
+
+        this.method;
+>this.method : () => void
+>this : { [x: string]: any; prop: number; method(): void; }
+>method : () => void
+    }
+}
+

--- a/tests/baselines/reference/contextualThisTypeInJavascript.types
+++ b/tests/baselines/reference/contextualThisTypeInJavascript.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/types/thisType/context.js ===
 const obj = {
 >obj : { [x: string]: any; prop: number; method(): void; }
->{    prop: 2,    method() {        this;        this.prop;        this.method;    }} : { [x: string]: any; prop: number; method(): void; }
+>{    prop: 2,    method() {        this;        this.prop;        this.method;        this.unknown; // ok, obj has a string indexer    }} : { [x: string]: any; prop: number; method(): void; }
 
     prop: 2,
 >prop : number
@@ -22,6 +22,11 @@ const obj = {
 >this.method : () => void
 >this : { [x: string]: any; prop: number; method(): void; }
 >method : () => void
+
+        this.unknown; // ok, obj has a string indexer
+>this.unknown : any
+>this : { [x: string]: any; prop: number; method(): void; }
+>unknown : any
     }
 }
 

--- a/tests/cases/conformance/types/thisType/contextualThisTypeInJavascript.ts
+++ b/tests/cases/conformance/types/thisType/contextualThisTypeInJavascript.ts
@@ -1,0 +1,12 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: context.js
+const obj = {
+    prop: 2,
+    method() {
+        this;
+        this.prop;
+        this.method;
+    }
+}

--- a/tests/cases/conformance/types/thisType/contextualThisTypeInJavascript.ts
+++ b/tests/cases/conformance/types/thisType/contextualThisTypeInJavascript.ts
@@ -8,5 +8,6 @@ const obj = {
         this;
         this.prop;
         this.method;
+        this.unknown; // ok, obj has a string indexer
     }
 }


### PR DESCRIPTION
Previously, `this` would only get a contextual type inside object literals with `--noImplicitThis` turned on in Typescript files.

Fixes #16184
