### PR TITLE
Context flag for with statements to avoid parent pointer walks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22546,12 +22546,7 @@ namespace ts {
 
         function isInsideWithStatementBody(node: Node): boolean {
             if (node) {
-                while (node.parent) {
-                    if (node.parent.kind === SyntaxKind.WithStatement && (<WithStatement>node.parent).statement === node) {
-                        return true;
-                    }
-                    node = node.parent;
-                }
+                return !!(node.flags & NodeFlags.WithContext);
             }
 
             return false;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4723,7 +4723,7 @@ namespace ts {
             parseExpected(SyntaxKind.OpenParenToken);
             node.expression = allowInAnd(parseExpression);
             parseExpected(SyntaxKind.CloseParenToken);
-            node.statement = parseStatement();
+            node.statement = doInsideOfContext(NodeFlags.WithContext, parseStatement);
             return finishNode(node);
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -451,6 +451,7 @@ namespace ts {
         /* @internal */
         PossiblyContainsDynamicImport = 1 << 19,
         JSDoc =              1 << 20, // If node was parsed inside jsdoc
+        WithContext =        1 << 21, // If node is within a `with` statement body
 
         BlockScoped = Let | Const,
 
@@ -458,7 +459,7 @@ namespace ts {
         ReachabilityAndEmitFlags = ReachabilityCheckFlags | HasAsyncFunctions,
 
         // Parsing context flags
-        ContextFlags = DisallowInContext | YieldContext | DecoratorContext | AwaitContext | JavaScriptFile,
+        ContextFlags = DisallowInContext | YieldContext | DecoratorContext | AwaitContext | JavaScriptFile | WithContext,
 
         // Exclude these flags when parsing a Type
         TypeExcludesFlags = YieldContext | AwaitContext,


### PR DESCRIPTION
We use `isInWithStatementBody` as a bailout condition all over the place in the checker - the most frequent places being at the top of `getTypeOfNode` and inside `getContextualType`. However it comes at a steep cost, as we are pretty much never within a `with` statement body (they're not even valid syntax in strict mode), so we always walk all the way up to the containing source file. 

On my noisy machine, I see 5+% improvements in check time from this change, and the larger the project, the more pronounced the effect is:

Metric | master | with-context-flag | Delta | Best | Worst
-- | -- | -- | -- | -- | --
Monaco - tsc (x86)
Parse Time | 1.32s (±  2.11%) | 1.51s (± 33.27%) | +0.19s (+ 14.67%) | 1.15s | 3.53s
Bind Time | 0.54s (±  4.87%) | 0.55s (±  7.08%) | +0.01s (+  2.60%) | 0.48s | 0.66s
Check Time | 3.33s (±  3.76%) | 3.17s (±  3.10%) | -0.16s (-  4.69%) | 3.00s | 3.46s
Emit Time | 7.54s (±  2.19%) | 7.31s (±  6.95%) | -0.22s (-  2.97%) | 6.92s | 9.34s
Total Time | 12.72s (±  1.98%) | 12.55s (±  7.97%) | -0.17s (-  1.32%) | 11.74s | 16.53s
TFS - tsc (x86)
Parse Time | 1.05s (±  5.25%) | 1.13s (± 33.00%) | +0.08s (+  7.63%) | 0.93s | 2.63s
Bind Time | 0.55s (±  6.96%) | 0.52s (±  7.95%) | -0.03s (-  5.46%) | 0.44s | 0.64s
Check Time | 2.77s (±  2.95%) | 2.57s (±  2.58%) | -0.20s (-  7.21%) | 2.43s | 2.78s
Emit Time | 4.39s (±  2.28%) | 4.19s (±  2.74%) | -0.19s (-  4.44%) | 3.99s | 4.44s
Total Time | 8.76s (±  2.23%) | 8.41s (±  5.17%) | -0.34s (-  3.93%) | 7.99s | 10.02s

