### PR TITLE
Enable interface-over-type-literal lint rule

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21448,7 +21448,7 @@ namespace ts {
                 return true;
             }
 
-            type InheritanceInfoMap = { prop: Symbol; containingType: Type };
+            interface InheritanceInfoMap { prop: Symbol; containingType: Type; }
             const seen = createUnderscoreEscapedMap<InheritanceInfoMap>();
             forEach(resolveDeclaredMembers(type).declaredProperties, p => { seen.set(p.escapedName, { prop: p, containingType: type }); });
             let ok = true;

--- a/src/harness/unittests/convertTypeAcquisitionFromJson.ts
+++ b/src/harness/unittests/convertTypeAcquisitionFromJson.ts
@@ -2,7 +2,7 @@
 /// <reference path="..\..\compiler\commandLineParser.ts" />
 
 namespace ts {
-    type ExpectedResult = { typeAcquisition: TypeAcquisition, errors: Diagnostic[] };
+    interface ExpectedResult { typeAcquisition: TypeAcquisition; errors: Diagnostic[]; }
     describe("convertTypeAcquisitionFromJson", () => {
         function assertTypeAcquisition(json: any, configFileName: string, expectedResult: ExpectedResult) {
             assertTypeAcquisitionWithJson(json, configFileName, expectedResult);

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -450,7 +450,7 @@ namespace ts.server.protocol {
      * Represents a single refactoring action - for example, the "Extract Method..." refactor might
      * offer several actions, each corresponding to a surround class or closure to extract into.
      */
-    export type RefactorActionInfo = {
+    export interface RefactorActionInfo {
         /**
          * The programmatic name of the refactoring action
          */
@@ -462,7 +462,7 @@ namespace ts.server.protocol {
          * so this description should make sense by itself if the parent is inlineable=true
          */
         description: string;
-    };
+    }
 
     export interface GetEditsForRefactorRequest extends Request {
         command: CommandTypes.GetEditsForRefactor;
@@ -485,7 +485,7 @@ namespace ts.server.protocol {
         body?: RefactorEditInfo;
     }
 
-    export type RefactorEditInfo = {
+    export interface RefactorEditInfo {
         edits: FileCodeEdits[];
 
         /**
@@ -494,7 +494,7 @@ namespace ts.server.protocol {
          */
         renameLocation?: Location;
         renameFilename?: string;
-    };
+    }
 
     /**
      * Request for the available codefixes at a specific position.

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -73,12 +73,12 @@ namespace ts.server.typingsInstaller {
     }
 
     export type RequestCompletedAction = (success: boolean) => void;
-    type PendingRequest = {
+    interface PendingRequest {
         requestId: number;
         args: string[];
         cwd: string;
         onRequestCompleted: RequestCompletedAction;
-    };
+    }
 
     export abstract class TypingsInstaller {
         private readonly packageNameToTypingLocation: Map<string> = createMap<string>();

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -1,6 +1,12 @@
 /* @internal */
 namespace ts.NavigateTo {
-    type RawNavigateToItem = { name: string; fileName: string; matchKind: PatternMatchKind; isCaseSensitive: boolean; declaration: Declaration };
+    interface RawNavigateToItem {
+        name: string;
+        fileName: string;
+        matchKind: PatternMatchKind;
+        isCaseSensitive: boolean;
+        declaration: Declaration;
+    }
 
     export function getNavigateToItems(sourceFiles: SourceFile[], checker: TypeChecker, cancellationToken: CancellationToken, searchValue: string, maxResultCount: number, excludeDtsFiles: boolean): NavigateToItem[] {
         const patternMatcher = createPatternMatcher(searchValue);

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -393,7 +393,7 @@ namespace ts {
      * Represents a single refactoring action - for example, the "Extract Method..." refactor might
      * offer several actions, each corresponding to a surround class or closure to extract into.
      */
-    export type RefactorActionInfo = {
+    export interface RefactorActionInfo {
         /**
          * The programmatic name of the refactoring action
          */
@@ -405,18 +405,17 @@ namespace ts {
          * so this description should make sense by itself if the parent is inlineable=true
          */
         description: string;
-    };
+    }
 
     /**
      * A set of edits to make in response to a refactor action, plus an optional
      * location where renaming should be invoked from
      */
-    export type RefactorEditInfo = {
+    export interface RefactorEditInfo {
         edits: FileTextChanges[];
         renameFilename?: string;
         renameLocation?: number;
-    };
-
+    }
 
     export interface TextInsertion {
         newText: string;

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,7 @@
         "indent": [true,
             "spaces"
         ],
+        "interface-over-type-literal": true,
         "jsdoc-format": true,
         "linebreak-style": [true, "CRLF"],
         "next-line": [true,


### PR DESCRIPTION
This would lint that we always use an interface instead of `type T = { ... };`.
Thoughts? We already mostly follow this pattern.