### PR TITLE
Handle empty directory path as the current directory Fixes #14559

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -153,7 +153,7 @@ namespace ts {
                         return;
                     }
                     watcher = _fs.watch(
-                        dirPath,
+                        dirPath || ".",
                         { persistent: true },
                         (eventName: string, relativeFileName: string) => fileEventHandler(eventName, relativeFileName, dirPath)
                     );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #14559

A very simple fix for the non-polling watcher. As described in the issue, it fails because `getDirectoryPath("filename")` returns `""` which cannot be passed to `fs.watch()`.