### PR TITLE
Create synthetic default exports for dynamic imports

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16330,8 +16330,7 @@ namespace ts {
                         const defaultSymbol = getPropertyOfType(type, InternalSymbolName.Default);
                         if (!defaultSymbol) {
                             const memberTable = createSymbolTable();
-                            const newSymbol = cloneSymbol(esModuleSymbol);
-                            newSymbol.escapedName = InternalSymbolName.Default;
+                            const newSymbol = copySymbol(esModuleSymbol, InternalSymbolName.Default);
                             memberTable.set(InternalSymbolName.Default, newSymbol);
                             const syntheticType = getIntersectionType([type, createAnonymousType(createSymbol(esModuleSymbol.flags, InternalSymbolName.Synthetic), memberTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined)]);
                             return createPromiseReturnType(node, syntheticType);
@@ -16341,6 +16340,17 @@ namespace ts {
                 }
             }
             return createPromiseReturnType(node, anyType);
+
+            function copySymbol(symbol: Symbol, name: __String): Symbol {
+                const result = createSymbol(symbol.flags, name);
+                result.declarations = symbol.declarations.slice(0);
+                result.parent = symbol.parent;
+                if (symbol.valueDeclaration) result.valueDeclaration = symbol.valueDeclaration;
+                if (symbol.constEnumOnlyModule) result.constEnumOnlyModule = true;
+                if (symbol.members) result.members = cloneMap(symbol.members);
+                if (symbol.exports) result.exports = cloneMap(symbol.exports);
+                return result;
+            }
         }
 
         function isCommonJsRequire(node: Node) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16335,19 +16335,15 @@ namespace ts {
             if (allowSyntheticDefaultImports && type && type !== unknownType) {
                 const synthType = type as SyntheticDefaultModuleType;
                 if (!synthType.syntheticType) {
-                    const defaultSymbol = getPropertyOfType(type, InternalSymbolName.Default);
-                    if (!defaultSymbol) {
+                    if (!getPropertyOfType(type, InternalSymbolName.Default)) {
                         const memberTable = createSymbolTable();
                         const newSymbol = createSymbol(SymbolFlags.Alias, InternalSymbolName.Default);
-                        getSymbolLinks(newSymbol).target = resolveSymbol(symbol);
+                        newSymbol.target = resolveSymbol(symbol);
                         memberTable.set(InternalSymbolName.Default, newSymbol);
                         const anonymousSymbol = createSymbol(SymbolFlags.TypeLiteral, InternalSymbolName.Type);
                         const defaultContainingObject = createAnonymousType(anonymousSymbol, memberTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
-                        const resolved = resolveStructuredTypeMembers(defaultContainingObject);
-                        resolved.properties = [newSymbol];
-                        getSymbolLinks(anonymousSymbol).type = defaultContainingObject;
-                        const newType = getIntersectionType([type, defaultContainingObject]);
-                        synthType.syntheticType = newType;
+                        anonymousSymbol.type = defaultContainingObject;
+                        synthType.syntheticType = getIntersectionType([type, defaultContainingObject]);
                     }
                     else {
                         synthType.syntheticType = type;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16325,13 +16325,13 @@ namespace ts {
             if (moduleSymbol) {
                 const esModuleSymbol = resolveESModuleSymbol(moduleSymbol, specifier, /*dontRecursivelyResolve*/ true);
                 if (esModuleSymbol) {
-                    return createPromiseReturnType(node, syntheticDefaultType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol));
+                    return createPromiseReturnType(node, getTypeWithSyntheticDefaultImportType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol));
                 }
             }
             return createPromiseReturnType(node, anyType);
         }
 
-        function syntheticDefaultType(type: Type, symbol: Symbol): Type {
+        function getTypeWithSyntheticDefaultImportType(type: Type, symbol: Symbol): Type {
             if (allowSyntheticDefaultImports && type && type !== unknownType) {
                 const synthType = type as SyntheticDefaultModuleType;
                 if (!synthType.syntheticType) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16333,20 +16333,27 @@ namespace ts {
 
         function syntheticDefaultType(type: Type, symbol: Symbol): Type {
             if (allowSyntheticDefaultImports && type && type !== unknownType) {
-                const defaultSymbol = getPropertyOfType(type, InternalSymbolName.Default);
-                if (!defaultSymbol) {
-                    const memberTable = createSymbolTable();
-                    const newSymbol = createSymbol(SymbolFlags.Alias, InternalSymbolName.Default);
-                    getSymbolLinks(newSymbol).target = resolveSymbol(symbol);
-                    memberTable.set(InternalSymbolName.Default, newSymbol);
-                    const anonymousSymbol = createSymbol(SymbolFlags.TypeLiteral, InternalSymbolName.Type);
-                    const defaultContainingObject = createAnonymousType(anonymousSymbol, memberTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
-                    const resolved = resolveStructuredTypeMembers(defaultContainingObject);
-                    resolved.properties = [newSymbol];
-                    getSymbolLinks(anonymousSymbol).type = defaultContainingObject;
-                    const newType = getIntersectionType([type, defaultContainingObject]);
-                    return newType;
+                const synthType = type as SyntheticDefaultModuleType;
+                if (!synthType.syntheticType) {
+                    const defaultSymbol = getPropertyOfType(type, InternalSymbolName.Default);
+                    if (!defaultSymbol) {
+                        const memberTable = createSymbolTable();
+                        const newSymbol = createSymbol(SymbolFlags.Alias, InternalSymbolName.Default);
+                        getSymbolLinks(newSymbol).target = resolveSymbol(symbol);
+                        memberTable.set(InternalSymbolName.Default, newSymbol);
+                        const anonymousSymbol = createSymbol(SymbolFlags.TypeLiteral, InternalSymbolName.Type);
+                        const defaultContainingObject = createAnonymousType(anonymousSymbol, memberTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
+                        const resolved = resolveStructuredTypeMembers(defaultContainingObject);
+                        resolved.properties = [newSymbol];
+                        getSymbolLinks(anonymousSymbol).type = defaultContainingObject;
+                        const newType = getIntersectionType([type, defaultContainingObject]);
+                        synthType.syntheticType = newType;
+                    }
+                    else {
+                        synthType.syntheticType = type;
+                    }
                 }
+                return synthType.syntheticType;
             }
             return type;
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2979,7 +2979,6 @@ namespace ts {
         Function = "__function", // Unnamed function expression
         Computed = "__computed", // Computed property name declaration with dynamic name
         Resolving = "__resolving__", // Indicator symbol used to mark partially resolved type aliases
-        Synthetic = "__synthetic", // Symbol name used for the object intersected to create a synthetic default export
         ExportEquals = "export=", // Export assignment symbol
         Default = "default", // Default export symbol (technically not wholly internal, but included here for usability)
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2979,6 +2979,7 @@ namespace ts {
         Function = "__function", // Unnamed function expression
         Computed = "__computed", // Computed property name declaration with dynamic name
         Resolving = "__resolving__", // Indicator symbol used to mark partially resolved type aliases
+        Synthetic = "__synthetic", // Symbol name used for the object intersected to create a synthetic default export
         ExportEquals = "export=", // Export assignment symbol
         Default = "default", // Default export symbol (technically not wholly internal, but included here for usability)
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3317,6 +3317,11 @@ namespace ts {
         awaitedTypeOfType?: Type;
     }
 
+    /* @internal */
+    export interface SyntheticDefaultModuleType extends Type {
+        syntheticType?: Type;
+    }
+
     export interface TypeVariable extends Type {
         /* @internal */
         resolvedBaseConstraint: Type;

--- a/tests/baselines/reference/importCallExpressionAsyncES3System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES3System.types
@@ -3,9 +3,9 @@ export async function fn() {
 >fn : () => Promise<void>
 
     const req = await import('./test') // ONE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
 }
 
@@ -16,9 +16,9 @@ export class cl1 {
 >m : () => Promise<void>
 
         const req = await import('./test') // TWO
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
     }
 }
@@ -32,9 +32,9 @@ export const obj = {
 >async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
 
         const req = await import('./test') // THREE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
     }
 }
@@ -51,9 +51,9 @@ export class cl2 {
 >async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
 
             const req = await import('./test') // FOUR
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
         }
     }
@@ -64,9 +64,9 @@ export const l = async () => {
 >async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
 
     const req = await import('./test') // FIVE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
 }
 

--- a/tests/baselines/reference/importCallExpressionAsyncES3System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES3System.types
@@ -3,9 +3,9 @@ export async function fn() {
 >fn : () => Promise<void>
 
     const req = await import('./test') // ONE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
 }
 
@@ -16,9 +16,9 @@ export class cl1 {
 >m : () => Promise<void>
 
         const req = await import('./test') // TWO
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
     }
 }
@@ -32,9 +32,9 @@ export const obj = {
 >async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
 
         const req = await import('./test') // THREE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
     }
 }
@@ -51,9 +51,9 @@ export class cl2 {
 >async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
 
             const req = await import('./test') // FOUR
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
         }
     }
@@ -64,9 +64,9 @@ export const l = async () => {
 >async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
 
     const req = await import('./test') // FIVE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
 }
 

--- a/tests/baselines/reference/importCallExpressionAsyncES5System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES5System.types
@@ -3,9 +3,9 @@ export async function fn() {
 >fn : () => Promise<void>
 
     const req = await import('./test') // ONE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
 }
 
@@ -16,9 +16,9 @@ export class cl1 {
 >m : () => Promise<void>
 
         const req = await import('./test') // TWO
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
     }
 }
@@ -32,9 +32,9 @@ export const obj = {
 >async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
 
         const req = await import('./test') // THREE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
     }
 }
@@ -51,9 +51,9 @@ export class cl2 {
 >async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
 
             const req = await import('./test') // FOUR
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
         }
     }
@@ -64,9 +64,9 @@ export const l = async () => {
 >async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
 
     const req = await import('./test') // FIVE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
 }
 

--- a/tests/baselines/reference/importCallExpressionAsyncES5System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES5System.types
@@ -3,9 +3,9 @@ export async function fn() {
 >fn : () => Promise<void>
 
     const req = await import('./test') // ONE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
 }
 
@@ -16,9 +16,9 @@ export class cl1 {
 >m : () => Promise<void>
 
         const req = await import('./test') // TWO
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
     }
 }
@@ -32,9 +32,9 @@ export const obj = {
 >async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
 
         const req = await import('./test') // THREE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
     }
 }
@@ -51,9 +51,9 @@ export class cl2 {
 >async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
 
             const req = await import('./test') // FOUR
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
         }
     }
@@ -64,9 +64,9 @@ export const l = async () => {
 >async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
 
     const req = await import('./test') // FIVE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
 }
 

--- a/tests/baselines/reference/importCallExpressionAsyncES6System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES6System.types
@@ -3,9 +3,9 @@ export async function fn() {
 >fn : () => Promise<void>
 
     const req = await import('./test') // ONE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
 }
 
@@ -16,9 +16,9 @@ export class cl1 {
 >m : () => Promise<void>
 
         const req = await import('./test') // TWO
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
     }
 }
@@ -32,9 +32,9 @@ export const obj = {
 >async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
 
         const req = await import('./test') // THREE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
     }
 }
@@ -51,9 +51,9 @@ export class cl2 {
 >async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
 
             const req = await import('./test') // FOUR
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
         }
     }
@@ -64,9 +64,9 @@ export const l = async () => {
 >async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
 
     const req = await import('./test') // FIVE
->req : typeof "tests/cases/conformance/dynamicImport/test"
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test"
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test">
+>req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
 >'./test' : "./test"
 }
 

--- a/tests/baselines/reference/importCallExpressionAsyncES6System.types
+++ b/tests/baselines/reference/importCallExpressionAsyncES6System.types
@@ -3,9 +3,9 @@ export async function fn() {
 >fn : () => Promise<void>
 
     const req = await import('./test') // ONE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
 }
 
@@ -16,9 +16,9 @@ export class cl1 {
 >m : () => Promise<void>
 
         const req = await import('./test') // TWO
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
     }
 }
@@ -32,9 +32,9 @@ export const obj = {
 >async () => {        const req = await import('./test') // THREE    } : () => Promise<void>
 
         const req = await import('./test') // THREE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
     }
 }
@@ -51,9 +51,9 @@ export class cl2 {
 >async () => {            const req = await import('./test') // FOUR        } : () => Promise<void>
 
             const req = await import('./test') // FOUR
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
         }
     }
@@ -64,9 +64,9 @@ export const l = async () => {
 >async () => {    const req = await import('./test') // FIVE} : () => Promise<void>
 
     const req = await import('./test') // FIVE
->req : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic
->import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & typeof __synthetic>
+>req : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>await import('./test') : typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }
+>import('./test') : Promise<typeof "tests/cases/conformance/dynamicImport/test" & { default: typeof "tests/cases/conformance/dynamicImport/test"; }>
 >'./test' : "./test"
 }
 

--- a/tests/baselines/reference/importCallExpressionES5System.types
+++ b/tests/baselines/reference/importCallExpressionES5System.types
@@ -5,41 +5,41 @@ export function foo() { return "foo"; }
 
 === tests/cases/conformance/dynamicImport/1.ts ===
 import("./0");
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 var p1 = import("./0");
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 p1.then(zero => {
 >p1.then(zero => {    return zero.foo();}) : Promise<string>
->p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0") => string
->zero : typeof "tests/cases/conformance/dynamicImport/0"
+>p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => string
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 
     return zero.foo();
 >zero.foo() : string
 >zero.foo : () => string
->zero : typeof "tests/cases/conformance/dynamicImport/0"
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 >foo : () => string
 
 });
 
 export var p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 function foo() {
 >foo : () => void
 
     const p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 }
 
@@ -50,8 +50,8 @@ class C {
 >method : () => void
 
         const loadAsync = import ("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
     }
 }
@@ -63,8 +63,8 @@ export class D {
 >method : () => void
 
         const loadAsync = import ("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
     }
 }

--- a/tests/baselines/reference/importCallExpressionES5System.types
+++ b/tests/baselines/reference/importCallExpressionES5System.types
@@ -5,41 +5,41 @@ export function foo() { return "foo"; }
 
 === tests/cases/conformance/dynamicImport/1.ts ===
 import("./0");
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 var p1 = import("./0");
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 p1.then(zero => {
 >p1.then(zero => {    return zero.foo();}) : Promise<string>
->p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => string
->zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => string
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 
     return zero.foo();
 >zero.foo() : string
 >zero.foo : () => string
->zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 >foo : () => string
 
 });
 
 export var p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 function foo() {
 >foo : () => void
 
     const p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 }
 
@@ -50,8 +50,8 @@ class C {
 >method : () => void
 
         const loadAsync = import ("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
     }
 }
@@ -63,8 +63,8 @@ export class D {
 >method : () => void
 
         const loadAsync = import ("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
     }
 }

--- a/tests/baselines/reference/importCallExpressionES6System.types
+++ b/tests/baselines/reference/importCallExpressionES6System.types
@@ -5,41 +5,41 @@ export function foo() { return "foo"; }
 
 === tests/cases/conformance/dynamicImport/1.ts ===
 import("./0");
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 var p1 = import("./0");
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 p1.then(zero => {
 >p1.then(zero => {    return zero.foo();}) : Promise<string>
->p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0") => string
->zero : typeof "tests/cases/conformance/dynamicImport/0"
+>p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => string
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 
     return zero.foo();
 >zero.foo() : string
 >zero.foo : () => string
->zero : typeof "tests/cases/conformance/dynamicImport/0"
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 >foo : () => string
 
 });
 
 export var p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 function foo() {
 >foo : () => void
 
     const p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 }
 
@@ -50,8 +50,8 @@ class C {
 >method : () => void
 
         const loadAsync = import ("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
     }
 }
@@ -63,8 +63,8 @@ export class D {
 >method : () => void
 
         const loadAsync = import ("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
     }
 }

--- a/tests/baselines/reference/importCallExpressionES6System.types
+++ b/tests/baselines/reference/importCallExpressionES6System.types
@@ -5,41 +5,41 @@ export function foo() { return "foo"; }
 
 === tests/cases/conformance/dynamicImport/1.ts ===
 import("./0");
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 var p1 = import("./0");
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 p1.then(zero => {
 >p1.then(zero => {    return zero.foo();}) : Promise<string>
->p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => string
->zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => string
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 
     return zero.foo();
 >zero.foo() : string
 >zero.foo : () => string
->zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 >foo : () => string
 
 });
 
 export var p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 function foo() {
 >foo : () => void
 
     const p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 }
 
@@ -50,8 +50,8 @@ class C {
 >method : () => void
 
         const loadAsync = import ("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
     }
 }
@@ -63,8 +63,8 @@ export class D {
 >method : () => void
 
         const loadAsync = import ("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import ("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
     }
 }

--- a/tests/baselines/reference/importCallExpressionInSystem1.types
+++ b/tests/baselines/reference/importCallExpressionInSystem1.types
@@ -5,40 +5,40 @@ export function foo() { return "foo"; }
 
 === tests/cases/conformance/dynamicImport/1.ts ===
 import("./0");
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 var p1 = import("./0");
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 p1.then(zero => {
 >p1.then(zero => {    return zero.foo();}) : Promise<string>
->p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => string
->zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => string
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 
     return zero.foo();
 >zero.foo() : string
 >zero.foo : () => string
->zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 >foo : () => string
 
 });
 
 export var p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
 function foo() {
 >foo : () => void
 
     const p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 }

--- a/tests/baselines/reference/importCallExpressionInSystem1.types
+++ b/tests/baselines/reference/importCallExpressionInSystem1.types
@@ -5,40 +5,40 @@ export function foo() { return "foo"; }
 
 === tests/cases/conformance/dynamicImport/1.ts ===
 import("./0");
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 var p1 = import("./0");
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 p1.then(zero => {
 >p1.then(zero => {    return zero.foo();}) : Promise<string>
->p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0") => string
->zero : typeof "tests/cases/conformance/dynamicImport/0"
+>p1.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>p1 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>zero => {    return zero.foo();} : (zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => string
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 
     return zero.foo();
 >zero.foo() : string
 >zero.foo : () => string
->zero : typeof "tests/cases/conformance/dynamicImport/0"
+>zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 >foo : () => string
 
 });
 
 export var p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
 function foo() {
 >foo : () => void
 
     const p2 = import("./0");
->p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>p2 : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 }

--- a/tests/baselines/reference/importCallExpressionInSystem2.types
+++ b/tests/baselines/reference/importCallExpressionInSystem2.types
@@ -41,6 +41,6 @@ function foo(x: Promise<any>) {
 foo(import("./0"));
 >foo(import("./0")) : void
 >foo : (x: Promise<any>) => void
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 

--- a/tests/baselines/reference/importCallExpressionInSystem2.types
+++ b/tests/baselines/reference/importCallExpressionInSystem2.types
@@ -41,6 +41,6 @@ function foo(x: Promise<any>) {
 foo(import("./0"));
 >foo(import("./0")) : void
 >foo : (x: Promise<any>) => void
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 

--- a/tests/baselines/reference/importCallExpressionInSystem3.types
+++ b/tests/baselines/reference/importCallExpressionInSystem3.types
@@ -14,9 +14,9 @@ async function foo() {
     class C extends (await import("./0")).B {}
 >C : C
 >(await import("./0")).B : B
->(await import("./0")) : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
->await import("./0") : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>(await import("./0")) : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
+>await import("./0") : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 >B : typeof B
 

--- a/tests/baselines/reference/importCallExpressionInSystem3.types
+++ b/tests/baselines/reference/importCallExpressionInSystem3.types
@@ -14,9 +14,9 @@ async function foo() {
     class C extends (await import("./0")).B {}
 >C : C
 >(await import("./0")).B : B
->(await import("./0")) : typeof "tests/cases/conformance/dynamicImport/0"
->await import("./0") : typeof "tests/cases/conformance/dynamicImport/0"
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>(await import("./0")) : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>await import("./0") : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 >B : typeof B
 

--- a/tests/baselines/reference/importCallExpressionInSystem4.types
+++ b/tests/baselines/reference/importCallExpressionInSystem4.types
@@ -24,27 +24,27 @@ class C {
 >C : C
 
     private myModule = import("./0");
->myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
     method() {
 >method : () => void
 
         const loadAsync = import("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
         this.myModule.then(Zero => {
 >this.myModule.then(Zero => {            console.log(Zero.foo());        }, async err => {            console.log(err);            let one = await import("./1");            console.log(one.backup());        }) : Promise<void>
->this.myModule.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->this.myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>this.myModule.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>this.myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >this : this
->myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->Zero => {            console.log(Zero.foo());        } : (Zero: typeof "tests/cases/conformance/dynamicImport/0") => void
->Zero : typeof "tests/cases/conformance/dynamicImport/0"
+>myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>Zero => {            console.log(Zero.foo());        } : (Zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => void
+>Zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 
             console.log(Zero.foo());
 >console.log(Zero.foo()) : any
@@ -53,7 +53,7 @@ class C {
 >log : any
 >Zero.foo() : string
 >Zero.foo : () => string
->Zero : typeof "tests/cases/conformance/dynamicImport/0"
+>Zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 >foo : () => string
 
         }, async err => {
@@ -68,9 +68,9 @@ class C {
 >err : any
 
             let one = await import("./1");
->one : typeof "tests/cases/conformance/dynamicImport/1"
->await import("./1") : typeof "tests/cases/conformance/dynamicImport/1"
->import("./1") : Promise<typeof "tests/cases/conformance/dynamicImport/1">
+>one : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
+>await import("./1") : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
+>import("./1") : Promise<typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic>
 >"./1" : "./1"
 
             console.log(one.backup());
@@ -80,7 +80,7 @@ class C {
 >log : any
 >one.backup() : string
 >one.backup : () => string
->one : typeof "tests/cases/conformance/dynamicImport/1"
+>one : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
 >backup : () => string
 
         });
@@ -91,27 +91,27 @@ export class D {
 >D : D
 
     private myModule = import("./0");
->myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
     method() {
 >method : () => void
 
         const loadAsync = import("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >"./0" : "./0"
 
         this.myModule.then(Zero => {
 >this.myModule.then(Zero => {            console.log(Zero.foo());        }, async err => {            console.log(err);            let one = await import("./1");            console.log(one.backup());        }) : Promise<void>
->this.myModule.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->this.myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0">
+>this.myModule.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>this.myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
 >this : this
->myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0">
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0", TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0") => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->Zero => {            console.log(Zero.foo());        } : (Zero: typeof "tests/cases/conformance/dynamicImport/0") => void
->Zero : typeof "tests/cases/conformance/dynamicImport/0"
+>myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>Zero => {            console.log(Zero.foo());        } : (Zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => void
+>Zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 
             console.log(Zero.foo());
 >console.log(Zero.foo()) : any
@@ -120,7 +120,7 @@ export class D {
 >log : any
 >Zero.foo() : string
 >Zero.foo : () => string
->Zero : typeof "tests/cases/conformance/dynamicImport/0"
+>Zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
 >foo : () => string
 
         }, async err => {
@@ -135,9 +135,9 @@ export class D {
 >err : any
 
             let one = await import("./1");
->one : typeof "tests/cases/conformance/dynamicImport/1"
->await import("./1") : typeof "tests/cases/conformance/dynamicImport/1"
->import("./1") : Promise<typeof "tests/cases/conformance/dynamicImport/1">
+>one : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
+>await import("./1") : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
+>import("./1") : Promise<typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic>
 >"./1" : "./1"
 
             console.log(one.backup());
@@ -147,7 +147,7 @@ export class D {
 >log : any
 >one.backup() : string
 >one.backup : () => string
->one : typeof "tests/cases/conformance/dynamicImport/1"
+>one : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
 >backup : () => string
 
         });

--- a/tests/baselines/reference/importCallExpressionInSystem4.types
+++ b/tests/baselines/reference/importCallExpressionInSystem4.types
@@ -24,27 +24,27 @@ class C {
 >C : C
 
     private myModule = import("./0");
->myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
     method() {
 >method : () => void
 
         const loadAsync = import("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
         this.myModule.then(Zero => {
 >this.myModule.then(Zero => {            console.log(Zero.foo());        }, async err => {            console.log(err);            let one = await import("./1");            console.log(one.backup());        }) : Promise<void>
->this.myModule.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->this.myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>this.myModule.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>this.myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >this : this
->myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->Zero => {            console.log(Zero.foo());        } : (Zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => void
->Zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>Zero => {            console.log(Zero.foo());        } : (Zero: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => void
+>Zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 
             console.log(Zero.foo());
 >console.log(Zero.foo()) : any
@@ -53,7 +53,7 @@ class C {
 >log : any
 >Zero.foo() : string
 >Zero.foo : () => string
->Zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>Zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 >foo : () => string
 
         }, async err => {
@@ -68,9 +68,9 @@ class C {
 >err : any
 
             let one = await import("./1");
->one : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
->await import("./1") : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
->import("./1") : Promise<typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic>
+>one : typeof "tests/cases/conformance/dynamicImport/1" & { default: typeof "tests/cases/conformance/dynamicImport/1"; }
+>await import("./1") : typeof "tests/cases/conformance/dynamicImport/1" & { default: typeof "tests/cases/conformance/dynamicImport/1"; }
+>import("./1") : Promise<typeof "tests/cases/conformance/dynamicImport/1" & { default: typeof "tests/cases/conformance/dynamicImport/1"; }>
 >"./1" : "./1"
 
             console.log(one.backup());
@@ -80,7 +80,7 @@ class C {
 >log : any
 >one.backup() : string
 >one.backup : () => string
->one : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
+>one : typeof "tests/cases/conformance/dynamicImport/1" & { default: typeof "tests/cases/conformance/dynamicImport/1"; }
 >backup : () => string
 
         });
@@ -91,27 +91,27 @@ export class D {
 >D : D
 
     private myModule = import("./0");
->myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
     method() {
 >method : () => void
 
         const loadAsync = import("./0");
->loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>loadAsync : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>import("./0") : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >"./0" : "./0"
 
         this.myModule.then(Zero => {
 >this.myModule.then(Zero => {            console.log(Zero.foo());        }, async err => {            console.log(err);            let one = await import("./1");            console.log(one.backup());        }) : Promise<void>
->this.myModule.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->this.myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
+>this.myModule.then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>this.myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
 >this : this
->myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic>
->then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->Zero => {            console.log(Zero.foo());        } : (Zero: typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic) => void
->Zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>myModule : Promise<typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }>
+>then : <TResult1 = typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }, TResult2 = never>(onfulfilled?: (value: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>Zero => {            console.log(Zero.foo());        } : (Zero: typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }) => void
+>Zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 
             console.log(Zero.foo());
 >console.log(Zero.foo()) : any
@@ -120,7 +120,7 @@ export class D {
 >log : any
 >Zero.foo() : string
 >Zero.foo : () => string
->Zero : typeof "tests/cases/conformance/dynamicImport/0" & typeof __synthetic
+>Zero : typeof "tests/cases/conformance/dynamicImport/0" & { default: typeof "tests/cases/conformance/dynamicImport/0"; }
 >foo : () => string
 
         }, async err => {
@@ -135,9 +135,9 @@ export class D {
 >err : any
 
             let one = await import("./1");
->one : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
->await import("./1") : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
->import("./1") : Promise<typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic>
+>one : typeof "tests/cases/conformance/dynamicImport/1" & { default: typeof "tests/cases/conformance/dynamicImport/1"; }
+>await import("./1") : typeof "tests/cases/conformance/dynamicImport/1" & { default: typeof "tests/cases/conformance/dynamicImport/1"; }
+>import("./1") : Promise<typeof "tests/cases/conformance/dynamicImport/1" & { default: typeof "tests/cases/conformance/dynamicImport/1"; }>
 >"./1" : "./1"
 
             console.log(one.backup());
@@ -147,7 +147,7 @@ export class D {
 >log : any
 >one.backup() : string
 >one.backup : () => string
->one : typeof "tests/cases/conformance/dynamicImport/1" & typeof __synthetic
+>one : typeof "tests/cases/conformance/dynamicImport/1" & { default: typeof "tests/cases/conformance/dynamicImport/1"; }
 >backup : () => string
 
         });

--- a/tests/baselines/reference/syntheticDefaultExportsWithDynamicImports.js
+++ b/tests/baselines/reference/syntheticDefaultExportsWithDynamicImports.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/syntheticDefaultExportsWithDynamicImports.ts] ////
+
+//// [index.d.ts]
+declare function packageExport(x: number): string;
+export = packageExport;
+
+//// [index.ts]
+import("package").then(({default: foo}) => foo(42));
+
+//// [index.js]
+System.register([], function (exports_1, context_1) {
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            context_1.import("package").then(({ default: foo }) => foo(42));
+        }
+    };
+});

--- a/tests/baselines/reference/syntheticDefaultExportsWithDynamicImports.symbols
+++ b/tests/baselines/reference/syntheticDefaultExportsWithDynamicImports.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/node_modules/package/index.d.ts ===
+declare function packageExport(x: number): string;
+>packageExport : Symbol(packageExport, Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 0, 31))
+
+export = packageExport;
+>packageExport : Symbol(packageExport, Decl(index.d.ts, 0, 0))
+
+=== tests/cases/compiler/index.ts ===
+import("package").then(({default: foo}) => foo(42));
+>import("package").then : Symbol(Promise.then, Decl(lib.es5.d.ts, --, --))
+>"package" : Symbol("tests/cases/compiler/node_modules/package/index", Decl(index.d.ts, 0, 0))
+>then : Symbol(Promise.then, Decl(lib.es5.d.ts, --, --))
+>default : Symbol(default, Decl(index.d.ts, 0, 50))
+>foo : Symbol(foo, Decl(index.ts, 0, 25))
+>foo : Symbol(foo, Decl(index.ts, 0, 25))
+

--- a/tests/baselines/reference/syntheticDefaultExportsWithDynamicImports.symbols
+++ b/tests/baselines/reference/syntheticDefaultExportsWithDynamicImports.symbols
@@ -11,7 +11,7 @@ import("package").then(({default: foo}) => foo(42));
 >import("package").then : Symbol(Promise.then, Decl(lib.es5.d.ts, --, --))
 >"package" : Symbol("tests/cases/compiler/node_modules/package/index", Decl(index.d.ts, 0, 0))
 >then : Symbol(Promise.then, Decl(lib.es5.d.ts, --, --))
->default : Symbol(default, Decl(index.d.ts, 0, 50))
+>default : Symbol(default)
 >foo : Symbol(foo, Decl(index.ts, 0, 25))
 >foo : Symbol(foo, Decl(index.ts, 0, 25))
 

--- a/tests/baselines/reference/syntheticDefaultExportsWithDynamicImports.types
+++ b/tests/baselines/reference/syntheticDefaultExportsWithDynamicImports.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/node_modules/package/index.d.ts ===
+declare function packageExport(x: number): string;
+>packageExport : (x: number) => string
+>x : number
+
+export = packageExport;
+>packageExport : (x: number) => string
+
+=== tests/cases/compiler/index.ts ===
+import("package").then(({default: foo}) => foo(42));
+>import("package").then(({default: foo}) => foo(42)) : Promise<string>
+>import("package").then : <TResult1 = ((x: number) => string) & { default: (x: number) => string; }, TResult2 = never>(onfulfilled?: (value: ((x: number) => string) & { default: (x: number) => string; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>import("package") : Promise<((x: number) => string) & { default: (x: number) => string; }>
+>"package" : "package"
+>then : <TResult1 = ((x: number) => string) & { default: (x: number) => string; }, TResult2 = never>(onfulfilled?: (value: ((x: number) => string) & { default: (x: number) => string; }) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>({default: foo}) => foo(42) : ({ default: foo }: ((x: number) => string) & { default: (x: number) => string; }) => string
+>default : any
+>foo : (x: number) => string
+>foo(42) : string
+>foo : (x: number) => string
+>42 : 42
+

--- a/tests/cases/compiler/syntheticDefaultExportsWithDynamicImports.ts
+++ b/tests/cases/compiler/syntheticDefaultExportsWithDynamicImports.ts
@@ -1,0 +1,9 @@
+// @module: system
+// @target: es6
+// @moduleResolution: node
+// @filename: node_modules/package/index.d.ts
+declare function packageExport(x: number): string;
+export = packageExport;
+
+// @filename: index.ts
+import("package").then(({default: foo}) => foo(42));


### PR DESCRIPTION
Fixes #17444

If synthetic default imports is on, we now intersect an anonymous object with a default member equal to the module with the module type itself iff there is no module default member already.