### PR TITLE
extract rest params

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6418,7 +6418,9 @@ namespace ts {
 
                     // adjust minimum argument count for tuple-bound rest parameters. could use `length` property given #17765.
                     if (param.dotDotDotToken) {
-                        const type = getApparentType(getTypeOfSymbol(paramSymbol));
+                        // clone symbol as getTypeOfSymbol mutates
+                        const symbol = clone(paramSymbol);
+                        const type = getApparentType(getTypeOfSymbol(symbol));
                         if (isTupleLikeType(type)) {
                             minArgumentCount += getTupleLikeLength(type);
                         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1920,6 +1920,10 @@
         "category": "Error",
         "code": 2562
     },
+    "A rest parameter in a function with optional parameters must be of an array type.": {
+        "category": "Error",
+        "code": 2563
+    },
     "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",
         "code": 2600

--- a/tests/baselines/reference/FunctionDeclaration10_es6.errors.txt
+++ b/tests/baselines/reference/FunctionDeclaration10_es6.errors.txt
@@ -1,14 +1,17 @@
 tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,16): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,20): error TS2523: 'yield' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,26): error TS1005: ',' expected.
 tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,29): error TS1138: Parameter declaration expected.
 tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,29): error TS2304: Cannot find name 'yield'.
 tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,34): error TS1005: ';' expected.
 
 
-==== tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts (5 errors) ====
+==== tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts (6 errors) ====
     function * foo(a = yield => yield) {
                    ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+                       ~~~~~
+!!! error TS2523: 'yield' expressions cannot be used in a parameter initializer.
                              ~~
 !!! error TS1005: ',' expected.
                                 ~~~~~

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es2017.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es2017.errors.txt
@@ -1,4 +1,5 @@
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,20): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,24): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,30): error TS1109: Expression expected.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,33): error TS1138: Parameter declaration expected.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,33): error TS2304: Cannot find name 'await'.
@@ -8,10 +9,12 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts (8 errors) ====
+==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts (9 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+                           ~~~~~
+!!! error TS2524: 'await' expressions cannot be used in a parameter initializer.
                                  ~~
 !!! error TS1109: Expression expected.
                                     ~~~~~

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es5.errors.txt
@@ -1,4 +1,5 @@
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,20): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,24): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,30): error TS1109: Expression expected.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,33): error TS1138: Parameter declaration expected.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,33): error TS2304: Cannot find name 'await'.
@@ -8,10 +9,12 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts (8 errors) ====
+==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts (9 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+                           ~~~~~
+!!! error TS2524: 'await' expressions cannot be used in a parameter initializer.
                                  ~~
 !!! error TS1109: Expression expected.
                                     ~~~~~

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es6.errors.txt
@@ -1,4 +1,5 @@
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,20): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,24): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,30): error TS1109: Expression expected.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,33): error TS1138: Parameter declaration expected.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,33): error TS2304: Cannot find name 'await'.
@@ -8,10 +9,12 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts (8 errors) ====
+==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts (9 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+                           ~~~~~
+!!! error TS2524: 'await' expressions cannot be used in a parameter initializer.
                                  ~~
 !!! error TS1109: Expression expected.
                                     ~~~~~

--- a/tests/baselines/reference/destructureGenerics.js
+++ b/tests/baselines/reference/destructureGenerics.js
@@ -1,0 +1,19 @@
+//// [destructureGenerics.ts]
+declare function f<T extends any[]>(...args: T): T;
+var x = f(1,2);
+var x: [1, 2];
+declare function g<T extends [number, number]>(...args: T): T;
+var z = g(1,2);
+var z: [1,2];
+declare function h<T>(...args: T[]): T;
+var b = h(1,2,3);
+var b: number;
+
+
+//// [destructureGenerics.js]
+var x = f(1, 2);
+var x;
+var z = g(1, 2);
+var z;
+var b = h(1, 2, 3);
+var b;

--- a/tests/baselines/reference/destructureGenerics.symbols
+++ b/tests/baselines/reference/destructureGenerics.symbols
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/destructureGenerics.ts ===
+declare function f<T extends any[]>(...args: T): T;
+>f : Symbol(f, Decl(destructureGenerics.ts, 0, 0))
+>T : Symbol(T, Decl(destructureGenerics.ts, 0, 19))
+>args : Symbol(args, Decl(destructureGenerics.ts, 0, 36))
+>T : Symbol(T, Decl(destructureGenerics.ts, 0, 19))
+>T : Symbol(T, Decl(destructureGenerics.ts, 0, 19))
+
+var x = f(1,2);
+>x : Symbol(x, Decl(destructureGenerics.ts, 1, 3), Decl(destructureGenerics.ts, 2, 3))
+>f : Symbol(f, Decl(destructureGenerics.ts, 0, 0))
+
+var x: [1, 2];
+>x : Symbol(x, Decl(destructureGenerics.ts, 1, 3), Decl(destructureGenerics.ts, 2, 3))
+
+declare function g<T extends [number, number]>(...args: T): T;
+>g : Symbol(g, Decl(destructureGenerics.ts, 2, 14))
+>T : Symbol(T, Decl(destructureGenerics.ts, 3, 19))
+>args : Symbol(args, Decl(destructureGenerics.ts, 3, 47))
+>T : Symbol(T, Decl(destructureGenerics.ts, 3, 19))
+>T : Symbol(T, Decl(destructureGenerics.ts, 3, 19))
+
+var z = g(1,2);
+>z : Symbol(z, Decl(destructureGenerics.ts, 4, 3), Decl(destructureGenerics.ts, 5, 3))
+>g : Symbol(g, Decl(destructureGenerics.ts, 2, 14))
+
+var z: [1,2];
+>z : Symbol(z, Decl(destructureGenerics.ts, 4, 3), Decl(destructureGenerics.ts, 5, 3))
+
+declare function h<T>(...args: T[]): T;
+>h : Symbol(h, Decl(destructureGenerics.ts, 5, 13))
+>T : Symbol(T, Decl(destructureGenerics.ts, 6, 19))
+>args : Symbol(args, Decl(destructureGenerics.ts, 6, 22))
+>T : Symbol(T, Decl(destructureGenerics.ts, 6, 19))
+>T : Symbol(T, Decl(destructureGenerics.ts, 6, 19))
+
+var b = h(1,2,3);
+>b : Symbol(b, Decl(destructureGenerics.ts, 7, 3), Decl(destructureGenerics.ts, 8, 3))
+>h : Symbol(h, Decl(destructureGenerics.ts, 5, 13))
+
+var b: number;
+>b : Symbol(b, Decl(destructureGenerics.ts, 7, 3), Decl(destructureGenerics.ts, 8, 3))
+

--- a/tests/baselines/reference/destructureGenerics.types
+++ b/tests/baselines/reference/destructureGenerics.types
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/destructureGenerics.ts ===
+declare function f<T extends any[]>(...args: T): T;
+>f : <T extends any[]>(...args: T) => T
+>T : T
+>args : T
+>T : T
+>T : T
+
+var x = f(1,2);
+>x : [1, 2]
+>f(1,2) : [1, 2]
+>f : <T extends any[]>(...args: T) => T
+>1 : 1
+>2 : 2
+
+var x: [1, 2];
+>x : [1, 2]
+
+declare function g<T extends [number, number]>(...args: T): T;
+>g : <T extends [number, number]>(...args: T) => T
+>T : T
+>args : T
+>T : T
+>T : T
+
+var z = g(1,2);
+>z : [1, 2]
+>g(1,2) : [1, 2]
+>g : <T extends [number, number]>(...args: T) => T
+>1 : 1
+>2 : 2
+
+var z: [1,2];
+>z : [1, 2]
+
+declare function h<T>(...args: T[]): T;
+>h : <T>(...args: T[]) => T
+>T : T
+>args : T[]
+>T : T
+>T : T
+
+var b = h(1,2,3);
+>b : number
+>h(1,2,3) : 1 | 2 | 3
+>h : <T>(...args: T[]) => T
+>1 : 1
+>2 : 2
+>3 : 3
+
+var b: number;
+>b : number
+

--- a/tests/baselines/reference/destructureGenericsErrors.errors.txt
+++ b/tests/baselines/reference/destructureGenericsErrors.errors.txt
@@ -1,15 +1,26 @@
 tests/cases/compiler/destructureGenericsErrors.ts(2,9): error TS2554: Expected 2 arguments, but got 1.
-tests/cases/compiler/destructureGenericsErrors.ts(4,9): error TS2554: Expected 2 arguments, but got 3.
+tests/cases/compiler/destructureGenericsErrors.ts(3,9): error TS2554: Expected 2 arguments, but got 3.
+tests/cases/compiler/destructureGenericsErrors.ts(4,48): error TS2563: A rest parameter in a function with optional parameters must be of an array type.
+tests/cases/compiler/destructureGenericsErrors.ts(4,55): error TS1047: A rest parameter cannot be optional.
+tests/cases/compiler/destructureGenericsErrors.ts(6,60): error TS2563: A rest parameter in a function with optional parameters must be of an array type.
 
 
-==== tests/cases/compiler/destructureGenericsErrors.ts (2 errors) ====
+==== tests/cases/compiler/destructureGenericsErrors.ts (5 errors) ====
     declare function g<T extends [number, number]>(...args: T): T;
     var y = g(1); // error
             ~~~~
 !!! error TS2554: Expected 2 arguments, but got 1.
-    var y: [1];
     var a = g(1,2,3); // error
             ~~~~~~~~
 !!! error TS2554: Expected 2 arguments, but got 3.
-    var a: [1,2,3];
+    declare function k<T extends [number, number]>(...args?: T): T;
+                                                   ~~~~~~~~~~~
+!!! error TS2563: A rest parameter in a function with optional parameters must be of an array type.
+                                                          ~
+!!! error TS1047: A rest parameter cannot be optional.
+    var u = k(1,2); // error
+    declare function m<T extends [number, number]>(a?: string, ...args: T): T;
+                                                               ~~~~~~~~~~
+!!! error TS2563: A rest parameter in a function with optional parameters must be of an array type.
+    var v = m('a',1,2); // error
     

--- a/tests/baselines/reference/destructureGenericsErrors.errors.txt
+++ b/tests/baselines/reference/destructureGenericsErrors.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/destructureGenericsErrors.ts(2,9): error TS2554: Expected 2 arguments, but got 1.
+tests/cases/compiler/destructureGenericsErrors.ts(4,9): error TS2554: Expected 2 arguments, but got 3.
+
+
+==== tests/cases/compiler/destructureGenericsErrors.ts (2 errors) ====
+    declare function g<T extends [number, number]>(...args: T): T;
+    var y = g(1); // error
+            ~~~~
+!!! error TS2554: Expected 2 arguments, but got 1.
+    var y: [1];
+    var a = g(1,2,3); // error
+            ~~~~~~~~
+!!! error TS2554: Expected 2 arguments, but got 3.
+    var a: [1,2,3];
+    

--- a/tests/baselines/reference/destructureGenericsErrors.js
+++ b/tests/baselines/reference/destructureGenericsErrors.js
@@ -1,13 +1,15 @@
 //// [destructureGenericsErrors.ts]
 declare function g<T extends [number, number]>(...args: T): T;
 var y = g(1); // error
-var y: [1];
 var a = g(1,2,3); // error
-var a: [1,2,3];
+declare function k<T extends [number, number]>(...args?: T): T;
+var u = k(1,2); // error
+declare function m<T extends [number, number]>(a?: string, ...args: T): T;
+var v = m('a',1,2); // error
 
 
 //// [destructureGenericsErrors.js]
 var y = g(1); // error
-var y;
 var a = g(1, 2, 3); // error
-var a;
+var u = k(1, 2); // error
+var v = m('a', 1, 2); // error

--- a/tests/baselines/reference/destructureGenericsErrors.js
+++ b/tests/baselines/reference/destructureGenericsErrors.js
@@ -1,0 +1,13 @@
+//// [destructureGenericsErrors.ts]
+declare function g<T extends [number, number]>(...args: T): T;
+var y = g(1); // error
+var y: [1];
+var a = g(1,2,3); // error
+var a: [1,2,3];
+
+
+//// [destructureGenericsErrors.js]
+var y = g(1); // error
+var y;
+var a = g(1, 2, 3); // error
+var a;

--- a/tests/baselines/reference/destructureGenericsErrors.symbols
+++ b/tests/baselines/reference/destructureGenericsErrors.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/destructureGenericsErrors.ts ===
+declare function g<T extends [number, number]>(...args: T): T;
+>g : Symbol(g, Decl(destructureGenericsErrors.ts, 0, 0))
+>T : Symbol(T, Decl(destructureGenericsErrors.ts, 0, 19))
+>args : Symbol(args, Decl(destructureGenericsErrors.ts, 0, 47))
+>T : Symbol(T, Decl(destructureGenericsErrors.ts, 0, 19))
+>T : Symbol(T, Decl(destructureGenericsErrors.ts, 0, 19))
+
+// var y = g(1); // error
+// var y: [1];
+var a = g(1,2,3); // error
+>a : Symbol(a, Decl(destructureGenericsErrors.ts, 3, 3), Decl(destructureGenericsErrors.ts, 4, 3))
+>g : Symbol(g, Decl(destructureGenericsErrors.ts, 0, 0))
+
+var a: [1,2,3];
+>a : Symbol(a, Decl(destructureGenericsErrors.ts, 3, 3), Decl(destructureGenericsErrors.ts, 4, 3))
+

--- a/tests/baselines/reference/destructureGenericsErrors.types
+++ b/tests/baselines/reference/destructureGenericsErrors.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/destructureGenericsErrors.ts ===
+declare function g<T extends [number, number]>(...args: T): T;
+>g : <T extends [number, number]>(...args: T) => T
+>T : T
+>args : T
+>T : T
+>T : T
+
+// var y = g(1); // error
+// var y: [1];
+var a = g(1,2,3); // error
+>a : [1, 2, 3]
+>g(1,2,3) : [1, 2, 3]
+>g : <T extends [number, number]>(...args: T) => T
+>1 : 1
+>2 : 2
+>3 : 3
+
+var a: [1,2,3];
+>a : [1, 2, 3]
+

--- a/tests/baselines/reference/destructuringParameterDeclaration4.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration4.errors.txt
@@ -1,5 +1,3 @@
-tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(11,13): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(13,13): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(14,17): error TS1047: A rest parameter cannot be optional.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(15,16): error TS1048: A rest parameter cannot have an initializer.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(20,19): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string | number'.
@@ -17,7 +15,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(34,28): error TS2304: Cannot find name 'E'.
 
 
-==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts (12 errors) ====
+==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts (10 errors) ====
     // If the parameter is a rest parameter, the parameter type is any[]
     // A type annotation for a rest parameter must denote an array type.
     
@@ -29,12 +27,8 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(
     type stringOrNumArray = Array<String|Number>;
     
     function a0(...x: [number, number, string]) { }  // Error, rest parameter must be array type
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     function a1(...x: (number|string)[]) { }
     function a2(...a: someArray) { }  // Error, rest parameter must be array type
-                ~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     function a3(...b?) { }            // Error, can't be optional
                     ~
 !!! error TS1047: A rest parameter cannot be optional.

--- a/tests/baselines/reference/iterableArrayPattern25.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern25.errors.txt
@@ -1,8 +1,11 @@
 tests/cases/conformance/es6/destructuring/iterableArrayPattern25.ts(1,33): error TS2501: A rest element cannot contain a binding pattern.
+tests/cases/conformance/es6/destructuring/iterableArrayPattern25.ts(2,1): error TS2554: Expected 2 arguments, but got 1.
 
 
-==== tests/cases/conformance/es6/destructuring/iterableArrayPattern25.ts (1 errors) ====
+==== tests/cases/conformance/es6/destructuring/iterableArrayPattern25.ts (2 errors) ====
     function takeFirstTwoEntries(...[[k1, v1], [k2, v2]]) { }
                                     ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2501: A rest element cannot contain a binding pattern.
     takeFirstTwoEntries(new Map([["", 0], ["hello", 1]]));
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2554: Expected 2 arguments, but got 1.

--- a/tests/baselines/reference/noImplicitAnyDestructuringParameterDeclaration.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyDestructuringParameterDeclaration.errors.txt
@@ -2,19 +2,22 @@ tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(1,14): er
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(1,19): error TS7031: Binding element 'b' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(1,23): error TS7006: Parameter 'c' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(1,26): error TS7006: Parameter 'd' implicitly has an 'any' type.
+tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(3,13): error TS7006: Parameter '[a = undefined]' implicitly has an '[any]' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(3,14): error TS7031: Binding element 'a' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(3,31): error TS7031: Binding element 'b' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(3,42): error TS7006: Parameter 'c' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(3,57): error TS7006: Parameter 'd' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(7,20): error TS7008: Member 'b' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(7,30): error TS7008: Member 'b' implicitly has an 'any' type.
+tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(9,13): error TS7006: Parameter '[a1]' implicitly has an '[any]' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(9,14): error TS7031: Binding element 'a1' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(9,34): error TS7031: Binding element 'b1' implicitly has an 'any' type.
+tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(9,42): error TS7018: Object literal's property 'b1' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(9,54): error TS7006: Parameter 'c1' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(9,70): error TS7006: Parameter 'd1' implicitly has an 'any' type.
 
 
-==== tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts (14 errors) ====
+==== tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts (17 errors) ====
     function f1([a], {b}, c, d) { // error
                  ~
 !!! error TS7031: Binding element 'a' implicitly has an 'any' type.
@@ -26,6 +29,8 @@ tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(9,70): er
 !!! error TS7006: Parameter 'd' implicitly has an 'any' type.
     }
     function f2([a = undefined], {b = null}, c = undefined, d = null) { // error
+                ~~~~~~~~~~~~~~~
+!!! error TS7006: Parameter '[a = undefined]' implicitly has an '[any]' type.
                  ~
 !!! error TS7031: Binding element 'a' implicitly has an 'any' type.
                                   ~
@@ -44,10 +49,14 @@ tests/cases/compiler/noImplicitAnyDestructuringParameterDeclaration.ts(9,70): er
 !!! error TS7008: Member 'b' implicitly has an 'any' type.
     }
     function f5([a1] = [undefined], {b1} = { b1: null }, c1 = undefined, d1 = null) { // error
+                ~~~~~~~~~~~~~~~~~~
+!!! error TS7006: Parameter '[a1]' implicitly has an '[any]' type.
                  ~~
 !!! error TS7031: Binding element 'a1' implicitly has an 'any' type.
                                      ~~
 !!! error TS7031: Binding element 'b1' implicitly has an 'any' type.
+                                             ~~~~~~~~
+!!! error TS7018: Object literal's property 'b1' implicitly has an 'any' type.
                                                          ~~~~~~~~~~~~~~
 !!! error TS7006: Parameter 'c1' implicitly has an 'any' type.
                                                                          ~~~~~~~~~

--- a/tests/baselines/reference/partiallyAnnotatedFunctionInferenceWithTypeParameter.types
+++ b/tests/baselines/reference/partiallyAnnotatedFunctionInferenceWithTypeParameter.types
@@ -119,7 +119,7 @@ testRest((t1, t2: D, t3) => {})
 >t3 : D
 
 testRest((t2: D, ...t3) => {})
->testRest((t2: D, ...t3) => {}) : any
+>testRest((t2: D, ...t3) => {}) : D
 >testRest : <T extends C>(a: (t: T, t1: T, ...ts: T[]) => void) => T
 >(t2: D, ...t3) => {} : (t2: D, ...t3: any[]) => void
 >t2 : D

--- a/tests/baselines/reference/promiseSpread.js
+++ b/tests/baselines/reference/promiseSpread.js
@@ -1,0 +1,8 @@
+//// [promiseSpread.ts]
+interface Promise<T> {
+    spread<U>(fulfilledHandler: (...values: T & any[]) => U | Promise<U>): Promise<U>;
+    spread<U>(fulfilledHandler: (...values: [T]) => U | Promise<U>): Promise<U>;
+}
+
+
+//// [promiseSpread.js]

--- a/tests/baselines/reference/promiseSpread.symbols
+++ b/tests/baselines/reference/promiseSpread.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/promiseSpread.ts ===
+interface Promise<T> {
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --), Decl(promiseSpread.ts, 0, 0))
+>T : Symbol(T, Decl(lib.d.ts, --, --), Decl(promiseSpread.ts, 0, 18))
+
+    spread<U>(fulfilledHandler: (...values: T & any[]) => U | Promise<U>): Promise<U>;
+>spread : Symbol(Promise.spread, Decl(promiseSpread.ts, 0, 22), Decl(promiseSpread.ts, 1, 86))
+>U : Symbol(U, Decl(promiseSpread.ts, 1, 11))
+>fulfilledHandler : Symbol(fulfilledHandler, Decl(promiseSpread.ts, 1, 14))
+>values : Symbol(values, Decl(promiseSpread.ts, 1, 33))
+>T : Symbol(T, Decl(lib.d.ts, --, --), Decl(promiseSpread.ts, 0, 18))
+>U : Symbol(U, Decl(promiseSpread.ts, 1, 11))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --), Decl(promiseSpread.ts, 0, 0))
+>U : Symbol(U, Decl(promiseSpread.ts, 1, 11))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --), Decl(promiseSpread.ts, 0, 0))
+>U : Symbol(U, Decl(promiseSpread.ts, 1, 11))
+
+    spread<U>(fulfilledHandler: (...values: [T]) => U | Promise<U>): Promise<U>;
+>spread : Symbol(Promise.spread, Decl(promiseSpread.ts, 0, 22), Decl(promiseSpread.ts, 1, 86))
+>U : Symbol(U, Decl(promiseSpread.ts, 2, 11))
+>fulfilledHandler : Symbol(fulfilledHandler, Decl(promiseSpread.ts, 2, 14))
+>values : Symbol(values, Decl(promiseSpread.ts, 2, 33))
+>T : Symbol(T, Decl(lib.d.ts, --, --), Decl(promiseSpread.ts, 0, 18))
+>U : Symbol(U, Decl(promiseSpread.ts, 2, 11))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --), Decl(promiseSpread.ts, 0, 0))
+>U : Symbol(U, Decl(promiseSpread.ts, 2, 11))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --), Decl(promiseSpread.ts, 0, 0))
+>U : Symbol(U, Decl(promiseSpread.ts, 2, 11))
+}
+

--- a/tests/baselines/reference/promiseSpread.types
+++ b/tests/baselines/reference/promiseSpread.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/promiseSpread.ts ===
+interface Promise<T> {
+>Promise : Promise<T>
+>T : T
+
+    spread<U>(fulfilledHandler: (...values: T & any[]) => U | Promise<U>): Promise<U>;
+>spread : { <U>(fulfilledHandler: (...values: T & any[]) => U | Promise<U>): Promise<U>; <U>(fulfilledHandler: (...values: [T]) => U | Promise<U>): Promise<U>; }
+>U : U
+>fulfilledHandler : (...values: T & any[]) => U | Promise<U>
+>values : T & any[]
+>T : T
+>U : U
+>Promise : Promise<T>
+>U : U
+>Promise : Promise<T>
+>U : U
+
+    spread<U>(fulfilledHandler: (...values: [T]) => U | Promise<U>): Promise<U>;
+>spread : { <U>(fulfilledHandler: (...values: T & any[]) => U | Promise<U>): Promise<U>; <U>(fulfilledHandler: (...values: [T]) => U | Promise<U>): Promise<U>; }
+>U : U
+>fulfilledHandler : (...values: [T]) => U | Promise<U>
+>values : [T]
+>T : T
+>U : U
+>Promise : Promise<T>
+>U : U
+>Promise : Promise<T>
+>U : U
+}
+

--- a/tests/baselines/reference/restParamModifier.errors.txt
+++ b/tests/baselines/reference/restParamModifier.errors.txt
@@ -1,15 +1,12 @@
-tests/cases/compiler/restParamModifier.ts(2,17): error TS2370: A rest parameter must be of an array type.
 tests/cases/compiler/restParamModifier.ts(2,27): error TS1005: '=' expected.
 tests/cases/compiler/restParamModifier.ts(2,27): error TS2304: Cannot find name 'rest'.
 tests/cases/compiler/restParamModifier.ts(2,31): error TS1005: ',' expected.
 tests/cases/compiler/restParamModifier.ts(2,39): error TS1005: '=' expected.
 
 
-==== tests/cases/compiler/restParamModifier.ts (5 errors) ====
+==== tests/cases/compiler/restParamModifier.ts (4 errors) ====
     class C {
         constructor(...public rest: string[]) {}
-                    ~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
                               ~~~~
 !!! error TS1005: '=' expected.
                               ~~~~

--- a/tests/baselines/reference/restParametersOfNonArrayTypes2.errors.txt
+++ b/tests/baselines/reference/restParametersOfNonArrayTypes2.errors.txt
@@ -1,40 +1,12 @@
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(7,14): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(8,22): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(9,11): error TS1014: A rest parameter must be last in a parameter list.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(9,11): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(9,26): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(12,9): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(16,6): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(17,9): error TS1014: A rest parameter must be last in a parameter list.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(17,9): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(17,24): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(21,6): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(22,9): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(26,9): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(27,21): error TS1014: A rest parameter must be last in a parameter list.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(27,21): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(27,36): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(28,9): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(34,15): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(35,23): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(36,11): error TS1014: A rest parameter must be last in a parameter list.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(36,11): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(36,35): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(39,9): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(43,6): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(44,9): error TS1014: A rest parameter must be last in a parameter list.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(44,9): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(44,33): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(48,6): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(49,9): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(53,9): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(54,21): error TS1014: A rest parameter must be last in a parameter list.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(54,21): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(54,45): error TS2370: A rest parameter must be of an array type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts(55,9): error TS2370: A rest parameter must be of an array type.
 
 
-==== tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts (34 errors) ====
+==== tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes2.ts (6 errors) ====
     // Rest parameters must be an array type if they have a type annotation, 
     // user defined subtypes of array do not count, all of these are errors
     
@@ -42,120 +14,64 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfN
     interface MyThing2<T> extends Array<T> { }
     
     function foo(...x: MyThing) { }
-                 ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     var f = function foo(...x: MyThing) { }
-                         ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     var f2 = (...x: MyThing, ...y: MyThing) => { }
               ~~~
 !!! error TS1014: A rest parameter must be last in a parameter list.
-              ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
-                             ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     
     class C {
         foo(...x: MyThing) { }
-            ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     }
     
     interface I {
         (...x: MyThing);
-         ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
         foo(...x: MyThing, ...y: MyThing);
             ~~~
 !!! error TS1014: A rest parameter must be last in a parameter list.
-            ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
-                           ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     }
     
     var a: {
         (...x: MyThing);
-         ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
         foo(...x: MyThing);
-            ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     }
     
     var b = {
         foo(...x: MyThing) { },
-            ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
         a: function foo(...x: MyThing, ...y: MyThing) { },
                         ~~~
 !!! error TS1014: A rest parameter must be last in a parameter list.
-                        ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
-                                       ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
         b: (...x: MyThing) => { }
-            ~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     }
     
     
     
     
     function foo2(...x: MyThing2<string>) { }
-                  ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     var f3 = function foo(...x: MyThing2<string>) { }
-                          ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     var f4 = (...x: MyThing2<string>, ...y: MyThing2<string>) => { }
               ~~~
 !!! error TS1014: A rest parameter must be last in a parameter list.
-              ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
-                                      ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     
     class C2 {
         foo(...x: MyThing2<string>) { }
-            ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     }
     
     interface I2 {
         (...x: MyThing2<string>);
-         ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
         foo(...x: MyThing2<string>, ...y: MyThing2<string>);
             ~~~
 !!! error TS1014: A rest parameter must be last in a parameter list.
-            ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
-                                    ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     }
     
     var a2: {
         (...x: MyThing2<string>);
-         ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
         foo(...x: MyThing2<string>);
-            ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     }
     
     var b2 = {
         foo(...x: MyThing2<string>) { },
-            ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
         a: function foo(...x: MyThing2<string>, ...y: MyThing2<string>) { },
                         ~~~
 !!! error TS1014: A rest parameter must be last in a parameter list.
-                        ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
-                                                ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
         b: (...x: MyThing2<string>) => { }
-            ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2370: A rest parameter must be of an array type.
     }

--- a/tests/cases/compiler/destructureGenerics.ts
+++ b/tests/cases/compiler/destructureGenerics.ts
@@ -1,0 +1,9 @@
+declare function f<T extends any[]>(...args: T): T;
+var x = f(1,2);
+var x: [1, 2];
+declare function g<T extends [number, number]>(...args: T): T;
+var z = g(1,2);
+var z: [1,2];
+declare function h<T>(...args: T[]): T;
+var b = h(1,2,3);
+var b: number;

--- a/tests/cases/compiler/destructureGenericsErrors.ts
+++ b/tests/cases/compiler/destructureGenericsErrors.ts
@@ -1,5 +1,7 @@
 declare function g<T extends [number, number]>(...args: T): T;
 var y = g(1); // error
-var y: [1];
 var a = g(1,2,3); // error
-var a: [1,2,3];
+declare function k<T extends [number, number]>(...args?: T): T;
+var u = k(1,2); // error
+declare function m<T extends [number, number]>(a?: string, ...args: T): T;
+var v = m('a',1,2); // error

--- a/tests/cases/compiler/destructureGenericsErrors.ts
+++ b/tests/cases/compiler/destructureGenericsErrors.ts
@@ -1,0 +1,5 @@
+declare function g<T extends [number, number]>(...args: T): T;
+var y = g(1); // error
+var y: [1];
+var a = g(1,2,3); // error
+var a: [1,2,3];

--- a/tests/cases/compiler/promiseSpread.ts
+++ b/tests/cases/compiler/promiseSpread.ts
@@ -1,0 +1,4 @@
+interface Promise<T> {
+    spread<U>(fulfilledHandler: (...values: T & any[]) => U | Promise<U>): Promise<U>;
+    spread<U>(fulfilledHandler: (...values: [T]) => U | Promise<U>): Promise<U>;
+}


### PR DESCRIPTION
This stub to extracting rest params into tuple types is the second part of my attempt to tackle #5453.

It allows specifying array-like types including tuple types and array-bound generics as rest constraints: `<T extends number[]>(...args: T)` / `(...args: [number, string])`. The former of these examples aims to extract the types of passed parameters on function application, while the latter is primarily useful to dynamically generate functions, e.g. to type `bind` or `curry`.

One may extract the types passed into generics from rest parameters as follows:
```ts
declare function f<T extends number[]>(...args: T): T;
const x = f(1,2);
// type: [1, 2]
```

Fixes a third of #5453, alongside other issues that ran into `A rest parameter must be of an array type`, like #1024, #2328, #5331, and #16931.
