### PR TITLE
Deduplicate inputfiles before running RWC tests

### DIFF
--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -91,7 +91,11 @@ namespace RWC {
                     }
 
                     // Deduplicate files so they are only printed once in baselines (they are deduplicated within the compiler already)
-                    fileNames = ts.filter(fileNames, n => fileNames.indexOf(n) === fileNames.lastIndexOf(n));
+                    const uniqueNames = ts.createMap<string>();
+                    for (const fileName of fileNames) {
+                            uniqueNames.set(ts.normalizeSlashes(fileName), fileName);
+                    }
+                    fileNames = ts.arrayFrom(uniqueNames.values());
                     
                     // Load the files
                     for (const fileName of fileNames) {

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -92,19 +92,14 @@ namespace RWC {
 
                     // Deduplicate files so they are only printed once in baselines (they are deduplicated within the compiler already)
                     const uniqueNames = ts.createMap<true>();
-                    const dedupedNames: string[] = [];
                     for (const fileName of fileNames) {
                         // Must maintain order, build result list while checking map
                         const normalized = ts.normalizeSlashes(fileName);
                         if (!uniqueNames.has(normalized)) {
                             uniqueNames.set(normalized, true);
-                            dedupedNames.push(fileName);
+                            // Load the file
+                            inputFiles.push(getHarnessCompilerInputUnit(fileName));
                         }
-                    }
-
-                    // Load the files
-                    for (const fileName of dedupedNames) {
-                        inputFiles.push(getHarnessCompilerInputUnit(fileName));
                     }
 
                     // Add files to compilation

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -90,6 +90,9 @@ namespace RWC {
                         ts.setConfigFileInOptions(opts.options, configParseResult.options.configFile);
                     }
 
+                    // Deduplicate files so they are only printed once in baselines (they are deduplicated within the compiler already)
+                    fileNames = ts.filter(fileNames, n => fileNames.indexOf(n) === fileNames.lastIndexOf(n));
+                    
                     // Load the files
                     for (const fileName of fileNames) {
                         inputFiles.push(getHarnessCompilerInputUnit(fileName));

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -96,7 +96,7 @@ namespace RWC {
                             uniqueNames.set(ts.normalizeSlashes(fileName), fileName);
                     }
                     fileNames = ts.arrayFrom(uniqueNames.values());
-                    
+
                     // Load the files
                     for (const fileName of fileNames) {
                         inputFiles.push(getHarnessCompilerInputUnit(fileName));

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -91,14 +91,19 @@ namespace RWC {
                     }
 
                     // Deduplicate files so they are only printed once in baselines (they are deduplicated within the compiler already)
-                    const uniqueNames = ts.createMap<string>();
+                    const uniqueNames = ts.createMap<true>();
+                    const dedupedNames: string[] = [];
                     for (const fileName of fileNames) {
-                            uniqueNames.set(ts.normalizeSlashes(fileName), fileName);
+                        // Must maintain order, build result list while checking map
+                        const normalized = ts.normalizeSlashes(fileName);
+                        if (!uniqueNames.has(normalized)) {
+                            uniqueNames.set(normalized, true);
+                            dedupedNames.push(fileName);
+                        }
                     }
-                    fileNames = ts.arrayFrom(uniqueNames.values());
 
                     // Load the files
-                    for (const fileName of fileNames) {
+                    for (const fileName of dedupedNames) {
                         inputFiles.push(getHarnessCompilerInputUnit(fileName));
                     }
 


### PR DESCRIPTION
We deduplicate in the compiler, but we don't in the harness - this causes tests where the same file is listed multiple times in the arguments to not have the expected errors written, because we write out the same file multiple times when we should not.

A pair of our RWC tests are currently failing because of this.