### PR TITLE
Add 'name' property to Identifier

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -242,7 +242,7 @@ namespace ts {
                     }
 
                     Debug.assert(isWellKnownSymbolSyntactically(nameExpression));
-                    return getPropertyNameForKnownSymbolName(unescapeLeadingUnderscores((<PropertyAccessExpression>nameExpression).name.text));
+                    return getPropertyNameForKnownSymbolName(unescapeLeadingUnderscores((<PropertyAccessExpression>nameExpression).name.escapedText));
                 }
                 return getEscapedTextOfIdentifierOrLiteral(<Identifier | LiteralExpression>name);
             }
@@ -287,8 +287,8 @@ namespace ts {
                     if (parentNode && parentNode.kind === SyntaxKind.VariableStatement) {
                         if ((<VariableStatement>parentNode).declarationList.declarations.length > 0) {
                             const nameIdentifier = (<VariableStatement>parentNode).declarationList.declarations[0].name;
-                            if (nameIdentifier.kind === SyntaxKind.Identifier) {
-                                nameFromParentNode = (<Identifier>nameIdentifier).text;
+                            if (isIdentifier(nameIdentifier)) {
+                                nameFromParentNode = nameIdentifier.escapedText;
                             }
                         }
                     }
@@ -1031,7 +1031,7 @@ namespace ts {
         function bindBreakOrContinueStatement(node: BreakOrContinueStatement): void {
             bind(node.label);
             if (node.label) {
-                const activeLabel = findActiveLabel(node.label.text);
+                const activeLabel = findActiveLabel(node.label.escapedText);
                 if (activeLabel) {
                     activeLabel.referenced = true;
                     bindBreakOrContinueFlow(node, activeLabel.breakTarget, activeLabel.continueTarget);
@@ -1192,7 +1192,7 @@ namespace ts {
             const postStatementLabel = createBranchLabel();
             bind(node.label);
             addAntecedent(preStatementLabel, currentFlow);
-            const activeLabel = pushActiveLabel(node.label.text, postStatementLabel, preStatementLabel);
+            const activeLabel = pushActiveLabel(node.label.escapedText, postStatementLabel, preStatementLabel);
             bind(node.statement);
             popActiveLabel();
             if (!activeLabel.referenced && !options.allowUnusedLabels) {
@@ -1680,9 +1680,9 @@ namespace ts {
                         ? ElementKind.Property
                         : ElementKind.Accessor;
 
-                    const existingKind = seen.get(identifier.text);
+                    const existingKind = seen.get(identifier.escapedText);
                     if (!existingKind) {
-                        seen.set(identifier.text, currentKind);
+                        seen.set(identifier.escapedText, currentKind);
                         continue;
                     }
 
@@ -1792,8 +1792,7 @@ namespace ts {
         }
 
         function isEvalOrArgumentsIdentifier(node: Node): boolean {
-            return node.kind === SyntaxKind.Identifier &&
-                ((<Identifier>node).text === "eval" || (<Identifier>node).text === "arguments");
+            return isIdentifier(node) && (node.escapedText === "eval" || node.escapedText === "arguments");
         }
 
         function checkStrictModeEvalOrArguments(contextNode: Node, name: Node) {
@@ -1804,7 +1803,7 @@ namespace ts {
                     // otherwise report generic error message.
                     const span = getErrorSpanForNode(file, name);
                     file.bindDiagnostics.push(createFileDiagnostic(file, span.start, span.length,
-                        getStrictModeEvalOrArgumentsMessage(contextNode), unescapeLeadingUnderscores(identifier.text)));
+                        getStrictModeEvalOrArgumentsMessage(contextNode), unescapeLeadingUnderscores(identifier.escapedText)));
                 }
             }
         }
@@ -2295,14 +2294,10 @@ namespace ts {
         }
 
         function isNameOfExportsOrModuleExportsAliasDeclaration(node: Node) {
-            if (node.kind === SyntaxKind.Identifier) {
-                const symbol = lookupSymbolForName((<Identifier>node).text);
-                if (symbol && symbol.valueDeclaration && symbol.valueDeclaration.kind === SyntaxKind.VariableDeclaration) {
-                    const declaration = symbol.valueDeclaration as VariableDeclaration;
-                    if (declaration.initializer) {
-                        return isExportsOrModuleExportsOrAliasOrAssignment(declaration.initializer);
-                    }
-                }
+            if (isIdentifier(node)) {
+                const symbol = lookupSymbolForName(node.escapedText);
+                return symbol && symbol.valueDeclaration && isVariableDeclaration(symbol.valueDeclaration) &&
+                    symbol.valueDeclaration.initializer && isExportsOrModuleExportsOrAliasOrAssignment(symbol.valueDeclaration.initializer);
             }
             return false;
         }
@@ -2369,7 +2364,7 @@ namespace ts {
             constructorFunction.parent = classPrototype;
             classPrototype.parent = leftSideOfAssignment;
 
-            bindPropertyAssignment(constructorFunction.text, leftSideOfAssignment, /*isPrototypeProperty*/ true);
+            bindPropertyAssignment(constructorFunction.escapedText, leftSideOfAssignment, /*isPrototypeProperty*/ true);
         }
 
         function bindStaticPropertyAssignment(node: BinaryExpression) {
@@ -2391,7 +2386,7 @@ namespace ts {
                 bindExportsPropertyAssignment(node);
             }
             else {
-                bindPropertyAssignment(target.text, leftSideOfAssignment, /*isPrototypeProperty*/ false);
+                bindPropertyAssignment(target.escapedText, leftSideOfAssignment, /*isPrototypeProperty*/ false);
             }
         }
 
@@ -2432,11 +2427,11 @@ namespace ts {
                 bindBlockScopedDeclaration(node, SymbolFlags.Class, SymbolFlags.ClassExcludes);
             }
             else {
-                const bindingName = node.name ? node.name.text : InternalSymbolName.Class;
+                const bindingName = node.name ? node.name.escapedText : InternalSymbolName.Class;
                 bindAnonymousDeclaration(node, SymbolFlags.Class, bindingName);
                 // Add name of class expression into the map for semantic classifier
                 if (node.name) {
-                    classifiableNames.set(node.name.text, true);
+                    classifiableNames.set(node.name.escapedText, true);
                 }
             }
 
@@ -2545,7 +2540,7 @@ namespace ts {
                 node.flowNode = currentFlow;
             }
             checkStrictModeFunctionName(node);
-            const bindingName = node.name ? node.name.text : InternalSymbolName.Function;
+            const bindingName = node.name ? node.name.escapedText : InternalSymbolName.Function;
             return bindAnonymousDeclaration(node, SymbolFlags.Function, bindingName);
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -502,7 +502,7 @@ namespace ts {
                 if (compilerOptions.jsxFactory) {
                     _jsxFactoryEntity = parseIsolatedEntityName(compilerOptions.jsxFactory, languageVersion);
                     if (_jsxFactoryEntity) {
-                        _jsxNamespace = getFirstIdentifier(_jsxFactoryEntity).text;
+                        _jsxNamespace = getFirstIdentifier(_jsxFactoryEntity).escapedText;
                     }
                 }
                 else if (compilerOptions.reactNamespace) {
@@ -1007,7 +1007,7 @@ namespace ts {
                         }
                         if (location.kind === SyntaxKind.ClassExpression && meaning & SymbolFlags.Class) {
                             const className = (<ClassExpression>location).name;
-                            if (className && name === className.text) {
+                            if (className && name === className.escapedText) {
                                 result = location.symbol;
                                 break loop;
                             }
@@ -1052,7 +1052,7 @@ namespace ts {
 
                         if (meaning & SymbolFlags.Function) {
                             const functionName = (<FunctionExpression>location).name;
-                            if (functionName && name === functionName.text) {
+                            if (functionName && name === functionName.escapedText) {
                                 result = location.symbol;
                                 break loop;
                             }
@@ -1414,7 +1414,7 @@ namespace ts {
             const targetSymbol = resolveESModuleSymbol(moduleSymbol, node.moduleSpecifier, dontResolveAlias);
             if (targetSymbol) {
                 const name = specifier.propertyName || specifier.name;
-                if (name.text) {
+                if (name.escapedText) {
                     if (isShorthandAmbientModuleSymbol(moduleSymbol)) {
                         return moduleSymbol;
                     }
@@ -1422,16 +1422,16 @@ namespace ts {
                     let symbolFromVariable: Symbol;
                     // First check if module was specified with "export=". If so, get the member from the resolved type
                     if (moduleSymbol && moduleSymbol.exports && moduleSymbol.exports.get("export=" as __String)) {
-                        symbolFromVariable = getPropertyOfType(getTypeOfSymbol(targetSymbol), name.text);
+                        symbolFromVariable = getPropertyOfType(getTypeOfSymbol(targetSymbol), name.escapedText);
                     }
                     else {
-                        symbolFromVariable = getPropertyOfVariable(targetSymbol, name.text);
+                        symbolFromVariable = getPropertyOfVariable(targetSymbol, name.escapedText);
                     }
                     // if symbolFromVariable is export - get its final target
                     symbolFromVariable = resolveSymbol(symbolFromVariable, dontResolveAlias);
-                    let symbolFromModule = getExportOfModule(targetSymbol, name.text, dontResolveAlias);
+                    let symbolFromModule = getExportOfModule(targetSymbol, name.escapedText, dontResolveAlias);
                     // If the export member we're looking for is default, and there is no real default but allowSyntheticDefaultImports is on, return the entire module as the default
-                    if (!symbolFromModule && allowSyntheticDefaultImports && name.text === "default") {
+                    if (!symbolFromModule && allowSyntheticDefaultImports && name.escapedText === "default") {
                         symbolFromModule = resolveExternalModuleSymbol(moduleSymbol, dontResolveAlias) || resolveSymbol(moduleSymbol, dontResolveAlias);
                     }
                     const symbol = symbolFromModule && symbolFromVariable ?
@@ -1591,7 +1591,7 @@ namespace ts {
             if (name.kind === SyntaxKind.Identifier) {
                 const message = meaning === SymbolFlags.Namespace ? Diagnostics.Cannot_find_namespace_0 : Diagnostics.Cannot_find_name_0;
 
-                symbol = resolveName(location || name, (<Identifier>name).text, meaning, ignoreErrors ? undefined : message, <Identifier>name);
+                symbol = resolveName(location || name, name.escapedText, meaning, ignoreErrors ? undefined : message, name);
                 if (!symbol) {
                     return undefined;
                 }
@@ -1621,7 +1621,7 @@ namespace ts {
                 else if (namespace === unknownSymbol) {
                     return namespace;
                 }
-                symbol = getSymbol(getExportsOfSymbol(namespace), right.text, meaning);
+                symbol = getSymbol(getExportsOfSymbol(namespace), right.escapedText, meaning);
                 if (!symbol) {
                     if (!ignoreErrors) {
                         error(right, Diagnostics.Namespace_0_has_no_exported_member_1, getFullyQualifiedName(namespace), declarationNameToString(right));
@@ -2263,7 +2263,7 @@ namespace ts {
             }
 
             const firstIdentifier = getFirstIdentifier(entityName);
-            const symbol = resolveName(enclosingDeclaration, (<Identifier>firstIdentifier).text, meaning, /*nodeNotFoundErrorMessage*/ undefined, /*nameArg*/ undefined);
+            const symbol = resolveName(enclosingDeclaration, firstIdentifier.escapedText, meaning, /*nodeNotFoundErrorMessage*/ undefined, /*nameArg*/ undefined);
 
             // Verify if the symbol is accessible
             return (symbol && hasVisibleDeclarations(symbol, /*shouldComputeAliasToMakeVisible*/ true)) || <SymbolVisibilityResult>{
@@ -3920,7 +3920,7 @@ namespace ts {
         function collectLinkedAliases(node: Identifier): Node[] {
             let exportSymbol: Symbol;
             if (node.parent && node.parent.kind === SyntaxKind.ExportAssignment) {
-                exportSymbol = resolveName(node.parent, node.text, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias, Diagnostics.Cannot_find_name_0, node);
+                exportSymbol = resolveName(node.parent, node.escapedText, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias, Diagnostics.Cannot_find_name_0, node);
             }
             else if (node.parent.kind === SyntaxKind.ExportSpecifier) {
                 exportSymbol = getTargetOfExportSpecifier(<ExportSpecifier>node.parent, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias);
@@ -3943,7 +3943,7 @@ namespace ts {
                         // Add the referenced top container visible
                         const internalModuleReference = <Identifier | QualifiedName>(<ImportEqualsDeclaration>declaration).moduleReference;
                         const firstIdentifier = getFirstIdentifier(internalModuleReference);
-                        const importSymbol = resolveName(declaration, firstIdentifier.text, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace,
+                        const importSymbol = resolveName(declaration, firstIdentifier.escapedText, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace,
                             undefined, undefined);
                         if (importSymbol) {
                             buildVisibleNodeList(importSymbol.declarations);
@@ -5112,10 +5112,18 @@ namespace ts {
             if (!expr) {
                 return !isInAmbientContext(member);
             }
-            return expr.kind === SyntaxKind.StringLiteral || expr.kind === SyntaxKind.NumericLiteral ||
-                expr.kind === SyntaxKind.PrefixUnaryExpression && (<PrefixUnaryExpression>expr).operator === SyntaxKind.MinusToken &&
-                (<PrefixUnaryExpression>expr).operand.kind === SyntaxKind.NumericLiteral ||
-                expr.kind === SyntaxKind.Identifier && (nodeIsMissing(expr) || !!getSymbolOfNode(member.parent).exports.get((<Identifier>expr).text));
+            switch (expr.kind) {
+                case SyntaxKind.StringLiteral:
+                case SyntaxKind.NumericLiteral:
+                    return true;
+                case SyntaxKind.PrefixUnaryExpression:
+                    return (<PrefixUnaryExpression>expr).operator === SyntaxKind.MinusToken &&
+                        (<PrefixUnaryExpression>expr).operand.kind === SyntaxKind.NumericLiteral;
+                case SyntaxKind.Identifier:
+                    return nodeIsMissing(expr) || !!getSymbolOfNode(member.parent).exports.get((<Identifier>expr).escapedText);
+                default:
+                    return false;
+            }
         }
 
         function getEnumKind(symbol: Symbol): EnumKind {
@@ -6256,11 +6264,11 @@ namespace ts {
         }
 
         function createTypePredicateFromTypePredicateNode(node: TypePredicateNode): IdentifierTypePredicate | ThisTypePredicate {
-            if (node.parameterName.kind === SyntaxKind.Identifier) {
-                const parameterName = node.parameterName as Identifier;
+            const { parameterName } = node;
+            if (parameterName.kind === SyntaxKind.Identifier) {
                 return {
                     kind: TypePredicateKind.Identifier,
-                    parameterName: parameterName ? parameterName.text : undefined,
+                    parameterName: parameterName ? parameterName.escapedText : undefined,
                     parameterIndex: parameterName ? getTypePredicateParameterIndex((node.parent as SignatureDeclaration).parameters, parameterName) : undefined,
                     type: getTypeFromTypeNode(node.type)
                 } as IdentifierTypePredicate;
@@ -6444,7 +6452,7 @@ namespace ts {
                 if (!node) return false;
                 switch (node.kind) {
                     case SyntaxKind.Identifier:
-                        return (<Identifier>node).text === "arguments" && isPartOfExpression(node);
+                        return (<Identifier>node).escapedText === "arguments" && isPartOfExpression(node);
 
                     case SyntaxKind.PropertyDeclaration:
                     case SyntaxKind.MethodDeclaration:
@@ -6880,7 +6888,7 @@ namespace ts {
 
         function getIntendedTypeFromJSDocTypeReference(node: TypeReferenceNode): Type {
             if (isIdentifier(node.typeName)) {
-                if (node.typeName.text === "Object") {
+                if (node.typeName.escapedText === "Object") {
                     if (node.typeArguments && node.typeArguments.length === 2) {
                         const indexed = getTypeFromTypeNode(node.typeArguments[0]);
                         const target = getTypeFromTypeNode(node.typeArguments[1]);
@@ -6891,7 +6899,7 @@ namespace ts {
                     }
                     return anyType;
                 }
-                switch (node.typeName.text) {
+                switch (node.typeName.escapedText) {
                     case "String":
                         return stringType;
                     case "Number":
@@ -7508,7 +7516,7 @@ namespace ts {
             const propName = indexType.flags & TypeFlags.StringOrNumberLiteral ?
                 escapeLeadingUnderscores("" + (<LiteralType>indexType).value) :
                 accessExpression && checkThatExpressionIsProperSymbolReference(accessExpression.argumentExpression, indexType, /*reportError*/ false) ?
-                    getPropertyNameForKnownSymbolName(unescapeLeadingUnderscores((<Identifier>(<PropertyAccessExpression>accessExpression.argumentExpression).name).text)) :
+                    getPropertyNameForKnownSymbolName(unescapeLeadingUnderscores((<Identifier>(<PropertyAccessExpression>accessExpression.argumentExpression).name).escapedText)) :
                     undefined;
             if (propName !== undefined) {
                 const prop = getPropertyOfType(objectType, propName);
@@ -10658,7 +10666,7 @@ namespace ts {
         function getResolvedSymbol(node: Identifier): Symbol {
             const links = getNodeLinks(node);
             if (!links.resolvedSymbol) {
-                links.resolvedSymbol = !nodeIsMissing(node) && resolveName(node, node.text, SymbolFlags.Value | SymbolFlags.ExportValue, Diagnostics.Cannot_find_name_0, node, Diagnostics.Cannot_find_name_0_Did_you_mean_1) || unknownSymbol;
+                links.resolvedSymbol = !nodeIsMissing(node) && resolveName(node, node.escapedText, SymbolFlags.Value | SymbolFlags.ExportValue, Diagnostics.Cannot_find_name_0, node, Diagnostics.Cannot_find_name_0_Did_you_mean_1) || unknownSymbol;
             }
             return links.resolvedSymbol;
         }
@@ -10688,7 +10696,7 @@ namespace ts {
             }
             if (node.kind === SyntaxKind.PropertyAccessExpression) {
                 const key = getFlowCacheKey((<PropertyAccessExpression>node).expression);
-                return key && key + "." + unescapeLeadingUnderscores((<PropertyAccessExpression>node).name.text);
+                return key && key + "." + unescapeLeadingUnderscores((<PropertyAccessExpression>node).name.escapedText);
             }
             if (node.kind === SyntaxKind.BindingElement) {
                 const container = (node as BindingElement).parent.parent;
@@ -10716,10 +10724,9 @@ namespace ts {
                 const name = element.propertyName || element.name;
                 switch (name.kind) {
                     case SyntaxKind.Identifier:
-                        return unescapeLeadingUnderscores(name.text);
+                        return unescapeLeadingUnderscores(name.escapedText);
                     case SyntaxKind.ComputedPropertyName:
-                        if (isComputedNonLiteralName(name as PropertyName)) return undefined;
-                        return (name.expression as LiteralExpression).text;
+                        return isStringOrNumericLiteral(name.expression) ? name.expression.text : undefined;
                     case SyntaxKind.StringLiteral:
                     case SyntaxKind.NumericLiteral:
                         return name.text;
@@ -10745,12 +10752,12 @@ namespace ts {
                     return target.kind === SyntaxKind.SuperKeyword;
                 case SyntaxKind.PropertyAccessExpression:
                     return target.kind === SyntaxKind.PropertyAccessExpression &&
-                        (<PropertyAccessExpression>source).name.text === (<PropertyAccessExpression>target).name.text &&
+                        (<PropertyAccessExpression>source).name.escapedText === (<PropertyAccessExpression>target).name.escapedText &&
                         isMatchingReference((<PropertyAccessExpression>source).expression, (<PropertyAccessExpression>target).expression);
                 case SyntaxKind.BindingElement:
                     if (target.kind !== SyntaxKind.PropertyAccessExpression) return false;
                     const t = target as PropertyAccessExpression;
-                    if (t.name.text !== getBindingElementNameText(source as BindingElement)) return false;
+                    if (t.name.escapedText !== getBindingElementNameText(source as BindingElement)) return false;
                     if (source.parent.parent.kind === SyntaxKind.BindingElement && isMatchingReference(source.parent.parent, t.expression)) {
                             return true;
                     }
@@ -10779,7 +10786,7 @@ namespace ts {
         function containsMatchingReferenceDiscriminant(source: Node, target: Node) {
             return target.kind === SyntaxKind.PropertyAccessExpression &&
                 containsMatchingReference(source, (<PropertyAccessExpression>target).expression) &&
-                isDiscriminantProperty(getDeclaredTypeOfReference((<PropertyAccessExpression>target).expression), (<PropertyAccessExpression>target).name.text);
+                isDiscriminantProperty(getDeclaredTypeOfReference((<PropertyAccessExpression>target).expression), (<PropertyAccessExpression>target).name.escapedText);
         }
 
         function getDeclaredTypeOfReference(expr: Node): Type {
@@ -10788,7 +10795,7 @@ namespace ts {
             }
             if (expr.kind === SyntaxKind.PropertyAccessExpression) {
                 const type = getDeclaredTypeOfReference((<PropertyAccessExpression>expr).expression);
-                return type && getTypeOfPropertyOfType(type, (<PropertyAccessExpression>expr).name.text);
+                return type && getTypeOfPropertyOfType(type, (<PropertyAccessExpression>expr).name.escapedText);
             }
             return undefined;
         }
@@ -11277,7 +11284,7 @@ namespace ts {
             const root = getReferenceRoot(node);
             const parent = root.parent;
             const isLengthPushOrUnshift = parent.kind === SyntaxKind.PropertyAccessExpression && (
-                (<PropertyAccessExpression>parent).name.text === "length" ||
+                (<PropertyAccessExpression>parent).name.escapedText === "length" ||
                 parent.parent.kind === SyntaxKind.CallExpression && isPushOrUnshiftIdentifier((<PropertyAccessExpression>parent).name));
             const isElementAssignment = parent.kind === SyntaxKind.ElementAccessExpression &&
                 (<ElementAccessExpression>parent).expression === root &&
@@ -11623,11 +11630,11 @@ namespace ts {
                 return expr.kind === SyntaxKind.PropertyAccessExpression &&
                     declaredType.flags & TypeFlags.Union &&
                     isMatchingReference(reference, (<PropertyAccessExpression>expr).expression) &&
-                    isDiscriminantProperty(declaredType, (<PropertyAccessExpression>expr).name.text);
+                    isDiscriminantProperty(declaredType, (<PropertyAccessExpression>expr).name.escapedText);
             }
 
             function narrowTypeByDiscriminant(type: Type, propAccess: PropertyAccessExpression, narrowType: (t: Type) => Type): Type {
-                const propName = propAccess.name.text;
+                const propName = propAccess.name.escapedText;
                 const propType = getTypeOfPropertyOfType(type, propName);
                 const narrowedPropType = propType && narrowType(propType);
                 return propType === narrowedPropType ? type : filterType(type, t => isTypeComparableTo(getTypeOfPropertyOfType(t, propName), narrowedPropType));
@@ -12431,7 +12438,7 @@ namespace ts {
                 const jsDocFunctionType = <JSDocFunctionType>jsdocType;
                 if (jsDocFunctionType.parameters.length > 0 &&
                     jsDocFunctionType.parameters[0].name &&
-                    (jsDocFunctionType.parameters[0].name as Identifier).text === "this") {
+                    (jsDocFunctionType.parameters[0].name as Identifier).escapedText === "this") {
                     return getTypeFromTypeNode(jsDocFunctionType.parameters[0].type);
                 }
             }
@@ -12994,7 +13001,7 @@ namespace ts {
 
             if (isJsxAttribute(node.parent)) {
                 // JSX expression is in JSX attribute
-                return getTypeOfPropertyOfType(attributesType, (node.parent as JsxAttribute).name.text);
+                return getTypeOfPropertyOfType(attributesType, node.parent.name.escapedText);
             }
             else if (node.parent.kind === SyntaxKind.JsxElement) {
                 // JSX expression is in children of JSX Element, we will look for an "children" atttribute (we get the name from JSX.ElementAttributesProperty)
@@ -13017,7 +13024,7 @@ namespace ts {
                 if (!attributesType || isTypeAny(attributesType)) {
                     return undefined;
                 }
-                return getTypeOfPropertyOfType(attributesType, (attribute as JsxAttribute).name.text);
+                return getTypeOfPropertyOfType(attributesType, attribute.name.escapedText);
             }
             else {
                 return attributesType;
@@ -13283,7 +13290,17 @@ namespace ts {
         }
 
         function isNumericName(name: DeclarationName): boolean {
-            return name.kind === SyntaxKind.ComputedPropertyName ? isNumericComputedName(<ComputedPropertyName>name) : isNumericLiteralName((<Identifier>name).text);
+            switch (name.kind) {
+                case SyntaxKind.ComputedPropertyName:
+                    return isNumericComputedName(name);
+                case SyntaxKind.Identifier:
+                    return isNumericLiteralName(name.escapedText);
+                case SyntaxKind.NumericLiteral:
+                case SyntaxKind.StringLiteral:
+                    return isNumericLiteralName(name.text);
+                default:
+                    return false;
+            }
         }
 
         function isNumericComputedName(name: ComputedPropertyName): boolean {
@@ -13576,11 +13593,14 @@ namespace ts {
          */
         function isJsxIntrinsicIdentifier(tagName: JsxTagNameExpression) {
             // TODO (yuisu): comment
-            if (tagName.kind === SyntaxKind.PropertyAccessExpression || tagName.kind === SyntaxKind.ThisKeyword) {
-                return false;
-            }
-            else {
-                return isIntrinsicJsxName((<Identifier>tagName).text);
+            switch (tagName.kind) {
+                case SyntaxKind.PropertyAccessExpression:
+                case SyntaxKind.ThisKeyword:
+                    return false;
+                case SyntaxKind.Identifier:
+                    return isIntrinsicJsxName((<Identifier>tagName).escapedText);
+                default:
+                    Debug.fail();
             }
         }
 
@@ -13620,7 +13640,7 @@ namespace ts {
                     attributeSymbol.target = member;
                     attributesTable.set(attributeSymbol.name, attributeSymbol);
                     attributesArray.push(attributeSymbol);
-                    if (attributeDecl.name.text === jsxChildrenPropertyName) {
+                    if (attributeDecl.name.escapedText === jsxChildrenPropertyName) {
                         explicitlySpecifyChildrenAttribute = true;
                     }
                 }
@@ -13745,7 +13765,8 @@ namespace ts {
                 const intrinsicElementsType = getJsxType(JsxNames.IntrinsicElements);
                 if (intrinsicElementsType !== unknownType) {
                     // Property case
-                    const intrinsicProp = getPropertyOfType(intrinsicElementsType, (<Identifier>node.tagName).text);
+                    if (!isIdentifier(node.tagName)) throw Debug.fail();
+                    const intrinsicProp = getPropertyOfType(intrinsicElementsType, node.tagName.escapedText);
                     if (intrinsicProp) {
                         links.jsxFlags |= JsxFlags.IntrinsicNamedElement;
                         return links.resolvedSymbol = intrinsicProp;
@@ -13759,7 +13780,7 @@ namespace ts {
                     }
 
                     // Wasn't found
-                    error(node, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores((<Identifier>node.tagName).text), "JSX." + JsxNames.IntrinsicElements);
+                    error(node, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(node.tagName.escapedText), "JSX." + JsxNames.IntrinsicElements);
                     return links.resolvedSymbol = unknownSymbol;
                 }
                 else {
@@ -13945,8 +13966,8 @@ namespace ts {
                             let shouldBeCandidate = true;
                             for (const attribute of openingLikeElement.attributes.properties) {
                                 if (isJsxAttribute(attribute) &&
-                                    isUnhyphenatedJsxName(attribute.name.text) &&
-                                    !getPropertyOfType(paramType, attribute.name.text)) {
+                                    isUnhyphenatedJsxName(attribute.name.escapedText) &&
+                                    !getPropertyOfType(paramType, attribute.name.escapedText)) {
                                     shouldBeCandidate = false;
                                     break;
                                 }
@@ -14174,7 +14195,7 @@ namespace ts {
          */
         function getJsxAttributePropertySymbol(attrib: JsxAttribute): Symbol {
             const attributesType = getAttributesTypeFromJsxOpeningLikeElement(attrib.parent.parent as JsxOpeningElement);
-            const prop = getPropertyOfType(attributesType, attrib.name.text);
+            const prop = getPropertyOfType(attributesType, attrib.name.escapedText);
             return prop || unknownSymbol;
         }
 
@@ -14317,8 +14338,8 @@ namespace ts {
                 // This will allow excess properties in spread type as it is very common pattern to spread outter attributes into React component in its render method.
                 if (isSourceAttributeTypeAssignableToTarget && !isTypeAny(sourceAttributesType) && !isTypeAny(targetAttributesType)) {
                     for (const attribute of openingLikeElement.attributes.properties) {
-                        if (isJsxAttribute(attribute) && !isKnownProperty(targetAttributesType, attribute.name.text, /*isComparingJsxAttributes*/ true)) {
-                            error(attribute, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(attribute.name.text), typeToString(targetAttributesType));
+                        if (isJsxAttribute(attribute) && !isKnownProperty(targetAttributesType, attribute.name.escapedText, /*isComparingJsxAttributes*/ true)) {
+                            error(attribute, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(attribute.name.escapedText), typeToString(targetAttributesType));
                             // We break here so that errors won't be cascading
                             break;
                         }
@@ -14489,13 +14510,13 @@ namespace ts {
                 // handle cases when type is Type parameter with invalid or any constraint
                 return apparentType;
             }
-            const prop = getPropertyOfType(apparentType, right.text);
+            const prop = getPropertyOfType(apparentType, right.escapedText);
             if (!prop) {
                 const stringIndexType = getIndexTypeOfType(apparentType, IndexKind.String);
                 if (stringIndexType) {
                     return stringIndexType;
                 }
-                if (right.text && !checkAndReportErrorForExtendingInterface(node)) {
+                if (right.escapedText && !checkAndReportErrorForExtendingInterface(node)) {
                     reportNonexistentProperty(right, type.flags & TypeFlags.TypeParameter && (type as TypeParameter).isThisType ? apparentType : type);
                 }
                 return unknownType;
@@ -14503,13 +14524,13 @@ namespace ts {
             if (prop.valueDeclaration) {
                 if (isInPropertyInitializer(node) &&
                     !isBlockScopedNameDeclaredBeforeUse(prop.valueDeclaration, right)) {
-                    error(right, Diagnostics.Block_scoped_variable_0_used_before_its_declaration, unescapeLeadingUnderscores(right.text));
+                    error(right, Diagnostics.Block_scoped_variable_0_used_before_its_declaration, unescapeLeadingUnderscores(right.escapedText));
                 }
                 if (prop.valueDeclaration.kind === SyntaxKind.ClassDeclaration &&
                     node.parent && node.parent.kind !== SyntaxKind.TypeReference &&
                     !isInAmbientContext(prop.valueDeclaration) &&
                     !isBlockScopedNameDeclaredBeforeUse(prop.valueDeclaration, right)) {
-                    error(right, Diagnostics.Class_0_used_before_its_declaration, unescapeLeadingUnderscores(right.text));
+                    error(right, Diagnostics.Class_0_used_before_its_declaration, unescapeLeadingUnderscores(right.escapedText));
                 }
             }
 
@@ -14524,7 +14545,7 @@ namespace ts {
 
             if (assignmentKind) {
                 if (isReferenceToReadonlyEntity(<Expression>node, prop) || isReferenceThroughNamespaceImport(<Expression>node)) {
-                    error(right, Diagnostics.Cannot_assign_to_0_because_it_is_a_constant_or_a_read_only_property, unescapeLeadingUnderscores(right.text));
+                    error(right, Diagnostics.Cannot_assign_to_0_because_it_is_a_constant_or_a_read_only_property, unescapeLeadingUnderscores(right.escapedText));
                     return unknownType;
                 }
             }
@@ -14545,7 +14566,7 @@ namespace ts {
             let errorInfo: DiagnosticMessageChain;
             if (containingType.flags & TypeFlags.Union && !(containingType.flags & TypeFlags.Primitive)) {
                 for (const subtype of (containingType as UnionType).types) {
-                    if (!getPropertyOfType(subtype, propNode.text)) {
+                    if (!getPropertyOfType(subtype, propNode.escapedText)) {
                         errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1, declarationNameToString(propNode), typeToString(subtype));
                         break;
                     }
@@ -14562,7 +14583,7 @@ namespace ts {
         }
 
         function getSuggestionForNonexistentProperty(node: Identifier, containingType: Type): __String | undefined {
-            const suggestion = getSpellingSuggestionForName(unescapeLeadingUnderscores(node.text), getPropertiesOfType(containingType), SymbolFlags.Value);
+            const suggestion = getSpellingSuggestionForName(unescapeLeadingUnderscores(node.escapedText), getPropertiesOfType(containingType), SymbolFlags.Value);
             return suggestion && suggestion.name;
         }
 
@@ -15428,13 +15449,13 @@ namespace ts {
                 const element = <ClassElement>node;
                 switch (element.name.kind) {
                     case SyntaxKind.Identifier:
-                        return getLiteralType(unescapeLeadingUnderscores((<Identifier>element.name).text));
+                        return getLiteralType(unescapeLeadingUnderscores(element.name.escapedText));
                     case SyntaxKind.NumericLiteral:
                     case SyntaxKind.StringLiteral:
-                        return getLiteralType((<LiteralExpression>element.name).text);
+                        return getLiteralType(element.name.text);
 
                     case SyntaxKind.ComputedPropertyName:
-                        const nameType = checkComputedPropertyName(<ComputedPropertyName>element.name);
+                        const nameType = checkComputedPropertyName(element.name);
                         if (isTypeOfKind(nameType, TypeFlags.ESSymbol)) {
                             return nameType;
                         }
@@ -16297,8 +16318,9 @@ namespace ts {
             if (!isRequireCall(node, /*checkArgumentIsStringLiteral*/ true)) {
                 return false;
             }
-                // Make sure require is not a local function
-            const resolvedRequire = resolveName(node.expression, (<Identifier>node.expression).text, SymbolFlags.Value, /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined);
+            // Make sure require is not a local function
+            if (!isIdentifier(node.expression)) throw Debug.fail();
+            const resolvedRequire = resolveName(node.expression, node.expression.escapedText, SymbolFlags.Value, /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined);
             if (!resolvedRequire) {
                 // project does not contain symbol named 'require' - assume commonjs require
                 return true;
@@ -17455,7 +17477,7 @@ namespace ts {
             }
 
             function isEvalNode(node: Expression) {
-                return node.kind === SyntaxKind.Identifier && (node as Identifier).text === "eval";
+                return node.kind === SyntaxKind.Identifier && (node as Identifier).escapedText === "eval";
             }
 
             // Return true if there was no error, false if there was an error.
@@ -17953,9 +17975,9 @@ namespace ts {
             if (node.questionToken && isBindingPattern(node.name) && (func as FunctionLikeDeclaration).body) {
                 error(node, Diagnostics.A_binding_pattern_parameter_cannot_be_optional_in_an_implementation_signature);
             }
-            if (node.name && ((node.name as Identifier).text === "this" || (node.name as Identifier).text === "new")) {
+            if (node.name && isIdentifier(node.name) && (node.name.escapedText === "this" || node.name.escapedText === "new")) {
                 if (indexOf(func.parameters, node) !== 0) {
-                    error(node, Diagnostics.A_0_parameter_must_be_the_first_parameter, (node.name as Identifier).text as string);
+                    error(node, Diagnostics.A_0_parameter_must_be_the_first_parameter, node.name.escapedText as string);
                 }
                 if (func.kind === SyntaxKind.Constructor || func.kind === SyntaxKind.ConstructSignature || func.kind === SyntaxKind.ConstructorType) {
                     error(node, Diagnostics.A_constructor_cannot_have_a_this_parameter);
@@ -17973,9 +17995,7 @@ namespace ts {
             if (parameterList) {
                 for (let i = 0; i < parameterList.length; i++) {
                     const param = parameterList[i];
-                    if (param.name.kind === SyntaxKind.Identifier &&
-                        (<Identifier>param.name).text === parameter.text) {
-
+                    if (param.name.kind === SyntaxKind.Identifier && param.name.escapedText === parameter.escapedText) {
                         return i;
                     }
                 }
@@ -18057,17 +18077,15 @@ namespace ts {
                 }
 
                 const name = element.name;
-                if (name.kind === SyntaxKind.Identifier &&
-                    (<Identifier>name).text === predicateVariableName) {
+                if (name.kind === SyntaxKind.Identifier && name.escapedText === predicateVariableName) {
                     error(predicateVariableNode,
                         Diagnostics.A_type_predicate_cannot_reference_element_0_in_a_binding_pattern,
                         predicateVariableName);
                     return true;
                 }
-                else if (name.kind === SyntaxKind.ArrayBindingPattern ||
-                    name.kind === SyntaxKind.ObjectBindingPattern) {
+                else if (name.kind === SyntaxKind.ArrayBindingPattern || name.kind === SyntaxKind.ObjectBindingPattern) {
                     if (checkIfTypePredicateVariableIsDeclaredInBindingPattern(
-                        <BindingPattern>name,
+                        name,
                         predicateVariableNode,
                         predicateVariableName)) {
                         return true;
@@ -18175,8 +18193,8 @@ namespace ts {
             for (const member of node.members) {
                 if (member.kind === SyntaxKind.Constructor) {
                     for (const param of (member as ConstructorDeclaration).parameters) {
-                        if (isParameterPropertyDeclaration(param)) {
-                            addName(instanceNames, param.name, (param.name as Identifier).text, Declaration.Property);
+                        if (isParameterPropertyDeclaration(param) && !isBindingPattern(param.name)) {
+                            addName(instanceNames, param.name, param.name.escapedText, Declaration.Property);
                         }
                     }
                 }
@@ -18271,7 +18289,7 @@ namespace ts {
                             memberName = member.name.text;
                             break;
                         case SyntaxKind.Identifier:
-                            memberName = unescapeLeadingUnderscores(member.name.text);
+                            memberName = unescapeLeadingUnderscores(member.name.escapedText);
                             break;
                         default:
                             continue;
@@ -18738,8 +18756,11 @@ namespace ts {
                 if (subsequentNode && subsequentNode.pos === node.end) {
                     if (subsequentNode.kind === node.kind) {
                         const errorNode: Node = (<FunctionLikeDeclaration>subsequentNode).name || subsequentNode;
-                        // TODO(jfreeman): These are methods, so handle computed name case
-                        if (node.name && (<FunctionLikeDeclaration>subsequentNode).name && (<Identifier>node.name).text === (<Identifier>(<FunctionLikeDeclaration>subsequentNode).name).text) {
+                        // TODO: GH#17345: These are methods, so handle computed name case. (`Always allowing computed property names is *not* the correct behavior!)
+                        const subsequentName = (<FunctionLikeDeclaration>subsequentNode).name;
+                        if (node.name && subsequentName &&
+                            (isComputedPropertyName(node.name) && isComputedPropertyName(subsequentName) ||
+                                !isComputedPropertyName(node.name) && !isComputedPropertyName(subsequentName) && getEscapedTextOfIdentifierOrLiteral(node.name) === getEscapedTextOfIdentifierOrLiteral(subsequentName))) {
                             const reportError =
                                 (node.kind === SyntaxKind.MethodDeclaration || node.kind === SyntaxKind.MethodSignature) &&
                                 (getModifierFlags(node) & ModifierFlags.Static) !== (getModifierFlags(subsequentNode) & ModifierFlags.Static);
@@ -19209,7 +19230,7 @@ namespace ts {
                 const promiseConstructorSymbol = resolveEntityName(promiseConstructorName, SymbolFlags.Value, /*ignoreErrors*/ true);
                 const promiseConstructorType = promiseConstructorSymbol ? getTypeOfSymbol(promiseConstructorSymbol) : unknownType;
                 if (promiseConstructorType === unknownType) {
-                    if (promiseConstructorName.kind === SyntaxKind.Identifier && promiseConstructorName.text === "Promise" && getTargetType(returnType) === getGlobalPromiseType(/*reportErrors*/ false)) {
+                    if (promiseConstructorName.kind === SyntaxKind.Identifier && promiseConstructorName.escapedText === "Promise" && getTargetType(returnType) === getGlobalPromiseType(/*reportErrors*/ false)) {
                         error(returnTypeNode, Diagnostics.An_async_function_or_method_in_ES5_SlashES3_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_for_the_Promise_constructor_or_include_ES2015_in_your_lib_option);
                     }
                     else {
@@ -19233,10 +19254,10 @@ namespace ts {
 
                 // Verify there is no local declaration that could collide with the promise constructor.
                 const rootName = promiseConstructorName && getFirstIdentifier(promiseConstructorName);
-                const collidingSymbol = getSymbol(node.locals, rootName.text, SymbolFlags.Value);
+                const collidingSymbol = getSymbol(node.locals, rootName.escapedText, SymbolFlags.Value);
                 if (collidingSymbol) {
                     error(collidingSymbol.valueDeclaration, Diagnostics.Duplicate_identifier_0_Compiler_uses_declaration_1_to_support_async_functions,
-                        unescapeLeadingUnderscores(rootName.text),
+                        unescapeLeadingUnderscores(rootName.escapedText),
                         entityNameToString(promiseConstructorName));
                     return unknownType;
                 }
@@ -19306,7 +19327,7 @@ namespace ts {
 
         function markEntityNameOrEntityExpressionAsReference(typeName: EntityNameOrEntityNameExpression) {
             const rootName = typeName && getFirstIdentifier(typeName);
-            const rootSymbol = rootName && resolveName(rootName, rootName.text, (typeName.kind === SyntaxKind.Identifier ? SymbolFlags.Type : SymbolFlags.Namespace) | SymbolFlags.Alias, /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined);
+            const rootSymbol = rootName && resolveName(rootName, rootName.escapedText, (typeName.kind === SyntaxKind.Identifier ? SymbolFlags.Type : SymbolFlags.Namespace) | SymbolFlags.Alias, /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined);
             if (rootSymbol
                 && rootSymbol.flags & SymbolFlags.Alias
                 && symbolIsValue(rootSymbol)
@@ -19351,7 +19372,7 @@ namespace ts {
                                 // return undefined if they dont match because we would emit object
                                 if (!isIdentifier(commonEntityName) ||
                                     !isIdentifier(individualEntityName) ||
-                                    commonEntityName.text !== individualEntityName.text) {
+                                    commonEntityName.escapedText !== individualEntityName.escapedText) {
                                     return undefined;
                                 }
                             }
@@ -19638,7 +19659,7 @@ namespace ts {
         }
 
         function isIdentifierThatStartsWithUnderScore(node: Node) {
-            return node.kind === SyntaxKind.Identifier && unescapeLeadingUnderscores((<Identifier>node).text).charCodeAt(0) === CharacterCodes._;
+            return node.kind === SyntaxKind.Identifier && unescapeLeadingUnderscores((<Identifier>node).escapedText).charCodeAt(0) === CharacterCodes._;
         }
 
         function checkUnusedClassMembers(node: ClassDeclaration | ClassExpression): void {
@@ -19713,14 +19734,14 @@ namespace ts {
             }
 
             forEach(node.parameters, p => {
-                if (p.name && !isBindingPattern(p.name) && (<Identifier>p.name).text === argumentsSymbol.name) {
+                if (p.name && !isBindingPattern(p.name) && p.name.escapedText === argumentsSymbol.name) {
                     error(p, Diagnostics.Duplicate_identifier_arguments_Compiler_uses_arguments_to_initialize_rest_parameters);
                 }
             });
         }
 
         function needCollisionCheckForIdentifier(node: Node, identifier: Identifier, name: string): boolean {
-            if (!(identifier && identifier.text === name)) {
+            if (!(identifier && identifier.escapedText === name)) {
                 return false;
             }
 
@@ -19897,7 +19918,8 @@ namespace ts {
 
             const symbol = getSymbolOfNode(node);
             if (symbol.flags & SymbolFlags.FunctionScopedVariable) {
-                const localDeclarationSymbol = resolveName(node, (<Identifier>node.name).text, SymbolFlags.Variable, /*nodeNotFoundErrorMessage*/ undefined, /*nameArg*/ undefined);
+                if (!isIdentifier(node.name)) throw Debug.fail();
+                const localDeclarationSymbol = resolveName(node, node.name.escapedText, SymbolFlags.Variable, /*nodeNotFoundErrorMessage*/ undefined, /*nameArg*/ undefined);
                 if (localDeclarationSymbol &&
                     localDeclarationSymbol !== symbol &&
                     localDeclarationSymbol.flags & SymbolFlags.BlockScopedVariable) {
@@ -19952,7 +19974,7 @@ namespace ts {
                 else if (n.kind === SyntaxKind.Identifier) {
                     // check FunctionLikeDeclaration.locals (stores parameters\function local variable)
                     // if it contains entry with a specified name
-                    const symbol = resolveName(n, (<Identifier>n).text, SymbolFlags.Value | SymbolFlags.Alias, /*nameNotFoundMessage*/undefined, /*nameArg*/undefined);
+                    const symbol = resolveName(n, (<Identifier>n).escapedText, SymbolFlags.Value | SymbolFlags.Alias, /*nameNotFoundMessage*/undefined, /*nameArg*/undefined);
                     if (!symbol || symbol === unknownSymbol || !symbol.valueDeclaration) {
                         return;
                     }
@@ -20793,7 +20815,7 @@ namespace ts {
                                  if (isFunctionLike(current)) {
                                      return "quit";
                                  }
-                                 if (current.kind === SyntaxKind.LabeledStatement && (<LabeledStatement>current).label.text === node.label.text) {
+                                 if (current.kind === SyntaxKind.LabeledStatement && (<LabeledStatement>current).label.escapedText === node.label.escapedText) {
                                      const sourceFile = getSourceFileOfNode(node);
                                      grammarErrorOnNode(node.label, Diagnostics.Duplicate_label_0, getTextOfNodeFromSourceText(sourceFile.text, node.label));
                                      return true;
@@ -20947,10 +20969,10 @@ namespace ts {
             }
         }
 
-        function checkTypeNameIsReserved(name: DeclarationName, message: DiagnosticMessage): void {
+        function checkTypeNameIsReserved(name: Identifier, message: DiagnosticMessage): void {
             // TS 1.0 spec (April 2014): 3.6.1
             // The predefined type keywords are reserved and cannot be used as names of user defined types.
-            switch ((<Identifier>name).text) {
+            switch (name.escapedText) {
                 case "any":
                 case "number":
                 case "boolean":
@@ -20958,7 +20980,7 @@ namespace ts {
                 case "symbol":
                 case "void":
                 case "object":
-                    error(name, message, (<Identifier>name).text as string);
+                    error(name, message, (<Identifier>name).escapedText as string);
             }
         }
 
@@ -21031,7 +21053,7 @@ namespace ts {
 
                     // If the type parameter node does not have the same as the resolved type
                     // parameter at this position, we report an error.
-                    if (source.name.text !== target.symbol.name) {
+                    if (source.name.escapedText !== target.symbol.name) {
                         return false;
                     }
 
@@ -21485,15 +21507,22 @@ namespace ts {
                     case SyntaxKind.ParenthesizedExpression:
                         return evaluate((<ParenthesizedExpression>expr).expression);
                     case SyntaxKind.Identifier:
-                        return nodeIsMissing(expr) ? 0 : evaluateEnumMember(expr, getSymbolOfNode(member.parent), (<Identifier>expr).text);
+                        return nodeIsMissing(expr) ? 0 : evaluateEnumMember(expr, getSymbolOfNode(member.parent), (<Identifier>expr).escapedText);
                     case SyntaxKind.ElementAccessExpression:
                     case SyntaxKind.PropertyAccessExpression:
-                        if (isConstantMemberAccess(expr)) {
-                            const type = getTypeOfExpression((<PropertyAccessExpression | ElementAccessExpression>expr).expression);
+                        const ex = <PropertyAccessExpression | ElementAccessExpression>expr;
+                        if (isConstantMemberAccess(ex)) {
+                            const type = getTypeOfExpression(ex.expression);
                             if (type.symbol && type.symbol.flags & SymbolFlags.Enum) {
-                                const name = expr.kind === SyntaxKind.PropertyAccessExpression ?
-                                    (<PropertyAccessExpression>expr).name.text :
-                                    (<LiteralExpression>(<ElementAccessExpression>expr).argumentExpression).text as __String;
+                                let name: __String;
+                                if (ex.kind === SyntaxKind.PropertyAccessExpression) {
+                                    name = ex.name.escapedText;
+                                }
+                                else {
+                                    const argument = ex.argumentExpression;
+                                    Debug.assert(isLiteralExpression(argument));
+                                    name = (argument as LiteralExpression).text as __String; // TODO: GH#17348
+                                }
                                 return evaluateEnumMember(expr, type.symbol, name);
                             }
                         }
@@ -21799,7 +21828,7 @@ namespace ts {
                     Diagnostics.Import_declarations_in_a_namespace_cannot_reference_a_module);
                 return false;
             }
-            if (inAmbientExternalModule && isExternalModuleNameRelative((<LiteralExpression>moduleName).text)) {
+            if (inAmbientExternalModule && isExternalModuleNameRelative(getTextOfIdentifierOrLiteral(<LiteralExpression | Identifier>moduleName))) {
                 // we have already reported errors on top level imports\exports in external module augmentations in checkModuleDeclaration
                 // no need to do this again.
                 if (!isTopLevelInExternalModuleAugmentation(node)) {
@@ -21964,10 +21993,10 @@ namespace ts {
             if (!(<ExportDeclaration>node.parent.parent).moduleSpecifier) {
                 const exportedName = node.propertyName || node.name;
                 // find immediate value referenced by exported name (SymbolFlags.Alias is set so we don't chase down aliases)
-                const symbol = resolveName(exportedName, exportedName.text, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias,
+                const symbol = resolveName(exportedName, exportedName.escapedText, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias,
                     /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined);
                 if (symbol && (symbol === undefinedSymbol || isGlobalSourceFile(getDeclarationContainer(symbol.declarations[0])))) {
-                    error(exportedName, Diagnostics.Cannot_export_0_Only_local_declarations_can_be_exported_from_a_module, unescapeLeadingUnderscores(exportedName.text));
+                    error(exportedName, Diagnostics.Cannot_export_0_Only_local_declarations_can_be_exported_from_a_module, unescapeLeadingUnderscores(exportedName.escapedText));
                 }
                 else {
                     markExportAsReferenced(node);
@@ -22694,7 +22723,7 @@ namespace ts {
                     node.parent.parent.kind === SyntaxKind.ObjectBindingPattern &&
                     node === (<BindingElement>node.parent).propertyName) {
                     const typeOfPattern = getTypeOfNode(node.parent.parent);
-                    const propertyDeclaration = typeOfPattern && getPropertyOfType(typeOfPattern, (<Identifier>node).text);
+                    const propertyDeclaration = typeOfPattern && getPropertyOfType(typeOfPattern, (<Identifier>node).escapedText);
 
                     if (propertyDeclaration) {
                         return propertyDeclaration;
@@ -22886,7 +22915,7 @@ namespace ts {
         function getPropertySymbolOfDestructuringAssignment(location: Identifier) {
             // Get the type of the object or array literal and then look for property of given name in the type
             const typeOfObjectLiteral = getTypeOfArrayLiteralOrObjectLiteralDestructuringAssignment(<Expression>location.parent.parent);
-            return typeOfObjectLiteral && getPropertyOfType(typeOfObjectLiteral, location.text);
+            return typeOfObjectLiteral && getPropertyOfType(typeOfObjectLiteral, location.escapedText);
         }
 
         function getRegularTypeOfExpression(expr: Expression): Type {
@@ -23363,7 +23392,7 @@ namespace ts {
                 }
             }
 
-            return resolveName(location, reference.text, SymbolFlags.Value | SymbolFlags.ExportValue | SymbolFlags.Alias, /*nodeNotFoundMessage*/ undefined, /*nameArg*/ undefined);
+            return resolveName(location, reference.escapedText, SymbolFlags.Value | SymbolFlags.ExportValue | SymbolFlags.Alias, /*nodeNotFoundMessage*/ undefined, /*nameArg*/ undefined);
         }
 
         function getReferencedValueDeclaration(reference: Identifier): Declaration {
@@ -24320,8 +24349,8 @@ namespace ts {
 
                 const jsxAttr = (<JsxAttribute>attr);
                 const name = jsxAttr.name;
-                if (!seen.get(name.text)) {
-                    seen.set(name.text, true);
+                if (!seen.get(name.escapedText)) {
+                    seen.set(name.escapedText, true);
                 }
                 else {
                     return grammarErrorOnNode(name, Diagnostics.JSX_elements_cannot_have_multiple_attributes_with_the_same_name);
@@ -24495,7 +24524,7 @@ namespace ts {
 
                 switch (current.kind) {
                     case SyntaxKind.LabeledStatement:
-                        if (node.label && (<LabeledStatement>current).label.text === node.label.text) {
+                        if (node.label && (<LabeledStatement>current).label.escapedText === node.label.escapedText) {
                             // found matching label - verify that label usage is correct
                             // continue can only target labels that are on iteration statements
                             const isMisplacedContinueLabel = node.kind === SyntaxKind.ContinueStatement
@@ -24616,7 +24645,7 @@ namespace ts {
 
         function checkESModuleMarker(name: Identifier | BindingPattern): boolean {
             if (name.kind === SyntaxKind.Identifier) {
-                if (unescapeLeadingUnderscores(name.text) === "__esModule") {
+                if (unescapeLeadingUnderscores(name.escapedText) === "__esModule") {
                     return grammarErrorOnNode(name, Diagnostics.Identifier_expected_esModule_is_reserved_as_an_exported_marker_when_transforming_ECMAScript_modules);
                 }
             }
@@ -24687,8 +24716,8 @@ namespace ts {
 
         function checkGrammarMetaProperty(node: MetaProperty) {
             if (node.keywordToken === SyntaxKind.NewKeyword) {
-                if (node.name.text !== "target") {
-                    return grammarErrorOnNode(node.name, Diagnostics._0_is_not_a_valid_meta_property_for_keyword_1_Did_you_mean_2, node.name.text, tokenToString(node.keywordToken), "target");
+                if (node.name.escapedText !== "target") {
+                    return grammarErrorOnNode(node.name, Diagnostics._0_is_not_a_valid_meta_property_for_keyword_1_Did_you_mean_2, node.name.escapedText, tokenToString(node.keywordToken), "target");
                 }
             }
         }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2047,7 +2047,7 @@ namespace ts {
                 for (const property of getPropertyAssignment(jsonSourceFile.jsonObject, specKey)) {
                     if (isArrayLiteralExpression(property.initializer)) {
                         for (const element of property.initializer.elements) {
-                            if (element.kind === SyntaxKind.StringLiteral && (<StringLiteral>element).text === spec) {
+                            if (isStringLiteral(element) && element.text === spec) {
                                 return createDiagnosticForNodeInSourceFile(jsonSourceFile, element, message, spec);
                             }
                         }

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -1164,7 +1164,7 @@ namespace ts {
             if (baseTypeNode && !isEntityNameExpression(baseTypeNode.expression)) {
                 tempVarName = baseTypeNode.expression.kind === SyntaxKind.NullKeyword ?
                     "null" :
-                    emitTempVariableDeclaration(baseTypeNode.expression, `${node.name.text}_base`, {
+                    emitTempVariableDeclaration(baseTypeNode.expression, `${node.name.escapedText}_base`, {
                         diagnosticMessage: Diagnostics.extends_clause_of_exported_class_0_has_or_is_using_private_name_1,
                         errorNode: baseTypeNode,
                         typeName: node.name

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2761,7 +2761,7 @@ namespace ts {
                 return generateName(node);
             }
             else if (isIdentifier(node) && (nodeIsSynthesized(node) || !node.parent)) {
-                return unescapeLeadingUnderscores(node.text);
+                return unescapeLeadingUnderscores(node.escapedText);
             }
             else if (node.kind === SyntaxKind.StringLiteral && (<StringLiteral>node).textSourceNode) {
                 return getTextOfNode((<StringLiteral>node).textSourceNode, includeTrivia);
@@ -2917,8 +2917,8 @@ namespace ts {
          */
         function generateNameForImportOrExportDeclaration(node: ImportDeclaration | ExportDeclaration) {
             const expr = getExternalModuleName(node);
-            const baseName = expr.kind === SyntaxKind.StringLiteral ?
-                makeIdentifierFromModuleName((<LiteralExpression>expr).text) : "module";
+            const baseName = isStringLiteral(expr) ?
+                makeIdentifierFromModuleName(expr.text) : "module";
             return makeUniqueName(baseName);
         }
 
@@ -2981,7 +2981,7 @@ namespace ts {
                 case GeneratedIdentifierKind.Loop:
                     return makeTempVariableName(TempFlags._i);
                 case GeneratedIdentifierKind.Unique:
-                    return makeUniqueName(unescapeLeadingUnderscores(name.text));
+                    return makeUniqueName(unescapeLeadingUnderscores(name.escapedText));
             }
 
             Debug.fail("Unsupported GeneratedIdentifierKind.");

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -114,7 +114,7 @@ namespace ts {
     export function createIdentifier(text: string, typeArguments: ReadonlyArray<TypeNode>): Identifier;
     export function createIdentifier(text: string, typeArguments?: ReadonlyArray<TypeNode>): Identifier {
         const node = <Identifier>createSynthesizedNode(SyntaxKind.Identifier);
-        node.text = escapeLeadingUnderscores(text);
+        node.escapedText = escapeLeadingUnderscores(text);
         node.originalKeywordKind = text ? stringToToken(text) : SyntaxKind.Unknown;
         node.autoGenerateKind = GeneratedIdentifierKind.None;
         node.autoGenerateId = 0;
@@ -126,7 +126,7 @@ namespace ts {
 
     export function updateIdentifier(node: Identifier, typeArguments: NodeArray<TypeNode> | undefined): Identifier {
         return node.typeArguments !== typeArguments
-        ? updateNode(createIdentifier(unescapeLeadingUnderscores(node.text), typeArguments), node)
+        ? updateNode(createIdentifier(unescapeLeadingUnderscores(node.escapedText), typeArguments), node)
         : node;
     }
 
@@ -2863,12 +2863,12 @@ namespace ts {
     function createJsxFactoryExpressionFromEntityName(jsxFactory: EntityName, parent: JsxOpeningLikeElement): Expression {
         if (isQualifiedName(jsxFactory)) {
             const left = createJsxFactoryExpressionFromEntityName(jsxFactory.left, parent);
-            const right = createIdentifier(unescapeLeadingUnderscores(jsxFactory.right.text));
-            right.text = jsxFactory.right.text;
+            const right = createIdentifier(unescapeLeadingUnderscores(jsxFactory.right.escapedText));
+            right.escapedText = jsxFactory.right.escapedText;
             return createPropertyAccess(left, right);
         }
         else {
-            return createReactNamespace(unescapeLeadingUnderscores(jsxFactory.text), parent);
+            return createReactNamespace(unescapeLeadingUnderscores(jsxFactory.escapedText), parent);
         }
     }
 
@@ -3477,7 +3477,7 @@ namespace ts {
     }
 
     function isUseStrictPrologue(node: ExpressionStatement): boolean {
-        return (node.expression as StringLiteral).text === "use strict";
+        return isStringLiteral(node.expression) && node.expression.text === "use strict";
     }
 
     /**

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1158,7 +1158,14 @@ namespace ts {
             }
 
             const result = createNode(kind, scanner.getStartPos());
-            (<Identifier>result).text = "" as __String;
+            switch (kind) {
+                case SyntaxKind.Identifier:
+                    (result as Identifier).escapedText = "" as __String;
+                    break;
+                default: // TODO: GH#17346
+                    (result as LiteralLikeNode).text = "";
+                    break;
+            }
             return finishNode(result);
         }
 
@@ -1182,7 +1189,7 @@ namespace ts {
                 if (token() !== SyntaxKind.Identifier) {
                     node.originalKeywordKind = token();
                 }
-                node.text = escapeLeadingUnderscores(internIdentifier(scanner.getTokenValue()));
+                node.escapedText = escapeLeadingUnderscores(internIdentifier(scanner.getTokenValue()));
                 nextToken();
                 return finishNode(node);
             }
@@ -3896,7 +3903,7 @@ namespace ts {
             }
 
             if (lhs.kind === SyntaxKind.Identifier) {
-                return (<Identifier>lhs).text === (<Identifier>rhs).text;
+                return (<Identifier>lhs).escapedText === (<Identifier>rhs).escapedText;
             }
 
             if (lhs.kind === SyntaxKind.ThisKeyword) {
@@ -3906,7 +3913,7 @@ namespace ts {
             // If we are at this statement then we must have PropertyAccessExpression and because tag name in Jsx element can only
             // take forms of JsxTagNameExpression which includes an identifier, "this" expression, or another propertyAccessExpression
             // it is safe to case the expression property as such. See parseJsxElementName for how we parse tag name in Jsx element
-            return (<PropertyAccessExpression>lhs).name.text === (<PropertyAccessExpression>rhs).name.text &&
+            return (<PropertyAccessExpression>lhs).name.escapedText === (<PropertyAccessExpression>rhs).name.escapedText &&
                 tagNamesAreEquivalent((<PropertyAccessExpression>lhs).expression as JsxTagNameExpression, (<PropertyAccessExpression>rhs).expression as JsxTagNameExpression);
         }
 
@@ -6323,7 +6330,7 @@ namespace ts {
 
                     let tag: JSDocTag;
                     if (tagName) {
-                        switch (tagName.text) {
+                        switch (tagName.escapedText) {
                             case "augments":
                                 tag = parseAugmentsTag(atToken, tagName);
                                 break;
@@ -6506,7 +6513,7 @@ namespace ts {
 
                 function parseReturnTag(atToken: AtToken, tagName: Identifier): JSDocReturnTag {
                     if (forEach(tags, t => t.kind === SyntaxKind.JSDocReturnTag)) {
-                        parseErrorAtPosition(tagName.pos, scanner.getTokenPos() - tagName.pos, Diagnostics._0_tag_already_specified, tagName.text);
+                        parseErrorAtPosition(tagName.pos, scanner.getTokenPos() - tagName.pos, Diagnostics._0_tag_already_specified, tagName.escapedText);
                     }
 
                     const result = <JSDocReturnTag>createNode(SyntaxKind.JSDocReturnTag, atToken.pos);
@@ -6518,7 +6525,7 @@ namespace ts {
 
                 function parseTypeTag(atToken: AtToken, tagName: Identifier): JSDocTypeTag {
                     if (forEach(tags, t => t.kind === SyntaxKind.JSDocTypeTag)) {
-                        parseErrorAtPosition(tagName.pos, scanner.getTokenPos() - tagName.pos, Diagnostics._0_tag_already_specified, tagName.text);
+                        parseErrorAtPosition(tagName.pos, scanner.getTokenPos() - tagName.pos, Diagnostics._0_tag_already_specified, tagName.escapedText);
                     }
 
                     const result = <JSDocTypeTag>createNode(SyntaxKind.JSDocTypeTag, atToken.pos);
@@ -6584,7 +6591,7 @@ namespace ts {
 
                     function isObjectTypeReference(node: TypeNode) {
                         return node.kind === SyntaxKind.ObjectKeyword ||
-                            isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) && node.typeName.text === "Object";
+                            isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) && node.typeName.escapedText === "Object";
                     }
 
                     function scanChildTags(): JSDocTypeLiteral {
@@ -6660,7 +6667,7 @@ namespace ts {
                         return false;
                     }
 
-                    switch (tagName.text) {
+                    switch (tagName.escapedText) {
                         case "type":
                             if (parentTag.jsDocTypeTag) {
                                 // already has a @type tag, terminate the parent tag now.
@@ -6686,7 +6693,7 @@ namespace ts {
 
                 function parseTemplateTag(atToken: AtToken, tagName: Identifier): JSDocTemplateTag {
                     if (forEach(tags, t => t.kind === SyntaxKind.JSDocTemplateTag)) {
-                        parseErrorAtPosition(tagName.pos, scanner.getTokenPos() - tagName.pos, Diagnostics._0_tag_already_specified, tagName.text);
+                        parseErrorAtPosition(tagName.pos, scanner.getTokenPos() - tagName.pos, Diagnostics._0_tag_already_specified, tagName.escapedText);
                     }
 
                     // Type parameter list looks like '@template T,U,V'
@@ -6746,7 +6753,7 @@ namespace ts {
                     const pos = scanner.getTokenPos();
                     const end = scanner.getTextPos();
                     const result = <Identifier>createNode(SyntaxKind.Identifier, pos);
-                    result.text = escapeLeadingUnderscores(content.substring(pos, end));
+                    result.escapedText = escapeLeadingUnderscores(content.substring(pos, end));
                     finishNode(result, end);
 
                     nextJSDocToken();

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1441,19 +1441,20 @@ namespace ts {
                         break;
                     case SyntaxKind.ModuleDeclaration:
                         if (isAmbientModule(<ModuleDeclaration>node) && (inAmbientModule || hasModifier(node, ModifierFlags.Ambient) || file.isDeclarationFile)) {
-                            const moduleName = <StringLiteral>(<ModuleDeclaration>node).name;
+                            const moduleName = <StringLiteral>(<ModuleDeclaration>node).name; // TODO: GH#17347
+                            const nameText = ts.getTextOfIdentifierOrLiteral(moduleName);
                             // Ambient module declarations can be interpreted as augmentations for some existing external modules.
                             // This will happen in two cases:
                             // - if current file is external module then module augmentation is a ambient module declaration defined in the top level scope
                             // - if current file is not external module then module augmentation is an ambient module declaration with non-relative module name
                             //   immediately nested in top level ambient module declaration .
-                            if (isExternalModuleFile || (inAmbientModule && !isExternalModuleNameRelative(moduleName.text))) {
+                            if (isExternalModuleFile || (inAmbientModule && !isExternalModuleNameRelative(nameText))) {
                                 (moduleAugmentations || (moduleAugmentations = [])).push(moduleName);
                             }
                             else if (!inAmbientModule) {
                                 if (file.isDeclarationFile) {
                                     // for global .d.ts files record name of ambient module
-                                    (ambientModules || (ambientModules = [])).push(moduleName.text);
+                                    (ambientModules || (ambientModules = [])).push(nameText);
                                 }
                                 // An AmbientExternalModuleDeclaration declares an external module.
                                 // This type of declaration is permitted only in the global module.

--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -415,7 +415,7 @@ namespace ts {
             return createElementAccess(value, argumentExpression);
         }
         else {
-            const name = createIdentifier(unescapeLeadingUnderscores(propertyName.text));
+            const name = createIdentifier(unescapeLeadingUnderscores(propertyName.escapedText));
             return createPropertyAccess(value, name);
         }
     }

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -647,7 +647,7 @@ namespace ts {
             if (isGeneratedIdentifier(node)) {
                 return node;
             }
-            if (node.text !== "arguments" || !resolver.isArgumentsLocalBinding(node)) {
+            if (node.escapedText !== "arguments" || !resolver.isArgumentsLocalBinding(node)) {
                 return node;
             }
             return convertedLoopState.argumentsName || (convertedLoopState.argumentsName = createUniqueName("arguments"));
@@ -661,7 +661,7 @@ namespace ts {
                 //   - break/continue is non-labeled and located in non-converted loop/switch statement
                 const jump = node.kind === SyntaxKind.BreakStatement ? Jump.Break : Jump.Continue;
                 const canUseBreakOrContinue =
-                    (node.label && convertedLoopState.labels && convertedLoopState.labels.get(unescapeLeadingUnderscores(node.label.text))) ||
+                    (node.label && convertedLoopState.labels && convertedLoopState.labels.get(unescapeLeadingUnderscores(node.label.escapedText))) ||
                     (!node.label && (convertedLoopState.allowedNonLabeledJumps & jump));
 
                 if (!canUseBreakOrContinue) {
@@ -679,12 +679,12 @@ namespace ts {
                     }
                     else {
                         if (node.kind === SyntaxKind.BreakStatement) {
-                            labelMarker = `break-${node.label.text}`;
-                            setLabeledJump(convertedLoopState, /*isBreak*/ true, unescapeLeadingUnderscores(node.label.text), labelMarker);
+                            labelMarker = `break-${node.label.escapedText}`;
+                            setLabeledJump(convertedLoopState, /*isBreak*/ true, unescapeLeadingUnderscores(node.label.escapedText), labelMarker);
                         }
                         else {
-                            labelMarker = `continue-${node.label.text}`;
-                            setLabeledJump(convertedLoopState, /*isBreak*/ false, unescapeLeadingUnderscores(node.label.text), labelMarker);
+                            labelMarker = `continue-${node.label.escapedText}`;
+                            setLabeledJump(convertedLoopState, /*isBreak*/ false, unescapeLeadingUnderscores(node.label.escapedText), labelMarker);
                         }
                     }
                     let returnExpression: Expression = createLiteral(labelMarker);
@@ -2236,11 +2236,11 @@ namespace ts {
         }
 
         function recordLabel(node: LabeledStatement) {
-            convertedLoopState.labels.set(unescapeLeadingUnderscores(node.label.text), true);
+            convertedLoopState.labels.set(unescapeLeadingUnderscores(node.label.escapedText), true);
         }
 
         function resetLabel(node: LabeledStatement) {
-            convertedLoopState.labels.set(unescapeLeadingUnderscores(node.label.text), false);
+            convertedLoopState.labels.set(unescapeLeadingUnderscores(node.label.escapedText), false);
         }
 
         function visitLabeledStatement(node: LabeledStatement): VisitResult<Statement> {
@@ -3053,7 +3053,7 @@ namespace ts {
             else {
                 loopParameters.push(createParameter(/*decorators*/ undefined, /*modifiers*/ undefined, /*dotDotDotToken*/ undefined, name));
                 if (resolver.getNodeCheckFlags(decl) & NodeCheckFlags.NeedsLoopOutParameter) {
-                    const outParamName = createUniqueName("out_" + unescapeLeadingUnderscores(name.text));
+                    const outParamName = createUniqueName("out_" + unescapeLeadingUnderscores(name.escapedText));
                     loopOutParameters.push({ originalName: name, outParamName });
                 }
             }
@@ -3591,7 +3591,7 @@ namespace ts {
                     if (isCallExpression(firstSegment)
                         && isIdentifier(firstSegment.expression)
                         && (getEmitFlags(firstSegment.expression) & EmitFlags.HelperName)
-                        && firstSegment.expression.text === "___spread") {
+                        && firstSegment.expression.escapedText === "___spread") {
                         return segments[0];
                     }
                 }
@@ -3842,7 +3842,7 @@ namespace ts {
         }
 
         function visitMetaProperty(node: MetaProperty) {
-            if (node.keywordToken === SyntaxKind.NewKeyword && node.name.text === "target") {
+            if (node.keywordToken === SyntaxKind.NewKeyword && node.name.escapedText === "target") {
                 if (hierarchyFacts & HierarchyFacts.ComputedPropertyName) {
                     hierarchyFacts |= HierarchyFacts.NewTargetInComputedPropertyName;
                 }
@@ -4067,7 +4067,7 @@ namespace ts {
             }
 
             const expression = (<SpreadElement>callArgument).expression;
-            return isIdentifier(expression) && expression.text === "arguments";
+            return isIdentifier(expression) && expression.escapedText === "arguments";
         }
     }
 

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -369,7 +369,7 @@ namespace ts {
         function substitutePropertyAccessExpression(node: PropertyAccessExpression) {
             if (node.expression.kind === SyntaxKind.SuperKeyword) {
                 return createSuperAccessInAsyncMethod(
-                    createLiteral(unescapeLeadingUnderscores(node.name.text)),
+                    createLiteral(unescapeLeadingUnderscores(node.name.escapedText)),
                     node
                 );
             }

--- a/src/compiler/transformers/es5.ts
+++ b/src/compiler/transformers/es5.ts
@@ -111,7 +111,7 @@ namespace ts {
          * @param name An Identifier
          */
         function trySubstituteReservedName(name: Identifier) {
-            const token = name.originalKeywordKind || (nodeIsSynthesized(name) ? stringToToken(unescapeLeadingUnderscores(name.text)) : undefined);
+            const token = name.originalKeywordKind || (nodeIsSynthesized(name) ? stringToToken(unescapeLeadingUnderscores(name.escapedText)) : undefined);
             if (token >= SyntaxKind.FirstReservedWord && token <= SyntaxKind.LastReservedWord) {
                 return setTextRange(createLiteral(name), name);
             }

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -776,7 +776,7 @@ namespace ts {
         function substitutePropertyAccessExpression(node: PropertyAccessExpression) {
             if (node.expression.kind === SyntaxKind.SuperKeyword) {
                 return createSuperAccessInAsyncMethod(
-                    createLiteral(unescapeLeadingUnderscores(node.name.text)),
+                    createLiteral(unescapeLeadingUnderscores(node.name.escapedText)),
                     node
                 );
             }

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -1635,14 +1635,14 @@ namespace ts {
         }
 
         function transformAndEmitContinueStatement(node: ContinueStatement): void {
-            const label = findContinueTarget(node.label ? unescapeLeadingUnderscores(node.label.text) : undefined);
+            const label = findContinueTarget(node.label ? unescapeLeadingUnderscores(node.label.escapedText) : undefined);
             Debug.assert(label > 0, "Expected continue statment to point to a valid Label.");
             emitBreak(label, /*location*/ node);
         }
 
         function visitContinueStatement(node: ContinueStatement): Statement {
             if (inStatementContainingYield) {
-                const label = findContinueTarget(node.label && unescapeLeadingUnderscores(node.label.text));
+                const label = findContinueTarget(node.label && unescapeLeadingUnderscores(node.label.escapedText));
                 if (label > 0) {
                     return createInlineBreak(label, /*location*/ node);
                 }
@@ -1652,14 +1652,14 @@ namespace ts {
         }
 
         function transformAndEmitBreakStatement(node: BreakStatement): void {
-            const label = findBreakTarget(node.label ? unescapeLeadingUnderscores(node.label.text) : undefined);
+            const label = findBreakTarget(node.label ? unescapeLeadingUnderscores(node.label.escapedText) : undefined);
             Debug.assert(label > 0, "Expected break statment to point to a valid Label.");
             emitBreak(label, /*location*/ node);
         }
 
         function visitBreakStatement(node: BreakStatement): Statement {
             if (inStatementContainingYield) {
-                const label = findBreakTarget(node.label && unescapeLeadingUnderscores(node.label.text));
+                const label = findBreakTarget(node.label && unescapeLeadingUnderscores(node.label.escapedText));
                 if (label > 0) {
                     return createInlineBreak(label, /*location*/ node);
                 }
@@ -1838,7 +1838,7 @@ namespace ts {
                 //      /*body*/
                 //  .endlabeled
                 //  .mark endLabel
-                beginLabeledBlock(unescapeLeadingUnderscores(node.label.text));
+                beginLabeledBlock(unescapeLeadingUnderscores(node.label.escapedText));
                 transformAndEmitEmbeddedStatement(node.statement);
                 endLabeledBlock();
             }
@@ -1849,7 +1849,7 @@ namespace ts {
 
         function visitLabeledStatement(node: LabeledStatement) {
             if (inStatementContainingYield) {
-                beginScriptLabeledBlock(unescapeLeadingUnderscores(node.label.text));
+                beginScriptLabeledBlock(unescapeLeadingUnderscores(node.label.escapedText));
             }
 
             node = visitEachChild(node, visitor, context);
@@ -1950,7 +1950,7 @@ namespace ts {
         }
 
         function substituteExpressionIdentifier(node: Identifier) {
-            if (!isGeneratedIdentifier(node) && renamedCatchVariables && renamedCatchVariables.has(unescapeLeadingUnderscores(node.text))) {
+            if (!isGeneratedIdentifier(node) && renamedCatchVariables && renamedCatchVariables.has(unescapeLeadingUnderscores(node.escapedText))) {
                 const original = getOriginalNode(node);
                 if (isIdentifier(original) && original.parent) {
                     const declaration = resolver.getReferencedValueDeclaration(original);
@@ -2123,7 +2123,7 @@ namespace ts {
                 hoistVariableDeclaration(variable.name);
             }
             else {
-                const text = unescapeLeadingUnderscores((<Identifier>variable.name).text);
+                const text = unescapeLeadingUnderscores((<Identifier>variable.name).escapedText);
                 name = declareLocal(text);
                 if (!renamedCatchVariables) {
                     renamedCatchVariables = createMap<boolean>();

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -252,8 +252,8 @@ namespace ts {
             }
             else {
                 const name = (<JsxOpeningLikeElement>node).tagName;
-                if (isIdentifier(name) && isIntrinsicJsxName(name.text)) {
-                    return createLiteral(unescapeLeadingUnderscores(name.text));
+                if (isIdentifier(name) && isIntrinsicJsxName(name.escapedText)) {
+                    return createLiteral(unescapeLeadingUnderscores(name.escapedText));
                 }
                 else {
                     return createExpressionFromEntityName(name);
@@ -268,11 +268,11 @@ namespace ts {
          */
         function getAttributeName(node: JsxAttribute): StringLiteral | Identifier {
             const name = node.name;
-            if (/^[A-Za-z_]\w*$/.test(unescapeLeadingUnderscores(name.text))) {
+            if (/^[A-Za-z_]\w*$/.test(unescapeLeadingUnderscores(name.escapedText))) {
                 return name;
             }
             else {
-                return createLiteral(unescapeLeadingUnderscores(name.text));
+                return createLiteral(unescapeLeadingUnderscores(name.escapedText));
             }
         }
 

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -1225,7 +1225,7 @@ namespace ts {
          */
         function appendExportsOfDeclaration(statements: Statement[] | undefined, decl: Declaration): Statement[] | undefined {
             const name = getDeclarationName(decl);
-            const exportSpecifiers = currentModuleInfo.exportSpecifiers.get(unescapeLeadingUnderscores(name.text));
+            const exportSpecifiers = currentModuleInfo.exportSpecifiers.get(unescapeLeadingUnderscores(name.escapedText));
             if (exportSpecifiers) {
                 for (const exportSpecifier of exportSpecifiers) {
                     statements = appendExportStatement(statements, exportSpecifier.name, name, /*location*/ exportSpecifier.name);

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -324,7 +324,7 @@ namespace ts {
             const exportedNames: ObjectLiteralElementLike[] = [];
             if (moduleInfo.exportedNames) {
                 for (const exportedLocalName of moduleInfo.exportedNames) {
-                    if (exportedLocalName.text === "default") {
+                    if (exportedLocalName.escapedText === "default") {
                         continue;
                     }
 
@@ -353,7 +353,7 @@ namespace ts {
                     // write name of indirectly exported entry, i.e. 'export {x} from ...'
                     exportedNames.push(
                         createPropertyAssignment(
-                            createLiteral(unescapeLeadingUnderscores((element.name || element.propertyName).text)),
+                            createLiteral(unescapeLeadingUnderscores((element.name || element.propertyName).escapedText)),
                             createTrue()
                         )
                     );
@@ -504,10 +504,10 @@ namespace ts {
                                 for (const e of (<ExportDeclaration>entry).exportClause.elements) {
                                     properties.push(
                                         createPropertyAssignment(
-                                            createLiteral(unescapeLeadingUnderscores(e.name.text)),
+                                            createLiteral(unescapeLeadingUnderscores(e.name.escapedText)),
                                             createElementAccess(
                                                 parameterName,
-                                                createLiteral(unescapeLeadingUnderscores((e.propertyName || e.name).text))
+                                                createLiteral(unescapeLeadingUnderscores((e.propertyName || e.name).escapedText))
                                             )
                                         )
                                     );
@@ -1028,7 +1028,7 @@ namespace ts {
                 let excludeName: string;
                 if (exportSelf) {
                     statements = appendExportStatement(statements, decl.name, getLocalName(decl));
-                    excludeName = unescapeLeadingUnderscores(decl.name.text);
+                    excludeName = unescapeLeadingUnderscores(decl.name.escapedText);
                 }
 
                 statements = appendExportsOfDeclaration(statements, decl, excludeName);
@@ -1080,10 +1080,10 @@ namespace ts {
             }
 
             const name = getDeclarationName(decl);
-            const exportSpecifiers = moduleInfo.exportSpecifiers.get(unescapeLeadingUnderscores(name.text));
+            const exportSpecifiers = moduleInfo.exportSpecifiers.get(unescapeLeadingUnderscores(name.escapedText));
             if (exportSpecifiers) {
                 for (const exportSpecifier of exportSpecifiers) {
-                    if (exportSpecifier.name.text !== excludeName) {
+                    if (exportSpecifier.name.escapedText !== excludeName) {
                         statements = appendExportStatement(statements, exportSpecifier.name, name);
                     }
                 }

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1692,7 +1692,7 @@ namespace ts {
                 const numParameters = parameters.length;
                 for (let i = 0; i < numParameters; i++) {
                     const parameter = parameters[i];
-                    if (i === 0 && isIdentifier(parameter.name) && parameter.name.text === "this") {
+                    if (i === 0 && isIdentifier(parameter.name) && parameter.name.escapedText === "this") {
                         continue;
                     }
                     if (parameter.dotDotDotToken) {
@@ -1841,7 +1841,7 @@ namespace ts {
             for (const typeNode of node.types) {
                 const serializedIndividual = serializeTypeNode(typeNode);
 
-                if (isIdentifier(serializedIndividual) && serializedIndividual.text === "Object") {
+                if (isIdentifier(serializedIndividual) && serializedIndividual.escapedText === "Object") {
                     // One of the individual is global object, return immediately
                     return serializedIndividual;
                 }
@@ -1851,7 +1851,7 @@ namespace ts {
                     // Different types
                     if (!isIdentifier(serializedUnion) ||
                         !isIdentifier(serializedIndividual) ||
-                        serializedUnion.text !== serializedIndividual.text) {
+                        serializedUnion.escapedText !== serializedIndividual.escapedText) {
                         return createIdentifier("Object");
                     }
                 }
@@ -2007,7 +2007,7 @@ namespace ts {
                     : (<ComputedPropertyName>name).expression;
             }
             else if (isIdentifier(name)) {
-                return createLiteral(unescapeLeadingUnderscores(name.text));
+                return createLiteral(unescapeLeadingUnderscores(name.escapedText));
             }
             else {
                 return getSynthesizedClone(name);
@@ -3210,7 +3210,7 @@ namespace ts {
         function getClassAliasIfNeeded(node: ClassDeclaration) {
             if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.ClassWithConstructorReference) {
                 enableSubstitutionForClassAliases();
-                const classAlias = createUniqueName(node.name && !isGeneratedIdentifier(node.name) ? unescapeLeadingUnderscores(node.name.text) : "default");
+                const classAlias = createUniqueName(node.name && !isGeneratedIdentifier(node.name) ? unescapeLeadingUnderscores(node.name.escapedText) : "default");
                 classAliases[getOriginalNodeId(node)] = classAlias;
                 hoistVariableDeclaration(classAlias);
                 return classAlias;

--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -58,9 +58,9 @@ namespace ts {
                     else {
                         // export { x, y }
                         for (const specifier of (<ExportDeclaration>node).exportClause.elements) {
-                            if (!uniqueExports.get(unescapeLeadingUnderscores(specifier.name.text))) {
+                            if (!uniqueExports.get(unescapeLeadingUnderscores(specifier.name.escapedText))) {
                                 const name = specifier.propertyName || specifier.name;
-                                exportSpecifiers.add(unescapeLeadingUnderscores(name.text), specifier);
+                                exportSpecifiers.add(unescapeLeadingUnderscores(name.escapedText), specifier);
 
                                 const decl = resolver.getReferencedImportDeclaration(name)
                                     || resolver.getReferencedValueDeclaration(name);
@@ -69,7 +69,7 @@ namespace ts {
                                     multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(decl), specifier.name);
                                 }
 
-                                uniqueExports.set(unescapeLeadingUnderscores(specifier.name.text), true);
+                                uniqueExports.set(unescapeLeadingUnderscores(specifier.name.escapedText), true);
                                 exportedNames = append(exportedNames, specifier.name);
                             }
                         }
@@ -103,9 +103,9 @@ namespace ts {
                         else {
                             // export function x() { }
                             const name = (<FunctionDeclaration>node).name;
-                            if (!uniqueExports.get(unescapeLeadingUnderscores(name.text))) {
+                            if (!uniqueExports.get(unescapeLeadingUnderscores(name.escapedText))) {
                                 multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), name);
-                                uniqueExports.set(unescapeLeadingUnderscores(name.text), true);
+                                uniqueExports.set(unescapeLeadingUnderscores(name.escapedText), true);
                                 exportedNames = append(exportedNames, name);
                             }
                         }
@@ -124,9 +124,9 @@ namespace ts {
                         else {
                             // export class x { }
                             const name = (<ClassDeclaration>node).name;
-                            if (!uniqueExports.get(unescapeLeadingUnderscores(name.text))) {
+                            if (!uniqueExports.get(unescapeLeadingUnderscores(name.escapedText))) {
                                 multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), name);
-                                uniqueExports.set(unescapeLeadingUnderscores(name.text), true);
+                                uniqueExports.set(unescapeLeadingUnderscores(name.escapedText), true);
                                 exportedNames = append(exportedNames, name);
                             }
                         }
@@ -158,8 +158,8 @@ namespace ts {
             }
         }
         else if (!isGeneratedIdentifier(decl.name)) {
-            if (!uniqueExports.get(unescapeLeadingUnderscores(decl.name.text))) {
-                uniqueExports.set(unescapeLeadingUnderscores(decl.name.text), true);
+            if (!uniqueExports.get(unescapeLeadingUnderscores(decl.name.escapedText))) {
+                uniqueExports.set(unescapeLeadingUnderscores(decl.name.escapedText), true);
                 exportedNames = append(exportedNames, decl.name);
             }
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -577,7 +577,7 @@ namespace ts {
          * Prefer to use `id.unescapedText`. (Note: This is available only in services, not internally to the TypeScript compiler.)
          * Text of identifier, but if the identifier begins with two underscores, this will begin with three.
          */
-        text: __String;
+        escapedText: __String;
         originalKeywordKind?: SyntaxKind;                         // Original syntaxKind which get set so that we can report an error later
         /*@internal*/ autoGenerateKind?: GeneratedIdentifierKind; // Specifies whether to auto-generate the text for an identifier.
         /*@internal*/ autoGenerateId?: number;                    // Ensures unique generated identifiers get unique names, but clones get the same name.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -574,7 +574,7 @@ namespace ts {
     export interface Identifier extends PrimaryExpression {
         kind: SyntaxKind.Identifier;
         /**
-         * Prefer to use `id.name`. (Note: This is available only in services, not internally to the TypeScript compiler.)
+         * Prefer to use `id.unescapedText`. (Note: This is available only in services, not internally to the TypeScript compiler.)
          * Text of identifier, but if the identifier begins with two underscores, this will begin with three.
          */
         text: __String;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -574,8 +574,8 @@ namespace ts {
     export interface Identifier extends PrimaryExpression {
         kind: SyntaxKind.Identifier;
         /**
-         * Text of identifier (with escapes converted to characters).
-         * If the identifier begins with two underscores, this will begin with three.
+         * Prefer to use `id.name`. (Note: This is available only in services, not internally to the TypeScript compiler.)
+         * Text of identifier, but if the identifier begins with two underscores, this will begin with three.
          */
         text: __String;
         originalKeywordKind?: SyntaxKind;                         // Original syntaxKind which get set so that we can report an error later

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -363,11 +363,11 @@ namespace ts {
     }
 
     /**
-     * @deprecated
+     * @deprecated Use `id.escapedText` to get the escaped text of an Identifier.
      * @param identifier The identifier to escape
      */
     export function escapeIdentifier(identifier: string): string {
-        return escapeLeadingUnderscores(identifier) as string;
+        return identifier;
     }
 
     // Make an identifier from an external module name by extracting the string after the last "/" and replacing
@@ -4038,12 +4038,12 @@ namespace ts {
 
     /**
      * Remove extra underscore from escaped identifier text content.
-     * @deprecated
+     * @deprecated Use `id.text` for the unescaped text.
      * @param identifier The escaped identifier text.
      * @returns The unescaped identifier text.
      */
     export function unescapeIdentifier(id: string): string {
-        return unescapeLeadingUnderscores(id as __String);
+        return id;
     }
 
     export function getNameOfDeclaration(declaration: Declaration): DeclarationName | undefined {

--- a/src/harness/unittests/textChanges.ts
+++ b/src/harness/unittests/textChanges.ts
@@ -11,7 +11,7 @@ namespace ts {
             return find(n);
 
             function find(node: Node): Node {
-                if (isDeclaration(node) && node.name && isIdentifier(node.name) && node.name.text === name) {
+                if (isDeclaration(node) && node.name && isIdentifier(node.name) && node.name.escapedText === name) {
                     return node;
                 }
                 else {

--- a/src/harness/unittests/transform.ts
+++ b/src/harness/unittests/transform.ts
@@ -8,7 +8,7 @@ namespace ts {
             context.enableSubstitution(SyntaxKind.Identifier);
             context.onSubstituteNode = (hint, node) => {
                 node = previousOnSubstituteNode(hint, node);
-                if (hint === EmitHint.Expression && node.kind === SyntaxKind.Identifier && (<Identifier>node).text === "undefined") {
+                if (hint === EmitHint.Expression && isIdentifier(node) && node.escapedText === "undefined") {
                     node = createPartiallyEmittedExpression(
                         addSyntheticTrailingComment(
                             setTextRange(
@@ -26,7 +26,7 @@ namespace ts {
             context.enableSubstitution(SyntaxKind.Identifier);
             context.onSubstituteNode = (hint, node) => {
                 node = previousOnSubstituteNode(hint, node);
-                if (node.kind === SyntaxKind.Identifier && (<Identifier>node).text === "oldName") {
+                if (isIdentifier(node) && node.escapedText === "oldName") {
                     node = setTextRange(createIdentifier("newName"), node);
                 }
                 return node;

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -557,7 +557,7 @@ namespace ts {
                     // Only bother calling into the typechecker if this is an identifier that
                     // could possibly resolve to a type name.  This makes classification run
                     // in a third of the time it would normally take.
-                    if (classifiableNames.has(identifier.text)) {
+                    if (classifiableNames.has(identifier.escapedText)) {
                         const symbol = typeChecker.getSymbolAtLocation(node);
                         if (symbol) {
                             const type = classifySymbol(symbol, getMeaningFromLocation(node));

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1453,7 +1453,7 @@ namespace ts.Completions {
                 }
 
                 const name = element.propertyName || element.name;
-                existingImportsOrExports.set(name.text, true);
+                existingImportsOrExports.set(name.escapedText, true);
             }
 
             if (existingImportsOrExports.size === 0) {
@@ -1496,7 +1496,7 @@ namespace ts.Completions {
                 if (m.kind === SyntaxKind.BindingElement && (<BindingElement>m).propertyName) {
                     // include only identifiers in completion list
                     if ((<BindingElement>m).propertyName.kind === SyntaxKind.Identifier) {
-                        existingName = (<Identifier>(<BindingElement>m).propertyName).text;
+                        existingName = (<Identifier>(<BindingElement>m).propertyName).escapedText;
                     }
                 }
                 else {
@@ -1592,7 +1592,7 @@ namespace ts.Completions {
                 }
 
                 if (attr.kind === SyntaxKind.JsxAttribute) {
-                    seenNames.set((<JsxAttribute>attr).name.text, true);
+                    seenNames.set((<JsxAttribute>attr).name.escapedText, true);
                 }
             }
 

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -248,7 +248,7 @@ namespace ts.DocumentHighlights {
                 case SyntaxKind.ForOfStatement:
                 case SyntaxKind.WhileStatement:
                 case SyntaxKind.DoStatement:
-                    if (!statement.label || isLabeledBy(node, statement.label.name)) {
+                    if (!statement.label || isLabeledBy(node, statement.label.unescapedText)) {
                         return node;
                     }
                     break;

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -606,7 +606,7 @@ namespace ts.DocumentHighlights {
      */
     function isLabeledBy(node: Node, labelName: string) {
         for (let owner = node.parent; owner.kind === SyntaxKind.LabeledStatement; owner = owner.parent) {
-            if ((<LabeledStatement>owner).label.text === labelName) {
+            if ((<LabeledStatement>owner).label.escapedText === labelName) {
                 return true;
             }
         }

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -248,7 +248,7 @@ namespace ts.DocumentHighlights {
                 case SyntaxKind.ForOfStatement:
                 case SyntaxKind.WhileStatement:
                 case SyntaxKind.DoStatement:
-                    if (!statement.label || isLabeledBy(node, unescapeLeadingUnderscores(statement.label.text))) {
+                    if (!statement.label || isLabeledBy(node, statement.label.name)) {
                         return node;
                     }
                     break;

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -248,7 +248,7 @@ namespace ts.DocumentHighlights {
                 case SyntaxKind.ForOfStatement:
                 case SyntaxKind.WhileStatement:
                 case SyntaxKind.DoStatement:
-                    if (!statement.label || isLabeledBy(node, statement.label.unescapedText)) {
+                    if (!statement.label || isLabeledBy(node, statement.label.text)) {
                         return node;
                     }
                     break;

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -122,7 +122,7 @@ namespace ts.FindAllReferences {
                 }
                 case "label": {
                     const { node } = def;
-                    return { node, name: node.name, kind: ScriptElementKind.label, displayParts: [displayPart(node.name, SymbolDisplayPartKind.text)] };
+                    return { node, name: node.unescapedText, kind: ScriptElementKind.label, displayParts: [displayPart(node.unescapedText, SymbolDisplayPartKind.text)] };
                 }
                 case "keyword": {
                     const { node } = def;
@@ -357,7 +357,7 @@ namespace ts.FindAllReferences.Core {
         // Labels
         if (isLabelName(node)) {
             if (isJumpStatementTarget(node)) {
-                const labelDefinition = getTargetLabel((<BreakOrContinueStatement>node.parent), (<Identifier>node).name);
+                const labelDefinition = getTargetLabel((<BreakOrContinueStatement>node.parent), (<Identifier>node).unescapedText);
                 // if we have a label definition, look within its statement for references, if not, then
                 // the label is undefined and we have no results..
                 return labelDefinition && getLabelReferencesInNode(labelDefinition.parent, labelDefinition);
@@ -606,7 +606,7 @@ namespace ts.FindAllReferences.Core {
         const bindingElement = getObjectBindingElementWithoutPropertyName(symbol);
         if (bindingElement) {
             const typeOfPattern = checker.getTypeAtLocation(bindingElement.parent);
-            return typeOfPattern && checker.getPropertyOfType(typeOfPattern, (<Identifier>bindingElement.name).name);
+            return typeOfPattern && checker.getPropertyOfType(typeOfPattern, (<Identifier>bindingElement.name).unescapedText);
         }
         return undefined;
     }
@@ -718,7 +718,7 @@ namespace ts.FindAllReferences.Core {
     function getLabelReferencesInNode(container: Node, targetLabel: Identifier): SymbolAndEntries[] {
         const references: Entry[] = [];
         const sourceFile = container.getSourceFile();
-        const labelName = targetLabel.name;
+        const labelName = targetLabel.unescapedText;
         const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, labelName, container);
         for (const position of possiblePositions) {
             const node = getTouchingWord(sourceFile, position, /*includeJsDocComment*/ false);
@@ -735,7 +735,7 @@ namespace ts.FindAllReferences.Core {
         // Compare the length so we filter out strict superstrings of the symbol we are looking for
         switch (node && node.kind) {
             case SyntaxKind.Identifier:
-                return (node as Identifier).name.length === searchSymbolName.length;
+                return (node as Identifier).unescapedText.length === searchSymbolName.length;
 
             case SyntaxKind.StringLiteral:
                 return (isLiteralNameOfPropertyDeclarationOrIndexAccess(node) || isNameOfExternalModuleImportOrDeclaration(node)) &&

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -122,7 +122,7 @@ namespace ts.FindAllReferences {
                 }
                 case "label": {
                     const { node } = def;
-                    return { node, name: node.unescapedText, kind: ScriptElementKind.label, displayParts: [displayPart(node.unescapedText, SymbolDisplayPartKind.text)] };
+                    return { node, name: node.text, kind: ScriptElementKind.label, displayParts: [displayPart(node.text, SymbolDisplayPartKind.text)] };
                 }
                 case "keyword": {
                     const { node } = def;
@@ -357,7 +357,7 @@ namespace ts.FindAllReferences.Core {
         // Labels
         if (isLabelName(node)) {
             if (isJumpStatementTarget(node)) {
-                const labelDefinition = getTargetLabel((<BreakOrContinueStatement>node.parent), (<Identifier>node).unescapedText);
+                const labelDefinition = getTargetLabel((<BreakOrContinueStatement>node.parent), (<Identifier>node).text);
                 // if we have a label definition, look within its statement for references, if not, then
                 // the label is undefined and we have no results..
                 return labelDefinition && getLabelReferencesInNode(labelDefinition.parent, labelDefinition);
@@ -606,7 +606,7 @@ namespace ts.FindAllReferences.Core {
         const bindingElement = getObjectBindingElementWithoutPropertyName(symbol);
         if (bindingElement) {
             const typeOfPattern = checker.getTypeAtLocation(bindingElement.parent);
-            return typeOfPattern && checker.getPropertyOfType(typeOfPattern, (<Identifier>bindingElement.name).unescapedText);
+            return typeOfPattern && checker.getPropertyOfType(typeOfPattern, (<Identifier>bindingElement.name).text);
         }
         return undefined;
     }
@@ -718,7 +718,7 @@ namespace ts.FindAllReferences.Core {
     function getLabelReferencesInNode(container: Node, targetLabel: Identifier): SymbolAndEntries[] {
         const references: Entry[] = [];
         const sourceFile = container.getSourceFile();
-        const labelName = targetLabel.unescapedText;
+        const labelName = targetLabel.text;
         const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, labelName, container);
         for (const position of possiblePositions) {
             const node = getTouchingWord(sourceFile, position, /*includeJsDocComment*/ false);
@@ -735,7 +735,7 @@ namespace ts.FindAllReferences.Core {
         // Compare the length so we filter out strict superstrings of the symbol we are looking for
         switch (node && node.kind) {
             case SyntaxKind.Identifier:
-                return (node as Identifier).unescapedText.length === searchSymbolName.length;
+                return (node as Identifier).text.length === searchSymbolName.length;
 
             case SyntaxKind.StringLiteral:
                 return (isLiteralNameOfPropertyDeclarationOrIndexAccess(node) || isNameOfExternalModuleImportOrDeclaration(node)) &&

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -122,7 +122,7 @@ namespace ts.FindAllReferences {
                 }
                 case "label": {
                     const { node } = def;
-                    return { node, name: unescapeLeadingUnderscores(node.text), kind: ScriptElementKind.label, displayParts: [displayPart(unescapeLeadingUnderscores(node.text), SymbolDisplayPartKind.text)] };
+                    return { node, name: node.name, kind: ScriptElementKind.label, displayParts: [displayPart(node.name, SymbolDisplayPartKind.text)] };
                 }
                 case "keyword": {
                     const { node } = def;
@@ -357,7 +357,7 @@ namespace ts.FindAllReferences.Core {
         // Labels
         if (isLabelName(node)) {
             if (isJumpStatementTarget(node)) {
-                const labelDefinition = getTargetLabel((<BreakOrContinueStatement>node.parent), unescapeLeadingUnderscores((<Identifier>node).text));
+                const labelDefinition = getTargetLabel((<BreakOrContinueStatement>node.parent), (<Identifier>node).name);
                 // if we have a label definition, look within its statement for references, if not, then
                 // the label is undefined and we have no results..
                 return labelDefinition && getLabelReferencesInNode(labelDefinition.parent, labelDefinition);
@@ -606,7 +606,7 @@ namespace ts.FindAllReferences.Core {
         const bindingElement = getObjectBindingElementWithoutPropertyName(symbol);
         if (bindingElement) {
             const typeOfPattern = checker.getTypeAtLocation(bindingElement.parent);
-            return typeOfPattern && checker.getPropertyOfType(typeOfPattern, unescapeLeadingUnderscores((<Identifier>bindingElement.name).text));
+            return typeOfPattern && checker.getPropertyOfType(typeOfPattern, (<Identifier>bindingElement.name).name);
         }
         return undefined;
     }
@@ -718,7 +718,7 @@ namespace ts.FindAllReferences.Core {
     function getLabelReferencesInNode(container: Node, targetLabel: Identifier): SymbolAndEntries[] {
         const references: Entry[] = [];
         const sourceFile = container.getSourceFile();
-        const labelName = unescapeLeadingUnderscores(targetLabel.text);
+        const labelName = targetLabel.name;
         const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, labelName, container);
         for (const position of possiblePositions) {
             const node = getTouchingWord(sourceFile, position, /*includeJsDocComment*/ false);
@@ -735,7 +735,7 @@ namespace ts.FindAllReferences.Core {
         // Compare the length so we filter out strict superstrings of the symbol we are looking for
         switch (node && node.kind) {
             case SyntaxKind.Identifier:
-                return unescapeLeadingUnderscores((node as Identifier).text).length === searchSymbolName.length;
+                return (node as Identifier).name.length === searchSymbolName.length;
 
             case SyntaxKind.StringLiteral:
                 return (isLiteralNameOfPropertyDeclarationOrIndexAccess(node) || isNameOfExternalModuleImportOrDeclaration(node)) &&

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -26,7 +26,7 @@ namespace ts.GoToDefinition {
 
         // Labels
         if (isJumpStatementTarget(node)) {
-            const labelName = unescapeLeadingUnderscores((<Identifier>node).text);
+            const labelName = (<Identifier>node).name;
             const label = getTargetLabel((<BreakOrContinueStatement>node.parent), labelName);
             return label ? [createDefinitionInfoFromName(label, ScriptElementKind.label, labelName, /*containerName*/ undefined)] : undefined;
         }

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -26,7 +26,7 @@ namespace ts.GoToDefinition {
 
         // Labels
         if (isJumpStatementTarget(node)) {
-            const labelName = (<Identifier>node).name;
+            const labelName = (<Identifier>node).unescapedText;
             const label = getTargetLabel((<BreakOrContinueStatement>node.parent), labelName);
             return label ? [createDefinitionInfoFromName(label, ScriptElementKind.label, labelName, /*containerName*/ undefined)] : undefined;
         }

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -26,7 +26,7 @@ namespace ts.GoToDefinition {
 
         // Labels
         if (isJumpStatementTarget(node)) {
-            const labelName = (<Identifier>node).unescapedText;
+            const labelName = (<Identifier>node).text;
             const label = getTargetLabel((<BreakOrContinueStatement>node.parent), labelName);
             return label ? [createDefinitionInfoFromName(label, ScriptElementKind.label, labelName, /*containerName*/ undefined)] : undefined;
         }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -238,7 +238,7 @@ namespace ts.FindAllReferences {
                 const { name } = importClause;
                 // If a default import has the same name as the default export, allow to rename it.
                 // Given `import f` and `export default function f`, we will rename both, but for `import g` we will rename just that.
-                if (name && (!isForRename || name.text === symbolName(exportSymbol))) {
+                if (name && (!isForRename || name.escapedText === symbolName(exportSymbol))) {
                     const defaultImportAlias = checker.getSymbolAtLocation(name);
                     addSearch(name, defaultImportAlias);
                 }
@@ -258,7 +258,7 @@ namespace ts.FindAllReferences {
          */
         function handleNamespaceImportLike(importName: Identifier): void {
             // Don't rename an import that already has a different name than the export.
-            if (exportKind === ExportKind.ExportEquals && (!isForRename || importName.text === exportName)) {
+            if (exportKind === ExportKind.ExportEquals && (!isForRename || importName.escapedText === exportName)) {
                 addSearch(importName, checker.getSymbolAtLocation(importName));
             }
         }
@@ -267,7 +267,7 @@ namespace ts.FindAllReferences {
             if (namedBindings) {
                 for (const element of namedBindings.elements) {
                     const { name, propertyName } = element;
-                    if ((propertyName || name).text !== exportName) {
+                    if ((propertyName || name).escapedText !== exportName) {
                         continue;
                     }
 
@@ -601,10 +601,10 @@ namespace ts.FindAllReferences {
 
         return forEach(symbol.declarations, decl => {
             if (isExportAssignment(decl)) {
-                return isIdentifier(decl.expression) ? decl.expression.text : undefined;
+                return isIdentifier(decl.expression) ? decl.expression.escapedText : undefined;
             }
             const name = getNameOfDeclaration(decl);
-            return name && name.kind === SyntaxKind.Identifier && name.text;
+            return name && name.kind === SyntaxKind.Identifier && name.escapedText;
         });
     }
 

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -71,7 +71,7 @@ namespace ts.JsDoc {
         forEachUnique(declarations, declaration => {
             for (const tag of getJSDocTags(declaration)) {
                 if (tag.kind === SyntaxKind.JSDocTag) {
-                    tags.push({ name: unescapeLeadingUnderscores(tag.tagName.text), text: tag.comment });
+                    tags.push({ name: tag.tagName.name, text: tag.comment });
                 }
             }
         });
@@ -120,7 +120,7 @@ namespace ts.JsDoc {
     }
 
     export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): CompletionEntry[] {
-        const nameThusFar = unescapeLeadingUnderscores(tag.name.text);
+        const nameThusFar = tag.name.name;
         const jsdoc = tag.parent;
         const fn = jsdoc.parent;
         if (!ts.isFunctionLike(fn)) return [];
@@ -128,7 +128,7 @@ namespace ts.JsDoc {
         return mapDefined(fn.parameters, param => {
             if (!isIdentifier(param.name)) return undefined;
 
-            const name = unescapeLeadingUnderscores(param.name.text);
+            const name = param.name.name;
             if (jsdoc.tags.some(t => t !== tag && isJSDocParameterTag(t) && t.name.text === name)
                 || nameThusFar !== undefined && !startsWith(name, nameThusFar)) {
                 return undefined;

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -71,7 +71,7 @@ namespace ts.JsDoc {
         forEachUnique(declarations, declaration => {
             for (const tag of getJSDocTags(declaration)) {
                 if (tag.kind === SyntaxKind.JSDocTag) {
-                    tags.push({ name: tag.tagName.unescapedText, text: tag.comment });
+                    tags.push({ name: tag.tagName.text, text: tag.comment });
                 }
             }
         });
@@ -120,7 +120,7 @@ namespace ts.JsDoc {
     }
 
     export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): CompletionEntry[] {
-        const nameThusFar = tag.name.unescapedText;
+        const nameThusFar = tag.name.text;
         const jsdoc = tag.parent;
         const fn = jsdoc.parent;
         if (!ts.isFunctionLike(fn)) return [];
@@ -128,7 +128,7 @@ namespace ts.JsDoc {
         return mapDefined(fn.parameters, param => {
             if (!isIdentifier(param.name)) return undefined;
 
-            const name = param.name.unescapedText;
+            const name = param.name.text;
             if (jsdoc.tags.some(t => t !== tag && isJSDocParameterTag(t) && t.name.escapedText === name)
                 || nameThusFar !== undefined && !startsWith(name, nameThusFar)) {
                 return undefined;

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -129,7 +129,7 @@ namespace ts.JsDoc {
             if (!isIdentifier(param.name)) return undefined;
 
             const name = param.name.unescapedText;
-            if (jsdoc.tags.some(t => t !== tag && isJSDocParameterTag(t) && t.name.text === name)
+            if (jsdoc.tags.some(t => t !== tag && isJSDocParameterTag(t) && t.name.escapedText === name)
                 || nameThusFar !== undefined && !startsWith(name, nameThusFar)) {
                 return undefined;
             }
@@ -213,7 +213,7 @@ namespace ts.JsDoc {
         for (let i = 0; i < parameters.length; i++) {
             const currentName = parameters[i].name;
             const paramName = currentName.kind === SyntaxKind.Identifier ?
-                (<Identifier>currentName).text :
+                (<Identifier>currentName).escapedText :
                 "param" + i;
             if (isJavaScriptFile) {
                 docParams += `${indentationStr} * @param {any} ${paramName}${newLine}`;

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -71,7 +71,7 @@ namespace ts.JsDoc {
         forEachUnique(declarations, declaration => {
             for (const tag of getJSDocTags(declaration)) {
                 if (tag.kind === SyntaxKind.JSDocTag) {
-                    tags.push({ name: tag.tagName.name, text: tag.comment });
+                    tags.push({ name: tag.tagName.unescapedText, text: tag.comment });
                 }
             }
         });
@@ -120,7 +120,7 @@ namespace ts.JsDoc {
     }
 
     export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): CompletionEntry[] {
-        const nameThusFar = tag.name.name;
+        const nameThusFar = tag.name.unescapedText;
         const jsdoc = tag.parent;
         const fn = jsdoc.parent;
         if (!ts.isFunctionLike(fn)) return [];
@@ -128,7 +128,7 @@ namespace ts.JsDoc {
         return mapDefined(fn.parameters, param => {
             if (!isIdentifier(param.name)) return undefined;
 
-            const name = param.name.name;
+            const name = param.name.unescapedText;
             if (jsdoc.tags.some(t => t !== tag && isJSDocParameterTag(t) && t.name.text === name)
                 || nameThusFar !== undefined && !startsWith(name, nameThusFar)) {
                 return undefined;

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -119,7 +119,7 @@ namespace ts.NavigateTo {
             if (expression.kind === SyntaxKind.PropertyAccessExpression) {
                 const propertyAccess = <PropertyAccessExpression>expression;
                 if (includeLastPortion) {
-                    containers.unshift(propertyAccess.name.name);
+                    containers.unshift(propertyAccess.name.unescapedText);
                 }
 
                 return tryAddComputedPropertyName(propertyAccess.expression, containers, /*includeLastPortion*/ true);
@@ -191,7 +191,7 @@ namespace ts.NavigateTo {
                 fileName: rawItem.fileName,
                 textSpan: createTextSpanFromNode(declaration),
                 // TODO(jfreeman): What should be the containerName when the container has a computed name?
-                containerName: containerName ? (<Identifier>containerName).name : "",
+                containerName: containerName ? (<Identifier>containerName).unescapedText : "",
                 containerKind: containerName ? getNodeKind(container) : ScriptElementKind.unknown
             };
         }

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -119,7 +119,7 @@ namespace ts.NavigateTo {
             if (expression.kind === SyntaxKind.PropertyAccessExpression) {
                 const propertyAccess = <PropertyAccessExpression>expression;
                 if (includeLastPortion) {
-                    containers.unshift(propertyAccess.name.unescapedText);
+                    containers.unshift(propertyAccess.name.text);
                 }
 
                 return tryAddComputedPropertyName(propertyAccess.expression, containers, /*includeLastPortion*/ true);
@@ -191,7 +191,7 @@ namespace ts.NavigateTo {
                 fileName: rawItem.fileName,
                 textSpan: createTextSpanFromNode(declaration),
                 // TODO(jfreeman): What should be the containerName when the container has a computed name?
-                containerName: containerName ? (<Identifier>containerName).unescapedText : "",
+                containerName: containerName ? (<Identifier>containerName).text : "",
                 containerKind: containerName ? getNodeKind(container) : ScriptElementKind.unknown
             };
         }

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -119,7 +119,7 @@ namespace ts.NavigateTo {
             if (expression.kind === SyntaxKind.PropertyAccessExpression) {
                 const propertyAccess = <PropertyAccessExpression>expression;
                 if (includeLastPortion) {
-                    containers.unshift(unescapeLeadingUnderscores(propertyAccess.name.text));
+                    containers.unshift(propertyAccess.name.name);
                 }
 
                 return tryAddComputedPropertyName(propertyAccess.expression, containers, /*includeLastPortion*/ true);
@@ -191,7 +191,7 @@ namespace ts.NavigateTo {
                 fileName: rawItem.fileName,
                 textSpan: createTextSpanFromNode(declaration),
                 // TODO(jfreeman): What should be the containerName when the container has a computed name?
-                containerName: containerName ? unescapeLeadingUnderscores((<Identifier>containerName).text) : "",
+                containerName: containerName ? (<Identifier>containerName).name : "",
                 containerKind: containerName ? getNodeKind(container) : ScriptElementKind.unknown
             };
         }

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -442,7 +442,7 @@ namespace ts.NavigationBar {
 
     function getJSDocTypedefTagName(node: JSDocTypedefTag): string {
         if (node.name) {
-            return unescapeLeadingUnderscores(node.name.text);
+            return node.name.name;
         }
         else {
             const parentNode = node.parent && node.parent.parent;
@@ -450,7 +450,7 @@ namespace ts.NavigationBar {
                 if ((<VariableStatement>parentNode).declarationList.declarations.length > 0) {
                     const nameIdentifier = (<VariableStatement>parentNode).declarationList.declarations[0].name;
                     if (nameIdentifier.kind === SyntaxKind.Identifier) {
-                        return unescapeLeadingUnderscores((<Identifier>nameIdentifier).text);
+                        return nameIdentifier.name;
                     }
                 }
             }

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -442,7 +442,7 @@ namespace ts.NavigationBar {
 
     function getJSDocTypedefTagName(node: JSDocTypedefTag): string {
         if (node.name) {
-            return node.name.unescapedText;
+            return node.name.text;
         }
         else {
             const parentNode = node.parent && node.parent.parent;
@@ -450,7 +450,7 @@ namespace ts.NavigationBar {
                 if ((<VariableStatement>parentNode).declarationList.declarations.length > 0) {
                     const nameIdentifier = (<VariableStatement>parentNode).declarationList.declarations[0].name;
                     if (nameIdentifier.kind === SyntaxKind.Identifier) {
-                        return nameIdentifier.unescapedText;
+                        return nameIdentifier.text;
                     }
                 }
             }

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -442,7 +442,7 @@ namespace ts.NavigationBar {
 
     function getJSDocTypedefTagName(node: JSDocTypedefTag): string {
         if (node.name) {
-            return node.name.name;
+            return node.name.unescapedText;
         }
         else {
             const parentNode = node.parent && node.parent.parent;
@@ -450,7 +450,7 @@ namespace ts.NavigationBar {
                 if ((<VariableStatement>parentNode).declarationList.declarations.length > 0) {
                     const nameIdentifier = (<VariableStatement>parentNode).declarationList.declarations[0].name;
                     if (nameIdentifier.kind === SyntaxKind.Identifier) {
-                        return nameIdentifier.name;
+                        return nameIdentifier.unescapedText;
                     }
                 }
             }

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -239,7 +239,7 @@ namespace ts.Completions.PathCompletions {
         const moduleNameFragment = isNestedModule ? fragment.substr(0, fragment.lastIndexOf(directorySeparator)) : undefined;
 
         // Get modules that the type checker picked up
-        const ambientModules = map(typeChecker.getAmbientModules(), sym => stripQuotes(unescapeLeadingUnderscores(sym.name)));
+        const ambientModules = map(typeChecker.getAmbientModules(), sym => stripQuotes(sym.getUnescapedName()));
         let nonRelativeModuleNames = filter(ambientModules, moduleName => startsWith(moduleName, fragment));
 
         // Nested modules of the form "module-name/sub" need to be adjusted to only return the string

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -375,6 +375,10 @@ namespace ts {
         constructor(_kind: SyntaxKind.Identifier, pos: number, end: number) {
             super(pos, end);
         }
+
+        get name(): string {
+            return unescapeLeadingUnderscores(this.text);
+        }
     }
     IdentifierObject.prototype.kind = SyntaxKind.Identifier;
 
@@ -601,7 +605,7 @@ namespace ts {
                     if (name.kind === SyntaxKind.ComputedPropertyName) {
                         const expr = (<ComputedPropertyName>name).expression;
                         if (expr.kind === SyntaxKind.PropertyAccessExpression) {
-                            return unescapeLeadingUnderscores((<PropertyAccessExpression>expr).name.text);
+                            return (<PropertyAccessExpression>expr).name.name;
                         }
 
                         return getTextOfIdentifierOrLiteral(expr as (Identifier | LiteralExpression));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -376,7 +376,7 @@ namespace ts {
             super(pos, end);
         }
 
-        get name(): string {
+        get unescapedText(): string {
             return unescapeLeadingUnderscores(this.text);
         }
     }
@@ -605,7 +605,7 @@ namespace ts {
                     if (name.kind === SyntaxKind.ComputedPropertyName) {
                         const expr = (<ComputedPropertyName>name).expression;
                         if (expr.kind === SyntaxKind.PropertyAccessExpression) {
-                            return (<PropertyAccessExpression>expr).name.name;
+                            return (<PropertyAccessExpression>expr).name.unescapedText;
                         }
 
                         return getTextOfIdentifierOrLiteral(expr as (Identifier | LiteralExpression));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -364,7 +364,7 @@ namespace ts {
 
     class IdentifierObject extends TokenOrIdentifierObject implements Identifier {
         public kind: SyntaxKind.Identifier;
-        public text: __String;
+        public escapedText: __String;
         _primaryExpressionBrand: any;
         _memberExpressionBrand: any;
         _leftHandSideExpressionBrand: any;
@@ -377,7 +377,7 @@ namespace ts {
         }
 
         get unescapedText(): string {
-            return unescapeLeadingUnderscores(this.text);
+            return unescapeLeadingUnderscores(this.escapedText);
         }
     }
     IdentifierObject.prototype.kind = SyntaxKind.Identifier;
@@ -2062,7 +2062,7 @@ namespace ts {
     function initializeNameTable(sourceFile: SourceFile): void {
         const nameTable = sourceFile.nameTable = createUnderscoreEscapedMap<number>();
         sourceFile.forEachChild(function walk(node) {
-            if ((isIdentifier(node) || isStringOrNumericLiteral(node) && literalIsName(node)) && node.text) {
+            if (isIdentifier(node) && node.escapedText || isStringOrNumericLiteral(node) && literalIsName(node)) {
                 const text = getEscapedTextOfIdentifierOrLiteral(node);
                 nameTable.set(text, nameTable.get(text) === undefined ? node.pos : -1);
             }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -376,7 +376,7 @@ namespace ts {
             super(pos, end);
         }
 
-        get unescapedText(): string {
+        get text(): string {
             return unescapeLeadingUnderscores(this.escapedText);
         }
     }
@@ -605,7 +605,7 @@ namespace ts {
                     if (name.kind === SyntaxKind.ComputedPropertyName) {
                         const expr = (<ComputedPropertyName>name).expression;
                         if (expr.kind === SyntaxKind.PropertyAccessExpression) {
-                            return (<PropertyAccessExpression>expr).name.unescapedText;
+                            return (<PropertyAccessExpression>expr).name.text;
                         }
 
                         return getTextOfIdentifierOrLiteral(expr as (Identifier | LiteralExpression));

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -72,7 +72,7 @@ namespace ts.SignatureHelp {
         const typeChecker = program.getTypeChecker();
         for (const sourceFile of program.getSourceFiles()) {
             const nameToDeclarations = sourceFile.getNamedDeclarations();
-            const declarations = nameToDeclarations.get(name.unescapedText);
+            const declarations = nameToDeclarations.get(name.text);
 
             if (declarations) {
                 for (const declaration of declarations) {

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -72,7 +72,7 @@ namespace ts.SignatureHelp {
         const typeChecker = program.getTypeChecker();
         for (const sourceFile of program.getSourceFiles()) {
             const nameToDeclarations = sourceFile.getNamedDeclarations();
-            const declarations = nameToDeclarations.get(unescapeLeadingUnderscores(name.text));
+            const declarations = nameToDeclarations.get(name.name);
 
             if (declarations) {
                 for (const declaration of declarations) {

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -72,7 +72,7 @@ namespace ts.SignatureHelp {
         const typeChecker = program.getTypeChecker();
         for (const sourceFile of program.getSourceFiles()) {
             const nameToDeclarations = sourceFile.getNamedDeclarations();
-            const declarations = nameToDeclarations.get(name.name);
+            const declarations = nameToDeclarations.get(name.unescapedText);
 
             if (declarations) {
                 for (const declaration of declarations) {

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -65,7 +65,7 @@ namespace ts.SignatureHelp {
                 ? (<PropertyAccessExpression>expression).name
                 : undefined;
 
-        if (!name || !name.text) {
+        if (!name || !name.escapedText) {
             return undefined;
         }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -23,7 +23,7 @@ namespace ts {
     }
 
     export interface Identifier {
-        readonly unescapedText: string;
+        readonly text: string;
     }
 
     export interface Symbol {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -22,6 +22,10 @@ namespace ts {
         forEachChild<T>(cbNode: (node: Node) => T | undefined, cbNodeArray?: (nodes: NodeArray<Node>) => T | undefined): T | undefined;
     }
 
+    export interface Identifier {
+        readonly name: string;
+    }
+
     export interface Symbol {
         getFlags(): SymbolFlags;
         getName(): __String;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -23,7 +23,7 @@ namespace ts {
     }
 
     export interface Identifier {
-        readonly name: string;
+        readonly unescapedText: string;
     }
 
     export interface Symbol {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -203,7 +203,7 @@ namespace ts {
 
     export function getTargetLabel(referenceNode: Node, labelName: string): Identifier {
         while (referenceNode) {
-            if (referenceNode.kind === SyntaxKind.LabeledStatement && (<LabeledStatement>referenceNode).label.text === labelName) {
+            if (referenceNode.kind === SyntaxKind.LabeledStatement && (<LabeledStatement>referenceNode).label.escapedText === labelName) {
                 return (<LabeledStatement>referenceNode).label;
             }
             referenceNode = referenceNode.parent;

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 12,
-                "text": "arg"
+                "escapedText": "arg"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -32,13 +32,13 @@
                 "kind": "Identifier",
                 "pos": 22,
                 "end": 27,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 22,
                 "end": 27,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": false,
             "comment": "Description"

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 17,
-                "text": "argument"
+                "escapedText": "argument"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -32,13 +32,13 @@
                 "kind": "Identifier",
                 "pos": 27,
                 "end": 32,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 27,
                 "end": 32,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": false,
             "comment": "Description"

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.leadingAsterisk.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.leadingAsterisk.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 13,
-                "text": "type"
+                "escapedText": "type"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noLeadingAsterisk.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noLeadingAsterisk.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 13,
-                "text": "type"
+                "escapedText": "type"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noReturnType.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noReturnType.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 15,
-                "text": "return"
+                "escapedText": "return"
             },
             "comment": ""
         },

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noType.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noType.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 13,
-                "text": "type"
+                "escapedText": "type"
             },
             "comment": ""
         },

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.oneParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.oneParamTag.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -32,13 +32,13 @@
                 "kind": "Identifier",
                 "pos": 24,
                 "end": 29,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 24,
                 "end": 29,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": false,
             "comment": ""

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -32,13 +32,13 @@
                 "kind": "Identifier",
                 "pos": 24,
                 "end": 29,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 24,
                 "end": 29,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": false,
             "comment": "Description text follows"

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -32,13 +32,13 @@
                 "kind": "Identifier",
                 "pos": 25,
                 "end": 30,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 25,
                 "end": 30,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": true,
             "comment": "Description text follows"

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -32,13 +32,13 @@
                 "kind": "Identifier",
                 "pos": 26,
                 "end": 31,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 26,
                 "end": 31,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": true,
             "comment": "Description text follows"

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType1.json
@@ -16,13 +16,13 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "preParameterName": {
                 "kind": "Identifier",
                 "pos": 15,
                 "end": 20,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -38,7 +38,7 @@
                 "kind": "Identifier",
                 "pos": 15,
                 "end": 20,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": false,
             "comment": ""

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
@@ -16,13 +16,13 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "preParameterName": {
                 "kind": "Identifier",
                 "pos": 15,
                 "end": 20,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -38,7 +38,7 @@
                 "kind": "Identifier",
                 "pos": 15,
                 "end": 20,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": false,
             "comment": "Description"

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramWithoutType.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramWithoutType.json
@@ -16,19 +16,19 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "preParameterName": {
                 "kind": "Identifier",
                 "pos": 15,
                 "end": 18,
-                "text": "foo"
+                "escapedText": "foo"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 15,
                 "end": 18,
-                "text": "foo"
+                "escapedText": "foo"
             },
             "isBracketed": false,
             "comment": ""

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag1.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 15,
-                "text": "return"
+                "escapedText": "return"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 15,
-                "text": "return"
+                "escapedText": "return"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnsTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnsTag1.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 16,
-                "text": "returns"
+                "escapedText": "returns"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 17,
-                "text": "template"
+                "escapedText": "template"
             },
             "typeParameters": {
                 "0": {
@@ -27,7 +27,7 @@
                         "kind": "Identifier",
                         "pos": 18,
                         "end": 19,
-                        "text": "T"
+                        "escapedText": "T"
                     }
                 },
                 "length": 1,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag2.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 17,
-                "text": "template"
+                "escapedText": "template"
             },
             "typeParameters": {
                 "0": {
@@ -27,7 +27,7 @@
                         "kind": "Identifier",
                         "pos": 18,
                         "end": 19,
-                        "text": "K"
+                        "escapedText": "K"
                     }
                 },
                 "1": {
@@ -38,7 +38,7 @@
                         "kind": "Identifier",
                         "pos": 20,
                         "end": 21,
-                        "text": "V"
+                        "escapedText": "V"
                     }
                 },
                 "length": 2,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag3.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag3.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 17,
-                "text": "template"
+                "escapedText": "template"
             },
             "typeParameters": {
                 "0": {
@@ -27,7 +27,7 @@
                         "kind": "Identifier",
                         "pos": 18,
                         "end": 19,
-                        "text": "K"
+                        "escapedText": "K"
                     }
                 },
                 "1": {
@@ -38,7 +38,7 @@
                         "kind": "Identifier",
                         "pos": 21,
                         "end": 22,
-                        "text": "V"
+                        "escapedText": "V"
                     }
                 },
                 "length": 2,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag4.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag4.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 17,
-                "text": "template"
+                "escapedText": "template"
             },
             "typeParameters": {
                 "0": {
@@ -27,7 +27,7 @@
                         "kind": "Identifier",
                         "pos": 18,
                         "end": 19,
-                        "text": "K"
+                        "escapedText": "K"
                     }
                 },
                 "1": {
@@ -38,7 +38,7 @@
                         "kind": "Identifier",
                         "pos": 21,
                         "end": 22,
-                        "text": "V"
+                        "escapedText": "V"
                     }
                 },
                 "length": 2,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag5.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag5.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 17,
-                "text": "template"
+                "escapedText": "template"
             },
             "typeParameters": {
                 "0": {
@@ -27,7 +27,7 @@
                         "kind": "Identifier",
                         "pos": 18,
                         "end": 19,
-                        "text": "K"
+                        "escapedText": "K"
                     }
                 },
                 "1": {
@@ -38,7 +38,7 @@
                         "kind": "Identifier",
                         "pos": 22,
                         "end": 23,
-                        "text": "V"
+                        "escapedText": "V"
                     }
                 },
                 "length": 2,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 17,
-                "text": "template"
+                "escapedText": "template"
             },
             "typeParameters": {
                 "0": {
@@ -27,7 +27,7 @@
                         "kind": "Identifier",
                         "pos": 18,
                         "end": 19,
-                        "text": "K"
+                        "escapedText": "K"
                     }
                 },
                 "1": {
@@ -38,7 +38,7 @@
                         "kind": "Identifier",
                         "pos": 22,
                         "end": 23,
-                        "text": "V"
+                        "escapedText": "V"
                     }
                 },
                 "length": 2,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTag2.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -32,13 +32,13 @@
                 "kind": "Identifier",
                 "pos": 24,
                 "end": 29,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 24,
                 "end": 29,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": false,
             "comment": ""
@@ -56,7 +56,7 @@
                 "kind": "Identifier",
                 "pos": 35,
                 "end": 40,
-                "text": "param"
+                "escapedText": "param"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -72,13 +72,13 @@
                 "kind": "Identifier",
                 "pos": 50,
                 "end": 55,
-                "text": "name2"
+                "escapedText": "name2"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 50,
                 "end": 55,
-                "text": "name2"
+                "escapedText": "name2"
             },
             "isBracketed": false,
             "comment": ""

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTagOnSameLine.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTagOnSameLine.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 14,
-                "text": "param"
+                "escapedText": "param"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -32,13 +32,13 @@
                 "kind": "Identifier",
                 "pos": 24,
                 "end": 29,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 24,
                 "end": 29,
-                "text": "name1"
+                "escapedText": "name1"
             },
             "isBracketed": false,
             "comment": ""
@@ -56,7 +56,7 @@
                 "kind": "Identifier",
                 "pos": 31,
                 "end": 36,
-                "text": "param"
+                "escapedText": "param"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
@@ -72,13 +72,13 @@
                 "kind": "Identifier",
                 "pos": 46,
                 "end": 51,
-                "text": "name2"
+                "escapedText": "name2"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 46,
                 "end": 51,
-                "text": "name2"
+                "escapedText": "name2"
             },
             "isBracketed": false,
             "comment": ""

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typeTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typeTag.json
@@ -16,7 +16,7 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 13,
-                "text": "type"
+                "escapedText": "type"
             },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
@@ -16,19 +16,19 @@
                 "kind": "Identifier",
                 "pos": 9,
                 "end": 16,
-                "text": "typedef"
+                "escapedText": "typedef"
             },
             "fullName": {
                 "kind": "Identifier",
                 "pos": 17,
                 "end": 23,
-                "text": "People"
+                "escapedText": "People"
             },
             "name": {
                 "kind": "Identifier",
                 "pos": 17,
                 "end": 23,
-                "text": "People"
+                "escapedText": "People"
             },
             "jsDocTypeLiteral": {
                 "kind": "JSDocTypeLiteral",
@@ -47,7 +47,7 @@
                         "kind": "Identifier",
                         "pos": 29,
                         "end": 33,
-                        "text": "type"
+                        "escapedText": "type"
                     },
                     "typeExpression": {
                         "kind": "JSDocTypeExpression",
@@ -61,7 +61,7 @@
                                 "kind": "Identifier",
                                 "pos": 35,
                                 "end": 41,
-                                "text": "Object"
+                                "escapedText": "Object"
                             }
                         }
                     }
@@ -80,7 +80,7 @@
                             "kind": "Identifier",
                             "pos": 48,
                             "end": 56,
-                            "text": "property"
+                            "escapedText": "property"
                         },
                         "typeExpression": {
                             "kind": "JSDocTypeExpression",
@@ -96,13 +96,13 @@
                             "kind": "Identifier",
                             "pos": 66,
                             "end": 69,
-                            "text": "age"
+                            "escapedText": "age"
                         },
                         "name": {
                             "kind": "Identifier",
                             "pos": 66,
                             "end": 69,
-                            "text": "age"
+                            "escapedText": "age"
                         },
                         "isBracketed": false
                     },
@@ -119,7 +119,7 @@
                             "kind": "Identifier",
                             "pos": 75,
                             "end": 83,
-                            "text": "property"
+                            "escapedText": "property"
                         },
                         "typeExpression": {
                             "kind": "JSDocTypeExpression",
@@ -135,13 +135,13 @@
                             "kind": "Identifier",
                             "pos": 93,
                             "end": 97,
-                            "text": "name"
+                            "escapedText": "name"
                         },
                         "name": {
                             "kind": "Identifier",
                             "pos": 93,
                             "end": 97,
-                            "text": "name"
+                            "escapedText": "name"
                         },
                         "isBracketed": false
                     }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType1.json
@@ -13,7 +13,7 @@
             "pos": 1,
             "end": 2,
             "flags": "JSDoc",
-            "text": "a"
+            "escapedText": "a"
         }
     }
 }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType2.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType2.json
@@ -18,7 +18,7 @@
                 "pos": 1,
                 "end": 2,
                 "flags": "JSDoc",
-                "text": "a"
+                "escapedText": "a"
             }
         }
     }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType3.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType3.json
@@ -28,7 +28,7 @@
                         "pos": 2,
                         "end": 3,
                         "flags": "JSDoc",
-                        "text": "a"
+                        "escapedText": "a"
                     }
                 }
             }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.functionTypeWithTrailingComma.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.functionTypeWithTrailingComma.json
@@ -19,7 +19,7 @@
                     "pos": 10,
                     "end": 11,
                     "flags": "JSDoc",
-                    "text": "a"
+                    "escapedText": "a"
                 }
             }
         },

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.keyword1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.keyword1.json
@@ -9,6 +9,6 @@
         "end": 4,
         "flags": "JSDoc",
         "originalKeywordKind": "VarKeyword",
-        "text": "var"
+        "escapedText": "var"
     }
 }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.methodInRecordType.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.methodInRecordType.json
@@ -14,7 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
-                "text": "foo"
+                "escapedText": "foo"
             },
             "parameters": {
                 "length": 0,

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.newType1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.newType1.json
@@ -15,7 +15,7 @@
                 "end": 13,
                 "flags": "JSDoc",
                 "originalKeywordKind": "NewKeyword",
-                "text": "new"
+                "escapedText": "new"
             },
             "type": {
                 "kind": "TypeReference",
@@ -32,14 +32,14 @@
                         "pos": 14,
                         "end": 15,
                         "flags": "JSDoc",
-                        "text": "a"
+                        "escapedText": "a"
                     },
                     "right": {
                         "kind": "Identifier",
                         "pos": 16,
                         "end": 17,
                         "flags": "JSDoc",
-                        "text": "b"
+                        "escapedText": "b"
                     }
                 }
             }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType2.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType2.json
@@ -14,7 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
-                "text": "foo"
+                "escapedText": "foo"
             }
         },
         "length": 1,

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType3.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType3.json
@@ -14,7 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
-                "text": "foo"
+                "escapedText": "foo"
             },
             "type": {
                 "kind": "NumberKeyword",

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType4.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType4.json
@@ -14,7 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
-                "text": "foo"
+                "escapedText": "foo"
             }
         },
         "1": {
@@ -27,7 +27,7 @@
                 "pos": 6,
                 "end": 10,
                 "flags": "JSDoc",
-                "text": "bar"
+                "escapedText": "bar"
             }
         },
         "length": 2,

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType5.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType5.json
@@ -14,7 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
-                "text": "foo"
+                "escapedText": "foo"
             },
             "type": {
                 "kind": "NumberKeyword",
@@ -33,7 +33,7 @@
                 "pos": 14,
                 "end": 18,
                 "flags": "JSDoc",
-                "text": "bar"
+                "escapedText": "bar"
             }
         },
         "length": 2,

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType6.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType6.json
@@ -14,7 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
-                "text": "foo"
+                "escapedText": "foo"
             }
         },
         "1": {
@@ -27,7 +27,7 @@
                 "pos": 6,
                 "end": 10,
                 "flags": "JSDoc",
-                "text": "bar"
+                "escapedText": "bar"
             },
             "type": {
                 "kind": "NumberKeyword",

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType7.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType7.json
@@ -14,7 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
-                "text": "foo"
+                "escapedText": "foo"
             },
             "type": {
                 "kind": "NumberKeyword",
@@ -33,7 +33,7 @@
                 "pos": 14,
                 "end": 18,
                 "flags": "JSDoc",
-                "text": "bar"
+                "escapedText": "bar"
             },
             "type": {
                 "kind": "NumberKeyword",

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType8.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType8.json
@@ -15,7 +15,7 @@
                 "end": 10,
                 "flags": "JSDoc",
                 "originalKeywordKind": "FunctionKeyword",
-                "text": "function"
+                "escapedText": "function"
             }
         },
         "length": 1,

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.thisType1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.thisType1.json
@@ -15,7 +15,7 @@
                 "end": 14,
                 "flags": "JSDoc",
                 "originalKeywordKind": "ThisKeyword",
-                "text": "this"
+                "escapedText": "this"
             },
             "type": {
                 "kind": "TypeReference",
@@ -32,14 +32,14 @@
                         "pos": 15,
                         "end": 16,
                         "flags": "JSDoc",
-                        "text": "a"
+                        "escapedText": "a"
                     },
                     "right": {
                         "kind": "Identifier",
                         "pos": 17,
                         "end": 18,
                         "flags": "JSDoc",
-                        "text": "b"
+                        "escapedText": "b"
                     }
                 }
             }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.trailingCommaInRecordType.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.trailingCommaInRecordType.json
@@ -14,7 +14,7 @@
                 "pos": 2,
                 "end": 3,
                 "flags": "JSDoc",
-                "text": "a"
+                "escapedText": "a"
             }
         },
         "length": 1,

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeArgumentsNotFollowingDot.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeArgumentsNotFollowingDot.json
@@ -8,7 +8,7 @@
         "pos": 1,
         "end": 2,
         "flags": "JSDoc",
-        "text": "a"
+        "escapedText": "a"
     },
     "typeArguments": {
         "length": 0,

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeOfType.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeOfType.json
@@ -8,6 +8,6 @@
         "pos": 7,
         "end": 9,
         "flags": "JSDoc",
-        "text": "M"
+        "escapedText": "M"
     }
 }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference1.json
@@ -8,7 +8,7 @@
         "pos": 1,
         "end": 2,
         "flags": "JSDoc",
-        "text": "a",
+        "escapedText": "a",
         "jsdocDotPos": 2
     },
     "typeArguments": {

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference2.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference2.json
@@ -8,7 +8,7 @@
         "pos": 1,
         "end": 2,
         "flags": "JSDoc",
-        "text": "a",
+        "escapedText": "a",
         "jsdocDotPos": 2
     },
     "typeArguments": {

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference3.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference3.json
@@ -13,7 +13,7 @@
             "pos": 1,
             "end": 2,
             "flags": "JSDoc",
-            "text": "a"
+            "escapedText": "a"
         },
         "right": {
             "kind": "Identifier",
@@ -21,7 +21,7 @@
             "end": 11,
             "flags": "JSDoc",
             "originalKeywordKind": "FunctionKeyword",
-            "text": "function"
+            "escapedText": "function"
         }
     }
 }


### PR DESCRIPTION
`id.name` will be more conventent than calling `ts.unescapeLeadingUnderscores(id.text)`.