### PR TITLE
Allow JSXAttribute to be IdentifierName

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1741,8 +1741,7 @@ namespace ts {
                 node.originalKeywordKind >= SyntaxKind.FirstFutureReservedWord &&
                 node.originalKeywordKind <= SyntaxKind.LastFutureReservedWord &&
                 !isIdentifierName(node) &&
-                !isInAmbientContext(node) &&
-                node.parent.kind !== SyntaxKind.JsxAttribute) {
+                !isInAmbientContext(node)) {
 
                 // Report error only if there are no parse errors in file
                 if (!file.parseDiagnostics.length) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1741,7 +1741,8 @@ namespace ts {
                 node.originalKeywordKind >= SyntaxKind.FirstFutureReservedWord &&
                 node.originalKeywordKind <= SyntaxKind.LastFutureReservedWord &&
                 !isIdentifierName(node) &&
-                !isInAmbientContext(node)) {
+                !isInAmbientContext(node) &&
+                node.parent.kind !== SyntaxKind.JsxAttribute) {
 
                 // Report error only if there are no parse errors in file
                 if (!file.parseDiagnostics.length) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1780,7 +1780,8 @@ namespace ts {
                 // Property name in binding element or import specifier
                 return (<BindingElement | ImportSpecifier>parent).propertyName === node;
             case SyntaxKind.ExportSpecifier:
-                // Any name in an export specifier
+            case SyntaxKind.JsxAttribute:
+                // Any name in an export specifier or JSX Attribute
                 return true;
         }
         return false;

--- a/tests/baselines/reference/jsxPropsAsIdentifierNames.js
+++ b/tests/baselines/reference/jsxPropsAsIdentifierNames.js
@@ -1,0 +1,16 @@
+//// [index.tsx]
+declare namespace JSX {
+    interface Element { }
+    interface IntrinsicElements {
+        div: {
+            static?: boolean;
+        };
+    }
+}
+export default <div static={true} />;
+
+
+//// [index.jsx]
+"use strict";
+exports.__esModule = true;
+exports["default"] = <div static={true}/>;

--- a/tests/baselines/reference/jsxPropsAsIdentifierNames.symbols
+++ b/tests/baselines/reference/jsxPropsAsIdentifierNames.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/index.tsx ===
+declare namespace JSX {
+>JSX : Symbol(JSX, Decl(index.tsx, 0, 0))
+
+    interface Element { }
+>Element : Symbol(Element, Decl(index.tsx, 0, 23))
+
+    interface IntrinsicElements {
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(index.tsx, 1, 25))
+
+        div: {
+>div : Symbol(IntrinsicElements.div, Decl(index.tsx, 2, 33))
+
+            static?: boolean;
+>static : Symbol(static, Decl(index.tsx, 3, 14))
+
+        };
+    }
+}
+export default <div static={true} />;
+>div : Symbol(unknown)
+>static : Symbol(static, Decl(index.tsx, 8, 19))
+

--- a/tests/baselines/reference/jsxPropsAsIdentifierNames.types
+++ b/tests/baselines/reference/jsxPropsAsIdentifierNames.types
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/index.tsx ===
+declare namespace JSX {
+>JSX : any
+
+    interface Element { }
+>Element : Element
+
+    interface IntrinsicElements {
+>IntrinsicElements : IntrinsicElements
+
+        div: {
+>div : { static?: boolean; }
+
+            static?: boolean;
+>static : boolean
+
+        };
+    }
+}
+export default <div static={true} />;
+><div static={true} /> : any
+>div : any
+>static : boolean
+>true : true
+

--- a/tests/cases/compiler/jsxPropsAsIdentifierNames.tsx
+++ b/tests/cases/compiler/jsxPropsAsIdentifierNames.tsx
@@ -1,0 +1,12 @@
+// @jsx: preserve
+
+// @filename: index.tsx
+declare namespace JSX {
+    interface Element { }
+    interface IntrinsicElements {
+        div: {
+            static?: boolean;
+        };
+    }
+}
+export default <div static={true} />;


### PR DESCRIPTION
Fixes #17452 

This change makes it so that we do not report strict mode identifier-name errors on jsx attributes.