### PR TITLE
Return an object from completions-full

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1173,10 +1173,10 @@ namespace ts.server {
             const position = this.getPosition(args, scriptInfo);
 
             const completions = project.getLanguageService().getCompletionsAtPosition(file, position);
-            if (!completions) {
-                return emptyArray;
-            }
             if (simplifiedResult) {
+                if (!completions) {
+                    return emptyArray;
+                }
                 return mapDefined(completions.entries, entry => {
                     if (completions.isMemberCompletion || (entry.name.toLowerCase().indexOf(prefix.toLowerCase()) === 0)) {
                         const { name, kind, kindModifiers, sortText, replacementSpan } = entry;
@@ -1186,7 +1186,12 @@ namespace ts.server {
                 }).sort((a, b) => compareStrings(a.name, b.name));
             }
             else {
-                return completions;
+                return completions || {
+                    isGlobalCompletion: false,
+                    isMemberCompletion: false,
+                    isNewIdentifierLocation: false,
+                    entries: [],
+                };
             }
         }
 


### PR DESCRIPTION
Simple completions return an array but full completions return an object
(containing an array).  We used to return null for both case when there
were no completions to return, but in
f124e199718b9cda06654af2ce487f1d6a332b34 we stopped returning
`undefined` for requests that require a response.  We started returning
`[]` instead, in both cases, which caused problems when deserializing
responses to `completions-full`.  Instead, return `[]` for simple
completions and and empty object (containing an empty array) for full
completions.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
