### PR TITLE
Bugs in missing import codefix

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2399,7 +2399,7 @@ namespace FourSlash {
             const sortedActualArray = actualTextArray.sort();
             if (!ts.arrayIsEqualTo(sortedExpectedArray, sortedActualArray)) {
                 this.raiseError(
-                    `Actual text array doesn't match expected text array. \nActual: \n"${sortedActualArray.join("\n\n")}"\n---\nExpected: \n'${sortedExpectedArray.join("\n\n")}'`);
+                    `Actual text array doesn't match expected text array. \nActual: \n'${sortedActualArray.join("\n\n")}'\n---\nExpected: \n'${sortedExpectedArray.join("\n\n")}'`);
             }
         }
 

--- a/tests/cases/fourslash/importNameCodeFixNewImportNodeModules4.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportNodeModules4.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+//// [|f1/*0*/('');|]
+
+// @Filename: package.json
+//// { "dependencies": { "package-name": "latest" } }
+
+// @Filename: node_modules/package-name/bin/lib/libfile.d.ts
+//// export function f1(text: string): string;
+
+// @Filename: node_modules/package-name/bin/lib/libfile.js
+//// function f1(text) { }
+//// exports.f1 = f1;
+
+// @Filename: node_modules/package-name/package.json
+//// {
+////   "main": "bin/lib/libfile.js",
+////   "types": "bin/lib/libfile.d.ts"
+//// }
+
+verify.importFixAtPosition([
+`import { f1 } from "package-name";
+
+f1('');`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportNodeModules5.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportNodeModules5.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+//// [|f1/*0*/('');|]
+
+// @Filename: package.json
+//// { "dependencies": { "package-name": "latest" } }
+
+// @Filename: node_modules/package-name/node_modules/package-name2/bin/lib/libfile.d.ts
+//// export function f1(text: string): string;
+
+// @Filename: node_modules/package-name/node_modules/package-name2/bin/lib/libfile.js
+//// function f1(text) { }
+//// exports.f1 = f1;
+
+// @Filename: node_modules/package-name/node_modules/package-name2/package.json
+//// {
+////   "main": "bin/lib/libfile.js",
+////   "types": "bin/lib/libfile.d.ts"
+//// }
+
+verify.importFixAtPosition([
+`import { f1 } from "package-name/node_modules/package-name2";
+
+f1('');`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportNodeModules6.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportNodeModules6.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+//// [|f1/*0*/('');|]
+
+// @Filename: package.json
+//// { "dependencies": { "package-name": "latest" } }
+
+// @Filename: node_modules/package-name/bin/lib/index.d.ts
+//// export function f1(text: string): string;
+
+// @Filename: node_modules/package-name/bin/lib/index.js
+//// function f1(text) { }
+//// exports.f1 = f1;
+
+// @Filename: node_modules/package-name/package.json
+//// {
+////   "main": "bin/lib/index.js",
+////   "types": "bin/lib/index.d.ts"
+//// }
+
+verify.importFixAtPosition([
+`import { f1 } from "package-name";
+
+f1('');`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportNodeModules7.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportNodeModules7.ts
@@ -1,0 +1,29 @@
+/// <reference path="fourslash.ts" />
+
+//// [|f1/*0*/('');|]
+
+// @Filename: package.json
+//// { "dependencies": { "package-name": "0.0.1" } }
+
+// @Filename: node_modules/package-name/bin/lib/libfile.d.ts
+//// export declare function f1(text: string): string;
+
+// @Filename: node_modules/package-name/bin/lib/libfile.js
+//// function f1(text) {}
+//// exports.f1 = f1;
+
+// @Filename: node_modules/package-name/package.json
+//// { "main": "bin/lib/libfile.js" }
+
+
+// In this case, importing the module by its package name:
+// import { f1 } from 'package-name'
+// could in theory work, however the resulting code compiles with a module resolution error
+// since bin/lib/libfile.d.ts isn't declared under "typings" in package.json
+// Therefore just import the module by its qualified path
+
+verify.importFixAtPosition([
+`import { f1 } from "package-name/bin/lib/libfile";
+
+f1('');`
+]);


### PR DESCRIPTION
- We didn't locate the ```package.json``` correctly in cases where the module to be imported is in a subdirectory of the package
- We didn't look at the ```types``` element in package.json (just ```typings```)
- We didn't remove ```/index.js``` from the path if the main module was in a subdirectory

Fixes #16963 