### PR TITLE
Rename `symbol.name` to `escapedName` and make `name` unescaped

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1649,7 +1649,7 @@ namespace ts {
             const typeLiteralSymbol = createSymbol(SymbolFlags.TypeLiteral, InternalSymbolName.Type);
             addDeclarationToSymbol(typeLiteralSymbol, node, SymbolFlags.TypeLiteral);
             typeLiteralSymbol.members = createSymbolTable();
-            typeLiteralSymbol.members.set(symbol.name, symbol);
+            typeLiteralSymbol.members.set(symbol.escapedName, symbol);
         }
 
         function bindObjectLiteralExpression(node: ObjectLiteralExpression) {
@@ -2447,14 +2447,14 @@ namespace ts {
             // module might have an exported variable called 'prototype'.  We can't allow that as
             // that would clash with the built-in 'prototype' for the class.
             const prototypeSymbol = createSymbol(SymbolFlags.Property | SymbolFlags.Prototype, "prototype" as __String);
-            const symbolExport = symbol.exports.get(prototypeSymbol.name);
+            const symbolExport = symbol.exports.get(prototypeSymbol.escapedName);
             if (symbolExport) {
                 if (node.name) {
                     node.name.parent = node;
                 }
-                file.bindDiagnostics.push(createDiagnosticForNode(symbolExport.declarations[0], Diagnostics.Duplicate_identifier_0, unescapeLeadingUnderscores(prototypeSymbol.name)));
+                file.bindDiagnostics.push(createDiagnosticForNode(symbolExport.declarations[0], Diagnostics.Duplicate_identifier_0, unescapeLeadingUnderscores(prototypeSymbol.escapedName)));
             }
-            symbol.exports.set(prototypeSymbol.name, prototypeSymbol);
+            symbol.exports.set(prototypeSymbol.escapedName, prototypeSymbol);
             prototypeSymbol.parent = symbol;
         }
 

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -59,7 +59,7 @@ namespace ts {
         const result = createMap<Symbol>() as SymbolTable;
         if (symbols) {
             for (const symbol of symbols) {
-                result.set(symbol.name, symbol);
+                result.set(symbol.escapedName, symbol);
             }
         }
         return result;
@@ -2306,7 +2306,7 @@ namespace ts {
 
     function Symbol(this: Symbol, flags: SymbolFlags, name: __String) {
         this.flags = flags;
-        this.name = name;
+        this.escapedName = name;
         this.declarations = undefined;
     }
 

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2644,7 +2644,7 @@ namespace ts {
          *       on symbol names.
          */
         function recordEmittedDeclarationInScope(node: Node) {
-            const name = node.symbol && node.symbol.name;
+            const name = node.symbol && node.symbol.escapedName;
             if (name) {
                 if (!currentScopeFirstDeclarationsOfName) {
                     currentScopeFirstDeclarationsOfName = createUnderscoreEscapedMap<Node>();
@@ -2662,7 +2662,7 @@ namespace ts {
          */
         function isFirstEmittedDeclarationInScope(node: Node) {
             if (currentScopeFirstDeclarationsOfName) {
-                const name = node.symbol && node.symbol.name;
+                const name = node.symbol && node.symbol.escapedName;
                 if (name) {
                     return currentScopeFirstDeclarationsOfName.get(name) === node;
                 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2899,7 +2899,7 @@ namespace ts {
 
     export interface Symbol {
         flags: SymbolFlags;                     // Symbol flags
-        name: __String;                           // Name of symbol
+        escapedName: __String;                           // Name of symbol
         declarations?: Declaration[];           // Declarations associated with this symbol
         valueDeclaration?: Declaration;         // First value declaration of the symbol
         members?: SymbolTable;                  // Class, interface or literal instance members

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -35,7 +35,7 @@ namespace ts.codefix {
      */
     export function createMissingMemberNodes(classDeclaration: ClassLikeDeclaration, possiblyMissingSymbols: Symbol[], checker: TypeChecker): Node[] {
         const classMembers = classDeclaration.symbol.members;
-        const missingMembers = possiblyMissingSymbols.filter(symbol => !classMembers.has(symbol.name));
+        const missingMembers = possiblyMissingSymbols.filter(symbol => !classMembers.has(symbol.escapedName));
 
         let newNodes: Node[] = [];
         for (const symbol of missingMembers) {
@@ -205,7 +205,7 @@ namespace ts.codefix {
             }
         }
         const maxNonRestArgs = maxArgsSignature.parameters.length - (maxArgsSignature.hasRestParameter ? 1 : 0);
-        const maxArgsParameterSymbolNames = maxArgsSignature.parameters.map(symbol => symbol.getUnescapedName());
+        const maxArgsParameterSymbolNames = maxArgsSignature.parameters.map(symbol => symbol.name);
 
         const parameters = createDummyParameters(maxNonRestArgs, maxArgsParameterSymbolNames, minArgumentCount, /*addAnyType*/ true);
 

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -148,7 +148,7 @@ namespace ts.codefix {
             else if (isJsxOpeningLikeElement(token.parent) && token.parent.tagName === token) {
                 // The error wasn't for the symbolAtLocation, it was for the JSX tag itself, which needs access to e.g. `React`.
                 symbol = checker.getAliasedSymbol(checker.resolveNameAtLocation(token, checker.getJsxNamespace(), SymbolFlags.Value));
-                symbolName = symbol.getUnescapedName();
+                symbolName = symbol.name;
             }
             else {
                 Debug.fail("Either the symbol or the JSX namespace should be a UMD global if we got here");
@@ -171,7 +171,7 @@ namespace ts.codefix {
             const defaultExport = checker.tryGetMemberInModuleExports("default", moduleSymbol);
             if (defaultExport) {
                 const localSymbol = getLocalSymbolForExportDefault(defaultExport);
-                if (localSymbol && localSymbol.name === name && checkSymbolHasMeaning(localSymbol, currentTokenMeaning)) {
+                if (localSymbol && localSymbol.escapedName === name && checkSymbolHasMeaning(localSymbol, currentTokenMeaning)) {
                     // check if this symbol is already used
                     const symbolId = getUniqueSymbolId(localSymbol);
                     symbolIdActionMap.addActions(symbolId, getCodeActionForImport(moduleSymbol, name, /*isDefault*/ true));

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -606,7 +606,7 @@ namespace ts.Completions {
                     if (symbol.flags & (SymbolFlags.Module | SymbolFlags.Enum)) {
                         // Extract module or enum members
                         const exportedSymbols = typeChecker.getExportsOfModule(symbol);
-                        const isValidValueAccess = (symbol: Symbol) => typeChecker.isValidPropertyAccess(<PropertyAccessExpression>(node.parent), symbol.getUnescapedName());
+                        const isValidValueAccess = (symbol: Symbol) => typeChecker.isValidPropertyAccess(<PropertyAccessExpression>(node.parent), symbol.name);
                         const isValidTypeAccess = (symbol: Symbol) => symbolCanBeReferencedAtTypeLocation(symbol);
                         const isValidAccess = isRhsOfImportDeclaration ?
                             // Any kind is allowed when dotting off namespace in internal import equals declaration
@@ -636,7 +636,7 @@ namespace ts.Completions {
         function addTypeProperties(type: Type) {
             // Filter private properties
             for (const symbol of type.getApparentProperties()) {
-                if (typeChecker.isValidPropertyAccess(<PropertyAccessExpression>(node.parent), symbol.getUnescapedName())) {
+                if (typeChecker.isValidPropertyAccess(<PropertyAccessExpression>(node.parent), symbol.name)) {
                     symbols.push(symbol);
                 }
             }
@@ -1457,10 +1457,10 @@ namespace ts.Completions {
             }
 
             if (existingImportsOrExports.size === 0) {
-                return filter(exportsOfModule, e => e.name !== "default");
+                return filter(exportsOfModule, e => e.escapedName !== "default");
             }
 
-            return filter(exportsOfModule, e => e.name !== "default" && !existingImportsOrExports.get(e.name));
+            return filter(exportsOfModule, e => e.escapedName !== "default" && !existingImportsOrExports.get(e.escapedName));
         }
 
         /**
@@ -1510,7 +1510,7 @@ namespace ts.Completions {
                 existingMemberNames.set(existingName, true);
             }
 
-            return filter(contextualMemberSymbols, m => !existingMemberNames.get(m.name));
+            return filter(contextualMemberSymbols, m => !existingMemberNames.get(m.escapedName));
         }
 
         /**
@@ -1571,7 +1571,7 @@ namespace ts.Completions {
             }
 
             function isValidProperty(propertySymbol: Symbol, inValidModifierFlags: ModifierFlags) {
-                return !existingMemberNames.get(propertySymbol.name) &&
+                return !existingMemberNames.get(propertySymbol.escapedName) &&
                     propertySymbol.getDeclarations() &&
                     !(getDeclarationModifierFlagsFromSymbol(propertySymbol) & inValidModifierFlags);
             }
@@ -1596,7 +1596,7 @@ namespace ts.Completions {
                 }
             }
 
-            return filter(symbols, a => !seenNames.get(a.name));
+            return filter(symbols, a => !seenNames.get(a.escapedName));
         }
 
         function isCurrentlyEditingNode(node: Node): boolean {
@@ -1610,7 +1610,7 @@ namespace ts.Completions {
      * @return undefined if the name is of external module
      */
     function getCompletionEntryDisplayNameForSymbol(symbol: Symbol, target: ScriptTarget, performCharacterChecks: boolean): string | undefined {
-        const name = symbol.getUnescapedName();
+        const name = symbol.name;
         if (!name) return undefined;
 
         // First check of the displayName is not external module; if it is an external module, it is not valid entry

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1417,7 +1417,7 @@ namespace ts.FindAllReferences.Core {
         // Property Declaration symbol is a member of the class, so the symbol is stored in its class Declaration.symbol.members
         if (symbol.valueDeclaration && symbol.valueDeclaration.kind === SyntaxKind.Parameter &&
             isParameterPropertyDeclaration(<ParameterDeclaration>symbol.valueDeclaration)) {
-            addRange(result, checker.getSymbolsOfParameterPropertyDeclaration(<ParameterDeclaration>symbol.valueDeclaration, symbol.getUnescapedName()));
+            addRange(result, checker.getSymbolsOfParameterPropertyDeclaration(<ParameterDeclaration>symbol.valueDeclaration, symbol.name));
         }
 
         // If this is symbol of binding element without propertyName declaration in Object binding pattern
@@ -1436,7 +1436,7 @@ namespace ts.FindAllReferences.Core {
 
             // Add symbol of properties/methods of the same name in base classes and implemented interfaces definitions
             if (!implementations && rootSymbol.parent && rootSymbol.parent.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
-                getPropertySymbolsFromBaseTypes(rootSymbol.parent, rootSymbol.getUnescapedName(), result, /*previousIterationSymbolsCache*/ createSymbolTable(), checker);
+                getPropertySymbolsFromBaseTypes(rootSymbol.parent, rootSymbol.name, result, /*previousIterationSymbolsCache*/ createSymbolTable(), checker);
             }
         }
 
@@ -1467,7 +1467,7 @@ namespace ts.FindAllReferences.Core {
         // the function will add any found symbol of the property-name, then its sub-routine will call
         // getPropertySymbolsFromBaseTypes again to walk up any base types to prevent revisiting already
         // visited symbol, interface "C", the sub-routine will pass the current symbol as previousIterationSymbol.
-        if (previousIterationSymbolsCache.has(symbol.name)) {
+        if (previousIterationSymbolsCache.has(symbol.escapedName)) {
             return;
         }
 
@@ -1494,7 +1494,7 @@ namespace ts.FindAllReferences.Core {
                     }
 
                     // Visit the typeReference as well to see if it directly or indirectly use that property
-                    previousIterationSymbolsCache.set(symbol.name, symbol);
+                    previousIterationSymbolsCache.set(symbol.escapedName, symbol);
                     getPropertySymbolsFromBaseTypes(type.symbol, propertyName, result, previousIterationSymbolsCache, checker);
                 }
             }
@@ -1554,7 +1554,7 @@ namespace ts.FindAllReferences.Core {
                 }
 
                 const result: Symbol[] = [];
-                getPropertySymbolsFromBaseTypes(rootSymbol.parent, rootSymbol.getUnescapedName(), result, /*previousIterationSymbolsCache*/ createSymbolTable(), state.checker);
+                getPropertySymbolsFromBaseTypes(rootSymbol.parent, rootSymbol.name, result, /*previousIterationSymbolsCache*/ createSymbolTable(), state.checker);
                 return find(result, search.includes);
             }
 

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -180,7 +180,7 @@ namespace ts.FindAllReferences {
      * But re-exports will be placed in 'singleReferences' since they cannot be locally referenced.
      */
     function getSearchesFromDirectImports(directImports: Importer[], exportSymbol: Symbol, exportKind: ExportKind, checker: TypeChecker, isForRename: boolean): Pick<ImportsResult, "importSearches" | "singleReferences"> {
-        const exportName = exportSymbol.name;
+        const exportName = exportSymbol.escapedName;
         const importSearches: Array<[Identifier, Symbol]> = [];
         const singleReferences: Identifier[] = [];
         function addSearch(location: Identifier, symbol: Symbol): void {
@@ -521,11 +521,11 @@ namespace ts.FindAllReferences {
             // Search on the local symbol in the exporting module, not the exported symbol.
             importedSymbol = skipExportSpecifierSymbol(importedSymbol, checker);
             // Similarly, skip past the symbol for 'export ='
-            if (importedSymbol.name === "export=") {
+            if (importedSymbol.escapedName === "export=") {
                 importedSymbol = getExportEqualsLocalSymbol(importedSymbol, checker);
             }
 
-            if (symbolName(importedSymbol) === symbol.name) { // If this is a rename import, do not continue searching.
+            if (symbolName(importedSymbol) === symbol.escapedName) { // If this is a rename import, do not continue searching.
                 return { kind: ImportExport.Import, symbol: importedSymbol, ...isImport };
             }
         }
@@ -595,8 +595,8 @@ namespace ts.FindAllReferences {
     }
 
     function symbolName(symbol: Symbol): __String | undefined {
-        if (symbol.name !== "default") {
-            return symbol.getName();
+        if (symbol.escapedName !== "default") {
+            return symbol.escapedName;
         }
 
         return forEach(symbol.declarations, decl => {

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -54,7 +54,7 @@ namespace ts.NavigateTo {
             if (decl.kind === SyntaxKind.ImportClause || decl.kind === SyntaxKind.ImportSpecifier || decl.kind === SyntaxKind.ImportEqualsDeclaration) {
                 const importer = checker.getSymbolAtLocation((decl as NamedDeclaration).name);
                 const imported = checker.getAliasedSymbol(importer);
-                return importer.name !== imported.name;
+                return importer.escapedName !== imported.escapedName;
             }
             else {
                 return true;

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -239,7 +239,7 @@ namespace ts.Completions.PathCompletions {
         const moduleNameFragment = isNestedModule ? fragment.substr(0, fragment.lastIndexOf(directorySeparator)) : undefined;
 
         // Get modules that the type checker picked up
-        const ambientModules = map(typeChecker.getAmbientModules(), sym => stripQuotes(sym.getUnescapedName()));
+        const ambientModules = map(typeChecker.getAmbientModules(), sym => stripQuotes(sym.name));
         let nonRelativeModuleNames = filter(ambientModules, moduleName => startsWith(moduleName, fragment));
 
         // Nested modules of the form "module-name/sub" need to be adjusted to only return the string

--- a/src/services/refactors/convertFunctionToEs6Class.ts
+++ b/src/services/refactors/convertFunctionToEs6Class.ts
@@ -163,7 +163,7 @@ namespace ts.refactor {
                 deleteNode(nodeToDelete);
 
                 if (!assignmentBinaryExpression.right) {
-                    return createProperty([], modifiers, symbol.getUnescapedName(), /*questionToken*/ undefined,
+                    return createProperty([], modifiers, symbol.name, /*questionToken*/ undefined,
                         /*type*/ undefined, /*initializer*/ undefined);
                 }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -304,7 +304,7 @@ namespace ts {
 
     class SymbolObject implements Symbol {
         flags: SymbolFlags;
-        name: __String;
+        escapedName: __String;
         declarations?: Declaration[];
 
         // Undefined is used to indicate the value has not been computed. If, after computing, the
@@ -317,19 +317,23 @@ namespace ts {
 
         constructor(flags: SymbolFlags, name: __String) {
             this.flags = flags;
-            this.name = name;
+            this.escapedName = name;
         }
 
         getFlags(): SymbolFlags {
             return this.flags;
         }
 
-        getName(): __String {
-            return this.name;
+        get name(): string {
+            return unescapeLeadingUnderscores(this.escapedName);
         }
 
-        getUnescapedName(): string {
-            return unescapeLeadingUnderscores(this.name);
+        getEscapedName(): __String {
+            return this.escapedName;
+        }
+
+        getName(): string {
+            return this.name;
         }
 
         getDeclarations(): Declaration[] | undefined {

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -414,7 +414,7 @@ namespace ts.SignatureHelp {
                 typeChecker.getSymbolDisplayBuilder().buildParameterDisplay(parameter, writer, invocation));
 
             return {
-                name: parameter.getUnescapedName(),
+                name: parameter.name,
                 documentation: parameter.getDocumentationComment(),
                 displayParts,
                 isOptional: typeChecker.isOptionalParameter(<ParameterDeclaration>parameter.valueDeclaration)
@@ -426,7 +426,7 @@ namespace ts.SignatureHelp {
                 typeChecker.getSymbolDisplayBuilder().buildTypeParameterDisplay(typeParameter, writer, invocation));
 
             return {
-                name: typeParameter.symbol.getUnescapedName(),
+                name: typeParameter.symbol.name,
                 documentation: emptyArray,
                 displayParts,
                 isOptional: false

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -27,9 +27,10 @@ namespace ts {
     }
 
     export interface Symbol {
+        readonly name: string;
         getFlags(): SymbolFlags;
-        getName(): __String;
-        getUnescapedName(): string;
+        getEscapedName(): __String;
+        getName(): string;
         getDeclarations(): Declaration[] | undefined;
         getDocumentationComment(): SymbolDisplayPart[];
         getJsDocTags(): JSDocTagInfo[];

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1090,7 +1090,7 @@ namespace ts {
     /** True if the symbol is for an external module, as opposed to a namespace. */
     export function isExternalModuleSymbol(moduleSymbol: Symbol): boolean {
         Debug.assert(!!(moduleSymbol.flags & SymbolFlags.Module));
-        return moduleSymbol.getUnescapedName().charCodeAt(0) === CharacterCodes.doubleQuote;
+        return moduleSymbol.name.charCodeAt(0) === CharacterCodes.doubleQuote;
     }
 
     /** Returns `true` the first time it encounters a node and `false` afterwards. */


### PR DESCRIPTION
Similar to #17329