### PR TITLE
Revert #17074

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -680,7 +680,7 @@ namespace ts {
         kind: SyntaxKind.Parameter;
         parent?: SignatureDeclaration;
         dotDotDotToken?: DotDotDotToken;    // Present on rest parameter
-        name: BindingName;                 // Declared parameter name. Missing if this is a parameter in a JSDocFunctionType.
+        name: BindingName;                  // Declared parameter name.
         questionToken?: QuestionToken;      // Present on optional parameter
         type?: TypeNode;                    // Optional type annotation
         initializer?: Expression;           // Optional initializer

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -680,7 +680,7 @@ namespace ts {
         kind: SyntaxKind.Parameter;
         parent?: SignatureDeclaration;
         dotDotDotToken?: DotDotDotToken;    // Present on rest parameter
-        name?: BindingName;                 // Declared parameter name. Missing if this is a parameter in a JSDocFunctionType.
+        name: BindingName;                 // Declared parameter name. Missing if this is a parameter in a JSDocFunctionType.
         questionToken?: QuestionToken;      // Present on optional parameter
         type?: TypeNode;                    // Optional type annotation
         initializer?: Expression;           // Optional initializer


### PR DESCRIPTION
Reverts #17074.
This caused many breaking changes in tslint, and wasn't well thought out in the first place.
`JSDocFunctionType` has little in common with `SignatureDeclaration`. It doesn't have a `name` or `typeParameters`, and its parameters won't have `dotDotDotToken`, `name`, `questionToken`, or `initializer`. We should rethink having it inherit from that.
