### PR TITLE
Generate diagnostics without a leading comma, retain old spaces

### DIFF
--- a/scripts/processDiagnosticMessages.ts
+++ b/scripts/processDiagnosticMessages.ts
@@ -82,7 +82,12 @@ function buildDiagnosticMessageOutput(messageTable: InputDiagnosticMessageTable)
     });
 
     // Shave trailing comma, then add newline and ending brace
-    return result.slice(0, result.length - 1) + '\r\n}';
+    result = result.slice(0, result.length - 1) + '\r\n}';
+
+    // Assert that we generated valid JSON
+    JSON.parse(result);
+
+    return result;
 }
 
 function createKey(name: string, code: number) : string {

--- a/scripts/processDiagnosticMessages.ts
+++ b/scripts/processDiagnosticMessages.ts
@@ -76,22 +76,13 @@ function buildInfoFileOutput(messageTable: InputDiagnosticMessageTable): string 
 
 function buildDiagnosticMessageOutput(messageTable: InputDiagnosticMessageTable): string {
     let result = '{';
-    let first = true;
     messageTable.forEach(({ code }, name) => {
-        if (!first) {
-            first = false;
-        }
-        else {
-            result += ',';
-        }
-
         const propName = convertPropertyName(name);
-        result += `\r\n  "${createKey(propName, code)}": "${name.replace(/[\"]/g, '\\"')}"`;
+        result += `\r\n  "${createKey(propName, code)}" : "${name.replace(/[\"]/g, '\\"')}",`;
     });
 
-    result += '\r\n}';
-
-    return result;
+    // Shave trailing comma, then add newline and ending brace
+    return result.slice(0, result.length - 1) + '\r\n}';
 }
 
 function createKey(name: string, code: number) : string {


### PR DESCRIPTION
@minestarks This should once more generate valid json, and with the same whitespace it did before; which should help with the diffs.

Fixes a comment on #17463