### PR TITLE
Remove duplicate helper

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -703,15 +703,15 @@ namespace ts.server {
 
             switch (project.projectKind) {
                 case ProjectKind.External:
-                    removeItemFromSet(this.externalProjects, <ExternalProject>project);
+                    unorderedRemoveItem(this.externalProjects, <ExternalProject>project);
                     this.projectToSizeMap.delete((project as ExternalProject).externalProjectName);
                     break;
                 case ProjectKind.Configured:
-                    removeItemFromSet(this.configuredProjects, <ConfiguredProject>project);
+                    unorderedRemoveItem(this.configuredProjects, <ConfiguredProject>project);
                     this.projectToSizeMap.delete((project as ConfiguredProject).canonicalConfigFilePath);
                     break;
                 case ProjectKind.Inferred:
-                    removeItemFromSet(this.inferredProjects, <InferredProject>project);
+                    unorderedRemoveItem(this.inferredProjects, <InferredProject>project);
                     break;
             }
         }
@@ -790,7 +790,7 @@ namespace ts.server {
             // to the disk, and the server's version of the file can be out of sync.
             info.close();
 
-            removeItemFromSet(this.openFiles, info);
+            unorderedRemoveItem(this.openFiles, info);
 
             // collect all projects that should be removed
             let projectsToRemove: Project[];

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -232,7 +232,7 @@ namespace ts.server {
                     }
                     break;
                 default:
-                    removeItemFromSet(this.containingProjects, project);
+                    unorderedRemoveItem(this.containingProjects, project);
                     break;
             }
         }

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -103,24 +103,6 @@ namespace ts.server {
         }
     }
 
-    export function removeItemFromSet<T>(items: T[], itemToRemove: T) {
-        if (items.length === 0) {
-            return;
-        }
-        const index = items.indexOf(itemToRemove);
-        if (index < 0) {
-            return;
-        }
-        if (index ===  items.length - 1) {
-            // last item - pop it
-            items.pop();
-        }
-        else {
-            // non-last item - replace it with the last one
-            items[index] = items.pop();
-        }
-    }
-
     export type NormalizedPath = string & { __normalizedPathTag: any };
 
     export function toNormalizedPath(fileName: string): NormalizedPath {


### PR DESCRIPTION
`removeItemFromSet` appears to do the same thing as `unorderedRemoveItem`.