### PR TITLE
Enable spelling quick fixes for left side of property access

### DIFF
--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -15,7 +15,8 @@ namespace ts.codefix {
         const node = getTokenAtPosition(sourceFile, context.span.start, /*includeJsDocComment*/ false); // TODO: GH#15852
         const checker = context.program.getTypeChecker();
         let suggestion: string;
-        if (node.kind === SyntaxKind.Identifier && isPropertyAccessExpression(node.parent)) {
+        if (isPropertyAccessExpression(node.parent) && node.parent.name === node) {
+            Debug.assert(node.kind === SyntaxKind.Identifier);
             const containingType = checker.getTypeAtLocation(node.parent.expression);
             suggestion = checker.getSuggestionForNonexistentProperty(node as Identifier, containingType);
         }

--- a/tests/cases/fourslash/codeFixCorrectSpelling4.ts
+++ b/tests/cases/fourslash/codeFixCorrectSpelling4.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+//// export declare const despite: { the: any };
+////
+//// [|dispite.the|]
+
+verify.rangeAfterCodeFix(`despite.the`);


### PR DESCRIPTION
Fixes #17472. This is also an alternative fix to #17460 (#17465 is the current one).