### PR TITLE
Discussion: Parameter type inference from function body

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16758,8 +16758,9 @@ namespace ts {
                     .filter(({ symbol }) => symbol && symbol.valueDeclaration === parameter)
                 if (!usages.length) return
                 const funcSymbol = getSymbolAtLocation(invocation.expression)
-                if (!funcSymbol) return
-                const sig = getSignatureFromDeclaration(funcSymbol.valueDeclaration as FunctionLikeDeclaration)
+                if (!funcSymbol || !isFunctionDeclaration(funcSymbol.valueDeclaration))
+                    return
+                const sig = getSignatureFromDeclaration(funcSymbol.valueDeclaration)
                 const parameterTypes = sig.parameters.map(getTypeOfParameter)
                 const argumentTypes = usages.map(({ i }) => parameterTypes[i])
                 usageTypes.splice(0, 0, ...argumentTypes);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16753,7 +16753,7 @@ namespace ts {
                 if (!usages.length)
                     return
                 const funcSymbol = getSymbolAtLocation(invocation.expression)
-                if (!funcSymbol || !isFunctionDeclaration(funcSymbol.valueDeclaration))
+                if (!funcSymbol || !isFunctionLike(funcSymbol.valueDeclaration))
                     return
                 const sig = getSignatureFromDeclaration(funcSymbol.valueDeclaration)
                 const parameterTypes = sig.parameters.map(getTypeOfParameter)

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4298,7 +4298,7 @@ namespace ts {
                     type = getContextualThisParameterType(func);
                 }
                 else {
-                    type = getContextuallyTypedParameterType(<ParameterDeclaration>declaration)
+                    type = getContextuallyTypedParameterType(<ParameterDeclaration>declaration);
                 }
                 if (type) {
                     return addOptionality(type, /*optional*/ declaration.questionToken && includeOptionality);
@@ -4329,8 +4329,8 @@ namespace ts {
 
             // Important to do this *after* attempt has been made to resolve via initializer
             if (declaration.kind === SyntaxKind.Parameter) {
-                const inferredType = getParameterTypeFromBody(<ParameterDeclaration>declaration)
-                if (inferredType) return inferredType
+                const inferredType = getParameterTypeFromBody(<ParameterDeclaration>declaration);
+                if (inferredType) return inferredType;
             }
 
             // No type specified and nothing can be inferred
@@ -12805,11 +12805,11 @@ namespace ts {
         }
 
         function getParameterTypeFromBody(parameter: ParameterDeclaration): Type {
-            const func = <FunctionLikeDeclaration>parameter.parent
-            if (!func.body || isRestParameter(parameter)) return
+            const func = <FunctionLikeDeclaration>parameter.parent;
+            if (!func.body || isRestParameter(parameter)) return;
 
-            const types = checkAndAggregateParameterExpressionTypes(parameter)
-            return types ? getWidenedType(getIntersectionType(types)) : undefined
+            const types = checkAndAggregateParameterExpressionTypes(parameter);
+            return types ? getWidenedType(getIntersectionType(types)) : undefined;
         }
 
         // Return contextual type of parameter or undefined if no contextual type is available
@@ -16744,20 +16744,18 @@ namespace ts {
         }
 
         function checkAndAggregateParameterExpressionTypes(parameter: ParameterDeclaration): Type[] {
-            const func = <FunctionLikeDeclaration>parameter.parent
-            const usageTypes: Type[] = []
+            const func = <FunctionLikeDeclaration>parameter.parent;
+            const usageTypes: Type[] = [];
             forEachInvocation(<Block>func.body, invocation => {
                 const usages = invocation.arguments
                     .map((arg, i) => ({ arg, symbol: getSymbolAtLocation(arg), i }))
-                    .filter(({ symbol }) => symbol && symbol.valueDeclaration === parameter)
-                if (!usages.length)
-                    return
-                const funcSymbol = getSymbolAtLocation(invocation.expression)
-                if (!funcSymbol || !isFunctionLike(funcSymbol.valueDeclaration))
-                    return
-                const sig = getSignatureFromDeclaration(funcSymbol.valueDeclaration)
-                const parameterTypes = sig.parameters.map(getTypeOfParameter)
-                const argumentTypes = usages.map(({ i }) => parameterTypes[i]).filter(t => !!t)
+                    .filter(({ symbol }) => symbol && symbol.valueDeclaration === parameter);
+                if (!usages.length) return;
+                const funcSymbol = getSymbolAtLocation(invocation.expression);
+                if (!funcSymbol || !isFunctionLike(funcSymbol.valueDeclaration)) return;
+                const sig = getSignatureFromDeclaration(funcSymbol.valueDeclaration);
+                const parameterTypes = sig.parameters.map(getTypeOfParameter);
+                const argumentTypes = usages.map(({ i }) => parameterTypes[i]).filter(t => !!t);
                 usageTypes.splice(0, 0, ...argumentTypes);
             });
             return usageTypes.length ? usageTypes : undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12806,9 +12806,7 @@ namespace ts {
 
         function getParameterTypeFromBody(parameter: ParameterDeclaration): Type {
             const func = <FunctionLikeDeclaration>parameter.parent
-            if (!func.body) {
-                return unknownType;
-            }
+            if (!func.body || isRestParameter(parameter)) return
 
             let type: Type;
             let types: Type[];

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16758,7 +16758,7 @@ namespace ts {
                 const argumentTypes = usages.map(({ i }) => parameterTypes[i])
                 usageTypes.splice(0, 0, ...argumentTypes);
             });
-            return usageTypes;
+            return usageTypes.length ? usageTypes : undefined;
         }
 
         function checkAndAggregateReturnExpressionTypes(func: FunctionLikeDeclaration, checkMode: CheckMode): Type[] {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16752,10 +16752,10 @@ namespace ts {
                 forEachInvocation(f, invocation => {
                     invocations.push(invocation);
                     invocation.arguments.filter(isFunctionExpressionOrArrowFunction).forEach(arg => seekInvocations(<Block>arg.body));
-                })
+                });
             }
 
-            seekInvocations(<Block>func.body)
+            seekInvocations(<Block>func.body);
 
             invocations.forEach(invocation => {
                 const usages = invocation.arguments

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12808,12 +12808,8 @@ namespace ts {
             const func = <FunctionLikeDeclaration>parameter.parent
             if (!func.body || isRestParameter(parameter)) return
 
-            let type: Type;
-            let types: Type[];
-            types = checkAndAggregateParameterExpressionTypes(parameter)
-            type = types ? getWidenedType(getIntersectionType(types)) : undefined;
-
-            return type;
+            const types = checkAndAggregateParameterExpressionTypes(parameter)
+            return types ? getWidenedType(getIntersectionType(types)) : undefined
         }
 
         // Return contextual type of parameter or undefined if no contextual type is available
@@ -16754,7 +16750,8 @@ namespace ts {
                 const usages = invocation.arguments
                     .map((arg, i) => ({ arg, symbol: getSymbolAtLocation(arg), i }))
                     .filter(({ symbol }) => symbol && symbol.valueDeclaration === parameter)
-                if (!usages.length) return
+                if (!usages.length)
+                    return
                 const funcSymbol = getSymbolAtLocation(invocation.expression)
                 if (!funcSymbol || !isFunctionDeclaration(funcSymbol.valueDeclaration))
                     return

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16757,7 +16757,9 @@ namespace ts {
                     .map((arg, i) => ({ arg, symbol: getSymbolAtLocation(arg), i }))
                     .filter(({ symbol }) => symbol && symbol.valueDeclaration === parameter)
                 if (!usages.length) return
-                const sig = getSignatureFromDeclaration(getSymbolAtLocation(invocation.expression).valueDeclaration as FunctionLikeDeclaration)
+                const funcSymbol = getSymbolAtLocation(invocation.expression)
+                if (!funcSymbol) return
+                const sig = getSignatureFromDeclaration(funcSymbol.valueDeclaration as FunctionLikeDeclaration)
                 const parameterTypes = sig.parameters.map(getTypeOfParameter)
                 const argumentTypes = usages.map(({ i }) => parameterTypes[i])
                 usageTypes.splice(0, 0, ...argumentTypes);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16757,7 +16757,7 @@ namespace ts {
                     return
                 const sig = getSignatureFromDeclaration(funcSymbol.valueDeclaration)
                 const parameterTypes = sig.parameters.map(getTypeOfParameter)
-                const argumentTypes = usages.map(({ i }) => parameterTypes[i])
+                const argumentTypes = usages.map(({ i }) => parameterTypes[i]).filter(t => !!t)
                 usageTypes.splice(0, 0, ...argumentTypes);
             });
             return usageTypes.length ? usageTypes : undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4327,10 +4327,14 @@ namespace ts {
                 return getTypeFromBindingPattern(<BindingPattern>declaration.name, /*includePatternInType*/ false, /*reportErrors*/ true);
             }
 
-            const inferredType = getParameterTypeFromBody(<ParameterDeclaration>declaration)
+            // Important to do this *after* attempt has been made to resolve via initializer
+            if (declaration.kind === SyntaxKind.Parameter) {
+                const inferredType = getParameterTypeFromBody(<ParameterDeclaration>declaration)
+                if (inferredType) return inferredType
+            }
 
             // No type specified and nothing can be inferred
-            return inferredType || undefined;
+            return undefined;
         }
 
         function getWidenedTypeFromJSSpecialPropertyDeclarations(symbol: Symbol) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -764,7 +764,7 @@ namespace ts {
         function traverse(node: Node): T {
             switch (node.kind) {
                 case SyntaxKind.CallExpression:
-                    return visitor(<CallExpression>node)
+                    return visitor(<CallExpression>node);
                 default:
                     return forEachChild(node, traverse);
             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -757,6 +757,20 @@ namespace ts {
         return false;
     }
 
+    export function forEachInvocation<T>(body: Block, visitor: (stmt: CallExpression) => T): T {
+
+        return traverse(body);
+
+        function traverse(node: Node): T {
+            switch (node.kind) {
+                case SyntaxKind.CallExpression:
+                    return visitor(<CallExpression>node)
+                default:
+                    return forEachChild(node, traverse);
+            }
+        }
+    }
+
     // Warning: This has the same semantics as the forEach family of functions,
     //          in that traversal terminates in the event that 'visitor' supplies a truthy value.
     export function forEachReturnStatement<T>(body: Block, visitor: (stmt: ReturnStatement) => T): T {

--- a/tests/baselines/reference/controlFlowPropertyDeclarations.types
+++ b/tests/baselines/reference/controlFlowPropertyDeclarations.types
@@ -196,8 +196,8 @@ function hyphenToCamelCase(string) {
  * Determines if the specified string consists entirely of whitespace.
  */
 function isEmpty(string) {
->isEmpty : (string: any) => boolean
->string : any
+>isEmpty : (string: string) => boolean
+>string : string
 
    return !/[^\s]/.test(string);
 >!/[^\s]/.test(string) : boolean
@@ -205,7 +205,7 @@ function isEmpty(string) {
 >/[^\s]/.test : (string: string) => boolean
 >/[^\s]/ : RegExp
 >test : (string: string) => boolean
->string : any
+>string : string
 }
 
 /**
@@ -216,15 +216,15 @@ function isEmpty(string) {
  * @return {boolean}
  */
 function isConvertiblePixelValue(value) {
->isConvertiblePixelValue : (value: any) => boolean
->value : any
+>isConvertiblePixelValue : (value: string) => boolean
+>value : string
 
   return /^\d+px$/.test(value);
 >/^\d+px$/.test(value) : boolean
 >/^\d+px$/.test : (string: string) => boolean
 >/^\d+px$/ : RegExp
 >test : (string: string) => boolean
->value : any
+>value : string
 }
 
 export class HTMLtoJSX {

--- a/tests/baselines/reference/parameterInference.js
+++ b/tests/baselines/reference/parameterInference.js
@@ -17,12 +17,20 @@ function subs(s) {
 // => (s: string) => number & (s: number) => string
 
 // CASE 3
-function f(x: number){
+function f3(x: number){
    return x;
 }
 
-function g(x){ return f(x); };
-// => function g(x: number): number
+function g3(x){ return f3(x); };
+// => function g3(x: number): number
+
+// CASE 4
+declare function f4(g: Function)
+function g4(x) {
+  f4(() => {
+    Math.sqrt(x)
+  })
+}
 
 
 //// [parameterInference.js]
@@ -37,9 +45,13 @@ function subs(s) {
 // NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
 // => (s: string) => number & (s: number) => string
 // CASE 3
-function f(x) {
+function f3(x) {
     return x;
 }
-function g(x) { return f(x); }
+function g3(x) { return f3(x); }
 ;
-// => function g(x: number): number
+function g4(x) {
+    f4(function () {
+        Math.sqrt(x);
+    });
+}

--- a/tests/baselines/reference/parameterInference.js
+++ b/tests/baselines/reference/parameterInference.js
@@ -1,0 +1,45 @@
+//// [parameterInference.ts]
+// CASE 1
+function foo(s) {
+    Math.sqrt(s)
+}
+// => function foo(s: number): void
+
+// CASE 2
+declare function swapNumberString(n: string): number;
+declare function swapNumberString(n: number): string;
+
+function subs(s) {
+  return swapNumberString(s);
+}
+// => function subs(s: string): number
+// NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
+// => (s: string) => number & (s: number) => string
+
+// CASE 3
+function f(x: number){
+   return x;
+}
+
+function g(x){ return f(x); };
+// => function g(x: number): number
+
+
+//// [parameterInference.js]
+// CASE 1
+function foo(s) {
+    Math.sqrt(s);
+}
+function subs(s) {
+    return swapNumberString(s);
+}
+// => function subs(s: string): number
+// NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
+// => (s: string) => number & (s: number) => string
+// CASE 3
+function f(x) {
+    return x;
+}
+function g(x) { return f(x); }
+;
+// => function g(x: number): number

--- a/tests/baselines/reference/parameterInference.symbols
+++ b/tests/baselines/reference/parameterInference.symbols
@@ -34,19 +34,41 @@ function subs(s) {
 // => (s: string) => number & (s: number) => string
 
 // CASE 3
-function f(x: number){
->f : Symbol(f, Decl(parameterInference.ts, 12, 1))
->x : Symbol(x, Decl(parameterInference.ts, 18, 11))
+function f3(x: number){
+>f3 : Symbol(f3, Decl(parameterInference.ts, 12, 1))
+>x : Symbol(x, Decl(parameterInference.ts, 18, 12))
 
    return x;
->x : Symbol(x, Decl(parameterInference.ts, 18, 11))
+>x : Symbol(x, Decl(parameterInference.ts, 18, 12))
 }
 
-function g(x){ return f(x); };
->g : Symbol(g, Decl(parameterInference.ts, 20, 1))
->x : Symbol(x, Decl(parameterInference.ts, 22, 11))
->f : Symbol(f, Decl(parameterInference.ts, 12, 1))
->x : Symbol(x, Decl(parameterInference.ts, 22, 11))
+function g3(x){ return f3(x); };
+>g3 : Symbol(g3, Decl(parameterInference.ts, 20, 1))
+>x : Symbol(x, Decl(parameterInference.ts, 22, 12))
+>f3 : Symbol(f3, Decl(parameterInference.ts, 12, 1))
+>x : Symbol(x, Decl(parameterInference.ts, 22, 12))
 
-// => function g(x: number): number
+// => function g3(x: number): number
+
+// CASE 4
+declare function f4(g: Function)
+>f4 : Symbol(f4, Decl(parameterInference.ts, 22, 32))
+>g : Symbol(g, Decl(parameterInference.ts, 26, 20))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+function g4(x) {
+>g4 : Symbol(g4, Decl(parameterInference.ts, 26, 32))
+>x : Symbol(x, Decl(parameterInference.ts, 27, 12))
+
+  f4(() => {
+>f4 : Symbol(f4, Decl(parameterInference.ts, 22, 32))
+
+    Math.sqrt(x)
+>Math.sqrt : Symbol(Math.sqrt, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>sqrt : Symbol(Math.sqrt, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(parameterInference.ts, 27, 12))
+
+  })
+}
 

--- a/tests/baselines/reference/parameterInference.symbols
+++ b/tests/baselines/reference/parameterInference.symbols
@@ -1,0 +1,52 @@
+=== tests/cases/compiler/parameterInference.ts ===
+// CASE 1
+function foo(s) {
+>foo : Symbol(foo, Decl(parameterInference.ts, 0, 0))
+>s : Symbol(s, Decl(parameterInference.ts, 1, 13))
+
+    Math.sqrt(s)
+>Math.sqrt : Symbol(Math.sqrt, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>sqrt : Symbol(Math.sqrt, Decl(lib.d.ts, --, --))
+>s : Symbol(s, Decl(parameterInference.ts, 1, 13))
+}
+// => function foo(s: number): void
+
+// CASE 2
+declare function swapNumberString(n: string): number;
+>swapNumberString : Symbol(swapNumberString, Decl(parameterInference.ts, 3, 1), Decl(parameterInference.ts, 7, 53))
+>n : Symbol(n, Decl(parameterInference.ts, 7, 34))
+
+declare function swapNumberString(n: number): string;
+>swapNumberString : Symbol(swapNumberString, Decl(parameterInference.ts, 3, 1), Decl(parameterInference.ts, 7, 53))
+>n : Symbol(n, Decl(parameterInference.ts, 8, 34))
+
+function subs(s) {
+>subs : Symbol(subs, Decl(parameterInference.ts, 8, 53))
+>s : Symbol(s, Decl(parameterInference.ts, 10, 14))
+
+  return swapNumberString(s);
+>swapNumberString : Symbol(swapNumberString, Decl(parameterInference.ts, 3, 1), Decl(parameterInference.ts, 7, 53))
+>s : Symbol(s, Decl(parameterInference.ts, 10, 14))
+}
+// => function subs(s: string): number
+// NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
+// => (s: string) => number & (s: number) => string
+
+// CASE 3
+function f(x: number){
+>f : Symbol(f, Decl(parameterInference.ts, 12, 1))
+>x : Symbol(x, Decl(parameterInference.ts, 18, 11))
+
+   return x;
+>x : Symbol(x, Decl(parameterInference.ts, 18, 11))
+}
+
+function g(x){ return f(x); };
+>g : Symbol(g, Decl(parameterInference.ts, 20, 1))
+>x : Symbol(x, Decl(parameterInference.ts, 22, 11))
+>f : Symbol(f, Decl(parameterInference.ts, 12, 1))
+>x : Symbol(x, Decl(parameterInference.ts, 22, 11))
+
+// => function g(x: number): number
+

--- a/tests/baselines/reference/parameterInference.types
+++ b/tests/baselines/reference/parameterInference.types
@@ -36,20 +36,45 @@ function subs(s) {
 // => (s: string) => number & (s: number) => string
 
 // CASE 3
-function f(x: number){
->f : (x: number) => number
+function f3(x: number){
+>f3 : (x: number) => number
 >x : number
 
    return x;
 >x : number
 }
 
-function g(x){ return f(x); };
->g : (x: number) => number
+function g3(x){ return f3(x); };
+>g3 : (x: number) => number
 >x : number
->f(x) : number
->f : (x: number) => number
+>f3(x) : number
+>f3 : (x: number) => number
 >x : number
 
-// => function g(x: number): number
+// => function g3(x: number): number
+
+// CASE 4
+declare function f4(g: Function)
+>f4 : (g: Function) => any
+>g : Function
+>Function : Function
+
+function g4(x) {
+>g4 : (x: number) => void
+>x : number
+
+  f4(() => {
+>f4(() => {    Math.sqrt(x)  }) : any
+>f4 : (g: Function) => any
+>() => {    Math.sqrt(x)  } : () => void
+
+    Math.sqrt(x)
+>Math.sqrt(x) : number
+>Math.sqrt : (x: number) => number
+>Math : Math
+>sqrt : (x: number) => number
+>x : number
+
+  })
+}
 

--- a/tests/baselines/reference/parameterInference.types
+++ b/tests/baselines/reference/parameterInference.types
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/parameterInference.ts ===
+// CASE 1
+function foo(s) {
+>foo : (s: number) => void
+>s : number
+
+    Math.sqrt(s)
+>Math.sqrt(s) : number
+>Math.sqrt : (x: number) => number
+>Math : Math
+>sqrt : (x: number) => number
+>s : number
+}
+// => function foo(s: number): void
+
+// CASE 2
+declare function swapNumberString(n: string): number;
+>swapNumberString : { (n: string): number; (n: number): string; }
+>n : string
+
+declare function swapNumberString(n: number): string;
+>swapNumberString : { (n: string): number; (n: number): string; }
+>n : number
+
+function subs(s) {
+>subs : (s: string) => number
+>s : string
+
+  return swapNumberString(s);
+>swapNumberString(s) : number
+>swapNumberString : { (n: string): number; (n: number): string; }
+>s : string
+}
+// => function subs(s: string): number
+// NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
+// => (s: string) => number & (s: number) => string
+
+// CASE 3
+function f(x: number){
+>f : (x: number) => number
+>x : number
+
+   return x;
+>x : number
+}
+
+function g(x){ return f(x); };
+>g : (x: number) => number
+>x : number
+>f(x) : number
+>f : (x: number) => number
+>x : number
+
+// => function g(x: number): number
+

--- a/tests/cases/compiler/parameterInference.ts
+++ b/tests/cases/compiler/parameterInference.ts
@@ -22,3 +22,10 @@ function f(x: number){
 
 function g(x){ return f(x); };
 // => function g(x: number): number
+// CASE 4
+declare function f4(g: Function)
+function g4(x) {
+  f4(() => {
+    Math.sqrt(x)
+  })
+}

--- a/tests/cases/compiler/parameterInference.ts
+++ b/tests/cases/compiler/parameterInference.ts
@@ -1,10 +1,10 @@
-// CASE 1
+// CASE 1 - Propagation of parameter types from invocations
 function foo(s) {
     Math.sqrt(s)
 }
 // => function foo(s: number): void
 
-// CASE 2
+// CASE 2 - Inference from invocation of overloaded functions
 declare function swapNumberString(n: string): number;
 declare function swapNumberString(n: number): string;
 
@@ -15,7 +15,7 @@ function subs(s) {
 // NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
 // => (s: string) => number & (s: number) => string
 
-// CASE 3
+// CASE 3 - Propagation of explicitly annotated parameter types
 function f3(x: number){
    return x;
 }
@@ -23,7 +23,7 @@ function f3(x: number){
 function g3(x){ return f3(x); };
 // => function g3(x: number): number
 
-// CASE 4
+// CASE 4 - Inference from invocation sites within function expressions passed as arguments 
 declare function f4(g: Function)
 function g4(x) {
   f4(() => {

--- a/tests/cases/compiler/parameterInference.ts
+++ b/tests/cases/compiler/parameterInference.ts
@@ -1,32 +1,68 @@
 // CASE 1 - Propagation of parameter types from invocations
-function foo(s) {
+function f1(s) {
     Math.sqrt(s)
 }
-// => function foo(s: number): void
+// => function f1(s: number): void
 
 // CASE 2 - Inference from invocation of overloaded functions
 declare function swapNumberString(n: string): number;
 declare function swapNumberString(n: number): string;
 
-function subs(s) {
+function f2(s) {
   return swapNumberString(s);
 }
-// => function subs(s: string): number
-// NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
+// => function f2(s: string): number
+// TODO: Broken, needs to deal with overloads. Should have been inferred as:
 // => (s: string) => number & (s: number) => string
 
 // CASE 3 - Propagation of explicitly annotated parameter types
-function f3(x: number){
-   return x;
-}
+declare function f3(x: number)
 
-function g3(x){ return f3(x); };
-// => function g3(x: number): number
+function g3(x){
+  return f3(x);
+}
+// => function g3(x: number): any
 
 // CASE 4 - Inference from invocation sites within function expressions passed as arguments 
 declare function f4(g: Function)
+
 function g4(x) {
   f4(() => {
     Math.sqrt(x)
   })
 }
+// => function g4(x: number): void
+
+// CASE 5 - Ensure termination for recursive invocations
+function f5(s) {
+  f5(s)
+}
+// => function f5(s: any): void
+
+// CASE 6 - Inference as intersection from multiple usages
+function f6(x) {
+  Math.sqrt(x)
+  "".indexOf(x)
+}
+// => function f6(x: string & number): void
+
+// CASE 7 - Inference as overloaded function from control-flow discriminated usages
+declare function isNumber<T>(x: T): x is T & number
+
+function f7(x) {
+  return isNumber(x) ? Math.sqrt(x) : "".indexOf(x)
+}
+// function f7(x: string & number & T): number
+// TODO: Broken, generic type parameter leaks and x is inferred too conservatively (string & number)
+// Should be:
+// => (s: string) => number & (s: number) => number
+
+// CASE 8 - Inference by substitution of constraints for generic functions
+declare function generic<T>(t: T)
+
+function f8(x) {
+  generic(x)
+}
+// function f8(x: T): void
+// TODO: Broken, type parameter leaks. Should be inferred as:
+// function f8(x: {}): void

--- a/tests/cases/compiler/parameterInference.ts
+++ b/tests/cases/compiler/parameterInference.ts
@@ -1,0 +1,13 @@
+// CASE 1
+function foo(s) {
+    Math.sqrt(s)
+}
+
+// CASE 2
+declare function swapNumberString(n: string): number;
+declare function swapNumberString(n: number): string;
+
+// Should have identical signature to swapNumberString
+function subs(s) {
+  return swapNumberString(s);
+}

--- a/tests/cases/compiler/parameterInference.ts
+++ b/tests/cases/compiler/parameterInference.ts
@@ -16,12 +16,13 @@ function subs(s) {
 // => (s: string) => number & (s: number) => string
 
 // CASE 3
-function f(x: number){
+function f3(x: number){
    return x;
 }
 
-function g(x){ return f(x); };
-// => function g(x: number): number
+function g3(x){ return f3(x); };
+// => function g3(x: number): number
+
 // CASE 4
 declare function f4(g: Function)
 function g4(x) {

--- a/tests/cases/compiler/parameterInference.ts
+++ b/tests/cases/compiler/parameterInference.ts
@@ -2,21 +2,23 @@
 function foo(s) {
     Math.sqrt(s)
 }
+// => function foo(s: number): void
 
 // CASE 2
 declare function swapNumberString(n: string): number;
 declare function swapNumberString(n: number): string;
 
-// Should have identical signature to swapNumberString
 function subs(s) {
   return swapNumberString(s);
 }
+// => function subs(s: string): number
+// NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
+// => (s: string) => number & (s: number) => string
 
 // CASE 3
 function f(x: number){
    return x;
 }
 
-function g(x){ return x};
-
-function h(x){ return f(x); };
+function g(x){ return f(x); };
+// => function g(x: number): number

--- a/tests/cases/compiler/parameterInference.ts
+++ b/tests/cases/compiler/parameterInference.ts
@@ -11,3 +11,12 @@ declare function swapNumberString(n: number): string;
 function subs(s) {
   return swapNumberString(s);
 }
+
+// CASE 3
+function f(x: number){
+   return x;
+}
+
+function g(x){ return x};
+
+function h(x){ return f(x); };


### PR DESCRIPTION
This PR is **not** intended to be merged as-is, it is an attempt at demonstrating the feasibility of #15114, and is a request for revisiting this topic.

The change facilitates inference of parameter types from usage as arguments within the function body. Some motivating examples and the inferred types are shown below:

```ts
// CASE 1
function foo(s) {
    Math.sqrt(s)
}
// => function foo(s: number): void

// CASE 2
declare function swapNumberString(n: string): number;
declare function swapNumberString(n: number): string;

function subs(s) {
  return swapNumberString(s);
}
// => function subs(s: string): number

// NOTE: Still broken, needs to deal with overloads. Should have been inferred as:
// => (s: string) => number & (s: number) => string

// CASE 3
function f(x: number){
   return x;
}

function g(x){ return f(x); };
// => function g(x: number): number
```