### PR TITLE
fix #16567: better coloring on light theme terminal

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -243,7 +243,7 @@ namespace ts {
     const redForegroundEscapeSequence = "\u001b[91m";
     const yellowForegroundEscapeSequence = "\u001b[93m";
     const blueForegroundEscapeSequence = "\u001b[93m";
-    const gutterStyleSequence = "\u001b[100;30m";
+    const gutterStyleSequence = "\u001b[30;47m";
     const gutterSeparator = " ";
     const resetEscapeSequence = "\u001b[0m";
     const ellipsis = "...";


### PR DESCRIPTION
Fixes #16567 
ANSI escape code cannot give a entirely satisfactory result across all color palette. This PR improve readability on light theme terminal, but some dark color palettes become worse(but still acceptable).

![screen shot 2017-08-08 at 10 00 47 am](https://user-images.githubusercontent.com/2883231/29054099-82aaf27c-7c26-11e7-8479-b93a1747f5c7.png)
![screen shot 2017-08-08 at 10 01 17 am](https://user-images.githubusercontent.com/2883231/29054101-82ad67c8-7c26-11e7-811a-a27cc1ee767e.png)
![screen shot 2017-08-08 at 10 01 27 am](https://user-images.githubusercontent.com/2883231/29054103-82bbbfa8-7c26-11e7-9eaa-259708e46d32.png)
![screen shot 2017-08-08 at 10 07 57 am](https://user-images.githubusercontent.com/2883231/29054100-82aae2fa-7c26-11e7-8e1f-44199d86d29a.png)
![screen shot 2017-08-08 at 10 08 08 am](https://user-images.githubusercontent.com/2883231/29054102-82bb56f8-7c26-11e7-82e4-9d324e358cee.png)
![screen shot 2017-08-08 at 10 08 18 am](https://user-images.githubusercontent.com/2883231/29054098-82aaf5ce-7c26-11e7-80cd-0f5131be803e.png)
![screen shot 2017-08-08 at 10 08 28 am](https://user-images.githubusercontent.com/2883231/29054104-82d4052c-7c26-11e7-902d-ac3c9d66be1f.png)
![screen shot 2017-08-08 at 10 08 39 am](https://user-images.githubusercontent.com/2883231/29054105-82d93efc-7c26-11e7-8832-d8305cce1d81.png)
