### PR TITLE
Fix stack overflow related to contextual signature instantiations

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -11,20 +11,6 @@ namespace ts {
 
 /* @internal */
 namespace ts {
-    /**
-     * Ternary values are defined such that
-     * x & y is False if either x or y is False.
-     * x & y is Maybe if either x or y is Maybe, but neither x or y is False.
-     * x & y is True if both x and y are True.
-     * x | y is False if both x and y are False.
-     * x | y is Maybe if either x or y is Maybe, but neither x or y is True.
-     * x | y is True if either x or y is True.
-     */
-    export const enum Ternary {
-        False = 0,
-        Maybe = 1,
-        True = -1
-    }
 
     // More efficient to create a collator once and use its `compare` than to call `a.localeCompare(b)` many times.
     export const collator: { compare(a: string, b: string): number } = typeof Intl === "object" && typeof Intl.Collator === "function" ? new Intl.Collator(/*locales*/ undefined, { usage: "sort", sensitivity: "accent" }) : undefined;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3425,11 +3425,29 @@ namespace ts {
         AnyDefault      = 1 << 2,  // Infer anyType for no inferences (otherwise emptyObjectType)
     }
 
+    /**
+     * Ternary values are defined such that
+     * x & y is False if either x or y is False.
+     * x & y is Maybe if either x or y is Maybe, but neither x or y is False.
+     * x & y is True if both x and y are True.
+     * x | y is False if both x and y are False.
+     * x | y is Maybe if either x or y is Maybe, but neither x or y is True.
+     * x | y is True if either x or y is True.
+     */
+    export const enum Ternary {
+        False = 0,
+        Maybe = 1,
+        True = -1
+    }
+
+    export type TypeComparer = (s: Type, t: Type, reportErrors?: boolean) => Ternary;
+
     /* @internal */
     export interface InferenceContext extends TypeMapper {
         signature: Signature;               // Generic signature for which inferences are made
         inferences: InferenceInfo[];        // Inferences made for each type parameter
         flags: InferenceFlags;              // Inference flags
+        compareTypes: TypeComparer;         // Type comparer function
     }
 
     /* @internal */

--- a/tests/baselines/reference/signatureInstantiationWithRecursiveConstraints.js
+++ b/tests/baselines/reference/signatureInstantiationWithRecursiveConstraints.js
@@ -1,0 +1,30 @@
+//// [signatureInstantiationWithRecursiveConstraints.ts]
+// Repro from #17148
+
+class Foo {
+  myFunc<T extends Foo>(arg: T) {}
+}
+
+class Bar {
+  myFunc<T extends Bar>(arg: T) {}
+}
+
+const myVar: Foo = new Bar();
+
+
+//// [signatureInstantiationWithRecursiveConstraints.js]
+"use strict";
+// Repro from #17148
+var Foo = (function () {
+    function Foo() {
+    }
+    Foo.prototype.myFunc = function (arg) { };
+    return Foo;
+}());
+var Bar = (function () {
+    function Bar() {
+    }
+    Bar.prototype.myFunc = function (arg) { };
+    return Bar;
+}());
+var myVar = new Bar();

--- a/tests/baselines/reference/signatureInstantiationWithRecursiveConstraints.symbols
+++ b/tests/baselines/reference/signatureInstantiationWithRecursiveConstraints.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts ===
+// Repro from #17148
+
+class Foo {
+>Foo : Symbol(Foo, Decl(signatureInstantiationWithRecursiveConstraints.ts, 0, 0))
+
+  myFunc<T extends Foo>(arg: T) {}
+>myFunc : Symbol(Foo.myFunc, Decl(signatureInstantiationWithRecursiveConstraints.ts, 2, 11))
+>T : Symbol(T, Decl(signatureInstantiationWithRecursiveConstraints.ts, 3, 9))
+>Foo : Symbol(Foo, Decl(signatureInstantiationWithRecursiveConstraints.ts, 0, 0))
+>arg : Symbol(arg, Decl(signatureInstantiationWithRecursiveConstraints.ts, 3, 24))
+>T : Symbol(T, Decl(signatureInstantiationWithRecursiveConstraints.ts, 3, 9))
+}
+
+class Bar {
+>Bar : Symbol(Bar, Decl(signatureInstantiationWithRecursiveConstraints.ts, 4, 1))
+
+  myFunc<T extends Bar>(arg: T) {}
+>myFunc : Symbol(Bar.myFunc, Decl(signatureInstantiationWithRecursiveConstraints.ts, 6, 11))
+>T : Symbol(T, Decl(signatureInstantiationWithRecursiveConstraints.ts, 7, 9))
+>Bar : Symbol(Bar, Decl(signatureInstantiationWithRecursiveConstraints.ts, 4, 1))
+>arg : Symbol(arg, Decl(signatureInstantiationWithRecursiveConstraints.ts, 7, 24))
+>T : Symbol(T, Decl(signatureInstantiationWithRecursiveConstraints.ts, 7, 9))
+}
+
+const myVar: Foo = new Bar();
+>myVar : Symbol(myVar, Decl(signatureInstantiationWithRecursiveConstraints.ts, 10, 5))
+>Foo : Symbol(Foo, Decl(signatureInstantiationWithRecursiveConstraints.ts, 0, 0))
+>Bar : Symbol(Bar, Decl(signatureInstantiationWithRecursiveConstraints.ts, 4, 1))
+

--- a/tests/baselines/reference/signatureInstantiationWithRecursiveConstraints.types
+++ b/tests/baselines/reference/signatureInstantiationWithRecursiveConstraints.types
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts ===
+// Repro from #17148
+
+class Foo {
+>Foo : Foo
+
+  myFunc<T extends Foo>(arg: T) {}
+>myFunc : <T extends Foo>(arg: T) => void
+>T : T
+>Foo : Foo
+>arg : T
+>T : T
+}
+
+class Bar {
+>Bar : Bar
+
+  myFunc<T extends Bar>(arg: T) {}
+>myFunc : <T extends Bar>(arg: T) => void
+>T : T
+>Bar : Bar
+>arg : T
+>T : T
+}
+
+const myVar: Foo = new Bar();
+>myVar : Foo
+>Foo : Foo
+>new Bar() : Bar
+>Bar : typeof Bar
+

--- a/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
+++ b/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
@@ -1,0 +1,13 @@
+// @strict: true
+
+// Repro from #17148
+
+class Foo {
+  myFunc<T extends Foo>(arg: T) {}
+}
+
+class Bar {
+  myFunc<T extends Bar>(arg: T) {}
+}
+
+const myVar: Foo = new Bar();


### PR DESCRIPTION
With this PR we properly propagate a type comparison function through to the type inference process used in contextual signature instantiation, such that type comparisons done during constraint checking become aware of other type comparisons already in progress.

Fixes #17148.