### PR TITLE
Make compiler options which map to a flag case-insensitive again

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1116,7 +1116,7 @@ namespace ts {
                     if (option && typeof option.type !== "string") {
                         const customOption = <CommandLineOptionOfCustomType>option;
                         // Validate custom option type
-                        if (!customOption.type.has(text)) {
+                        if (!customOption.type.has(text.toLowerCase())) {
                             errors.push(
                                 createDiagnosticForInvalidCustomType(
                                     customOption,
@@ -1811,7 +1811,7 @@ namespace ts {
             return value;
         }
         else if (typeof option.type !== "string") {
-            return option.type.get(value);
+            return option.type.get(typeof value === "string" ? value.toLowerCase() : value);
         }
         return normalizeNonListOptionValue(option, basePath, value);
     }

--- a/tests/baselines/reference/tsconfigMapOptionsAreCaseInsensitive.js
+++ b/tests/baselines/reference/tsconfigMapOptionsAreCaseInsensitive.js
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/tsconfigMapOptionsAreCaseInsensitive.ts] ////
+
+//// [other.ts]
+export default 42;
+
+//// [index.ts]
+import Answer from "./other.js";
+const x = 10 + Answer;
+export {
+    x
+};
+
+//// [other.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    exports["default"] = 42;
+});
+//// [index.js]
+define(["require", "exports", "./other.js"], function (require, exports, other_js_1) {
+    "use strict";
+    exports.__esModule = true;
+    var x = 10 + other_js_1["default"];
+    exports.x = x;
+});

--- a/tests/baselines/reference/tsconfigMapOptionsAreCaseInsensitive.symbols
+++ b/tests/baselines/reference/tsconfigMapOptionsAreCaseInsensitive.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/other.ts ===
+export default 42;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/index.ts ===
+import Answer from "./other.js";
+>Answer : Symbol(Answer, Decl(index.ts, 0, 6))
+
+const x = 10 + Answer;
+>x : Symbol(x, Decl(index.ts, 1, 5))
+>Answer : Symbol(Answer, Decl(index.ts, 0, 6))
+
+export {
+    x
+>x : Symbol(x, Decl(index.ts, 2, 8))
+
+};

--- a/tests/baselines/reference/tsconfigMapOptionsAreCaseInsensitive.types
+++ b/tests/baselines/reference/tsconfigMapOptionsAreCaseInsensitive.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/other.ts ===
+export default 42;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/index.ts ===
+import Answer from "./other.js";
+>Answer : 42
+
+const x = 10 + Answer;
+>x : number
+>10 + Answer : number
+>10 : 10
+>Answer : 42
+
+export {
+    x
+>x : number
+
+};

--- a/tests/cases/compiler/tsconfigMapOptionsAreCaseInsensitive.ts
+++ b/tests/cases/compiler/tsconfigMapOptionsAreCaseInsensitive.ts
@@ -1,0 +1,16 @@
+// @filename: tsconfig.json
+{
+    "compilerOptions": {
+        "module": "AmD"
+    }
+}
+
+// @filename: other.ts
+export default 42;
+
+// @filename: index.ts
+import Answer from "./other.js";
+const x = 10 + Answer;
+export {
+    x
+};


### PR DESCRIPTION
Fixes some breaks in our RWC suite. We were not case sensitive before, so it was breaking to be so (and, more importantly, we didn't issue an error on case mismatch - we just silently did the wrong thing). This reintroduces case-insensitivity in our normalization of option-based options.
