### PR TITLE
Fix https://github.com/Microsoft/TypeScript/issues/15436

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4697,6 +4697,9 @@ namespace ts {
         }
 
         function getTypeOfSymbol(symbol: Symbol): Type {
+            if (!symbol) {
+                return unknownType;
+            }
             if (getCheckFlags(symbol) & CheckFlags.Instantiated) {
                 return getTypeOfInstantiatedSymbol(symbol);
             }


### PR DESCRIPTION
I have found out that ```getTypeOfSymbol``` does not check if its parameter, ```symbol```, exists and produce ```TypeError: Cannot read property 'flags' of undefined``` when using ```no-unused-variable``` from TSLint.

Fixes https://github.com/palantir/tslint/issues/3001 
Also, it is related to https://github.com/Microsoft/TypeScript/issues/15436