### PR TITLE
Mapped type and string index signature relations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9614,6 +9614,11 @@ namespace ts {
                 if (sourceInfo) {
                     return indexInfoRelatedTo(sourceInfo, targetInfo, reportErrors);
                 }
+                if (isGenericMappedType(source)) {
+                    // A generic mapped type { [P in K]: T } is related to an index signature { [x: string]: U }
+                    // if T is related to U.
+                    return kind === IndexKind.String && isRelatedTo(getTemplateTypeFromMappedType(<MappedType>source), targetInfo.type, reportErrors);
+                }
                 if (isObjectLiteralType(source)) {
                     let related = Ternary.True;
                     if (kind === IndexKind.String) {

--- a/tests/baselines/reference/indexSignatureAndMappedType.errors.txt
+++ b/tests/baselines/reference/indexSignatureAndMappedType.errors.txt
@@ -1,0 +1,47 @@
+tests/cases/compiler/indexSignatureAndMappedType.ts(6,5): error TS2322: Type '{ [key: string]: T; }' is not assignable to type 'Record<K, T>'.
+tests/cases/compiler/indexSignatureAndMappedType.ts(15,5): error TS2322: Type 'Record<K, U>' is not assignable to type '{ [key: string]: T; }'.
+  Type 'U' is not assignable to type 'T'.
+tests/cases/compiler/indexSignatureAndMappedType.ts(16,5): error TS2322: Type '{ [key: string]: T; }' is not assignable to type 'Record<K, U>'.
+
+
+==== tests/cases/compiler/indexSignatureAndMappedType.ts (3 errors) ====
+    // A mapped type { [P in K]: X }, where K is a generic type, is related to
+    // { [key: string]: Y } if X is related to Y.
+    
+    function f1<T, K extends string>(x: { [key: string]: T }, y: Record<K, T>) {
+        x = y;
+        y = x;  // Error
+        ~
+!!! error TS2322: Type '{ [key: string]: T; }' is not assignable to type 'Record<K, T>'.
+    }
+    
+    function f2<T, K extends string>(x: { [key: string]: T }, y: Record<string, T>) {
+        x = y;
+        y = x;
+    }
+    
+    function f3<T, U, K extends string>(x: { [key: string]: T }, y: Record<K, U>) {
+        x = y;  // Error
+        ~
+!!! error TS2322: Type 'Record<K, U>' is not assignable to type '{ [key: string]: T; }'.
+!!! error TS2322:   Type 'U' is not assignable to type 'T'.
+        y = x;  // Error
+        ~
+!!! error TS2322: Type '{ [key: string]: T; }' is not assignable to type 'Record<K, U>'.
+    }
+    
+    // Repro from #14548
+    
+    type Dictionary = {
+        [key: string]: string;
+    };
+    
+    interface IBaseEntity {
+        name: string;
+        properties: Dictionary;
+    }
+    
+    interface IEntity<T extends string> extends IBaseEntity {
+        properties: Record<T, string>;
+    }
+    

--- a/tests/baselines/reference/indexSignatureAndMappedType.errors.txt
+++ b/tests/baselines/reference/indexSignatureAndMappedType.errors.txt
@@ -15,7 +15,7 @@ tests/cases/compiler/indexSignatureAndMappedType.ts(16,5): error TS2322: Type '{
 !!! error TS2322: Type '{ [key: string]: T; }' is not assignable to type 'Record<K, T>'.
     }
     
-    function f2<T, K extends string>(x: { [key: string]: T }, y: Record<string, T>) {
+    function f2<T>(x: { [key: string]: T }, y: Record<string, T>) {
         x = y;
         y = x;
     }

--- a/tests/baselines/reference/indexSignatureAndMappedType.js
+++ b/tests/baselines/reference/indexSignatureAndMappedType.js
@@ -1,0 +1,73 @@
+//// [indexSignatureAndMappedType.ts]
+// A mapped type { [P in K]: X }, where K is a generic type, is related to
+// { [key: string]: Y } if X is related to Y.
+
+function f1<T, K extends string>(x: { [key: string]: T }, y: Record<K, T>) {
+    x = y;
+    y = x;  // Error
+}
+
+function f2<T, K extends string>(x: { [key: string]: T }, y: Record<string, T>) {
+    x = y;
+    y = x;
+}
+
+function f3<T, U, K extends string>(x: { [key: string]: T }, y: Record<K, U>) {
+    x = y;  // Error
+    y = x;  // Error
+}
+
+// Repro from #14548
+
+type Dictionary = {
+    [key: string]: string;
+};
+
+interface IBaseEntity {
+    name: string;
+    properties: Dictionary;
+}
+
+interface IEntity<T extends string> extends IBaseEntity {
+    properties: Record<T, string>;
+}
+
+
+//// [indexSignatureAndMappedType.js]
+"use strict";
+// A mapped type { [P in K]: X }, where K is a generic type, is related to
+// { [key: string]: Y } if X is related to Y.
+function f1(x, y) {
+    x = y;
+    y = x; // Error
+}
+function f2(x, y) {
+    x = y;
+    y = x;
+}
+function f3(x, y) {
+    x = y; // Error
+    y = x; // Error
+}
+
+
+//// [indexSignatureAndMappedType.d.ts]
+declare function f1<T, K extends string>(x: {
+    [key: string]: T;
+}, y: Record<K, T>): void;
+declare function f2<T, K extends string>(x: {
+    [key: string]: T;
+}, y: Record<string, T>): void;
+declare function f3<T, U, K extends string>(x: {
+    [key: string]: T;
+}, y: Record<K, U>): void;
+declare type Dictionary = {
+    [key: string]: string;
+};
+interface IBaseEntity {
+    name: string;
+    properties: Dictionary;
+}
+interface IEntity<T extends string> extends IBaseEntity {
+    properties: Record<T, string>;
+}

--- a/tests/baselines/reference/indexSignatureAndMappedType.js
+++ b/tests/baselines/reference/indexSignatureAndMappedType.js
@@ -7,7 +7,7 @@ function f1<T, K extends string>(x: { [key: string]: T }, y: Record<K, T>) {
     y = x;  // Error
 }
 
-function f2<T, K extends string>(x: { [key: string]: T }, y: Record<string, T>) {
+function f2<T>(x: { [key: string]: T }, y: Record<string, T>) {
     x = y;
     y = x;
 }
@@ -55,7 +55,7 @@ function f3(x, y) {
 declare function f1<T, K extends string>(x: {
     [key: string]: T;
 }, y: Record<K, T>): void;
-declare function f2<T, K extends string>(x: {
+declare function f2<T>(x: {
     [key: string]: T;
 }, y: Record<string, T>): void;
 declare function f3<T, U, K extends string>(x: {

--- a/tests/cases/compiler/indexSignatureAndMappedType.ts
+++ b/tests/cases/compiler/indexSignatureAndMappedType.ts
@@ -1,0 +1,35 @@
+// @strict: true
+// @declaration: true
+
+// A mapped type { [P in K]: X }, where K is a generic type, is related to
+// { [key: string]: Y } if X is related to Y.
+
+function f1<T, K extends string>(x: { [key: string]: T }, y: Record<K, T>) {
+    x = y;
+    y = x;  // Error
+}
+
+function f2<T, K extends string>(x: { [key: string]: T }, y: Record<string, T>) {
+    x = y;
+    y = x;
+}
+
+function f3<T, U, K extends string>(x: { [key: string]: T }, y: Record<K, U>) {
+    x = y;  // Error
+    y = x;  // Error
+}
+
+// Repro from #14548
+
+type Dictionary = {
+    [key: string]: string;
+};
+
+interface IBaseEntity {
+    name: string;
+    properties: Dictionary;
+}
+
+interface IEntity<T extends string> extends IBaseEntity {
+    properties: Record<T, string>;
+}

--- a/tests/cases/compiler/indexSignatureAndMappedType.ts
+++ b/tests/cases/compiler/indexSignatureAndMappedType.ts
@@ -9,7 +9,7 @@ function f1<T, K extends string>(x: { [key: string]: T }, y: Record<K, T>) {
     y = x;  // Error
 }
 
-function f2<T, K extends string>(x: { [key: string]: T }, y: Record<string, T>) {
+function f2<T>(x: { [key: string]: T }, y: Record<string, T>) {
     x = y;
     y = x;
 }


### PR DESCRIPTION
With this PR a mapped type `{ [P in K]: T }`, where `K` is generic, is related to a string index signature `{ [key: string]: U }` if `T` is related to `U`. For example:

```ts
function f<K extends string>(x: { [key: string]: number }, y: Record<K, number>) {
    x = y;  // Ok
}
```
Fixes #14548. Also fixes an unintended effect of #17382 that would allow *any* generic mapped type to be assignable to a string index signature (because generic mapped types have no manifest properties they were being mistaken for empty object types).