### PR TITLE
JsTyping: Remove "safeList" global variable

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3,6 +3,7 @@
 /* @internal */
 namespace ts {
     export const emptyArray: never[] = [] as never[];
+    export const emptyMap: ReadonlyMap<never> = createMap<never>();
 
     export const externalHelpersModuleNameText = "tslib";
 

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1027,6 +1027,8 @@ namespace ts.projectSystem {
     });
 
     describe("discover typings", () => {
+        const emptySafeList = emptyMap;
+
         it("should use mappings from safe list", () => {
             const app = {
                 path: "/a/b/app.js",
@@ -1040,11 +1042,12 @@ namespace ts.projectSystem {
                 path: "/a/b/chroma.min.js",
                 content: ""
             };
-            const cache = createMap<string>();
+
+            const safeList = createMapFromTemplate({ jquery: "jquery", chroma: "chroma-js" });
 
             const host = createServerHost([app, jquery, chroma]);
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path, jquery.path, chroma.path], getDirectoryPath(<Path>app.path), /*safeListPath*/ undefined, cache, { enable: true }, []);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path, jquery.path, chroma.path], getDirectoryPath(<Path>app.path), safeList, emptyMap, { enable: true }, emptyArray);
             assert.deepEqual(logger.finish(), [
                 'Inferred typings from file names: ["jquery","chroma-js"]',
                 'Result: {"cachedTypingPaths":[],"newTypingNames":["jquery","chroma-js"],"filesToWatch":["/a/b/bower_components","/a/b/node_modules"]}',
@@ -1062,7 +1065,7 @@ namespace ts.projectSystem {
 
             for (const name of JsTyping.nodeCoreModuleList) {
                 const logger = trackingLogger();
-                const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(<Path>f.path), /*safeListPath*/ undefined, cache, { enable: true }, [name, "somename"]);
+                const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(<Path>f.path), emptySafeList, cache, { enable: true }, [name, "somename"]);
                 assert.deepEqual(logger.finish(), [
                     'Inferred typings from unresolved imports: ["node","somename"]',
                     'Result: {"cachedTypingPaths":[],"newTypingNames":["node","somename"],"filesToWatch":["/a/b/bower_components","/a/b/node_modules"]}',
@@ -1083,7 +1086,7 @@ namespace ts.projectSystem {
             const host = createServerHost([f, node]);
             const cache = createMapFromTemplate<string>({ "node": node.path });
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(<Path>f.path), /*safeListPath*/ undefined, cache, { enable: true }, ["fs", "bar"]);
+            const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(<Path>f.path), emptySafeList, cache, { enable: true }, ["fs", "bar"]);
             assert.deepEqual(logger.finish(), [
                 'Inferred typings from unresolved imports: ["node","bar"]',
                 'Result: {"cachedTypingPaths":["/a/b/node.d.ts"],"newTypingNames":["bar"],"filesToWatch":["/a/b/bower_components","/a/b/node_modules"]}',
@@ -1108,7 +1111,7 @@ namespace ts.projectSystem {
             const host = createServerHost([app, a, b]);
             const cache = createMap<string>();
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(<Path>app.path), /*safeListPath*/ undefined, cache, { enable: true }, /*unresolvedImports*/ []);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(<Path>app.path), emptySafeList, cache, { enable: true }, /*unresolvedImports*/ []);
             assert.deepEqual(logger.finish(), [
                 'Searching for typing names in /node_modules; all files: ["/node_modules/a/package.json"]',
                 'Result: {"cachedTypingPaths":[],"newTypingNames":["a"],"filesToWatch":["/bower_components","/node_modules"]}',

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -85,6 +85,7 @@ namespace ts.server.typingsInstaller {
         private readonly missingTypingsSet: Map<true> = createMap<true>();
         private readonly knownCachesSet: Map<true> = createMap<true>();
         private readonly projectWatchers: Map<FileWatcher[]> = createMap<FileWatcher[]>();
+        private safeList: JsTyping.SafeList | undefined;
         readonly pendingRunRequests: PendingRequest[] = [];
 
         private installRunCount = 1;
@@ -143,12 +144,15 @@ namespace ts.server.typingsInstaller {
                 this.processCacheLocation(req.cachePath);
             }
 
+            if (this.safeList === undefined) {
+                this.safeList = JsTyping.loadSafeList(this.installTypingHost, this.safeListPath);
+            }
             const discoverTypingsResult = JsTyping.discoverTypings(
                 this.installTypingHost,
                 this.log.isEnabled() ? this.log.writeLine : undefined,
                 req.fileNames,
                 req.projectRootPath,
-                this.safeListPath,
+                this.safeList,
                 this.packageNameToTypingLocation,
                 req.typeAcquisition,
                 req.unresolvedImports);


### PR DESCRIPTION
This code used a "safeList" global variable to cache the result of loading the safe list.
This has the unintuitive behavior that the value of the `safeListPath` parameter isn't observed after the first time `discoverTypings` is called.
Instead, we require the caller of `discoverTypings` to pass in the safe list itself instead of a path, and require the caller to handle caching of the safe list.

There is also a `private static safelist` in `editorServices.ts` that looks suspicious, but I'll leave that for later.