### PR TITLE
Fix circular contextual return type error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6576,6 +6576,10 @@ namespace ts {
             return signature.resolvedReturnType;
         }
 
+        function isResolvingReturnTypeOfSignature(signature: Signature) {
+            return !signature.resolvedReturnType && findResolutionCycleStartIndex(signature, TypeSystemPropertyName.ResolvedReturnType) >= 0;
+        }
+
         function getRestTypeOfSignature(signature: Signature): Type {
             if (signature.hasRestParameter) {
                 const type = getTypeOfSymbol(lastOrUndefined(signature.parameters));
@@ -12949,7 +12953,7 @@ namespace ts {
             // Otherwise, if the containing function is contextually typed by a function type with exactly one call signature
             // and that call signature is non-generic, return statements are contextually typed by the return type of the signature
             const signature = getContextualSignatureForFunctionLikeDeclaration(<FunctionExpression>functionDecl);
-            if (signature) {
+            if (signature && !isResolvingReturnTypeOfSignature(signature)) {
                 return getReturnTypeOfSignature(signature);
             }
 

--- a/tests/baselines/reference/circularContextualReturnType.js
+++ b/tests/baselines/reference/circularContextualReturnType.js
@@ -1,0 +1,18 @@
+//// [circularContextualReturnType.ts]
+// Repro from #17711
+
+Object.freeze({
+    foo() {
+        return Object.freeze('a');
+    },
+});
+
+
+//// [circularContextualReturnType.js]
+"use strict";
+// Repro from #17711
+Object.freeze({
+    foo: function () {
+        return Object.freeze('a');
+    }
+});

--- a/tests/baselines/reference/circularContextualReturnType.symbols
+++ b/tests/baselines/reference/circularContextualReturnType.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/circularContextualReturnType.ts ===
+// Repro from #17711
+
+Object.freeze({
+>Object.freeze : Symbol(ObjectConstructor.freeze, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>freeze : Symbol(ObjectConstructor.freeze, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+    foo() {
+>foo : Symbol(foo, Decl(circularContextualReturnType.ts, 2, 15))
+
+        return Object.freeze('a');
+>Object.freeze : Symbol(ObjectConstructor.freeze, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>freeze : Symbol(ObjectConstructor.freeze, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+    },
+});
+

--- a/tests/baselines/reference/circularContextualReturnType.types
+++ b/tests/baselines/reference/circularContextualReturnType.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/circularContextualReturnType.ts ===
+// Repro from #17711
+
+Object.freeze({
+>Object.freeze({    foo() {        return Object.freeze('a');    },}) : Readonly<{ foo(): string; }>
+>Object.freeze : { <T>(a: T[]): ReadonlyArray<T>; <T extends Function>(f: T): T; <T>(o: T): Readonly<T>; }
+>Object : ObjectConstructor
+>freeze : { <T>(a: T[]): ReadonlyArray<T>; <T extends Function>(f: T): T; <T>(o: T): Readonly<T>; }
+>{    foo() {        return Object.freeze('a');    },} : { foo(): string; }
+
+    foo() {
+>foo : () => string
+
+        return Object.freeze('a');
+>Object.freeze('a') : string
+>Object.freeze : { <T>(a: T[]): ReadonlyArray<T>; <T extends Function>(f: T): T; <T>(o: T): Readonly<T>; }
+>Object : ObjectConstructor
+>freeze : { <T>(a: T[]): ReadonlyArray<T>; <T extends Function>(f: T): T; <T>(o: T): Readonly<T>; }
+>'a' : "a"
+
+    },
+});
+

--- a/tests/cases/compiler/circularContextualReturnType.ts
+++ b/tests/cases/compiler/circularContextualReturnType.ts
@@ -1,0 +1,9 @@
+// @strict: true
+
+// Repro from #17711
+
+Object.freeze({
+    foo() {
+        return Object.freeze('a');
+    },
+});


### PR DESCRIPTION
With this PR, if obtaining the contextual type for a return statement or return expression would cause a circularity error (because the type depends on itself), we instead say there is no contextual type.

Fixes #17711.