### PR TITLE
Update lib.es5.d.ts

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -236,7 +236,7 @@ interface ObjectConstructor {
       * Returns the names of the enumerable properties and methods of an object.
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
-    keys(o: any): string[];
+    keys(o: {}): string[];
 }
 
 /**


### PR DESCRIPTION
`Objects.keys()` does not take null or undefined

```js
> Object.keys(undefined)
TypeError: Cannot convert undefined or null to object
> Object.keys(null)
TypeError: Cannot convert undefined or null to object
```

[x] You've signed the CLA
[x] There are new or updated unit tests validating the change
