### PR TITLE
Fix #17554 - allow RegExp as first argument of constructor

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -829,9 +829,9 @@ interface RegExp {
 
 interface RegExpConstructor {
     new(pattern: RegExp | string): RegExp;
-    new(pattern: string, flags?: string): RegExp;
+    new(pattern: RegExp | string, flags?: string): RegExp;
     (pattern: RegExp | string): RegExp;
-    (pattern: string, flags?: string): RegExp;
+    (pattern: RegExp | string, flags?: string): RegExp;
     readonly prototype: RegExp;
 
     // Non-standard extensions

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -828,9 +828,7 @@ interface RegExp {
 }
 
 interface RegExpConstructor {
-    new(pattern: RegExp | string): RegExp;
     new(pattern: RegExp | string, flags?: string): RegExp;
-    (pattern: RegExp | string): RegExp;
     (pattern: RegExp | string, flags?: string): RegExp;
     readonly prototype: RegExp;
 


### PR DESCRIPTION
When passing flags as a second argument.

Fixes #17554 
