### PR TITLE
Add support to infer the quote style for import code fix

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -999,6 +999,7 @@ namespace ts {
     export interface StringLiteral extends LiteralExpression {
         kind: SyntaxKind.StringLiteral;
         /* @internal */ textSourceNode?: Identifier | StringLiteral | NumericLiteral; // Allows a StringLiteral to get its text from another node (used by transforms).
+        /* @internal */ singleQuote?: boolean;
     }
 
     // Note: 'brands' in our syntax nodes serve to give us a small amount of nominal typing.

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -439,18 +439,19 @@ namespace ts.codefix {
 
                 function getSingleQuoteStyleFromExistingImports() {
                     const firstModuleSpecifier = forEach(sourceFile.statements, node => {
-                        switch (node.kind) {
-                            case SyntaxKind.ImportDeclaration:
-                                return (<ImportDeclaration>node).moduleSpecifier;
-                            case SyntaxKind.ImportEqualsDeclaration:
-                                const moduleReference = (<ImportEqualsDeclaration>node).moduleReference;
-                                return moduleReference.kind === SyntaxKind.ExternalModuleReference ? moduleReference.expression : undefined;
-                            case SyntaxKind.ExportDeclaration:
-                                return (<ExportDeclaration>node).moduleSpecifier;
+                        if (isImportDeclaration(node) || isExportDeclaration(node)) {
+                            if (node.moduleSpecifier && isStringLiteral(node.moduleSpecifier)) {
+                                return node.moduleSpecifier;
+                            }
+                        }
+                        else if (isImportEqualsDeclaration(node)) {
+                            if (isExternalModuleReference(node.moduleReference) && isStringLiteral(node.moduleReference.expression)) {
+                                return node.moduleReference.expression;
+                            }
                         }
                     });
-                    if (firstModuleSpecifier && isStringLiteral(firstModuleSpecifier)) {
-                        return sourceFile.text.charCodeAt(skipTrivia(sourceFile.text, firstModuleSpecifier.pos)) === CharacterCodes.singleQuote;
+                    if (firstModuleSpecifier) {
+                        return sourceFile.text.charCodeAt(firstModuleSpecifier.getStart()) === CharacterCodes.singleQuote;
                     }
                 }
 

--- a/tests/cases/fourslash/importNameCodeFixNewImportFile6.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFile6.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+//// [|import { v2 } from './module2';
+////
+//// f1/*0*/();|]
+
+// @Filename: module.ts
+//// export function f1() {}
+//// export var v1 = 5;
+
+// @Filename: module2.ts
+//// export var v2 = 6;
+
+verify.importFixAtPosition([
+`import { v2 } from './module2';
+import { f1 } from './module';
+
+f1();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle0.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle0.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+//// [|import { v2 } from './module2';
+////
+//// f1/*0*/();|]
+
+// @Filename: module1.ts
+//// export function f1() {}
+
+// @Filename: module2.ts
+//// export var v2 = 6;
+
+verify.importFixAtPosition([
+`import { v2 } from './module2';
+import { f1 } from './module1';
+
+f1();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle1.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle1.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+//// [|import { v2 } from "./module2";
+////
+//// f1/*0*/();|]
+
+// @Filename: module1.ts
+//// export function f1() {}
+
+// @Filename: module2.ts
+//// export var v2 = 6;
+
+verify.importFixAtPosition([
+`import { v2 } from "./module2";
+import { f1 } from "./module1";
+
+f1();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle2.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle2.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+//// [|import m2 = require('./module2');
+////
+//// f1/*0*/();|]
+
+// @Filename: module1.ts
+//// export function f1() {}
+
+// @Filename: module2.ts
+//// export var v2 = 6;
+
+verify.importFixAtPosition([
+`import m2 = require('./module2');
+import { f1 } from './module1';
+
+f1();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle3.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle3.ts
@@ -1,19 +1,19 @@
 /// <reference path="fourslash.ts" />
 
-//// [|import { v2 } from './module2';
+//// [|export { v2 } from './module2';
 ////
 //// f1/*0*/();|]
 
-// @Filename: module.ts
+// @Filename: module1.ts
 //// export function f1() {}
-//// export var v1 = 5;
 
 // @Filename: module2.ts
 //// export var v2 = 6;
 
 verify.importFixAtPosition([
-`import { v2 } from './module2';
-import { f1 } from './module';
+`import { f1 } from './module1';
+
+export { v2 } from './module2';
 
 f1();`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyleMixed0.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyleMixed0.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+//// [|import { v2 } from "./module2";
+//// import { v3 } from './module3';
+////
+//// f1/*0*/();|]
+
+// @Filename: module1.ts
+//// export function f1() {}
+
+// @Filename: module2.ts
+//// export var v2 = 6;
+
+// @Filename: module3.ts
+//// export var v3 = 6;
+
+verify.importFixAtPosition([
+`import { v2 } from "./module2";
+import { v3 } from './module3';
+import { f1 } from "./module1";
+
+f1();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyleMixed1.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyleMixed1.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+//// [|import { v2 } from './module2';
+//// import { v3 } from "./module3";
+////
+//// f1/*0*/();|]
+
+// @Filename: module1.ts
+//// export function f1() {}
+
+// @Filename: module2.ts
+//// export var v2 = 6;
+
+// @Filename: module3.ts
+//// export var v3 = 6;
+
+verify.importFixAtPosition([
+`import { v2 } from './module2';
+import { v3 } from "./module3";
+import { f1 } from './module1';
+
+f1();`
+]);


### PR DESCRIPTION
This adds the ability to determine whether to use single or double quotes for new imports added via code fixes. When a new import is added, we scan the top-most statements of the source file for existing import or export declarations with module specifiers. We then use the quote style of the first one we find. If there are no existing imports in the file we fall back to using double quotes.

Fixes #13270
