### PR TITLE
Convert two arrays to readonly

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -326,8 +326,8 @@ namespace ts.server {
         typingsInstaller: ITypingsInstaller;
         eventHandler?: ProjectServiceEventHandler;
         throttleWaitMilliseconds?: number;
-        globalPlugins?: string[];
-        pluginProbeLocations?: string[];
+        globalPlugins?: ReadonlyArray<string>;
+        pluginProbeLocations?: ReadonlyArray<string>;
         allowLocalPluginLoads?: boolean;
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -15,8 +15,8 @@ namespace ts.server {
         typingSafeListLocation: string;
         npmLocation: string | undefined;
         telemetryEnabled: boolean;
-        globalPlugins: string[];
-        pluginProbeLocations: string[];
+        globalPlugins: ReadonlyArray<string>;
+        pluginProbeLocations: ReadonlyArray<string>;
         allowLocalPluginLoads: boolean;
     }
 
@@ -760,10 +760,10 @@ namespace ts.server {
     const typingSafeListLocation = findArgument(Arguments.TypingSafeListLocation);
     const npmLocation = findArgument(Arguments.NpmLocation);
 
-    function parseStringArray(argName: string): string[] {
+    function parseStringArray(argName: string): ReadonlyArray<string> {
         const arg = findArgument(argName);
         if (arg === undefined) {
-            return emptyArray as string[]; // TODO: https://github.com/Microsoft/TypeScript/issues/16312
+            return emptyArray;
         }
         return arg.split(",").filter(name => name !== "");
     }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -259,8 +259,8 @@ namespace ts.server {
         eventHandler?: ProjectServiceEventHandler;
         throttleWaitMilliseconds?: number;
 
-        globalPlugins?: string[];
-        pluginProbeLocations?: string[];
+        globalPlugins?: ReadonlyArray<string>;
+        pluginProbeLocations?: ReadonlyArray<string>;
         allowLocalPluginLoads?: boolean;
     }
 


### PR DESCRIPTION
The cast is currently causing errors when running `gulp local` on the master branch. Turns out it's pretty easy to fix just this without any big API changes.

```
return emptyArray as string[]; // TODO: https://github.com/Microsoft/TypeScript/issues/16312

                       ~~~~~~~~~~~~~~~~~~~~~~

src/server/server.ts(772,20): error TS2352: Type 'SortedReadonlyArray<never>' cannot be converted to type 'string[]'.
```