### PR TITLE
TSLint now realizes when you attempt to use a rule which is not present

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -1122,14 +1122,15 @@ task("update-sublime", ["local", serverFile], function () {
 
 var tslintRuleDir = "scripts/tslint";
 var tslintRules = [
-    "nextLineRule",
     "booleanTriviaRule",
-    "typeOperatorSpacingRule",
-    "noInOperatorRule",
+    "debugAssertRule",
+    "nextLineRule",
+    "noBomRule",
     "noIncrementDecrementRule",
-    "objectLiteralSurroundingSpaceRule",
+    "noInOperatorRule",
     "noTypeAssertionWhitespaceRule",
-    "noBomRule"
+    "objectLiteralSurroundingSpaceRule",
+    "typeOperatorSpacingRule",
 ];
 var tslintRulesFiles = tslintRules.map(function (p) {
     return path.join(tslintRuleDir, p + ".ts");


### PR DESCRIPTION
And as it turns out, one of our lint rules (`"debugAssertRule"`) was never being built by our Jakefile (it doesn't use a wildcard like our Gulpfile does, so it was just never added), causing lint to break once the latest version of tslint was retrieved. This will start being noticeable in public CI once caches clear, but it's already manifesting on our internal CI server.