### PR TITLE
tuple type spread

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3351,6 +3351,7 @@ namespace ts {
             case SyntaxKind.TypeLiteral:
             case SyntaxKind.ArrayType:
             case SyntaxKind.TupleType:
+            case SyntaxKind.TypeSpread:
             case SyntaxKind.UnionType:
             case SyntaxKind.IntersectionType:
             case SyntaxKind.ParenthesizedType:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2555,6 +2555,10 @@ namespace ts {
                     const indexTypeNode = typeToTypeNodeHelper((<IndexedAccessType>type).indexType, context);
                     return createIndexedAccessTypeNode(objectTypeNode, indexTypeNode);
                 }
+                if (type.flags & TypeFlags.SpreadTuple) {
+                    const typeNodes = map((<SpreadTupleType>type).elements, (tp: Type) => typeToTypeNodeHelper(tp, context));
+                    return createTupleTypeNode(typeNodes, (<SpreadTupleType>type).idxIsSpread);
+                }
 
                 Debug.fail("Should be unreachable.");
 
@@ -3324,6 +3328,12 @@ namespace ts {
                         writeType((<IndexedAccessType>type).indexType, TypeFormatFlags.None);
                         writePunctuation(writer, SyntaxKind.CloseBracketToken);
                     }
+                    else if (type.flags & TypeFlags.SpreadTuple) {
+                        writePunctuation(writer, SyntaxKind.OpenBracketToken);
+                        writePunctuation(writer, SyntaxKind.DotDotDotToken);
+                        writeTypeList((<SpreadTupleType>type).elements, SyntaxKind.CommaToken, (<SpreadTupleType>type).idxIsSpread);
+                        writePunctuation(writer, SyntaxKind.CloseBracketToken);
+                    }
                     else {
                         // Should never get here
                         // { ... }
@@ -3336,7 +3346,7 @@ namespace ts {
                 }
 
 
-                function writeTypeList(types: Type[], delimiter: SyntaxKind) {
+                function writeTypeList(types: Type[], delimiter: SyntaxKind, idxIsSpread: boolean[] = []) {
                     for (let i = 0; i < types.length; i++) {
                         if (i > 0) {
                             if (delimiter !== SyntaxKind.CommaToken) {
@@ -3344,6 +3354,9 @@ namespace ts {
                             }
                             writePunctuation(writer, delimiter);
                             writeSpace(writer);
+                        }
+                        if (idxIsSpread[i]) {
+                            writePunctuation(writer, SyntaxKind.DotDotDotToken);
                         }
                         writeType(types[i], delimiter === SyntaxKind.CommaToken ? TypeFormatFlags.None : TypeFormatFlags.InElementType);
                     }
@@ -7262,9 +7275,65 @@ namespace ts {
         function getTypeFromTupleTypeNode(node: TupleTypeNode): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
-                links.resolvedType = createTupleType(map(node.elementTypes, getTypeFromTypeNode));
+                links.resolvedType = getTypeForTupleNode(node);
             }
             return links.resolvedType;
+        }
+
+        function getSpreadTupleTypes(elements: Type[], idxIsSpread: boolean[]): Type {
+            return createTupleType(flatMap(elements, (tp: Type, i: number) => idxIsSpread[i] ? getTypeSpreadTypes(tp) : tp));
+        }
+
+        function getTypeSpreadTypes(tuple: Type): Type[] {
+            if (isTupleLikeType(tuple)) {
+                return getTupleTypeElementTypes(tuple);
+            }
+            else {
+                // console.error("not a tuple, don't resolve?");
+                return [];
+            }
+        }
+
+        function isGenericTupleType(type: Type): boolean {
+            return type.flags & TypeFlags.TypeVariable ? true :
+                type.flags & TypeFlags.UnionOrIntersection ? forEach((<UnionOrIntersectionType>type).types, isGenericTupleType) :
+                false;
+        }
+
+        function getTypeForTupleNode(node: TupleTypeNode): Type {
+            if (some(node.elementTypes, (n: TypeNode) => n.kind === SyntaxKind.TypeSpread &&
+                    isGenericTupleType(getTypeFromTypeNode((n as TypeSpreadTypeNode).type)))) {
+                const elements = map(node.elementTypes, (n: TypeNode) => getTypeFromTypeNode(n.kind === SyntaxKind.TypeSpread ? (n as TypeSpreadTypeNode).type : n));
+                const idxIsSpread = map(node.elementTypes, (n: TypeNode) => n.kind === SyntaxKind.TypeSpread);
+                return createTupleSpreadType(elements, idxIsSpread);
+            }
+            else {
+                return createTupleType(flatMap(node.elementTypes, getTypeFromTupleElement));
+            }
+        }
+
+        function getTupleTypeElementTypes(type: Type): Type[] {
+            Debug.assert(isTupleLikeType(type));
+            const types = [];
+            let idx = 0;
+            let symbol: Symbol;
+            while (symbol = getPropertyOfObjectType(type, idx++ + "" as __String)) {
+                types.push(getTypeOfSymbol(symbol));
+            }
+            return types;
+        }
+
+        function getTypeFromTupleElement(node: TypeNode | TypeSpreadTypeNode): Type | Type[] {
+            if (node.kind === SyntaxKind.TypeSpread) {
+                const links = getNodeLinks(node);
+                if (!links.resolvedType) {
+                    links.resolvedType = getTypeFromTypeNode((node as TypeSpreadTypeNode).type);
+                }
+                return getTypeSpreadTypes(links.resolvedType);
+            }
+            else {
+                return getTypeFromTypeNode(node as TypeNode);
+            }
         }
 
         interface TypeSet extends Array<Type> {
@@ -7627,6 +7696,13 @@ namespace ts {
             const type = <IndexedAccessType>createType(TypeFlags.IndexedAccess);
             type.objectType = objectType;
             type.indexType = indexType;
+            return type;
+        }
+
+        function createTupleSpreadType(elements: Type[], idxIsSpread: boolean[]) {
+            const type = <SpreadTupleType>createType(TypeFlags.SpreadTuple);
+            type.elements = elements;
+            type.idxIsSpread = idxIsSpread;
             return type;
         }
 
@@ -8365,6 +8441,9 @@ namespace ts {
                 if (type.flags & TypeFlags.IndexedAccess) {
                     return getIndexedAccessType(instantiateType((<IndexedAccessType>type).objectType, mapper), instantiateType((<IndexedAccessType>type).indexType, mapper));
                 }
+            }
+            if (type.flags & TypeFlags.SpreadTuple) {
+                return getSpreadTupleTypes(instantiateTypes((<SpreadTupleType>type).elements, mapper), (<SpreadTupleType>type).idxIsSpread);
             }
             return type;
         }
@@ -18930,6 +19009,14 @@ namespace ts {
             forEach(node.elementTypes, checkSourceElement);
         }
 
+        function checkTypeSpreadTypeNode(node: TypeSpreadTypeNode) {
+            checkSourceElement(node.type);
+            const type = getApparentType(getTypeFromTypeNode(node.type));
+            if (!isArrayLikeType(type)) { // isTupleLikeType
+                grammarErrorOnNode(node, Diagnostics.Tuple_type_spreads_may_only_be_created_from_tuple_types);
+            }
+        }
+
         function checkUnionOrIntersectionType(node: UnionOrIntersectionTypeNode) {
             forEach(node.types, checkSourceElement);
         }
@@ -22494,6 +22581,8 @@ namespace ts {
                     return checkArrayType(<ArrayTypeNode>node);
                 case SyntaxKind.TupleType:
                     return checkTupleType(<TupleTypeNode>node);
+                case SyntaxKind.TypeSpread:
+                    return checkTypeSpreadTypeNode(<TypeSpreadTypeNode>node);
                 case SyntaxKind.UnionType:
                 case SyntaxKind.IntersectionType:
                     return checkUnionOrIntersectionType(<UnionOrIntersectionTypeNode>node);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2216,6 +2216,10 @@
         "category": "Error",
         "code": 2714
     },
+    "Tuple type spreads may only be created from tuple types.": {
+        "category": "Error",
+        "code": 2715
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -712,6 +712,8 @@ namespace ts {
                     return emitShorthandPropertyAssignment(<ShorthandPropertyAssignment>node);
                 case SyntaxKind.SpreadAssignment:
                     return emitSpreadAssignment(node as SpreadAssignment);
+                case SyntaxKind.TypeSpread:
+                    return emitTypeSpread(node as TypeSpreadTypeNode);
 
                 // Enum
                 case SyntaxKind.EnumMember:
@@ -2180,6 +2182,13 @@ namespace ts {
             if (node.expression) {
                 write("...");
                 emitExpression(node.expression);
+            }
+        }
+
+        function emitTypeSpread(node: TypeSpreadTypeNode) {
+            if (node.type) {
+                write("...");
+                emit(node.type);
             }
         }
 

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -674,9 +674,10 @@ namespace ts {
             : node;
     }
 
-    export function createTupleTypeNode(elementTypes: ReadonlyArray<TypeNode>) {
+    export function createTupleTypeNode(elementTypes: ReadonlyArray<TypeNode>, idxIsSpread: boolean[] = []) {
         const node = createSynthesizedNode(SyntaxKind.TupleType) as TupleTypeNode;
-        node.elementTypes = createNodeArray(elementTypes);
+        const elements = map(elementTypes, (type: TypeNode, idx: number) => idxIsSpread[idx] ? createTypeSpread(type) : type);
+        node.elementTypes = createNodeArray(elements);
         return node;
     }
 
@@ -2232,6 +2233,18 @@ namespace ts {
     export function updateSpreadAssignment(node: SpreadAssignment, expression: Expression) {
         return node.expression !== expression
             ? updateNode(createSpreadAssignment(expression), node)
+            : node;
+    }
+
+    export function createTypeSpread(type: TypeNode) {
+        const node = <TypeSpreadTypeNode>createSynthesizedNode(SyntaxKind.TypeSpread);
+        node.type = type !== undefined ? parenthesizeElementTypeMember(type) : undefined;
+        return node;
+    }
+
+    export function updateTypeSpread(node: TypeSpreadTypeNode, type: TypeNode) {
+        return node.type !== type
+            ? updateNode(createTypeSpread(type), node)
             : node;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -343,6 +343,7 @@ namespace ts {
         PropertyAssignment,
         ShorthandPropertyAssignment,
         SpreadAssignment,
+        TypeSpread,
 
         // Enum
         EnumMember,
@@ -1007,7 +1008,12 @@ namespace ts {
 
     export interface TupleTypeNode extends TypeNode {
         kind: SyntaxKind.TupleType;
-        elementTypes: NodeArray<TypeNode>;
+        elementTypes: NodeArray<TypeNode | TypeSpreadTypeNode>;
+    }
+
+    export interface TypeSpreadTypeNode extends TypeNode {
+        kind: SyntaxKind.TypeSpread;
+        type: TypeNode;
     }
 
     export type UnionOrIntersectionTypeNode = UnionTypeNode | IntersectionTypeNode;
@@ -3215,6 +3221,7 @@ namespace ts {
         NonPrimitive            = 1 << 24,  // intrinsic object type
         /* @internal */
         JsxAttributes           = 1 << 25,  // Jsx attributes type
+        SpreadTuple             = 1 << 26,  // tuple types containing spreads
 
         /* @internal */
         Nullable = Undefined | Null,
@@ -3461,6 +3468,12 @@ namespace ts {
         objectType: Type;
         indexType: Type;
         constraint?: Type;
+    }
+
+    // spread tuple types (TypeFlags.SpreadTuple)
+    export interface SpreadTupleType extends Type {
+        elements: Type[];
+        idxIsSpread: boolean[];
     }
 
     // keyof T types (TypeFlags.Index)

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4695,6 +4695,10 @@ namespace ts {
         return node.kind === SyntaxKind.SpreadAssignment;
     }
 
+    export function isTypeSpread(node: Node): node is TypeSpreadTypeNode {
+        return node.kind === SyntaxKind.TypeSpread;
+    }
+
     // Enum
 
     export function isEnumMember(node: Node): node is EnumMember {

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -872,6 +872,10 @@ namespace ts {
                 return updateSpreadAssignment(<SpreadAssignment>node,
                     visitNode((<SpreadAssignment>node).expression, visitor, isExpression));
 
+            case SyntaxKind.TypeSpread:
+                return updateTypeSpread(<TypeSpreadTypeNode>node,
+                    visitNode((<TypeSpreadTypeNode>node).type, visitor, isTypeNode));
+
             // Enum
             case SyntaxKind.EnumMember:
                 return updateEnumMember(<EnumMember>node,
@@ -1392,6 +1396,10 @@ namespace ts {
 
             case SyntaxKind.SpreadAssignment:
                 result = reduceNode((<SpreadAssignment>node).expression, cbNode, result);
+                break;
+
+            case SyntaxKind.TypeSpread:
+                result = reduceNode((<TypeSpreadTypeNode>node).type, cbNode, result);
                 break;
 
             // Enum

--- a/tests/baselines/reference/tupleTypeSpread.js
+++ b/tests/baselines/reference/tupleTypeSpread.js
@@ -1,0 +1,7 @@
+//// [tupleTypeSpread.ts]
+type a = [1, ...[2]];
+type Combine<Head, Tail extends any[]> = [Head, ...Tail];
+type b = Combine<1, [2, 3]>;
+
+
+//// [tupleTypeSpread.js]

--- a/tests/baselines/reference/tupleTypeSpread.symbols
+++ b/tests/baselines/reference/tupleTypeSpread.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/tupleTypeSpread.ts ===
+type a = [1, ...[2]];
+>a : Symbol(a, Decl(tupleTypeSpread.ts, 0, 0))
+
+type Combine<Head, Tail extends any[]> = [Head, ...Tail];
+>Combine : Symbol(Combine, Decl(tupleTypeSpread.ts, 0, 21))
+>Head : Symbol(Head, Decl(tupleTypeSpread.ts, 1, 13))
+>Tail : Symbol(Tail, Decl(tupleTypeSpread.ts, 1, 18))
+>Head : Symbol(Head, Decl(tupleTypeSpread.ts, 1, 13))
+>Tail : Symbol(Tail, Decl(tupleTypeSpread.ts, 1, 18))
+
+type b = Combine<1, [2, 3]>;
+>b : Symbol(b, Decl(tupleTypeSpread.ts, 1, 57))
+>Combine : Symbol(Combine, Decl(tupleTypeSpread.ts, 0, 21))
+

--- a/tests/baselines/reference/tupleTypeSpread.types
+++ b/tests/baselines/reference/tupleTypeSpread.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/tupleTypeSpread.ts ===
+type a = [1, ...[2]];
+>a : [1, 2]
+
+type Combine<Head, Tail extends any[]> = [Head, ...Tail];
+>Combine : [Head, ...Tail]
+>Head : Head
+>Tail : Tail
+>Head : Head
+>Tail : Tail
+
+type b = Combine<1, [2, 3]>;
+>b : [1, 2, 3]
+>Combine : [Head, ...Tail]
+

--- a/tests/baselines/reference/tupleTypeSpreadErrors.errors.txt
+++ b/tests/baselines/reference/tupleTypeSpreadErrors.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/tupleTypeSpreadErrors.ts(1,32): error TS2714: Tuple type spreads may only be created from tuple types.
+
+
+==== tests/cases/compiler/tupleTypeSpreadErrors.ts (1 errors) ====
+    type Boom<T extends string> = [...T];
+                                   ~~~~
+!!! error TS2714: Tuple type spreads may only be created from tuple types.
+    

--- a/tests/baselines/reference/tupleTypeSpreadErrors.js
+++ b/tests/baselines/reference/tupleTypeSpreadErrors.js
@@ -1,0 +1,5 @@
+//// [tupleTypeSpreadErrors.ts]
+type Boom<T extends string> = [...T];
+
+
+//// [tupleTypeSpreadErrors.js]

--- a/tests/cases/compiler/tupleTypeSpread.ts
+++ b/tests/cases/compiler/tupleTypeSpread.ts
@@ -1,0 +1,4 @@
+// @allowSyntheticDefaultImports: true
+type a = [1, ...[2]];
+type Combine<Head, Tail extends any[]> = [Head, ...Tail];
+type b = Combine<1, [2, 3]>;

--- a/tests/cases/compiler/tupleTypeSpreadErrors.ts
+++ b/tests/cases/compiler/tupleTypeSpreadErrors.ts
@@ -1,0 +1,1 @@
+type Boom<T extends string> = [...T];


### PR DESCRIPTION
This tuple type spread is part of my attempt at tackling #5453 following the [tuple-flavored variant](https://github.com/Microsoft/TypeScript/issues/5453#issuecomment-181695629) of the proposal laid out by @Artazor.

It adds a new spread node as a type-level equivalent of the one for the expression level. This could potentially be reused for another part of #5453 that'd require #6606, spreads in type-level function 'application' e.g. `Fn(...Args)`.

Progress: evaluation with generics delayed too much.
```ts
type a = [1, ...[2]];
>a : [1, 2]
type Combine<Head, Tail extends any[]> = [Head, ...Tail];
>Combine : [Head, ...Tail]
type b = Combine<1, [2, 3]>;
>b : [1, ...Tail] 
```
