### PR TITLE
add compiler flag to enable granular inference outside var/let

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -2630,7 +2630,7 @@ Each element expression in a non-empty array literal is processed as follows:
 
 The resulting type an array literal expression is determined as follows:
 
-* If the array literal is empty, the resulting type is an array type with the element type Undefined.
+* If the array literal is empty, the resulting type is an empty tuple type in `granularConst` mode, otherwise an array type with the element type Undefined. 
 * Otherwise, if the array literal contains no spread elements and is contextually typed by a tuple-like type (section [3.3.3](#3.3.3)), the resulting type is a tuple type constructed from the types of the element expressions.
 * Otherwise, if the array literal contains no spread elements and is an array assignment pattern in a destructuring assignment (section [4.21.1](#4.21.1)), the resulting type is a tuple type constructed from the types of the element expressions.
 * Otherwise, the resulting type is an array type with an element type that is the union of the types of the non-spread element expressions and the numeric index signature types of the spread element expressions.

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -2630,7 +2630,7 @@ Each element expression in a non-empty array literal is processed as follows:
 
 The resulting type an array literal expression is determined as follows:
 
-* If the array literal is empty, the resulting type is an empty tuple type in `granularConst` mode, otherwise an array type with the element type Undefined. 
+* If the array literal is empty, the resulting type is an empty tuple type if `widenTypes` is disabled, otherwise an array type with the element type Undefined. 
 * Otherwise, if the array literal contains no spread elements and is contextually typed by a tuple-like type (section [3.3.3](#3.3.3)), the resulting type is a tuple type constructed from the types of the element expressions.
 * Otherwise, if the array literal contains no spread elements and is an array assignment pattern in a destructuring assignment (section [4.21.1](#4.21.1)), the resulting type is a tuple type constructed from the types of the element expressions.
 * Otherwise, the resulting type is an array type with an element type that is the union of the types of the non-spread element expressions and the numeric index signature types of the spread element expressions.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -64,6 +64,8 @@ namespace ts {
         const noUnusedIdentifiers = !!compilerOptions.noUnusedLocals || !!compilerOptions.noUnusedParameters;
         const allowSyntheticDefaultImports = typeof compilerOptions.allowSyntheticDefaultImports !== "undefined" ? compilerOptions.allowSyntheticDefaultImports : modulekind === ModuleKind.System;
         const strictNullChecks = compilerOptions.strictNullChecks === undefined ? compilerOptions.strict : compilerOptions.strictNullChecks;
+        const widenTypes = compilerOptions.widenTypes === undefined ? true : compilerOptions.widenTypes;
+        const granularConst = !widenTypes;
         const noImplicitAny = compilerOptions.noImplicitAny === undefined ? compilerOptions.strict : compilerOptions.noImplicitAny;
         const noImplicitThis = compilerOptions.noImplicitThis === undefined ? compilerOptions.strict : compilerOptions.noImplicitThis;
 
@@ -13302,12 +13304,12 @@ namespace ts {
             return result;
         }
 
-        function checkSpreadExpression(node: SpreadElement, checkMode?: CheckMode): Type {
+        function checkSpreadExpression(node: SpreadElement, checkMode?: CheckMode, granular?: boolean): Type {
             if (languageVersion < ScriptTarget.ES2015 && compilerOptions.downlevelIteration) {
                 checkExternalEmitHelpers(node, ExternalEmitHelpers.SpreadIncludes);
             }
 
-            const arrayOrIterableType = checkExpression(node.expression, checkMode);
+            const arrayOrIterableType = checkExpression(node.expression, checkMode, granular);
             return checkIteratedTypeOrElementType(arrayOrIterableType, node.expression, /*allowStringInput*/ false, /*allowAsyncIterables*/ false);
         }
 
@@ -13316,7 +13318,7 @@ namespace ts {
                 (node.kind === SyntaxKind.BinaryExpression && (<BinaryExpression>node).operatorToken.kind === SyntaxKind.EqualsToken);
         }
 
-        function checkArrayLiteral(node: ArrayLiteralExpression, checkMode?: CheckMode): Type {
+        function checkArrayLiteral(node: ArrayLiteralExpression, checkMode?: CheckMode, granular?: boolean): Type {
             const elements = node.elements;
             let hasSpreadElement = false;
             const elementTypes: Type[] = [];
@@ -13335,7 +13337,7 @@ namespace ts {
                     // get the contextual element type from it. So we do something similar to
                     // getContextualTypeForElementExpression, which will crucially not error
                     // if there is no index type / iterated type.
-                    const restArrayType = checkExpression((<SpreadElement>e).expression, checkMode);
+                    const restArrayType = checkExpression((<SpreadElement>e).expression, checkMode, granular);
                     const restElementType = getIndexTypeOfType(restArrayType, IndexKind.Number) ||
                         getIteratedTypeOrElementType(restArrayType, /*errorNode*/ undefined, /*allowStringInput*/ false, /*allowAsyncIterables*/ false, /*checkAssignability*/ false);
                     if (restElementType) {
@@ -13343,7 +13345,7 @@ namespace ts {
                     }
                 }
                 else {
-                    const type = checkExpressionForMutableLocation(e, checkMode);
+                    const type = checkExpressionForMutableLocation(e, checkMode, granular);
                     elementTypes.push(type);
                 }
                 hasSpreadElement = hasSpreadElement || e.kind === SyntaxKind.SpreadElement;
@@ -13381,9 +13383,10 @@ namespace ts {
                     }
                 }
             }
-            return createArrayType(elementTypes.length ?
-                getUnionType(elementTypes, /*subtypeReduction*/ true) :
-                strictNullChecks ? neverType : undefinedWideningType);
+            return granular ? createTupleType(elementTypes) :
+                createArrayType(elementTypes.length ?
+                    getUnionType(elementTypes, /*subtypeReduction*/ true) :
+                    strictNullChecks ? neverType : undefinedWideningType);
         }
 
         function isNumericName(name: DeclarationName): boolean {
@@ -13465,7 +13468,7 @@ namespace ts {
             return createIndexInfo(unionType, /*isReadonly*/ false);
         }
 
-        function checkObjectLiteral(node: ObjectLiteralExpression, checkMode?: CheckMode): Type {
+        function checkObjectLiteral(node: ObjectLiteralExpression, checkMode?: CheckMode, granular?: boolean): Type {
             const inDestructuringPattern = isAssignmentTarget(node);
             // Grammar checking
             checkGrammarObjectLiteralExpression(node, inDestructuringPattern);
@@ -13499,14 +13502,14 @@ namespace ts {
 
                     let type: Type;
                     if (memberDecl.kind === SyntaxKind.PropertyAssignment) {
-                        type = checkPropertyAssignment(<PropertyAssignment>memberDecl, checkMode);
+                        type = checkPropertyAssignment(<PropertyAssignment>memberDecl, checkMode, granular);
                     }
                     else if (memberDecl.kind === SyntaxKind.MethodDeclaration) {
-                        type = checkObjectLiteralMethod(<MethodDeclaration>memberDecl, checkMode);
+                        type = checkObjectLiteralMethod(<MethodDeclaration>memberDecl, checkMode, granular);
                     }
                     else {
                         Debug.assert(memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment);
-                        type = checkExpressionForMutableLocation((<ShorthandPropertyAssignment>memberDecl).name, checkMode);
+                        type = checkExpressionForMutableLocation((<ShorthandPropertyAssignment>memberDecl).name, checkMode, granular);
                     }
 
                     if (jsdocType) {
@@ -13707,7 +13710,7 @@ namespace ts {
          * @remarks Because this function calls getSpreadType, it needs to use the same checks as checkObjectLiteral,
          * which also calls getSpreadType.
          */
-        function createJsxAttributesTypeFromAttributesProperty(openingLikeElement: JsxOpeningLikeElement, filter?: (symbol: Symbol) => boolean, checkMode?: CheckMode) {
+        function createJsxAttributesTypeFromAttributesProperty(openingLikeElement: JsxOpeningLikeElement, filter?: (symbol: Symbol) => boolean, checkMode?: CheckMode, granular?: boolean) {
             const attributes = openingLikeElement.attributes;
             let attributesTable = createSymbolTable();
             let spread: Type = emptyObjectType;
@@ -13721,7 +13724,7 @@ namespace ts {
                 const member = attributeDecl.symbol;
                 if (isJsxAttribute(attributeDecl)) {
                     const exprType = attributeDecl.initializer ?
-                        checkExpression(attributeDecl.initializer, checkMode) :
+                        checkExpression(attributeDecl.initializer, checkMode, granular) :
                         trueType;  // <Elem attr /> is sugar for <Elem attr={true} />
 
                     const attributeSymbol = <TransientSymbol>createSymbol(SymbolFlags.Property | SymbolFlags.Transient | member.flags, member.escapedName);
@@ -13835,8 +13838,8 @@ namespace ts {
          * (See "checkApplicableSignatureForJsxOpeningLikeElement" for how the function is used)
          * @param node a JSXAttributes to be resolved of its type
          */
-        function checkJsxAttributes(node: JsxAttributes, checkMode?: CheckMode) {
-            return createJsxAttributesTypeFromAttributesProperty(node.parent as JsxOpeningLikeElement, /*filter*/ undefined, checkMode);
+        function checkJsxAttributes(node: JsxAttributes, checkMode?: CheckMode, granular?: boolean) {
+            return createJsxAttributesTypeFromAttributesProperty(node.parent as JsxOpeningLikeElement, /*filter*/ undefined, checkMode, granular);
         }
 
         function getJsxType(name: __String) {
@@ -14440,9 +14443,9 @@ namespace ts {
             }
         }
 
-        function checkJsxExpression(node: JsxExpression, checkMode?: CheckMode) {
+        function checkJsxExpression(node: JsxExpression, checkMode?: CheckMode, granular?: boolean) {
             if (node.expression) {
-                const type = checkExpression(node.expression, checkMode);
+                const type = checkExpression(node.expression, checkMode, granular);
                 if (node.dotDotDotToken && type !== anyType && !isArrayType(type)) {
                     error(node, Diagnostics.JSX_spread_child_must_be_an_array_type, node.toString(), typeToString(type));
                 }
@@ -16486,8 +16489,8 @@ namespace ts {
             return checkAssertionWorker(node, node.type, node.expression);
         }
 
-        function checkAssertionWorker(errNode: Node, type: TypeNode, expression: UnaryExpression | Expression, checkMode?: CheckMode) {
-            const exprType = getRegularTypeOfObjectLiteral(getBaseTypeOfLiteralType(checkExpression(expression, checkMode)));
+        function checkAssertionWorker(errNode: Node, type: TypeNode, expression: UnaryExpression | Expression, checkMode?: CheckMode, granular?: boolean) {
+            const exprType = getRegularTypeOfObjectLiteral(getBaseTypeOfLiteralType(checkExpression(expression, checkMode, granular)));
 
             checkSourceElement(type);
             const targetType = getTypeFromTypeNode(type);
@@ -16643,7 +16646,7 @@ namespace ts {
             return promiseType;
         }
 
-        function getReturnTypeFromBody(func: FunctionLikeDeclaration, checkMode?: CheckMode): Type {
+        function getReturnTypeFromBody(func: FunctionLikeDeclaration, checkMode?: CheckMode, granular?: boolean): Type {
             const contextualSignature = getContextualSignatureForFunctionLikeDeclaration(func);
             if (!func.body) {
                 return unknownType;
@@ -16652,7 +16655,7 @@ namespace ts {
             const functionFlags = getFunctionFlags(func);
             let type: Type;
             if (func.body.kind !== SyntaxKind.Block) {
-                type = checkExpressionCached(<Expression>func.body, checkMode);
+                type = checkExpressionCached(<Expression>func.body, checkMode, granular);
                 if (functionFlags & FunctionFlags.Async) {
                     // From within an async function you can return either a non-promise value or a promise. Any
                     // Promise/A+ compatible implementation will always assimilate any foreign promise, so the
@@ -16664,7 +16667,7 @@ namespace ts {
             else {
                 let types: Type[];
                 if (functionFlags & FunctionFlags.Generator) { // Generator or AsyncGenerator function
-                    types = concatenate(checkAndAggregateYieldOperandTypes(func, checkMode), checkAndAggregateReturnExpressionTypes(func, checkMode));
+                    types = concatenate(checkAndAggregateYieldOperandTypes(func, checkMode, granular), checkAndAggregateReturnExpressionTypes(func, checkMode, granular));
                     if (!types || types.length === 0) {
                         const iterableIteratorAny = functionFlags & FunctionFlags.Async
                             ? createAsyncIterableIteratorType(anyType) // AsyncGenerator function
@@ -16677,7 +16680,7 @@ namespace ts {
                     }
                 }
                 else {
-                    types = checkAndAggregateReturnExpressionTypes(func, checkMode);
+                    types = checkAndAggregateReturnExpressionTypes(func, checkMode, granular);
                     if (!types) {
                         // For an async function, the return type will not be never, but rather a Promise for never.
                         return functionFlags & FunctionFlags.Async
@@ -16721,13 +16724,13 @@ namespace ts {
                 : widenedType; // Generator function, AsyncGenerator function, or normal function
         }
 
-        function checkAndAggregateYieldOperandTypes(func: FunctionLikeDeclaration, checkMode: CheckMode): Type[] {
+        function checkAndAggregateYieldOperandTypes(func: FunctionLikeDeclaration, checkMode: CheckMode, granular?: boolean): Type[] {
             const aggregatedTypes: Type[] = [];
             const functionFlags = getFunctionFlags(func);
             forEachYieldExpression(<Block>func.body, yieldExpression => {
                 const expr = yieldExpression.expression;
                 if (expr) {
-                    let type = checkExpressionCached(expr, checkMode);
+                    let type = checkExpressionCached(expr, checkMode, granular);
                     if (yieldExpression.asteriskToken) {
                         // A yield* expression effectively yields everything that its operand yields
                         type = checkIteratedTypeOrElementType(type, yieldExpression.expression, /*allowStringInput*/ false, (functionFlags & FunctionFlags.Async) !== 0);
@@ -16772,7 +16775,7 @@ namespace ts {
             return true;
         }
 
-        function checkAndAggregateReturnExpressionTypes(func: FunctionLikeDeclaration, checkMode: CheckMode): Type[] {
+        function checkAndAggregateReturnExpressionTypes(func: FunctionLikeDeclaration, checkMode: CheckMode, granular?: boolean): Type[] {
             const functionFlags = getFunctionFlags(func);
             const aggregatedTypes: Type[] = [];
             let hasReturnWithNoExpression = functionHasImplicitReturn(func);
@@ -16780,7 +16783,7 @@ namespace ts {
             forEachReturnStatement(<Block>func.body, returnStatement => {
                 const expr = returnStatement.expression;
                 if (expr) {
-                    let type = checkExpressionCached(expr, checkMode);
+                    let type = checkExpressionCached(expr, checkMode, granular);
                     if (functionFlags & FunctionFlags.Async) {
                         // From within an async function you can return either a non-promise value or a promise. Any
                         // Promise/A+ compatible implementation will always assimilate any foreign promise, so the
@@ -16867,7 +16870,7 @@ namespace ts {
             }
         }
 
-        function checkFunctionExpressionOrObjectLiteralMethod(node: FunctionExpression | MethodDeclaration, checkMode?: CheckMode): Type {
+        function checkFunctionExpressionOrObjectLiteralMethod(node: FunctionExpression | MethodDeclaration, checkMode?: CheckMode, granular?: boolean): Type {
             Debug.assert(node.kind !== SyntaxKind.MethodDeclaration || isObjectLiteralMethod(node));
 
             // The identityMapper object is used to indicate that function expressions are wildcards
@@ -16905,7 +16908,7 @@ namespace ts {
                             assignContextualParameterTypes(signature, instantiatedContextualSignature);
                         }
                         if (!getEffectiveReturnTypeNode(node) && !signature.resolvedReturnType) {
-                            const returnType = getReturnTypeFromBody(node, checkMode);
+                            const returnType = getReturnTypeFromBody(node, checkMode, granular);
                             if (!signature.resolvedReturnType) {
                                 signature.resolvedReturnType = returnType;
                             }
@@ -17276,7 +17279,7 @@ namespace ts {
             }
         }
 
-        function checkArrayLiteralAssignment(node: ArrayLiteralExpression, sourceType: Type, checkMode?: CheckMode): Type {
+        function checkArrayLiteralAssignment(node: ArrayLiteralExpression, sourceType: Type, checkMode?: CheckMode, granular?: boolean): Type {
             if (languageVersion < ScriptTarget.ES2015 && compilerOptions.downlevelIteration) {
                 checkExternalEmitHelpers(node, ExternalEmitHelpers.Read);
             }
@@ -17287,13 +17290,13 @@ namespace ts {
             const elementType = checkIteratedTypeOrElementType(sourceType, node, /*allowStringInput*/ false, /*allowAsyncIterables*/ false) || unknownType;
             const elements = node.elements;
             for (let i = 0; i < elements.length; i++) {
-                checkArrayLiteralDestructuringElementAssignment(node, sourceType, i, elementType, checkMode);
+                checkArrayLiteralDestructuringElementAssignment(node, sourceType, i, elementType, checkMode, granular);
             }
             return sourceType;
         }
 
         function checkArrayLiteralDestructuringElementAssignment(node: ArrayLiteralExpression, sourceType: Type,
-            elementIndex: number, elementType: Type, checkMode?: CheckMode) {
+            elementIndex: number, elementType: Type, checkMode?: CheckMode, granular?: boolean) {
             const elements = node.elements;
             const element = elements[elementIndex];
             if (element.kind !== SyntaxKind.OmittedExpression) {
@@ -17305,7 +17308,7 @@ namespace ts {
                             ? getTypeOfPropertyOfType(sourceType, propName)
                             : elementType;
                     if (type) {
-                        return checkDestructuringAssignment(element, type, checkMode);
+                        return checkDestructuringAssignment(element, type, checkMode, granular);
                     }
                     else {
                         // We still need to check element expression here because we may need to set appropriate flag on the expression
@@ -17329,7 +17332,7 @@ namespace ts {
                             error((<BinaryExpression>restExpression).operatorToken, Diagnostics.A_rest_element_cannot_have_an_initializer);
                         }
                         else {
-                            return checkDestructuringAssignment(restExpression, createArrayType(elementType), checkMode);
+                            return checkDestructuringAssignment(restExpression, createArrayType(elementType), checkMode, granular);
                         }
                     }
                 }
@@ -17337,7 +17340,7 @@ namespace ts {
             return undefined;
         }
 
-        function checkDestructuringAssignment(exprOrAssignment: Expression | ShorthandPropertyAssignment, sourceType: Type, checkMode?: CheckMode): Type {
+        function checkDestructuringAssignment(exprOrAssignment: Expression | ShorthandPropertyAssignment, sourceType: Type, checkMode?: CheckMode, granular?: boolean): Type {
             let target: Expression;
             if (exprOrAssignment.kind === SyntaxKind.ShorthandPropertyAssignment) {
                 const prop = <ShorthandPropertyAssignment>exprOrAssignment;
@@ -17348,7 +17351,7 @@ namespace ts {
                         !(getFalsyFlags(checkExpression(prop.objectAssignmentInitializer)) & TypeFlags.Undefined)) {
                         sourceType = getTypeWithFacts(sourceType, TypeFacts.NEUndefined);
                     }
-                    checkBinaryLikeExpression(prop.name, prop.equalsToken, prop.objectAssignmentInitializer, checkMode);
+                    checkBinaryLikeExpression(prop.name, prop.equalsToken, prop.objectAssignmentInitializer, checkMode, granular);
                 }
                 target = (<ShorthandPropertyAssignment>exprOrAssignment).name;
             }
@@ -17357,20 +17360,20 @@ namespace ts {
             }
 
             if (target.kind === SyntaxKind.BinaryExpression && (<BinaryExpression>target).operatorToken.kind === SyntaxKind.EqualsToken) {
-                checkBinaryExpression(<BinaryExpression>target, checkMode);
+                checkBinaryExpression(<BinaryExpression>target, checkMode, granular);
                 target = (<BinaryExpression>target).left;
             }
             if (target.kind === SyntaxKind.ObjectLiteralExpression) {
                 return checkObjectLiteralAssignment(<ObjectLiteralExpression>target, sourceType);
             }
             if (target.kind === SyntaxKind.ArrayLiteralExpression) {
-                return checkArrayLiteralAssignment(<ArrayLiteralExpression>target, sourceType, checkMode);
+                return checkArrayLiteralAssignment(<ArrayLiteralExpression>target, sourceType, checkMode, granular);
             }
-            return checkReferenceAssignment(target, sourceType, checkMode);
+            return checkReferenceAssignment(target, sourceType, checkMode, granular);
         }
 
-        function checkReferenceAssignment(target: Expression, sourceType: Type, checkMode?: CheckMode): Type {
-            const targetType = checkExpression(target, checkMode);
+        function checkReferenceAssignment(target: Expression, sourceType: Type, checkMode?: CheckMode, granular?: boolean): Type {
+            const targetType = checkExpression(target, checkMode, granular);
             const error = target.parent.kind === SyntaxKind.SpreadAssignment ?
                 Diagnostics.The_target_of_an_object_rest_assignment_must_be_a_variable_or_a_property_access :
                 Diagnostics.The_left_hand_side_of_an_assignment_expression_must_be_a_variable_or_a_property_access;
@@ -17458,17 +17461,17 @@ namespace ts {
                 getUnionType([type1, type2], /*subtypeReduction*/ true);
         }
 
-        function checkBinaryExpression(node: BinaryExpression, checkMode?: CheckMode) {
-            return checkBinaryLikeExpression(node.left, node.operatorToken, node.right, checkMode, node);
+        function checkBinaryExpression(node: BinaryExpression, checkMode?: CheckMode, granular?: boolean) {
+            return checkBinaryLikeExpression(node.left, node.operatorToken, node.right, checkMode, granular, node);
         }
 
-        function checkBinaryLikeExpression(left: Expression, operatorToken: Node, right: Expression, checkMode?: CheckMode, errorNode?: Node) {
+        function checkBinaryLikeExpression(left: Expression, operatorToken: Node, right: Expression, checkMode?: CheckMode, granular?: boolean, errorNode?: Node) {
             const operator = operatorToken.kind;
             if (operator === SyntaxKind.EqualsToken && (left.kind === SyntaxKind.ObjectLiteralExpression || left.kind === SyntaxKind.ArrayLiteralExpression)) {
-                return checkDestructuringAssignment(left, checkExpression(right, checkMode), checkMode);
+                return checkDestructuringAssignment(left, checkExpression(right, checkMode, granular), checkMode, granular);
             }
-            let leftType = checkExpression(left, checkMode);
-            let rightType = checkExpression(right, checkMode);
+            let leftType = checkExpression(left, checkMode, granular);
+            let rightType = checkExpression(right, checkMode, granular);
             switch (operator) {
                 case SyntaxKind.AsteriskToken:
                 case SyntaxKind.AsteriskAsteriskToken:
@@ -17750,10 +17753,10 @@ namespace ts {
             return anyType;
         }
 
-        function checkConditionalExpression(node: ConditionalExpression, checkMode?: CheckMode): Type {
+        function checkConditionalExpression(node: ConditionalExpression, checkMode?: CheckMode, granular?: boolean): Type {
             checkExpression(node.condition);
-            const type1 = checkExpression(node.whenTrue, checkMode);
-            const type2 = checkExpression(node.whenFalse, checkMode);
+            const type1 = checkExpression(node.whenTrue, checkMode, granular);
+            const type2 = checkExpression(node.whenFalse, checkMode, granular);
             return getBestChoiceType(type1, type2);
         }
 
@@ -17792,13 +17795,13 @@ namespace ts {
             node.contextualMapper = contextualMapper;
             const checkMode = contextualMapper === identityMapper ? CheckMode.SkipContextSensitive :
                 contextualMapper ? CheckMode.Inferential : CheckMode.Normal;
-            const result = checkExpression(node, checkMode);
+            const result = checkExpression(node, checkMode, granularConst);
             node.contextualType = saveContextualType;
             node.contextualMapper = saveContextualMapper;
             return result;
         }
 
-        function checkExpressionCached(node: Expression, checkMode?: CheckMode): Type {
+        function checkExpressionCached(node: Expression, checkMode?: CheckMode, granular?: boolean): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
                 // When computing a type that we're going to cache, we need to ignore any ongoing control flow
@@ -17806,7 +17809,8 @@ namespace ts {
                 // to the top of the stack ensures all transient types are computed from a known point.
                 const saveFlowLoopStart = flowLoopStart;
                 flowLoopStart = flowLoopCount;
-                links.resolvedType = checkExpression(node, checkMode);
+                 // every node is expected to always be checked using the same options, so no mix-ups
+                links.resolvedType = checkExpression(node, checkMode, granular);
                 flowLoopStart = saveFlowLoopStart;
             }
             return links.resolvedType;
@@ -17817,8 +17821,9 @@ namespace ts {
             return node.kind === SyntaxKind.TypeAssertionExpression || node.kind === SyntaxKind.AsExpression;
         }
 
-        function checkDeclarationInitializer(declaration: VariableLikeDeclaration) {
-            const type = getTypeOfExpression(declaration.initializer, /*cache*/ true);
+        function checkDeclarationInitializer(declaration: VariableLikeDeclaration): Type {
+            const granular = granularConst && !!(getCombinedNodeFlags(declaration) & NodeFlags.Const);
+            const type = getTypeOfExpression(declaration.initializer, /*cache*/ true, granular);
             return getCombinedNodeFlags(declaration) & NodeFlags.Const ||
                 getCombinedModifierFlags(declaration) & ModifierFlags.Readonly && !isParameterPropertyDeclaration(declaration) ||
                 isTypeAssertion(declaration.initializer) ? type : getWidenedLiteralType(type);
@@ -17841,12 +17846,12 @@ namespace ts {
             return false;
         }
 
-        function checkExpressionForMutableLocation(node: Expression, checkMode?: CheckMode): Type {
-            const type = checkExpression(node, checkMode);
-            return isTypeAssertion(node) || isLiteralContextualType(getContextualType(node)) ? type : getWidenedLiteralType(type);
+        function checkExpressionForMutableLocation(node: Expression, checkMode?: CheckMode, granular?: boolean): Type {
+            const type = checkExpression(node, checkMode, granular);
+            return granular || isTypeAssertion(node) || isLiteralContextualType(getContextualType(node)) ? type : getWidenedLiteralType(type);
         }
 
-        function checkPropertyAssignment(node: PropertyAssignment, checkMode?: CheckMode): Type {
+        function checkPropertyAssignment(node: PropertyAssignment, checkMode?: CheckMode, granular?: boolean): Type {
             // Do not use hasDynamicName here, because that returns false for well known symbols.
             // We want to perform checkComputedPropertyName for all computed properties, including
             // well known symbols.
@@ -17854,10 +17859,10 @@ namespace ts {
                 checkComputedPropertyName(<ComputedPropertyName>node.name);
             }
 
-            return checkExpressionForMutableLocation((<PropertyAssignment>node).initializer, checkMode);
+            return checkExpressionForMutableLocation((<PropertyAssignment>node).initializer, checkMode, granular);
         }
 
-        function checkObjectLiteralMethod(node: MethodDeclaration, checkMode?: CheckMode): Type {
+        function checkObjectLiteralMethod(node: MethodDeclaration, checkMode?: CheckMode, granular?: boolean): Type {
             // Grammar checking
             checkGrammarMethod(node);
 
@@ -17868,7 +17873,7 @@ namespace ts {
                 checkComputedPropertyName(<ComputedPropertyName>node.name);
             }
 
-            const uninstantiatedType = checkFunctionExpressionOrObjectLiteralMethod(node, checkMode);
+            const uninstantiatedType = checkFunctionExpressionOrObjectLiteralMethod(node, checkMode, granular);
             return instantiateTypeWithSingleGenericCallSignature(node, uninstantiatedType, checkMode);
         }
 
@@ -17895,7 +17900,7 @@ namespace ts {
          * A cache argument of true indicates that if the function performs a full type check, it is ok
          * to cache the result.
          */
-        function getTypeOfExpression(node: Expression, cache?: boolean) {
+        function getTypeOfExpression(node: Expression, cache?: boolean, granular?: boolean): Type {
             // Optimize for the common case of a call to a function with a single non-generic call
             // signature where we can just fetch the return type without checking the arguments.
             if (node.kind === SyntaxKind.CallExpression && (<CallExpression>node).expression.kind !== SyntaxKind.SuperKeyword && !isRequireCall(node, /*checkArgumentIsStringLiteral*/ true)) {
@@ -17908,7 +17913,8 @@ namespace ts {
             // Otherwise simply call checkExpression. Ideally, the entire family of checkXXX functions
             // should have a parameter that indicates whether full error checking is required such that
             // we can perform the optimizations locally.
-            return cache ? checkExpressionCached(node) : checkExpression(node);
+            const checkMode = CheckMode.Normal;
+            return cache ? checkExpressionCached(node, checkMode, granular) : checkExpression(node, checkMode, granular);
         }
 
         /**
@@ -17933,13 +17939,13 @@ namespace ts {
         // object, it serves as an indicator that all contained function and arrow expressions should be considered to
         // have the wildcard function type; this form of type check is used during overload resolution to exclude
         // contextually typed function and arrow expressions in the initial phase.
-        function checkExpression(node: Expression | QualifiedName, checkMode?: CheckMode): Type {
+        function checkExpression(node: Expression | QualifiedName, checkMode?: CheckMode, granular?: boolean): Type {
             let type: Type;
             if (node.kind === SyntaxKind.QualifiedName) {
                 type = checkQualifiedName(<QualifiedName>node);
             }
             else {
-                const uninstantiatedType = checkExpressionWorker(<Expression>node, checkMode);
+                const uninstantiatedType = checkExpressionWorker(<Expression>node, checkMode, granular);
                 type = instantiateTypeWithSingleGenericCallSignature(<Expression>node, uninstantiatedType, checkMode);
             }
 
@@ -17960,19 +17966,19 @@ namespace ts {
             return type;
         }
 
-        function checkParenthesizedExpression(node: ParenthesizedExpression, checkMode?: CheckMode): Type {
+        function checkParenthesizedExpression(node: ParenthesizedExpression, checkMode?: CheckMode, granular?: boolean): Type {
             if (isInJavaScriptFile(node) && node.jsDoc) {
                 const typecasts = flatMap(node.jsDoc, doc => filter(doc.tags, tag => tag.kind === SyntaxKind.JSDocTypeTag));
                 if (typecasts && typecasts.length) {
                     // We should have already issued an error if there were multiple type jsdocs
                     const cast = typecasts[0] as JSDocTypeTag;
-                    return checkAssertionWorker(cast, cast.typeExpression.type, node.expression, checkMode);
+                    return checkAssertionWorker(cast, cast.typeExpression.type, node.expression, checkMode, granular);
                 }
             }
-            return checkExpression(node.expression, checkMode);
+            return checkExpression(node.expression, checkMode, granular);
         }
 
-        function checkExpressionWorker(node: Expression, checkMode: CheckMode): Type {
+        function checkExpressionWorker(node: Expression, checkMode: CheckMode, granular?: boolean): Type {
             switch (node.kind) {
                 case SyntaxKind.Identifier:
                     return checkIdentifier(<Identifier>node);
@@ -17993,9 +17999,9 @@ namespace ts {
                 case SyntaxKind.RegularExpressionLiteral:
                     return globalRegExpType;
                 case SyntaxKind.ArrayLiteralExpression:
-                    return checkArrayLiteral(<ArrayLiteralExpression>node, checkMode);
+                    return checkArrayLiteral(<ArrayLiteralExpression>node, checkMode, granular);
                 case SyntaxKind.ObjectLiteralExpression:
-                    return checkObjectLiteral(<ObjectLiteralExpression>node, checkMode);
+                    return checkObjectLiteral(<ObjectLiteralExpression>node, checkMode, granular);
                 case SyntaxKind.PropertyAccessExpression:
                     return checkPropertyAccessExpression(<PropertyAccessExpression>node);
                 case SyntaxKind.ElementAccessExpression:
@@ -23055,7 +23061,7 @@ namespace ts {
             if (isRightSideOfQualifiedNameOrPropertyAccess(expr)) {
                 expr = <Expression>expr.parent;
             }
-            return getRegularTypeOfLiteralType(getTypeOfExpression(expr));
+            return getRegularTypeOfLiteralType(getTypeOfExpression(expr, granularConst));
         }
 
         /**

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -270,6 +270,13 @@ namespace ts {
             description: Diagnostics.Enable_strict_null_checks
         },
         {
+            name: "widenTypes",
+            type: "boolean",
+            showInSimplifiedHelpView: true,
+            category: Diagnostics.Strict_Type_Checking_Options,
+            description: Diagnostics.Automatically_widen_types_even_in_params_and_const
+        },
+        {
             name: "noImplicitThis",
             type: "boolean",
             showInSimplifiedHelpView: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3302,6 +3302,10 @@
         "category": "Message",
         "code": 6185
     },
+    "Automatically widen types even in params and `const`.": {
+        "category": "Message",
+        "code": 6186
+    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3622,6 +3622,7 @@ namespace ts {
         sourceRoot?: string;
         strict?: boolean;
         strictNullChecks?: boolean;  // Always combine with strict property
+        widenTypes?: boolean;
         /* @internal */ stripInternal?: boolean;
         suppressExcessPropertyErrors?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;

--- a/src/harness/unittests/configurationExtension.ts
+++ b/src/harness/unittests/configurationExtension.ts
@@ -16,6 +16,12 @@ namespace ts {
                 strictNullChecks: false
             }
         },
+        "/dev/tsconfig.widenTypes.json": {
+            extends: "./tsconfig",
+            compilerOptions: {
+                widenTypes: false
+            }
+        },
         "/dev/configs/base.json": {
             compilerOptions: {
                 allowJs: true,

--- a/src/harness/unittests/transpile.ts
+++ b/src/harness/unittests/transpile.ts
@@ -413,6 +413,10 @@ var x = 0;`, {
             options: { compilerOptions: { strictNullChecks: true }, fileName: "input.js", reportDiagnostics: true }
         });
 
+        transpilesCorrectly("Supports setting 'widenTypes'", "x;", {
+            options: { compilerOptions: { widenTypes: true }, fileName: "input.js", reportDiagnostics: true }
+        });
+
         transpilesCorrectly("Supports setting 'stripInternal'", "x;", {
             options: { compilerOptions: { stripInternal: true }, fileName: "input.js", reportDiagnostics: true }
         });

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2448,6 +2448,7 @@ namespace ts.server.protocol {
         sourceRoot?: string;
         strict?: boolean;
         strictNullChecks?: boolean;
+        widenTypes?: boolean;
         suppressExcessPropertyErrors?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;
         target?: ScriptTarget | ts.ScriptTarget;

--- a/tests/baselines/reference/dontWiden.js
+++ b/tests/baselines/reference/dontWiden.js
@@ -1,0 +1,41 @@
+//// [dontWiden.ts]
+const c = [1, 'a'];
+const d = { a: 1, b: 'c' };
+
+interface SomeInterface { a: boolean }
+declare function foo<T extends any[]>(arg: T): { hi: T };
+declare function boo<T extends number[]>(arg: T): { hi: T };
+declare function bar(arg: SomeInterface): void
+declare function baz(arg: [number, 2, 3 | number]): void
+declare function bag(arg: number[]): void
+
+// As variable assignees
+const a: number[] = [1, 2, 3];
+const b: SomeInterface = {a: true};
+const e = [1, 2, 3];
+
+// Same, but as arguments
+foo([1, 2, 3]);
+bar({a: true});
+baz([1, 2, 3]);
+bag([1, 2, 3]);
+bag(e);
+boo([1, 2, 3]);
+boo(e);
+
+
+//// [dontWiden.js]
+var c = [1, 'a'];
+var d = { a: 1, b: 'c' };
+// As variable assignees
+var a = [1, 2, 3];
+var b = { a: true };
+var e = [1, 2, 3];
+// Same, but as arguments
+foo([1, 2, 3]);
+bar({ a: true });
+baz([1, 2, 3]);
+bag([1, 2, 3]);
+bag(e);
+boo([1, 2, 3]);
+boo(e);

--- a/tests/baselines/reference/dontWiden.symbols
+++ b/tests/baselines/reference/dontWiden.symbols
@@ -1,0 +1,79 @@
+=== tests/cases/compiler/dontWiden.ts ===
+const c = [1, 'a'];
+>c : Symbol(c, Decl(dontWiden.ts, 0, 5))
+
+const d = { a: 1, b: 'c' };
+>d : Symbol(d, Decl(dontWiden.ts, 1, 5))
+>a : Symbol(a, Decl(dontWiden.ts, 1, 11))
+>b : Symbol(b, Decl(dontWiden.ts, 1, 17))
+
+interface SomeInterface { a: boolean }
+>SomeInterface : Symbol(SomeInterface, Decl(dontWiden.ts, 1, 27))
+>a : Symbol(SomeInterface.a, Decl(dontWiden.ts, 3, 25))
+
+declare function foo<T extends any[]>(arg: T): { hi: T };
+>foo : Symbol(foo, Decl(dontWiden.ts, 3, 38))
+>T : Symbol(T, Decl(dontWiden.ts, 4, 21))
+>arg : Symbol(arg, Decl(dontWiden.ts, 4, 38))
+>T : Symbol(T, Decl(dontWiden.ts, 4, 21))
+>hi : Symbol(hi, Decl(dontWiden.ts, 4, 48))
+>T : Symbol(T, Decl(dontWiden.ts, 4, 21))
+
+declare function boo<T extends number[]>(arg: T): { hi: T };
+>boo : Symbol(boo, Decl(dontWiden.ts, 4, 57))
+>T : Symbol(T, Decl(dontWiden.ts, 5, 21))
+>arg : Symbol(arg, Decl(dontWiden.ts, 5, 41))
+>T : Symbol(T, Decl(dontWiden.ts, 5, 21))
+>hi : Symbol(hi, Decl(dontWiden.ts, 5, 51))
+>T : Symbol(T, Decl(dontWiden.ts, 5, 21))
+
+declare function bar(arg: SomeInterface): void
+>bar : Symbol(bar, Decl(dontWiden.ts, 5, 60))
+>arg : Symbol(arg, Decl(dontWiden.ts, 6, 21))
+>SomeInterface : Symbol(SomeInterface, Decl(dontWiden.ts, 1, 27))
+
+declare function baz(arg: [number, 2, 3 | number]): void
+>baz : Symbol(baz, Decl(dontWiden.ts, 6, 46))
+>arg : Symbol(arg, Decl(dontWiden.ts, 7, 21))
+
+declare function bag(arg: number[]): void
+>bag : Symbol(bag, Decl(dontWiden.ts, 7, 56))
+>arg : Symbol(arg, Decl(dontWiden.ts, 8, 21))
+
+// As variable assignees
+const a: number[] = [1, 2, 3];
+>a : Symbol(a, Decl(dontWiden.ts, 11, 5))
+
+const b: SomeInterface = {a: true};
+>b : Symbol(b, Decl(dontWiden.ts, 12, 5))
+>SomeInterface : Symbol(SomeInterface, Decl(dontWiden.ts, 1, 27))
+>a : Symbol(a, Decl(dontWiden.ts, 12, 26))
+
+const e = [1, 2, 3];
+>e : Symbol(e, Decl(dontWiden.ts, 13, 5))
+
+// Same, but as arguments
+foo([1, 2, 3]);
+>foo : Symbol(foo, Decl(dontWiden.ts, 3, 38))
+
+bar({a: true});
+>bar : Symbol(bar, Decl(dontWiden.ts, 5, 60))
+>a : Symbol(a, Decl(dontWiden.ts, 17, 5))
+
+baz([1, 2, 3]);
+>baz : Symbol(baz, Decl(dontWiden.ts, 6, 46))
+
+bag([1, 2, 3]);
+>bag : Symbol(bag, Decl(dontWiden.ts, 7, 56))
+
+bag(e);
+>bag : Symbol(bag, Decl(dontWiden.ts, 7, 56))
+>e : Symbol(e, Decl(dontWiden.ts, 13, 5))
+
+boo([1, 2, 3]);
+>boo : Symbol(boo, Decl(dontWiden.ts, 4, 57))
+
+boo(e);
+>boo : Symbol(boo, Decl(dontWiden.ts, 4, 57))
+>e : Symbol(e, Decl(dontWiden.ts, 13, 5))
+

--- a/tests/baselines/reference/dontWiden.types
+++ b/tests/baselines/reference/dontWiden.types
@@ -1,0 +1,120 @@
+=== tests/cases/compiler/dontWiden.ts ===
+const c = [1, 'a'];
+>c : [1, "a"]
+>[1, 'a'] : [1, "a"]
+>1 : 1
+>'a' : "a"
+
+const d = { a: 1, b: 'c' };
+>d : { a: 1; b: "c"; }
+>{ a: 1, b: 'c' } : { a: 1; b: "c"; }
+>a : number
+>1 : 1
+>b : string
+>'c' : "c"
+
+interface SomeInterface { a: boolean }
+>SomeInterface : SomeInterface
+>a : boolean
+
+declare function foo<T extends any[]>(arg: T): { hi: T };
+>foo : <T extends any[]>(arg: T) => { hi: T; }
+>T : T
+>arg : T
+>T : T
+>hi : T
+>T : T
+
+declare function boo<T extends number[]>(arg: T): { hi: T };
+>boo : <T extends number[]>(arg: T) => { hi: T; }
+>T : T
+>arg : T
+>T : T
+>hi : T
+>T : T
+
+declare function bar(arg: SomeInterface): void
+>bar : (arg: SomeInterface) => void
+>arg : SomeInterface
+>SomeInterface : SomeInterface
+
+declare function baz(arg: [number, 2, 3 | number]): void
+>baz : (arg: [number, 2, number]) => void
+>arg : [number, 2, number]
+
+declare function bag(arg: number[]): void
+>bag : (arg: number[]) => void
+>arg : number[]
+
+// As variable assignees
+const a: number[] = [1, 2, 3];
+>a : number[]
+>[1, 2, 3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+
+const b: SomeInterface = {a: true};
+>b : SomeInterface
+>SomeInterface : SomeInterface
+>{a: true} : { a: true; }
+>a : boolean
+>true : true
+
+const e = [1, 2, 3];
+>e : [1, 2, 3]
+>[1, 2, 3] : [1, 2, 3]
+>1 : 1
+>2 : 2
+>3 : 3
+
+// Same, but as arguments
+foo([1, 2, 3]);
+>foo([1, 2, 3]) : { hi: [1, 2, 3]; }
+>foo : <T extends any[]>(arg: T) => { hi: T; }
+>[1, 2, 3] : [1, 2, 3]
+>1 : 1
+>2 : 2
+>3 : 3
+
+bar({a: true});
+>bar({a: true}) : void
+>bar : (arg: SomeInterface) => void
+>{a: true} : { a: true; }
+>a : boolean
+>true : true
+
+baz([1, 2, 3]);
+>baz([1, 2, 3]) : void
+>baz : (arg: [number, 2, number]) => void
+>[1, 2, 3] : [number, 2, number]
+>1 : 1
+>2 : 2
+>3 : 3
+
+bag([1, 2, 3]);
+>bag([1, 2, 3]) : void
+>bag : (arg: number[]) => void
+>[1, 2, 3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+
+bag(e);
+>bag(e) : void
+>bag : (arg: number[]) => void
+>e : [1, 2, 3]
+
+boo([1, 2, 3]);
+>boo([1, 2, 3]) : { hi: [1, 2, 3]; }
+>boo : <T extends number[]>(arg: T) => { hi: T; }
+>[1, 2, 3] : [1, 2, 3]
+>1 : 1
+>2 : 2
+>3 : 3
+
+boo(e);
+>boo(e) : { hi: [1, 2, 3]; }
+>boo : <T extends number[]>(arg: T) => { hi: T; }
+>e : [1, 2, 3]
+

--- a/tests/baselines/reference/transpile/Supports setting granularConst.js
+++ b/tests/baselines/reference/transpile/Supports setting granularConst.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting widenTypes.js
+++ b/tests/baselines/reference/transpile/Supports setting widenTypes.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
@@ -22,6 +22,7 @@
     "strict": true                            /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "widenTypes": true,                    /* Automatically widen types even in params and `const`. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -22,6 +22,7 @@
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "widenTypes": true,                    /* Automatically widen types even in params and `const`. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -22,6 +22,7 @@
     "strict": true                            /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "widenTypes": true,                    /* Automatically widen types even in params and `const`. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
@@ -22,6 +22,7 @@
     "strict": true                            /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "widenTypes": true,                    /* Automatically widen types even in params and `const`. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -22,6 +22,7 @@
     "strict": true                            /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "widenTypes": true,                    /* Automatically widen types even in params and `const`. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -22,6 +22,7 @@
     "strict": true                            /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "widenTypes": true,                    /* Automatically widen types even in params and `const`. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -22,6 +22,7 @@
     "strict": true                            /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "widenTypes": true,                    /* Automatically widen types even in params and `const`. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -22,6 +22,7 @@
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "widenTypes": true,                    /* Automatically widen types even in params and `const`. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/tests/cases/compiler/dontWiden.ts
+++ b/tests/cases/compiler/dontWiden.ts
@@ -1,0 +1,25 @@
+// @widenTypes: false
+
+const c = [1, 'a'];
+const d = { a: 1, b: 'c' };
+
+interface SomeInterface { a: boolean }
+declare function foo<T extends any[]>(arg: T): { hi: T };
+declare function boo<T extends number[]>(arg: T): { hi: T };
+declare function bar(arg: SomeInterface): void
+declare function baz(arg: [number, 2, 3 | number]): void
+declare function bag(arg: number[]): void
+
+// As variable assignees
+const a: number[] = [1, 2, 3];
+const b: SomeInterface = {a: true};
+const e = [1, 2, 3];
+
+// Same, but as arguments
+foo([1, 2, 3]);
+bar({a: true});
+baz([1, 2, 3]);
+bag([1, 2, 3]);
+bag(e);
+boo([1, 2, 3]);
+boo(e);


### PR DESCRIPTION
This is a new compiler flag (idea: https://github.com/Microsoft/TypeScript/issues/16389#issuecomment-308651207) to cancel type widening for objects / arrays (and even infer those as tuples) in `const` declarations as well as parameters:
```ts
// @widenTypes: false 
let a = [1, 2, 3];
// as before: number[]
a.push(4);
// ok
const b = [1, 2, 3];
// now [1, 2, 3]
b.push(4);
// boom
let c = { a: true };
// as before: { a: boolean }
const d = { a: true };
// now { a: true }
```

This would fix inference issues that spawned #3369, #6574, #7799, #8276, #9216, #9217, #10195, #12308, #12955, #15656, #16276, #16389, #16523, #16656, #17181. (Probably not exhaustive, just followed some links.)
Some of those propose alternate solutions like new keywords, though I presume this would address their issues as well.

Sometimes one may want granular types, sometimes one may want widened types. And in parameter positions, unfortunately only one of the two can be default, so either will end up wrong in some cases.
For declarations this holds as well, but the appeal of this flag there is that it yields users more control, based on whether they use the `let` or `const` keyword.

Notes:
- Yes, it overloads the semantics of these JS keywords, if in a way that makes a surprising amount of sense.
- it feels a bit unfortunate I had to propagate this boolean across 20 methods, should their params (new one and `checkMode`, or even the nodes too) be standardized into some options objects?
