### PR TITLE
Missing import codefix: Take scoped packages (@foo/bar) into consideration

### DIFF
--- a/tests/cases/fourslash/importNameCodeFixNewImportNodeModules8.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportNodeModules8.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+//// [|f1/*0*/('');|]
+
+// @Filename: package.json
+//// { "dependencies": { "package-name": "latest" } }
+
+// @Filename: node_modules/@scope/package-name/bin/lib/index.d.ts
+//// export function f1(text: string): string;
+
+// @Filename: node_modules/@scope/package-name/bin/lib/index.js
+//// function f1(text) { }
+//// exports.f1 = f1;
+
+// @Filename: node_modules/@scope/package-name/package.json
+//// {
+////   "main": "bin/lib/index.js",
+////   "types": "bin/lib/index.d.ts"
+//// }
+
+verify.importFixAtPosition([
+`import { f1 } from "@scope/package-name";
+
+f1('');`
+]);


### PR DESCRIPTION
Fixes #15223

When a package name has a [scope](https://docs.npmjs.com/misc/scope), like ```@angular/core```, we weren't able to locate package.json correctly, only looking under the ```@angular``` directory. Which meant that we never read the 'main```/`typings``` property in package.json which would have helped us simplify the import module specifier. 

This fixes the parsing of the path so we can find package.json.