### PR TITLE
Fix runtests-browser with latest node

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
         "setup-hooks": "node scripts/link-hooks.js"
     },
     "browser": {
-        "buffer": false,
         "fs": false,
         "os": false,
         "path": false

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -132,17 +132,16 @@ namespace Utils {
         return content;
     }
 
-    export function memoize<T extends Function>(f: T): T {
+    export function memoize<T extends Function>(f: T, memoKey?: (...anything: any[]) => string): T {
         const cache: { [idx: string]: any } = {};
 
-        return <any>(function(this: any) {
-            const key = Array.prototype.join.call(arguments);
-            const cachedResult = cache[key];
-            if (cachedResult) {
-                return cachedResult;
+        return <any>(function(this: any, ...args: any[]) {
+            const key = memoKey ? memoKey(...args) : Array.prototype.join.call(args);
+            if (key in cache) {
+                return cache[key];
             }
             else {
-                return cache[key] = f.apply(this, arguments);
+                return cache[key] = f.apply(this, args);
             }
         });
     }
@@ -718,7 +717,7 @@ namespace Harness {
                 else {
                     return [""];
                 }
-            });
+            }, (path: string, spec?: RegExp, options?: { recursive?: boolean }) => `${path}${spec}${options ? options.recursive : undefined}`);
 
             export function readFile(file: string): string | undefined {
                 const response = Http.getFileFromServerSync(serverRoot + file);

--- a/tests/webTestServer.ts
+++ b/tests/webTestServer.ts
@@ -288,7 +288,7 @@ console.log(`Static file server running at\n  => http://localhost:${port}/\nCTRL
 
 http.createServer((req: http.ServerRequest, res: http.ServerResponse) => {
     log(`${req.method} ${req.url}`);
-    const uri = url.parse(req.url).pathname;
+    const uri = decodeURIComponent(url.parse(req.url).pathname);
     const reqPath = path.join(process.cwd(), uri);
     const operation = getRequestOperation(req);
     handleRequestOperation(req, res, operation, reqPath);


### PR DESCRIPTION
And assorted other small harness fixes for failing browser tests, potentially also due to small differences in how the newest node handles URLs.

Summary:
- Use browserify's `buffer` for proper unicode handling in the browser - previously it was missing things we used, but it is very complete nowadays.
- Write the properly unicode-encoded file to disk, not the unencoded one
- Decode the path we get from the `url` library to purge `%20` and other escaped characters before we use it
- Respect the `recursive` flag on `listFiles` to prevent fourslash from running tests multiple times and in the wrong harness
-  Make `memoize` safe to use on the newer `listFiles`

I'm still witnessing timeouts of a few tests in the browser, which deserves looking into, since the browser is a newer version of v8, but this fixes the more-major problems it had with running the entire suite. (Except for being really slow)
