### PR TITLE
Do not inline sourcemaps in jake - source-map-support can't handle it

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -946,7 +946,7 @@ compileFile(nodeServerOutFile, [nodeServerInFile], [builtLocalDirectory, tscFile
 desc("Runs browserify on run.js to produce a file suitable for running tests in the browser");
 task("browserify", [], function() {
     // Shell out to `gulp`, since we do the work to handle sourcemaps correctly w/o inline maps there
-    var cmd = 'gulp browserify';
+    var cmd = 'gulp browserify --silent';
     exec(cmd);
 }, { async: true });
 

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -533,7 +533,6 @@ var tscFile = path.join(builtLocalDirectory, compilerFilename);
 compileFile(tscFile, compilerSources, [builtLocalDirectory, copyright].concat(compilerSources), [copyright], /*useBuiltCompiler:*/ false);
 
 var servicesFile = path.join(builtLocalDirectory, "typescriptServices.js");
-var servicesFileInBrowserTest = path.join(builtLocalDirectory, "typescriptServicesInBrowserTest.js");
 var standaloneDefinitionsFile = path.join(builtLocalDirectory, "typescriptServices.d.ts");
 var nodePackageFile = path.join(builtLocalDirectory, "typescript.js");
 var nodeDefinitionsFile = path.join(builtLocalDirectory, "typescript.d.ts");
@@ -570,22 +569,6 @@ compileFile(servicesFile, servicesSources, [builtLocalDirectory, copyright].conc
         // 'ts' namespace with '"typescript"' as a module.
         var nodeStandaloneDefinitionsFileContents = definitionFileContents.replace(/declare (namespace|module) ts/g, 'declare module "typescript"');
         fs.writeFileSync(nodeStandaloneDefinitionsFile, nodeStandaloneDefinitionsFileContents);
-    });
-
-compileFile(
-    servicesFileInBrowserTest,
-    servicesSources,
-    [builtLocalDirectory, copyright].concat(servicesSources),
-    /*prefixes*/[copyright],
-    /*useBuiltCompiler*/ true,
-    {
-        noOutFile: false,
-        generateDeclarations: true,
-        preserveConstEnums: true,
-        keepComments: true,
-        noResolve: false,
-        stripInternal: true,
-        inlineSourceMap: true
     });
 
 file(typescriptServicesDts, [servicesFile]);
@@ -725,7 +708,7 @@ compileFile(
     /*prereqs*/[builtLocalDirectory, tscFile].concat(libraryTargets).concat(servicesSources).concat(harnessSources),
     /*prefixes*/[],
     /*useBuiltCompiler:*/ true,
-    /*opts*/ { inlineSourceMap: true, types: ["node", "mocha", "chai"], lib: "es6" });
+    /*opts*/ { types: ["node", "mocha", "chai"], lib: "es6" });
 
 var internalTests = "internal/";
 
@@ -961,13 +944,14 @@ var nodeServerInFile = "tests/webTestServer.ts";
 compileFile(nodeServerOutFile, [nodeServerInFile], [builtLocalDirectory, tscFile], [], /*useBuiltCompiler:*/ true, { noOutFile: true, lib: "es6" });
 
 desc("Runs browserify on run.js to produce a file suitable for running tests in the browser");
-task("browserify", ["tests", run, builtLocalDirectory, nodeServerOutFile], function() {
-    var cmd = 'browserify built/local/run.js -t ./scripts/browserify-optional -d -o built/local/bundle.js';
+task("browserify", [], function() {
+    // Shell out to `gulp`, since we do the work to handle sourcemaps correctly w/o inline maps there
+    var cmd = 'gulp browserify';
     exec(cmd);
 }, { async: true });
 
 desc("Runs the tests using the built run.js file like 'jake runtests'. Syntax is jake runtests-browser. Additional optional parameters tests=[regex], browser=[chrome|IE]");
-task("runtests-browser", ["tests", "browserify", builtLocalDirectory, servicesFileInBrowserTest], function () {
+task("runtests-browser", ["browserify", nodeServerOutFile], function () {
     cleanTestDirs();
     host = "node";
     browser = process.env.browser || process.env.b ||  (os.platform() === "linux" ? "chrome" : "IE");


### PR DESCRIPTION
Internally, `source-map-support` (which we enable during tests/debugging for sourcemapped stack traces, and recently started inspecting during tests when we stopped using a noop logger for them) uses a regexp to find the source mapping url - except with inline sources and inline source maps, we have a 25MB file it operates over. With a backtracking regexp, this sometimes triggers [this v8 behavior](https://bugs.chromium.org/p/v8/issues/detail?id=3878) (if the heap is in heavy use - like when we're deep inside our test suite in a single process). This was causing tests to fail on our internal CI server. Best I can tell, this doesn't happen on travis because the memory pressure is different (specifically, travis is already on node `8.3`, while both myself and the CI server (the only machines which repo'd this issue) were on node `8.1.2` - best I can tell, [`8.1.3`](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.1.3) apparently reduced the memory usage of the profiler API by [instantiating fewer regexes](https://github.com/nodejs/node/pull/13709) in the node profiler polyfill). 

The fix is to just not use 15MB of inline sourcemaps. In the `Jakefile`, we were doing this to enable sourcemaps to work with `runtests-browser` - but we've had this working for awhile without using inline sources in our implementation in the `Gulpfile`. So now the `Jakefile` no longer builds tests with inline sourcemaps _and_ shells out to `gulp` to build tests for the browser.

If you're using `jake`, you should not notice much of a difference in your workflow.