### PR TITLE
Change isStartOfParameter to be more general

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2219,8 +2219,7 @@ namespace ts {
             return token() === SyntaxKind.DotDotDotToken ||
                 isIdentifierOrPattern() ||
                 isModifierKind(token()) ||
-                token() === SyntaxKind.AtToken || token() === SyntaxKind.ThisKeyword || token() === SyntaxKind.NewKeyword ||
-                token() === SyntaxKind.StringLiteral || token() === SyntaxKind.NumericLiteral;
+                token() === SyntaxKind.AtToken || isStartOfType();
         }
 
         function parseParameter(): ParameterDeclaration {

--- a/tests/baselines/reference/fatarrowfunctionsOptionalArgsErrors2.errors.txt
+++ b/tests/baselines/reference/fatarrowfunctionsOptionalArgsErrors2.errors.txt
@@ -1,10 +1,7 @@
-tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,12): error TS2304: Cannot find name 'a'.
-tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,12): error TS2695: Left side of comma operator is unused and has no side effects.
+tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,15): error TS1003: Identifier expected.
 tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,16): error TS2304: Cannot find name 'b'.
 tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,16): error TS2695: Left side of comma operator is unused and has no side effects.
 tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,19): error TS2304: Cannot find name 'c'.
-tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,23): error TS1005: ';' expected.
-tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,26): error TS2304: Cannot find name 'a'.
 tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,28): error TS2304: Cannot find name 'b'.
 tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(1,30): error TS2304: Cannot find name 'c'.
 tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(2,12): error TS2695: Left side of comma operator is unused and has no side effects.
@@ -21,22 +18,16 @@ tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(4,17): error TS1005
 tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts(4,20): error TS2304: Cannot find name 'a'.
 
 
-==== tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts (21 errors) ====
+==== tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors2.ts (18 errors) ====
     var tt1 = (a, (b, c)) => a+b+c;
-               ~
-!!! error TS2304: Cannot find name 'a'.
-               ~
-!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                  ~
+!!! error TS1003: Identifier expected.
                    ~
 !!! error TS2304: Cannot find name 'b'.
                    ~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
                       ~
 !!! error TS2304: Cannot find name 'c'.
-                          ~~
-!!! error TS1005: ';' expected.
-                             ~
-!!! error TS2304: Cannot find name 'a'.
                                ~
 !!! error TS2304: Cannot find name 'b'.
                                  ~

--- a/tests/baselines/reference/fatarrowfunctionsOptionalArgsErrors2.js
+++ b/tests/baselines/reference/fatarrowfunctionsOptionalArgsErrors2.js
@@ -5,8 +5,10 @@ var tt2 = ((a), b, c) => a+b+c;
 var tt3 = ((a)) => a;
 
 //// [fatarrowfunctionsOptionalArgsErrors2.js]
-var tt1 = (a, (b, c));
-a + b + c;
+var tt1 = function (a, ) {
+    if ( === void 0) {  = (b, c); }
+    return a + b + c;
+};
 var tt2 = ((a), b, c);
 a + b + c;
 var tt3 = ((a));

--- a/tests/baselines/reference/parser512325.errors.txt
+++ b/tests/baselines/reference/parser512325.errors.txt
@@ -1,30 +1,21 @@
-tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,11): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,11): error TS2695: Left side of comma operator is unused and has no side effects.
+tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,14): error TS1003: Identifier expected.
 tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,15): error TS2304: Cannot find name 'b'.
 tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,15): error TS2695: Left side of comma operator is unused and has no side effects.
 tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,18): error TS2304: Cannot find name 'c'.
-tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,22): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,25): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,27): error TS2304: Cannot find name 'b'.
 tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts(1,29): error TS2304: Cannot find name 'c'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts (9 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512325.ts (6 errors) ====
     var tt = (a, (b, c)) => a+b+c;
-              ~
-!!! error TS2304: Cannot find name 'a'.
-              ~
-!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                 ~
+!!! error TS1003: Identifier expected.
                   ~
 !!! error TS2304: Cannot find name 'b'.
                   ~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
                      ~
 !!! error TS2304: Cannot find name 'c'.
-                         ~~
-!!! error TS1005: ';' expected.
-                            ~
-!!! error TS2304: Cannot find name 'a'.
                               ~
 !!! error TS2304: Cannot find name 'b'.
                                 ~

--- a/tests/baselines/reference/parser512325.js
+++ b/tests/baselines/reference/parser512325.js
@@ -2,5 +2,7 @@
 var tt = (a, (b, c)) => a+b+c;
 
 //// [parser512325.js]
-var tt = (a, (b, c));
-a + b + c;
+var tt = function (a, ) {
+    if ( === void 0) {  = (b, c); }
+    return a + b + c;
+};


### PR DESCRIPTION
@sandersn said he wanted to do this while updating our jsdoc parser, but kept running into infinite loops in the parser. With the general fix to that issue applied in #17420, `isStartOfParameter` can now be less ad-hoc and express its intent better, by using `isStartOfType` in full.

This changes our parser errors (and thereby our emit) on a pair of bad-parse baselines, arguably for the better (since the kinda-parameter lists actually get parsed as such now, rather than as parenthesized expressions).