### PR TITLE
Don't use a cached union/intersection type if there is an aliasSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7344,17 +7344,27 @@ namespace ts {
             if (types.length === 1) {
                 return types[0];
             }
+            if (aliasSymbol) {
+                // Don't reuse types that would have different `aliasSymbol`s.
+                return create();
+            }
+
             const id = getTypeListId(types);
             let type = unionTypes.get(id);
             if (!type) {
-                const propagatedFlags = getPropagatingFlagsOfTypes(types, /*excludeKinds*/ TypeFlags.Nullable);
-                type = <UnionType>createType(TypeFlags.Union | propagatedFlags);
+                type = create();
                 unionTypes.set(id, type);
+            }
+            return type;
+
+            function create() {
+                const propagatedFlags = getPropagatingFlagsOfTypes(types, /*excludeKinds*/ TypeFlags.Nullable);
+                const type = <UnionType>createType(TypeFlags.Union | propagatedFlags);
                 type.types = types;
                 type.aliasSymbol = aliasSymbol;
                 type.aliasTypeArguments = aliasTypeArguments;
+                return type;
             }
-            return type;
         }
 
         function getTypeFromUnionTypeNode(node: UnionTypeNode): Type {
@@ -7437,17 +7447,27 @@ namespace ts {
                 return getUnionType(map(unionType.types, t => getIntersectionType(replaceElement(typeSet, unionIndex, t))),
                     /*subtypeReduction*/ false, aliasSymbol, aliasTypeArguments);
             }
+            if (aliasSymbol) {
+                // Don't reuse types that would have different `aliasSymbol`s.
+                return create();
+            }
+
             const id = getTypeListId(typeSet);
             let type = intersectionTypes.get(id);
             if (!type) {
-                const propagatedFlags = getPropagatingFlagsOfTypes(typeSet, /*excludeKinds*/ TypeFlags.Nullable);
-                type = <IntersectionType>createType(TypeFlags.Intersection | propagatedFlags);
+                type = create();
                 intersectionTypes.set(id, type);
+            }
+            return type;
+
+            function create(): IntersectionType {
+                const propagatedFlags = getPropagatingFlagsOfTypes(typeSet, /*excludeKinds*/ TypeFlags.Nullable);
+                const type = <IntersectionType>createType(TypeFlags.Intersection | propagatedFlags);
                 type.types = typeSet;
                 type.aliasSymbol = aliasSymbol;
                 type.aliasTypeArguments = aliasTypeArguments;
+                return type;
             }
-            return type;
         }
 
         function getTypeFromIntersectionTypeNode(node: IntersectionTypeNode): Type {

--- a/tests/baselines/reference/booleanLiteralTypes1.types
+++ b/tests/baselines/reference/booleanLiteralTypes1.types
@@ -1,11 +1,11 @@
 === tests/cases/conformance/types/literal/booleanLiteralTypes1.ts ===
 type A1 = true | false;
->A1 : boolean
+>A1 : A1
 >true : true
 >false : false
 
 type A2 = false | true;
->A2 : boolean
+>A2 : A2
 >false : false
 >true : true
 
@@ -13,20 +13,20 @@ function f1() {
 >f1 : () => void
 
     var a: A1;
->a : boolean
->A1 : boolean
+>a : A1
+>A1 : A1
 
     var a: A2;
->a : boolean
->A2 : boolean
+>a : A1
+>A2 : A2
 
     var a: true | false;
->a : boolean
+>a : A1
 >true : true
 >false : false
 
     var a: false | true;
->a : boolean
+>a : A1
 >false : false
 >true : true
 }

--- a/tests/baselines/reference/booleanLiteralTypes2.types
+++ b/tests/baselines/reference/booleanLiteralTypes2.types
@@ -1,11 +1,11 @@
 === tests/cases/conformance/types/literal/booleanLiteralTypes2.ts ===
 type A1 = true | false;
->A1 : boolean
+>A1 : A1
 >true : true
 >false : false
 
 type A2 = false | true;
->A2 : boolean
+>A2 : A2
 >false : false
 >true : true
 
@@ -13,20 +13,20 @@ function f1() {
 >f1 : () => void
 
     var a: A1;
->a : boolean
->A1 : boolean
+>a : A1
+>A1 : A1
 
     var a: A2;
->a : boolean
->A2 : boolean
+>a : A1
+>A2 : A2
 
     var a: true | false;
->a : boolean
+>a : A1
 >true : true
 >false : false
 
     var a: false | true;
->a : boolean
+>a : A1
 >false : false
 >true : true
 }

--- a/tests/baselines/reference/declarationEmitInferedTypeAlias5.js
+++ b/tests/baselines/reference/declarationEmitInferedTypeAlias5.js
@@ -25,6 +25,5 @@ exports.v = v;
 //// [0.d.ts]
 export declare type Data = string | boolean;
 //// [1.d.ts]
-import * as Z from "./0";
-declare let v: Z.Data;
+declare let v: string | boolean;
 export { v };

--- a/tests/baselines/reference/declarationEmitInferedTypeAlias5.types
+++ b/tests/baselines/reference/declarationEmitInferedTypeAlias5.types
@@ -13,11 +13,11 @@ import * as Z from "./0"
 
 //let v2: Z.Data;
 let v = "str" || true;
->v : Z.Data
+>v : string | boolean
 >"str" || true : true | "str"
 >"str" : "str"
 >true : true
 
 export { v }
->v : Z.Data
+>v : string | boolean
 

--- a/tests/baselines/reference/enumLiteralTypes1.types
+++ b/tests/baselines/reference/enumLiteralTypes1.types
@@ -13,14 +13,14 @@ type YesNo = Choice.Yes | Choice.No;
 >No : Choice.No
 
 type NoYes = Choice.No | Choice.Yes;
->NoYes : YesNo
+>NoYes : NoYes
 >Choice : any
 >No : Choice.No
 >Choice : any
 >Yes : Choice.Yes
 
 type UnknownYesNo = Choice.Unknown | Choice.Yes | Choice.No;
->UnknownYesNo : Choice
+>UnknownYesNo : UnknownYesNo
 >Choice : any
 >Unknown : Choice.Unknown
 >Choice : any
@@ -37,7 +37,7 @@ function f1() {
 
     var a: NoYes;
 >a : YesNo
->NoYes : YesNo
+>NoYes : NoYes
 
     var a: Choice.Yes | Choice.No;
 >a : YesNo
@@ -55,17 +55,17 @@ function f1() {
 }
 
 function f2(a: YesNo, b: UnknownYesNo, c: Choice) {
->f2 : (a: YesNo, b: Choice, c: Choice) => void
+>f2 : (a: YesNo, b: UnknownYesNo, c: Choice) => void
 >a : YesNo
 >YesNo : YesNo
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 >c : Choice
 >Choice : Choice
 
     b = a;
 >b = a : YesNo
->b : Choice
+>b : UnknownYesNo
 >a : YesNo
 
     c = a;
@@ -74,9 +74,9 @@ function f2(a: YesNo, b: UnknownYesNo, c: Choice) {
 >a : YesNo
 
     c = b;
->c = b : YesNo
+>c = b : Choice.Yes | Choice.No
 >c : Choice
->b : YesNo
+>b : Choice.Yes | Choice.No
 }
 
 function f3(a: Choice.Yes, b: YesNo) {
@@ -234,11 +234,11 @@ declare function g(x: Choice): number;
 >Choice : Choice
 
 function f5(a: YesNo, b: UnknownYesNo, c: Choice) {
->f5 : (a: YesNo, b: Choice, c: Choice) => void
+>f5 : (a: YesNo, b: UnknownYesNo, c: Choice) => void
 >a : YesNo
 >YesNo : YesNo
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 >c : Choice
 >Choice : Choice
 
@@ -268,7 +268,7 @@ function f5(a: YesNo, b: UnknownYesNo, c: Choice) {
 >z4 : number
 >g(b) : number
 >g : { (x: Choice.Yes): string; (x: Choice.No): boolean; (x: Choice): number; }
->b : Choice
+>b : UnknownYesNo
 
     var z5 = g(c);
 >z5 : number
@@ -336,30 +336,30 @@ function f11(x: YesNo) {
 }
 
 function f12(x: UnknownYesNo) {
->f12 : (x: Choice) => void
->x : Choice
->UnknownYesNo : Choice
+>f12 : (x: UnknownYesNo) => void
+>x : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     if (x) {
->x : Choice
+>x : UnknownYesNo
 
         x;
->x : YesNo
+>x : Choice.Yes | Choice.No
     }
     else {
         x;
->x : Choice
+>x : UnknownYesNo
     }
 }
 
 function f13(x: UnknownYesNo) {
->f13 : (x: Choice) => void
->x : Choice
->UnknownYesNo : Choice
+>f13 : (x: UnknownYesNo) => void
+>x : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     if (x === Choice.Yes) {
 >x === Choice.Yes : boolean
->x : Choice
+>x : UnknownYesNo
 >Choice.Yes : Choice.Yes
 >Choice : typeof Choice
 >Yes : Choice.Yes
@@ -394,9 +394,9 @@ function f20(x: Item) {
 >Item : Item
 
     switch (x.kind) {
->x.kind : YesNo
+>x.kind : Choice.Yes | Choice.No
 >x : Item
->kind : YesNo
+>kind : Choice.Yes | Choice.No
 
         case Choice.Yes: return x.a;
 >Choice.Yes : Choice.Yes
@@ -422,9 +422,9 @@ function f21(x: Item) {
 >Item : Item
 
     switch (x.kind) {
->x.kind : YesNo
+>x.kind : Choice.Yes | Choice.No
 >x : Item
->kind : YesNo
+>kind : Choice.Yes | Choice.No
 
         case Choice.Yes: return x.a;
 >Choice.Yes : Choice.Yes

--- a/tests/baselines/reference/enumLiteralTypes2.types
+++ b/tests/baselines/reference/enumLiteralTypes2.types
@@ -13,14 +13,14 @@ type YesNo = Choice.Yes | Choice.No;
 >No : Choice.No
 
 type NoYes = Choice.No | Choice.Yes;
->NoYes : YesNo
+>NoYes : NoYes
 >Choice : any
 >No : Choice.No
 >Choice : any
 >Yes : Choice.Yes
 
 type UnknownYesNo = Choice.Unknown | Choice.Yes | Choice.No;
->UnknownYesNo : Choice
+>UnknownYesNo : UnknownYesNo
 >Choice : any
 >Unknown : Choice.Unknown
 >Choice : any
@@ -37,7 +37,7 @@ function f1() {
 
     var a: NoYes;
 >a : YesNo
->NoYes : YesNo
+>NoYes : NoYes
 
     var a: Choice.Yes | Choice.No;
 >a : YesNo
@@ -55,17 +55,17 @@ function f1() {
 }
 
 function f2(a: YesNo, b: UnknownYesNo, c: Choice) {
->f2 : (a: YesNo, b: Choice, c: Choice) => void
+>f2 : (a: YesNo, b: UnknownYesNo, c: Choice) => void
 >a : YesNo
 >YesNo : YesNo
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 >c : Choice
 >Choice : Choice
 
     b = a;
 >b = a : YesNo
->b : Choice
+>b : UnknownYesNo
 >a : YesNo
 
     c = a;
@@ -74,138 +74,138 @@ function f2(a: YesNo, b: UnknownYesNo, c: Choice) {
 >a : YesNo
 
     c = b;
->c = b : YesNo
+>c = b : Choice.Yes | Choice.No
 >c : Choice
->b : YesNo
+>b : Choice.Yes | Choice.No
 }
 
 function f3(a: Choice.Yes, b: UnknownYesNo) {
->f3 : (a: Choice.Yes, b: Choice) => void
+>f3 : (a: Choice.Yes, b: UnknownYesNo) => void
 >a : Choice.Yes
 >Choice : any
 >Yes : Choice.Yes
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     var x = a + b;
 >x : number
 >a + b : number
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var x = a - b;
 >x : number
 >a - b : number
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var x = a * b;
 >x : number
 >a * b : number
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var x = a / b;
 >x : number
 >a / b : number
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var x = a % b;
 >x : number
 >a % b : number
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var x = a | b;
 >x : number
 >a | b : number
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var x = a & b;
 >x : number
 >a & b : number
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var x = a ^ b;
 >x : number
 >a ^ b : number
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var x = -b;
 >x : number
 >-b : number
->b : Choice
+>b : UnknownYesNo
 
     var x = ~b;
 >x : number
 >~b : number
->b : Choice
+>b : UnknownYesNo
 
     var y = a == b;
 >y : boolean
 >a == b : boolean
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var y = a != b;
 >y : boolean
 >a != b : boolean
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var y = a === b;
 >y : boolean
 >a === b : boolean
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var y = a !== b;
 >y : boolean
 >a !== b : boolean
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var y = a > b;
 >y : boolean
 >a > b : boolean
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var y = a < b;
 >y : boolean
 >a < b : boolean
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var y = a >= b;
 >y : boolean
 >a >= b : boolean
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var y = a <= b;
 >y : boolean
 >a <= b : boolean
 >a : Choice.Yes
->b : Choice
+>b : UnknownYesNo
 
     var y = !b;
 >y : boolean
 >!b : boolean
->b : Choice
+>b : UnknownYesNo
 }
 
 function f4(a: Choice.Yes, b: UnknownYesNo) {
->f4 : (a: Choice.Yes, b: Choice) => void
+>f4 : (a: Choice.Yes, b: UnknownYesNo) => void
 >a : Choice.Yes
 >Choice : any
 >Yes : Choice.Yes
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     a++;
 >a++ : number
@@ -234,11 +234,11 @@ declare function g(x: Choice): number;
 >Choice : Choice
 
 function f5(a: YesNo, b: UnknownYesNo, c: Choice) {
->f5 : (a: YesNo, b: Choice, c: Choice) => void
+>f5 : (a: YesNo, b: UnknownYesNo, c: Choice) => void
 >a : YesNo
 >YesNo : YesNo
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 >c : Choice
 >Choice : Choice
 
@@ -268,7 +268,7 @@ function f5(a: YesNo, b: UnknownYesNo, c: Choice) {
 >z4 : number
 >g(b) : number
 >g : { (x: Choice.Yes): string; (x: Choice.No): boolean; (x: Choice): number; }
->b : Choice
+>b : UnknownYesNo
 
     var z5 = g(c);
 >z5 : number
@@ -336,15 +336,15 @@ function f11(x: YesNo) {
 }
 
 function f12(x: UnknownYesNo) {
->f12 : (x: Choice) => void
->x : Choice
->UnknownYesNo : Choice
+>f12 : (x: UnknownYesNo) => void
+>x : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     if (x) {
->x : Choice
+>x : UnknownYesNo
 
         x;
->x : YesNo
+>x : Choice.Yes | Choice.No
     }
     else {
         x;
@@ -353,13 +353,13 @@ function f12(x: UnknownYesNo) {
 }
 
 function f13(x: UnknownYesNo) {
->f13 : (x: Choice) => void
->x : Choice
->UnknownYesNo : Choice
+>f13 : (x: UnknownYesNo) => void
+>x : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     if (x === Choice.Yes) {
 >x === Choice.Yes : boolean
->x : Choice
+>x : UnknownYesNo
 >Choice.Yes : Choice.Yes
 >Choice : typeof Choice
 >Yes : Choice.Yes
@@ -394,9 +394,9 @@ function f20(x: Item) {
 >Item : Item
 
     switch (x.kind) {
->x.kind : YesNo
+>x.kind : Choice.Yes | Choice.No
 >x : Item
->kind : YesNo
+>kind : Choice.Yes | Choice.No
 
         case Choice.Yes: return x.a;
 >Choice.Yes : Choice.Yes
@@ -422,9 +422,9 @@ function f21(x: Item) {
 >Item : Item
 
     switch (x.kind) {
->x.kind : YesNo
+>x.kind : Choice.Yes | Choice.No
 >x : Item
->kind : YesNo
+>kind : Choice.Yes | Choice.No
 
         case Choice.Yes: return x.a;
 >Choice.Yes : Choice.Yes

--- a/tests/baselines/reference/enumLiteralTypes3.errors.txt
+++ b/tests/baselines/reference/enumLiteralTypes3.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/conformance/types/literal/enumLiteralTypes3.ts(10,5): error TS2322: Type 'YesNo' is not assignable to type 'Choice.Yes'.
   Type 'Choice.No' is not assignable to type 'Choice.Yes'.
-tests/cases/conformance/types/literal/enumLiteralTypes3.ts(11,5): error TS2322: Type 'Choice' is not assignable to type 'Choice.Yes'.
+tests/cases/conformance/types/literal/enumLiteralTypes3.ts(11,5): error TS2322: Type 'UnknownYesNo' is not assignable to type 'Choice.Yes'.
+  Type 'Choice.Unknown' is not assignable to type 'Choice.Yes'.
 tests/cases/conformance/types/literal/enumLiteralTypes3.ts(12,5): error TS2322: Type 'Choice' is not assignable to type 'Choice.Yes'.
-tests/cases/conformance/types/literal/enumLiteralTypes3.ts(18,5): error TS2322: Type 'Choice' is not assignable to type 'YesNo'.
+tests/cases/conformance/types/literal/enumLiteralTypes3.ts(18,5): error TS2322: Type 'UnknownYesNo' is not assignable to type 'YesNo'.
+  Type 'Choice.Unknown' is not assignable to type 'YesNo'.
 tests/cases/conformance/types/literal/enumLiteralTypes3.ts(19,5): error TS2322: Type 'Choice' is not assignable to type 'YesNo'.
 tests/cases/conformance/types/literal/enumLiteralTypes3.ts(37,5): error TS2322: Type 'Choice.Unknown' is not assignable to type 'Choice.Yes'.
 tests/cases/conformance/types/literal/enumLiteralTypes3.ts(39,5): error TS2322: Type 'Choice.No' is not assignable to type 'Choice.Yes'.
@@ -31,7 +33,8 @@ tests/cases/conformance/types/literal/enumLiteralTypes3.ts(96,14): error TS2678:
 !!! error TS2322:   Type 'Choice.No' is not assignable to type 'Choice.Yes'.
         a = c;
         ~
-!!! error TS2322: Type 'Choice' is not assignable to type 'Choice.Yes'.
+!!! error TS2322: Type 'UnknownYesNo' is not assignable to type 'Choice.Yes'.
+!!! error TS2322:   Type 'Choice.Unknown' is not assignable to type 'Choice.Yes'.
         a = d;
         ~
 !!! error TS2322: Type 'Choice' is not assignable to type 'Choice.Yes'.
@@ -42,7 +45,8 @@ tests/cases/conformance/types/literal/enumLiteralTypes3.ts(96,14): error TS2678:
         b = b;
         b = c;
         ~
-!!! error TS2322: Type 'Choice' is not assignable to type 'YesNo'.
+!!! error TS2322: Type 'UnknownYesNo' is not assignable to type 'YesNo'.
+!!! error TS2322:   Type 'Choice.Unknown' is not assignable to type 'YesNo'.
         b = d;
         ~
 !!! error TS2322: Type 'Choice' is not assignable to type 'YesNo'.

--- a/tests/baselines/reference/enumLiteralsSubtypeReduction.types
+++ b/tests/baselines/reference/enumLiteralsSubtypeReduction.types
@@ -3075,7 +3075,7 @@ enum E {
 >E1023 : E.E1023
 }
 function run(a: number) {
->run : (a: number) => E[]
+>run : (a: number) => (E)[]
 >a : number
 
     switch (a) {
@@ -3085,7 +3085,7 @@ function run(a: number) {
 >0 : 0
 
             return [ E.E0, E.E1]
->[ E.E0, E.E1] : E[]
+>[ E.E0, E.E1] : (E)[]
 >E.E0 : E.E0
 >E : typeof E
 >E0 : E.E0
@@ -3097,7 +3097,7 @@ function run(a: number) {
 >2 : 2
 
             return [ E.E2, E.E3]
->[ E.E2, E.E3] : E[]
+>[ E.E2, E.E3] : (E)[]
 >E.E2 : E.E2
 >E : typeof E
 >E2 : E.E2
@@ -3109,7 +3109,7 @@ function run(a: number) {
 >4 : 4
 
             return [ E.E4, E.E5]
->[ E.E4, E.E5] : E[]
+>[ E.E4, E.E5] : (E)[]
 >E.E4 : E.E4
 >E : typeof E
 >E4 : E.E4
@@ -3121,7 +3121,7 @@ function run(a: number) {
 >6 : 6
 
             return [ E.E6, E.E7]
->[ E.E6, E.E7] : E[]
+>[ E.E6, E.E7] : (E)[]
 >E.E6 : E.E6
 >E : typeof E
 >E6 : E.E6
@@ -3133,7 +3133,7 @@ function run(a: number) {
 >8 : 8
 
             return [ E.E8, E.E9]
->[ E.E8, E.E9] : E[]
+>[ E.E8, E.E9] : (E)[]
 >E.E8 : E.E8
 >E : typeof E
 >E8 : E.E8
@@ -3145,7 +3145,7 @@ function run(a: number) {
 >10 : 10
 
             return [ E.E10, E.E11]
->[ E.E10, E.E11] : E[]
+>[ E.E10, E.E11] : (E)[]
 >E.E10 : E.E10
 >E : typeof E
 >E10 : E.E10
@@ -3157,7 +3157,7 @@ function run(a: number) {
 >12 : 12
 
             return [ E.E12, E.E13]
->[ E.E12, E.E13] : E[]
+>[ E.E12, E.E13] : (E)[]
 >E.E12 : E.E12
 >E : typeof E
 >E12 : E.E12
@@ -3169,7 +3169,7 @@ function run(a: number) {
 >14 : 14
 
             return [ E.E14, E.E15]
->[ E.E14, E.E15] : E[]
+>[ E.E14, E.E15] : (E)[]
 >E.E14 : E.E14
 >E : typeof E
 >E14 : E.E14
@@ -3181,7 +3181,7 @@ function run(a: number) {
 >16 : 16
 
             return [ E.E16, E.E17]
->[ E.E16, E.E17] : E[]
+>[ E.E16, E.E17] : (E)[]
 >E.E16 : E.E16
 >E : typeof E
 >E16 : E.E16
@@ -3193,7 +3193,7 @@ function run(a: number) {
 >18 : 18
 
             return [ E.E18, E.E19]
->[ E.E18, E.E19] : E[]
+>[ E.E18, E.E19] : (E)[]
 >E.E18 : E.E18
 >E : typeof E
 >E18 : E.E18
@@ -3205,7 +3205,7 @@ function run(a: number) {
 >20 : 20
 
             return [ E.E20, E.E21]
->[ E.E20, E.E21] : E[]
+>[ E.E20, E.E21] : (E)[]
 >E.E20 : E.E20
 >E : typeof E
 >E20 : E.E20
@@ -3217,7 +3217,7 @@ function run(a: number) {
 >22 : 22
 
             return [ E.E22, E.E23]
->[ E.E22, E.E23] : E[]
+>[ E.E22, E.E23] : (E)[]
 >E.E22 : E.E22
 >E : typeof E
 >E22 : E.E22
@@ -3229,7 +3229,7 @@ function run(a: number) {
 >24 : 24
 
             return [ E.E24, E.E25]
->[ E.E24, E.E25] : E[]
+>[ E.E24, E.E25] : (E)[]
 >E.E24 : E.E24
 >E : typeof E
 >E24 : E.E24
@@ -3241,7 +3241,7 @@ function run(a: number) {
 >26 : 26
 
             return [ E.E26, E.E27]
->[ E.E26, E.E27] : E[]
+>[ E.E26, E.E27] : (E)[]
 >E.E26 : E.E26
 >E : typeof E
 >E26 : E.E26
@@ -3253,7 +3253,7 @@ function run(a: number) {
 >28 : 28
 
             return [ E.E28, E.E29]
->[ E.E28, E.E29] : E[]
+>[ E.E28, E.E29] : (E)[]
 >E.E28 : E.E28
 >E : typeof E
 >E28 : E.E28
@@ -3265,7 +3265,7 @@ function run(a: number) {
 >30 : 30
 
             return [ E.E30, E.E31]
->[ E.E30, E.E31] : E[]
+>[ E.E30, E.E31] : (E)[]
 >E.E30 : E.E30
 >E : typeof E
 >E30 : E.E30
@@ -3277,7 +3277,7 @@ function run(a: number) {
 >32 : 32
 
             return [ E.E32, E.E33]
->[ E.E32, E.E33] : E[]
+>[ E.E32, E.E33] : (E)[]
 >E.E32 : E.E32
 >E : typeof E
 >E32 : E.E32
@@ -3289,7 +3289,7 @@ function run(a: number) {
 >34 : 34
 
             return [ E.E34, E.E35]
->[ E.E34, E.E35] : E[]
+>[ E.E34, E.E35] : (E)[]
 >E.E34 : E.E34
 >E : typeof E
 >E34 : E.E34
@@ -3301,7 +3301,7 @@ function run(a: number) {
 >36 : 36
 
             return [ E.E36, E.E37]
->[ E.E36, E.E37] : E[]
+>[ E.E36, E.E37] : (E)[]
 >E.E36 : E.E36
 >E : typeof E
 >E36 : E.E36
@@ -3313,7 +3313,7 @@ function run(a: number) {
 >38 : 38
 
             return [ E.E38, E.E39]
->[ E.E38, E.E39] : E[]
+>[ E.E38, E.E39] : (E)[]
 >E.E38 : E.E38
 >E : typeof E
 >E38 : E.E38
@@ -3325,7 +3325,7 @@ function run(a: number) {
 >40 : 40
 
             return [ E.E40, E.E41]
->[ E.E40, E.E41] : E[]
+>[ E.E40, E.E41] : (E)[]
 >E.E40 : E.E40
 >E : typeof E
 >E40 : E.E40
@@ -3337,7 +3337,7 @@ function run(a: number) {
 >42 : 42
 
             return [ E.E42, E.E43]
->[ E.E42, E.E43] : E[]
+>[ E.E42, E.E43] : (E)[]
 >E.E42 : E.E42
 >E : typeof E
 >E42 : E.E42
@@ -3349,7 +3349,7 @@ function run(a: number) {
 >44 : 44
 
             return [ E.E44, E.E45]
->[ E.E44, E.E45] : E[]
+>[ E.E44, E.E45] : (E)[]
 >E.E44 : E.E44
 >E : typeof E
 >E44 : E.E44
@@ -3361,7 +3361,7 @@ function run(a: number) {
 >46 : 46
 
             return [ E.E46, E.E47]
->[ E.E46, E.E47] : E[]
+>[ E.E46, E.E47] : (E)[]
 >E.E46 : E.E46
 >E : typeof E
 >E46 : E.E46
@@ -3373,7 +3373,7 @@ function run(a: number) {
 >48 : 48
 
             return [ E.E48, E.E49]
->[ E.E48, E.E49] : E[]
+>[ E.E48, E.E49] : (E)[]
 >E.E48 : E.E48
 >E : typeof E
 >E48 : E.E48
@@ -3385,7 +3385,7 @@ function run(a: number) {
 >50 : 50
 
             return [ E.E50, E.E51]
->[ E.E50, E.E51] : E[]
+>[ E.E50, E.E51] : (E)[]
 >E.E50 : E.E50
 >E : typeof E
 >E50 : E.E50
@@ -3397,7 +3397,7 @@ function run(a: number) {
 >52 : 52
 
             return [ E.E52, E.E53]
->[ E.E52, E.E53] : E[]
+>[ E.E52, E.E53] : (E)[]
 >E.E52 : E.E52
 >E : typeof E
 >E52 : E.E52
@@ -3409,7 +3409,7 @@ function run(a: number) {
 >54 : 54
 
             return [ E.E54, E.E55]
->[ E.E54, E.E55] : E[]
+>[ E.E54, E.E55] : (E)[]
 >E.E54 : E.E54
 >E : typeof E
 >E54 : E.E54
@@ -3421,7 +3421,7 @@ function run(a: number) {
 >56 : 56
 
             return [ E.E56, E.E57]
->[ E.E56, E.E57] : E[]
+>[ E.E56, E.E57] : (E)[]
 >E.E56 : E.E56
 >E : typeof E
 >E56 : E.E56
@@ -3433,7 +3433,7 @@ function run(a: number) {
 >58 : 58
 
             return [ E.E58, E.E59]
->[ E.E58, E.E59] : E[]
+>[ E.E58, E.E59] : (E)[]
 >E.E58 : E.E58
 >E : typeof E
 >E58 : E.E58
@@ -3445,7 +3445,7 @@ function run(a: number) {
 >60 : 60
 
             return [ E.E60, E.E61]
->[ E.E60, E.E61] : E[]
+>[ E.E60, E.E61] : (E)[]
 >E.E60 : E.E60
 >E : typeof E
 >E60 : E.E60
@@ -3457,7 +3457,7 @@ function run(a: number) {
 >62 : 62
 
             return [ E.E62, E.E63]
->[ E.E62, E.E63] : E[]
+>[ E.E62, E.E63] : (E)[]
 >E.E62 : E.E62
 >E : typeof E
 >E62 : E.E62
@@ -3469,7 +3469,7 @@ function run(a: number) {
 >64 : 64
 
             return [ E.E64, E.E65]
->[ E.E64, E.E65] : E[]
+>[ E.E64, E.E65] : (E)[]
 >E.E64 : E.E64
 >E : typeof E
 >E64 : E.E64
@@ -3481,7 +3481,7 @@ function run(a: number) {
 >66 : 66
 
             return [ E.E66, E.E67]
->[ E.E66, E.E67] : E[]
+>[ E.E66, E.E67] : (E)[]
 >E.E66 : E.E66
 >E : typeof E
 >E66 : E.E66
@@ -3493,7 +3493,7 @@ function run(a: number) {
 >68 : 68
 
             return [ E.E68, E.E69]
->[ E.E68, E.E69] : E[]
+>[ E.E68, E.E69] : (E)[]
 >E.E68 : E.E68
 >E : typeof E
 >E68 : E.E68
@@ -3505,7 +3505,7 @@ function run(a: number) {
 >70 : 70
 
             return [ E.E70, E.E71]
->[ E.E70, E.E71] : E[]
+>[ E.E70, E.E71] : (E)[]
 >E.E70 : E.E70
 >E : typeof E
 >E70 : E.E70
@@ -3517,7 +3517,7 @@ function run(a: number) {
 >72 : 72
 
             return [ E.E72, E.E73]
->[ E.E72, E.E73] : E[]
+>[ E.E72, E.E73] : (E)[]
 >E.E72 : E.E72
 >E : typeof E
 >E72 : E.E72
@@ -3529,7 +3529,7 @@ function run(a: number) {
 >74 : 74
 
             return [ E.E74, E.E75]
->[ E.E74, E.E75] : E[]
+>[ E.E74, E.E75] : (E)[]
 >E.E74 : E.E74
 >E : typeof E
 >E74 : E.E74
@@ -3541,7 +3541,7 @@ function run(a: number) {
 >76 : 76
 
             return [ E.E76, E.E77]
->[ E.E76, E.E77] : E[]
+>[ E.E76, E.E77] : (E)[]
 >E.E76 : E.E76
 >E : typeof E
 >E76 : E.E76
@@ -3553,7 +3553,7 @@ function run(a: number) {
 >78 : 78
 
             return [ E.E78, E.E79]
->[ E.E78, E.E79] : E[]
+>[ E.E78, E.E79] : (E)[]
 >E.E78 : E.E78
 >E : typeof E
 >E78 : E.E78
@@ -3565,7 +3565,7 @@ function run(a: number) {
 >80 : 80
 
             return [ E.E80, E.E81]
->[ E.E80, E.E81] : E[]
+>[ E.E80, E.E81] : (E)[]
 >E.E80 : E.E80
 >E : typeof E
 >E80 : E.E80
@@ -3577,7 +3577,7 @@ function run(a: number) {
 >82 : 82
 
             return [ E.E82, E.E83]
->[ E.E82, E.E83] : E[]
+>[ E.E82, E.E83] : (E)[]
 >E.E82 : E.E82
 >E : typeof E
 >E82 : E.E82
@@ -3589,7 +3589,7 @@ function run(a: number) {
 >84 : 84
 
             return [ E.E84, E.E85]
->[ E.E84, E.E85] : E[]
+>[ E.E84, E.E85] : (E)[]
 >E.E84 : E.E84
 >E : typeof E
 >E84 : E.E84
@@ -3601,7 +3601,7 @@ function run(a: number) {
 >86 : 86
 
             return [ E.E86, E.E87]
->[ E.E86, E.E87] : E[]
+>[ E.E86, E.E87] : (E)[]
 >E.E86 : E.E86
 >E : typeof E
 >E86 : E.E86
@@ -3613,7 +3613,7 @@ function run(a: number) {
 >88 : 88
 
             return [ E.E88, E.E89]
->[ E.E88, E.E89] : E[]
+>[ E.E88, E.E89] : (E)[]
 >E.E88 : E.E88
 >E : typeof E
 >E88 : E.E88
@@ -3625,7 +3625,7 @@ function run(a: number) {
 >90 : 90
 
             return [ E.E90, E.E91]
->[ E.E90, E.E91] : E[]
+>[ E.E90, E.E91] : (E)[]
 >E.E90 : E.E90
 >E : typeof E
 >E90 : E.E90
@@ -3637,7 +3637,7 @@ function run(a: number) {
 >92 : 92
 
             return [ E.E92, E.E93]
->[ E.E92, E.E93] : E[]
+>[ E.E92, E.E93] : (E)[]
 >E.E92 : E.E92
 >E : typeof E
 >E92 : E.E92
@@ -3649,7 +3649,7 @@ function run(a: number) {
 >94 : 94
 
             return [ E.E94, E.E95]
->[ E.E94, E.E95] : E[]
+>[ E.E94, E.E95] : (E)[]
 >E.E94 : E.E94
 >E : typeof E
 >E94 : E.E94
@@ -3661,7 +3661,7 @@ function run(a: number) {
 >96 : 96
 
             return [ E.E96, E.E97]
->[ E.E96, E.E97] : E[]
+>[ E.E96, E.E97] : (E)[]
 >E.E96 : E.E96
 >E : typeof E
 >E96 : E.E96
@@ -3673,7 +3673,7 @@ function run(a: number) {
 >98 : 98
 
             return [ E.E98, E.E99]
->[ E.E98, E.E99] : E[]
+>[ E.E98, E.E99] : (E)[]
 >E.E98 : E.E98
 >E : typeof E
 >E98 : E.E98
@@ -3685,7 +3685,7 @@ function run(a: number) {
 >100 : 100
 
             return [ E.E100, E.E101]
->[ E.E100, E.E101] : E[]
+>[ E.E100, E.E101] : (E)[]
 >E.E100 : E.E100
 >E : typeof E
 >E100 : E.E100
@@ -3697,7 +3697,7 @@ function run(a: number) {
 >102 : 102
 
             return [ E.E102, E.E103]
->[ E.E102, E.E103] : E[]
+>[ E.E102, E.E103] : (E)[]
 >E.E102 : E.E102
 >E : typeof E
 >E102 : E.E102
@@ -3709,7 +3709,7 @@ function run(a: number) {
 >104 : 104
 
             return [ E.E104, E.E105]
->[ E.E104, E.E105] : E[]
+>[ E.E104, E.E105] : (E)[]
 >E.E104 : E.E104
 >E : typeof E
 >E104 : E.E104
@@ -3721,7 +3721,7 @@ function run(a: number) {
 >106 : 106
 
             return [ E.E106, E.E107]
->[ E.E106, E.E107] : E[]
+>[ E.E106, E.E107] : (E)[]
 >E.E106 : E.E106
 >E : typeof E
 >E106 : E.E106
@@ -3733,7 +3733,7 @@ function run(a: number) {
 >108 : 108
 
             return [ E.E108, E.E109]
->[ E.E108, E.E109] : E[]
+>[ E.E108, E.E109] : (E)[]
 >E.E108 : E.E108
 >E : typeof E
 >E108 : E.E108
@@ -3745,7 +3745,7 @@ function run(a: number) {
 >110 : 110
 
             return [ E.E110, E.E111]
->[ E.E110, E.E111] : E[]
+>[ E.E110, E.E111] : (E)[]
 >E.E110 : E.E110
 >E : typeof E
 >E110 : E.E110
@@ -3757,7 +3757,7 @@ function run(a: number) {
 >112 : 112
 
             return [ E.E112, E.E113]
->[ E.E112, E.E113] : E[]
+>[ E.E112, E.E113] : (E)[]
 >E.E112 : E.E112
 >E : typeof E
 >E112 : E.E112
@@ -3769,7 +3769,7 @@ function run(a: number) {
 >114 : 114
 
             return [ E.E114, E.E115]
->[ E.E114, E.E115] : E[]
+>[ E.E114, E.E115] : (E)[]
 >E.E114 : E.E114
 >E : typeof E
 >E114 : E.E114
@@ -3781,7 +3781,7 @@ function run(a: number) {
 >116 : 116
 
             return [ E.E116, E.E117]
->[ E.E116, E.E117] : E[]
+>[ E.E116, E.E117] : (E)[]
 >E.E116 : E.E116
 >E : typeof E
 >E116 : E.E116
@@ -3793,7 +3793,7 @@ function run(a: number) {
 >118 : 118
 
             return [ E.E118, E.E119]
->[ E.E118, E.E119] : E[]
+>[ E.E118, E.E119] : (E)[]
 >E.E118 : E.E118
 >E : typeof E
 >E118 : E.E118
@@ -3805,7 +3805,7 @@ function run(a: number) {
 >120 : 120
 
             return [ E.E120, E.E121]
->[ E.E120, E.E121] : E[]
+>[ E.E120, E.E121] : (E)[]
 >E.E120 : E.E120
 >E : typeof E
 >E120 : E.E120
@@ -3817,7 +3817,7 @@ function run(a: number) {
 >122 : 122
 
             return [ E.E122, E.E123]
->[ E.E122, E.E123] : E[]
+>[ E.E122, E.E123] : (E)[]
 >E.E122 : E.E122
 >E : typeof E
 >E122 : E.E122
@@ -3829,7 +3829,7 @@ function run(a: number) {
 >124 : 124
 
             return [ E.E124, E.E125]
->[ E.E124, E.E125] : E[]
+>[ E.E124, E.E125] : (E)[]
 >E.E124 : E.E124
 >E : typeof E
 >E124 : E.E124
@@ -3841,7 +3841,7 @@ function run(a: number) {
 >126 : 126
 
             return [ E.E126, E.E127]
->[ E.E126, E.E127] : E[]
+>[ E.E126, E.E127] : (E)[]
 >E.E126 : E.E126
 >E : typeof E
 >E126 : E.E126
@@ -3853,7 +3853,7 @@ function run(a: number) {
 >128 : 128
 
             return [ E.E128, E.E129]
->[ E.E128, E.E129] : E[]
+>[ E.E128, E.E129] : (E)[]
 >E.E128 : E.E128
 >E : typeof E
 >E128 : E.E128
@@ -3865,7 +3865,7 @@ function run(a: number) {
 >130 : 130
 
             return [ E.E130, E.E131]
->[ E.E130, E.E131] : E[]
+>[ E.E130, E.E131] : (E)[]
 >E.E130 : E.E130
 >E : typeof E
 >E130 : E.E130
@@ -3877,7 +3877,7 @@ function run(a: number) {
 >132 : 132
 
             return [ E.E132, E.E133]
->[ E.E132, E.E133] : E[]
+>[ E.E132, E.E133] : (E)[]
 >E.E132 : E.E132
 >E : typeof E
 >E132 : E.E132
@@ -3889,7 +3889,7 @@ function run(a: number) {
 >134 : 134
 
             return [ E.E134, E.E135]
->[ E.E134, E.E135] : E[]
+>[ E.E134, E.E135] : (E)[]
 >E.E134 : E.E134
 >E : typeof E
 >E134 : E.E134
@@ -3901,7 +3901,7 @@ function run(a: number) {
 >136 : 136
 
             return [ E.E136, E.E137]
->[ E.E136, E.E137] : E[]
+>[ E.E136, E.E137] : (E)[]
 >E.E136 : E.E136
 >E : typeof E
 >E136 : E.E136
@@ -3913,7 +3913,7 @@ function run(a: number) {
 >138 : 138
 
             return [ E.E138, E.E139]
->[ E.E138, E.E139] : E[]
+>[ E.E138, E.E139] : (E)[]
 >E.E138 : E.E138
 >E : typeof E
 >E138 : E.E138
@@ -3925,7 +3925,7 @@ function run(a: number) {
 >140 : 140
 
             return [ E.E140, E.E141]
->[ E.E140, E.E141] : E[]
+>[ E.E140, E.E141] : (E)[]
 >E.E140 : E.E140
 >E : typeof E
 >E140 : E.E140
@@ -3937,7 +3937,7 @@ function run(a: number) {
 >142 : 142
 
             return [ E.E142, E.E143]
->[ E.E142, E.E143] : E[]
+>[ E.E142, E.E143] : (E)[]
 >E.E142 : E.E142
 >E : typeof E
 >E142 : E.E142
@@ -3949,7 +3949,7 @@ function run(a: number) {
 >144 : 144
 
             return [ E.E144, E.E145]
->[ E.E144, E.E145] : E[]
+>[ E.E144, E.E145] : (E)[]
 >E.E144 : E.E144
 >E : typeof E
 >E144 : E.E144
@@ -3961,7 +3961,7 @@ function run(a: number) {
 >146 : 146
 
             return [ E.E146, E.E147]
->[ E.E146, E.E147] : E[]
+>[ E.E146, E.E147] : (E)[]
 >E.E146 : E.E146
 >E : typeof E
 >E146 : E.E146
@@ -3973,7 +3973,7 @@ function run(a: number) {
 >148 : 148
 
             return [ E.E148, E.E149]
->[ E.E148, E.E149] : E[]
+>[ E.E148, E.E149] : (E)[]
 >E.E148 : E.E148
 >E : typeof E
 >E148 : E.E148
@@ -3985,7 +3985,7 @@ function run(a: number) {
 >150 : 150
 
             return [ E.E150, E.E151]
->[ E.E150, E.E151] : E[]
+>[ E.E150, E.E151] : (E)[]
 >E.E150 : E.E150
 >E : typeof E
 >E150 : E.E150
@@ -3997,7 +3997,7 @@ function run(a: number) {
 >152 : 152
 
             return [ E.E152, E.E153]
->[ E.E152, E.E153] : E[]
+>[ E.E152, E.E153] : (E)[]
 >E.E152 : E.E152
 >E : typeof E
 >E152 : E.E152
@@ -4009,7 +4009,7 @@ function run(a: number) {
 >154 : 154
 
             return [ E.E154, E.E155]
->[ E.E154, E.E155] : E[]
+>[ E.E154, E.E155] : (E)[]
 >E.E154 : E.E154
 >E : typeof E
 >E154 : E.E154
@@ -4021,7 +4021,7 @@ function run(a: number) {
 >156 : 156
 
             return [ E.E156, E.E157]
->[ E.E156, E.E157] : E[]
+>[ E.E156, E.E157] : (E)[]
 >E.E156 : E.E156
 >E : typeof E
 >E156 : E.E156
@@ -4033,7 +4033,7 @@ function run(a: number) {
 >158 : 158
 
             return [ E.E158, E.E159]
->[ E.E158, E.E159] : E[]
+>[ E.E158, E.E159] : (E)[]
 >E.E158 : E.E158
 >E : typeof E
 >E158 : E.E158
@@ -4045,7 +4045,7 @@ function run(a: number) {
 >160 : 160
 
             return [ E.E160, E.E161]
->[ E.E160, E.E161] : E[]
+>[ E.E160, E.E161] : (E)[]
 >E.E160 : E.E160
 >E : typeof E
 >E160 : E.E160
@@ -4057,7 +4057,7 @@ function run(a: number) {
 >162 : 162
 
             return [ E.E162, E.E163]
->[ E.E162, E.E163] : E[]
+>[ E.E162, E.E163] : (E)[]
 >E.E162 : E.E162
 >E : typeof E
 >E162 : E.E162
@@ -4069,7 +4069,7 @@ function run(a: number) {
 >164 : 164
 
             return [ E.E164, E.E165]
->[ E.E164, E.E165] : E[]
+>[ E.E164, E.E165] : (E)[]
 >E.E164 : E.E164
 >E : typeof E
 >E164 : E.E164
@@ -4081,7 +4081,7 @@ function run(a: number) {
 >166 : 166
 
             return [ E.E166, E.E167]
->[ E.E166, E.E167] : E[]
+>[ E.E166, E.E167] : (E)[]
 >E.E166 : E.E166
 >E : typeof E
 >E166 : E.E166
@@ -4093,7 +4093,7 @@ function run(a: number) {
 >168 : 168
 
             return [ E.E168, E.E169]
->[ E.E168, E.E169] : E[]
+>[ E.E168, E.E169] : (E)[]
 >E.E168 : E.E168
 >E : typeof E
 >E168 : E.E168
@@ -4105,7 +4105,7 @@ function run(a: number) {
 >170 : 170
 
             return [ E.E170, E.E171]
->[ E.E170, E.E171] : E[]
+>[ E.E170, E.E171] : (E)[]
 >E.E170 : E.E170
 >E : typeof E
 >E170 : E.E170
@@ -4117,7 +4117,7 @@ function run(a: number) {
 >172 : 172
 
             return [ E.E172, E.E173]
->[ E.E172, E.E173] : E[]
+>[ E.E172, E.E173] : (E)[]
 >E.E172 : E.E172
 >E : typeof E
 >E172 : E.E172
@@ -4129,7 +4129,7 @@ function run(a: number) {
 >174 : 174
 
             return [ E.E174, E.E175]
->[ E.E174, E.E175] : E[]
+>[ E.E174, E.E175] : (E)[]
 >E.E174 : E.E174
 >E : typeof E
 >E174 : E.E174
@@ -4141,7 +4141,7 @@ function run(a: number) {
 >176 : 176
 
             return [ E.E176, E.E177]
->[ E.E176, E.E177] : E[]
+>[ E.E176, E.E177] : (E)[]
 >E.E176 : E.E176
 >E : typeof E
 >E176 : E.E176
@@ -4153,7 +4153,7 @@ function run(a: number) {
 >178 : 178
 
             return [ E.E178, E.E179]
->[ E.E178, E.E179] : E[]
+>[ E.E178, E.E179] : (E)[]
 >E.E178 : E.E178
 >E : typeof E
 >E178 : E.E178
@@ -4165,7 +4165,7 @@ function run(a: number) {
 >180 : 180
 
             return [ E.E180, E.E181]
->[ E.E180, E.E181] : E[]
+>[ E.E180, E.E181] : (E)[]
 >E.E180 : E.E180
 >E : typeof E
 >E180 : E.E180
@@ -4177,7 +4177,7 @@ function run(a: number) {
 >182 : 182
 
             return [ E.E182, E.E183]
->[ E.E182, E.E183] : E[]
+>[ E.E182, E.E183] : (E)[]
 >E.E182 : E.E182
 >E : typeof E
 >E182 : E.E182
@@ -4189,7 +4189,7 @@ function run(a: number) {
 >184 : 184
 
             return [ E.E184, E.E185]
->[ E.E184, E.E185] : E[]
+>[ E.E184, E.E185] : (E)[]
 >E.E184 : E.E184
 >E : typeof E
 >E184 : E.E184
@@ -4201,7 +4201,7 @@ function run(a: number) {
 >186 : 186
 
             return [ E.E186, E.E187]
->[ E.E186, E.E187] : E[]
+>[ E.E186, E.E187] : (E)[]
 >E.E186 : E.E186
 >E : typeof E
 >E186 : E.E186
@@ -4213,7 +4213,7 @@ function run(a: number) {
 >188 : 188
 
             return [ E.E188, E.E189]
->[ E.E188, E.E189] : E[]
+>[ E.E188, E.E189] : (E)[]
 >E.E188 : E.E188
 >E : typeof E
 >E188 : E.E188
@@ -4225,7 +4225,7 @@ function run(a: number) {
 >190 : 190
 
             return [ E.E190, E.E191]
->[ E.E190, E.E191] : E[]
+>[ E.E190, E.E191] : (E)[]
 >E.E190 : E.E190
 >E : typeof E
 >E190 : E.E190
@@ -4237,7 +4237,7 @@ function run(a: number) {
 >192 : 192
 
             return [ E.E192, E.E193]
->[ E.E192, E.E193] : E[]
+>[ E.E192, E.E193] : (E)[]
 >E.E192 : E.E192
 >E : typeof E
 >E192 : E.E192
@@ -4249,7 +4249,7 @@ function run(a: number) {
 >194 : 194
 
             return [ E.E194, E.E195]
->[ E.E194, E.E195] : E[]
+>[ E.E194, E.E195] : (E)[]
 >E.E194 : E.E194
 >E : typeof E
 >E194 : E.E194
@@ -4261,7 +4261,7 @@ function run(a: number) {
 >196 : 196
 
             return [ E.E196, E.E197]
->[ E.E196, E.E197] : E[]
+>[ E.E196, E.E197] : (E)[]
 >E.E196 : E.E196
 >E : typeof E
 >E196 : E.E196
@@ -4273,7 +4273,7 @@ function run(a: number) {
 >198 : 198
 
             return [ E.E198, E.E199]
->[ E.E198, E.E199] : E[]
+>[ E.E198, E.E199] : (E)[]
 >E.E198 : E.E198
 >E : typeof E
 >E198 : E.E198
@@ -4285,7 +4285,7 @@ function run(a: number) {
 >200 : 200
 
             return [ E.E200, E.E201]
->[ E.E200, E.E201] : E[]
+>[ E.E200, E.E201] : (E)[]
 >E.E200 : E.E200
 >E : typeof E
 >E200 : E.E200
@@ -4297,7 +4297,7 @@ function run(a: number) {
 >202 : 202
 
             return [ E.E202, E.E203]
->[ E.E202, E.E203] : E[]
+>[ E.E202, E.E203] : (E)[]
 >E.E202 : E.E202
 >E : typeof E
 >E202 : E.E202
@@ -4309,7 +4309,7 @@ function run(a: number) {
 >204 : 204
 
             return [ E.E204, E.E205]
->[ E.E204, E.E205] : E[]
+>[ E.E204, E.E205] : (E)[]
 >E.E204 : E.E204
 >E : typeof E
 >E204 : E.E204
@@ -4321,7 +4321,7 @@ function run(a: number) {
 >206 : 206
 
             return [ E.E206, E.E207]
->[ E.E206, E.E207] : E[]
+>[ E.E206, E.E207] : (E)[]
 >E.E206 : E.E206
 >E : typeof E
 >E206 : E.E206
@@ -4333,7 +4333,7 @@ function run(a: number) {
 >208 : 208
 
             return [ E.E208, E.E209]
->[ E.E208, E.E209] : E[]
+>[ E.E208, E.E209] : (E)[]
 >E.E208 : E.E208
 >E : typeof E
 >E208 : E.E208
@@ -4345,7 +4345,7 @@ function run(a: number) {
 >210 : 210
 
             return [ E.E210, E.E211]
->[ E.E210, E.E211] : E[]
+>[ E.E210, E.E211] : (E)[]
 >E.E210 : E.E210
 >E : typeof E
 >E210 : E.E210
@@ -4357,7 +4357,7 @@ function run(a: number) {
 >212 : 212
 
             return [ E.E212, E.E213]
->[ E.E212, E.E213] : E[]
+>[ E.E212, E.E213] : (E)[]
 >E.E212 : E.E212
 >E : typeof E
 >E212 : E.E212
@@ -4369,7 +4369,7 @@ function run(a: number) {
 >214 : 214
 
             return [ E.E214, E.E215]
->[ E.E214, E.E215] : E[]
+>[ E.E214, E.E215] : (E)[]
 >E.E214 : E.E214
 >E : typeof E
 >E214 : E.E214
@@ -4381,7 +4381,7 @@ function run(a: number) {
 >216 : 216
 
             return [ E.E216, E.E217]
->[ E.E216, E.E217] : E[]
+>[ E.E216, E.E217] : (E)[]
 >E.E216 : E.E216
 >E : typeof E
 >E216 : E.E216
@@ -4393,7 +4393,7 @@ function run(a: number) {
 >218 : 218
 
             return [ E.E218, E.E219]
->[ E.E218, E.E219] : E[]
+>[ E.E218, E.E219] : (E)[]
 >E.E218 : E.E218
 >E : typeof E
 >E218 : E.E218
@@ -4405,7 +4405,7 @@ function run(a: number) {
 >220 : 220
 
             return [ E.E220, E.E221]
->[ E.E220, E.E221] : E[]
+>[ E.E220, E.E221] : (E)[]
 >E.E220 : E.E220
 >E : typeof E
 >E220 : E.E220
@@ -4417,7 +4417,7 @@ function run(a: number) {
 >222 : 222
 
             return [ E.E222, E.E223]
->[ E.E222, E.E223] : E[]
+>[ E.E222, E.E223] : (E)[]
 >E.E222 : E.E222
 >E : typeof E
 >E222 : E.E222
@@ -4429,7 +4429,7 @@ function run(a: number) {
 >224 : 224
 
             return [ E.E224, E.E225]
->[ E.E224, E.E225] : E[]
+>[ E.E224, E.E225] : (E)[]
 >E.E224 : E.E224
 >E : typeof E
 >E224 : E.E224
@@ -4441,7 +4441,7 @@ function run(a: number) {
 >226 : 226
 
             return [ E.E226, E.E227]
->[ E.E226, E.E227] : E[]
+>[ E.E226, E.E227] : (E)[]
 >E.E226 : E.E226
 >E : typeof E
 >E226 : E.E226
@@ -4453,7 +4453,7 @@ function run(a: number) {
 >228 : 228
 
             return [ E.E228, E.E229]
->[ E.E228, E.E229] : E[]
+>[ E.E228, E.E229] : (E)[]
 >E.E228 : E.E228
 >E : typeof E
 >E228 : E.E228
@@ -4465,7 +4465,7 @@ function run(a: number) {
 >230 : 230
 
             return [ E.E230, E.E231]
->[ E.E230, E.E231] : E[]
+>[ E.E230, E.E231] : (E)[]
 >E.E230 : E.E230
 >E : typeof E
 >E230 : E.E230
@@ -4477,7 +4477,7 @@ function run(a: number) {
 >232 : 232
 
             return [ E.E232, E.E233]
->[ E.E232, E.E233] : E[]
+>[ E.E232, E.E233] : (E)[]
 >E.E232 : E.E232
 >E : typeof E
 >E232 : E.E232
@@ -4489,7 +4489,7 @@ function run(a: number) {
 >234 : 234
 
             return [ E.E234, E.E235]
->[ E.E234, E.E235] : E[]
+>[ E.E234, E.E235] : (E)[]
 >E.E234 : E.E234
 >E : typeof E
 >E234 : E.E234
@@ -4501,7 +4501,7 @@ function run(a: number) {
 >236 : 236
 
             return [ E.E236, E.E237]
->[ E.E236, E.E237] : E[]
+>[ E.E236, E.E237] : (E)[]
 >E.E236 : E.E236
 >E : typeof E
 >E236 : E.E236
@@ -4513,7 +4513,7 @@ function run(a: number) {
 >238 : 238
 
             return [ E.E238, E.E239]
->[ E.E238, E.E239] : E[]
+>[ E.E238, E.E239] : (E)[]
 >E.E238 : E.E238
 >E : typeof E
 >E238 : E.E238
@@ -4525,7 +4525,7 @@ function run(a: number) {
 >240 : 240
 
             return [ E.E240, E.E241]
->[ E.E240, E.E241] : E[]
+>[ E.E240, E.E241] : (E)[]
 >E.E240 : E.E240
 >E : typeof E
 >E240 : E.E240
@@ -4537,7 +4537,7 @@ function run(a: number) {
 >242 : 242
 
             return [ E.E242, E.E243]
->[ E.E242, E.E243] : E[]
+>[ E.E242, E.E243] : (E)[]
 >E.E242 : E.E242
 >E : typeof E
 >E242 : E.E242
@@ -4549,7 +4549,7 @@ function run(a: number) {
 >244 : 244
 
             return [ E.E244, E.E245]
->[ E.E244, E.E245] : E[]
+>[ E.E244, E.E245] : (E)[]
 >E.E244 : E.E244
 >E : typeof E
 >E244 : E.E244
@@ -4561,7 +4561,7 @@ function run(a: number) {
 >246 : 246
 
             return [ E.E246, E.E247]
->[ E.E246, E.E247] : E[]
+>[ E.E246, E.E247] : (E)[]
 >E.E246 : E.E246
 >E : typeof E
 >E246 : E.E246
@@ -4573,7 +4573,7 @@ function run(a: number) {
 >248 : 248
 
             return [ E.E248, E.E249]
->[ E.E248, E.E249] : E[]
+>[ E.E248, E.E249] : (E)[]
 >E.E248 : E.E248
 >E : typeof E
 >E248 : E.E248
@@ -4585,7 +4585,7 @@ function run(a: number) {
 >250 : 250
 
             return [ E.E250, E.E251]
->[ E.E250, E.E251] : E[]
+>[ E.E250, E.E251] : (E)[]
 >E.E250 : E.E250
 >E : typeof E
 >E250 : E.E250
@@ -4597,7 +4597,7 @@ function run(a: number) {
 >252 : 252
 
             return [ E.E252, E.E253]
->[ E.E252, E.E253] : E[]
+>[ E.E252, E.E253] : (E)[]
 >E.E252 : E.E252
 >E : typeof E
 >E252 : E.E252
@@ -4609,7 +4609,7 @@ function run(a: number) {
 >254 : 254
 
             return [ E.E254, E.E255]
->[ E.E254, E.E255] : E[]
+>[ E.E254, E.E255] : (E)[]
 >E.E254 : E.E254
 >E : typeof E
 >E254 : E.E254
@@ -4621,7 +4621,7 @@ function run(a: number) {
 >256 : 256
 
             return [ E.E256, E.E257]
->[ E.E256, E.E257] : E[]
+>[ E.E256, E.E257] : (E)[]
 >E.E256 : E.E256
 >E : typeof E
 >E256 : E.E256
@@ -4633,7 +4633,7 @@ function run(a: number) {
 >258 : 258
 
             return [ E.E258, E.E259]
->[ E.E258, E.E259] : E[]
+>[ E.E258, E.E259] : (E)[]
 >E.E258 : E.E258
 >E : typeof E
 >E258 : E.E258
@@ -4645,7 +4645,7 @@ function run(a: number) {
 >260 : 260
 
             return [ E.E260, E.E261]
->[ E.E260, E.E261] : E[]
+>[ E.E260, E.E261] : (E)[]
 >E.E260 : E.E260
 >E : typeof E
 >E260 : E.E260
@@ -4657,7 +4657,7 @@ function run(a: number) {
 >262 : 262
 
             return [ E.E262, E.E263]
->[ E.E262, E.E263] : E[]
+>[ E.E262, E.E263] : (E)[]
 >E.E262 : E.E262
 >E : typeof E
 >E262 : E.E262
@@ -4669,7 +4669,7 @@ function run(a: number) {
 >264 : 264
 
             return [ E.E264, E.E265]
->[ E.E264, E.E265] : E[]
+>[ E.E264, E.E265] : (E)[]
 >E.E264 : E.E264
 >E : typeof E
 >E264 : E.E264
@@ -4681,7 +4681,7 @@ function run(a: number) {
 >266 : 266
 
             return [ E.E266, E.E267]
->[ E.E266, E.E267] : E[]
+>[ E.E266, E.E267] : (E)[]
 >E.E266 : E.E266
 >E : typeof E
 >E266 : E.E266
@@ -4693,7 +4693,7 @@ function run(a: number) {
 >268 : 268
 
             return [ E.E268, E.E269]
->[ E.E268, E.E269] : E[]
+>[ E.E268, E.E269] : (E)[]
 >E.E268 : E.E268
 >E : typeof E
 >E268 : E.E268
@@ -4705,7 +4705,7 @@ function run(a: number) {
 >270 : 270
 
             return [ E.E270, E.E271]
->[ E.E270, E.E271] : E[]
+>[ E.E270, E.E271] : (E)[]
 >E.E270 : E.E270
 >E : typeof E
 >E270 : E.E270
@@ -4717,7 +4717,7 @@ function run(a: number) {
 >272 : 272
 
             return [ E.E272, E.E273]
->[ E.E272, E.E273] : E[]
+>[ E.E272, E.E273] : (E)[]
 >E.E272 : E.E272
 >E : typeof E
 >E272 : E.E272
@@ -4729,7 +4729,7 @@ function run(a: number) {
 >274 : 274
 
             return [ E.E274, E.E275]
->[ E.E274, E.E275] : E[]
+>[ E.E274, E.E275] : (E)[]
 >E.E274 : E.E274
 >E : typeof E
 >E274 : E.E274
@@ -4741,7 +4741,7 @@ function run(a: number) {
 >276 : 276
 
             return [ E.E276, E.E277]
->[ E.E276, E.E277] : E[]
+>[ E.E276, E.E277] : (E)[]
 >E.E276 : E.E276
 >E : typeof E
 >E276 : E.E276
@@ -4753,7 +4753,7 @@ function run(a: number) {
 >278 : 278
 
             return [ E.E278, E.E279]
->[ E.E278, E.E279] : E[]
+>[ E.E278, E.E279] : (E)[]
 >E.E278 : E.E278
 >E : typeof E
 >E278 : E.E278
@@ -4765,7 +4765,7 @@ function run(a: number) {
 >280 : 280
 
             return [ E.E280, E.E281]
->[ E.E280, E.E281] : E[]
+>[ E.E280, E.E281] : (E)[]
 >E.E280 : E.E280
 >E : typeof E
 >E280 : E.E280
@@ -4777,7 +4777,7 @@ function run(a: number) {
 >282 : 282
 
             return [ E.E282, E.E283]
->[ E.E282, E.E283] : E[]
+>[ E.E282, E.E283] : (E)[]
 >E.E282 : E.E282
 >E : typeof E
 >E282 : E.E282
@@ -4789,7 +4789,7 @@ function run(a: number) {
 >284 : 284
 
             return [ E.E284, E.E285]
->[ E.E284, E.E285] : E[]
+>[ E.E284, E.E285] : (E)[]
 >E.E284 : E.E284
 >E : typeof E
 >E284 : E.E284
@@ -4801,7 +4801,7 @@ function run(a: number) {
 >286 : 286
 
             return [ E.E286, E.E287]
->[ E.E286, E.E287] : E[]
+>[ E.E286, E.E287] : (E)[]
 >E.E286 : E.E286
 >E : typeof E
 >E286 : E.E286
@@ -4813,7 +4813,7 @@ function run(a: number) {
 >288 : 288
 
             return [ E.E288, E.E289]
->[ E.E288, E.E289] : E[]
+>[ E.E288, E.E289] : (E)[]
 >E.E288 : E.E288
 >E : typeof E
 >E288 : E.E288
@@ -4825,7 +4825,7 @@ function run(a: number) {
 >290 : 290
 
             return [ E.E290, E.E291]
->[ E.E290, E.E291] : E[]
+>[ E.E290, E.E291] : (E)[]
 >E.E290 : E.E290
 >E : typeof E
 >E290 : E.E290
@@ -4837,7 +4837,7 @@ function run(a: number) {
 >292 : 292
 
             return [ E.E292, E.E293]
->[ E.E292, E.E293] : E[]
+>[ E.E292, E.E293] : (E)[]
 >E.E292 : E.E292
 >E : typeof E
 >E292 : E.E292
@@ -4849,7 +4849,7 @@ function run(a: number) {
 >294 : 294
 
             return [ E.E294, E.E295]
->[ E.E294, E.E295] : E[]
+>[ E.E294, E.E295] : (E)[]
 >E.E294 : E.E294
 >E : typeof E
 >E294 : E.E294
@@ -4861,7 +4861,7 @@ function run(a: number) {
 >296 : 296
 
             return [ E.E296, E.E297]
->[ E.E296, E.E297] : E[]
+>[ E.E296, E.E297] : (E)[]
 >E.E296 : E.E296
 >E : typeof E
 >E296 : E.E296
@@ -4873,7 +4873,7 @@ function run(a: number) {
 >298 : 298
 
             return [ E.E298, E.E299]
->[ E.E298, E.E299] : E[]
+>[ E.E298, E.E299] : (E)[]
 >E.E298 : E.E298
 >E : typeof E
 >E298 : E.E298
@@ -4885,7 +4885,7 @@ function run(a: number) {
 >300 : 300
 
             return [ E.E300, E.E301]
->[ E.E300, E.E301] : E[]
+>[ E.E300, E.E301] : (E)[]
 >E.E300 : E.E300
 >E : typeof E
 >E300 : E.E300
@@ -4897,7 +4897,7 @@ function run(a: number) {
 >302 : 302
 
             return [ E.E302, E.E303]
->[ E.E302, E.E303] : E[]
+>[ E.E302, E.E303] : (E)[]
 >E.E302 : E.E302
 >E : typeof E
 >E302 : E.E302
@@ -4909,7 +4909,7 @@ function run(a: number) {
 >304 : 304
 
             return [ E.E304, E.E305]
->[ E.E304, E.E305] : E[]
+>[ E.E304, E.E305] : (E)[]
 >E.E304 : E.E304
 >E : typeof E
 >E304 : E.E304
@@ -4921,7 +4921,7 @@ function run(a: number) {
 >306 : 306
 
             return [ E.E306, E.E307]
->[ E.E306, E.E307] : E[]
+>[ E.E306, E.E307] : (E)[]
 >E.E306 : E.E306
 >E : typeof E
 >E306 : E.E306
@@ -4933,7 +4933,7 @@ function run(a: number) {
 >308 : 308
 
             return [ E.E308, E.E309]
->[ E.E308, E.E309] : E[]
+>[ E.E308, E.E309] : (E)[]
 >E.E308 : E.E308
 >E : typeof E
 >E308 : E.E308
@@ -4945,7 +4945,7 @@ function run(a: number) {
 >310 : 310
 
             return [ E.E310, E.E311]
->[ E.E310, E.E311] : E[]
+>[ E.E310, E.E311] : (E)[]
 >E.E310 : E.E310
 >E : typeof E
 >E310 : E.E310
@@ -4957,7 +4957,7 @@ function run(a: number) {
 >312 : 312
 
             return [ E.E312, E.E313]
->[ E.E312, E.E313] : E[]
+>[ E.E312, E.E313] : (E)[]
 >E.E312 : E.E312
 >E : typeof E
 >E312 : E.E312
@@ -4969,7 +4969,7 @@ function run(a: number) {
 >314 : 314
 
             return [ E.E314, E.E315]
->[ E.E314, E.E315] : E[]
+>[ E.E314, E.E315] : (E)[]
 >E.E314 : E.E314
 >E : typeof E
 >E314 : E.E314
@@ -4981,7 +4981,7 @@ function run(a: number) {
 >316 : 316
 
             return [ E.E316, E.E317]
->[ E.E316, E.E317] : E[]
+>[ E.E316, E.E317] : (E)[]
 >E.E316 : E.E316
 >E : typeof E
 >E316 : E.E316
@@ -4993,7 +4993,7 @@ function run(a: number) {
 >318 : 318
 
             return [ E.E318, E.E319]
->[ E.E318, E.E319] : E[]
+>[ E.E318, E.E319] : (E)[]
 >E.E318 : E.E318
 >E : typeof E
 >E318 : E.E318
@@ -5005,7 +5005,7 @@ function run(a: number) {
 >320 : 320
 
             return [ E.E320, E.E321]
->[ E.E320, E.E321] : E[]
+>[ E.E320, E.E321] : (E)[]
 >E.E320 : E.E320
 >E : typeof E
 >E320 : E.E320
@@ -5017,7 +5017,7 @@ function run(a: number) {
 >322 : 322
 
             return [ E.E322, E.E323]
->[ E.E322, E.E323] : E[]
+>[ E.E322, E.E323] : (E)[]
 >E.E322 : E.E322
 >E : typeof E
 >E322 : E.E322
@@ -5029,7 +5029,7 @@ function run(a: number) {
 >324 : 324
 
             return [ E.E324, E.E325]
->[ E.E324, E.E325] : E[]
+>[ E.E324, E.E325] : (E)[]
 >E.E324 : E.E324
 >E : typeof E
 >E324 : E.E324
@@ -5041,7 +5041,7 @@ function run(a: number) {
 >326 : 326
 
             return [ E.E326, E.E327]
->[ E.E326, E.E327] : E[]
+>[ E.E326, E.E327] : (E)[]
 >E.E326 : E.E326
 >E : typeof E
 >E326 : E.E326
@@ -5053,7 +5053,7 @@ function run(a: number) {
 >328 : 328
 
             return [ E.E328, E.E329]
->[ E.E328, E.E329] : E[]
+>[ E.E328, E.E329] : (E)[]
 >E.E328 : E.E328
 >E : typeof E
 >E328 : E.E328
@@ -5065,7 +5065,7 @@ function run(a: number) {
 >330 : 330
 
             return [ E.E330, E.E331]
->[ E.E330, E.E331] : E[]
+>[ E.E330, E.E331] : (E)[]
 >E.E330 : E.E330
 >E : typeof E
 >E330 : E.E330
@@ -5077,7 +5077,7 @@ function run(a: number) {
 >332 : 332
 
             return [ E.E332, E.E333]
->[ E.E332, E.E333] : E[]
+>[ E.E332, E.E333] : (E)[]
 >E.E332 : E.E332
 >E : typeof E
 >E332 : E.E332
@@ -5089,7 +5089,7 @@ function run(a: number) {
 >334 : 334
 
             return [ E.E334, E.E335]
->[ E.E334, E.E335] : E[]
+>[ E.E334, E.E335] : (E)[]
 >E.E334 : E.E334
 >E : typeof E
 >E334 : E.E334
@@ -5101,7 +5101,7 @@ function run(a: number) {
 >336 : 336
 
             return [ E.E336, E.E337]
->[ E.E336, E.E337] : E[]
+>[ E.E336, E.E337] : (E)[]
 >E.E336 : E.E336
 >E : typeof E
 >E336 : E.E336
@@ -5113,7 +5113,7 @@ function run(a: number) {
 >338 : 338
 
             return [ E.E338, E.E339]
->[ E.E338, E.E339] : E[]
+>[ E.E338, E.E339] : (E)[]
 >E.E338 : E.E338
 >E : typeof E
 >E338 : E.E338
@@ -5125,7 +5125,7 @@ function run(a: number) {
 >340 : 340
 
             return [ E.E340, E.E341]
->[ E.E340, E.E341] : E[]
+>[ E.E340, E.E341] : (E)[]
 >E.E340 : E.E340
 >E : typeof E
 >E340 : E.E340
@@ -5137,7 +5137,7 @@ function run(a: number) {
 >342 : 342
 
             return [ E.E342, E.E343]
->[ E.E342, E.E343] : E[]
+>[ E.E342, E.E343] : (E)[]
 >E.E342 : E.E342
 >E : typeof E
 >E342 : E.E342
@@ -5149,7 +5149,7 @@ function run(a: number) {
 >344 : 344
 
             return [ E.E344, E.E345]
->[ E.E344, E.E345] : E[]
+>[ E.E344, E.E345] : (E)[]
 >E.E344 : E.E344
 >E : typeof E
 >E344 : E.E344
@@ -5161,7 +5161,7 @@ function run(a: number) {
 >346 : 346
 
             return [ E.E346, E.E347]
->[ E.E346, E.E347] : E[]
+>[ E.E346, E.E347] : (E)[]
 >E.E346 : E.E346
 >E : typeof E
 >E346 : E.E346
@@ -5173,7 +5173,7 @@ function run(a: number) {
 >348 : 348
 
             return [ E.E348, E.E349]
->[ E.E348, E.E349] : E[]
+>[ E.E348, E.E349] : (E)[]
 >E.E348 : E.E348
 >E : typeof E
 >E348 : E.E348
@@ -5185,7 +5185,7 @@ function run(a: number) {
 >350 : 350
 
             return [ E.E350, E.E351]
->[ E.E350, E.E351] : E[]
+>[ E.E350, E.E351] : (E)[]
 >E.E350 : E.E350
 >E : typeof E
 >E350 : E.E350
@@ -5197,7 +5197,7 @@ function run(a: number) {
 >352 : 352
 
             return [ E.E352, E.E353]
->[ E.E352, E.E353] : E[]
+>[ E.E352, E.E353] : (E)[]
 >E.E352 : E.E352
 >E : typeof E
 >E352 : E.E352
@@ -5209,7 +5209,7 @@ function run(a: number) {
 >354 : 354
 
             return [ E.E354, E.E355]
->[ E.E354, E.E355] : E[]
+>[ E.E354, E.E355] : (E)[]
 >E.E354 : E.E354
 >E : typeof E
 >E354 : E.E354
@@ -5221,7 +5221,7 @@ function run(a: number) {
 >356 : 356
 
             return [ E.E356, E.E357]
->[ E.E356, E.E357] : E[]
+>[ E.E356, E.E357] : (E)[]
 >E.E356 : E.E356
 >E : typeof E
 >E356 : E.E356
@@ -5233,7 +5233,7 @@ function run(a: number) {
 >358 : 358
 
             return [ E.E358, E.E359]
->[ E.E358, E.E359] : E[]
+>[ E.E358, E.E359] : (E)[]
 >E.E358 : E.E358
 >E : typeof E
 >E358 : E.E358
@@ -5245,7 +5245,7 @@ function run(a: number) {
 >360 : 360
 
             return [ E.E360, E.E361]
->[ E.E360, E.E361] : E[]
+>[ E.E360, E.E361] : (E)[]
 >E.E360 : E.E360
 >E : typeof E
 >E360 : E.E360
@@ -5257,7 +5257,7 @@ function run(a: number) {
 >362 : 362
 
             return [ E.E362, E.E363]
->[ E.E362, E.E363] : E[]
+>[ E.E362, E.E363] : (E)[]
 >E.E362 : E.E362
 >E : typeof E
 >E362 : E.E362
@@ -5269,7 +5269,7 @@ function run(a: number) {
 >364 : 364
 
             return [ E.E364, E.E365]
->[ E.E364, E.E365] : E[]
+>[ E.E364, E.E365] : (E)[]
 >E.E364 : E.E364
 >E : typeof E
 >E364 : E.E364
@@ -5281,7 +5281,7 @@ function run(a: number) {
 >366 : 366
 
             return [ E.E366, E.E367]
->[ E.E366, E.E367] : E[]
+>[ E.E366, E.E367] : (E)[]
 >E.E366 : E.E366
 >E : typeof E
 >E366 : E.E366
@@ -5293,7 +5293,7 @@ function run(a: number) {
 >368 : 368
 
             return [ E.E368, E.E369]
->[ E.E368, E.E369] : E[]
+>[ E.E368, E.E369] : (E)[]
 >E.E368 : E.E368
 >E : typeof E
 >E368 : E.E368
@@ -5305,7 +5305,7 @@ function run(a: number) {
 >370 : 370
 
             return [ E.E370, E.E371]
->[ E.E370, E.E371] : E[]
+>[ E.E370, E.E371] : (E)[]
 >E.E370 : E.E370
 >E : typeof E
 >E370 : E.E370
@@ -5317,7 +5317,7 @@ function run(a: number) {
 >372 : 372
 
             return [ E.E372, E.E373]
->[ E.E372, E.E373] : E[]
+>[ E.E372, E.E373] : (E)[]
 >E.E372 : E.E372
 >E : typeof E
 >E372 : E.E372
@@ -5329,7 +5329,7 @@ function run(a: number) {
 >374 : 374
 
             return [ E.E374, E.E375]
->[ E.E374, E.E375] : E[]
+>[ E.E374, E.E375] : (E)[]
 >E.E374 : E.E374
 >E : typeof E
 >E374 : E.E374
@@ -5341,7 +5341,7 @@ function run(a: number) {
 >376 : 376
 
             return [ E.E376, E.E377]
->[ E.E376, E.E377] : E[]
+>[ E.E376, E.E377] : (E)[]
 >E.E376 : E.E376
 >E : typeof E
 >E376 : E.E376
@@ -5353,7 +5353,7 @@ function run(a: number) {
 >378 : 378
 
             return [ E.E378, E.E379]
->[ E.E378, E.E379] : E[]
+>[ E.E378, E.E379] : (E)[]
 >E.E378 : E.E378
 >E : typeof E
 >E378 : E.E378
@@ -5365,7 +5365,7 @@ function run(a: number) {
 >380 : 380
 
             return [ E.E380, E.E381]
->[ E.E380, E.E381] : E[]
+>[ E.E380, E.E381] : (E)[]
 >E.E380 : E.E380
 >E : typeof E
 >E380 : E.E380
@@ -5377,7 +5377,7 @@ function run(a: number) {
 >382 : 382
 
             return [ E.E382, E.E383]
->[ E.E382, E.E383] : E[]
+>[ E.E382, E.E383] : (E)[]
 >E.E382 : E.E382
 >E : typeof E
 >E382 : E.E382
@@ -5389,7 +5389,7 @@ function run(a: number) {
 >384 : 384
 
             return [ E.E384, E.E385]
->[ E.E384, E.E385] : E[]
+>[ E.E384, E.E385] : (E)[]
 >E.E384 : E.E384
 >E : typeof E
 >E384 : E.E384
@@ -5401,7 +5401,7 @@ function run(a: number) {
 >386 : 386
 
             return [ E.E386, E.E387]
->[ E.E386, E.E387] : E[]
+>[ E.E386, E.E387] : (E)[]
 >E.E386 : E.E386
 >E : typeof E
 >E386 : E.E386
@@ -5413,7 +5413,7 @@ function run(a: number) {
 >388 : 388
 
             return [ E.E388, E.E389]
->[ E.E388, E.E389] : E[]
+>[ E.E388, E.E389] : (E)[]
 >E.E388 : E.E388
 >E : typeof E
 >E388 : E.E388
@@ -5425,7 +5425,7 @@ function run(a: number) {
 >390 : 390
 
             return [ E.E390, E.E391]
->[ E.E390, E.E391] : E[]
+>[ E.E390, E.E391] : (E)[]
 >E.E390 : E.E390
 >E : typeof E
 >E390 : E.E390
@@ -5437,7 +5437,7 @@ function run(a: number) {
 >392 : 392
 
             return [ E.E392, E.E393]
->[ E.E392, E.E393] : E[]
+>[ E.E392, E.E393] : (E)[]
 >E.E392 : E.E392
 >E : typeof E
 >E392 : E.E392
@@ -5449,7 +5449,7 @@ function run(a: number) {
 >394 : 394
 
             return [ E.E394, E.E395]
->[ E.E394, E.E395] : E[]
+>[ E.E394, E.E395] : (E)[]
 >E.E394 : E.E394
 >E : typeof E
 >E394 : E.E394
@@ -5461,7 +5461,7 @@ function run(a: number) {
 >396 : 396
 
             return [ E.E396, E.E397]
->[ E.E396, E.E397] : E[]
+>[ E.E396, E.E397] : (E)[]
 >E.E396 : E.E396
 >E : typeof E
 >E396 : E.E396
@@ -5473,7 +5473,7 @@ function run(a: number) {
 >398 : 398
 
             return [ E.E398, E.E399]
->[ E.E398, E.E399] : E[]
+>[ E.E398, E.E399] : (E)[]
 >E.E398 : E.E398
 >E : typeof E
 >E398 : E.E398
@@ -5485,7 +5485,7 @@ function run(a: number) {
 >400 : 400
 
             return [ E.E400, E.E401]
->[ E.E400, E.E401] : E[]
+>[ E.E400, E.E401] : (E)[]
 >E.E400 : E.E400
 >E : typeof E
 >E400 : E.E400
@@ -5497,7 +5497,7 @@ function run(a: number) {
 >402 : 402
 
             return [ E.E402, E.E403]
->[ E.E402, E.E403] : E[]
+>[ E.E402, E.E403] : (E)[]
 >E.E402 : E.E402
 >E : typeof E
 >E402 : E.E402
@@ -5509,7 +5509,7 @@ function run(a: number) {
 >404 : 404
 
             return [ E.E404, E.E405]
->[ E.E404, E.E405] : E[]
+>[ E.E404, E.E405] : (E)[]
 >E.E404 : E.E404
 >E : typeof E
 >E404 : E.E404
@@ -5521,7 +5521,7 @@ function run(a: number) {
 >406 : 406
 
             return [ E.E406, E.E407]
->[ E.E406, E.E407] : E[]
+>[ E.E406, E.E407] : (E)[]
 >E.E406 : E.E406
 >E : typeof E
 >E406 : E.E406
@@ -5533,7 +5533,7 @@ function run(a: number) {
 >408 : 408
 
             return [ E.E408, E.E409]
->[ E.E408, E.E409] : E[]
+>[ E.E408, E.E409] : (E)[]
 >E.E408 : E.E408
 >E : typeof E
 >E408 : E.E408
@@ -5545,7 +5545,7 @@ function run(a: number) {
 >410 : 410
 
             return [ E.E410, E.E411]
->[ E.E410, E.E411] : E[]
+>[ E.E410, E.E411] : (E)[]
 >E.E410 : E.E410
 >E : typeof E
 >E410 : E.E410
@@ -5557,7 +5557,7 @@ function run(a: number) {
 >412 : 412
 
             return [ E.E412, E.E413]
->[ E.E412, E.E413] : E[]
+>[ E.E412, E.E413] : (E)[]
 >E.E412 : E.E412
 >E : typeof E
 >E412 : E.E412
@@ -5569,7 +5569,7 @@ function run(a: number) {
 >414 : 414
 
             return [ E.E414, E.E415]
->[ E.E414, E.E415] : E[]
+>[ E.E414, E.E415] : (E)[]
 >E.E414 : E.E414
 >E : typeof E
 >E414 : E.E414
@@ -5581,7 +5581,7 @@ function run(a: number) {
 >416 : 416
 
             return [ E.E416, E.E417]
->[ E.E416, E.E417] : E[]
+>[ E.E416, E.E417] : (E)[]
 >E.E416 : E.E416
 >E : typeof E
 >E416 : E.E416
@@ -5593,7 +5593,7 @@ function run(a: number) {
 >418 : 418
 
             return [ E.E418, E.E419]
->[ E.E418, E.E419] : E[]
+>[ E.E418, E.E419] : (E)[]
 >E.E418 : E.E418
 >E : typeof E
 >E418 : E.E418
@@ -5605,7 +5605,7 @@ function run(a: number) {
 >420 : 420
 
             return [ E.E420, E.E421]
->[ E.E420, E.E421] : E[]
+>[ E.E420, E.E421] : (E)[]
 >E.E420 : E.E420
 >E : typeof E
 >E420 : E.E420
@@ -5617,7 +5617,7 @@ function run(a: number) {
 >422 : 422
 
             return [ E.E422, E.E423]
->[ E.E422, E.E423] : E[]
+>[ E.E422, E.E423] : (E)[]
 >E.E422 : E.E422
 >E : typeof E
 >E422 : E.E422
@@ -5629,7 +5629,7 @@ function run(a: number) {
 >424 : 424
 
             return [ E.E424, E.E425]
->[ E.E424, E.E425] : E[]
+>[ E.E424, E.E425] : (E)[]
 >E.E424 : E.E424
 >E : typeof E
 >E424 : E.E424
@@ -5641,7 +5641,7 @@ function run(a: number) {
 >426 : 426
 
             return [ E.E426, E.E427]
->[ E.E426, E.E427] : E[]
+>[ E.E426, E.E427] : (E)[]
 >E.E426 : E.E426
 >E : typeof E
 >E426 : E.E426
@@ -5653,7 +5653,7 @@ function run(a: number) {
 >428 : 428
 
             return [ E.E428, E.E429]
->[ E.E428, E.E429] : E[]
+>[ E.E428, E.E429] : (E)[]
 >E.E428 : E.E428
 >E : typeof E
 >E428 : E.E428
@@ -5665,7 +5665,7 @@ function run(a: number) {
 >430 : 430
 
             return [ E.E430, E.E431]
->[ E.E430, E.E431] : E[]
+>[ E.E430, E.E431] : (E)[]
 >E.E430 : E.E430
 >E : typeof E
 >E430 : E.E430
@@ -5677,7 +5677,7 @@ function run(a: number) {
 >432 : 432
 
             return [ E.E432, E.E433]
->[ E.E432, E.E433] : E[]
+>[ E.E432, E.E433] : (E)[]
 >E.E432 : E.E432
 >E : typeof E
 >E432 : E.E432
@@ -5689,7 +5689,7 @@ function run(a: number) {
 >434 : 434
 
             return [ E.E434, E.E435]
->[ E.E434, E.E435] : E[]
+>[ E.E434, E.E435] : (E)[]
 >E.E434 : E.E434
 >E : typeof E
 >E434 : E.E434
@@ -5701,7 +5701,7 @@ function run(a: number) {
 >436 : 436
 
             return [ E.E436, E.E437]
->[ E.E436, E.E437] : E[]
+>[ E.E436, E.E437] : (E)[]
 >E.E436 : E.E436
 >E : typeof E
 >E436 : E.E436
@@ -5713,7 +5713,7 @@ function run(a: number) {
 >438 : 438
 
             return [ E.E438, E.E439]
->[ E.E438, E.E439] : E[]
+>[ E.E438, E.E439] : (E)[]
 >E.E438 : E.E438
 >E : typeof E
 >E438 : E.E438
@@ -5725,7 +5725,7 @@ function run(a: number) {
 >440 : 440
 
             return [ E.E440, E.E441]
->[ E.E440, E.E441] : E[]
+>[ E.E440, E.E441] : (E)[]
 >E.E440 : E.E440
 >E : typeof E
 >E440 : E.E440
@@ -5737,7 +5737,7 @@ function run(a: number) {
 >442 : 442
 
             return [ E.E442, E.E443]
->[ E.E442, E.E443] : E[]
+>[ E.E442, E.E443] : (E)[]
 >E.E442 : E.E442
 >E : typeof E
 >E442 : E.E442
@@ -5749,7 +5749,7 @@ function run(a: number) {
 >444 : 444
 
             return [ E.E444, E.E445]
->[ E.E444, E.E445] : E[]
+>[ E.E444, E.E445] : (E)[]
 >E.E444 : E.E444
 >E : typeof E
 >E444 : E.E444
@@ -5761,7 +5761,7 @@ function run(a: number) {
 >446 : 446
 
             return [ E.E446, E.E447]
->[ E.E446, E.E447] : E[]
+>[ E.E446, E.E447] : (E)[]
 >E.E446 : E.E446
 >E : typeof E
 >E446 : E.E446
@@ -5773,7 +5773,7 @@ function run(a: number) {
 >448 : 448
 
             return [ E.E448, E.E449]
->[ E.E448, E.E449] : E[]
+>[ E.E448, E.E449] : (E)[]
 >E.E448 : E.E448
 >E : typeof E
 >E448 : E.E448
@@ -5785,7 +5785,7 @@ function run(a: number) {
 >450 : 450
 
             return [ E.E450, E.E451]
->[ E.E450, E.E451] : E[]
+>[ E.E450, E.E451] : (E)[]
 >E.E450 : E.E450
 >E : typeof E
 >E450 : E.E450
@@ -5797,7 +5797,7 @@ function run(a: number) {
 >452 : 452
 
             return [ E.E452, E.E453]
->[ E.E452, E.E453] : E[]
+>[ E.E452, E.E453] : (E)[]
 >E.E452 : E.E452
 >E : typeof E
 >E452 : E.E452
@@ -5809,7 +5809,7 @@ function run(a: number) {
 >454 : 454
 
             return [ E.E454, E.E455]
->[ E.E454, E.E455] : E[]
+>[ E.E454, E.E455] : (E)[]
 >E.E454 : E.E454
 >E : typeof E
 >E454 : E.E454
@@ -5821,7 +5821,7 @@ function run(a: number) {
 >456 : 456
 
             return [ E.E456, E.E457]
->[ E.E456, E.E457] : E[]
+>[ E.E456, E.E457] : (E)[]
 >E.E456 : E.E456
 >E : typeof E
 >E456 : E.E456
@@ -5833,7 +5833,7 @@ function run(a: number) {
 >458 : 458
 
             return [ E.E458, E.E459]
->[ E.E458, E.E459] : E[]
+>[ E.E458, E.E459] : (E)[]
 >E.E458 : E.E458
 >E : typeof E
 >E458 : E.E458
@@ -5845,7 +5845,7 @@ function run(a: number) {
 >460 : 460
 
             return [ E.E460, E.E461]
->[ E.E460, E.E461] : E[]
+>[ E.E460, E.E461] : (E)[]
 >E.E460 : E.E460
 >E : typeof E
 >E460 : E.E460
@@ -5857,7 +5857,7 @@ function run(a: number) {
 >462 : 462
 
             return [ E.E462, E.E463]
->[ E.E462, E.E463] : E[]
+>[ E.E462, E.E463] : (E)[]
 >E.E462 : E.E462
 >E : typeof E
 >E462 : E.E462
@@ -5869,7 +5869,7 @@ function run(a: number) {
 >464 : 464
 
             return [ E.E464, E.E465]
->[ E.E464, E.E465] : E[]
+>[ E.E464, E.E465] : (E)[]
 >E.E464 : E.E464
 >E : typeof E
 >E464 : E.E464
@@ -5881,7 +5881,7 @@ function run(a: number) {
 >466 : 466
 
             return [ E.E466, E.E467]
->[ E.E466, E.E467] : E[]
+>[ E.E466, E.E467] : (E)[]
 >E.E466 : E.E466
 >E : typeof E
 >E466 : E.E466
@@ -5893,7 +5893,7 @@ function run(a: number) {
 >468 : 468
 
             return [ E.E468, E.E469]
->[ E.E468, E.E469] : E[]
+>[ E.E468, E.E469] : (E)[]
 >E.E468 : E.E468
 >E : typeof E
 >E468 : E.E468
@@ -5905,7 +5905,7 @@ function run(a: number) {
 >470 : 470
 
             return [ E.E470, E.E471]
->[ E.E470, E.E471] : E[]
+>[ E.E470, E.E471] : (E)[]
 >E.E470 : E.E470
 >E : typeof E
 >E470 : E.E470
@@ -5917,7 +5917,7 @@ function run(a: number) {
 >472 : 472
 
             return [ E.E472, E.E473]
->[ E.E472, E.E473] : E[]
+>[ E.E472, E.E473] : (E)[]
 >E.E472 : E.E472
 >E : typeof E
 >E472 : E.E472
@@ -5929,7 +5929,7 @@ function run(a: number) {
 >474 : 474
 
             return [ E.E474, E.E475]
->[ E.E474, E.E475] : E[]
+>[ E.E474, E.E475] : (E)[]
 >E.E474 : E.E474
 >E : typeof E
 >E474 : E.E474
@@ -5941,7 +5941,7 @@ function run(a: number) {
 >476 : 476
 
             return [ E.E476, E.E477]
->[ E.E476, E.E477] : E[]
+>[ E.E476, E.E477] : (E)[]
 >E.E476 : E.E476
 >E : typeof E
 >E476 : E.E476
@@ -5953,7 +5953,7 @@ function run(a: number) {
 >478 : 478
 
             return [ E.E478, E.E479]
->[ E.E478, E.E479] : E[]
+>[ E.E478, E.E479] : (E)[]
 >E.E478 : E.E478
 >E : typeof E
 >E478 : E.E478
@@ -5965,7 +5965,7 @@ function run(a: number) {
 >480 : 480
 
             return [ E.E480, E.E481]
->[ E.E480, E.E481] : E[]
+>[ E.E480, E.E481] : (E)[]
 >E.E480 : E.E480
 >E : typeof E
 >E480 : E.E480
@@ -5977,7 +5977,7 @@ function run(a: number) {
 >482 : 482
 
             return [ E.E482, E.E483]
->[ E.E482, E.E483] : E[]
+>[ E.E482, E.E483] : (E)[]
 >E.E482 : E.E482
 >E : typeof E
 >E482 : E.E482
@@ -5989,7 +5989,7 @@ function run(a: number) {
 >484 : 484
 
             return [ E.E484, E.E485]
->[ E.E484, E.E485] : E[]
+>[ E.E484, E.E485] : (E)[]
 >E.E484 : E.E484
 >E : typeof E
 >E484 : E.E484
@@ -6001,7 +6001,7 @@ function run(a: number) {
 >486 : 486
 
             return [ E.E486, E.E487]
->[ E.E486, E.E487] : E[]
+>[ E.E486, E.E487] : (E)[]
 >E.E486 : E.E486
 >E : typeof E
 >E486 : E.E486
@@ -6013,7 +6013,7 @@ function run(a: number) {
 >488 : 488
 
             return [ E.E488, E.E489]
->[ E.E488, E.E489] : E[]
+>[ E.E488, E.E489] : (E)[]
 >E.E488 : E.E488
 >E : typeof E
 >E488 : E.E488
@@ -6025,7 +6025,7 @@ function run(a: number) {
 >490 : 490
 
             return [ E.E490, E.E491]
->[ E.E490, E.E491] : E[]
+>[ E.E490, E.E491] : (E)[]
 >E.E490 : E.E490
 >E : typeof E
 >E490 : E.E490
@@ -6037,7 +6037,7 @@ function run(a: number) {
 >492 : 492
 
             return [ E.E492, E.E493]
->[ E.E492, E.E493] : E[]
+>[ E.E492, E.E493] : (E)[]
 >E.E492 : E.E492
 >E : typeof E
 >E492 : E.E492
@@ -6049,7 +6049,7 @@ function run(a: number) {
 >494 : 494
 
             return [ E.E494, E.E495]
->[ E.E494, E.E495] : E[]
+>[ E.E494, E.E495] : (E)[]
 >E.E494 : E.E494
 >E : typeof E
 >E494 : E.E494
@@ -6061,7 +6061,7 @@ function run(a: number) {
 >496 : 496
 
             return [ E.E496, E.E497]
->[ E.E496, E.E497] : E[]
+>[ E.E496, E.E497] : (E)[]
 >E.E496 : E.E496
 >E : typeof E
 >E496 : E.E496
@@ -6073,7 +6073,7 @@ function run(a: number) {
 >498 : 498
 
             return [ E.E498, E.E499]
->[ E.E498, E.E499] : E[]
+>[ E.E498, E.E499] : (E)[]
 >E.E498 : E.E498
 >E : typeof E
 >E498 : E.E498
@@ -6085,7 +6085,7 @@ function run(a: number) {
 >500 : 500
 
             return [ E.E500, E.E501]
->[ E.E500, E.E501] : E[]
+>[ E.E500, E.E501] : (E)[]
 >E.E500 : E.E500
 >E : typeof E
 >E500 : E.E500
@@ -6097,7 +6097,7 @@ function run(a: number) {
 >502 : 502
 
             return [ E.E502, E.E503]
->[ E.E502, E.E503] : E[]
+>[ E.E502, E.E503] : (E)[]
 >E.E502 : E.E502
 >E : typeof E
 >E502 : E.E502
@@ -6109,7 +6109,7 @@ function run(a: number) {
 >504 : 504
 
             return [ E.E504, E.E505]
->[ E.E504, E.E505] : E[]
+>[ E.E504, E.E505] : (E)[]
 >E.E504 : E.E504
 >E : typeof E
 >E504 : E.E504
@@ -6121,7 +6121,7 @@ function run(a: number) {
 >506 : 506
 
             return [ E.E506, E.E507]
->[ E.E506, E.E507] : E[]
+>[ E.E506, E.E507] : (E)[]
 >E.E506 : E.E506
 >E : typeof E
 >E506 : E.E506
@@ -6133,7 +6133,7 @@ function run(a: number) {
 >508 : 508
 
             return [ E.E508, E.E509]
->[ E.E508, E.E509] : E[]
+>[ E.E508, E.E509] : (E)[]
 >E.E508 : E.E508
 >E : typeof E
 >E508 : E.E508
@@ -6145,7 +6145,7 @@ function run(a: number) {
 >510 : 510
 
             return [ E.E510, E.E511]
->[ E.E510, E.E511] : E[]
+>[ E.E510, E.E511] : (E)[]
 >E.E510 : E.E510
 >E : typeof E
 >E510 : E.E510
@@ -6157,7 +6157,7 @@ function run(a: number) {
 >512 : 512
 
             return [ E.E512, E.E513]
->[ E.E512, E.E513] : E[]
+>[ E.E512, E.E513] : (E)[]
 >E.E512 : E.E512
 >E : typeof E
 >E512 : E.E512
@@ -6169,7 +6169,7 @@ function run(a: number) {
 >514 : 514
 
             return [ E.E514, E.E515]
->[ E.E514, E.E515] : E[]
+>[ E.E514, E.E515] : (E)[]
 >E.E514 : E.E514
 >E : typeof E
 >E514 : E.E514
@@ -6181,7 +6181,7 @@ function run(a: number) {
 >516 : 516
 
             return [ E.E516, E.E517]
->[ E.E516, E.E517] : E[]
+>[ E.E516, E.E517] : (E)[]
 >E.E516 : E.E516
 >E : typeof E
 >E516 : E.E516
@@ -6193,7 +6193,7 @@ function run(a: number) {
 >518 : 518
 
             return [ E.E518, E.E519]
->[ E.E518, E.E519] : E[]
+>[ E.E518, E.E519] : (E)[]
 >E.E518 : E.E518
 >E : typeof E
 >E518 : E.E518
@@ -6205,7 +6205,7 @@ function run(a: number) {
 >520 : 520
 
             return [ E.E520, E.E521]
->[ E.E520, E.E521] : E[]
+>[ E.E520, E.E521] : (E)[]
 >E.E520 : E.E520
 >E : typeof E
 >E520 : E.E520
@@ -6217,7 +6217,7 @@ function run(a: number) {
 >522 : 522
 
             return [ E.E522, E.E523]
->[ E.E522, E.E523] : E[]
+>[ E.E522, E.E523] : (E)[]
 >E.E522 : E.E522
 >E : typeof E
 >E522 : E.E522
@@ -6229,7 +6229,7 @@ function run(a: number) {
 >524 : 524
 
             return [ E.E524, E.E525]
->[ E.E524, E.E525] : E[]
+>[ E.E524, E.E525] : (E)[]
 >E.E524 : E.E524
 >E : typeof E
 >E524 : E.E524
@@ -6241,7 +6241,7 @@ function run(a: number) {
 >526 : 526
 
             return [ E.E526, E.E527]
->[ E.E526, E.E527] : E[]
+>[ E.E526, E.E527] : (E)[]
 >E.E526 : E.E526
 >E : typeof E
 >E526 : E.E526
@@ -6253,7 +6253,7 @@ function run(a: number) {
 >528 : 528
 
             return [ E.E528, E.E529]
->[ E.E528, E.E529] : E[]
+>[ E.E528, E.E529] : (E)[]
 >E.E528 : E.E528
 >E : typeof E
 >E528 : E.E528
@@ -6265,7 +6265,7 @@ function run(a: number) {
 >530 : 530
 
             return [ E.E530, E.E531]
->[ E.E530, E.E531] : E[]
+>[ E.E530, E.E531] : (E)[]
 >E.E530 : E.E530
 >E : typeof E
 >E530 : E.E530
@@ -6277,7 +6277,7 @@ function run(a: number) {
 >532 : 532
 
             return [ E.E532, E.E533]
->[ E.E532, E.E533] : E[]
+>[ E.E532, E.E533] : (E)[]
 >E.E532 : E.E532
 >E : typeof E
 >E532 : E.E532
@@ -6289,7 +6289,7 @@ function run(a: number) {
 >534 : 534
 
             return [ E.E534, E.E535]
->[ E.E534, E.E535] : E[]
+>[ E.E534, E.E535] : (E)[]
 >E.E534 : E.E534
 >E : typeof E
 >E534 : E.E534
@@ -6301,7 +6301,7 @@ function run(a: number) {
 >536 : 536
 
             return [ E.E536, E.E537]
->[ E.E536, E.E537] : E[]
+>[ E.E536, E.E537] : (E)[]
 >E.E536 : E.E536
 >E : typeof E
 >E536 : E.E536
@@ -6313,7 +6313,7 @@ function run(a: number) {
 >538 : 538
 
             return [ E.E538, E.E539]
->[ E.E538, E.E539] : E[]
+>[ E.E538, E.E539] : (E)[]
 >E.E538 : E.E538
 >E : typeof E
 >E538 : E.E538
@@ -6325,7 +6325,7 @@ function run(a: number) {
 >540 : 540
 
             return [ E.E540, E.E541]
->[ E.E540, E.E541] : E[]
+>[ E.E540, E.E541] : (E)[]
 >E.E540 : E.E540
 >E : typeof E
 >E540 : E.E540
@@ -6337,7 +6337,7 @@ function run(a: number) {
 >542 : 542
 
             return [ E.E542, E.E543]
->[ E.E542, E.E543] : E[]
+>[ E.E542, E.E543] : (E)[]
 >E.E542 : E.E542
 >E : typeof E
 >E542 : E.E542
@@ -6349,7 +6349,7 @@ function run(a: number) {
 >544 : 544
 
             return [ E.E544, E.E545]
->[ E.E544, E.E545] : E[]
+>[ E.E544, E.E545] : (E)[]
 >E.E544 : E.E544
 >E : typeof E
 >E544 : E.E544
@@ -6361,7 +6361,7 @@ function run(a: number) {
 >546 : 546
 
             return [ E.E546, E.E547]
->[ E.E546, E.E547] : E[]
+>[ E.E546, E.E547] : (E)[]
 >E.E546 : E.E546
 >E : typeof E
 >E546 : E.E546
@@ -6373,7 +6373,7 @@ function run(a: number) {
 >548 : 548
 
             return [ E.E548, E.E549]
->[ E.E548, E.E549] : E[]
+>[ E.E548, E.E549] : (E)[]
 >E.E548 : E.E548
 >E : typeof E
 >E548 : E.E548
@@ -6385,7 +6385,7 @@ function run(a: number) {
 >550 : 550
 
             return [ E.E550, E.E551]
->[ E.E550, E.E551] : E[]
+>[ E.E550, E.E551] : (E)[]
 >E.E550 : E.E550
 >E : typeof E
 >E550 : E.E550
@@ -6397,7 +6397,7 @@ function run(a: number) {
 >552 : 552
 
             return [ E.E552, E.E553]
->[ E.E552, E.E553] : E[]
+>[ E.E552, E.E553] : (E)[]
 >E.E552 : E.E552
 >E : typeof E
 >E552 : E.E552
@@ -6409,7 +6409,7 @@ function run(a: number) {
 >554 : 554
 
             return [ E.E554, E.E555]
->[ E.E554, E.E555] : E[]
+>[ E.E554, E.E555] : (E)[]
 >E.E554 : E.E554
 >E : typeof E
 >E554 : E.E554
@@ -6421,7 +6421,7 @@ function run(a: number) {
 >556 : 556
 
             return [ E.E556, E.E557]
->[ E.E556, E.E557] : E[]
+>[ E.E556, E.E557] : (E)[]
 >E.E556 : E.E556
 >E : typeof E
 >E556 : E.E556
@@ -6433,7 +6433,7 @@ function run(a: number) {
 >558 : 558
 
             return [ E.E558, E.E559]
->[ E.E558, E.E559] : E[]
+>[ E.E558, E.E559] : (E)[]
 >E.E558 : E.E558
 >E : typeof E
 >E558 : E.E558
@@ -6445,7 +6445,7 @@ function run(a: number) {
 >560 : 560
 
             return [ E.E560, E.E561]
->[ E.E560, E.E561] : E[]
+>[ E.E560, E.E561] : (E)[]
 >E.E560 : E.E560
 >E : typeof E
 >E560 : E.E560
@@ -6457,7 +6457,7 @@ function run(a: number) {
 >562 : 562
 
             return [ E.E562, E.E563]
->[ E.E562, E.E563] : E[]
+>[ E.E562, E.E563] : (E)[]
 >E.E562 : E.E562
 >E : typeof E
 >E562 : E.E562
@@ -6469,7 +6469,7 @@ function run(a: number) {
 >564 : 564
 
             return [ E.E564, E.E565]
->[ E.E564, E.E565] : E[]
+>[ E.E564, E.E565] : (E)[]
 >E.E564 : E.E564
 >E : typeof E
 >E564 : E.E564
@@ -6481,7 +6481,7 @@ function run(a: number) {
 >566 : 566
 
             return [ E.E566, E.E567]
->[ E.E566, E.E567] : E[]
+>[ E.E566, E.E567] : (E)[]
 >E.E566 : E.E566
 >E : typeof E
 >E566 : E.E566
@@ -6493,7 +6493,7 @@ function run(a: number) {
 >568 : 568
 
             return [ E.E568, E.E569]
->[ E.E568, E.E569] : E[]
+>[ E.E568, E.E569] : (E)[]
 >E.E568 : E.E568
 >E : typeof E
 >E568 : E.E568
@@ -6505,7 +6505,7 @@ function run(a: number) {
 >570 : 570
 
             return [ E.E570, E.E571]
->[ E.E570, E.E571] : E[]
+>[ E.E570, E.E571] : (E)[]
 >E.E570 : E.E570
 >E : typeof E
 >E570 : E.E570
@@ -6517,7 +6517,7 @@ function run(a: number) {
 >572 : 572
 
             return [ E.E572, E.E573]
->[ E.E572, E.E573] : E[]
+>[ E.E572, E.E573] : (E)[]
 >E.E572 : E.E572
 >E : typeof E
 >E572 : E.E572
@@ -6529,7 +6529,7 @@ function run(a: number) {
 >574 : 574
 
             return [ E.E574, E.E575]
->[ E.E574, E.E575] : E[]
+>[ E.E574, E.E575] : (E)[]
 >E.E574 : E.E574
 >E : typeof E
 >E574 : E.E574
@@ -6541,7 +6541,7 @@ function run(a: number) {
 >576 : 576
 
             return [ E.E576, E.E577]
->[ E.E576, E.E577] : E[]
+>[ E.E576, E.E577] : (E)[]
 >E.E576 : E.E576
 >E : typeof E
 >E576 : E.E576
@@ -6553,7 +6553,7 @@ function run(a: number) {
 >578 : 578
 
             return [ E.E578, E.E579]
->[ E.E578, E.E579] : E[]
+>[ E.E578, E.E579] : (E)[]
 >E.E578 : E.E578
 >E : typeof E
 >E578 : E.E578
@@ -6565,7 +6565,7 @@ function run(a: number) {
 >580 : 580
 
             return [ E.E580, E.E581]
->[ E.E580, E.E581] : E[]
+>[ E.E580, E.E581] : (E)[]
 >E.E580 : E.E580
 >E : typeof E
 >E580 : E.E580
@@ -6577,7 +6577,7 @@ function run(a: number) {
 >582 : 582
 
             return [ E.E582, E.E583]
->[ E.E582, E.E583] : E[]
+>[ E.E582, E.E583] : (E)[]
 >E.E582 : E.E582
 >E : typeof E
 >E582 : E.E582
@@ -6589,7 +6589,7 @@ function run(a: number) {
 >584 : 584
 
             return [ E.E584, E.E585]
->[ E.E584, E.E585] : E[]
+>[ E.E584, E.E585] : (E)[]
 >E.E584 : E.E584
 >E : typeof E
 >E584 : E.E584
@@ -6601,7 +6601,7 @@ function run(a: number) {
 >586 : 586
 
             return [ E.E586, E.E587]
->[ E.E586, E.E587] : E[]
+>[ E.E586, E.E587] : (E)[]
 >E.E586 : E.E586
 >E : typeof E
 >E586 : E.E586
@@ -6613,7 +6613,7 @@ function run(a: number) {
 >588 : 588
 
             return [ E.E588, E.E589]
->[ E.E588, E.E589] : E[]
+>[ E.E588, E.E589] : (E)[]
 >E.E588 : E.E588
 >E : typeof E
 >E588 : E.E588
@@ -6625,7 +6625,7 @@ function run(a: number) {
 >590 : 590
 
             return [ E.E590, E.E591]
->[ E.E590, E.E591] : E[]
+>[ E.E590, E.E591] : (E)[]
 >E.E590 : E.E590
 >E : typeof E
 >E590 : E.E590
@@ -6637,7 +6637,7 @@ function run(a: number) {
 >592 : 592
 
             return [ E.E592, E.E593]
->[ E.E592, E.E593] : E[]
+>[ E.E592, E.E593] : (E)[]
 >E.E592 : E.E592
 >E : typeof E
 >E592 : E.E592
@@ -6649,7 +6649,7 @@ function run(a: number) {
 >594 : 594
 
             return [ E.E594, E.E595]
->[ E.E594, E.E595] : E[]
+>[ E.E594, E.E595] : (E)[]
 >E.E594 : E.E594
 >E : typeof E
 >E594 : E.E594
@@ -6661,7 +6661,7 @@ function run(a: number) {
 >596 : 596
 
             return [ E.E596, E.E597]
->[ E.E596, E.E597] : E[]
+>[ E.E596, E.E597] : (E)[]
 >E.E596 : E.E596
 >E : typeof E
 >E596 : E.E596
@@ -6673,7 +6673,7 @@ function run(a: number) {
 >598 : 598
 
             return [ E.E598, E.E599]
->[ E.E598, E.E599] : E[]
+>[ E.E598, E.E599] : (E)[]
 >E.E598 : E.E598
 >E : typeof E
 >E598 : E.E598
@@ -6685,7 +6685,7 @@ function run(a: number) {
 >600 : 600
 
             return [ E.E600, E.E601]
->[ E.E600, E.E601] : E[]
+>[ E.E600, E.E601] : (E)[]
 >E.E600 : E.E600
 >E : typeof E
 >E600 : E.E600
@@ -6697,7 +6697,7 @@ function run(a: number) {
 >602 : 602
 
             return [ E.E602, E.E603]
->[ E.E602, E.E603] : E[]
+>[ E.E602, E.E603] : (E)[]
 >E.E602 : E.E602
 >E : typeof E
 >E602 : E.E602
@@ -6709,7 +6709,7 @@ function run(a: number) {
 >604 : 604
 
             return [ E.E604, E.E605]
->[ E.E604, E.E605] : E[]
+>[ E.E604, E.E605] : (E)[]
 >E.E604 : E.E604
 >E : typeof E
 >E604 : E.E604
@@ -6721,7 +6721,7 @@ function run(a: number) {
 >606 : 606
 
             return [ E.E606, E.E607]
->[ E.E606, E.E607] : E[]
+>[ E.E606, E.E607] : (E)[]
 >E.E606 : E.E606
 >E : typeof E
 >E606 : E.E606
@@ -6733,7 +6733,7 @@ function run(a: number) {
 >608 : 608
 
             return [ E.E608, E.E609]
->[ E.E608, E.E609] : E[]
+>[ E.E608, E.E609] : (E)[]
 >E.E608 : E.E608
 >E : typeof E
 >E608 : E.E608
@@ -6745,7 +6745,7 @@ function run(a: number) {
 >610 : 610
 
             return [ E.E610, E.E611]
->[ E.E610, E.E611] : E[]
+>[ E.E610, E.E611] : (E)[]
 >E.E610 : E.E610
 >E : typeof E
 >E610 : E.E610
@@ -6757,7 +6757,7 @@ function run(a: number) {
 >612 : 612
 
             return [ E.E612, E.E613]
->[ E.E612, E.E613] : E[]
+>[ E.E612, E.E613] : (E)[]
 >E.E612 : E.E612
 >E : typeof E
 >E612 : E.E612
@@ -6769,7 +6769,7 @@ function run(a: number) {
 >614 : 614
 
             return [ E.E614, E.E615]
->[ E.E614, E.E615] : E[]
+>[ E.E614, E.E615] : (E)[]
 >E.E614 : E.E614
 >E : typeof E
 >E614 : E.E614
@@ -6781,7 +6781,7 @@ function run(a: number) {
 >616 : 616
 
             return [ E.E616, E.E617]
->[ E.E616, E.E617] : E[]
+>[ E.E616, E.E617] : (E)[]
 >E.E616 : E.E616
 >E : typeof E
 >E616 : E.E616
@@ -6793,7 +6793,7 @@ function run(a: number) {
 >618 : 618
 
             return [ E.E618, E.E619]
->[ E.E618, E.E619] : E[]
+>[ E.E618, E.E619] : (E)[]
 >E.E618 : E.E618
 >E : typeof E
 >E618 : E.E618
@@ -6805,7 +6805,7 @@ function run(a: number) {
 >620 : 620
 
             return [ E.E620, E.E621]
->[ E.E620, E.E621] : E[]
+>[ E.E620, E.E621] : (E)[]
 >E.E620 : E.E620
 >E : typeof E
 >E620 : E.E620
@@ -6817,7 +6817,7 @@ function run(a: number) {
 >622 : 622
 
             return [ E.E622, E.E623]
->[ E.E622, E.E623] : E[]
+>[ E.E622, E.E623] : (E)[]
 >E.E622 : E.E622
 >E : typeof E
 >E622 : E.E622
@@ -6829,7 +6829,7 @@ function run(a: number) {
 >624 : 624
 
             return [ E.E624, E.E625]
->[ E.E624, E.E625] : E[]
+>[ E.E624, E.E625] : (E)[]
 >E.E624 : E.E624
 >E : typeof E
 >E624 : E.E624
@@ -6841,7 +6841,7 @@ function run(a: number) {
 >626 : 626
 
             return [ E.E626, E.E627]
->[ E.E626, E.E627] : E[]
+>[ E.E626, E.E627] : (E)[]
 >E.E626 : E.E626
 >E : typeof E
 >E626 : E.E626
@@ -6853,7 +6853,7 @@ function run(a: number) {
 >628 : 628
 
             return [ E.E628, E.E629]
->[ E.E628, E.E629] : E[]
+>[ E.E628, E.E629] : (E)[]
 >E.E628 : E.E628
 >E : typeof E
 >E628 : E.E628
@@ -6865,7 +6865,7 @@ function run(a: number) {
 >630 : 630
 
             return [ E.E630, E.E631]
->[ E.E630, E.E631] : E[]
+>[ E.E630, E.E631] : (E)[]
 >E.E630 : E.E630
 >E : typeof E
 >E630 : E.E630
@@ -6877,7 +6877,7 @@ function run(a: number) {
 >632 : 632
 
             return [ E.E632, E.E633]
->[ E.E632, E.E633] : E[]
+>[ E.E632, E.E633] : (E)[]
 >E.E632 : E.E632
 >E : typeof E
 >E632 : E.E632
@@ -6889,7 +6889,7 @@ function run(a: number) {
 >634 : 634
 
             return [ E.E634, E.E635]
->[ E.E634, E.E635] : E[]
+>[ E.E634, E.E635] : (E)[]
 >E.E634 : E.E634
 >E : typeof E
 >E634 : E.E634
@@ -6901,7 +6901,7 @@ function run(a: number) {
 >636 : 636
 
             return [ E.E636, E.E637]
->[ E.E636, E.E637] : E[]
+>[ E.E636, E.E637] : (E)[]
 >E.E636 : E.E636
 >E : typeof E
 >E636 : E.E636
@@ -6913,7 +6913,7 @@ function run(a: number) {
 >638 : 638
 
             return [ E.E638, E.E639]
->[ E.E638, E.E639] : E[]
+>[ E.E638, E.E639] : (E)[]
 >E.E638 : E.E638
 >E : typeof E
 >E638 : E.E638
@@ -6925,7 +6925,7 @@ function run(a: number) {
 >640 : 640
 
             return [ E.E640, E.E641]
->[ E.E640, E.E641] : E[]
+>[ E.E640, E.E641] : (E)[]
 >E.E640 : E.E640
 >E : typeof E
 >E640 : E.E640
@@ -6937,7 +6937,7 @@ function run(a: number) {
 >642 : 642
 
             return [ E.E642, E.E643]
->[ E.E642, E.E643] : E[]
+>[ E.E642, E.E643] : (E)[]
 >E.E642 : E.E642
 >E : typeof E
 >E642 : E.E642
@@ -6949,7 +6949,7 @@ function run(a: number) {
 >644 : 644
 
             return [ E.E644, E.E645]
->[ E.E644, E.E645] : E[]
+>[ E.E644, E.E645] : (E)[]
 >E.E644 : E.E644
 >E : typeof E
 >E644 : E.E644
@@ -6961,7 +6961,7 @@ function run(a: number) {
 >646 : 646
 
             return [ E.E646, E.E647]
->[ E.E646, E.E647] : E[]
+>[ E.E646, E.E647] : (E)[]
 >E.E646 : E.E646
 >E : typeof E
 >E646 : E.E646
@@ -6973,7 +6973,7 @@ function run(a: number) {
 >648 : 648
 
             return [ E.E648, E.E649]
->[ E.E648, E.E649] : E[]
+>[ E.E648, E.E649] : (E)[]
 >E.E648 : E.E648
 >E : typeof E
 >E648 : E.E648
@@ -6985,7 +6985,7 @@ function run(a: number) {
 >650 : 650
 
             return [ E.E650, E.E651]
->[ E.E650, E.E651] : E[]
+>[ E.E650, E.E651] : (E)[]
 >E.E650 : E.E650
 >E : typeof E
 >E650 : E.E650
@@ -6997,7 +6997,7 @@ function run(a: number) {
 >652 : 652
 
             return [ E.E652, E.E653]
->[ E.E652, E.E653] : E[]
+>[ E.E652, E.E653] : (E)[]
 >E.E652 : E.E652
 >E : typeof E
 >E652 : E.E652
@@ -7009,7 +7009,7 @@ function run(a: number) {
 >654 : 654
 
             return [ E.E654, E.E655]
->[ E.E654, E.E655] : E[]
+>[ E.E654, E.E655] : (E)[]
 >E.E654 : E.E654
 >E : typeof E
 >E654 : E.E654
@@ -7021,7 +7021,7 @@ function run(a: number) {
 >656 : 656
 
             return [ E.E656, E.E657]
->[ E.E656, E.E657] : E[]
+>[ E.E656, E.E657] : (E)[]
 >E.E656 : E.E656
 >E : typeof E
 >E656 : E.E656
@@ -7033,7 +7033,7 @@ function run(a: number) {
 >658 : 658
 
             return [ E.E658, E.E659]
->[ E.E658, E.E659] : E[]
+>[ E.E658, E.E659] : (E)[]
 >E.E658 : E.E658
 >E : typeof E
 >E658 : E.E658
@@ -7045,7 +7045,7 @@ function run(a: number) {
 >660 : 660
 
             return [ E.E660, E.E661]
->[ E.E660, E.E661] : E[]
+>[ E.E660, E.E661] : (E)[]
 >E.E660 : E.E660
 >E : typeof E
 >E660 : E.E660
@@ -7057,7 +7057,7 @@ function run(a: number) {
 >662 : 662
 
             return [ E.E662, E.E663]
->[ E.E662, E.E663] : E[]
+>[ E.E662, E.E663] : (E)[]
 >E.E662 : E.E662
 >E : typeof E
 >E662 : E.E662
@@ -7069,7 +7069,7 @@ function run(a: number) {
 >664 : 664
 
             return [ E.E664, E.E665]
->[ E.E664, E.E665] : E[]
+>[ E.E664, E.E665] : (E)[]
 >E.E664 : E.E664
 >E : typeof E
 >E664 : E.E664
@@ -7081,7 +7081,7 @@ function run(a: number) {
 >666 : 666
 
             return [ E.E666, E.E667]
->[ E.E666, E.E667] : E[]
+>[ E.E666, E.E667] : (E)[]
 >E.E666 : E.E666
 >E : typeof E
 >E666 : E.E666
@@ -7093,7 +7093,7 @@ function run(a: number) {
 >668 : 668
 
             return [ E.E668, E.E669]
->[ E.E668, E.E669] : E[]
+>[ E.E668, E.E669] : (E)[]
 >E.E668 : E.E668
 >E : typeof E
 >E668 : E.E668
@@ -7105,7 +7105,7 @@ function run(a: number) {
 >670 : 670
 
             return [ E.E670, E.E671]
->[ E.E670, E.E671] : E[]
+>[ E.E670, E.E671] : (E)[]
 >E.E670 : E.E670
 >E : typeof E
 >E670 : E.E670
@@ -7117,7 +7117,7 @@ function run(a: number) {
 >672 : 672
 
             return [ E.E672, E.E673]
->[ E.E672, E.E673] : E[]
+>[ E.E672, E.E673] : (E)[]
 >E.E672 : E.E672
 >E : typeof E
 >E672 : E.E672
@@ -7129,7 +7129,7 @@ function run(a: number) {
 >674 : 674
 
             return [ E.E674, E.E675]
->[ E.E674, E.E675] : E[]
+>[ E.E674, E.E675] : (E)[]
 >E.E674 : E.E674
 >E : typeof E
 >E674 : E.E674
@@ -7141,7 +7141,7 @@ function run(a: number) {
 >676 : 676
 
             return [ E.E676, E.E677]
->[ E.E676, E.E677] : E[]
+>[ E.E676, E.E677] : (E)[]
 >E.E676 : E.E676
 >E : typeof E
 >E676 : E.E676
@@ -7153,7 +7153,7 @@ function run(a: number) {
 >678 : 678
 
             return [ E.E678, E.E679]
->[ E.E678, E.E679] : E[]
+>[ E.E678, E.E679] : (E)[]
 >E.E678 : E.E678
 >E : typeof E
 >E678 : E.E678
@@ -7165,7 +7165,7 @@ function run(a: number) {
 >680 : 680
 
             return [ E.E680, E.E681]
->[ E.E680, E.E681] : E[]
+>[ E.E680, E.E681] : (E)[]
 >E.E680 : E.E680
 >E : typeof E
 >E680 : E.E680
@@ -7177,7 +7177,7 @@ function run(a: number) {
 >682 : 682
 
             return [ E.E682, E.E683]
->[ E.E682, E.E683] : E[]
+>[ E.E682, E.E683] : (E)[]
 >E.E682 : E.E682
 >E : typeof E
 >E682 : E.E682
@@ -7189,7 +7189,7 @@ function run(a: number) {
 >684 : 684
 
             return [ E.E684, E.E685]
->[ E.E684, E.E685] : E[]
+>[ E.E684, E.E685] : (E)[]
 >E.E684 : E.E684
 >E : typeof E
 >E684 : E.E684
@@ -7201,7 +7201,7 @@ function run(a: number) {
 >686 : 686
 
             return [ E.E686, E.E687]
->[ E.E686, E.E687] : E[]
+>[ E.E686, E.E687] : (E)[]
 >E.E686 : E.E686
 >E : typeof E
 >E686 : E.E686
@@ -7213,7 +7213,7 @@ function run(a: number) {
 >688 : 688
 
             return [ E.E688, E.E689]
->[ E.E688, E.E689] : E[]
+>[ E.E688, E.E689] : (E)[]
 >E.E688 : E.E688
 >E : typeof E
 >E688 : E.E688
@@ -7225,7 +7225,7 @@ function run(a: number) {
 >690 : 690
 
             return [ E.E690, E.E691]
->[ E.E690, E.E691] : E[]
+>[ E.E690, E.E691] : (E)[]
 >E.E690 : E.E690
 >E : typeof E
 >E690 : E.E690
@@ -7237,7 +7237,7 @@ function run(a: number) {
 >692 : 692
 
             return [ E.E692, E.E693]
->[ E.E692, E.E693] : E[]
+>[ E.E692, E.E693] : (E)[]
 >E.E692 : E.E692
 >E : typeof E
 >E692 : E.E692
@@ -7249,7 +7249,7 @@ function run(a: number) {
 >694 : 694
 
             return [ E.E694, E.E695]
->[ E.E694, E.E695] : E[]
+>[ E.E694, E.E695] : (E)[]
 >E.E694 : E.E694
 >E : typeof E
 >E694 : E.E694
@@ -7261,7 +7261,7 @@ function run(a: number) {
 >696 : 696
 
             return [ E.E696, E.E697]
->[ E.E696, E.E697] : E[]
+>[ E.E696, E.E697] : (E)[]
 >E.E696 : E.E696
 >E : typeof E
 >E696 : E.E696
@@ -7273,7 +7273,7 @@ function run(a: number) {
 >698 : 698
 
             return [ E.E698, E.E699]
->[ E.E698, E.E699] : E[]
+>[ E.E698, E.E699] : (E)[]
 >E.E698 : E.E698
 >E : typeof E
 >E698 : E.E698
@@ -7285,7 +7285,7 @@ function run(a: number) {
 >700 : 700
 
             return [ E.E700, E.E701]
->[ E.E700, E.E701] : E[]
+>[ E.E700, E.E701] : (E)[]
 >E.E700 : E.E700
 >E : typeof E
 >E700 : E.E700
@@ -7297,7 +7297,7 @@ function run(a: number) {
 >702 : 702
 
             return [ E.E702, E.E703]
->[ E.E702, E.E703] : E[]
+>[ E.E702, E.E703] : (E)[]
 >E.E702 : E.E702
 >E : typeof E
 >E702 : E.E702
@@ -7309,7 +7309,7 @@ function run(a: number) {
 >704 : 704
 
             return [ E.E704, E.E705]
->[ E.E704, E.E705] : E[]
+>[ E.E704, E.E705] : (E)[]
 >E.E704 : E.E704
 >E : typeof E
 >E704 : E.E704
@@ -7321,7 +7321,7 @@ function run(a: number) {
 >706 : 706
 
             return [ E.E706, E.E707]
->[ E.E706, E.E707] : E[]
+>[ E.E706, E.E707] : (E)[]
 >E.E706 : E.E706
 >E : typeof E
 >E706 : E.E706
@@ -7333,7 +7333,7 @@ function run(a: number) {
 >708 : 708
 
             return [ E.E708, E.E709]
->[ E.E708, E.E709] : E[]
+>[ E.E708, E.E709] : (E)[]
 >E.E708 : E.E708
 >E : typeof E
 >E708 : E.E708
@@ -7345,7 +7345,7 @@ function run(a: number) {
 >710 : 710
 
             return [ E.E710, E.E711]
->[ E.E710, E.E711] : E[]
+>[ E.E710, E.E711] : (E)[]
 >E.E710 : E.E710
 >E : typeof E
 >E710 : E.E710
@@ -7357,7 +7357,7 @@ function run(a: number) {
 >712 : 712
 
             return [ E.E712, E.E713]
->[ E.E712, E.E713] : E[]
+>[ E.E712, E.E713] : (E)[]
 >E.E712 : E.E712
 >E : typeof E
 >E712 : E.E712
@@ -7369,7 +7369,7 @@ function run(a: number) {
 >714 : 714
 
             return [ E.E714, E.E715]
->[ E.E714, E.E715] : E[]
+>[ E.E714, E.E715] : (E)[]
 >E.E714 : E.E714
 >E : typeof E
 >E714 : E.E714
@@ -7381,7 +7381,7 @@ function run(a: number) {
 >716 : 716
 
             return [ E.E716, E.E717]
->[ E.E716, E.E717] : E[]
+>[ E.E716, E.E717] : (E)[]
 >E.E716 : E.E716
 >E : typeof E
 >E716 : E.E716
@@ -7393,7 +7393,7 @@ function run(a: number) {
 >718 : 718
 
             return [ E.E718, E.E719]
->[ E.E718, E.E719] : E[]
+>[ E.E718, E.E719] : (E)[]
 >E.E718 : E.E718
 >E : typeof E
 >E718 : E.E718
@@ -7405,7 +7405,7 @@ function run(a: number) {
 >720 : 720
 
             return [ E.E720, E.E721]
->[ E.E720, E.E721] : E[]
+>[ E.E720, E.E721] : (E)[]
 >E.E720 : E.E720
 >E : typeof E
 >E720 : E.E720
@@ -7417,7 +7417,7 @@ function run(a: number) {
 >722 : 722
 
             return [ E.E722, E.E723]
->[ E.E722, E.E723] : E[]
+>[ E.E722, E.E723] : (E)[]
 >E.E722 : E.E722
 >E : typeof E
 >E722 : E.E722
@@ -7429,7 +7429,7 @@ function run(a: number) {
 >724 : 724
 
             return [ E.E724, E.E725]
->[ E.E724, E.E725] : E[]
+>[ E.E724, E.E725] : (E)[]
 >E.E724 : E.E724
 >E : typeof E
 >E724 : E.E724
@@ -7441,7 +7441,7 @@ function run(a: number) {
 >726 : 726
 
             return [ E.E726, E.E727]
->[ E.E726, E.E727] : E[]
+>[ E.E726, E.E727] : (E)[]
 >E.E726 : E.E726
 >E : typeof E
 >E726 : E.E726
@@ -7453,7 +7453,7 @@ function run(a: number) {
 >728 : 728
 
             return [ E.E728, E.E729]
->[ E.E728, E.E729] : E[]
+>[ E.E728, E.E729] : (E)[]
 >E.E728 : E.E728
 >E : typeof E
 >E728 : E.E728
@@ -7465,7 +7465,7 @@ function run(a: number) {
 >730 : 730
 
             return [ E.E730, E.E731]
->[ E.E730, E.E731] : E[]
+>[ E.E730, E.E731] : (E)[]
 >E.E730 : E.E730
 >E : typeof E
 >E730 : E.E730
@@ -7477,7 +7477,7 @@ function run(a: number) {
 >732 : 732
 
             return [ E.E732, E.E733]
->[ E.E732, E.E733] : E[]
+>[ E.E732, E.E733] : (E)[]
 >E.E732 : E.E732
 >E : typeof E
 >E732 : E.E732
@@ -7489,7 +7489,7 @@ function run(a: number) {
 >734 : 734
 
             return [ E.E734, E.E735]
->[ E.E734, E.E735] : E[]
+>[ E.E734, E.E735] : (E)[]
 >E.E734 : E.E734
 >E : typeof E
 >E734 : E.E734
@@ -7501,7 +7501,7 @@ function run(a: number) {
 >736 : 736
 
             return [ E.E736, E.E737]
->[ E.E736, E.E737] : E[]
+>[ E.E736, E.E737] : (E)[]
 >E.E736 : E.E736
 >E : typeof E
 >E736 : E.E736
@@ -7513,7 +7513,7 @@ function run(a: number) {
 >738 : 738
 
             return [ E.E738, E.E739]
->[ E.E738, E.E739] : E[]
+>[ E.E738, E.E739] : (E)[]
 >E.E738 : E.E738
 >E : typeof E
 >E738 : E.E738
@@ -7525,7 +7525,7 @@ function run(a: number) {
 >740 : 740
 
             return [ E.E740, E.E741]
->[ E.E740, E.E741] : E[]
+>[ E.E740, E.E741] : (E)[]
 >E.E740 : E.E740
 >E : typeof E
 >E740 : E.E740
@@ -7537,7 +7537,7 @@ function run(a: number) {
 >742 : 742
 
             return [ E.E742, E.E743]
->[ E.E742, E.E743] : E[]
+>[ E.E742, E.E743] : (E)[]
 >E.E742 : E.E742
 >E : typeof E
 >E742 : E.E742
@@ -7549,7 +7549,7 @@ function run(a: number) {
 >744 : 744
 
             return [ E.E744, E.E745]
->[ E.E744, E.E745] : E[]
+>[ E.E744, E.E745] : (E)[]
 >E.E744 : E.E744
 >E : typeof E
 >E744 : E.E744
@@ -7561,7 +7561,7 @@ function run(a: number) {
 >746 : 746
 
             return [ E.E746, E.E747]
->[ E.E746, E.E747] : E[]
+>[ E.E746, E.E747] : (E)[]
 >E.E746 : E.E746
 >E : typeof E
 >E746 : E.E746
@@ -7573,7 +7573,7 @@ function run(a: number) {
 >748 : 748
 
             return [ E.E748, E.E749]
->[ E.E748, E.E749] : E[]
+>[ E.E748, E.E749] : (E)[]
 >E.E748 : E.E748
 >E : typeof E
 >E748 : E.E748
@@ -7585,7 +7585,7 @@ function run(a: number) {
 >750 : 750
 
             return [ E.E750, E.E751]
->[ E.E750, E.E751] : E[]
+>[ E.E750, E.E751] : (E)[]
 >E.E750 : E.E750
 >E : typeof E
 >E750 : E.E750
@@ -7597,7 +7597,7 @@ function run(a: number) {
 >752 : 752
 
             return [ E.E752, E.E753]
->[ E.E752, E.E753] : E[]
+>[ E.E752, E.E753] : (E)[]
 >E.E752 : E.E752
 >E : typeof E
 >E752 : E.E752
@@ -7609,7 +7609,7 @@ function run(a: number) {
 >754 : 754
 
             return [ E.E754, E.E755]
->[ E.E754, E.E755] : E[]
+>[ E.E754, E.E755] : (E)[]
 >E.E754 : E.E754
 >E : typeof E
 >E754 : E.E754
@@ -7621,7 +7621,7 @@ function run(a: number) {
 >756 : 756
 
             return [ E.E756, E.E757]
->[ E.E756, E.E757] : E[]
+>[ E.E756, E.E757] : (E)[]
 >E.E756 : E.E756
 >E : typeof E
 >E756 : E.E756
@@ -7633,7 +7633,7 @@ function run(a: number) {
 >758 : 758
 
             return [ E.E758, E.E759]
->[ E.E758, E.E759] : E[]
+>[ E.E758, E.E759] : (E)[]
 >E.E758 : E.E758
 >E : typeof E
 >E758 : E.E758
@@ -7645,7 +7645,7 @@ function run(a: number) {
 >760 : 760
 
             return [ E.E760, E.E761]
->[ E.E760, E.E761] : E[]
+>[ E.E760, E.E761] : (E)[]
 >E.E760 : E.E760
 >E : typeof E
 >E760 : E.E760
@@ -7657,7 +7657,7 @@ function run(a: number) {
 >762 : 762
 
             return [ E.E762, E.E763]
->[ E.E762, E.E763] : E[]
+>[ E.E762, E.E763] : (E)[]
 >E.E762 : E.E762
 >E : typeof E
 >E762 : E.E762
@@ -7669,7 +7669,7 @@ function run(a: number) {
 >764 : 764
 
             return [ E.E764, E.E765]
->[ E.E764, E.E765] : E[]
+>[ E.E764, E.E765] : (E)[]
 >E.E764 : E.E764
 >E : typeof E
 >E764 : E.E764
@@ -7681,7 +7681,7 @@ function run(a: number) {
 >766 : 766
 
             return [ E.E766, E.E767]
->[ E.E766, E.E767] : E[]
+>[ E.E766, E.E767] : (E)[]
 >E.E766 : E.E766
 >E : typeof E
 >E766 : E.E766
@@ -7693,7 +7693,7 @@ function run(a: number) {
 >768 : 768
 
             return [ E.E768, E.E769]
->[ E.E768, E.E769] : E[]
+>[ E.E768, E.E769] : (E)[]
 >E.E768 : E.E768
 >E : typeof E
 >E768 : E.E768
@@ -7705,7 +7705,7 @@ function run(a: number) {
 >770 : 770
 
             return [ E.E770, E.E771]
->[ E.E770, E.E771] : E[]
+>[ E.E770, E.E771] : (E)[]
 >E.E770 : E.E770
 >E : typeof E
 >E770 : E.E770
@@ -7717,7 +7717,7 @@ function run(a: number) {
 >772 : 772
 
             return [ E.E772, E.E773]
->[ E.E772, E.E773] : E[]
+>[ E.E772, E.E773] : (E)[]
 >E.E772 : E.E772
 >E : typeof E
 >E772 : E.E772
@@ -7729,7 +7729,7 @@ function run(a: number) {
 >774 : 774
 
             return [ E.E774, E.E775]
->[ E.E774, E.E775] : E[]
+>[ E.E774, E.E775] : (E)[]
 >E.E774 : E.E774
 >E : typeof E
 >E774 : E.E774
@@ -7741,7 +7741,7 @@ function run(a: number) {
 >776 : 776
 
             return [ E.E776, E.E777]
->[ E.E776, E.E777] : E[]
+>[ E.E776, E.E777] : (E)[]
 >E.E776 : E.E776
 >E : typeof E
 >E776 : E.E776
@@ -7753,7 +7753,7 @@ function run(a: number) {
 >778 : 778
 
             return [ E.E778, E.E779]
->[ E.E778, E.E779] : E[]
+>[ E.E778, E.E779] : (E)[]
 >E.E778 : E.E778
 >E : typeof E
 >E778 : E.E778
@@ -7765,7 +7765,7 @@ function run(a: number) {
 >780 : 780
 
             return [ E.E780, E.E781]
->[ E.E780, E.E781] : E[]
+>[ E.E780, E.E781] : (E)[]
 >E.E780 : E.E780
 >E : typeof E
 >E780 : E.E780
@@ -7777,7 +7777,7 @@ function run(a: number) {
 >782 : 782
 
             return [ E.E782, E.E783]
->[ E.E782, E.E783] : E[]
+>[ E.E782, E.E783] : (E)[]
 >E.E782 : E.E782
 >E : typeof E
 >E782 : E.E782
@@ -7789,7 +7789,7 @@ function run(a: number) {
 >784 : 784
 
             return [ E.E784, E.E785]
->[ E.E784, E.E785] : E[]
+>[ E.E784, E.E785] : (E)[]
 >E.E784 : E.E784
 >E : typeof E
 >E784 : E.E784
@@ -7801,7 +7801,7 @@ function run(a: number) {
 >786 : 786
 
             return [ E.E786, E.E787]
->[ E.E786, E.E787] : E[]
+>[ E.E786, E.E787] : (E)[]
 >E.E786 : E.E786
 >E : typeof E
 >E786 : E.E786
@@ -7813,7 +7813,7 @@ function run(a: number) {
 >788 : 788
 
             return [ E.E788, E.E789]
->[ E.E788, E.E789] : E[]
+>[ E.E788, E.E789] : (E)[]
 >E.E788 : E.E788
 >E : typeof E
 >E788 : E.E788
@@ -7825,7 +7825,7 @@ function run(a: number) {
 >790 : 790
 
             return [ E.E790, E.E791]
->[ E.E790, E.E791] : E[]
+>[ E.E790, E.E791] : (E)[]
 >E.E790 : E.E790
 >E : typeof E
 >E790 : E.E790
@@ -7837,7 +7837,7 @@ function run(a: number) {
 >792 : 792
 
             return [ E.E792, E.E793]
->[ E.E792, E.E793] : E[]
+>[ E.E792, E.E793] : (E)[]
 >E.E792 : E.E792
 >E : typeof E
 >E792 : E.E792
@@ -7849,7 +7849,7 @@ function run(a: number) {
 >794 : 794
 
             return [ E.E794, E.E795]
->[ E.E794, E.E795] : E[]
+>[ E.E794, E.E795] : (E)[]
 >E.E794 : E.E794
 >E : typeof E
 >E794 : E.E794
@@ -7861,7 +7861,7 @@ function run(a: number) {
 >796 : 796
 
             return [ E.E796, E.E797]
->[ E.E796, E.E797] : E[]
+>[ E.E796, E.E797] : (E)[]
 >E.E796 : E.E796
 >E : typeof E
 >E796 : E.E796
@@ -7873,7 +7873,7 @@ function run(a: number) {
 >798 : 798
 
             return [ E.E798, E.E799]
->[ E.E798, E.E799] : E[]
+>[ E.E798, E.E799] : (E)[]
 >E.E798 : E.E798
 >E : typeof E
 >E798 : E.E798
@@ -7885,7 +7885,7 @@ function run(a: number) {
 >800 : 800
 
             return [ E.E800, E.E801]
->[ E.E800, E.E801] : E[]
+>[ E.E800, E.E801] : (E)[]
 >E.E800 : E.E800
 >E : typeof E
 >E800 : E.E800
@@ -7897,7 +7897,7 @@ function run(a: number) {
 >802 : 802
 
             return [ E.E802, E.E803]
->[ E.E802, E.E803] : E[]
+>[ E.E802, E.E803] : (E)[]
 >E.E802 : E.E802
 >E : typeof E
 >E802 : E.E802
@@ -7909,7 +7909,7 @@ function run(a: number) {
 >804 : 804
 
             return [ E.E804, E.E805]
->[ E.E804, E.E805] : E[]
+>[ E.E804, E.E805] : (E)[]
 >E.E804 : E.E804
 >E : typeof E
 >E804 : E.E804
@@ -7921,7 +7921,7 @@ function run(a: number) {
 >806 : 806
 
             return [ E.E806, E.E807]
->[ E.E806, E.E807] : E[]
+>[ E.E806, E.E807] : (E)[]
 >E.E806 : E.E806
 >E : typeof E
 >E806 : E.E806
@@ -7933,7 +7933,7 @@ function run(a: number) {
 >808 : 808
 
             return [ E.E808, E.E809]
->[ E.E808, E.E809] : E[]
+>[ E.E808, E.E809] : (E)[]
 >E.E808 : E.E808
 >E : typeof E
 >E808 : E.E808
@@ -7945,7 +7945,7 @@ function run(a: number) {
 >810 : 810
 
             return [ E.E810, E.E811]
->[ E.E810, E.E811] : E[]
+>[ E.E810, E.E811] : (E)[]
 >E.E810 : E.E810
 >E : typeof E
 >E810 : E.E810
@@ -7957,7 +7957,7 @@ function run(a: number) {
 >812 : 812
 
             return [ E.E812, E.E813]
->[ E.E812, E.E813] : E[]
+>[ E.E812, E.E813] : (E)[]
 >E.E812 : E.E812
 >E : typeof E
 >E812 : E.E812
@@ -7969,7 +7969,7 @@ function run(a: number) {
 >814 : 814
 
             return [ E.E814, E.E815]
->[ E.E814, E.E815] : E[]
+>[ E.E814, E.E815] : (E)[]
 >E.E814 : E.E814
 >E : typeof E
 >E814 : E.E814
@@ -7981,7 +7981,7 @@ function run(a: number) {
 >816 : 816
 
             return [ E.E816, E.E817]
->[ E.E816, E.E817] : E[]
+>[ E.E816, E.E817] : (E)[]
 >E.E816 : E.E816
 >E : typeof E
 >E816 : E.E816
@@ -7993,7 +7993,7 @@ function run(a: number) {
 >818 : 818
 
             return [ E.E818, E.E819]
->[ E.E818, E.E819] : E[]
+>[ E.E818, E.E819] : (E)[]
 >E.E818 : E.E818
 >E : typeof E
 >E818 : E.E818
@@ -8005,7 +8005,7 @@ function run(a: number) {
 >820 : 820
 
             return [ E.E820, E.E821]
->[ E.E820, E.E821] : E[]
+>[ E.E820, E.E821] : (E)[]
 >E.E820 : E.E820
 >E : typeof E
 >E820 : E.E820
@@ -8017,7 +8017,7 @@ function run(a: number) {
 >822 : 822
 
             return [ E.E822, E.E823]
->[ E.E822, E.E823] : E[]
+>[ E.E822, E.E823] : (E)[]
 >E.E822 : E.E822
 >E : typeof E
 >E822 : E.E822
@@ -8029,7 +8029,7 @@ function run(a: number) {
 >824 : 824
 
             return [ E.E824, E.E825]
->[ E.E824, E.E825] : E[]
+>[ E.E824, E.E825] : (E)[]
 >E.E824 : E.E824
 >E : typeof E
 >E824 : E.E824
@@ -8041,7 +8041,7 @@ function run(a: number) {
 >826 : 826
 
             return [ E.E826, E.E827]
->[ E.E826, E.E827] : E[]
+>[ E.E826, E.E827] : (E)[]
 >E.E826 : E.E826
 >E : typeof E
 >E826 : E.E826
@@ -8053,7 +8053,7 @@ function run(a: number) {
 >828 : 828
 
             return [ E.E828, E.E829]
->[ E.E828, E.E829] : E[]
+>[ E.E828, E.E829] : (E)[]
 >E.E828 : E.E828
 >E : typeof E
 >E828 : E.E828
@@ -8065,7 +8065,7 @@ function run(a: number) {
 >830 : 830
 
             return [ E.E830, E.E831]
->[ E.E830, E.E831] : E[]
+>[ E.E830, E.E831] : (E)[]
 >E.E830 : E.E830
 >E : typeof E
 >E830 : E.E830
@@ -8077,7 +8077,7 @@ function run(a: number) {
 >832 : 832
 
             return [ E.E832, E.E833]
->[ E.E832, E.E833] : E[]
+>[ E.E832, E.E833] : (E)[]
 >E.E832 : E.E832
 >E : typeof E
 >E832 : E.E832
@@ -8089,7 +8089,7 @@ function run(a: number) {
 >834 : 834
 
             return [ E.E834, E.E835]
->[ E.E834, E.E835] : E[]
+>[ E.E834, E.E835] : (E)[]
 >E.E834 : E.E834
 >E : typeof E
 >E834 : E.E834
@@ -8101,7 +8101,7 @@ function run(a: number) {
 >836 : 836
 
             return [ E.E836, E.E837]
->[ E.E836, E.E837] : E[]
+>[ E.E836, E.E837] : (E)[]
 >E.E836 : E.E836
 >E : typeof E
 >E836 : E.E836
@@ -8113,7 +8113,7 @@ function run(a: number) {
 >838 : 838
 
             return [ E.E838, E.E839]
->[ E.E838, E.E839] : E[]
+>[ E.E838, E.E839] : (E)[]
 >E.E838 : E.E838
 >E : typeof E
 >E838 : E.E838
@@ -8125,7 +8125,7 @@ function run(a: number) {
 >840 : 840
 
             return [ E.E840, E.E841]
->[ E.E840, E.E841] : E[]
+>[ E.E840, E.E841] : (E)[]
 >E.E840 : E.E840
 >E : typeof E
 >E840 : E.E840
@@ -8137,7 +8137,7 @@ function run(a: number) {
 >842 : 842
 
             return [ E.E842, E.E843]
->[ E.E842, E.E843] : E[]
+>[ E.E842, E.E843] : (E)[]
 >E.E842 : E.E842
 >E : typeof E
 >E842 : E.E842
@@ -8149,7 +8149,7 @@ function run(a: number) {
 >844 : 844
 
             return [ E.E844, E.E845]
->[ E.E844, E.E845] : E[]
+>[ E.E844, E.E845] : (E)[]
 >E.E844 : E.E844
 >E : typeof E
 >E844 : E.E844
@@ -8161,7 +8161,7 @@ function run(a: number) {
 >846 : 846
 
             return [ E.E846, E.E847]
->[ E.E846, E.E847] : E[]
+>[ E.E846, E.E847] : (E)[]
 >E.E846 : E.E846
 >E : typeof E
 >E846 : E.E846
@@ -8173,7 +8173,7 @@ function run(a: number) {
 >848 : 848
 
             return [ E.E848, E.E849]
->[ E.E848, E.E849] : E[]
+>[ E.E848, E.E849] : (E)[]
 >E.E848 : E.E848
 >E : typeof E
 >E848 : E.E848
@@ -8185,7 +8185,7 @@ function run(a: number) {
 >850 : 850
 
             return [ E.E850, E.E851]
->[ E.E850, E.E851] : E[]
+>[ E.E850, E.E851] : (E)[]
 >E.E850 : E.E850
 >E : typeof E
 >E850 : E.E850
@@ -8197,7 +8197,7 @@ function run(a: number) {
 >852 : 852
 
             return [ E.E852, E.E853]
->[ E.E852, E.E853] : E[]
+>[ E.E852, E.E853] : (E)[]
 >E.E852 : E.E852
 >E : typeof E
 >E852 : E.E852
@@ -8209,7 +8209,7 @@ function run(a: number) {
 >854 : 854
 
             return [ E.E854, E.E855]
->[ E.E854, E.E855] : E[]
+>[ E.E854, E.E855] : (E)[]
 >E.E854 : E.E854
 >E : typeof E
 >E854 : E.E854
@@ -8221,7 +8221,7 @@ function run(a: number) {
 >856 : 856
 
             return [ E.E856, E.E857]
->[ E.E856, E.E857] : E[]
+>[ E.E856, E.E857] : (E)[]
 >E.E856 : E.E856
 >E : typeof E
 >E856 : E.E856
@@ -8233,7 +8233,7 @@ function run(a: number) {
 >858 : 858
 
             return [ E.E858, E.E859]
->[ E.E858, E.E859] : E[]
+>[ E.E858, E.E859] : (E)[]
 >E.E858 : E.E858
 >E : typeof E
 >E858 : E.E858
@@ -8245,7 +8245,7 @@ function run(a: number) {
 >860 : 860
 
             return [ E.E860, E.E861]
->[ E.E860, E.E861] : E[]
+>[ E.E860, E.E861] : (E)[]
 >E.E860 : E.E860
 >E : typeof E
 >E860 : E.E860
@@ -8257,7 +8257,7 @@ function run(a: number) {
 >862 : 862
 
             return [ E.E862, E.E863]
->[ E.E862, E.E863] : E[]
+>[ E.E862, E.E863] : (E)[]
 >E.E862 : E.E862
 >E : typeof E
 >E862 : E.E862
@@ -8269,7 +8269,7 @@ function run(a: number) {
 >864 : 864
 
             return [ E.E864, E.E865]
->[ E.E864, E.E865] : E[]
+>[ E.E864, E.E865] : (E)[]
 >E.E864 : E.E864
 >E : typeof E
 >E864 : E.E864
@@ -8281,7 +8281,7 @@ function run(a: number) {
 >866 : 866
 
             return [ E.E866, E.E867]
->[ E.E866, E.E867] : E[]
+>[ E.E866, E.E867] : (E)[]
 >E.E866 : E.E866
 >E : typeof E
 >E866 : E.E866
@@ -8293,7 +8293,7 @@ function run(a: number) {
 >868 : 868
 
             return [ E.E868, E.E869]
->[ E.E868, E.E869] : E[]
+>[ E.E868, E.E869] : (E)[]
 >E.E868 : E.E868
 >E : typeof E
 >E868 : E.E868
@@ -8305,7 +8305,7 @@ function run(a: number) {
 >870 : 870
 
             return [ E.E870, E.E871]
->[ E.E870, E.E871] : E[]
+>[ E.E870, E.E871] : (E)[]
 >E.E870 : E.E870
 >E : typeof E
 >E870 : E.E870
@@ -8317,7 +8317,7 @@ function run(a: number) {
 >872 : 872
 
             return [ E.E872, E.E873]
->[ E.E872, E.E873] : E[]
+>[ E.E872, E.E873] : (E)[]
 >E.E872 : E.E872
 >E : typeof E
 >E872 : E.E872
@@ -8329,7 +8329,7 @@ function run(a: number) {
 >874 : 874
 
             return [ E.E874, E.E875]
->[ E.E874, E.E875] : E[]
+>[ E.E874, E.E875] : (E)[]
 >E.E874 : E.E874
 >E : typeof E
 >E874 : E.E874
@@ -8341,7 +8341,7 @@ function run(a: number) {
 >876 : 876
 
             return [ E.E876, E.E877]
->[ E.E876, E.E877] : E[]
+>[ E.E876, E.E877] : (E)[]
 >E.E876 : E.E876
 >E : typeof E
 >E876 : E.E876
@@ -8353,7 +8353,7 @@ function run(a: number) {
 >878 : 878
 
             return [ E.E878, E.E879]
->[ E.E878, E.E879] : E[]
+>[ E.E878, E.E879] : (E)[]
 >E.E878 : E.E878
 >E : typeof E
 >E878 : E.E878
@@ -8365,7 +8365,7 @@ function run(a: number) {
 >880 : 880
 
             return [ E.E880, E.E881]
->[ E.E880, E.E881] : E[]
+>[ E.E880, E.E881] : (E)[]
 >E.E880 : E.E880
 >E : typeof E
 >E880 : E.E880
@@ -8377,7 +8377,7 @@ function run(a: number) {
 >882 : 882
 
             return [ E.E882, E.E883]
->[ E.E882, E.E883] : E[]
+>[ E.E882, E.E883] : (E)[]
 >E.E882 : E.E882
 >E : typeof E
 >E882 : E.E882
@@ -8389,7 +8389,7 @@ function run(a: number) {
 >884 : 884
 
             return [ E.E884, E.E885]
->[ E.E884, E.E885] : E[]
+>[ E.E884, E.E885] : (E)[]
 >E.E884 : E.E884
 >E : typeof E
 >E884 : E.E884
@@ -8401,7 +8401,7 @@ function run(a: number) {
 >886 : 886
 
             return [ E.E886, E.E887]
->[ E.E886, E.E887] : E[]
+>[ E.E886, E.E887] : (E)[]
 >E.E886 : E.E886
 >E : typeof E
 >E886 : E.E886
@@ -8413,7 +8413,7 @@ function run(a: number) {
 >888 : 888
 
             return [ E.E888, E.E889]
->[ E.E888, E.E889] : E[]
+>[ E.E888, E.E889] : (E)[]
 >E.E888 : E.E888
 >E : typeof E
 >E888 : E.E888
@@ -8425,7 +8425,7 @@ function run(a: number) {
 >890 : 890
 
             return [ E.E890, E.E891]
->[ E.E890, E.E891] : E[]
+>[ E.E890, E.E891] : (E)[]
 >E.E890 : E.E890
 >E : typeof E
 >E890 : E.E890
@@ -8437,7 +8437,7 @@ function run(a: number) {
 >892 : 892
 
             return [ E.E892, E.E893]
->[ E.E892, E.E893] : E[]
+>[ E.E892, E.E893] : (E)[]
 >E.E892 : E.E892
 >E : typeof E
 >E892 : E.E892
@@ -8449,7 +8449,7 @@ function run(a: number) {
 >894 : 894
 
             return [ E.E894, E.E895]
->[ E.E894, E.E895] : E[]
+>[ E.E894, E.E895] : (E)[]
 >E.E894 : E.E894
 >E : typeof E
 >E894 : E.E894
@@ -8461,7 +8461,7 @@ function run(a: number) {
 >896 : 896
 
             return [ E.E896, E.E897]
->[ E.E896, E.E897] : E[]
+>[ E.E896, E.E897] : (E)[]
 >E.E896 : E.E896
 >E : typeof E
 >E896 : E.E896
@@ -8473,7 +8473,7 @@ function run(a: number) {
 >898 : 898
 
             return [ E.E898, E.E899]
->[ E.E898, E.E899] : E[]
+>[ E.E898, E.E899] : (E)[]
 >E.E898 : E.E898
 >E : typeof E
 >E898 : E.E898
@@ -8485,7 +8485,7 @@ function run(a: number) {
 >900 : 900
 
             return [ E.E900, E.E901]
->[ E.E900, E.E901] : E[]
+>[ E.E900, E.E901] : (E)[]
 >E.E900 : E.E900
 >E : typeof E
 >E900 : E.E900
@@ -8497,7 +8497,7 @@ function run(a: number) {
 >902 : 902
 
             return [ E.E902, E.E903]
->[ E.E902, E.E903] : E[]
+>[ E.E902, E.E903] : (E)[]
 >E.E902 : E.E902
 >E : typeof E
 >E902 : E.E902
@@ -8509,7 +8509,7 @@ function run(a: number) {
 >904 : 904
 
             return [ E.E904, E.E905]
->[ E.E904, E.E905] : E[]
+>[ E.E904, E.E905] : (E)[]
 >E.E904 : E.E904
 >E : typeof E
 >E904 : E.E904
@@ -8521,7 +8521,7 @@ function run(a: number) {
 >906 : 906
 
             return [ E.E906, E.E907]
->[ E.E906, E.E907] : E[]
+>[ E.E906, E.E907] : (E)[]
 >E.E906 : E.E906
 >E : typeof E
 >E906 : E.E906
@@ -8533,7 +8533,7 @@ function run(a: number) {
 >908 : 908
 
             return [ E.E908, E.E909]
->[ E.E908, E.E909] : E[]
+>[ E.E908, E.E909] : (E)[]
 >E.E908 : E.E908
 >E : typeof E
 >E908 : E.E908
@@ -8545,7 +8545,7 @@ function run(a: number) {
 >910 : 910
 
             return [ E.E910, E.E911]
->[ E.E910, E.E911] : E[]
+>[ E.E910, E.E911] : (E)[]
 >E.E910 : E.E910
 >E : typeof E
 >E910 : E.E910
@@ -8557,7 +8557,7 @@ function run(a: number) {
 >912 : 912
 
             return [ E.E912, E.E913]
->[ E.E912, E.E913] : E[]
+>[ E.E912, E.E913] : (E)[]
 >E.E912 : E.E912
 >E : typeof E
 >E912 : E.E912
@@ -8569,7 +8569,7 @@ function run(a: number) {
 >914 : 914
 
             return [ E.E914, E.E915]
->[ E.E914, E.E915] : E[]
+>[ E.E914, E.E915] : (E)[]
 >E.E914 : E.E914
 >E : typeof E
 >E914 : E.E914
@@ -8581,7 +8581,7 @@ function run(a: number) {
 >916 : 916
 
             return [ E.E916, E.E917]
->[ E.E916, E.E917] : E[]
+>[ E.E916, E.E917] : (E)[]
 >E.E916 : E.E916
 >E : typeof E
 >E916 : E.E916
@@ -8593,7 +8593,7 @@ function run(a: number) {
 >918 : 918
 
             return [ E.E918, E.E919]
->[ E.E918, E.E919] : E[]
+>[ E.E918, E.E919] : (E)[]
 >E.E918 : E.E918
 >E : typeof E
 >E918 : E.E918
@@ -8605,7 +8605,7 @@ function run(a: number) {
 >920 : 920
 
             return [ E.E920, E.E921]
->[ E.E920, E.E921] : E[]
+>[ E.E920, E.E921] : (E)[]
 >E.E920 : E.E920
 >E : typeof E
 >E920 : E.E920
@@ -8617,7 +8617,7 @@ function run(a: number) {
 >922 : 922
 
             return [ E.E922, E.E923]
->[ E.E922, E.E923] : E[]
+>[ E.E922, E.E923] : (E)[]
 >E.E922 : E.E922
 >E : typeof E
 >E922 : E.E922
@@ -8629,7 +8629,7 @@ function run(a: number) {
 >924 : 924
 
             return [ E.E924, E.E925]
->[ E.E924, E.E925] : E[]
+>[ E.E924, E.E925] : (E)[]
 >E.E924 : E.E924
 >E : typeof E
 >E924 : E.E924
@@ -8641,7 +8641,7 @@ function run(a: number) {
 >926 : 926
 
             return [ E.E926, E.E927]
->[ E.E926, E.E927] : E[]
+>[ E.E926, E.E927] : (E)[]
 >E.E926 : E.E926
 >E : typeof E
 >E926 : E.E926
@@ -8653,7 +8653,7 @@ function run(a: number) {
 >928 : 928
 
             return [ E.E928, E.E929]
->[ E.E928, E.E929] : E[]
+>[ E.E928, E.E929] : (E)[]
 >E.E928 : E.E928
 >E : typeof E
 >E928 : E.E928
@@ -8665,7 +8665,7 @@ function run(a: number) {
 >930 : 930
 
             return [ E.E930, E.E931]
->[ E.E930, E.E931] : E[]
+>[ E.E930, E.E931] : (E)[]
 >E.E930 : E.E930
 >E : typeof E
 >E930 : E.E930
@@ -8677,7 +8677,7 @@ function run(a: number) {
 >932 : 932
 
             return [ E.E932, E.E933]
->[ E.E932, E.E933] : E[]
+>[ E.E932, E.E933] : (E)[]
 >E.E932 : E.E932
 >E : typeof E
 >E932 : E.E932
@@ -8689,7 +8689,7 @@ function run(a: number) {
 >934 : 934
 
             return [ E.E934, E.E935]
->[ E.E934, E.E935] : E[]
+>[ E.E934, E.E935] : (E)[]
 >E.E934 : E.E934
 >E : typeof E
 >E934 : E.E934
@@ -8701,7 +8701,7 @@ function run(a: number) {
 >936 : 936
 
             return [ E.E936, E.E937]
->[ E.E936, E.E937] : E[]
+>[ E.E936, E.E937] : (E)[]
 >E.E936 : E.E936
 >E : typeof E
 >E936 : E.E936
@@ -8713,7 +8713,7 @@ function run(a: number) {
 >938 : 938
 
             return [ E.E938, E.E939]
->[ E.E938, E.E939] : E[]
+>[ E.E938, E.E939] : (E)[]
 >E.E938 : E.E938
 >E : typeof E
 >E938 : E.E938
@@ -8725,7 +8725,7 @@ function run(a: number) {
 >940 : 940
 
             return [ E.E940, E.E941]
->[ E.E940, E.E941] : E[]
+>[ E.E940, E.E941] : (E)[]
 >E.E940 : E.E940
 >E : typeof E
 >E940 : E.E940
@@ -8737,7 +8737,7 @@ function run(a: number) {
 >942 : 942
 
             return [ E.E942, E.E943]
->[ E.E942, E.E943] : E[]
+>[ E.E942, E.E943] : (E)[]
 >E.E942 : E.E942
 >E : typeof E
 >E942 : E.E942
@@ -8749,7 +8749,7 @@ function run(a: number) {
 >944 : 944
 
             return [ E.E944, E.E945]
->[ E.E944, E.E945] : E[]
+>[ E.E944, E.E945] : (E)[]
 >E.E944 : E.E944
 >E : typeof E
 >E944 : E.E944
@@ -8761,7 +8761,7 @@ function run(a: number) {
 >946 : 946
 
             return [ E.E946, E.E947]
->[ E.E946, E.E947] : E[]
+>[ E.E946, E.E947] : (E)[]
 >E.E946 : E.E946
 >E : typeof E
 >E946 : E.E946
@@ -8773,7 +8773,7 @@ function run(a: number) {
 >948 : 948
 
             return [ E.E948, E.E949]
->[ E.E948, E.E949] : E[]
+>[ E.E948, E.E949] : (E)[]
 >E.E948 : E.E948
 >E : typeof E
 >E948 : E.E948
@@ -8785,7 +8785,7 @@ function run(a: number) {
 >950 : 950
 
             return [ E.E950, E.E951]
->[ E.E950, E.E951] : E[]
+>[ E.E950, E.E951] : (E)[]
 >E.E950 : E.E950
 >E : typeof E
 >E950 : E.E950
@@ -8797,7 +8797,7 @@ function run(a: number) {
 >952 : 952
 
             return [ E.E952, E.E953]
->[ E.E952, E.E953] : E[]
+>[ E.E952, E.E953] : (E)[]
 >E.E952 : E.E952
 >E : typeof E
 >E952 : E.E952
@@ -8809,7 +8809,7 @@ function run(a: number) {
 >954 : 954
 
             return [ E.E954, E.E955]
->[ E.E954, E.E955] : E[]
+>[ E.E954, E.E955] : (E)[]
 >E.E954 : E.E954
 >E : typeof E
 >E954 : E.E954
@@ -8821,7 +8821,7 @@ function run(a: number) {
 >956 : 956
 
             return [ E.E956, E.E957]
->[ E.E956, E.E957] : E[]
+>[ E.E956, E.E957] : (E)[]
 >E.E956 : E.E956
 >E : typeof E
 >E956 : E.E956
@@ -8833,7 +8833,7 @@ function run(a: number) {
 >958 : 958
 
             return [ E.E958, E.E959]
->[ E.E958, E.E959] : E[]
+>[ E.E958, E.E959] : (E)[]
 >E.E958 : E.E958
 >E : typeof E
 >E958 : E.E958
@@ -8845,7 +8845,7 @@ function run(a: number) {
 >960 : 960
 
             return [ E.E960, E.E961]
->[ E.E960, E.E961] : E[]
+>[ E.E960, E.E961] : (E)[]
 >E.E960 : E.E960
 >E : typeof E
 >E960 : E.E960
@@ -8857,7 +8857,7 @@ function run(a: number) {
 >962 : 962
 
             return [ E.E962, E.E963]
->[ E.E962, E.E963] : E[]
+>[ E.E962, E.E963] : (E)[]
 >E.E962 : E.E962
 >E : typeof E
 >E962 : E.E962
@@ -8869,7 +8869,7 @@ function run(a: number) {
 >964 : 964
 
             return [ E.E964, E.E965]
->[ E.E964, E.E965] : E[]
+>[ E.E964, E.E965] : (E)[]
 >E.E964 : E.E964
 >E : typeof E
 >E964 : E.E964
@@ -8881,7 +8881,7 @@ function run(a: number) {
 >966 : 966
 
             return [ E.E966, E.E967]
->[ E.E966, E.E967] : E[]
+>[ E.E966, E.E967] : (E)[]
 >E.E966 : E.E966
 >E : typeof E
 >E966 : E.E966
@@ -8893,7 +8893,7 @@ function run(a: number) {
 >968 : 968
 
             return [ E.E968, E.E969]
->[ E.E968, E.E969] : E[]
+>[ E.E968, E.E969] : (E)[]
 >E.E968 : E.E968
 >E : typeof E
 >E968 : E.E968
@@ -8905,7 +8905,7 @@ function run(a: number) {
 >970 : 970
 
             return [ E.E970, E.E971]
->[ E.E970, E.E971] : E[]
+>[ E.E970, E.E971] : (E)[]
 >E.E970 : E.E970
 >E : typeof E
 >E970 : E.E970
@@ -8917,7 +8917,7 @@ function run(a: number) {
 >972 : 972
 
             return [ E.E972, E.E973]
->[ E.E972, E.E973] : E[]
+>[ E.E972, E.E973] : (E)[]
 >E.E972 : E.E972
 >E : typeof E
 >E972 : E.E972
@@ -8929,7 +8929,7 @@ function run(a: number) {
 >974 : 974
 
             return [ E.E974, E.E975]
->[ E.E974, E.E975] : E[]
+>[ E.E974, E.E975] : (E)[]
 >E.E974 : E.E974
 >E : typeof E
 >E974 : E.E974
@@ -8941,7 +8941,7 @@ function run(a: number) {
 >976 : 976
 
             return [ E.E976, E.E977]
->[ E.E976, E.E977] : E[]
+>[ E.E976, E.E977] : (E)[]
 >E.E976 : E.E976
 >E : typeof E
 >E976 : E.E976
@@ -8953,7 +8953,7 @@ function run(a: number) {
 >978 : 978
 
             return [ E.E978, E.E979]
->[ E.E978, E.E979] : E[]
+>[ E.E978, E.E979] : (E)[]
 >E.E978 : E.E978
 >E : typeof E
 >E978 : E.E978
@@ -8965,7 +8965,7 @@ function run(a: number) {
 >980 : 980
 
             return [ E.E980, E.E981]
->[ E.E980, E.E981] : E[]
+>[ E.E980, E.E981] : (E)[]
 >E.E980 : E.E980
 >E : typeof E
 >E980 : E.E980
@@ -8977,7 +8977,7 @@ function run(a: number) {
 >982 : 982
 
             return [ E.E982, E.E983]
->[ E.E982, E.E983] : E[]
+>[ E.E982, E.E983] : (E)[]
 >E.E982 : E.E982
 >E : typeof E
 >E982 : E.E982
@@ -8989,7 +8989,7 @@ function run(a: number) {
 >984 : 984
 
             return [ E.E984, E.E985]
->[ E.E984, E.E985] : E[]
+>[ E.E984, E.E985] : (E)[]
 >E.E984 : E.E984
 >E : typeof E
 >E984 : E.E984
@@ -9001,7 +9001,7 @@ function run(a: number) {
 >986 : 986
 
             return [ E.E986, E.E987]
->[ E.E986, E.E987] : E[]
+>[ E.E986, E.E987] : (E)[]
 >E.E986 : E.E986
 >E : typeof E
 >E986 : E.E986
@@ -9013,7 +9013,7 @@ function run(a: number) {
 >988 : 988
 
             return [ E.E988, E.E989]
->[ E.E988, E.E989] : E[]
+>[ E.E988, E.E989] : (E)[]
 >E.E988 : E.E988
 >E : typeof E
 >E988 : E.E988
@@ -9025,7 +9025,7 @@ function run(a: number) {
 >990 : 990
 
             return [ E.E990, E.E991]
->[ E.E990, E.E991] : E[]
+>[ E.E990, E.E991] : (E)[]
 >E.E990 : E.E990
 >E : typeof E
 >E990 : E.E990
@@ -9037,7 +9037,7 @@ function run(a: number) {
 >992 : 992
 
             return [ E.E992, E.E993]
->[ E.E992, E.E993] : E[]
+>[ E.E992, E.E993] : (E)[]
 >E.E992 : E.E992
 >E : typeof E
 >E992 : E.E992
@@ -9049,7 +9049,7 @@ function run(a: number) {
 >994 : 994
 
             return [ E.E994, E.E995]
->[ E.E994, E.E995] : E[]
+>[ E.E994, E.E995] : (E)[]
 >E.E994 : E.E994
 >E : typeof E
 >E994 : E.E994
@@ -9061,7 +9061,7 @@ function run(a: number) {
 >996 : 996
 
             return [ E.E996, E.E997]
->[ E.E996, E.E997] : E[]
+>[ E.E996, E.E997] : (E)[]
 >E.E996 : E.E996
 >E : typeof E
 >E996 : E.E996
@@ -9073,7 +9073,7 @@ function run(a: number) {
 >998 : 998
 
             return [ E.E998, E.E999]
->[ E.E998, E.E999] : E[]
+>[ E.E998, E.E999] : (E)[]
 >E.E998 : E.E998
 >E : typeof E
 >E998 : E.E998
@@ -9085,7 +9085,7 @@ function run(a: number) {
 >1000 : 1000
 
             return [ E.E1000, E.E1001]
->[ E.E1000, E.E1001] : E[]
+>[ E.E1000, E.E1001] : (E)[]
 >E.E1000 : E.E1000
 >E : typeof E
 >E1000 : E.E1000
@@ -9097,7 +9097,7 @@ function run(a: number) {
 >1002 : 1002
 
             return [ E.E1002, E.E1003]
->[ E.E1002, E.E1003] : E[]
+>[ E.E1002, E.E1003] : (E)[]
 >E.E1002 : E.E1002
 >E : typeof E
 >E1002 : E.E1002
@@ -9109,7 +9109,7 @@ function run(a: number) {
 >1004 : 1004
 
             return [ E.E1004, E.E1005]
->[ E.E1004, E.E1005] : E[]
+>[ E.E1004, E.E1005] : (E)[]
 >E.E1004 : E.E1004
 >E : typeof E
 >E1004 : E.E1004
@@ -9121,7 +9121,7 @@ function run(a: number) {
 >1006 : 1006
 
             return [ E.E1006, E.E1007]
->[ E.E1006, E.E1007] : E[]
+>[ E.E1006, E.E1007] : (E)[]
 >E.E1006 : E.E1006
 >E : typeof E
 >E1006 : E.E1006
@@ -9133,7 +9133,7 @@ function run(a: number) {
 >1008 : 1008
 
             return [ E.E1008, E.E1009]
->[ E.E1008, E.E1009] : E[]
+>[ E.E1008, E.E1009] : (E)[]
 >E.E1008 : E.E1008
 >E : typeof E
 >E1008 : E.E1008
@@ -9145,7 +9145,7 @@ function run(a: number) {
 >1010 : 1010
 
             return [ E.E1010, E.E1011]
->[ E.E1010, E.E1011] : E[]
+>[ E.E1010, E.E1011] : (E)[]
 >E.E1010 : E.E1010
 >E : typeof E
 >E1010 : E.E1010
@@ -9157,7 +9157,7 @@ function run(a: number) {
 >1012 : 1012
 
             return [ E.E1012, E.E1013]
->[ E.E1012, E.E1013] : E[]
+>[ E.E1012, E.E1013] : (E)[]
 >E.E1012 : E.E1012
 >E : typeof E
 >E1012 : E.E1012
@@ -9169,7 +9169,7 @@ function run(a: number) {
 >1014 : 1014
 
             return [ E.E1014, E.E1015]
->[ E.E1014, E.E1015] : E[]
+>[ E.E1014, E.E1015] : (E)[]
 >E.E1014 : E.E1014
 >E : typeof E
 >E1014 : E.E1014
@@ -9181,7 +9181,7 @@ function run(a: number) {
 >1016 : 1016
 
             return [ E.E1016, E.E1017]
->[ E.E1016, E.E1017] : E[]
+>[ E.E1016, E.E1017] : (E)[]
 >E.E1016 : E.E1016
 >E : typeof E
 >E1016 : E.E1016
@@ -9193,7 +9193,7 @@ function run(a: number) {
 >1018 : 1018
 
             return [ E.E1018, E.E1019]
->[ E.E1018, E.E1019] : E[]
+>[ E.E1018, E.E1019] : (E)[]
 >E.E1018 : E.E1018
 >E : typeof E
 >E1018 : E.E1018
@@ -9205,7 +9205,7 @@ function run(a: number) {
 >1020 : 1020
 
             return [ E.E1020, E.E1021]
->[ E.E1020, E.E1021] : E[]
+>[ E.E1020, E.E1021] : (E)[]
 >E.E1020 : E.E1020
 >E : typeof E
 >E1020 : E.E1020
@@ -9217,7 +9217,7 @@ function run(a: number) {
 >1022 : 1022
 
             return [ E.E1022, E.E1023]
->[ E.E1022, E.E1023] : E[]
+>[ E.E1022, E.E1023] : (E)[]
 >E.E1022 : E.E1022
 >E : typeof E
 >E1022 : E.E1022

--- a/tests/baselines/reference/enumMerging.types
+++ b/tests/baselines/reference/enumMerging.types
@@ -48,8 +48,8 @@ module M1 {
     }
 
     var x = [EConst1.A, EConst1.B, EConst1.C, EConst1.D, EConst1.E, EConst1.F];
->x : EConst1[]
->[EConst1.A, EConst1.B, EConst1.C, EConst1.D, EConst1.E, EConst1.F] : EConst1[]
+>x : (EConst1)[]
+>[EConst1.A, EConst1.B, EConst1.C, EConst1.D, EConst1.E, EConst1.F] : (EConst1)[]
 >EConst1.A : EConst1.A
 >EConst1 : typeof EConst1
 >A : EConst1.A

--- a/tests/baselines/reference/instantiatedTypeAliasDisplay.js
+++ b/tests/baselines/reference/instantiatedTypeAliasDisplay.js
@@ -31,5 +31,5 @@ interface Y<B> {
 declare type Z<A, B> = X<A> | Y<B>;
 declare function f1<A>(): Z<A, number>;
 declare function f2<A, B, C, D, E>(a: A, b: B, c: C, d: D): Z<A, string[]>;
-declare const x1: Z<string, number>;
-declare const x2: Z<{}, string[]>;
+declare const x1: Y<number> | X<string>;
+declare const x2: Y<string[]> | X<{}>;

--- a/tests/baselines/reference/interfaceExtendsObjectIntersection.types
+++ b/tests/baselines/reference/interfaceExtendsObjectIntersection.types
@@ -224,7 +224,7 @@ class C21 extends Constructor<Readonly<T1>>() { x: string }
 
 class C22 extends Constructor<Identifiable<T1>>() { x: string }
 >C22 : C22
->Constructor<Identifiable<T1>>() : Identifiable<T1>
+>Constructor<Identifiable<T1>>() : { _id: string; } & T1
 >Constructor : <T>() => Constructor<T>
 >Identifiable : Identifiable<T>
 >T1 : T1
@@ -232,7 +232,7 @@ class C22 extends Constructor<Identifiable<T1>>() { x: string }
 
 class C23 extends Constructor<Identifiable<T1 & { b: number}>>() { x: string }
 >C23 : C23
->Constructor<Identifiable<T1 & { b: number}>>() : Identifiable<T1 & { b: number; }>
+>Constructor<Identifiable<T1 & { b: number}>>() : { _id: string; } & T1 & { b: number; }
 >Constructor : <T>() => Constructor<T>
 >Identifiable : Identifiable<T>
 >T1 : T1

--- a/tests/baselines/reference/interfaceExtendsObjectIntersectionErrors.errors.txt
+++ b/tests/baselines/reference/interfaceExtendsObjectIntersectionErrors.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(7,11): error TS2430: Interface 'I1' incorrectly extends interface 'T1'.
   Types of property 'a' are incompatible.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(8,11): error TS2430: Interface 'I2' incorrectly extends interface 'T2'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(8,11): error TS2430: Interface 'I2' incorrectly extends interface 'T1 & { b: number; }'.
   Type 'I2' is not assignable to type '{ b: number; }'.
     Types of property 'b' are incompatible.
       Type 'string' is not assignable to type 'number'.
@@ -17,7 +17,7 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(16,7): error TS2415: Class 'C1' incorrectly extends base class 'T1'.
   Types of property 'a' are incompatible.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(17,7): error TS2415: Class 'C2' incorrectly extends base class 'T2'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(17,7): error TS2415: Class 'C2' incorrectly extends base class 'T1 & { b: number; }'.
   Type 'C2' is not assignable to type '{ b: number; }'.
     Types of property 'b' are incompatible.
       Type 'string' is not assignable to type 'number'.
@@ -49,11 +49,11 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(40,11): error TS2430: Interface 'I21' incorrectly extends interface 'Readonly<T1>'.
   Types of property 'a' are incompatible.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(41,11): error TS2430: Interface 'I22' incorrectly extends interface 'Identifiable<T1>'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(41,11): error TS2430: Interface 'I22' incorrectly extends interface '{ _id: string; } & T1'.
   Type 'I22' is not assignable to type 'T1'.
     Types of property 'a' are incompatible.
       Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(42,11): error TS2430: Interface 'I23' incorrectly extends interface 'Identifiable<T1 & { b: number; }>'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(42,11): error TS2430: Interface 'I23' incorrectly extends interface '{ _id: string; } & T1 & { b: number; }'.
   Type 'I23' is not assignable to type 'T1'.
     Types of property 'a' are incompatible.
       Type 'string' is not assignable to type 'number'.
@@ -75,7 +75,7 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
 !!! error TS2430:     Type 'string' is not assignable to type 'number'.
     interface I2 extends T2 { b: string }
               ~~
-!!! error TS2430: Interface 'I2' incorrectly extends interface 'T2'.
+!!! error TS2430: Interface 'I2' incorrectly extends interface 'T1 & { b: number; }'.
 !!! error TS2430:   Type 'I2' is not assignable to type '{ b: number; }'.
 !!! error TS2430:     Types of property 'b' are incompatible.
 !!! error TS2430:       Type 'string' is not assignable to type 'number'.
@@ -105,7 +105,7 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
 !!! error TS2415:     Type 'string' is not assignable to type 'number'.
     class C2 extends Constructor<T2>() { b: string }
           ~~
-!!! error TS2415: Class 'C2' incorrectly extends base class 'T2'.
+!!! error TS2415: Class 'C2' incorrectly extends base class 'T1 & { b: number; }'.
 !!! error TS2415:   Type 'C2' is not assignable to type '{ b: number; }'.
 !!! error TS2415:     Types of property 'b' are incompatible.
 !!! error TS2415:       Type 'string' is not assignable to type 'number'.
@@ -174,13 +174,13 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
 !!! error TS2430:     Type 'string' is not assignable to type 'number'.
     interface I22 extends Identifiable<T1> { a: string }
               ~~~
-!!! error TS2430: Interface 'I22' incorrectly extends interface 'Identifiable<T1>'.
+!!! error TS2430: Interface 'I22' incorrectly extends interface '{ _id: string; } & T1'.
 !!! error TS2430:   Type 'I22' is not assignable to type 'T1'.
 !!! error TS2430:     Types of property 'a' are incompatible.
 !!! error TS2430:       Type 'string' is not assignable to type 'number'.
     interface I23 extends Identifiable<T1 & { b: number}> { a: string }
               ~~~
-!!! error TS2430: Interface 'I23' incorrectly extends interface 'Identifiable<T1 & { b: number; }>'.
+!!! error TS2430: Interface 'I23' incorrectly extends interface '{ _id: string; } & T1 & { b: number; }'.
 !!! error TS2430:   Type 'I23' is not assignable to type 'T1'.
 !!! error TS2430:     Types of property 'a' are incompatible.
 !!! error TS2430:       Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/intersectionTypeNormalization.types
+++ b/tests/baselines/reference/intersectionTypeNormalization.types
@@ -24,7 +24,7 @@ type X1 = (A | B) & (C | D);
 >D : D
 
 type X2 = A & (C | D) | B & (C | D)
->X2 : X1
+>X2 : X2
 >A : A
 >C : C
 >D : D
@@ -33,7 +33,7 @@ type X2 = A & (C | D) | B & (C | D)
 >D : D
 
 type X3 = A & C | A & D | B & C | B & D;
->X3 : X1
+>X3 : X3
 >A : A
 >C : C
 >A : A
@@ -49,11 +49,11 @@ var x: X1;
 
 var x: X2;
 >x : X1
->X2 : X1
+>X2 : X2
 
 var x: X3;
 >x : X1
->X3 : X1
+>X3 : X3
 
 interface X { x: string }
 >X : X
@@ -73,7 +73,7 @@ type Y1 = (A | X & Y) & (C | D);
 >D : D
 
 type Y2 = A & (C | D) | X & Y & (C | D)
->Y2 : Y1
+>Y2 : Y2
 >A : A
 >C : C
 >D : D
@@ -83,7 +83,7 @@ type Y2 = A & (C | D) | X & Y & (C | D)
 >D : D
 
 type Y3 = A & C | A & D | X & Y & C | X & Y & D;
->Y3 : Y1
+>Y3 : Y3
 >A : A
 >C : C
 >A : A
@@ -101,11 +101,11 @@ var y: Y1;
 
 var y: Y2;
 >y : Y1
->Y2 : Y1
+>Y2 : Y2
 
 var y: Y3;
 >y : Y1
->Y3 : Y1
+>Y3 : Y3
 
 interface M { m: string }
 >M : M
@@ -126,7 +126,7 @@ type Z1 = (A | X & (M | N)) & (C | D);
 >D : D
 
 type Z2 = A & (C | D) | X & (M | N) & (C | D)
->Z2 : Z1
+>Z2 : Z2
 >A : A
 >C : C
 >D : D
@@ -137,7 +137,7 @@ type Z2 = A & (C | D) | X & (M | N) & (C | D)
 >D : D
 
 type Z3 = A & C | A & D | X & (M | N) & C | X & (M | N) & D;
->Z3 : Z1
+>Z3 : Z3
 >A : A
 >C : C
 >A : A
@@ -152,7 +152,7 @@ type Z3 = A & C | A & D | X & (M | N) & C | X & (M | N) & D;
 >D : D
 
 type Z4 = A & C | A & D | X & M & C | X & N & C | X & M & D | X & N & D;
->Z4 : Z1
+>Z4 : Z4
 >A : A
 >C : C
 >A : A
@@ -176,15 +176,15 @@ var z: Z1;
 
 var z: Z2;
 >z : Z1
->Z2 : Z1
+>Z2 : Z2
 
 var z: Z3;
 >z : Z1
->Z3 : Z1
+>Z3 : Z3
 
 var z: Z4;
 >z : Z1
->Z4 : Z1
+>Z4 : Z4
 
 // Repro from #9919
 

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -145,7 +145,7 @@ type NAME = "name";
 >NAME : "name"
 
 type WIDTH_OR_HEIGHT = "width" | "height";
->WIDTH_OR_HEIGHT : "width" | "height"
+>WIDTH_OR_HEIGHT : WIDTH_OR_HEIGHT
 
 type Q10 = Shape["name"];  // string
 >Q10 : string
@@ -167,7 +167,7 @@ type Q20 = Shape[NAME];  // string
 type Q21 = Shape[WIDTH_OR_HEIGHT];  // number
 >Q21 : number
 >Shape : Shape
->WIDTH_OR_HEIGHT : "width" | "height"
+>WIDTH_OR_HEIGHT : WIDTH_OR_HEIGHT
 
 type Q30 = [string, number][0];  // string
 >Q30 : string
@@ -1988,17 +1988,17 @@ let result = dispatchMethod<SomeMethodDescriptor>("someMethod", ["hello", 35]);
 // Repro from #13073
 
 type KeyTypes = "a" | "b"
->KeyTypes : "a" | "b"
+>KeyTypes : KeyTypes
 
 let MyThingy: { [key in KeyTypes]: string[] };
 >MyThingy : { a: string[]; b: string[]; }
 >key : key
->KeyTypes : "a" | "b"
+>KeyTypes : KeyTypes
 
 function addToMyThingy<S extends KeyTypes>(key: S) {
->addToMyThingy : <S extends "a" | "b">(key: S) => void
+>addToMyThingy : <S extends KeyTypes>(key: S) => void
 >S : S
->KeyTypes : "a" | "b"
+>KeyTypes : KeyTypes
 >key : S
 >S : S
 

--- a/tests/baselines/reference/literalTypeWidening.types
+++ b/tests/baselines/reference/literalTypeWidening.types
@@ -286,14 +286,14 @@ function increment(x: number): number {
 }
 
 let result = doWork<number>();
->result : Result<number>
+>result : number | "FAILURE"
 >doWork<number>() : Result<number>
 >doWork : <T>() => Result<T>
 
 if (isSuccess(result)) {
 >isSuccess(result) : boolean
 >isSuccess : <T>(result: Result<T>) => result is T
->result : Result<number>
+>result : number | "FAILURE"
 
   increment(result);
 >increment(result) : number
@@ -312,7 +312,7 @@ function onMouseOver(): TestEvent { return "onmouseover"; }
 >"onmouseover" : "onmouseover"
 
 let x = onMouseOver();
->x : TestEvent
+>x : "onmouseover" | "onmouseout"
 >onMouseOver() : TestEvent
 >onMouseOver : () => TestEvent
 

--- a/tests/baselines/reference/literalTypes2.types
+++ b/tests/baselines/reference/literalTypes2.types
@@ -797,20 +797,20 @@ function append<T>(a: T[], x: T): T[] {
 }
 
 type Bit = 0 | 1;
->Bit : 0 | 1
+>Bit : Bit
 
 let aa = makeArray<Bit>(0);
->aa : (0 | 1)[]
->makeArray<Bit>(0) : (0 | 1)[]
+>aa : Bit[]
+>makeArray<Bit>(0) : Bit[]
 >makeArray : <T>(x: T) => T[]
->Bit : 0 | 1
+>Bit : Bit
 >0 : 0
 
 aa = append(aa, 1);
 >aa = append(aa, 1) : (0 | 1)[]
->aa : (0 | 1)[]
+>aa : Bit[]
 >append(aa, 1) : (0 | 1)[]
 >append : <T>(a: T[], x: T) => T[]
->aa : (0 | 1)[]
+>aa : Bit[]
 >1 : 1
 

--- a/tests/baselines/reference/narrowTypeByInstanceof.types
+++ b/tests/baselines/reference/narrowTypeByInstanceof.types
@@ -63,7 +63,7 @@ if (elementA instanceof FileMatch && elementB instanceof FileMatch) {
 } else if (elementA instanceof Match && elementB instanceof Match) {
 >elementA instanceof Match && elementB instanceof Match : boolean
 >elementA instanceof Match : boolean
->elementA : FileMatchOrMatch
+>elementA : Match | FileMatch
 >Match : typeof Match
 >elementB instanceof Match : boolean
 >elementB : FileMatchOrMatch

--- a/tests/baselines/reference/numericLiteralTypes1.types
+++ b/tests/baselines/reference/numericLiteralTypes1.types
@@ -49,12 +49,12 @@ type B1 = -1 | 0 | 1;
 >1 : 1
 
 type B2 = 1 | 0 | -1;
->B2 : B1
+>B2 : B2
 >-1 : -1
 >1 : 1
 
 type B3 = 0 | -1 | 1;
->B3 : B1
+>B3 : B3
 >-1 : -1
 >1 : 1
 
@@ -69,12 +69,12 @@ function f2() {
 
     var b: B2 = 0;
 >b : B1
->B2 : B1
+>B2 : B2
 >0 : 0
 
     var b: B3 = 1;
 >b : B1
->B3 : B1
+>B3 : B3
 >1 : 1
 }
 
@@ -268,15 +268,15 @@ function assertNever(x: never): never {
 }
 
 type Tag = 0 | 1 | 2;
->Tag : 0 | 1 | 2
+>Tag : Tag
 
 function f10(x: Tag) {
->f10 : (x: 0 | 1 | 2) => "a" | "b" | "c"
->x : 0 | 1 | 2
->Tag : 0 | 1 | 2
+>f10 : (x: Tag) => "a" | "b" | "c"
+>x : Tag
+>Tag : Tag
 
     switch (x) {
->x : 0 | 1 | 2
+>x : Tag
 
         case 0: return "a";
 >0 : 0
@@ -293,12 +293,12 @@ function f10(x: Tag) {
 }
 
 function f11(x: Tag) {
->f11 : (x: 0 | 1 | 2) => "a" | "b" | "c"
->x : 0 | 1 | 2
->Tag : 0 | 1 | 2
+>f11 : (x: Tag) => "a" | "b" | "c"
+>x : Tag
+>Tag : Tag
 
     switch (x) {
->x : 0 | 1 | 2
+>x : Tag
 
         case 0: return "a";
 >0 : 0
@@ -319,31 +319,31 @@ function f11(x: Tag) {
 }
 
 function f12(x: Tag) {
->f12 : (x: 0 | 1 | 2) => void
->x : 0 | 1 | 2
->Tag : 0 | 1 | 2
+>f12 : (x: Tag) => void
+>x : Tag
+>Tag : Tag
 
     if (x) {
->x : 0 | 1 | 2
+>x : Tag
 
         x;
 >x : 1 | 2
     }
     else {
         x;
->x : 0 | 1 | 2
+>x : Tag
     }
 }
 
 function f13(x: Tag) {
->f13 : (x: 0 | 1 | 2) => void
->x : 0 | 1 | 2
->Tag : 0 | 1 | 2
+>f13 : (x: Tag) => void
+>x : Tag
+>Tag : Tag
 
     if (x === 0 || x === 2) {
 >x === 0 || x === 2 : boolean
 >x === 0 : boolean
->x : 0 | 1 | 2
+>x : Tag
 >0 : 0
 >x === 2 : boolean
 >x : 1 | 2

--- a/tests/baselines/reference/numericLiteralTypes2.types
+++ b/tests/baselines/reference/numericLiteralTypes2.types
@@ -49,12 +49,12 @@ type B1 = -1 | 0 | 1;
 >1 : 1
 
 type B2 = 1 | 0 | -1;
->B2 : B1
+>B2 : B2
 >-1 : -1
 >1 : 1
 
 type B3 = 0 | -1 | 1;
->B3 : B1
+>B3 : B3
 >-1 : -1
 >1 : 1
 
@@ -69,12 +69,12 @@ function f2() {
 
     var b: B2 = 0;
 >b : B1
->B2 : B1
+>B2 : B2
 >0 : 0
 
     var b: B3 = 1;
 >b : B1
->B3 : B1
+>B3 : B3
 >1 : 1
 }
 
@@ -268,15 +268,15 @@ function assertNever(x: never): never {
 }
 
 type Tag = 0 | 1 | 2;
->Tag : 0 | 1 | 2
+>Tag : Tag
 
 function f10(x: Tag) {
->f10 : (x: 0 | 1 | 2) => "a" | "b" | "c"
->x : 0 | 1 | 2
->Tag : 0 | 1 | 2
+>f10 : (x: Tag) => "a" | "b" | "c"
+>x : Tag
+>Tag : Tag
 
     switch (x) {
->x : 0 | 1 | 2
+>x : Tag
 
         case 0: return "a";
 >0 : 0
@@ -293,12 +293,12 @@ function f10(x: Tag) {
 }
 
 function f11(x: Tag) {
->f11 : (x: 0 | 1 | 2) => "a" | "b" | "c"
->x : 0 | 1 | 2
->Tag : 0 | 1 | 2
+>f11 : (x: Tag) => "a" | "b" | "c"
+>x : Tag
+>Tag : Tag
 
     switch (x) {
->x : 0 | 1 | 2
+>x : Tag
 
         case 0: return "a";
 >0 : 0
@@ -319,12 +319,12 @@ function f11(x: Tag) {
 }
 
 function f12(x: Tag) {
->f12 : (x: 0 | 1 | 2) => void
->x : 0 | 1 | 2
->Tag : 0 | 1 | 2
+>f12 : (x: Tag) => void
+>x : Tag
+>Tag : Tag
 
     if (x) {
->x : 0 | 1 | 2
+>x : Tag
 
         x;
 >x : 1 | 2
@@ -336,14 +336,14 @@ function f12(x: Tag) {
 }
 
 function f13(x: Tag) {
->f13 : (x: 0 | 1 | 2) => void
->x : 0 | 1 | 2
->Tag : 0 | 1 | 2
+>f13 : (x: Tag) => void
+>x : Tag
+>Tag : Tag
 
     if (x === 0 || x === 2) {
 >x === 0 || x === 2 : boolean
 >x === 0 : boolean
->x : 0 | 1 | 2
+>x : Tag
 >0 : 0
 >x === 2 : boolean
 >x : 1 | 2

--- a/tests/baselines/reference/partiallyDiscriminantedUnions.types
+++ b/tests/baselines/reference/partiallyDiscriminantedUnions.types
@@ -115,7 +115,7 @@ function fail(s: Shapes) {
         if (s.kind === "circle") {
 >s.kind === "circle" : boolean
 >s.kind : "square" | "circle"
->s : Shape
+>s : Square | Circle
 >kind : "square" | "circle"
 >"circle" : "circle"
 

--- a/tests/baselines/reference/recursiveIntersectionTypes.errors.txt
+++ b/tests/baselines/reference/recursiveIntersectionTypes.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/types/intersection/recursiveIntersectionTypes.ts(19,1): error TS2322: Type 'LinkedList<Entity>' is not assignable to type 'LinkedList<Product>'.
   Type 'LinkedList<Entity>' is not assignable to type 'Product'.
-    Property 'price' is missing in type 'LinkedList<Entity>'.
+    Property 'price' is missing in type 'Entity & { next: LinkedList<Entity>; }'.
 
 
 ==== tests/cases/conformance/types/intersection/recursiveIntersectionTypes.ts (1 errors) ====
@@ -26,5 +26,5 @@ tests/cases/conformance/types/intersection/recursiveIntersectionTypes.ts(19,1): 
     ~~~~~~~~~~~
 !!! error TS2322: Type 'LinkedList<Entity>' is not assignable to type 'LinkedList<Product>'.
 !!! error TS2322:   Type 'LinkedList<Entity>' is not assignable to type 'Product'.
-!!! error TS2322:     Property 'price' is missing in type 'LinkedList<Entity>'.
+!!! error TS2322:     Property 'price' is missing in type 'Entity & { next: LinkedList<Entity>; }'.
     

--- a/tests/baselines/reference/stringEnumLiteralTypes1.types
+++ b/tests/baselines/reference/stringEnumLiteralTypes1.types
@@ -16,14 +16,14 @@ type YesNo = Choice.Yes | Choice.No;
 >No : Choice.No
 
 type NoYes = Choice.No | Choice.Yes;
->NoYes : YesNo
+>NoYes : NoYes
 >Choice : any
 >No : Choice.No
 >Choice : any
 >Yes : Choice.Yes
 
 type UnknownYesNo = Choice.Unknown | Choice.Yes | Choice.No;
->UnknownYesNo : Choice
+>UnknownYesNo : UnknownYesNo
 >Choice : any
 >Unknown : Choice.Unknown
 >Choice : any
@@ -40,7 +40,7 @@ function f1() {
 
     var a: NoYes;
 >a : YesNo
->NoYes : YesNo
+>NoYes : NoYes
 
     var a: Choice.Yes | Choice.No;
 >a : YesNo
@@ -58,17 +58,17 @@ function f1() {
 }
 
 function f2(a: YesNo, b: UnknownYesNo, c: Choice) {
->f2 : (a: YesNo, b: Choice, c: Choice) => void
+>f2 : (a: YesNo, b: UnknownYesNo, c: Choice) => void
 >a : YesNo
 >YesNo : YesNo
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 >c : Choice
 >Choice : Choice
 
     b = a;
 >b = a : YesNo
->b : Choice
+>b : UnknownYesNo
 >a : YesNo
 
     c = a;
@@ -77,9 +77,9 @@ function f2(a: YesNo, b: UnknownYesNo, c: Choice) {
 >a : YesNo
 
     c = b;
->c = b : YesNo
+>c = b : Choice.Yes | Choice.No
 >c : Choice
->b : YesNo
+>b : Choice.Yes | Choice.No
 }
 
 function f3(a: Choice.Yes, b: YesNo) {
@@ -168,11 +168,11 @@ declare function g(x: Choice): number;
 >Choice : Choice
 
 function f5(a: YesNo, b: UnknownYesNo, c: Choice) {
->f5 : (a: YesNo, b: Choice, c: Choice) => void
+>f5 : (a: YesNo, b: UnknownYesNo, c: Choice) => void
 >a : YesNo
 >YesNo : YesNo
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 >c : Choice
 >Choice : Choice
 
@@ -202,7 +202,7 @@ function f5(a: YesNo, b: UnknownYesNo, c: Choice) {
 >z4 : number
 >g(b) : number
 >g : { (x: Choice.Yes): string; (x: Choice.No): boolean; (x: Choice): number; }
->b : Choice
+>b : UnknownYesNo
 
     var z5 = g(c);
 >z5 : number
@@ -270,30 +270,30 @@ function f11(x: YesNo) {
 }
 
 function f12(x: UnknownYesNo) {
->f12 : (x: Choice) => void
->x : Choice
->UnknownYesNo : Choice
+>f12 : (x: UnknownYesNo) => void
+>x : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     if (x) {
->x : Choice
+>x : UnknownYesNo
 
         x;
->x : YesNo
+>x : Choice.Yes | Choice.No
     }
     else {
         x;
->x : Choice
+>x : UnknownYesNo
     }
 }
 
 function f13(x: UnknownYesNo) {
->f13 : (x: Choice) => void
->x : Choice
->UnknownYesNo : Choice
+>f13 : (x: UnknownYesNo) => void
+>x : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     if (x === Choice.Yes) {
 >x === Choice.Yes : boolean
->x : Choice
+>x : UnknownYesNo
 >Choice.Yes : Choice.Yes
 >Choice : typeof Choice
 >Yes : Choice.Yes
@@ -328,9 +328,9 @@ function f20(x: Item) {
 >Item : Item
 
     switch (x.kind) {
->x.kind : YesNo
+>x.kind : Choice.Yes | Choice.No
 >x : Item
->kind : YesNo
+>kind : Choice.Yes | Choice.No
 
         case Choice.Yes: return x.a;
 >Choice.Yes : Choice.Yes
@@ -356,9 +356,9 @@ function f21(x: Item) {
 >Item : Item
 
     switch (x.kind) {
->x.kind : YesNo
+>x.kind : Choice.Yes | Choice.No
 >x : Item
->kind : YesNo
+>kind : Choice.Yes | Choice.No
 
         case Choice.Yes: return x.a;
 >Choice.Yes : Choice.Yes

--- a/tests/baselines/reference/stringEnumLiteralTypes2.types
+++ b/tests/baselines/reference/stringEnumLiteralTypes2.types
@@ -16,14 +16,14 @@ type YesNo = Choice.Yes | Choice.No;
 >No : Choice.No
 
 type NoYes = Choice.No | Choice.Yes;
->NoYes : YesNo
+>NoYes : NoYes
 >Choice : any
 >No : Choice.No
 >Choice : any
 >Yes : Choice.Yes
 
 type UnknownYesNo = Choice.Unknown | Choice.Yes | Choice.No;
->UnknownYesNo : Choice
+>UnknownYesNo : UnknownYesNo
 >Choice : any
 >Unknown : Choice.Unknown
 >Choice : any
@@ -40,7 +40,7 @@ function f1() {
 
     var a: NoYes;
 >a : YesNo
->NoYes : YesNo
+>NoYes : NoYes
 
     var a: Choice.Yes | Choice.No;
 >a : YesNo
@@ -58,17 +58,17 @@ function f1() {
 }
 
 function f2(a: YesNo, b: UnknownYesNo, c: Choice) {
->f2 : (a: YesNo, b: Choice, c: Choice) => void
+>f2 : (a: YesNo, b: UnknownYesNo, c: Choice) => void
 >a : YesNo
 >YesNo : YesNo
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 >c : Choice
 >Choice : Choice
 
     b = a;
 >b = a : YesNo
->b : Choice
+>b : UnknownYesNo
 >a : YesNo
 
     c = a;
@@ -77,9 +77,9 @@ function f2(a: YesNo, b: UnknownYesNo, c: Choice) {
 >a : YesNo
 
     c = b;
->c = b : YesNo
+>c = b : Choice.Yes | Choice.No
 >c : Choice
->b : YesNo
+>b : Choice.Yes | Choice.No
 }
 
 function f3(a: Choice.Yes, b: YesNo) {
@@ -168,11 +168,11 @@ declare function g(x: Choice): number;
 >Choice : Choice
 
 function f5(a: YesNo, b: UnknownYesNo, c: Choice) {
->f5 : (a: YesNo, b: Choice, c: Choice) => void
+>f5 : (a: YesNo, b: UnknownYesNo, c: Choice) => void
 >a : YesNo
 >YesNo : YesNo
->b : Choice
->UnknownYesNo : Choice
+>b : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 >c : Choice
 >Choice : Choice
 
@@ -202,7 +202,7 @@ function f5(a: YesNo, b: UnknownYesNo, c: Choice) {
 >z4 : number
 >g(b) : number
 >g : { (x: Choice.Yes): string; (x: Choice.No): boolean; (x: Choice): number; }
->b : Choice
+>b : UnknownYesNo
 
     var z5 = g(c);
 >z5 : number
@@ -270,15 +270,15 @@ function f11(x: YesNo) {
 }
 
 function f12(x: UnknownYesNo) {
->f12 : (x: Choice) => void
->x : Choice
->UnknownYesNo : Choice
+>f12 : (x: UnknownYesNo) => void
+>x : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     if (x) {
->x : Choice
+>x : UnknownYesNo
 
         x;
->x : YesNo
+>x : Choice.Yes | Choice.No
     }
     else {
         x;
@@ -287,13 +287,13 @@ function f12(x: UnknownYesNo) {
 }
 
 function f13(x: UnknownYesNo) {
->f13 : (x: Choice) => void
->x : Choice
->UnknownYesNo : Choice
+>f13 : (x: UnknownYesNo) => void
+>x : UnknownYesNo
+>UnknownYesNo : UnknownYesNo
 
     if (x === Choice.Yes) {
 >x === Choice.Yes : boolean
->x : Choice
+>x : UnknownYesNo
 >Choice.Yes : Choice.Yes
 >Choice : typeof Choice
 >Yes : Choice.Yes
@@ -328,9 +328,9 @@ function f20(x: Item) {
 >Item : Item
 
     switch (x.kind) {
->x.kind : YesNo
+>x.kind : Choice.Yes | Choice.No
 >x : Item
->kind : YesNo
+>kind : Choice.Yes | Choice.No
 
         case Choice.Yes: return x.a;
 >Choice.Yes : Choice.Yes
@@ -356,9 +356,9 @@ function f21(x: Item) {
 >Item : Item
 
     switch (x.kind) {
->x.kind : YesNo
+>x.kind : Choice.Yes | Choice.No
 >x : Item
->kind : YesNo
+>kind : Choice.Yes | Choice.No
 
         case Choice.Yes: return x.a;
 >Choice.Yes : Choice.Yes

--- a/tests/baselines/reference/stringEnumLiteralTypes3.errors.txt
+++ b/tests/baselines/reference/stringEnumLiteralTypes3.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(10,5): error TS2322: Type 'YesNo' is not assignable to type 'Choice.Yes'.
   Type 'Choice.No' is not assignable to type 'Choice.Yes'.
-tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(11,5): error TS2322: Type 'Choice' is not assignable to type 'Choice.Yes'.
+tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(11,5): error TS2322: Type 'UnknownYesNo' is not assignable to type 'Choice.Yes'.
+  Type 'Choice.Unknown' is not assignable to type 'Choice.Yes'.
 tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(12,5): error TS2322: Type 'Choice' is not assignable to type 'Choice.Yes'.
-tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(18,5): error TS2322: Type 'Choice' is not assignable to type 'YesNo'.
+tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(18,5): error TS2322: Type 'UnknownYesNo' is not assignable to type 'YesNo'.
+  Type 'Choice.Unknown' is not assignable to type 'YesNo'.
 tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(19,5): error TS2322: Type 'Choice' is not assignable to type 'YesNo'.
 tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(37,5): error TS2322: Type 'Choice.Unknown' is not assignable to type 'Choice.Yes'.
 tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(39,5): error TS2322: Type 'Choice.No' is not assignable to type 'Choice.Yes'.
@@ -31,7 +33,8 @@ tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(96,14): error T
 !!! error TS2322:   Type 'Choice.No' is not assignable to type 'Choice.Yes'.
         a = c;
         ~
-!!! error TS2322: Type 'Choice' is not assignable to type 'Choice.Yes'.
+!!! error TS2322: Type 'UnknownYesNo' is not assignable to type 'Choice.Yes'.
+!!! error TS2322:   Type 'Choice.Unknown' is not assignable to type 'Choice.Yes'.
         a = d;
         ~
 !!! error TS2322: Type 'Choice' is not assignable to type 'Choice.Yes'.
@@ -42,7 +45,8 @@ tests/cases/conformance/types/literal/stringEnumLiteralTypes3.ts(96,14): error T
         b = b;
         b = c;
         ~
-!!! error TS2322: Type 'Choice' is not assignable to type 'YesNo'.
+!!! error TS2322: Type 'UnknownYesNo' is not assignable to type 'YesNo'.
+!!! error TS2322:   Type 'Choice.Unknown' is not assignable to type 'YesNo'.
         b = d;
         ~
 !!! error TS2322: Type 'Choice' is not assignable to type 'YesNo'.

--- a/tests/baselines/reference/stringLiteralCheckedInIf01.types
+++ b/tests/baselines/reference/stringLiteralCheckedInIf01.types
@@ -8,7 +8,7 @@ type T = S[] | S;
 >S : S
 
 function f(foo: T) {
->f : (foo: T) => S
+>f : (foo: T) => "a" | "b"
 >foo : T
 >T : T
 

--- a/tests/baselines/reference/stringLiteralCheckedInIf02.types
+++ b/tests/baselines/reference/stringLiteralCheckedInIf02.types
@@ -25,7 +25,7 @@ function isS(t: T): t is S {
 }
 
 function f(foo: T) {
->f : (foo: T) => S
+>f : (foo: T) => "a" | "b"
 >foo : T
 >T : T
 
@@ -35,7 +35,7 @@ function f(foo: T) {
 >foo : T
 
         return foo;
->foo : S
+>foo : "a" | "b"
     }
     else { 
         return foo[0];

--- a/tests/baselines/reference/stringLiteralTypesAndTuples01.js
+++ b/tests/baselines/reference/stringLiteralTypesAndTuples01.js
@@ -37,5 +37,5 @@ function rawr(dino) {
 //// [stringLiteralTypesAndTuples01.d.ts]
 declare let hello: string, brave: string, newish: string, world: string;
 declare type RexOrRaptor = "t-rex" | "raptor";
-declare let im: "I'm", a: "a", dinosaur: RexOrRaptor;
+declare let im: "I'm", a: "a", dinosaur: "t-rex" | "raptor";
 declare function rawr(dino: RexOrRaptor): "ROAAAAR!" | "yip yip!";

--- a/tests/baselines/reference/stringLiteralTypesInUnionTypes01.types
+++ b/tests/baselines/reference/stringLiteralTypesInUnionTypes01.types
@@ -1,14 +1,14 @@
 === tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes01.ts ===
 type T = "foo" | "bar" | "baz";
->T : "foo" | "bar" | "baz"
+>T : T
 
 var x: "foo" | "bar" | "baz" = undefined;
 >x : "foo" | "bar" | "baz"
 >undefined : undefined
 
 var y: T = undefined;
->y : "foo" | "bar" | "baz"
->T : "foo" | "bar" | "baz"
+>y : T
+>T : T
 >undefined : undefined
 
 if (x === "foo") {
@@ -27,9 +27,9 @@ else if (x !== "bar") {
 
     let b = x || y;
 >b : "foo" | "bar" | "baz"
->x || y : "foo" | "bar" | "baz"
+>x || y : T
 >x : "baz"
->y : "foo" | "bar" | "baz"
+>y : T
 }
 else {
     let c = x;
@@ -38,24 +38,24 @@ else {
 
     let d = y;
 >d : "foo" | "bar" | "baz"
->y : "foo" | "bar" | "baz"
+>y : T
 
     let e: (typeof x) | (typeof y) = c || d;
 >e : "foo" | "bar" | "baz"
 >x : "bar"
->y : "foo" | "bar" | "baz"
+>y : T
 >c || d : "foo" | "bar" | "baz"
 >c : "bar"
 >d : "foo" | "bar" | "baz"
 }
 
 x = y;
->x = y : "foo" | "bar" | "baz"
+>x = y : T
 >x : "foo" | "bar" | "baz"
->y : "foo" | "bar" | "baz"
+>y : T
 
 y = x;
 >y = x : "foo" | "bar" | "baz"
->y : "foo" | "bar" | "baz"
+>y : T
 >x : "foo" | "bar" | "baz"
 

--- a/tests/baselines/reference/stringLiteralTypesInUnionTypes03.types
+++ b/tests/baselines/reference/stringLiteralTypesInUnionTypes03.types
@@ -1,13 +1,13 @@
 === tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes03.ts ===
 type T = number | "foo" | "bar";
->T : number | "foo" | "bar"
+>T : T
 
 var x: "foo" | "bar" | number;
 >x : number | "foo" | "bar"
 
 var y: T = undefined;
->y : number | "foo" | "bar"
->T : number | "foo" | "bar"
+>y : T
+>T : T
 >undefined : undefined
 
 if (x === "foo") {
@@ -26,9 +26,9 @@ else if (x !== "bar") {
 
     let b = x || y;
 >b : number | "foo" | "bar"
->x || y : number | "foo" | "bar"
+>x || y : T
 >x : number
->y : number | "foo" | "bar"
+>y : T
 }
 else {
     let c = x;
@@ -37,24 +37,24 @@ else {
 
     let d = y;
 >d : number | "foo" | "bar"
->y : number | "foo" | "bar"
+>y : T
 
     let e: (typeof x) | (typeof y) = c || d;
 >e : number | "foo" | "bar"
 >x : "bar"
->y : number | "foo" | "bar"
+>y : T
 >c || d : number | "foo" | "bar"
 >c : "bar"
 >d : number | "foo" | "bar"
 }
 
 x = y;
->x = y : number | "foo" | "bar"
+>x = y : T
 >x : number | "foo" | "bar"
->y : number | "foo" | "bar"
+>y : T
 
 y = x;
 >y = x : number | "foo" | "bar"
->y : number | "foo" | "bar"
+>y : T
 >x : number | "foo" | "bar"
 

--- a/tests/baselines/reference/stringLiteralTypesInUnionTypes04.types
+++ b/tests/baselines/reference/stringLiteralTypesInUnionTypes04.types
@@ -24,7 +24,7 @@ if (x === "") {
 
 if (x !== "") {
 >x !== "" : boolean
->x : T
+>x : "" | "foo"
 >"" : ""
 
     let b = x;
@@ -34,7 +34,7 @@ if (x !== "") {
 
 if (x == "") {
 >x == "" : boolean
->x : T
+>x : "" | "foo"
 >"" : ""
 
     let c = x;
@@ -44,7 +44,7 @@ if (x == "") {
 
 if (x != "") {
 >x != "" : boolean
->x : T
+>x : "" | "foo"
 >"" : ""
 
     let d = x;
@@ -53,7 +53,7 @@ if (x != "") {
 }
 
 if (x) {
->x : T
+>x : "" | "foo"
 
     let e = x;
 >e : "foo"
@@ -62,17 +62,17 @@ if (x) {
 
 if (!x) {
 >!x : boolean
->x : T
+>x : "" | "foo"
 
     let f = x;
->f : T
->x : T
+>f : "" | "foo"
+>x : "" | "foo"
 }
 
 if (!!x) {
 >!!x : boolean
 >!x : boolean
->x : T
+>x : "" | "foo"
 
     let g = x;
 >g : "foo"
@@ -83,9 +83,9 @@ if (!!!x) {
 >!!!x : boolean
 >!!x : boolean
 >!x : boolean
->x : T
+>x : "" | "foo"
 
     let h = x;
->h : T
->x : T
+>h : "" | "foo"
+>x : "" | "foo"
 }

--- a/tests/baselines/reference/stringLiteralTypesOverloads01.js
+++ b/tests/baselines/reference/stringLiteralTypesOverloads01.js
@@ -108,6 +108,6 @@ declare const boolean: "boolean";
 declare const stringOrNumber: "string" | "number";
 declare const stringOrBoolean: "string" | "boolean";
 declare const booleanOrNumber: "number" | "boolean";
-declare const stringOrBooleanOrNumber: PrimitiveName;
+declare const stringOrBooleanOrNumber: "string" | "number" | "boolean";
 declare namespace Consts2 {
 }

--- a/tests/baselines/reference/stringLiteralTypesOverloads01.types
+++ b/tests/baselines/reference/stringLiteralTypesOverloads01.types
@@ -3,35 +3,35 @@ type PrimitiveName = 'string' | 'number' | 'boolean';
 >PrimitiveName : PrimitiveName
 
 function getFalsyPrimitive(x: "string"): string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >x : "string"
 
 function getFalsyPrimitive(x: "number"): number;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >x : "number"
 
 function getFalsyPrimitive(x: "boolean"): boolean;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >x : "boolean"
 
 function getFalsyPrimitive(x: "boolean" | "string"): boolean | string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >x : "string" | "boolean"
 
 function getFalsyPrimitive(x: "boolean" | "number"): boolean | number;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >x : "number" | "boolean"
 
 function getFalsyPrimitive(x: "number" | "string"): number | string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >x : "string" | "number"
 
 function getFalsyPrimitive(x: "number" | "string" | "boolean"): number | string | boolean;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
->x : PrimitiveName
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>x : "string" | "number" | "boolean"
 
 function getFalsyPrimitive(x: PrimitiveName): number | string | boolean {
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >x : PrimitiveName
 >PrimitiveName : PrimitiveName
 
@@ -71,19 +71,19 @@ namespace Consts1 {
     const EMPTY_STRING = getFalsyPrimitive("string");
 >EMPTY_STRING : string
 >getFalsyPrimitive("string") : string
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >"string" : "string"
 
     const ZERO = getFalsyPrimitive('number');
 >ZERO : number
 >getFalsyPrimitive('number') : number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >'number' : "number"
 
     const FALSE = getFalsyPrimitive("boolean");
 >FALSE : boolean
 >getFalsyPrimitive("boolean") : boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >"boolean" : "boolean"
 }
 
@@ -118,8 +118,8 @@ const booleanOrNumber = number || boolean;
 >boolean : "boolean"
 
 const stringOrBooleanOrNumber = stringOrBoolean || number;
->stringOrBooleanOrNumber : PrimitiveName
->stringOrBoolean || number : PrimitiveName
+>stringOrBooleanOrNumber : "string" | "number" | "boolean"
+>stringOrBoolean || number : "string" | "number" | "boolean"
 >stringOrBoolean : "string" | "boolean"
 >number : "number"
 
@@ -129,44 +129,44 @@ namespace Consts2 {
     const EMPTY_STRING = getFalsyPrimitive(string);
 >EMPTY_STRING : string
 >getFalsyPrimitive(string) : string
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >string : "string"
 
     const ZERO = getFalsyPrimitive(number);
 >ZERO : number
 >getFalsyPrimitive(number) : number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >number : "number"
 
     const FALSE = getFalsyPrimitive(boolean);
 >FALSE : boolean
 >getFalsyPrimitive(boolean) : boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >boolean : "boolean"
 
     const a = getFalsyPrimitive(stringOrNumber);
 >a : string | number
 >getFalsyPrimitive(stringOrNumber) : string | number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >stringOrNumber : "string" | "number"
 
     const b = getFalsyPrimitive(stringOrBoolean);
 >b : string | boolean
 >getFalsyPrimitive(stringOrBoolean) : string | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >stringOrBoolean : "string" | "boolean"
 
     const c = getFalsyPrimitive(booleanOrNumber);
 >c : number | boolean
 >getFalsyPrimitive(booleanOrNumber) : number | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
 >booleanOrNumber : "number" | "boolean"
 
     const d = getFalsyPrimitive(stringOrBooleanOrNumber);
 >d : string | number | boolean
 >getFalsyPrimitive(stringOrBooleanOrNumber) : string | number | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
->stringOrBooleanOrNumber : PrimitiveName
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>stringOrBooleanOrNumber : "string" | "number" | "boolean"
 }
 
 

--- a/tests/baselines/reference/stringLiteralTypesTypePredicates01.types
+++ b/tests/baselines/reference/stringLiteralTypesTypePredicates01.types
@@ -54,7 +54,7 @@ if (!kindIs(x, "B")) {
 >!kindIs(x, "B") : boolean
 >kindIs(x, "B") : boolean
 >kindIs : { (kind: Kind, is: "A"): kind is "A"; (kind: Kind, is: "B"): kind is "B"; }
->x : Kind
+>x : "A" | "B"
 >"B" : "B"
 
     let c = x;

--- a/tests/baselines/reference/typeAliases.types
+++ b/tests/baselines/reference/typeAliases.types
@@ -84,14 +84,14 @@ var x7: T7;
 >T7 : C7
 
 type T8 = string | boolean;
->T8 : string | boolean
+>T8 : T8
 
 var x8: string | boolean;
 >x8 : string | boolean
 
 var x8: T8;
 >x8 : string | boolean
->T8 : string | boolean
+>T8 : T8
 
 type T9 = () => string;
 >T9 : T9

--- a/tests/baselines/reference/typeGuardsAsAssertions.types
+++ b/tests/baselines/reference/typeGuardsAsAssertions.types
@@ -74,7 +74,7 @@ export function fn<r>(makeSome: () => r): void {
 >cond : boolean
 
         result;  // Some<r> | None
->result : Optional<r>
+>result : None | Some<r>
 
         result = someFrom(isSome(result) ? result.some : makeSome());
 >result = someFrom(isSome(result) ? result.some : makeSome()) : { some: r; }
@@ -84,7 +84,7 @@ export function fn<r>(makeSome: () => r): void {
 >isSome(result) ? result.some : makeSome() : r
 >isSome(result) : boolean
 >isSome : <a>(value: Optional<a>) => value is Some<a>
->result : Optional<r>
+>result : None | Some<r>
 >result.some : r
 >result : Some<r>
 >some : r


### PR DESCRIPTION
It's not safe to cache the creation of a value based on only some of the inputs to that creation. This updates the code to not cache the creation of a type alias with `aliasSymbol` defined. (Presumably we will never create a type for the same symbol twice?)