### PR TITLE
Forbid type assertions in '.js' files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16384,10 +16384,6 @@ namespace ts {
         }
 
         function checkNonNullAssertion(node: NonNullExpression) {
-            if (isInJavaScriptFile(node)) {
-                error(node, Diagnostics.non_null_assertions_can_only_be_used_in_a_ts_file);
-            }
-
             return getNonNullableType(checkExpression(node.expression));
         }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1196,10 +1196,14 @@ namespace ts {
                         case SyntaxKind.EnumDeclaration:
                             diagnostics.push(createDiagnosticForNode(node, Diagnostics.enum_declarations_can_only_be_used_in_a_ts_file));
                             return;
-                        case SyntaxKind.TypeAssertionExpression:
-                            const typeAssertionExpression = <TypeAssertion>node;
-                            diagnostics.push(createDiagnosticForNode(typeAssertionExpression.type, Diagnostics.type_assertion_expressions_can_only_be_used_in_a_ts_file));
+                        case SyntaxKind.NonNullExpression:
+                            diagnostics.push(createDiagnosticForNode(node, Diagnostics.non_null_assertions_can_only_be_used_in_a_ts_file));
                             return;
+                        case SyntaxKind.AsExpression:
+                            diagnostics.push(createDiagnosticForNode((node as AsExpression).type, Diagnostics.type_assertion_expressions_can_only_be_used_in_a_ts_file));
+                            return;
+                        case SyntaxKind.TypeAssertionExpression:
+                            Debug.fail(); // Won't parse these in a JS file anyway, as they are interpreted as JSX.
                     }
 
                     const prevParent = parent;

--- a/tests/baselines/reference/jsFileCompilationTypeAssertions.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationTypeAssertions.errors.txt
@@ -1,14 +1,15 @@
-error TS5055: Cannot write file 'tests/cases/compiler/a.js' because it would overwrite input file.
-  Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-tests/cases/compiler/a.js(1,10): error TS17008: JSX element 'string' has no corresponding closing tag.
-tests/cases/compiler/a.js(1,27): error TS1005: '</' expected.
+/src/a.js(1,6): error TS8016: 'type assertion expressions' can only be used in a .ts file.
+/src/a.js(2,10): error TS17008: JSX element 'string' has no corresponding closing tag.
+/src/a.js(3,1): error TS1005: '</' expected.
 
 
-!!! error TS5055: Cannot write file 'tests/cases/compiler/a.js' because it would overwrite input file.
-!!! error TS5055:   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-==== tests/cases/compiler/a.js (2 errors) ====
+==== /src/a.js (3 errors) ====
+    0 as number;
+         ~~~~~~
+!!! error TS8016: 'type assertion expressions' can only be used in a .ts file.
     var v = <string>undefined;
              ~~~~~~
 !!! error TS17008: JSX element 'string' has no corresponding closing tag.
-                              
+    
+    
 !!! error TS1005: '</' expected.

--- a/tests/baselines/reference/jsFileCompilationTypeAssertions.js
+++ b/tests/baselines/reference/jsFileCompilationTypeAssertions.js
@@ -1,0 +1,9 @@
+//// [a.js]
+0 as number;
+var v = <string>undefined;
+
+
+//// [a.js]
+0;
+var v = <string>undefined;
+</>;

--- a/tests/cases/compiler/jsFileCompilationNonNullAssertion.ts
+++ b/tests/cases/compiler/jsFileCompilationNonNullAssertion.ts
@@ -1,5 +1,4 @@
 // @allowJs: true
-// @checkJs: true
 // @filename: /src/a.js
 // @out: /bin/a.js
 0!

--- a/tests/cases/compiler/jsFileCompilationTypeAssertions.ts
+++ b/tests/cases/compiler/jsFileCompilationTypeAssertions.ts
@@ -1,3 +1,5 @@
 // @allowJs: true
-// @filename: a.js
+// @filename: /src/a.js
+// @out: /lib/a.js
+0 as number;
 var v = <string>undefined;


### PR DESCRIPTION
After doing #17481, I realized we didn't show a diagnostic for `foo as T` casts either.
I also realized that I implemented #17481 wrong, and the error handling should be done in `getJavaScriptSyntacticDiagnosticsForFile` instead of in the checker (which only runs on `checkJs` files).