### PR TITLE
WIP: type-level assertion operator (!)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7986,8 +7986,8 @@ namespace ts {
                     return getTypeFromIntersectionTypeNode(<IntersectionTypeNode>node);
                 case SyntaxKind.JSDocNullableType:
                     return getTypeFromJSDocNullableTypeNode(<JSDocNullableType>node);
-                case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.JSDocNonNullableType:
+                case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.JSDocOptionalType:
                 case SyntaxKind.JSDocTypeExpression:
                     return getTypeFromTypeNode((<ParenthesizedTypeNode | JSDocTypeReferencingNode | JSDocTypeExpression>node).type);
@@ -22374,7 +22374,8 @@ namespace ts {
                     return checkUnionOrIntersectionType(<UnionOrIntersectionTypeNode>node);
                 case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.TypeOperator:
-                    return checkSourceElement((<ParenthesizedTypeNode | TypeOperatorNode>node).type);
+                case SyntaxKind.JSDocNonNullableType:
+                    return checkSourceElement((<ParenthesizedTypeNode | TypeOperatorNode | JSDocNonNullableType>node).type);
                 case SyntaxKind.JSDocComment:
                     return checkJSDocComment(node as JSDoc);
                 case SyntaxKind.JSDocParameterTag:
@@ -22383,7 +22384,6 @@ namespace ts {
                     checkSignatureDeclaration(node as JSDocFunctionType);
                     // falls through
                 case SyntaxKind.JSDocVariadicType:
-                case SyntaxKind.JSDocNonNullableType:
                 case SyntaxKind.JSDocNullableType:
                 case SyntaxKind.JSDocAllType:
                 case SyntaxKind.JSDocUnknownType:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7987,10 +7987,11 @@ namespace ts {
                 case SyntaxKind.JSDocNullableType:
                     return getTypeFromJSDocNullableTypeNode(<JSDocNullableType>node);
                 case SyntaxKind.JSDocNonNullableType:
+                    return getTypeFromNonNullableType((<JSDocNullableType>node).type);
                 case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.JSDocOptionalType:
                 case SyntaxKind.JSDocTypeExpression:
-                    return getTypeFromTypeNode((<ParenthesizedTypeNode | JSDocTypeReferencingNode | JSDocTypeExpression>node).type);
+                    return getTypeFromTypeNode((<ParenthesizedTypeNode | JSDocTypeReferencingNode>node).type);
                 case SyntaxKind.FunctionType:
                 case SyntaxKind.ConstructorType:
                 case SyntaxKind.TypeLiteral:
@@ -8014,6 +8015,10 @@ namespace ts {
                 default:
                     return unknownType;
             }
+        }
+
+        function getTypeFromNonNullableType(node: TypeNode) {
+            return getNonNullableType(getTypeFromTypeNode(node));
         }
 
         function instantiateList<T>(items: T[], mapper: TypeMapper, instantiator: (item: T, mapper: TypeMapper) => T): T[] {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -703,6 +703,9 @@ namespace ts {
                     return emitEnumMember(<EnumMember>node);
 
                 // JSDoc nodes (ignored)
+                case SyntaxKind.JSDocNonNullableType:
+                    return emitNonNullType(<JSDocNonNullableType>node);
+
                 // Transformation nodes (ignored)
             }
 
@@ -1410,6 +1413,11 @@ namespace ts {
 
         function emitNonNullExpression(node: NonNullExpression) {
             emitExpression(node.expression);
+            write("!");
+        }
+
+        function emitNonNullType(node: JSDocNonNullableType) {
+            emit(node.type);
             write("!");
         }
 

--- a/tests/baselines/reference/jsdocDisallowedInTypescript.errors.txt
+++ b/tests/baselines/reference/jsdocDisallowedInTypescript.errors.txt
@@ -8,13 +8,11 @@ tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(13,14): error TS802
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(14,11): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(15,8): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(16,15): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(17,11): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(18,17): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(19,5): error TS2322: Type 'undefined' is not assignable to type 'number | null'.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(19,17): error TS8020: JSDoc types can only be used inside documentation comments.
 
 
-==== tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts (14 errors) ====
+==== tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts (12 errors) ====
     // grammar error from checker
     var ara: Array.<number> = [1,2,3];
                   ~
@@ -52,11 +50,7 @@ tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(19,17): error TS802
                   ~~~~~~~~~~
 !!! error TS8020: JSDoc types can only be used inside documentation comments.
     var most: !string = 'definite';
-              ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var postfixdef: number! = 101;
-                    ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var postfixopt: number? = undefined;
         ~~~~~~~~~~
 !!! error TS2322: Type 'undefined' is not assignable to type 'number | null'.

--- a/tests/baselines/reference/nonNullType.js
+++ b/tests/baselines/reference/nonNullType.js
@@ -1,5 +1,11 @@
-// @strictNullChecks: true
+//// [nonNullType.ts]
 let a: string | undefined | null | never;
 let b: typeof a!;
 type Assert<T> = T!;
 let c: Assert<typeof a>;
+
+
+//// [nonNullType.js]
+var a;
+var b;
+var c;

--- a/tests/baselines/reference/nonNullType.symbols
+++ b/tests/baselines/reference/nonNullType.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/nonNullType.ts ===
+let a: string | undefined | null | never;
+>a : Symbol(a, Decl(nonNullType.ts, 0, 3))
+
+let b: typeof a!;
+>b : Symbol(b, Decl(nonNullType.ts, 1, 3))
+>a : Symbol(a, Decl(nonNullType.ts, 0, 3))
+
+type Assert<T> = T!;
+>Assert : Symbol(Assert, Decl(nonNullType.ts, 1, 17))
+>T : Symbol(T, Decl(nonNullType.ts, 2, 12))
+>T : Symbol(T, Decl(nonNullType.ts, 2, 12))
+
+let c: Assert<typeof a>;
+>c : Symbol(c, Decl(nonNullType.ts, 3, 3))
+>Assert : Symbol(Assert, Decl(nonNullType.ts, 1, 17))
+>a : Symbol(a, Decl(nonNullType.ts, 0, 3))
+

--- a/tests/baselines/reference/nonNullType.types
+++ b/tests/baselines/reference/nonNullType.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/nonNullType.ts ===
+let a: string | undefined | null | never;
+>a : string | null | undefined
+>null : null
+
+let b: typeof a!;
+>b : string
+>a : string | null | undefined
+
+type Assert<T> = T!;
+>Assert : T
+>T : T
+>T : T
+
+let c: Assert<typeof a>;
+>c : string | null | undefined
+>Assert : T
+>a : string | null | undefined
+

--- a/tests/cases/compiler/nonNullType.ts
+++ b/tests/cases/compiler/nonNullType.ts
@@ -1,0 +1,7 @@
+// @strictNullChecks: true
+type z = string | undefined | null | never;
+type a = string | undefined | null | never;
+type b = a!;
+type Assert<T> = T!;
+type c = Assert<a>;
+

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax7.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax7.ts
@@ -1,4 +1,0 @@
-/// <reference path='fourslash.ts' />
-//// var x: [|!number|] = 12;
-
-verify.rangeAfterCodeFix("number");


### PR DESCRIPTION
Fixes #14366.

I'm just extending the existing `JSDocNullableType` so it's usable outside of JSDoc and gets the functionality of the expression-level non-nullable / assertion operator (`!`).
This still evaluates too eagerly to deal with generics though.
