### PR TITLE
findAllReferences: Handle root symbols of binding element property symbol

### DIFF
--- a/tests/cases/fourslash/findAllRefsDestructureGeneric.ts
+++ b/tests/cases/fourslash/findAllRefsDestructureGeneric.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+////interface I<T> {
+////    [|{| "isWriteAccess": true, "isDefinition": true |}x|]: boolean;
+////}
+////declare const i: I<number>;
+////const { [|{| "isWriteAccess": true, "isDefinition": true |}x|] } = i;
+
+const [r0, r1] = test.ranges();
+
+verify.referenceGroups(r0, [{ definition: "(property) I<T>.x: boolean", ranges: [r0, r1] }]);
+verify.referenceGroups(r1, [
+    { definition: "(property) I<T>.x: boolean", ranges: [r0] },
+    { definition: "const x: boolean", ranges: [r1] }
+]);

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfBindingPattern.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfBindingPattern.ts
@@ -1,5 +1,10 @@
 /// <reference path='fourslash.ts' />
-////const { [|{| "isWriteAccess": true, "isDefinition": true |}x|], y } = { x: 1, y: 2 };
-////const z = [|{| "isDefinition": false |}x|];
+////const { [|{| "isWriteAccess": true, "isDefinition": true |}x|], y } = { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: 1, y: 2 };
+////const z = [|x|];
 
-verify.singleReferenceGroup("const x: number");
+const [r0, r1, r2] = test.ranges();
+verify.referenceGroups([r0, r2], [
+    { definition: "const x: number", ranges: [r0, r2] },
+    { definition: "(property) x: number", ranges: [r1] },
+]);
+verify.referenceGroups(r1, [{ definition: "(property) x: number", ranges: [r0, r1, r2] }]);


### PR DESCRIPTION
Fixes #17731

We were adding the binding element itself, but not its root symbols. This matters if the destructured type is an instantiation of the generic type -- we want to handle the symbol for the original (generic) declaration too.