### PR TITLE
JSDoc Instantiation Fixes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18593,7 +18593,9 @@ namespace ts {
                     if (produceDiagnostics) {
                         const symbol = getNodeLinks(node).resolvedSymbol;
                         if (!symbol) {
-                            // There is no resolved symbol cached if the type resolved to a builtin via jsdoc type reference resolution, none of which are generic when they have no associated symbol
+                            // There is no resolved symbol cached if the type resolved to a builtin
+                            // via JSDoc type reference resolution (eg, Boolean became boolean), none
+                            // of which are generic when they have no associated symbol
                             error(node, Diagnostics.Type_0_is_not_generic, typeToString(type));
                             return;
                         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18599,7 +18599,10 @@ namespace ts {
                             error(node, Diagnostics.Type_0_is_not_generic, typeToString(type));
                             return;
                         }
-                        const typeParameters = symbol.flags & SymbolFlags.TypeAlias ? getSymbolLinks(symbol).typeParameters : (<TypeReference>type).target.localTypeParameters;
+                        let typeParameters = symbol.flags & SymbolFlags.TypeAlias && getSymbolLinks(symbol).typeParameters;
+                        if (!typeParameters && getObjectFlags(type) & ObjectFlags.Reference) {
+                            typeParameters = (<TypeReference>type).target.localTypeParameters;
+                        }
                         checkTypeArgumentConstraints(typeParameters, node.typeArguments);
                     }
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18592,6 +18592,11 @@ namespace ts {
                     forEach(node.typeArguments, checkSourceElement);
                     if (produceDiagnostics) {
                         const symbol = getNodeLinks(node).resolvedSymbol;
+                        if (!symbol) {
+                            // There is no resolved symbol cached if the type resolved to a builtin via jsdoc type reference resolution, none of which are generic when they have no associated symbol
+                            error(node, Diagnostics.Type_0_is_not_generic, typeToString(type));
+                            return;
+                        }
                         const typeParameters = symbol.flags & SymbolFlags.TypeAlias ? getSymbolLinks(symbol).typeParameters : (<TypeReference>type).target.localTypeParameters;
                         checkTypeArgumentConstraints(typeParameters, node.typeArguments);
                     }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2700,6 +2700,7 @@ namespace ts {
                 case SyntaxKind.TrueKeyword:
                 case SyntaxKind.FalseKeyword:
                 case SyntaxKind.ObjectKeyword:
+                case SyntaxKind.AsteriskToken:
                     return true;
                 case SyntaxKind.MinusToken:
                     return lookAhead(nextTokenIsNumericLiteral);

--- a/tests/baselines/reference/jsdocTypeGenericInstantiationAttempt.symbols
+++ b/tests/baselines/reference/jsdocTypeGenericInstantiationAttempt.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/index.js ===
+/**
+ * @param {Array<*>} list
+ */
+function thing(list) {
+>thing : Symbol(thing, Decl(index.js, 0, 0))
+>list : Symbol(list, Decl(index.js, 3, 15))
+
+    return list;
+>list : Symbol(list, Decl(index.js, 3, 15))
+}
+

--- a/tests/baselines/reference/jsdocTypeGenericInstantiationAttempt.types
+++ b/tests/baselines/reference/jsdocTypeGenericInstantiationAttempt.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/index.js ===
+/**
+ * @param {Array<*>} list
+ */
+function thing(list) {
+>thing : (list: any[]) => any[]
+>list : any[]
+
+    return list;
+>list : any[]
+}
+

--- a/tests/baselines/reference/jsdocTypeNongenericInstantiationAttempt.errors.txt
+++ b/tests/baselines/reference/jsdocTypeNongenericInstantiationAttempt.errors.txt
@@ -5,6 +5,8 @@ tests/cases/compiler/index4.js(2,19): error TS2315: Type 'Function' is not gener
 tests/cases/compiler/index5.js(2,19): error TS2315: Type 'string' is not generic.
 tests/cases/compiler/index6.js(2,19): error TS2315: Type 'number' is not generic.
 tests/cases/compiler/index7.js(2,19): error TS2315: Type 'any' is not generic.
+tests/cases/compiler/index8.js(4,12): error TS2304: Cannot find name 'fn'.
+tests/cases/compiler/index8.js(4,15): error TS2304: Cannot find name 'T'.
 
 
 ==== tests/cases/compiler/index.js (1 errors) ====
@@ -81,3 +83,15 @@ tests/cases/compiler/index7.js(2,19): error TS2315: Type 'any' is not generic.
     function sayHello7(somebody) {
         return 'Hello ' + somebody;
     }
+    
+==== tests/cases/compiler/index8.js (2 errors) ====
+    function fn() {}
+    
+    /**
+     * @param {fn<T>} somebody
+               ~~
+!!! error TS2304: Cannot find name 'fn'.
+                  ~
+!!! error TS2304: Cannot find name 'T'.
+     */
+    function sayHello8(somebody) { }

--- a/tests/baselines/reference/jsdocTypeNongenericInstantiationAttempt.errors.txt
+++ b/tests/baselines/reference/jsdocTypeNongenericInstantiationAttempt.errors.txt
@@ -1,0 +1,83 @@
+tests/cases/compiler/index.js(2,19): error TS2315: Type 'boolean' is not generic.
+tests/cases/compiler/index2.js(2,19): error TS2315: Type 'void' is not generic.
+tests/cases/compiler/index3.js(2,19): error TS2315: Type 'undefined' is not generic.
+tests/cases/compiler/index4.js(2,19): error TS2315: Type 'Function' is not generic.
+tests/cases/compiler/index5.js(2,19): error TS2315: Type 'string' is not generic.
+tests/cases/compiler/index6.js(2,19): error TS2315: Type 'number' is not generic.
+tests/cases/compiler/index7.js(2,19): error TS2315: Type 'any' is not generic.
+
+
+==== tests/cases/compiler/index.js (1 errors) ====
+    /**
+     * @param {<T>(m: Boolean<T>) => string} somebody
+                      ~~~~~~~~~~
+!!! error TS2315: Type 'boolean' is not generic.
+     */
+    function sayHello(somebody) {
+        return 'Hello ' + somebody;
+    }
+    
+==== tests/cases/compiler/index2.js (1 errors) ====
+    /**
+     * @param {<T>(m: Void<T>) => string} somebody
+                      ~~~~~~~
+!!! error TS2315: Type 'void' is not generic.
+     */
+    function sayHello2(somebody) {
+        return 'Hello ' + somebody;
+    }
+    
+    
+==== tests/cases/compiler/index3.js (1 errors) ====
+    /**
+     * @param {<T>(m: Undefined<T>) => string} somebody
+                      ~~~~~~~~~~~~
+!!! error TS2315: Type 'undefined' is not generic.
+     */
+    function sayHello3(somebody) {
+        return 'Hello ' + somebody;
+    }
+    
+    
+==== tests/cases/compiler/index4.js (1 errors) ====
+    /**
+     * @param {<T>(m: Function<T>) => string} somebody
+                      ~~~~~~~~~~~
+!!! error TS2315: Type 'Function' is not generic.
+     */
+    function sayHello4(somebody) {
+        return 'Hello ' + somebody;
+    }
+    
+    
+==== tests/cases/compiler/index5.js (1 errors) ====
+    /**
+     * @param {<T>(m: String<T>) => string} somebody
+                      ~~~~~~~~~
+!!! error TS2315: Type 'string' is not generic.
+     */
+    function sayHello5(somebody) {
+        return 'Hello ' + somebody;
+    }
+    
+    
+==== tests/cases/compiler/index6.js (1 errors) ====
+    /**
+     * @param {<T>(m: Number<T>) => string} somebody
+                      ~~~~~~~~~
+!!! error TS2315: Type 'number' is not generic.
+     */
+    function sayHello6(somebody) {
+        return 'Hello ' + somebody;
+    }
+    
+    
+==== tests/cases/compiler/index7.js (1 errors) ====
+    /**
+     * @param {<T>(m: Object<T>) => string} somebody
+                      ~~~~~~~~~
+!!! error TS2315: Type 'any' is not generic.
+     */
+    function sayHello7(somebody) {
+        return 'Hello ' + somebody;
+    }

--- a/tests/cases/compiler/jsdocTypeGenericInstantiationAttempt.ts
+++ b/tests/cases/compiler/jsdocTypeGenericInstantiationAttempt.ts
@@ -1,0 +1,10 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @filename: index.js
+/**
+ * @param {Array<*>} list
+ */
+function thing(list) {
+    return list;
+}

--- a/tests/cases/compiler/jsdocTypeNongenericInstantiationAttempt.ts
+++ b/tests/cases/compiler/jsdocTypeNongenericInstantiationAttempt.ts
@@ -61,3 +61,11 @@ function sayHello6(somebody) {
 function sayHello7(somebody) {
     return 'Hello ' + somebody;
 }
+
+// @filename: index8.js
+function fn() {}
+
+/**
+ * @param {fn<T>} somebody
+ */
+function sayHello8(somebody) { }

--- a/tests/cases/compiler/jsdocTypeNongenericInstantiationAttempt.ts
+++ b/tests/cases/compiler/jsdocTypeNongenericInstantiationAttempt.ts
@@ -1,0 +1,63 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @filename: index.js
+/**
+ * @param {<T>(m: Boolean<T>) => string} somebody
+ */
+function sayHello(somebody) {
+    return 'Hello ' + somebody;
+}
+
+// @filename: index2.js
+/**
+ * @param {<T>(m: Void<T>) => string} somebody
+ */
+function sayHello2(somebody) {
+    return 'Hello ' + somebody;
+}
+
+
+// @filename: index3.js
+/**
+ * @param {<T>(m: Undefined<T>) => string} somebody
+ */
+function sayHello3(somebody) {
+    return 'Hello ' + somebody;
+}
+
+
+// @filename: index4.js
+/**
+ * @param {<T>(m: Function<T>) => string} somebody
+ */
+function sayHello4(somebody) {
+    return 'Hello ' + somebody;
+}
+
+
+// @filename: index5.js
+/**
+ * @param {<T>(m: String<T>) => string} somebody
+ */
+function sayHello5(somebody) {
+    return 'Hello ' + somebody;
+}
+
+
+// @filename: index6.js
+/**
+ * @param {<T>(m: Number<T>) => string} somebody
+ */
+function sayHello6(somebody) {
+    return 'Hello ' + somebody;
+}
+
+
+// @filename: index7.js
+/**
+ * @param {<T>(m: Object<T>) => string} somebody
+ */
+function sayHello7(somebody) {
+    return 'Hello ' + somebody;
+}


### PR DESCRIPTION
Fixes #17383. - We now assume that if a symbol does not exist, then we found a builtin, but tried to instantiate it, which does not work.
Fixes #17377. - We now assume that instantiation can fail (ie, if the type doesn't exist as a type) and only look up the type arguments if instantiation was a success.
Fixes #17525. - We now consider `*` the potential start of a type.