### PR TITLE
Update type definition of Object.keys

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -236,7 +236,7 @@ interface ObjectConstructor {
       * Returns the names of the enumerable properties and methods of an object.
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
-    keys(o: any): string[];
+    keys<A>(o: A): (keyof A)[];
 }
 
 /**


### PR DESCRIPTION
Solves need to explicitly specify type of `key` when in **Strict Mode**.

## Issue it solves

```ts
const someObj = {
  a: 42,
  b: 'Hello'
}

Object.keys(someObj)
  .forEach(key =>
    someObj[key] // ERROR: Element implicitly has an 'any' type because type ... has no index signature.
  )
```

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->