### PR TITLE
Lower RWC Harness Memory Overhead

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1295,7 +1295,11 @@ namespace Harness {
 
             let firstLine = true;
             function newLine() {
-                return firstLine ? (firstLine = false, "") : "\r\n";
+                if (firstLine) {
+                    firstLine = false;
+                    return "";
+                }
+                return "\r\n";
             }
 
             function outputErrorText(error: ts.Diagnostic) {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1220,7 +1220,7 @@ namespace Harness {
             if (options.declaration && result.errors.length === 0 && result.declFilesCode.length > 0) {
                 ts.forEach(inputFiles, file => addDtsFile(file, declInputFiles));
                 ts.forEach(otherFiles, file => addDtsFile(file, declOtherFiles));
-                return {declInputFiles, declOtherFiles, harnessSettings, options, currentDirectory: currentDirectory || harnessSettings["currentDirectory"]};
+                return { declInputFiles, declOtherFiles, harnessSettings, options, currentDirectory: currentDirectory || harnessSettings["currentDirectory"] };
             }
 
             function addDtsFile(file: TestFile, dtsFiles: TestFile[]) {
@@ -1289,13 +1289,13 @@ namespace Harness {
 
         export function getErrorBaseline(inputFiles: TestFile[], diagnostics: ts.Diagnostic[]) {
             diagnostics.sort(ts.compareDiagnostics);
-            let outputLines: string = "";
+            let outputLines = "";
             // Count up all errors that were found in files other than lib.d.ts so we don't miss any
             let totalErrorsReportedInNonLibraryFiles = 0;
 
             let firstLine = true;
             function newLine() {
-                return firstLine ? (firstLine = false, "") : "\r\n"; 
+                return firstLine ? (firstLine = false, "") : "\r\n";
             }
 
             function outputErrorText(error: ts.Diagnostic) {

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -208,6 +208,14 @@ namespace RWC {
                 }, baselineOpts);
             });
 
+            it("has the expected types", () => {
+                // We don't need to pass the extension here because "doTypeAndSymbolBaseline" will append appropriate extension of ".types" or ".symbols"
+                Harness.Compiler.doTypeAndSymbolBaseline(baseName, compilerResult, inputFiles
+                    .concat(otherFiles)
+                    .filter(file => !!compilerResult.program.getSourceFile(file.unitName))
+                    .filter(e => !Harness.isDefaultLibraryFile(e.unitName)), baselineOpts);
+            });
+
             // Ideally, a generated declaration file will have no errors. But we allow generated
             // declaration file errors as part of the baseline.
             it("has the expected errors in generated declaration files", () => {
@@ -217,22 +225,18 @@ namespace RWC {
                             return null;
                         }
 
-                        const declFileCompilationResult = Harness.Compiler.compileDeclarationFiles(
-                            inputFiles, otherFiles, compilerResult, /*harnessSettings*/ undefined, compilerOptions, currentDirectory);
+                        const declContext = Harness.Compiler.prepareDeclarationCompilationContext(
+                            inputFiles, otherFiles, compilerResult, /*harnessSettings*/ undefined, compilerOptions, currentDirectory
+                        );
+                        // Reset compilerResult before calling into `compileDeclarationFiles` so the memory from the original compilation can be freed
+                        compilerResult = undefined;
+                        const declFileCompilationResult = Harness.Compiler.compileDeclarationFiles(declContext);
 
                         return Harness.Compiler.minimalDiagnosticsToString(declFileCompilationResult.declResult.errors) +
                             Harness.IO.newLine() + Harness.IO.newLine() +
                             Harness.Compiler.getErrorBaseline(tsconfigFiles.concat(declFileCompilationResult.declInputFiles, declFileCompilationResult.declOtherFiles), declFileCompilationResult.declResult.errors);
                     }, baselineOpts);
                 }
-            });
-
-            it("has the expected types", () => {
-                // We don't need to pass the extension here because "doTypeAndSymbolBaseline" will append appropriate extension of ".types" or ".symbols"
-                Harness.Compiler.doTypeAndSymbolBaseline(baseName, compilerResult, inputFiles
-                    .concat(otherFiles)
-                    .filter(file => !!compilerResult.program.getSourceFile(file.unitName))
-                    .filter(e => !Harness.isDefaultLibraryFile(e.unitName)), baselineOpts);
             });
         });
     }


### PR DESCRIPTION
Just a bit. Swaps to using string concatenation instead of `array.join` for baseline creation, and moves RWC declaration checking to the final step, and factors making the compilation context out of starting the compilation, so the original compilation can be disposed before the new compilation is started (and then moves to testing the declarations last so that it can be disposed).