### PR TITLE
Simplify use of array helpers

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -239,10 +239,7 @@ namespace ts.server {
     const fileNamePropertyReader: FilePropertyReader<string> = {
         getFileName: x => x,
         getScriptKind: _ => undefined,
-        hasMixedContent: (fileName, extraFileExtensions) => {
-            const mixedContentExtensions = map(filter(extraFileExtensions, item => item.isMixedContent), item => item.extension);
-            return forEach(mixedContentExtensions, extension => fileExtensionIs(fileName, extension));
-        }
+        hasMixedContent: (fileName, extraFileExtensions) => some(extraFileExtensions, ext => ext.isMixedContent && fileExtensionIs(fileName, ext.extension)),
     };
 
     const externalFilePropertyReader: FilePropertyReader<protocol.ExternalFile> = {


### PR DESCRIPTION
Old:
* `filter` over items to get just the ones with `isMixedContent`
* `map` to get `extensions` of each.
* `foreach` to see if `fileName` has any of those extensions.

New: The same, without any intermediate arrays.