### PR TITLE
Fix bad parameter comment

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17598,7 +17598,7 @@ namespace ts {
                 }
 
                 if (functionFlags & FunctionFlags.Generator) {
-                    const expressionType = checkExpressionCached(node.expression, /*contextualMapper*/ undefined);
+                    const expressionType = checkExpressionCached(node.expression);
                     let expressionElementType: Type;
                     const nodeIsYieldStar = !!node.asteriskToken;
                     if (nodeIsYieldStar) {


### PR DESCRIPTION
`checkExpressionCached` doesn't take a `contextualMapper` parameter.