### PR TITLE
Filter + log undefined elements from the codeActions array

### DIFF
--- a/src/services/codeFixProvider.ts
+++ b/src/services/codeFixProvider.ts
@@ -36,12 +36,19 @@ namespace ts {
 
         export function getFixes(context: CodeFixContext): CodeAction[] {
             const fixes = codeFixes[context.errorCode];
-            let allActions: CodeAction[] = [];
+            const allActions: CodeAction[] = [];
 
             forEach(fixes, f => {
                 const actions = f.getCodeActions(context);
                 if (actions && actions.length > 0) {
-                    allActions = allActions.concat(actions);
+                    for (const action of actions) {
+                        if (action === undefined) {
+                            context.host.log(`Action for error code ${context.errorCode} added an invalid action entry; please log a bug`);
+                        }
+                        else {
+                            allActions.push(action);
+                        }
+                    }
                 }
             });
 


### PR DESCRIPTION
Fixes #17544. There's still an underlying bug somewhere (one of the CodeActions is returning `undefined` in an array position where it shouldn't) but without a repro it's going to be very hard to track down. This will replace the crash with a log message so we can figure out which action is responsible.