### PR TITLE
Fix type predicate index in error reporting

### DIFF
--- a/tests/baselines/reference/thisTypeInTypePredicate.js
+++ b/tests/baselines/reference/thisTypeInTypePredicate.js
@@ -1,0 +1,7 @@
+//// [thisTypeInTypePredicate.ts]
+declare function filter<S>(f: (this: void, x: any) => x is S): S[];
+const numbers = filter<number>((x): x is number => 'number' == typeof x)
+
+
+//// [thisTypeInTypePredicate.js]
+var numbers = filter(function (x) { return 'number' == typeof x; });

--- a/tests/baselines/reference/thisTypeInTypePredicate.symbols
+++ b/tests/baselines/reference/thisTypeInTypePredicate.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts ===
+declare function filter<S>(f: (this: void, x: any) => x is S): S[];
+>filter : Symbol(filter, Decl(thisTypeInTypePredicate.ts, 0, 0))
+>S : Symbol(S, Decl(thisTypeInTypePredicate.ts, 0, 24))
+>f : Symbol(f, Decl(thisTypeInTypePredicate.ts, 0, 27))
+>this : Symbol(this, Decl(thisTypeInTypePredicate.ts, 0, 31))
+>x : Symbol(x, Decl(thisTypeInTypePredicate.ts, 0, 42))
+>x : Symbol(x, Decl(thisTypeInTypePredicate.ts, 0, 42))
+>S : Symbol(S, Decl(thisTypeInTypePredicate.ts, 0, 24))
+>S : Symbol(S, Decl(thisTypeInTypePredicate.ts, 0, 24))
+
+const numbers = filter<number>((x): x is number => 'number' == typeof x)
+>numbers : Symbol(numbers, Decl(thisTypeInTypePredicate.ts, 1, 5))
+>filter : Symbol(filter, Decl(thisTypeInTypePredicate.ts, 0, 0))
+>x : Symbol(x, Decl(thisTypeInTypePredicate.ts, 1, 32))
+>x : Symbol(x, Decl(thisTypeInTypePredicate.ts, 1, 32))
+>x : Symbol(x, Decl(thisTypeInTypePredicate.ts, 1, 32))
+

--- a/tests/baselines/reference/thisTypeInTypePredicate.types
+++ b/tests/baselines/reference/thisTypeInTypePredicate.types
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts ===
+declare function filter<S>(f: (this: void, x: any) => x is S): S[];
+>filter : <S>(f: (this: void, x: any) => x is S) => S[]
+>S : S
+>f : (this: void, x: any) => x is S
+>this : void
+>x : any
+>x : any
+>S : S
+>S : S
+
+const numbers = filter<number>((x): x is number => 'number' == typeof x)
+>numbers : number[]
+>filter<number>((x): x is number => 'number' == typeof x) : number[]
+>filter : <S>(f: (this: void, x: any) => x is S) => S[]
+>(x): x is number => 'number' == typeof x : (this: void, x: any) => x is number
+>x : any
+>x : any
+>'number' == typeof x : boolean
+>'number' : "number"
+>typeof x : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : any
+

--- a/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
+++ b/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
@@ -1,0 +1,2 @@
+declare function filter<S>(f: (this: void, x: any) => x is S): S[];
+const numbers = filter<number>((x): x is number => 'number' == typeof x)


### PR DESCRIPTION
Fixes #16021

Previously, type predicate error checking didn't take the `this` parameter into account when checking for errors. This led to spurious errors. Note that it's not feasible to change the initial value of `parameterIndex` because several checks refer to the original declaration, for example to make sure that a type predicate doesn't refer to a rest parameter.
