### PR TITLE
session.ts: Revert some `emptyArray` back to `undefined`

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -585,7 +585,7 @@ namespace ts.server {
             ): ReadonlyArray<protocol.DiagnosticWithLinePosition> | ReadonlyArray<protocol.Diagnostic> {
             const { project, file } = this.getFileAndProject(args);
             if (isSemantic && isDeclarationFileInJSOnlyNonConfiguredProject(project, file)) {
-                return emptyArray;
+                return undefined;
             }
             const scriptInfo = project.getScriptInfoForNormalizedPath(file);
             const diagnostics = selector(project, file);
@@ -601,7 +601,7 @@ namespace ts.server {
 
             const definitions = project.getLanguageService().getDefinitionAtPosition(file, position);
             if (!definitions) {
-                return emptyArray;
+                return undefined;
             }
 
             if (simplifiedResult) {
@@ -669,7 +669,7 @@ namespace ts.server {
             const occurrences = project.getLanguageService().getOccurrencesAtPosition(file, position);
 
             if (!occurrences) {
-                return emptyArray;
+                return undefined;
             }
 
             return occurrences.map(occurrence => {
@@ -913,7 +913,7 @@ namespace ts.server {
             if (simplifiedResult) {
                 const nameInfo = defaultProject.getLanguageService().getQuickInfoAtPosition(file, position);
                 if (!nameInfo) {
-                    return emptyArray;
+                    return undefined;
                 }
 
                 const displayString = displayPartsToString(nameInfo.displayParts);
@@ -1176,7 +1176,7 @@ namespace ts.server {
 
             const completions = project.getLanguageService().getCompletionsAtPosition(file, position);
             if (!completions) {
-                return emptyArray;
+                return undefined;
             }
             if (simplifiedResult) {
                 return mapDefined(completions.entries, entry => {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -585,7 +585,7 @@ namespace ts.server {
             ): ReadonlyArray<protocol.DiagnosticWithLinePosition> | ReadonlyArray<protocol.Diagnostic> {
             const { project, file } = this.getFileAndProject(args);
             if (isSemantic && isDeclarationFileInJSOnlyNonConfiguredProject(project, file)) {
-                return undefined;
+                return emptyArray;
             }
             const scriptInfo = project.getScriptInfoForNormalizedPath(file);
             const diagnostics = selector(project, file);


### PR DESCRIPTION
Reverts the changes in #17165 that changed return values from `undefined` to `emptyArray`.
Does not revert any type-only changes or changes from `[]` to `emptyArray`.
Ref: https://github.com/Microsoft/TypeScript/pull/17165#discussion_r132546867