### PR TITLE
Fix infinite loop in jsdoc parsing

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1865,9 +1865,12 @@ namespace ts {
             let commaStart = -1; // Meaning the previous token was not a comma
             while (true) {
                 if (isListElement(kind, /*inErrorRecovery*/ false)) {
+                    const startPos = scanner.getStartPos();
                     result.push(parseListElement(kind, parseElement));
                     commaStart = scanner.getTokenPos();
+
                     if (parseOptional(SyntaxKind.CommaToken)) {
+                        // No need to check for a zero length node since we know we parsed a comma
                         continue;
                     }
 
@@ -1888,6 +1891,7 @@ namespace ts {
                     if (considerSemicolonAsDelimiter && token() === SyntaxKind.SemicolonToken && !scanner.hasPrecedingLineBreak()) {
                         nextToken();
                     }
+                    checkZeroLengthNode(startPos);
                     continue;
                 }
 
@@ -1913,6 +1917,16 @@ namespace ts {
             result.end = getNodeEnd();
             parsingContext = saveParsingContext;
             return result;
+
+            function checkZeroLengthNode(startPos: number) {
+                if (startPos === scanner.getStartPos()) {
+                    // What we're parsing isn't actually remotely recognizable as a parameter and we've consumed no tokens whatsoever
+                    // Consume a token to advance the parser in some way and avoid an infinite loop in `parseDelimitedList`
+                    // This can happen when we're speculatively parsing parenthesized expressions which we think may be arrow functions,
+                    // or when a modifier keyword which is disallowed as a parameter name (ie, `static` in strict mode) is supplied
+                    nextToken();
+                }
+            }
         }
 
         function createMissingList<T extends Node>(): NodeArray<T> {
@@ -2221,7 +2235,6 @@ namespace ts {
                 return finishNode(node);
             }
 
-            const startPos = scanner.getStartPos();
             node.decorators = parseDecorators();
             node.modifiers = parseModifiers();
             node.dotDotDotToken = parseOptionalToken(SyntaxKind.DotDotDotToken);
@@ -2244,14 +2257,6 @@ namespace ts {
             node.questionToken = parseOptionalToken(SyntaxKind.QuestionToken);
             node.type = parseParameterType();
             node.initializer = parseBindingElementInitializer(/*inParameter*/ true);
-
-            if (startPos === scanner.getStartPos()) {
-                // What we're parsing isn't actually remotely recognizable as a parameter and we've consumed no tokens whatsoever
-                // Consume a token to advance the parser in some way and avoid an infinite loop in `parseDelimitedList`
-                // This can happen when we're speculatively parsing parenthesized expressions which we think may be arrow functions,
-                // or when a modifier keyword which is disallowed as a parameter name (ie, `static` in strict mode) is supplied
-                nextToken();
-            }
 
             return addJSDocComment(finishNode(node));
         }

--- a/tests/baselines/reference/jsdocParameterParsingInfiniteLoop.errors.txt
+++ b/tests/baselines/reference/jsdocParameterParsingInfiniteLoop.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/example.js(3,20): error TS1003: Identifier expected.
+
+
+==== tests/cases/compiler/example.js (1 errors) ====
+    // @ts-check
+    /**
+     * @type {function(@foo)}
+                       ~
+!!! error TS1003: Identifier expected.
+     */
+    let x;

--- a/tests/cases/compiler/jsdocParameterParsingInfiniteLoop.ts
+++ b/tests/cases/compiler/jsdocParameterParsingInfiniteLoop.ts
@@ -1,0 +1,9 @@
+// @filename: example.js
+// @checkJs: true
+// @allowJs: true
+// @noEmit: true
+// @ts-check
+/**
+ * @type {function(@foo)}
+ */
+let x;


### PR DESCRIPTION
I've included a test case demonstrating a (behaviorally) similar bug to those fixed in #17354, but in jsdoc. @sandersn and I were talking about how, after looking at it, it was likely we had a bug like this, so I looked into it and found a reproduction.
The fix generalizes the fix applied in #17354, by moving it into `parseDelimitedList`.
