### PR TITLE
Set a high stack trace limit in command-line and server scenarios

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -4,6 +4,18 @@ declare function setTimeout(handler: (...args: any[]) => void, timeout: number):
 declare function clearTimeout(handle: any): void;
 
 namespace ts {
+    /**
+     * Set a high stack trace limit to provide more information in case of an error.
+     * Called for command-line and server use cases.
+     * Not called if TypeScript is used as a library.
+     */
+    /* @internal */
+    export function setStackTraceLimit() {
+        if ((Error as any).stackTraceLimit < 100) { // Also tests that we won't set the property if it doesn't exist.
+            (Error as any).stackTraceLimit = 100;
+        }
+    }
+
     export enum FileWatcherEventKind {
         Created,
         Changed,

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -665,6 +665,8 @@ namespace ts {
     }
 }
 
+ts.setStackTraceLimit();
+
 if (ts.Debug.isDebugging) {
     ts.Debug.enableDebugInfo();
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -757,6 +757,8 @@ namespace ts.server {
         validateLocaleAndSetLanguage(localeStr, sys);
     }
 
+    setStackTraceLimit();
+
     const typingSafeListLocation = findArgument(Arguments.TypingSafeListLocation);
     const npmLocation = findArgument(Arguments.NpmLocation);
 


### PR DESCRIPTION
This would make errors easier to debug.
Tested by adding `Debug.assert(!ts.endsWith(getSourceFileOfNode(node).fileName, "honeypot.ts"));` inside of `checkLiteralExpression`, and got a full stack trace when running `node ../../TypeScript/built/local/tsc.js honeypot.ts`. Also tested it in vscode and got a full stack trace in `tsserver.log`.