### PR TITLE
Add a seperate cache for the all attributes version of the jsx attributes type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14025,11 +14025,8 @@ namespace ts {
          */
         function resolveCustomJsxElementAttributesType(openingLikeElement: JsxOpeningLikeElement,
             shouldIncludeAllStatelessAttributesType: boolean,
-            elementType?: Type,
+            elementType: Type = checkExpression(openingLikeElement.tagName),
             elementClassType?: Type): Type {
-            if (!elementType) {
-                elementType = checkExpression(openingLikeElement.tagName);
-            }
 
             if (elementType.flags & TypeFlags.Union) {
                 const types = (elementType as UnionType).types;
@@ -14163,11 +14160,12 @@ namespace ts {
          */
         function getCustomJsxElementAttributesType(node: JsxOpeningLikeElement, shouldIncludeAllStatelessAttributesType: boolean): Type {
             const links = getNodeLinks(node);
-            if (!links.resolvedJsxElementAttributesType) {
+            const linkLocation = shouldIncludeAllStatelessAttributesType ? "resolvedJsxElementAllAttributesType" : "resolvedJsxElementAttributesType";
+            if (!links[linkLocation]) {
                 const elemClassType = getJsxGlobalElementClassType();
-                return links.resolvedJsxElementAttributesType = resolveCustomJsxElementAttributesType(node, shouldIncludeAllStatelessAttributesType, /*elementType*/ undefined, elemClassType);
+                return links[linkLocation] = resolveCustomJsxElementAttributesType(node, shouldIncludeAllStatelessAttributesType, /*elementType*/ undefined, elemClassType);
             }
-            return links.resolvedJsxElementAttributesType;
+            return links[linkLocation];
         }
 
         /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3067,6 +3067,7 @@ namespace ts {
         hasReportedStatementInAmbientContext?: boolean;  // Cache boolean if we report statements in ambient context
         jsxFlags?: JsxFlags;              // flags for knowing what kind of element/attributes we're dealing with
         resolvedJsxElementAttributesType?: Type;  // resolved element attributes type of a JSX openinglike element
+        resolvedJsxElementAllAttributesType?: Type;  // resolved all element attributes type of a JSX openinglike element
         hasSuperCall?: boolean;           // recorded result when we try to find super-call. We only try to find one if this flag is undefined, indicating that we haven't made an attempt.
         superCall?: ExpressionStatement;  // Cached first super-call found in the constructor. Used in checking whether super is called before this-accessing
         switchTypes?: Type[];             // Cached array of switch case expression types


### PR DESCRIPTION
I was working on another issue and noticed this. `getCustomJsxElementAttributesType` was actually used to query for two (similar, but) different types, but cached them both in the same place. This would be likely to surface as odd stateful behavior when alternating between type-checking and querying for completions in jsx attributes in the language server (which is where the `AllAttributes` kind of type is used).

It was difficult to make a test case where this actually causes a bug in fourslash, since the `AllAttributes` kind is always compatible with the normal kind (it just has even more intersected in), and the difference should only be visible in completion results vs `getContextualType` results (which are the two primary code paths this gets used to actually return a value, rather than report diagnostics), but I managed to come up with a test which actually exhibits a change in behavior because of the bug; on stable, we produce a completion of `a: string` when it should be `a: string & number` (by our rules) because the contextual type got cached with the `false` flag and then was reused for completions:

```ts
declare module JSX {
    interface Element { }
    interface IntrinsicElements {
        div: any;
    }
    interface ElementAttributesProperty { props: {}; }
}

function CompletionsPlease<T, U extends T>(props: { attr: U, children: (x: T) => U, a: number }): JSX.Element;
function CompletionsPlease<T>(props: { attr: T, children: (x: T) => T, a: string }): JSX.Element;
function CompletionsPlease(props: any): JSX.Element {
    return <div />;
}

<CompletionsPlease attr="2" /*2*/ >{y/*1*/es => yes}</CompletionsPlease>;
```
First get quick info at the `yes` argument and observe a type of any. Then get completions at the whitespace after the attribute in the tag - observe `a: string` on master, but `a: string & number` after the fix. This test is not in this PR, however, because doing this, in fourslash:
```ts
goTo.marker("1");
verify.quickInfoAt("1", "(parameter) yes: any");
goTo.marker("2");
verify.completionListContains("a", "(property) a: number & string");
```
does _not_ exhibit the same behavior as the equivalent actions in an editor (ie, vscode) - for some reason even on master it reports the correct behavior.