### PR TITLE
JSDoc:Object<string, T> creates index signature

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6876,9 +6876,9 @@ namespace ts {
                     if (node.typeArguments && node.typeArguments.length === 2) {
                         const indexed = getTypeFromTypeNode(node.typeArguments[0]);
                         const target = getTypeFromTypeNode(node.typeArguments[1]);
-                        let index = createIndexInfo(target, /*isReadonly*/ false);
+                        const index = createIndexInfo(target, /*isReadonly*/ false);
                         if (indexed === stringType || indexed === numberType) {
-                            return createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, indexed === stringType && index, indexed === numberType && index)
+                            return createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, indexed === stringType && index, indexed === numberType && index);
                         }
                     }
                     return anyType;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6872,6 +6872,17 @@ namespace ts {
 
         function getPrimitiveTypeFromJSDocTypeReference(node: TypeReferenceNode): Type {
             if (isIdentifier(node.typeName)) {
+                if (node.typeName.text === "Object") {
+                    if (node.typeArguments && node.typeArguments.length === 2) {
+                        const from = getTypeFromTypeNode(node.typeArguments[0]);
+                        const to = getTypeFromTypeNode(node.typeArguments[1]);
+                        let index = createIndexInfo(to, /*isReadonly*/ false);
+                        if (from === stringType || from === numberType) {
+                            return createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, from === stringType ? index : undefined, from === numberType ? index : undefined)
+                        }
+                    }
+                    return anyType;
+                }
                 switch (node.typeName.text) {
                     case "String":
                         return stringType;
@@ -6885,8 +6896,6 @@ namespace ts {
                         return undefinedType;
                     case "Null":
                         return nullType;
-                    case "Object":
-                        return anyType;
                     case "Function":
                     case "function":
                         return globalFunctionType;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6870,7 +6870,7 @@ namespace ts {
             return node.flags & NodeFlags.JSDoc && node.kind === SyntaxKind.TypeReference;
         }
 
-        function getPrimitiveTypeFromJSDocTypeReference(node: TypeReferenceNode): Type {
+        function getIntendedTypeFromJSDocTypeReference(node: TypeReferenceNode): Type {
             if (isIdentifier(node.typeName)) {
                 if (node.typeName.text === "Object") {
                     if (node.typeArguments && node.typeArguments.length === 2) {
@@ -6921,7 +6921,7 @@ namespace ts {
                 let type: Type;
                 let meaning = SymbolFlags.Type;
                 if (isJSDocTypeReference(node)) {
-                    type = getPrimitiveTypeFromJSDocTypeReference(node);
+                    type = getIntendedTypeFromJSDocTypeReference(node);
                     meaning |= SymbolFlags.Value;
                 }
                 if (!type) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6874,11 +6874,11 @@ namespace ts {
             if (isIdentifier(node.typeName)) {
                 if (node.typeName.text === "Object") {
                     if (node.typeArguments && node.typeArguments.length === 2) {
-                        const from = getTypeFromTypeNode(node.typeArguments[0]);
-                        const to = getTypeFromTypeNode(node.typeArguments[1]);
-                        let index = createIndexInfo(to, /*isReadonly*/ false);
-                        if (from === stringType || from === numberType) {
-                            return createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, from === stringType ? index : undefined, from === numberType ? index : undefined)
+                        const indexed = getTypeFromTypeNode(node.typeArguments[0]);
+                        const target = getTypeFromTypeNode(node.typeArguments[1]);
+                        let index = createIndexInfo(target, /*isReadonly*/ false);
+                        if (indexed === stringType || indexed === numberType) {
+                            return createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, indexed === stringType && index, indexed === numberType && index)
                         }
                     }
                     return anyType;

--- a/tests/baselines/reference/jsdocIndexSignature.symbols
+++ b/tests/baselines/reference/jsdocIndexSignature.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/jsdoc/indices.js ===
+/** @type {Object.<string, number>} */
+var o1;
+>o1 : Symbol(o1, Decl(indices.js, 1, 3))
+
+/** @type {Object.<number, boolean>} */
+var o2;
+>o2 : Symbol(o2, Decl(indices.js, 3, 3))
+
+/** @type {Object.<boolean, string>} */
+var o3;
+>o3 : Symbol(o3, Decl(indices.js, 5, 3))
+

--- a/tests/baselines/reference/jsdocIndexSignature.types
+++ b/tests/baselines/reference/jsdocIndexSignature.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/jsdoc/indices.js ===
+/** @type {Object.<string, number>} */
+var o1;
+>o1 : { [x: string]: number; }
+
+/** @type {Object.<number, boolean>} */
+var o2;
+>o2 : { [x: number]: boolean; }
+
+/** @type {Object.<boolean, string>} */
+var o3;
+>o3 : any
+

--- a/tests/cases/conformance/jsdoc/jsdocIndexSignature.ts
+++ b/tests/cases/conformance/jsdoc/jsdocIndexSignature.ts
@@ -1,0 +1,10 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: indices.js
+/** @type {Object.<string, number>} */
+var o1;
+/** @type {Object.<number, boolean>} */
+var o2;
+/** @type {Object.<boolean, string>} */
+var o3;


### PR DESCRIPTION
And `Object<number, T>` creates a numeric index signature. Other uses still map to `any` as before.

Fixes #15105 
