### PR TITLE
Fix runtests-browser in gulp, including RWC, remove into-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
         "gulp-newer": "latest",
         "gulp-sourcemaps": "latest",
         "gulp-typescript": "latest",
-        "into-stream": "latest",
         "istanbul": "latest",
         "jake": "latest",
         "merge2": "latest",

--- a/scripts/types/ambient.d.ts
+++ b/scripts/types/ambient.d.ts
@@ -13,13 +13,5 @@ declare module "gulp-insert" {
     export function transform(cb: (contents: string, file: {path: string, relative: string}) => string): NodeJS.ReadWriteStream; // file is a vinyl file
 }
 
-declare module "into-stream" {
-    function IntoStream(content: string | Buffer | (string | Buffer)[]): NodeJS.ReadableStream;
-    namespace IntoStream {
-        export function obj(content: any): NodeJS.ReadableStream
-    }
-    export = IntoStream;
-}
-
 declare module "sorcery";
 declare module "travis-fold";

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -54,7 +54,8 @@ namespace RWC {
                 useCustomLibraryFile = undefined;
             });
 
-            it("can compile", () => {
+            it("can compile", function(this: Mocha.ITestCallbackContext) {
+                this.timeout(800000); // Allow long timeouts for RWC compilations
                 let opts: ts.ParsedCommandLine;
 
                 const ioLog: IOLog = JSON.parse(Harness.IO.readFile(jsonPath));


### PR DESCRIPTION
Fixes #17010

Browserify/gulp-typescript had taken some minor version bumps in the last year that made what we were doing before ever-so-slightly completely nonfunctional (mostly a more correct handling of the current directory and paths). It's now better and, additionally, does not rely on `into-stream`.

Also adds the long timeout we specify for RWC tests directly into the RWC tests themselves, this way the timeout works in the browser (meaning you can debug RWC tests in the browser, like I'm about to).