### PR TITLE
Tests for #17371

### DIFF
--- a/tests/baselines/reference/importCallExpressionAsyncES3AMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES3AMD.js
@@ -1,0 +1,153 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var _this = this;
+    exports.__esModule = true;
+    function fn() {
+        return __awaiter(this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, new Promise(function (resolve_1, reject_1) { require(['./test'], resolve_1, reject_1); })]; // ONE
+                    case 1:
+                        req = _a.sent() // ONE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        });
+    }
+    exports.fn = fn;
+    var cl1 = (function () {
+        function cl1() {
+        }
+        cl1.prototype.m = function () {
+            return __awaiter(this, void 0, void 0, function () {
+                var req;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, new Promise(function (resolve_2, reject_2) { require(['./test'], resolve_2, reject_2); })]; // TWO
+                        case 1:
+                            req = _a.sent() // TWO
+                            ;
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        };
+        return cl1;
+    }());
+    exports.cl1 = cl1;
+    exports.obj = {
+        m: function () { return __awaiter(_this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, new Promise(function (resolve_3, reject_3) { require(['./test'], resolve_3, reject_3); })]; // THREE
+                    case 1:
+                        req = _a.sent() // THREE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        }); }
+    };
+    var cl2 = (function () {
+        function cl2() {
+            var _this = this;
+            this.p = {
+                m: function () { return __awaiter(_this, void 0, void 0, function () {
+                    var req;
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, new Promise(function (resolve_4, reject_4) { require(['./test'], resolve_4, reject_4); })]; // FOUR
+                            case 1:
+                                req = _a.sent() // FOUR
+                                ;
+                                return [2 /*return*/];
+                        }
+                    });
+                }); }
+            };
+        }
+        return cl2;
+    }());
+    exports.cl2 = cl2;
+    exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+        var req;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, new Promise(function (resolve_5, reject_5) { require(['./test'], resolve_5, reject_5); })]; // FIVE
+                case 1:
+                    req = _a.sent() // FIVE
+                    ;
+                    return [2 /*return*/];
+            }
+        });
+    }); };
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES3AMD.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES3AMD.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES3AMD.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES3AMD.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES3CJS.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES3CJS.js
@@ -1,0 +1,151 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var _this = this;
+exports.__esModule = true;
+function fn() {
+    return __awaiter(this, void 0, void 0, function () {
+        var req;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // ONE
+                case 1:
+                    req = _a.sent() // ONE
+                    ;
+                    return [2 /*return*/];
+            }
+        });
+    });
+}
+exports.fn = fn;
+var cl1 = (function () {
+    function cl1() {
+    }
+    cl1.prototype.m = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // TWO
+                    case 1:
+                        req = _a.sent() // TWO
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    return cl1;
+}());
+exports.cl1 = cl1;
+exports.obj = {
+    m: function () { return __awaiter(_this, void 0, void 0, function () {
+        var req;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // THREE
+                case 1:
+                    req = _a.sent() // THREE
+                    ;
+                    return [2 /*return*/];
+            }
+        });
+    }); }
+};
+var cl2 = (function () {
+    function cl2() {
+        var _this = this;
+        this.p = {
+            m: function () { return __awaiter(_this, void 0, void 0, function () {
+                var req;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // FOUR
+                        case 1:
+                            req = _a.sent() // FOUR
+                            ;
+                            return [2 /*return*/];
+                    }
+                });
+            }); }
+        };
+    }
+    return cl2;
+}());
+exports.cl2 = cl2;
+exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+    var req;
+    return __generator(this, function (_a) {
+        switch (_a.label) {
+            case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // FIVE
+            case 1:
+                req = _a.sent() // FIVE
+                ;
+                return [2 /*return*/];
+        }
+    });
+}); };

--- a/tests/baselines/reference/importCallExpressionAsyncES3CJS.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES3CJS.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES3CJS.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES3CJS.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES3System.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES3System.js
@@ -1,0 +1,159 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+    var __generator = (this && this.__generator) || function (thisArg, body) {
+        var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+        return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+        function verb(n) { return function (v) { return step([n, v]); }; }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_) try {
+                if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+                if (y = 0, t) op = [0, t.value];
+                switch (op[0]) {
+                    case 0: case 1: t = op; break;
+                    case 4: _.label++; return { value: op[1], done: false };
+                    case 5: _.label++; y = op[1]; op = [0]; continue;
+                    case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                    default:
+                        if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                        if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                        if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                        if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                        if (t[2]) _.ops.pop();
+                        _.trys.pop(); continue;
+                }
+                op = body.call(thisArg, _);
+            } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+            if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+    _this = this;
+    var __moduleName = context_1 && context_1.id;
+    function fn() {
+        return __awaiter(this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, context_1["import"]('./test')]; // ONE
+                    case 1:
+                        req = _a.sent() // ONE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        });
+    }
+    exports_1("fn", fn);
+    var _this, cl1, obj, cl2, l;
+    return {
+        setters: [],
+        execute: function () {
+            cl1 = (function () {
+                function cl1() {
+                }
+                cl1.prototype.m = function () {
+                    return __awaiter(this, void 0, void 0, function () {
+                        var req;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4 /*yield*/, context_1["import"]('./test')]; // TWO
+                                case 1:
+                                    req = _a.sent() // TWO
+                                    ;
+                                    return [2 /*return*/];
+                            }
+                        });
+                    });
+                };
+                return cl1;
+            }());
+            exports_1("cl1", cl1);
+            exports_1("obj", obj = {
+                m: function () { return __awaiter(_this, void 0, void 0, function () {
+                    var req;
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, context_1["import"]('./test')]; // THREE
+                            case 1:
+                                req = _a.sent() // THREE
+                                ;
+                                return [2 /*return*/];
+                        }
+                    });
+                }); }
+            });
+            cl2 = (function () {
+                function cl2() {
+                    var _this = this;
+                    this.p = {
+                        m: function () { return __awaiter(_this, void 0, void 0, function () {
+                            var req;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0: return [4 /*yield*/, context_1["import"]('./test')]; // FOUR
+                                    case 1:
+                                        req = _a.sent() // FOUR
+                                        ;
+                                        return [2 /*return*/];
+                                }
+                            });
+                        }); }
+                    };
+                }
+                return cl2;
+            }());
+            exports_1("cl2", cl2);
+            exports_1("l", l = function () { return __awaiter(_this, void 0, void 0, function () {
+                var req;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, context_1["import"]('./test')]; // FIVE
+                        case 1:
+                            req = _a.sent() // FIVE
+                            ;
+                            return [2 /*return*/];
+                    }
+                });
+            }); });
+        }
+    };
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES3System.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES3System.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES3System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES3System.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES3UMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES3UMD.js
@@ -1,0 +1,162 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    var __syncRequire = typeof module === "object" && typeof module.exports === "object";
+    var _this = this;
+    exports.__esModule = true;
+    function fn() {
+        return __awaiter(this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_1, reject_1) { require(['./test'], resolve_1, reject_1); })]; // ONE
+                    case 1:
+                        req = _a.sent() // ONE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        });
+    }
+    exports.fn = fn;
+    var cl1 = (function () {
+        function cl1() {
+        }
+        cl1.prototype.m = function () {
+            return __awaiter(this, void 0, void 0, function () {
+                var req;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_2, reject_2) { require(['./test'], resolve_2, reject_2); })]; // TWO
+                        case 1:
+                            req = _a.sent() // TWO
+                            ;
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        };
+        return cl1;
+    }());
+    exports.cl1 = cl1;
+    exports.obj = {
+        m: function () { return __awaiter(_this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_3, reject_3) { require(['./test'], resolve_3, reject_3); })]; // THREE
+                    case 1:
+                        req = _a.sent() // THREE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        }); }
+    };
+    var cl2 = (function () {
+        function cl2() {
+            var _this = this;
+            this.p = {
+                m: function () { return __awaiter(_this, void 0, void 0, function () {
+                    var req;
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_4, reject_4) { require(['./test'], resolve_4, reject_4); })]; // FOUR
+                            case 1:
+                                req = _a.sent() // FOUR
+                                ;
+                                return [2 /*return*/];
+                        }
+                    });
+                }); }
+            };
+        }
+        return cl2;
+    }());
+    exports.cl2 = cl2;
+    exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+        var req;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_5, reject_5) { require(['./test'], resolve_5, reject_5); })]; // FIVE
+                case 1:
+                    req = _a.sent() // FIVE
+                    ;
+                    return [2 /*return*/];
+            }
+        });
+    }); };
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES3UMD.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES3UMD.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES3UMD.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES3UMD.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES5AMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES5AMD.js
@@ -1,0 +1,153 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var _this = this;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    function fn() {
+        return __awaiter(this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, new Promise(function (resolve_1, reject_1) { require(['./test'], resolve_1, reject_1); })]; // ONE
+                    case 1:
+                        req = _a.sent() // ONE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        });
+    }
+    exports.fn = fn;
+    var cl1 = (function () {
+        function cl1() {
+        }
+        cl1.prototype.m = function () {
+            return __awaiter(this, void 0, void 0, function () {
+                var req;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, new Promise(function (resolve_2, reject_2) { require(['./test'], resolve_2, reject_2); })]; // TWO
+                        case 1:
+                            req = _a.sent() // TWO
+                            ;
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        };
+        return cl1;
+    }());
+    exports.cl1 = cl1;
+    exports.obj = {
+        m: function () { return __awaiter(_this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, new Promise(function (resolve_3, reject_3) { require(['./test'], resolve_3, reject_3); })]; // THREE
+                    case 1:
+                        req = _a.sent() // THREE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        }); }
+    };
+    var cl2 = (function () {
+        function cl2() {
+            var _this = this;
+            this.p = {
+                m: function () { return __awaiter(_this, void 0, void 0, function () {
+                    var req;
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, new Promise(function (resolve_4, reject_4) { require(['./test'], resolve_4, reject_4); })]; // FOUR
+                            case 1:
+                                req = _a.sent() // FOUR
+                                ;
+                                return [2 /*return*/];
+                        }
+                    });
+                }); }
+            };
+        }
+        return cl2;
+    }());
+    exports.cl2 = cl2;
+    exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+        var req;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, new Promise(function (resolve_5, reject_5) { require(['./test'], resolve_5, reject_5); })]; // FIVE
+                case 1:
+                    req = _a.sent() // FIVE
+                    ;
+                    return [2 /*return*/];
+            }
+        });
+    }); };
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES5AMD.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES5AMD.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES5AMD.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES5AMD.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES5CJS.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES5CJS.js
@@ -1,0 +1,151 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var _this = this;
+Object.defineProperty(exports, "__esModule", { value: true });
+function fn() {
+    return __awaiter(this, void 0, void 0, function () {
+        var req;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // ONE
+                case 1:
+                    req = _a.sent() // ONE
+                    ;
+                    return [2 /*return*/];
+            }
+        });
+    });
+}
+exports.fn = fn;
+var cl1 = (function () {
+    function cl1() {
+    }
+    cl1.prototype.m = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // TWO
+                    case 1:
+                        req = _a.sent() // TWO
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    return cl1;
+}());
+exports.cl1 = cl1;
+exports.obj = {
+    m: function () { return __awaiter(_this, void 0, void 0, function () {
+        var req;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // THREE
+                case 1:
+                    req = _a.sent() // THREE
+                    ;
+                    return [2 /*return*/];
+            }
+        });
+    }); }
+};
+var cl2 = (function () {
+    function cl2() {
+        var _this = this;
+        this.p = {
+            m: function () { return __awaiter(_this, void 0, void 0, function () {
+                var req;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // FOUR
+                        case 1:
+                            req = _a.sent() // FOUR
+                            ;
+                            return [2 /*return*/];
+                    }
+                });
+            }); }
+        };
+    }
+    return cl2;
+}());
+exports.cl2 = cl2;
+exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+    var req;
+    return __generator(this, function (_a) {
+        switch (_a.label) {
+            case 0: return [4 /*yield*/, Promise.resolve().then(function () { return require('./test'); })]; // FIVE
+            case 1:
+                req = _a.sent() // FIVE
+                ;
+                return [2 /*return*/];
+        }
+    });
+}); };

--- a/tests/baselines/reference/importCallExpressionAsyncES5CJS.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES5CJS.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES5CJS.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES5CJS.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES5System.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES5System.js
@@ -1,0 +1,159 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+    var __generator = (this && this.__generator) || function (thisArg, body) {
+        var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+        return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+        function verb(n) { return function (v) { return step([n, v]); }; }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_) try {
+                if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+                if (y = 0, t) op = [0, t.value];
+                switch (op[0]) {
+                    case 0: case 1: t = op; break;
+                    case 4: _.label++; return { value: op[1], done: false };
+                    case 5: _.label++; y = op[1]; op = [0]; continue;
+                    case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                    default:
+                        if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                        if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                        if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                        if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                        if (t[2]) _.ops.pop();
+                        _.trys.pop(); continue;
+                }
+                op = body.call(thisArg, _);
+            } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+            if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+    _this = this;
+    var __moduleName = context_1 && context_1.id;
+    function fn() {
+        return __awaiter(this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, context_1.import('./test')]; // ONE
+                    case 1:
+                        req = _a.sent() // ONE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        });
+    }
+    exports_1("fn", fn);
+    var _this, cl1, obj, cl2, l;
+    return {
+        setters: [],
+        execute: function () {
+            cl1 = (function () {
+                function cl1() {
+                }
+                cl1.prototype.m = function () {
+                    return __awaiter(this, void 0, void 0, function () {
+                        var req;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0: return [4 /*yield*/, context_1.import('./test')]; // TWO
+                                case 1:
+                                    req = _a.sent() // TWO
+                                    ;
+                                    return [2 /*return*/];
+                            }
+                        });
+                    });
+                };
+                return cl1;
+            }());
+            exports_1("cl1", cl1);
+            exports_1("obj", obj = {
+                m: function () { return __awaiter(_this, void 0, void 0, function () {
+                    var req;
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, context_1.import('./test')]; // THREE
+                            case 1:
+                                req = _a.sent() // THREE
+                                ;
+                                return [2 /*return*/];
+                        }
+                    });
+                }); }
+            });
+            cl2 = (function () {
+                function cl2() {
+                    var _this = this;
+                    this.p = {
+                        m: function () { return __awaiter(_this, void 0, void 0, function () {
+                            var req;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0: return [4 /*yield*/, context_1.import('./test')]; // FOUR
+                                    case 1:
+                                        req = _a.sent() // FOUR
+                                        ;
+                                        return [2 /*return*/];
+                                }
+                            });
+                        }); }
+                    };
+                }
+                return cl2;
+            }());
+            exports_1("cl2", cl2);
+            exports_1("l", l = function () { return __awaiter(_this, void 0, void 0, function () {
+                var req;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, context_1.import('./test')]; // FIVE
+                        case 1:
+                            req = _a.sent() // FIVE
+                            ;
+                            return [2 /*return*/];
+                    }
+                });
+            }); });
+        }
+    };
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES5System.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES5System.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES5System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES5System.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES5UMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES5UMD.js
@@ -1,0 +1,162 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    var __syncRequire = typeof module === "object" && typeof module.exports === "object";
+    var _this = this;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    function fn() {
+        return __awaiter(this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_1, reject_1) { require(['./test'], resolve_1, reject_1); })]; // ONE
+                    case 1:
+                        req = _a.sent() // ONE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        });
+    }
+    exports.fn = fn;
+    var cl1 = (function () {
+        function cl1() {
+        }
+        cl1.prototype.m = function () {
+            return __awaiter(this, void 0, void 0, function () {
+                var req;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_2, reject_2) { require(['./test'], resolve_2, reject_2); })]; // TWO
+                        case 1:
+                            req = _a.sent() // TWO
+                            ;
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        };
+        return cl1;
+    }());
+    exports.cl1 = cl1;
+    exports.obj = {
+        m: function () { return __awaiter(_this, void 0, void 0, function () {
+            var req;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_3, reject_3) { require(['./test'], resolve_3, reject_3); })]; // THREE
+                    case 1:
+                        req = _a.sent() // THREE
+                        ;
+                        return [2 /*return*/];
+                }
+            });
+        }); }
+    };
+    var cl2 = (function () {
+        function cl2() {
+            var _this = this;
+            this.p = {
+                m: function () { return __awaiter(_this, void 0, void 0, function () {
+                    var req;
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_4, reject_4) { require(['./test'], resolve_4, reject_4); })]; // FOUR
+                            case 1:
+                                req = _a.sent() // FOUR
+                                ;
+                                return [2 /*return*/];
+                        }
+                    });
+                }); }
+            };
+        }
+        return cl2;
+    }());
+    exports.cl2 = cl2;
+    exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+        var req;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_5, reject_5) { require(['./test'], resolve_5, reject_5); })]; // FIVE
+                case 1:
+                    req = _a.sent() // FIVE
+                    ;
+                    return [2 /*return*/];
+            }
+        });
+    }); };
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES5UMD.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES5UMD.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES5UMD.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES5UMD.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES6AMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES6AMD.js
@@ -1,0 +1,75 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    function fn() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const req = yield new Promise(function (resolve_1, reject_1) { require(['./test'], resolve_1, reject_1); }); // ONE
+        });
+    }
+    exports.fn = fn;
+    class cl1 {
+        m() {
+            return __awaiter(this, void 0, void 0, function* () {
+                const req = yield new Promise(function (resolve_2, reject_2) { require(['./test'], resolve_2, reject_2); }); // TWO
+            });
+        }
+    }
+    exports.cl1 = cl1;
+    exports.obj = {
+        m: () => __awaiter(this, void 0, void 0, function* () {
+            const req = yield new Promise(function (resolve_3, reject_3) { require(['./test'], resolve_3, reject_3); }); // THREE
+        })
+    };
+    class cl2 {
+        constructor() {
+            this.p = {
+                m: () => __awaiter(this, void 0, void 0, function* () {
+                    const req = yield new Promise(function (resolve_4, reject_4) { require(['./test'], resolve_4, reject_4); }); // FOUR
+                })
+            };
+        }
+    }
+    exports.cl2 = cl2;
+    exports.l = () => __awaiter(this, void 0, void 0, function* () {
+        const req = yield new Promise(function (resolve_5, reject_5) { require(['./test'], resolve_5, reject_5); }); // FIVE
+    });
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES6AMD.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES6AMD.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES6AMD.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES6AMD.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES6CJS.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES6CJS.js
@@ -1,0 +1,73 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+function fn() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const req = yield Promise.resolve().then(function () { return require('./test'); }); // ONE
+    });
+}
+exports.fn = fn;
+class cl1 {
+    m() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const req = yield Promise.resolve().then(function () { return require('./test'); }); // TWO
+        });
+    }
+}
+exports.cl1 = cl1;
+exports.obj = {
+    m: () => __awaiter(this, void 0, void 0, function* () {
+        const req = yield Promise.resolve().then(function () { return require('./test'); }); // THREE
+    })
+};
+class cl2 {
+    constructor() {
+        this.p = {
+            m: () => __awaiter(this, void 0, void 0, function* () {
+                const req = yield Promise.resolve().then(function () { return require('./test'); }); // FOUR
+            })
+        };
+    }
+}
+exports.cl2 = cl2;
+exports.l = () => __awaiter(this, void 0, void 0, function* () {
+    const req = yield Promise.resolve().then(function () { return require('./test'); }); // FIVE
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES6CJS.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES6CJS.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES6CJS.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES6CJS.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES6System.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES6System.js
@@ -1,0 +1,81 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+    var __moduleName = context_1 && context_1.id;
+    function fn() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const req = yield context_1.import('./test'); // ONE
+        });
+    }
+    exports_1("fn", fn);
+    var cl1, obj, cl2, l;
+    return {
+        setters: [],
+        execute: function () {
+            cl1 = class cl1 {
+                m() {
+                    return __awaiter(this, void 0, void 0, function* () {
+                        const req = yield context_1.import('./test'); // TWO
+                    });
+                }
+            };
+            exports_1("cl1", cl1);
+            exports_1("obj", obj = {
+                m: () => __awaiter(this, void 0, void 0, function* () {
+                    const req = yield context_1.import('./test'); // THREE
+                })
+            });
+            cl2 = class cl2 {
+                constructor() {
+                    this.p = {
+                        m: () => __awaiter(this, void 0, void 0, function* () {
+                            const req = yield context_1.import('./test'); // FOUR
+                        })
+                    };
+                }
+            };
+            exports_1("cl2", cl2);
+            exports_1("l", l = () => __awaiter(this, void 0, void 0, function* () {
+                const req = yield context_1.import('./test'); // FIVE
+            }));
+        }
+    };
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES6System.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES6System.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES6System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES6System.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES6UMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES6UMD.js
@@ -1,0 +1,84 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    var __syncRequire = typeof module === "object" && typeof module.exports === "object";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    function fn() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const req = yield __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_1, reject_1) { require(['./test'], resolve_1, reject_1); }); // ONE
+        });
+    }
+    exports.fn = fn;
+    class cl1 {
+        m() {
+            return __awaiter(this, void 0, void 0, function* () {
+                const req = yield __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_2, reject_2) { require(['./test'], resolve_2, reject_2); }); // TWO
+            });
+        }
+    }
+    exports.cl1 = cl1;
+    exports.obj = {
+        m: () => __awaiter(this, void 0, void 0, function* () {
+            const req = yield __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_3, reject_3) { require(['./test'], resolve_3, reject_3); }); // THREE
+        })
+    };
+    class cl2 {
+        constructor() {
+            this.p = {
+                m: () => __awaiter(this, void 0, void 0, function* () {
+                    const req = yield __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_4, reject_4) { require(['./test'], resolve_4, reject_4); }); // FOUR
+                })
+            };
+        }
+    }
+    exports.cl2 = cl2;
+    exports.l = () => __awaiter(this, void 0, void 0, function* () {
+        const req = yield __syncRequire ? Promise.resolve().then(function () { return require('./test'); }) : new Promise(function (resolve_5, reject_5) { require(['./test'], resolve_5, reject_5); }); // FIVE
+    });
+});

--- a/tests/baselines/reference/importCallExpressionAsyncES6UMD.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncES6UMD.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncES6UMD.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES6UMD.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncESNext.js
+++ b/tests/baselines/reference/importCallExpressionAsyncESNext.js
@@ -1,0 +1,56 @@
+//// [test.ts]
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}
+
+
+//// [test.js]
+export async function fn() {
+    const req = await import('./test'); // ONE
+}
+export class cl1 {
+    async m() {
+        const req = await import('./test'); // TWO
+    }
+}
+export const obj = {
+    m: async () => {
+        const req = await import('./test'); // THREE
+    }
+};
+export class cl2 {
+    constructor() {
+        this.p = {
+            m: async () => {
+                const req = await import('./test'); // FOUR
+            }
+        };
+    }
+}
+export const l = async () => {
+    const req = await import('./test'); // FIVE
+};

--- a/tests/baselines/reference/importCallExpressionAsyncESNext.symbols
+++ b/tests/baselines/reference/importCallExpressionAsyncESNext.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : Symbol(fn, Decl(test.ts, 0, 0))
+
+    const req = await import('./test') // ONE
+>req : Symbol(req, Decl(test.ts, 1, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+
+export class cl1 {
+>cl1 : Symbol(cl1, Decl(test.ts, 2, 1))
+
+    public async m() {
+>m : Symbol(cl1.m, Decl(test.ts, 4, 18))
+
+        const req = await import('./test') // TWO
+>req : Symbol(req, Decl(test.ts, 6, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export const obj = {
+>obj : Symbol(obj, Decl(test.ts, 10, 12))
+
+    m: async () => {
+>m : Symbol(m, Decl(test.ts, 10, 20))
+
+        const req = await import('./test') // THREE
+>req : Symbol(req, Decl(test.ts, 12, 13))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+    }
+}
+
+export class cl2 {
+>cl2 : Symbol(cl2, Decl(test.ts, 14, 1))
+
+    public p = {
+>p : Symbol(cl2.p, Decl(test.ts, 16, 18))
+
+        m: async () => {
+>m : Symbol(m, Decl(test.ts, 17, 16))
+
+            const req = await import('./test') // FOUR
+>req : Symbol(req, Decl(test.ts, 19, 17))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+        }
+    }
+}
+
+export const l = async () => {
+>l : Symbol(l, Decl(test.ts, 24, 12))
+
+    const req = await import('./test') // FIVE
+>req : Symbol(req, Decl(test.ts, 25, 9))
+>'./test' : Symbol("tests/cases/conformance/dynamicImport/test", Decl(test.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/importCallExpressionAsyncESNext.types
+++ b/tests/baselines/reference/importCallExpressionAsyncESNext.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/dynamicImport/test.ts ===
+export async function fn() {
+>fn : () => Promise<void>
+
+    const req = await import('./test') // ONE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+
+export class cl1 {
+>cl1 : cl1
+
+    public async m() {
+>m : () => Promise<void>
+
+        const req = await import('./test') // TWO
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export const obj = {
+>obj : { m: () => Promise<void>; }
+>{    m: async () => {        const req = await import('./test') // THREE    }} : { m: () => Promise<void>; }
+
+    m: async () => {
+>m : () => Promise<void>
+>async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
+
+        const req = await import('./test') // THREE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+    }
+}
+
+export class cl2 {
+>cl2 : cl2
+
+    public p = {
+>p : { m: () => Promise<void>; }
+>{        m: async () => {            const req = await import('./test') // FOUR        }    } : { m: () => Promise<void>; }
+
+        m: async () => {
+>m : () => Promise<void>
+>async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
+
+            const req = await import('./test') // FOUR
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+        }
+    }
+}
+
+export const l = async () => {
+>l : () => Promise<void>
+>async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
+
+    const req = await import('./test') // FIVE
+>req : typeof "tests/cases/conformance/dynamicImport/test"
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>'./test' : "./test"
+}
+

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES3AMD.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES3AMD.ts
@@ -1,0 +1,31 @@
+// @module: amd
+// @target: es3
+// @lib: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES3CJS.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES3CJS.ts
@@ -1,0 +1,31 @@
+// @module: commonjs
+// @target: es3
+// @lib: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES3System.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES3System.ts
@@ -1,0 +1,31 @@
+// @module: system
+// @target: es3
+// @lib: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES3UMD.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES3UMD.ts
@@ -1,0 +1,31 @@
+// @module: umd
+// @target: es3
+// @lib: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES5AMD.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES5AMD.ts
@@ -1,0 +1,31 @@
+// @module: amd
+// @target: es5
+// @lib: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES5CJS.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES5CJS.ts
@@ -1,0 +1,31 @@
+// @module: commonjs
+// @target: es5
+// @lib: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES5System.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES5System.ts
@@ -1,0 +1,31 @@
+// @module: system
+// @target: es5
+// @lib: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES5UMD.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES5UMD.ts
@@ -1,0 +1,31 @@
+// @module: umd
+// @target: es5
+// @lib: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6AMD.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6AMD.ts
@@ -1,0 +1,30 @@
+// @module: amd
+// @target: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6CJS.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6CJS.ts
@@ -1,0 +1,30 @@
+// @module: commonjs
+// @target: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6System.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6System.ts
@@ -1,0 +1,30 @@
+// @module: system
+// @target: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6UMD.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6UMD.ts
@@ -1,0 +1,30 @@
+// @module: umd
+// @target: es6
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionAsyncESNext.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionAsyncESNext.ts
@@ -1,0 +1,30 @@
+// @module: esnext
+// @target: esnext
+// @filename: test.ts
+export async function fn() {
+    const req = await import('./test') // ONE
+}
+
+export class cl1 {
+    public async m() {
+        const req = await import('./test') // TWO
+    }
+}
+
+export const obj = {
+    m: async () => {
+        const req = await import('./test') // THREE
+    }
+}
+
+export class cl2 {
+    public p = {
+        m: async () => {
+            const req = await import('./test') // FOUR
+        }
+    }
+}
+
+export const l = async () => {
+    const req = await import('./test') // FIVE
+}


### PR DESCRIPTION
Adds conformance tests covering #17371, which, as these tests should show, is already fixed. I couldn't find a test for dynamic imports that was simply "awaited dyamic import within an async method", so these tests from the issue add that.

The specific case mentioned in the issue is `importCallExpressionAsyncES6CJS`, however I've also added cover for all the module/target combinations, which seems to be standard for the dynamic import emit (as it depends on both).