### PR TITLE
Add a leading space on binary operator token trailing comments

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1348,7 +1348,7 @@ namespace ts {
             increaseIndentIf(indentBeforeOperator, isCommaOperator ? " " : undefined);
             emitLeadingCommentsOfPosition(node.operatorToken.pos);
             writeTokenNode(node.operatorToken);
-            emitTrailingCommentsOfPosition(node.operatorToken.end, /*prefixSpace*/ true); // Comma should have a space after it
+            emitTrailingCommentsOfPosition(node.operatorToken.end, /*prefixSpace*/ true); // Binary operators should have a space before the comment starts
             increaseIndentIf(indentAfterOperator, " ");
             emitExpression(node.right);
             decreaseIndentIf(indentBeforeOperator, indentAfterOperator);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1348,7 +1348,7 @@ namespace ts {
             increaseIndentIf(indentBeforeOperator, isCommaOperator ? " " : undefined);
             emitLeadingCommentsOfPosition(node.operatorToken.pos);
             writeTokenNode(node.operatorToken);
-            emitTrailingCommentsOfPosition(node.operatorToken.end);
+            emitTrailingCommentsOfPosition(node.operatorToken.end, /*prefixSpace*/ true); // Comma should have a space after it
             increaseIndentIf(indentAfterOperator, " ");
             emitExpression(node.right);
             decreaseIndentIf(indentBeforeOperator, indentAfterOperator);

--- a/tests/baselines/reference/commentOnBinaryOperator1.js
+++ b/tests/baselines/reference/commentOnBinaryOperator1.js
@@ -21,5 +21,5 @@ var b = 'some'
     + 'text';
 var c = 'some'
     /* comment */
-    +/*comment1*/ 
+    + /*comment1*/
         'text';

--- a/tests/baselines/reference/commentsArgumentsOfCallExpression2.js
+++ b/tests/baselines/reference/commentsArgumentsOfCallExpression2.js
@@ -14,7 +14,7 @@ foo(
 function foo(/*c1*/ x, /*d1*/ y, /*e1*/ w) { }
 var a, b;
 foo(/*c2*/ 1, /*d2*/ 1 + 2, /*e1*/ a + b);
-foo(/*c3*/ function () { }, /*d2*/ function () { }, /*e2*/ a +/*e3*/  b);
+foo(/*c3*/ function () { }, /*d2*/ function () { }, /*e2*/ a + /*e3*/ b);
 foo(/*c3*/ function () { }, /*d3*/ function () { }, /*e3*/ (a + b));
 foo(
 /*c4*/ function () { }, 

--- a/tests/baselines/reference/jsdocTypeTagCast.js
+++ b/tests/baselines/reference/jsdocTypeTagCast.js
@@ -97,7 +97,7 @@ var a;
 /** @type {string} */
 var s;
 var a = ("" + 4);
-var s = "" +/** @type {*} */  (4);
+var s = "" + /** @type {*} */ (4);
 var SomeBase = (function () {
     function SomeBase() {
         this.p = 42;
@@ -128,19 +128,19 @@ var someBase = new SomeBase();
 var someDerived = new SomeDerived();
 var someOther = new SomeOther();
 var someFakeClass = new SomeFakeClass();
-someBase =/** @type {SomeBase} */  (someDerived);
-someBase =/** @type {SomeBase} */  (someBase);
-someBase =/** @type {SomeBase} */  (someOther); // Error
-someDerived =/** @type {SomeDerived} */  (someDerived);
-someDerived =/** @type {SomeDerived} */  (someBase);
-someDerived =/** @type {SomeDerived} */  (someOther); // Error
-someOther =/** @type {SomeOther} */  (someDerived); // Error
-someOther =/** @type {SomeOther} */  (someBase); // Error
-someOther =/** @type {SomeOther} */  (someOther);
+someBase = /** @type {SomeBase} */ (someDerived);
+someBase = /** @type {SomeBase} */ (someBase);
+someBase = /** @type {SomeBase} */ (someOther); // Error
+someDerived = /** @type {SomeDerived} */ (someDerived);
+someDerived = /** @type {SomeDerived} */ (someBase);
+someDerived = /** @type {SomeDerived} */ (someOther); // Error
+someOther = /** @type {SomeOther} */ (someDerived); // Error
+someOther = /** @type {SomeOther} */ (someBase); // Error
+someOther = /** @type {SomeOther} */ (someOther);
 someFakeClass = someBase;
 someFakeClass = someDerived;
 someBase = someFakeClass; // Error
-someBase =/** @type {SomeBase} */  (someFakeClass);
+someBase = /** @type {SomeBase} */ (someFakeClass);
 // Type assertion cannot be a type-predicate type
 /** @type {number | string} */
 var numOrStr;

--- a/tests/baselines/reference/parser15.4.4.14-9-2.js
+++ b/tests/baselines/reference/parser15.4.4.14-9-2.js
@@ -41,9 +41,9 @@ function testcase() {
     var one = 1;
     var _float = -(4 / 3);
     var a = new Array(false, undefined, null, "0", obj, -1.3333333333333, "str", -0, true, +0, one, 1, 0, false, _float, -(4 / 3));
-    if (a.indexOf(-(4 / 3)) === 14 &&// a[14]=_float===-(4/3)
-        a.indexOf(0) === 7 &&// a[7] = +0, 0===+0
-        a.indexOf(-0) === 7 &&// a[7] = +0, -0===+0
+    if (a.indexOf(-(4 / 3)) === 14 && // a[14]=_float===-(4/3)
+        a.indexOf(0) === 7 && // a[7] = +0, 0===+0
+        a.indexOf(-0) === 7 && // a[7] = +0, -0===+0
         a.indexOf(1) === 10) {
         return true;
     }

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity10.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity10.js
@@ -7,5 +7,5 @@
 //// [parserGreaterThanTokenAmbiguity10.js]
 1
     // before
-    >>>// after
+    >>> // after
         2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity15.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity15.js
@@ -7,5 +7,5 @@
 //// [parserGreaterThanTokenAmbiguity15.js]
 1
     // before
-    >>=// after
+    >>= // after
         2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity20.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity20.js
@@ -7,5 +7,5 @@
 //// [parserGreaterThanTokenAmbiguity20.js]
 1
     // Before
-    >>>=// after
+    >>>= // after
         2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity5.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity5.js
@@ -7,5 +7,5 @@
 //// [parserGreaterThanTokenAmbiguity5.js]
 1
     // before
-    >>// after
+    >> // after
         2;

--- a/tests/baselines/reference/typeGuardsInConditionalExpression.js
+++ b/tests/baselines/reference/typeGuardsInConditionalExpression.js
@@ -138,7 +138,7 @@ function foo8(x) {
     var b;
     return typeof x === "string"
         ? x === "hello"
-        : ((b = x) &&//  number | boolean
+        : ((b = x) && //  number | boolean
             (typeof x === "boolean"
                 ? x // boolean
                 : x == 10)); // boolean


### PR DESCRIPTION
Looking through our RWC results, I realized that we could be a bit better in how we emitted comments on binary expressions (from #16584), thanks to work done in #17557.
