### PR TITLE
[es5.d.ts] Intl NumberFormat format function value can be string.

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -3967,7 +3967,7 @@ declare namespace Intl {
     }
 
     interface NumberFormat {
-        format(value: number): string;
+        format(value: number | string): string;
         resolvedOptions(): ResolvedNumberFormatOptions;
     }
     var NumberFormat: {


### PR DESCRIPTION
https://github.com/Microsoft/TypeScript/blob/a6a27ab66132087d889ded64373d42174e85f2fe/src/lib/es5.d.ts#L3970

Link to [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/format).

Link to [specification](http://www.ecma-international.org/ecma-402/2.0/#sec-number-format-functions).

According to `es5.d.ts` interface Intl NumberFormat format function can only accept `number` value, but actually it can accept `string` too.

For example:
```ts
Intl.NumberFormat("en", {
	style: "currency",
	currency: "EUR"
}).format("20.17");
```

Result:
```ts
"€20.17"
```

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
- Intl NumberFormat format function value type changed to `number | string`.