### PR TITLE
Actually let you disable colors with jake

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -802,6 +802,13 @@ function deleteTemporaryProjectOutput() {
     }
 }
 
+const boolLookup = {
+    "true": true,
+    "1": true,
+    "false": false,
+    "0": false
+};
+
 function runConsoleTests(defaultReporter, runInParallel) {
     var dirty = process.env.dirty;
     if (!dirty) {
@@ -840,7 +847,7 @@ function runConsoleTests(defaultReporter, runInParallel) {
         testTimeout = 800000;
     }
 
-    var colors = process.env.colors || process.env.color || true;
+    var colors = boolLookup[process.env.colors] !== undefined ? boolLookup[process.env.colors] : boolLookup[process.env.color] !== undefined ? boolLookup[process.env.color] : true;
     var reporter = process.env.reporter || process.env.r || defaultReporter;
     var bail = process.env.bail || process.env.b;
     var lintFlag = process.env.lint !== 'false';

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -802,13 +802,6 @@ function deleteTemporaryProjectOutput() {
     }
 }
 
-const boolLookup = {
-    "true": true,
-    "1": true,
-    "false": false,
-    "0": false
-};
-
 function runConsoleTests(defaultReporter, runInParallel) {
     var dirty = process.env.dirty;
     if (!dirty) {
@@ -847,7 +840,8 @@ function runConsoleTests(defaultReporter, runInParallel) {
         testTimeout = 800000;
     }
 
-    var colors = boolLookup[process.env.colors] !== undefined ? boolLookup[process.env.colors] : boolLookup[process.env.color] !== undefined ? boolLookup[process.env.color] : true;
+    var colorsFlag = process.env.color || process.env.colors;
+    var colors = colorsFlag !== "false" && colorsFlag !== "0";
     var reporter = process.env.reporter || process.env.r || defaultReporter;
     var bail = process.env.bail || process.env.b;
     var lintFlag = process.env.lint !== 'false';


### PR DESCRIPTION
`jake runtests colors=false` ran tests with color. This was (super) noticable in our RWC logs. 

The `Gulpefile` uses minimist for argument parsing and handles the flag correctly on `colors` (just not its aliases, which are not coerced - but that's a minimist issue), so does not need a change.