### PR TITLE
Defer indexed access type resolution

### DIFF
--- a/tests/baselines/reference/anyIndexedAccessArrayNoException.errors.txt
+++ b/tests/baselines/reference/anyIndexedAccessArrayNoException.errors.txt
@@ -1,8 +1,11 @@
+tests/cases/compiler/anyIndexedAccessArrayNoException.ts(1,12): error TS1122: A tuple type element list cannot be empty.
 tests/cases/compiler/anyIndexedAccessArrayNoException.ts(1,12): error TS2538: Type '[]' cannot be used as an index type.
 
 
-==== tests/cases/compiler/anyIndexedAccessArrayNoException.ts (1 errors) ====
+==== tests/cases/compiler/anyIndexedAccessArrayNoException.ts (2 errors) ====
     var x: any[[]];
+               ~~
+!!! error TS1122: A tuple type element list cannot be empty.
                ~~
 !!! error TS2538: Type '[]' cannot be used as an index type.
     

--- a/tests/baselines/reference/deferredLookupTypeResolution.js
+++ b/tests/baselines/reference/deferredLookupTypeResolution.js
@@ -1,0 +1,64 @@
+//// [deferredLookupTypeResolution.ts]
+// Repro from #17456
+
+type StringContains<S extends string, L extends string> = (
+    { [K in S]:      'true' } &
+    { [key: string]: 'false' }
+  )[L]
+
+type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>
+
+type First<T> = ObjectHasKey<T, '0'>;  // Should be deferred
+
+type T1 = ObjectHasKey<{ a: string }, 'a'>;  // 'true'
+type T2 = ObjectHasKey<{ a: string }, 'b'>;  // 'false'
+
+// Verify that mapped type isn't eagerly resolved in type-to-string operation
+
+declare function f1<A extends string, B extends string>(a: A, b: B): { [P in A | B]: any };
+
+function f2<A extends string>(a: A) {
+    return f1(a, 'x');
+}
+
+function f3(x: 'a' | 'b') {
+    return f2(x);
+}
+
+
+//// [deferredLookupTypeResolution.js]
+"use strict";
+// Repro from #17456
+function f2(a) {
+    return f1(a, 'x');
+}
+function f3(x) {
+    return f2(x);
+}
+
+
+//// [deferredLookupTypeResolution.d.ts]
+declare type StringContains<S extends string, L extends string> = ({
+    [K in S]: 'true';
+} & {
+    [key: string]: 'false';
+})[L];
+declare type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+declare type First<T> = ObjectHasKey<T, '0'>;
+declare type T1 = ObjectHasKey<{
+    a: string;
+}, 'a'>;
+declare type T2 = ObjectHasKey<{
+    a: string;
+}, 'b'>;
+declare function f1<A extends string, B extends string>(a: A, b: B): {
+    [P in A | B]: any;
+};
+declare function f2<A extends string>(a: A): {
+    [P in A | "x"]: any;
+};
+declare function f3(x: 'a' | 'b'): {
+    a: any;
+    b: any;
+    x: any;
+};

--- a/tests/baselines/reference/deferredLookupTypeResolution.symbols
+++ b/tests/baselines/reference/deferredLookupTypeResolution.symbols
@@ -1,0 +1,76 @@
+=== tests/cases/compiler/deferredLookupTypeResolution.ts ===
+// Repro from #17456
+
+type StringContains<S extends string, L extends string> = (
+>StringContains : Symbol(StringContains, Decl(deferredLookupTypeResolution.ts, 0, 0))
+>S : Symbol(S, Decl(deferredLookupTypeResolution.ts, 2, 20))
+>L : Symbol(L, Decl(deferredLookupTypeResolution.ts, 2, 37))
+
+    { [K in S]:      'true' } &
+>K : Symbol(K, Decl(deferredLookupTypeResolution.ts, 3, 7))
+>S : Symbol(S, Decl(deferredLookupTypeResolution.ts, 2, 20))
+
+    { [key: string]: 'false' }
+>key : Symbol(key, Decl(deferredLookupTypeResolution.ts, 4, 7))
+
+  )[L]
+>L : Symbol(L, Decl(deferredLookupTypeResolution.ts, 2, 37))
+
+type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>
+>ObjectHasKey : Symbol(ObjectHasKey, Decl(deferredLookupTypeResolution.ts, 5, 6))
+>O : Symbol(O, Decl(deferredLookupTypeResolution.ts, 7, 18))
+>L : Symbol(L, Decl(deferredLookupTypeResolution.ts, 7, 20))
+>StringContains : Symbol(StringContains, Decl(deferredLookupTypeResolution.ts, 0, 0))
+>O : Symbol(O, Decl(deferredLookupTypeResolution.ts, 7, 18))
+>L : Symbol(L, Decl(deferredLookupTypeResolution.ts, 7, 20))
+
+type First<T> = ObjectHasKey<T, '0'>;  // Should be deferred
+>First : Symbol(First, Decl(deferredLookupTypeResolution.ts, 7, 67))
+>T : Symbol(T, Decl(deferredLookupTypeResolution.ts, 9, 11))
+>ObjectHasKey : Symbol(ObjectHasKey, Decl(deferredLookupTypeResolution.ts, 5, 6))
+>T : Symbol(T, Decl(deferredLookupTypeResolution.ts, 9, 11))
+
+type T1 = ObjectHasKey<{ a: string }, 'a'>;  // 'true'
+>T1 : Symbol(T1, Decl(deferredLookupTypeResolution.ts, 9, 37))
+>ObjectHasKey : Symbol(ObjectHasKey, Decl(deferredLookupTypeResolution.ts, 5, 6))
+>a : Symbol(a, Decl(deferredLookupTypeResolution.ts, 11, 24))
+
+type T2 = ObjectHasKey<{ a: string }, 'b'>;  // 'false'
+>T2 : Symbol(T2, Decl(deferredLookupTypeResolution.ts, 11, 43))
+>ObjectHasKey : Symbol(ObjectHasKey, Decl(deferredLookupTypeResolution.ts, 5, 6))
+>a : Symbol(a, Decl(deferredLookupTypeResolution.ts, 12, 24))
+
+// Verify that mapped type isn't eagerly resolved in type-to-string operation
+
+declare function f1<A extends string, B extends string>(a: A, b: B): { [P in A | B]: any };
+>f1 : Symbol(f1, Decl(deferredLookupTypeResolution.ts, 12, 43))
+>A : Symbol(A, Decl(deferredLookupTypeResolution.ts, 16, 20))
+>B : Symbol(B, Decl(deferredLookupTypeResolution.ts, 16, 37))
+>a : Symbol(a, Decl(deferredLookupTypeResolution.ts, 16, 56))
+>A : Symbol(A, Decl(deferredLookupTypeResolution.ts, 16, 20))
+>b : Symbol(b, Decl(deferredLookupTypeResolution.ts, 16, 61))
+>B : Symbol(B, Decl(deferredLookupTypeResolution.ts, 16, 37))
+>P : Symbol(P, Decl(deferredLookupTypeResolution.ts, 16, 72))
+>A : Symbol(A, Decl(deferredLookupTypeResolution.ts, 16, 20))
+>B : Symbol(B, Decl(deferredLookupTypeResolution.ts, 16, 37))
+
+function f2<A extends string>(a: A) {
+>f2 : Symbol(f2, Decl(deferredLookupTypeResolution.ts, 16, 91))
+>A : Symbol(A, Decl(deferredLookupTypeResolution.ts, 18, 12))
+>a : Symbol(a, Decl(deferredLookupTypeResolution.ts, 18, 30))
+>A : Symbol(A, Decl(deferredLookupTypeResolution.ts, 18, 12))
+
+    return f1(a, 'x');
+>f1 : Symbol(f1, Decl(deferredLookupTypeResolution.ts, 12, 43))
+>a : Symbol(a, Decl(deferredLookupTypeResolution.ts, 18, 30))
+}
+
+function f3(x: 'a' | 'b') {
+>f3 : Symbol(f3, Decl(deferredLookupTypeResolution.ts, 20, 1))
+>x : Symbol(x, Decl(deferredLookupTypeResolution.ts, 22, 12))
+
+    return f2(x);
+>f2 : Symbol(f2, Decl(deferredLookupTypeResolution.ts, 16, 91))
+>x : Symbol(x, Decl(deferredLookupTypeResolution.ts, 22, 12))
+}
+

--- a/tests/baselines/reference/deferredLookupTypeResolution.types
+++ b/tests/baselines/reference/deferredLookupTypeResolution.types
@@ -1,0 +1,79 @@
+=== tests/cases/compiler/deferredLookupTypeResolution.ts ===
+// Repro from #17456
+
+type StringContains<S extends string, L extends string> = (
+>StringContains : ({ [K in S]: "true"; } & { [key: string]: "false"; })[L]
+>S : S
+>L : L
+
+    { [K in S]:      'true' } &
+>K : K
+>S : S
+
+    { [key: string]: 'false' }
+>key : string
+
+  )[L]
+>L : L
+
+type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>
+>ObjectHasKey : ({ [K in S]: "true"; } & { [key: string]: "false"; })[L]
+>O : O
+>L : L
+>StringContains : ({ [K in S]: "true"; } & { [key: string]: "false"; })[L]
+>O : O
+>L : L
+
+type First<T> = ObjectHasKey<T, '0'>;  // Should be deferred
+>First : ({ [K in S]: "true"; } & { [key: string]: "false"; })["0"]
+>T : T
+>ObjectHasKey : ({ [K in S]: "true"; } & { [key: string]: "false"; })[L]
+>T : T
+
+type T1 = ObjectHasKey<{ a: string }, 'a'>;  // 'true'
+>T1 : "true"
+>ObjectHasKey : ({ [K in S]: "true"; } & { [key: string]: "false"; })[L]
+>a : string
+
+type T2 = ObjectHasKey<{ a: string }, 'b'>;  // 'false'
+>T2 : "false"
+>ObjectHasKey : ({ [K in S]: "true"; } & { [key: string]: "false"; })[L]
+>a : string
+
+// Verify that mapped type isn't eagerly resolved in type-to-string operation
+
+declare function f1<A extends string, B extends string>(a: A, b: B): { [P in A | B]: any };
+>f1 : <A extends string, B extends string>(a: A, b: B) => { [P in A | B]: any; }
+>A : A
+>B : B
+>a : A
+>A : A
+>b : B
+>B : B
+>P : P
+>A : A
+>B : B
+
+function f2<A extends string>(a: A) {
+>f2 : <A extends string>(a: A) => { [P in A | B]: any; }
+>A : A
+>a : A
+>A : A
+
+    return f1(a, 'x');
+>f1(a, 'x') : { [P in A | B]: any; }
+>f1 : <A extends string, B extends string>(a: A, b: B) => { [P in A | B]: any; }
+>a : A
+>'x' : "x"
+}
+
+function f3(x: 'a' | 'b') {
+>f3 : (x: "a" | "b") => { a: any; b: any; x: any; }
+>x : "a" | "b"
+
+    return f2(x);
+>f2(x) : { a: any; b: any; x: any; }
+>f2 : <A extends string>(a: A) => { [P in A | B]: any; }
+>x : "a" | "b"
+}
+

--- a/tests/baselines/reference/deferredLookupTypeResolution2.errors.txt
+++ b/tests/baselines/reference/deferredLookupTypeResolution2.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/compiler/deferredLookupTypeResolution2.ts(14,13): error TS2536: Type '({ [K in S]: "true"; } & { [key: string]: "false"; })["1"]' cannot be used to index type '{ true: "true"; }'.
+tests/cases/compiler/deferredLookupTypeResolution2.ts(19,21): error TS2536: Type '({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in S]: "true"; } & { [key: string]: "false"; })["1"]]' cannot be used to index type '{ true: "true"; }'.
+
+
+==== tests/cases/compiler/deferredLookupTypeResolution2.ts (2 errors) ====
+    // Repro from #17456
+    
+    type StringContains<S extends string, L extends string> = ({ [K in S]: 'true' } & { [key: string]: 'false'})[L];
+    
+    type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+    
+    type A<T> = ObjectHasKey<T, '0'>;
+    
+    type B = ObjectHasKey<[string, number], '1'>;  // "true"
+    type C = ObjectHasKey<[string, number], '2'>;  // "false"
+    type D = A<[string]>;  // "true"
+    
+    // Error, "false" not handled
+    type E<T> = { true: 'true' }[ObjectHasKey<T, '1'>];
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2536: Type '({ [K in S]: "true"; } & { [key: string]: "false"; })["1"]' cannot be used to index type '{ true: "true"; }'.
+    
+    type Juxtapose<T> = ({ true: 'otherwise' } & { [k: string]: 'true' })[ObjectHasKey<T, '1'>];
+    
+    // Error, "otherwise" is missing
+    type DeepError<T> = { true: 'true' }[Juxtapose<T>];
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2536: Type '({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in S]: "true"; } & { [key: string]: "false"; })["1"]]' cannot be used to index type '{ true: "true"; }'.
+    
+    type DeepOK<T> = { true: 'true', otherwise: 'false' }[Juxtapose<T>];
+    

--- a/tests/baselines/reference/deferredLookupTypeResolution2.js
+++ b/tests/baselines/reference/deferredLookupTypeResolution2.js
@@ -1,0 +1,55 @@
+//// [deferredLookupTypeResolution2.ts]
+// Repro from #17456
+
+type StringContains<S extends string, L extends string> = ({ [K in S]: 'true' } & { [key: string]: 'false'})[L];
+
+type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+
+type A<T> = ObjectHasKey<T, '0'>;
+
+type B = ObjectHasKey<[string, number], '1'>;  // "true"
+type C = ObjectHasKey<[string, number], '2'>;  // "false"
+type D = A<[string]>;  // "true"
+
+// Error, "false" not handled
+type E<T> = { true: 'true' }[ObjectHasKey<T, '1'>];
+
+type Juxtapose<T> = ({ true: 'otherwise' } & { [k: string]: 'true' })[ObjectHasKey<T, '1'>];
+
+// Error, "otherwise" is missing
+type DeepError<T> = { true: 'true' }[Juxtapose<T>];
+
+type DeepOK<T> = { true: 'true', otherwise: 'false' }[Juxtapose<T>];
+
+
+//// [deferredLookupTypeResolution2.js]
+"use strict";
+// Repro from #17456
+
+
+//// [deferredLookupTypeResolution2.d.ts]
+declare type StringContains<S extends string, L extends string> = ({
+    [K in S]: 'true';
+} & {
+    [key: string]: 'false';
+})[L];
+declare type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+declare type A<T> = ObjectHasKey<T, '0'>;
+declare type B = ObjectHasKey<[string, number], '1'>;
+declare type C = ObjectHasKey<[string, number], '2'>;
+declare type D = A<[string]>;
+declare type E<T> = {
+    true: 'true';
+}[ObjectHasKey<T, '1'>];
+declare type Juxtapose<T> = ({
+    true: 'otherwise';
+} & {
+    [k: string]: 'true';
+})[ObjectHasKey<T, '1'>];
+declare type DeepError<T> = {
+    true: 'true';
+}[Juxtapose<T>];
+declare type DeepOK<T> = {
+    true: 'true';
+    otherwise: 'false';
+}[Juxtapose<T>];

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -15,6 +15,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(35,21): error
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(36,21): error TS2538: Type 'boolean' cannot be used as an index type.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(41,31): error TS2538: Type 'boolean' cannot be used as an index type.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(46,16): error TS2538: Type 'boolean' cannot be used as an index type.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(49,12): error TS1122: A tuple type element list cannot be empty.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(63,33): error TS2345: Argument of type '"size"' is not assignable to parameter of type '"name" | "width" | "height" | "visible"'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(64,33): error TS2345: Argument of type '"name" | "size"' is not assignable to parameter of type '"name" | "width" | "height" | "visible"'.
   Type '"size"' is not assignable to type '"name" | "width" | "height" | "visible"'.
@@ -28,7 +29,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(76,5): error 
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(77,5): error TS2322: Type 'keyof (T & U)' is not assignable to type 'keyof (T | U)'.
 
 
-==== tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts (24 errors) ====
+==== tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts (25 errors) ====
     class Shape {
         name: string;
         width: number;
@@ -112,6 +113,8 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(77,5): error 
     
     type T60 = {}["toString"];
     type T61 = []["toString"];
+               ~~
+!!! error TS1122: A tuple type element list cannot be empty.
     
     declare let cond: boolean;
     

--- a/tests/cases/compiler/deferredLookupTypeResolution.ts
+++ b/tests/cases/compiler/deferredLookupTypeResolution.ts
@@ -1,0 +1,28 @@
+// @strict: true
+// @declaration: true
+
+// Repro from #17456
+
+type StringContains<S extends string, L extends string> = (
+    { [K in S]:      'true' } &
+    { [key: string]: 'false' }
+  )[L]
+
+type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>
+
+type First<T> = ObjectHasKey<T, '0'>;  // Should be deferred
+
+type T1 = ObjectHasKey<{ a: string }, 'a'>;  // 'true'
+type T2 = ObjectHasKey<{ a: string }, 'b'>;  // 'false'
+
+// Verify that mapped type isn't eagerly resolved in type-to-string operation
+
+declare function f1<A extends string, B extends string>(a: A, b: B): { [P in A | B]: any };
+
+function f2<A extends string>(a: A) {
+    return f1(a, 'x');
+}
+
+function f3(x: 'a' | 'b') {
+    return f2(x);
+}

--- a/tests/cases/compiler/deferredLookupTypeResolution2.ts
+++ b/tests/cases/compiler/deferredLookupTypeResolution2.ts
@@ -1,0 +1,24 @@
+// @strict: true
+// @declaration: true
+
+// Repro from #17456
+
+type StringContains<S extends string, L extends string> = ({ [K in S]: 'true' } & { [key: string]: 'false'})[L];
+
+type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+
+type A<T> = ObjectHasKey<T, '0'>;
+
+type B = ObjectHasKey<[string, number], '1'>;  // "true"
+type C = ObjectHasKey<[string, number], '2'>;  // "false"
+type D = A<[string]>;  // "true"
+
+// Error, "false" not handled
+type E<T> = { true: 'true' }[ObjectHasKey<T, '1'>];
+
+type Juxtapose<T> = ({ true: 'otherwise' } & { [k: string]: 'true' })[ObjectHasKey<T, '1'>];
+
+// Error, "otherwise" is missing
+type DeepError<T> = { true: 'true' }[Juxtapose<T>];
+
+type DeepOK<T> = { true: 'true', otherwise: 'false' }[Juxtapose<T>];


### PR DESCRIPTION
With this PR we defer resolution of indexed access types in situations where we were previously too eager.

Fixes #17456.