### PR TITLE
tsc --watch should clear screen on new compilation

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -66,6 +66,7 @@ namespace ts {
         /*@internal*/ debugMode?: boolean;
         setTimeout?(callback: (...args: any[]) => void, ms: number, ...args: any[]): any;
         clearTimeout?(timeoutId: any): void;
+        clearScreen?(): void;
     }
 
     export interface FileWatcher {
@@ -342,6 +343,9 @@ namespace ts {
 
             const noOpFileWatcher: FileWatcher = { close: noop };
             const nodeSystem: System = {
+                clearScreen: () => {
+                    process.stdout.write("\x1Bc");
+                },
                 args: process.argv.slice(2),
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames,

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -184,6 +184,10 @@ namespace ts {
         }
 
         if (isWatchSet(commandLine.options)) {
+            if (sys.clearScreen) {
+                sys.clearScreen();
+            }
+
             if (!sys.watchFile) {
                 reportDiagnostic(createCompilerDiagnostic(Diagnostics.The_current_host_does_not_support_the_0_option, "--watch"), /* host */ undefined);
                 return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
@@ -402,6 +406,9 @@ namespace ts {
         }
 
         function recompile() {
+            if (sys.clearScreen()) {
+                sys.clearScreen();
+            }
             timerHandleForRecompilation = undefined;
             reportWatchDiagnostic(createCompilerDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation));
             performCompilation();


### PR DESCRIPTION
* added optional clearScreen method to System]
* implemented via `x1Bc`, reset screen
* fixes #13020

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change
