### PR TITLE
Add simple version of `chooseOverload` for common case of single non-generic signature

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15786,23 +15786,19 @@ namespace ts {
             function chooseOverload(candidates: Signature[], relation: Map<RelationComparisonResult>, signatureHelpTrailingComma = false) {
                 candidateForArgumentError = undefined;
                 candidateForTypeArgumentError = undefined;
-                return isSingleNonGenericCandidate ? chooseOverloadSimple(candidates[0], relation, signatureHelpTrailingComma) : chooseOverloadComplex(candidates, relation, signatureHelpTrailingComma);
-            }
 
-            function chooseOverloadSimple(candidate: Signature, relation: Map<RelationComparisonResult>, signatureHelpTrailingComma: boolean): Signature | undefined {
-                if (!hasCorrectArity(node, args, candidate, signatureHelpTrailingComma)) {
-                    return undefined;
-                }
-                else if (!checkApplicableSignature(node, args, candidate, relation, excludeArgument, /*reportErrors*/ false)) {
-                    candidateForArgumentError = candidate;
-                    return undefined;
-                }
-                else {
+                if (isSingleNonGenericCandidate) {
+                    const candidate = candidates[0];
+                    if (!hasCorrectArity(node, args, candidate, signatureHelpTrailingComma)) {
+                        return undefined;
+                    }
+                    if (!checkApplicableSignature(node, args, candidate, relation, excludeArgument, /*reportErrors*/ false)) {
+                        candidateForArgumentError = candidate;
+                        return undefined;
+                    }
                     return candidate;
                 }
-            }
 
-            function chooseOverloadComplex(candidates: Signature[], relation: Map<RelationComparisonResult>, signatureHelpTrailingComma: boolean): Signature | undefined {
                 for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex++) {
                     const originalCandidate = candidates[candidateIndex];
                     if (!hasCorrectArity(node, args, originalCandidate, signatureHelpTrailingComma)) {

--- a/tests/baselines/reference/contextualTypingFunctionReturningFunction.js
+++ b/tests/baselines/reference/contextualTypingFunctionReturningFunction.js
@@ -1,0 +1,19 @@
+//// [contextualTypingFunctionReturningFunction.ts]
+interface I {
+	a(s: string): void;
+	b(): (n: number) => void;
+}
+
+declare function f(i: I): void;
+
+f({
+	a: s => {},
+	b: () => n => {},
+});
+
+
+//// [contextualTypingFunctionReturningFunction.js]
+f({
+    a: function (s) { },
+    b: function () { return function (n) { }; }
+});

--- a/tests/baselines/reference/contextualTypingFunctionReturningFunction.symbols
+++ b/tests/baselines/reference/contextualTypingFunctionReturningFunction.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/contextualTypingFunctionReturningFunction.ts ===
+interface I {
+>I : Symbol(I, Decl(contextualTypingFunctionReturningFunction.ts, 0, 0))
+
+	a(s: string): void;
+>a : Symbol(I.a, Decl(contextualTypingFunctionReturningFunction.ts, 0, 13))
+>s : Symbol(s, Decl(contextualTypingFunctionReturningFunction.ts, 1, 3))
+
+	b(): (n: number) => void;
+>b : Symbol(I.b, Decl(contextualTypingFunctionReturningFunction.ts, 1, 20))
+>n : Symbol(n, Decl(contextualTypingFunctionReturningFunction.ts, 2, 7))
+}
+
+declare function f(i: I): void;
+>f : Symbol(f, Decl(contextualTypingFunctionReturningFunction.ts, 3, 1))
+>i : Symbol(i, Decl(contextualTypingFunctionReturningFunction.ts, 5, 19))
+>I : Symbol(I, Decl(contextualTypingFunctionReturningFunction.ts, 0, 0))
+
+f({
+>f : Symbol(f, Decl(contextualTypingFunctionReturningFunction.ts, 3, 1))
+
+	a: s => {},
+>a : Symbol(a, Decl(contextualTypingFunctionReturningFunction.ts, 7, 3))
+>s : Symbol(s, Decl(contextualTypingFunctionReturningFunction.ts, 8, 3))
+
+	b: () => n => {},
+>b : Symbol(b, Decl(contextualTypingFunctionReturningFunction.ts, 8, 12))
+>n : Symbol(n, Decl(contextualTypingFunctionReturningFunction.ts, 9, 9))
+
+});
+

--- a/tests/baselines/reference/contextualTypingFunctionReturningFunction.types
+++ b/tests/baselines/reference/contextualTypingFunctionReturningFunction.types
@@ -1,0 +1,36 @@
+=== tests/cases/compiler/contextualTypingFunctionReturningFunction.ts ===
+interface I {
+>I : I
+
+	a(s: string): void;
+>a : (s: string) => void
+>s : string
+
+	b(): (n: number) => void;
+>b : () => (n: number) => void
+>n : number
+}
+
+declare function f(i: I): void;
+>f : (i: I) => void
+>i : I
+>I : I
+
+f({
+>f({	a: s => {},	b: () => n => {},}) : void
+>f : (i: I) => void
+>{	a: s => {},	b: () => n => {},} : { a: (s: string) => void; b: () => (n: number) => void; }
+
+	a: s => {},
+>a : (s: string) => void
+>s => {} : (s: string) => void
+>s : string
+
+	b: () => n => {},
+>b : () => (n: number) => void
+>() => n => {} : () => (n: number) => void
+>n => {} : (n: number) => void
+>n : number
+
+});
+

--- a/tests/baselines/reference/invalidThisEmitInContextualObjectLiteral.types
+++ b/tests/baselines/reference/invalidThisEmitInContextualObjectLiteral.types
@@ -25,7 +25,7 @@ class TestController {
 >this.m : (def: IDef) => void
 >this : this
 >m : (def: IDef) => void
->{		p1: e => { },		p2: () => { return vvvvvvvvv => this; },	} : { p1: (e: string) => void; p2: () => {}; }
+>{		p1: e => { },		p2: () => { return vvvvvvvvv => this; },	} : { p1: (e: string) => void; p2: () => (vvvvvvvvv: number) => this; }
 
 		p1: e => { },
 >p1 : (e: string) => void
@@ -33,8 +33,8 @@ class TestController {
 >e : string
 
 		p2: () => { return vvvvvvvvv => this; },
->p2 : () => {}
->() => { return vvvvvvvvv => this; } : () => {}
+>p2 : () => (vvvvvvvvv: number) => this
+>() => { return vvvvvvvvv => this; } : () => (vvvvvvvvv: number) => this
 >vvvvvvvvv => this : (vvvvvvvvv: number) => this
 >vvvvvvvvv : number
 >this : this

--- a/tests/cases/compiler/contextualTypingFunctionReturningFunction.ts
+++ b/tests/cases/compiler/contextualTypingFunctionReturningFunction.ts
@@ -1,0 +1,11 @@
+interface I {
+	a(s: string): void;
+	b(): (n: number) => void;
+}
+
+declare function f(i: I): void;
+
+f({
+	a: s => {},
+	b: () => n => {},
+});


### PR DESCRIPTION
This does change one baseline; I think the change is an improvement. I've added a simpler way to reproduce the change in the `contextualTypingFunctionReturningFunction.ts` test. Previously, the `types` baseline would have contained `b: () => {}`, while now it uses `b : () => (n: number) => void`. I think this change is related to #17586, so it won't be fully fixed until that is.

There was a 2% performance improvement in the Monaco baseline and no improvement in the TFS baseline. If you look at just the changes to check time (which is the only thing that should have changed) there is an average 1% improvement.

#### Monaco - node (v8.2.1, x64)
| Project     |            Baseline |             Current |             Delta |     Best |    Worst |
| ----------- | ------------------- | ------------------- | ----------------- | -------- | -------- |
| Memory used | 356,878k (±  0.00%) | 356,876k (±  0.00%) |    -2k (-  0.00%) | 356,847k | 356,929k |
| Parse Time  |    2.13s (±  1.54%) |    2.11s (±  0.56%) | -0.02s (-  0.99%) |    2.09s |    2.15s |
| Bind Time   |    0.83s (±  1.89%) |    0.82s (±  1.35%) | -0.01s (-  1.21%) |    0.80s |    0.85s |
| Check Time  |    4.30s (±  1.57%) |    4.22s (±  0.67%) | -0.08s (-  1.88%) |    4.14s |    4.30s |
| Emit Time   |    2.87s (±  3.28%) |    2.73s (±  0.34%) | -0.14s (-  4.74%) |    2.71s |    2.75s |
| Total Time  |   10.13s (±  1.79%) |    9.88s (±  0.36%) | -0.25s (-  2.45%) |    9.79s |    9.99s |

#### TFS - node (v8.2.1, x64)
| Project     |            Baseline |             Current |             Delta |     Best |    Worst |
| ----------- | ------------------- | ------------------- | ----------------- | -------- | -------- |
| Memory used | 309,614k (±  0.01%) | 309,573k (±  0.01%) |   -41k (-  0.01%) | 309,510k | 309,626k |
| Parse Time  |    1.55s (±  1.77%) |    1.55s (±  1.69%) | +0.00s (+  0.13%) |    1.45s |    1.58s |
| Bind Time   |    0.68s (±  4.50%) |    0.69s (±  4.55%) | +0.01s (+  1.03%) |    0.66s |    0.81s |
| Check Time  |    3.66s (±  0.32%) |    3.64s (±  0.55%) | -0.02s (-  0.41%) |    3.60s |    3.69s |
| Emit Time   |    2.38s (±  0.52%) |    2.41s (±  0.68%) | +0.03s (+  1.09%) |    2.37s |    2.45s |
| Total Time  |    8.27s (±  0.23%) |    8.29s (±  0.36%) | +0.01s (+  0.17%) |    8.22s |    8.35s |