### PR TITLE
Array arguments to `concat` should be `ReadonlyArray`s

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -980,12 +980,12 @@ interface ReadonlyArray<T> {
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
-    concat(...items: T[][]): T[];
+    concat(...items: ReadonlyArray<T>[]): T[];
     /**
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
-    concat(...items: (T | T[])[]): T[];
+    concat(...items: (T | ReadonlyArray<T>)[]): T[];
     /**
       * Adds all the elements of an array separated by the specified separator string.
       * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
@@ -1099,12 +1099,12 @@ interface Array<T> {
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
-    concat(...items: T[][]): T[];
+    concat(...items: ReadonlyArray<T>[]): T[];
     /**
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
-    concat(...items: (T | T[])[]): T[];
+    concat(...items: (T | ReadonlyArray<T>)[]): T[];
     /**
       * Adds all the elements of an array separated by the specified separator string.
       * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.

--- a/tests/baselines/reference/arrayConcat2.types
+++ b/tests/baselines/reference/arrayConcat2.types
@@ -5,17 +5,17 @@ var a: string[] = [];
 
 a.concat("hello", 'world');
 >a.concat("hello", 'world') : string[]
->a.concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
+>a.concat : { (...items: ReadonlyArray<string>[]): string[]; (...items: (string | ReadonlyArray<string>)[]): string[]; }
 >a : string[]
->concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
+>concat : { (...items: ReadonlyArray<string>[]): string[]; (...items: (string | ReadonlyArray<string>)[]): string[]; }
 >"hello" : "hello"
 >'world' : "world"
 
 a.concat('Hello');
 >a.concat('Hello') : string[]
->a.concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
+>a.concat : { (...items: ReadonlyArray<string>[]): string[]; (...items: (string | ReadonlyArray<string>)[]): string[]; }
 >a : string[]
->concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
+>concat : { (...items: ReadonlyArray<string>[]): string[]; (...items: (string | ReadonlyArray<string>)[]): string[]; }
 >'Hello' : "Hello"
 
 var b = new Array<string>();
@@ -25,8 +25,8 @@ var b = new Array<string>();
 
 b.concat('hello');
 >b.concat('hello') : string[]
->b.concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
+>b.concat : { (...items: ReadonlyArray<string>[]): string[]; (...items: (string | ReadonlyArray<string>)[]): string[]; }
 >b : string[]
->concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
+>concat : { (...items: ReadonlyArray<string>[]): string[]; (...items: (string | ReadonlyArray<string>)[]): string[]; }
 >'hello' : "hello"
 

--- a/tests/baselines/reference/arrayConcatMap.types
+++ b/tests/baselines/reference/arrayConcatMap.types
@@ -4,9 +4,9 @@ var x = [].concat([{ a: 1 }], [{ a: 2 }])
 >[].concat([{ a: 1 }], [{ a: 2 }])          .map(b => b.a) : any[]
 >[].concat([{ a: 1 }], [{ a: 2 }])          .map : <U>(callbackfn: (value: any, index: number, array: any[]) => U, thisArg?: any) => U[]
 >[].concat([{ a: 1 }], [{ a: 2 }]) : any[]
->[].concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
+>[].concat : { (...items: ReadonlyArray<any>[]): any[]; (...items: any[]): any[]; }
 >[] : undefined[]
->concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
+>concat : { (...items: ReadonlyArray<any>[]): any[]; (...items: any[]): any[]; }
 >[{ a: 1 }] : { a: number; }[]
 >{ a: 1 } : { a: number; }
 >a : number

--- a/tests/baselines/reference/arrayOfSubtypeIsAssignableToReadonlyArray.errors.txt
+++ b/tests/baselines/reference/arrayOfSubtypeIsAssignableToReadonlyArray.errors.txt
@@ -1,12 +1,12 @@
 tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts(13,1): error TS2322: Type 'A[]' is not assignable to type 'ReadonlyArray<B>'.
   Types of property 'concat' are incompatible.
-    Type '{ (...items: A[][]): A[]; (...items: (A | A[])[]): A[]; }' is not assignable to type '{ (...items: B[][]): B[]; (...items: (B | B[])[]): B[]; }'.
+    Type '{ (...items: ReadonlyArray<A>[]): A[]; (...items: (A | ReadonlyArray<A>)[]): A[]; }' is not assignable to type '{ (...items: ReadonlyArray<B>[]): B[]; (...items: (B | ReadonlyArray<B>)[]): B[]; }'.
       Type 'A[]' is not assignable to type 'B[]'.
         Type 'A' is not assignable to type 'B'.
           Property 'b' is missing in type 'A'.
 tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts(18,1): error TS2322: Type 'C<A>' is not assignable to type 'ReadonlyArray<B>'.
   Types of property 'concat' are incompatible.
-    Type '{ (...items: A[][]): A[]; (...items: (A | A[])[]): A[]; }' is not assignable to type '{ (...items: B[][]): B[]; (...items: (B | B[])[]): B[]; }'.
+    Type '{ (...items: ReadonlyArray<A>[]): A[]; (...items: (A | ReadonlyArray<A>)[]): A[]; }' is not assignable to type '{ (...items: ReadonlyArray<B>[]): B[]; (...items: (B | ReadonlyArray<B>)[]): B[]; }'.
       Type 'A[]' is not assignable to type 'B[]'.
 
 
@@ -27,7 +27,7 @@ tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts(18,1): error T
     ~~~
 !!! error TS2322: Type 'A[]' is not assignable to type 'ReadonlyArray<B>'.
 !!! error TS2322:   Types of property 'concat' are incompatible.
-!!! error TS2322:     Type '{ (...items: A[][]): A[]; (...items: (A | A[])[]): A[]; }' is not assignable to type '{ (...items: B[][]): B[]; (...items: (B | B[])[]): B[]; }'.
+!!! error TS2322:     Type '{ (...items: ReadonlyArray<A>[]): A[]; (...items: (A | ReadonlyArray<A>)[]): A[]; }' is not assignable to type '{ (...items: ReadonlyArray<B>[]): B[]; (...items: (B | ReadonlyArray<B>)[]): B[]; }'.
 !!! error TS2322:       Type 'A[]' is not assignable to type 'B[]'.
 !!! error TS2322:         Type 'A' is not assignable to type 'B'.
 !!! error TS2322:           Property 'b' is missing in type 'A'.
@@ -39,6 +39,6 @@ tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts(18,1): error T
     ~~~
 !!! error TS2322: Type 'C<A>' is not assignable to type 'ReadonlyArray<B>'.
 !!! error TS2322:   Types of property 'concat' are incompatible.
-!!! error TS2322:     Type '{ (...items: A[][]): A[]; (...items: (A | A[])[]): A[]; }' is not assignable to type '{ (...items: B[][]): B[]; (...items: (B | B[])[]): B[]; }'.
+!!! error TS2322:     Type '{ (...items: ReadonlyArray<A>[]): A[]; (...items: (A | ReadonlyArray<A>)[]): A[]; }' is not assignable to type '{ (...items: ReadonlyArray<B>[]): B[]; (...items: (B | ReadonlyArray<B>)[]): B[]; }'.
 !!! error TS2322:       Type 'A[]' is not assignable to type 'B[]'.
     

--- a/tests/baselines/reference/concatError.types
+++ b/tests/baselines/reference/concatError.types
@@ -15,9 +15,9 @@ fa = fa.concat([0]);
 >fa = fa.concat([0]) : number[]
 >fa : number[]
 >fa.concat([0]) : number[]
->fa.concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
+>fa.concat : { (...items: ReadonlyArray<number>[]): number[]; (...items: (number | ReadonlyArray<number>)[]): number[]; }
 >fa : number[]
->concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
+>concat : { (...items: ReadonlyArray<number>[]): number[]; (...items: (number | ReadonlyArray<number>)[]): number[]; }
 >[0] : number[]
 >0 : 0
 
@@ -25,9 +25,9 @@ fa = fa.concat(0);
 >fa = fa.concat(0) : number[]
 >fa : number[]
 >fa.concat(0) : number[]
->fa.concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
+>fa.concat : { (...items: ReadonlyArray<number>[]): number[]; (...items: (number | ReadonlyArray<number>)[]): number[]; }
 >fa : number[]
->concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
+>concat : { (...items: ReadonlyArray<number>[]): number[]; (...items: (number | ReadonlyArray<number>)[]): number[]; }
 >0 : 0
 
 

--- a/tests/baselines/reference/concatTuples.types
+++ b/tests/baselines/reference/concatTuples.types
@@ -10,9 +10,9 @@ ijs = ijs.concat([[3, 4], [5, 6]]);
 >ijs = ijs.concat([[3, 4], [5, 6]]) : [number, number][]
 >ijs : [number, number][]
 >ijs.concat([[3, 4], [5, 6]]) : [number, number][]
->ijs.concat : { (...items: [number, number][][]): [number, number][]; (...items: ([number, number] | [number, number][])[]): [number, number][]; }
+>ijs.concat : { (...items: ReadonlyArray<[number, number]>[]): [number, number][]; (...items: ([number, number] | ReadonlyArray<[number, number]>)[]): [number, number][]; }
 >ijs : [number, number][]
->concat : { (...items: [number, number][][]): [number, number][]; (...items: ([number, number] | [number, number][])[]): [number, number][]; }
+>concat : { (...items: ReadonlyArray<[number, number]>[]): [number, number][]; (...items: ([number, number] | ReadonlyArray<[number, number]>)[]): [number, number][]; }
 >[[3, 4], [5, 6]] : [number, number][]
 >[3, 4] : [number, number]
 >3 : 3

--- a/tests/baselines/reference/emitSkipsThisWithRestParameter.types
+++ b/tests/baselines/reference/emitSkipsThisWithRestParameter.types
@@ -18,10 +18,10 @@ function rebase(fn: (base: any, ...args: any[]) => any): (...args: any[]) => any
 >apply : (this: Function, thisArg: any, argArray?: any) => any
 >this : any
 >[ this ].concat(args) : any[]
->[ this ].concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
+>[ this ].concat : { (...items: ReadonlyArray<any>[]): any[]; (...items: any[]): any[]; }
 >[ this ] : any[]
 >this : any
->concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
+>concat : { (...items: ReadonlyArray<any>[]): any[]; (...items: any[]): any[]; }
 >args : any[]
 
     };

--- a/tests/baselines/reference/iteratorSpreadInArray6.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInArray6.errors.txt
@@ -1,6 +1,10 @@
-tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts(15,14): error TS2345: Argument of type 'symbol[]' is not assignable to parameter of type 'number | number[]'.
-  Type 'symbol[]' is not assignable to type 'number[]'.
-    Type 'symbol' is not assignable to type 'number'.
+tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts(15,14): error TS2345: Argument of type 'symbol[]' is not assignable to parameter of type 'number | ReadonlyArray<number>'.
+  Type 'symbol[]' is not assignable to type 'ReadonlyArray<number>'.
+    Types of property 'concat' are incompatible.
+      Type '{ (...items: ReadonlyArray<symbol>[]): symbol[]; (...items: (symbol | ReadonlyArray<symbol>)[]): symbol[]; }' is not assignable to type '{ (...items: ReadonlyArray<number>[]): number[]; (...items: (number | ReadonlyArray<number>)[]): number[]; }'.
+        Types of parameters 'items' and 'items' are incompatible.
+          Type 'ReadonlyArray<number>' is not assignable to type 'ReadonlyArray<symbol>'.
+            Type 'number' is not assignable to type 'symbol'.
 
 
 ==== tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts (1 errors) ====
@@ -20,6 +24,10 @@ tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts(15,14): error TS234
     var array: number[] = [0, 1];
     array.concat([...new SymbolIterator]);
                  ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type 'symbol[]' is not assignable to parameter of type 'number | number[]'.
-!!! error TS2345:   Type 'symbol[]' is not assignable to type 'number[]'.
-!!! error TS2345:     Type 'symbol' is not assignable to type 'number'.
+!!! error TS2345: Argument of type 'symbol[]' is not assignable to parameter of type 'number | ReadonlyArray<number>'.
+!!! error TS2345:   Type 'symbol[]' is not assignable to type 'ReadonlyArray<number>'.
+!!! error TS2345:     Types of property 'concat' are incompatible.
+!!! error TS2345:       Type '{ (...items: ReadonlyArray<symbol>[]): symbol[]; (...items: (symbol | ReadonlyArray<symbol>)[]): symbol[]; }' is not assignable to type '{ (...items: ReadonlyArray<number>[]): number[]; (...items: (number | ReadonlyArray<number>)[]): number[]; }'.
+!!! error TS2345:         Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2345:           Type 'ReadonlyArray<number>' is not assignable to type 'ReadonlyArray<symbol>'.
+!!! error TS2345:             Type 'number' is not assignable to type 'symbol'.

--- a/tests/baselines/reference/iteratorSpreadInArray7.types
+++ b/tests/baselines/reference/iteratorSpreadInArray7.types
@@ -35,9 +35,9 @@ var array: symbol[];
 
 array.concat([...new SymbolIterator]);
 >array.concat([...new SymbolIterator]) : symbol[]
->array.concat : { (...items: symbol[][]): symbol[]; (...items: (symbol | symbol[])[]): symbol[]; }
+>array.concat : { (...items: ReadonlyArray<symbol>[]): symbol[]; (...items: (symbol | ReadonlyArray<symbol>)[]): symbol[]; }
 >array : symbol[]
->concat : { (...items: symbol[][]): symbol[]; (...items: (symbol | symbol[])[]): symbol[]; }
+>concat : { (...items: ReadonlyArray<symbol>[]): symbol[]; (...items: (symbol | ReadonlyArray<symbol>)[]): symbol[]; }
 >[...new SymbolIterator] : symbol[]
 >...new SymbolIterator : symbol
 >new SymbolIterator : SymbolIterator

--- a/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.types
+++ b/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.types
@@ -348,9 +348,9 @@ class ListWrapper {
 >a : any[]
 >b : any[]
 >a.concat(b) : any[]
->a.concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
+>a.concat : { (...items: ReadonlyArray<any>[]): any[]; (...items: any[]): any[]; }
 >a : any[]
->concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
+>concat : { (...items: ReadonlyArray<any>[]): any[]; (...items: any[]): any[]; }
 >b : any[]
 
   static insert<T>(dit: typeof ListWrapper, list: T[], index: number, value: T) { list.splice(index, 0, value); }


### PR DESCRIPTION
Fixes #17076
@sandersn You added the second overload in #10374, is there a reason we need two?