### PR TITLE
Remove redundant `isExpression` check

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1992,7 +1992,7 @@ namespace ts {
                     }
                 // falls through
                 case SyntaxKind.ThisKeyword:
-                    if (currentFlow && (isExpression(node) || parent.kind === SyntaxKind.ShorthandPropertyAssignment)) {
+                    if (currentFlow) {
                         node.flowNode = currentFlow;
                     }
                     return checkStrictModeIdentifier(<Identifier>node);


### PR DESCRIPTION
`isExpression` always retrns `true` for a `ThisKeyword`. Should there be a different check instead?