### PR TITLE
Fix linter

### DIFF
--- a/scripts/tslint/typeOperatorSpacingRule.ts
+++ b/scripts/tslint/typeOperatorSpacingRule.ts
@@ -19,7 +19,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
         ts.forEachChild(node, recur);
     }
 
-    function check(types: ts.TypeNode[]): void {
+    function check(types: ReadonlyArray<ts.TypeNode>): void {
         let expectedStart = types[0].end + 2; // space, | or &
         for (let i = 1; i < types.length; i++) {
             const currentType = types[i];


### PR DESCRIPTION
We just merged a change which makes the `.types` member of a union or intersection type a readonly array. Our lint rule's type annotation needs to reflect that.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This is currently breaking CI on #17311 with the new nightly publish.
