### PR TITLE
Fix import addition location

### DIFF
--- a/src/compiler/comments.ts
+++ b/src/compiler/comments.ts
@@ -415,17 +415,7 @@ namespace ts {
          * @return true if the comment is a triple-slash comment else false
          */
         function isTripleSlashComment(commentPos: number, commentEnd: number) {
-            // Verify this is /// comment, but do the regexp match only when we first can find /// in the comment text
-            // so that we don't end up computing comment string and doing match for all // comments
-            if (currentText.charCodeAt(commentPos + 1) === CharacterCodes.slash &&
-                commentPos + 2 < commentEnd &&
-                currentText.charCodeAt(commentPos + 2) === CharacterCodes.slash) {
-                const textSubStr = currentText.substring(commentPos, commentEnd);
-                return textSubStr.match(fullTripleSlashReferencePathRegEx) ||
-                    textSubStr.match(fullTripleSlashAMDReferencePathRegEx) ?
-                    true : false;
-            }
-            return false;
+            return isRecognizedTripleSlashComment(currentText, commentPos, commentEnd);
         }
     }
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -284,7 +284,33 @@ namespace ts {
             return getTokenPosOfNode((<SyntaxList>node)._children[0], sourceFile, includeJsDoc);
         }
 
+        // For a source file, it is possible there are detached comments we should not skip
+        if (node.kind === SyntaxKind.SourceFile && includeJsDoc) {
+            const text = (node as SourceFile).text;
+            let ranges = getLeadingCommentRanges(text, 0);
+            if (!ranges) return 0;
+            let position = 0;
+            // However we should still skip a pinned comment at the top
+            if (ranges.length && ranges[0].kind === SyntaxKind.MultiLineCommentTrivia && isPinnedComment(text, ranges[0])) {
+                position = ranges[0].end + 1;
+                ranges = ranges.slice(1);
+            }
+            // As well as any triple slash references
+            for (const range of ranges) {
+                if (range.kind === SyntaxKind.SingleLineCommentTrivia && (node as SourceFile).text.substring(range.pos, range.pos + 3) === "///") {
+                    position = range.end + 1;
+                    continue;
+                }
+                break;
+            }
+            return position;
+        }
         return skipTrivia((sourceFile || getSourceFileOfNode(node)).text, node.pos);
+
+        function isPinnedComment(text: string, comment: CommentRange) {
+            return text.charCodeAt(comment.pos + 1) === CharacterCodes.asterisk &&
+                text.charCodeAt(comment.pos + 2) === CharacterCodes.exclamation;
+        }
     }
 
     export function getNonDecoratorTokenPosOfNode(node: Node, sourceFile?: SourceFileLike): number {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -310,27 +310,6 @@ namespace ts {
             return getTokenPosOfNode((<SyntaxList>node)._children[0], sourceFile, includeJsDoc);
         }
 
-        // For a source file, it is possible there are detached comments we should not skip
-        if (node.kind === SyntaxKind.SourceFile && includeJsDoc) {
-            const text = (node as SourceFile).text;
-            let ranges = getLeadingCommentRanges(text, 0);
-            if (!ranges) return 0;
-            let position = 0;
-            // However we should still skip a pinned comment at the top
-            if (ranges.length && ranges[0].kind === SyntaxKind.MultiLineCommentTrivia && isPinnedComment(text, ranges[0])) {
-                position = ranges[0].end + 1;
-                ranges = ranges.slice(1);
-            }
-            // As well as any triple slash references
-            for (const range of ranges) {
-                if (range.kind === SyntaxKind.SingleLineCommentTrivia && isRecognizedTripleSlashComment((node as SourceFile).text, range.pos, range.end)) {
-                    position = range.end + 1;
-                    continue;
-                }
-                break;
-            }
-            return position;
-        }
         return skipTrivia((sourceFile || getSourceFileOfNode(node)).text, node.pos);
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -681,10 +681,6 @@ namespace ts {
     export let fullTripleSlashReferenceTypeReferenceDirectiveRegEx = /^(\/\/\/\s*<reference\s+types\s*=\s*)('|")(.+?)\2.*?\/>/;
     export let fullTripleSlashAMDReferencePathRegEx = /^(\/\/\/\s*<amd-dependency\s+path\s*=\s*)('|")(.+?)\2.*?\/>/;
     export let defaultLibReferenceRegEx = /^(\/\/\/\s*<reference\s+no-default-lib\s*=\s*)('|")(.+?)\2\s*\/>/;
-    /**
-     * Copy with new flags via RegExp constructor is ES6+, so this needs to be manually synced with the above
-     */
-    const defaultLibReferenceRegExGIM = /^(\/\/\/\s*<reference\s+no-default-lib\s*=\s*)('|")(.+?)\2\s*\/>/gim;
 
     export function isPartOfTypeNode(node: Node): boolean {
         if (SyntaxKind.FirstTypeNode <= node.kind && node.kind <= SyntaxKind.LastTypeNode) {
@@ -1876,7 +1872,7 @@ namespace ts {
 
     export function getFileReferenceFromReferencePath(comment: string, commentRange: CommentRange): ReferencePathMatchResult {
         const simpleReferenceRegEx = /^\/\/\/\s*<reference\s+/gim;
-        const isNoDefaultLibRegEx = new RegExp(defaultLibReferenceRegExGIM);
+        const isNoDefaultLibRegEx = new RegExp(defaultLibReferenceRegEx.source, "gim");
         if (simpleReferenceRegEx.test(comment)) {
             if (isNoDefaultLibRegEx.test(comment)) {
                 return { isNoDefaultLib: true };

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -275,7 +275,8 @@ namespace ts {
             const textSubStr = text.substring(commentPos, commentEnd);
             return textSubStr.match(fullTripleSlashReferencePathRegEx) ||
                 textSubStr.match(fullTripleSlashAMDReferencePathRegEx) ||
-                textSubStr.match(fullTripleSlashReferenceTypeReferenceDirectiveRegEx) ?
+                textSubStr.match(fullTripleSlashReferenceTypeReferenceDirectiveRegEx) ||
+                textSubStr.match(defaultLibReferenceRegEx) ?
                 true : false;
         }
         return false;
@@ -700,6 +701,7 @@ namespace ts {
     export let fullTripleSlashReferencePathRegEx = /^(\/\/\/\s*<reference\s+path\s*=\s*)('|")(.+?)\2.*?\/>/;
     export let fullTripleSlashReferenceTypeReferenceDirectiveRegEx = /^(\/\/\/\s*<reference\s+types\s*=\s*)('|")(.+?)\2.*?\/>/;
     export let fullTripleSlashAMDReferencePathRegEx = /^(\/\/\/\s*<amd-dependency\s+path\s*=\s*)('|")(.+?)\2.*?\/>/;
+    export let defaultLibReferenceRegEx = /^(\/\/\/\s*<reference\s+no-default-lib\s*=\s*)('|")(.+?)\2\s*\/>/;
 
     export function isPartOfTypeNode(node: Node): boolean {
         if (SyntaxKind.FirstTypeNode <= node.kind && node.kind <= SyntaxKind.LastTypeNode) {
@@ -1891,7 +1893,7 @@ namespace ts {
 
     export function getFileReferenceFromReferencePath(comment: string, commentRange: CommentRange): ReferencePathMatchResult {
         const simpleReferenceRegEx = /^\/\/\/\s*<reference\s+/gim;
-        const isNoDefaultLibRegEx = /^(\/\/\/\s*<reference\s+no-default-lib\s*=\s*)('|")(.+?)\2\s*\/>/gim;
+        const isNoDefaultLibRegEx = new RegExp(defaultLibReferenceRegEx as any, "gim"); // TODO (weswigham): Remove cast after #17555 is a published lib change
         if (simpleReferenceRegEx.test(comment)) {
             if (isNoDefaultLibRegEx.test(comment)) {
                 return { isNoDefaultLib: true };

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -274,7 +274,8 @@ namespace ts {
             text.charCodeAt(commentPos + 2) === CharacterCodes.slash) {
             const textSubStr = text.substring(commentPos, commentEnd);
             return textSubStr.match(fullTripleSlashReferencePathRegEx) ||
-                textSubStr.match(fullTripleSlashAMDReferencePathRegEx) ?
+                textSubStr.match(fullTripleSlashAMDReferencePathRegEx) ||
+                textSubStr.match(fullTripleSlashReferenceTypeReferenceDirectiveRegEx) ?
                 true : false;
         }
         return false;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -681,6 +681,10 @@ namespace ts {
     export let fullTripleSlashReferenceTypeReferenceDirectiveRegEx = /^(\/\/\/\s*<reference\s+types\s*=\s*)('|")(.+?)\2.*?\/>/;
     export let fullTripleSlashAMDReferencePathRegEx = /^(\/\/\/\s*<amd-dependency\s+path\s*=\s*)('|")(.+?)\2.*?\/>/;
     export let defaultLibReferenceRegEx = /^(\/\/\/\s*<reference\s+no-default-lib\s*=\s*)('|")(.+?)\2\s*\/>/;
+    /**
+     * Copy with new flags via RegExp constructor is ES6+, so this needs to be manually synced with the above
+     */
+    const defaultLibReferenceRegExGIM = /^(\/\/\/\s*<reference\s+no-default-lib\s*=\s*)('|")(.+?)\2\s*\/>/gim;
 
     export function isPartOfTypeNode(node: Node): boolean {
         if (SyntaxKind.FirstTypeNode <= node.kind && node.kind <= SyntaxKind.LastTypeNode) {
@@ -1872,7 +1876,7 @@ namespace ts {
 
     export function getFileReferenceFromReferencePath(comment: string, commentRange: CommentRange): ReferencePathMatchResult {
         const simpleReferenceRegEx = /^\/\/\/\s*<reference\s+/gim;
-        const isNoDefaultLibRegEx = new RegExp(defaultLibReferenceRegEx as any, "gim"); // TODO (weswigham): Remove cast after #17555 is a published lib change
+        const isNoDefaultLibRegEx = new RegExp(defaultLibReferenceRegExGIM);
         if (simpleReferenceRegEx.test(comment)) {
             if (isNoDefaultLibRegEx.test(comment)) {
                 return { isNoDefaultLib: true };

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -393,7 +393,7 @@ namespace ts.codefix {
                         : createImportClause(/*name*/ undefined, createNamedImports([createImportSpecifier(/*propertyName*/ undefined, createIdentifier(symbolName))]));
                 const importDecl = createImportDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, importClause, createLiteral(moduleSpecifierWithoutQuotes));
                 if (!lastImportDeclaration) {
-                    changeTracker.insertNodeAt(sourceFile, sourceFile.getStart(), importDecl, { suffix: `${context.newLineCharacter}${context.newLineCharacter}` });
+                    changeTracker.insertNodeAt(sourceFile, sourceFile.getStart(sourceFile, /*includeJsDoc*/ true), importDecl, { suffix: `${context.newLineCharacter}${context.newLineCharacter}` });
                 }
                 else {
                     changeTracker.insertNodeAfter(sourceFile, lastImportDeclaration, importDecl, { suffix: context.newLineCharacter });

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -393,7 +393,7 @@ namespace ts.codefix {
                         : createImportClause(/*name*/ undefined, createNamedImports([createImportSpecifier(/*propertyName*/ undefined, createIdentifier(symbolName))]));
                 const importDecl = createImportDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, importClause, createLiteral(moduleSpecifierWithoutQuotes));
                 if (!lastImportDeclaration) {
-                    changeTracker.insertNodeAt(sourceFile, sourceFile.getStart(sourceFile, /*includeJsDoc*/ true), importDecl, { suffix: `${context.newLineCharacter}${context.newLineCharacter}` });
+                    changeTracker.insertNodeAt(sourceFile, getSourceFileImportLocation(sourceFile), importDecl, { suffix: `${context.newLineCharacter}${context.newLineCharacter}` });
                 }
                 else {
                     changeTracker.insertNodeAfter(sourceFile, lastImportDeclaration, importDecl, { suffix: context.newLineCharacter });
@@ -409,6 +409,28 @@ namespace ts.codefix {
                     "NewImport",
                     moduleSpecifierWithoutQuotes
                 );
+
+                function getSourceFileImportLocation(node: SourceFile) {
+                    // For a source file, it is possible there are detached comments we should not skip
+                    const text = node.text;
+                    let ranges = getLeadingCommentRanges(text, 0);
+                    if (!ranges) return 0;
+                    let position = 0;
+                    // However we should still skip a pinned comment at the top
+                    if (ranges.length && ranges[0].kind === SyntaxKind.MultiLineCommentTrivia && isPinnedComment(text, ranges[0])) {
+                        position = ranges[0].end + 1;
+                        ranges = ranges.slice(1);
+                    }
+                    // As well as any triple slash references
+                    for (const range of ranges) {
+                        if (range.kind === SyntaxKind.SingleLineCommentTrivia && isRecognizedTripleSlashComment(node.text, range.pos, range.end)) {
+                            position = range.end + 1;
+                            continue;
+                        }
+                        break;
+                    }
+                    return position;
+                }
 
                 function getModuleSpecifierForNewImport() {
                     const fileName = sourceFile.fileName;

--- a/tests/baselines/reference/1.0lib-noErrors.js
+++ b/tests/baselines/reference/1.0lib-noErrors.js
@@ -1158,3 +1158,4 @@ MERCHANTABLITY OR NON-INFRINGEMENT.
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
+/// <reference no-default-lib="true"/>

--- a/tests/baselines/reference/typeReferenceDirectives1.js
+++ b/tests/baselines/reference/typeReferenceDirectives1.js
@@ -10,6 +10,7 @@ interface A {
 }
 
 //// [app.js]
+/// <reference types="lib"/>
 
 
 //// [app.d.ts]

--- a/tests/baselines/reference/typeReferenceDirectives3.js
+++ b/tests/baselines/reference/typeReferenceDirectives3.js
@@ -16,6 +16,7 @@ interface A {
 }
 
 //// [app.js]
+/// <reference types="lib"/>
 /// <reference path="ref.d.ts" />
 
 

--- a/tests/cases/fourslash/importNameCodeFixNewImportAmbient2.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportAmbient2.ts
@@ -1,6 +1,6 @@
 /// <reference path="fourslash.ts" />
 
-////[|/*
+////[|/*!
 //// * I'm a license or something
 //// */
 ////f1/*0*/();|]
@@ -12,7 +12,7 @@
 //// }
 
 verify.importFixAtPosition([
-`/*
+`/*!
  * I'm a license or something
  */
 import { f1 } from "ambient-module";

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileAllComments.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileAllComments.ts
@@ -5,7 +5,6 @@
 ////  */
 //// /// <reference types="node" />
 //// /// <reference path="./a.ts" />
-//// /// <reference no-default-lib="test" />
 //// /// <amd-dependency path="./b.ts" />
 //// /**
 ////  * This is a comment intended to be attached to this interface
@@ -24,7 +23,6 @@ verify.importFixAtPosition([
  */
 /// <reference types="node" />
 /// <reference path="./a.ts" />
-/// <reference no-default-lib="test" />
 /// <amd-dependency path="./b.ts" />
 import { f1 } from "./module";
 

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileAllComments.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileAllComments.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+//// [|/*!
+////  * This is a license or something
+////  */
+//// /// <reference types="node" />
+//// /**
+////  * This is a comment intended to be attached to this interface
+////  */
+//// export interface SomeInterface {
+//// }
+//// f1/*0*/();|]
+
+// @Filename: module.ts
+//// export function f1() {}
+//// export var v1 = 5;
+
+verify.importFixAtPosition([
+`/*!
+ * This is a license or something
+ */
+/// <reference types="node" />
+import { f1 } from "./module";
+
+/**
+ * This is a comment intended to be attached to this interface
+ */
+export interface SomeInterface {
+}
+f1();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileAllComments.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileAllComments.ts
@@ -4,6 +4,9 @@
 ////  * This is a license or something
 ////  */
 //// /// <reference types="node" />
+//// /// <reference path="./a.ts" />
+//// /// <reference no-default-lib />
+//// /// <amd-dependency path="./b.ts" />
 //// /**
 ////  * This is a comment intended to be attached to this interface
 ////  */
@@ -20,6 +23,9 @@ verify.importFixAtPosition([
  * This is a license or something
  */
 /// <reference types="node" />
+/// <reference path="./a.ts" />
+/// <reference no-default-lib />
+/// <amd-dependency path="./b.ts" />
 import { f1 } from "./module";
 
 /**

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileAllComments.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileAllComments.ts
@@ -5,7 +5,7 @@
 ////  */
 //// /// <reference types="node" />
 //// /// <reference path="./a.ts" />
-//// /// <reference no-default-lib />
+//// /// <reference no-default-lib="test" />
 //// /// <amd-dependency path="./b.ts" />
 //// /**
 ////  * This is a comment intended to be attached to this interface
@@ -24,7 +24,7 @@ verify.importFixAtPosition([
  */
 /// <reference types="node" />
 /// <reference path="./a.ts" />
-/// <reference no-default-lib />
+/// <reference no-default-lib="test" />
 /// <amd-dependency path="./b.ts" />
 import { f1 } from "./module";
 

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileDetachedComments.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileDetachedComments.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+//// [|/**
+////  * This is a comment intended to be attached to this interface
+////  */
+//// export interface SomeInterface {
+//// }
+//// f1/*0*/();|]
+
+// @Filename: module.ts
+//// export function f1() {}
+//// export var v1 = 5;
+
+verify.importFixAtPosition([
+`import { f1 } from "./module";
+
+/**
+ * This is a comment intended to be attached to this interface
+ */
+export interface SomeInterface {
+}
+f1();`
+]);


### PR DESCRIPTION
Fixes #17318

We now distinguish between pinned and jsdoc comments (and triple slash references) when looking for the start of the file for this quickfix. Namely, we not assume that jsdoc comments are meant to be after the import unless pinned.