### PR TITLE
Cache most calls to isRelatedTo

### DIFF
--- a/tests/baselines/reference/arityAndOrderCompatibility01.errors.txt
+++ b/tests/baselines/reference/arityAndOrderCompatibility01.errors.txt
@@ -31,7 +31,6 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(26,5): error
   Types of property 'pop' are incompatible.
     Type '() => string | number' is not assignable to type '() => string'.
       Type 'string | number' is not assignable to type 'string'.
-        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(27,5): error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[string]'.
   Property 'length' is missing in type '{ 0: string; 1: number; }'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(28,5): error TS2322: Type '[string, number]' is not assignable to type '[number, string]'.
@@ -118,7 +117,6 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(30,5): error
 !!! error TS2322:   Types of property 'pop' are incompatible.
 !!! error TS2322:     Type '() => string | number' is not assignable to type '() => string'.
 !!! error TS2322:       Type 'string | number' is not assignable to type 'string'.
-!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     var m3: [string] = z;
         ~~
 !!! error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[string]'.

--- a/tests/baselines/reference/callWithSpread2.errors.txt
+++ b/tests/baselines/reference/callWithSpread2.errors.txt
@@ -1,15 +1,10 @@
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(30,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(31,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-  Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(32,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-  Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(33,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-  Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(34,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-  Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(35,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-  Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,1): error TS2556: Expected 1-3 arguments, but got a minimum of 0.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(37,1): error TS2556: Expected 1-3 arguments, but got a minimum of 0.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(38,1): error TS2556: Expected 1-3 arguments, but got a minimum of 0.
@@ -52,23 +47,18 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(38,1): erro
     all(...tuple)
         ~~~~~~~~
 !!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
     prefix("b", ...mixed)
                 ~~~~~~~~
 !!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
     prefix("c", ...tuple)
                 ~~~~~~~~
 !!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
     rest("e", ...mixed)
               ~~~~~~~~
 !!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
     rest("f", ...tuple)
               ~~~~~~~~
 !!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
     prefix(...ns) // required parameters are required
     ~~~~~~~~~~~~~
 !!! error TS2556: Expected 1-3 arguments, but got a minimum of 0.

--- a/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
@@ -9,12 +9,10 @@ tests/cases/conformance/jsx/file.tsx(25,16): error TS2322: Type '{ a: 10; b: "hi
   Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-        Type '(string | Element)[]' is not assignable to type 'Element[]'.
 tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-        Type '(string | Element)[]' is not assignable to type 'Element[]'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -56,7 +54,6 @@ tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ a: 10; b: "hi
 !!! error TS2322:   Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
         <AnotherButton />  </Comp>;
     let k3 = <Comp a={10} b="hi">    <Button />
                    ~~~~~~~~~~~~~
@@ -64,5 +61,4 @@ tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ a: 10; b: "hi
 !!! error TS2322:   Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
         <AnotherButton /></Comp>;

--- a/tests/baselines/reference/contextualTypeWithTuple.errors.txt
+++ b/tests/baselines/reference/contextualTypeWithTuple.errors.txt
@@ -18,7 +18,6 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(24,1): error TS23
   Property '2' is missing in type '[C, string | number]'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(25,1): error TS2322: Type '[number, string | number]' is not assignable to type '[number, string]'.
   Type 'string | number' is not assignable to type 'string'.
-    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts (7 errors) ====
@@ -74,4 +73,3 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(25,1): error TS23
     ~~~~~~~~~~~
 !!! error TS2322: Type '[number, string | number]' is not assignable to type '[number, string]'.
 !!! error TS2322:   Type 'string | number' is not assignable to type 'string'.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/contextualTypeWithUnionTypeObjectLiteral.errors.txt
+++ b/tests/baselines/reference/contextualTypeWithUnionTypeObjectLiteral.errors.txt
@@ -7,12 +7,10 @@ tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(
   Type '{ prop: string | number; }' is not assignable to type '{ prop: number; }'.
     Types of property 'prop' are incompatible.
       Type 'string | number' is not assignable to type 'number'.
-        Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(21,5): error TS2322: Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: string; anotherP: string; } | { prop: number; }'.
   Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: number; }'.
     Types of property 'prop' are incompatible.
       Type 'string | number' is not assignable to type 'number'.
-        Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(25,5): error TS2322: Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: string; anotherP: string; } | { prop: number; anotherP1: number; }'.
   Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: number; anotherP1: number; }'.
     Property 'anotherP1' is missing in type '{ prop: string | number; anotherP: string; }'.
@@ -20,13 +18,11 @@ tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(
   Type '{ prop: string | number; anotherP: string; anotherP1: number; }' is not assignable to type '{ prop: number; anotherP1: number; }'.
     Types of property 'prop' are incompatible.
       Type 'string | number' is not assignable to type 'number'.
-        Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(57,5): error TS2322: Type '{ commonMethodDifferentReturnType: (a: string, b: number) => string | number; }' is not assignable to type 'I11 | I21'.
   Type '{ commonMethodDifferentReturnType: (a: string, b: number) => string | number; }' is not assignable to type 'I21'.
     Types of property 'commonMethodDifferentReturnType' are incompatible.
       Type '(a: string, b: number) => string | number' is not assignable to type '(a: string, b: number) => number'.
         Type 'string | number' is not assignable to type 'number'.
-          Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts (6 errors) ====
@@ -61,14 +57,12 @@ tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(
 !!! error TS2322:   Type '{ prop: string | number; }' is not assignable to type '{ prop: number; }'.
 !!! error TS2322:     Types of property 'prop' are incompatible.
 !!! error TS2322:       Type 'string | number' is not assignable to type 'number'.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
     var objStrOrNum6: { prop: string; anotherP: string; } | { prop: number } = {
         ~~~~~~~~~~~~
 !!! error TS2322: Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: string; anotherP: string; } | { prop: number; }'.
 !!! error TS2322:   Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: number; }'.
 !!! error TS2322:     Types of property 'prop' are incompatible.
 !!! error TS2322:       Type 'string | number' is not assignable to type 'number'.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
         prop: strOrNumber,
         anotherP: str
     };
@@ -86,7 +80,6 @@ tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(
 !!! error TS2322:   Type '{ prop: string | number; anotherP: string; anotherP1: number; }' is not assignable to type '{ prop: number; anotherP1: number; }'.
 !!! error TS2322:     Types of property 'prop' are incompatible.
 !!! error TS2322:       Type 'string | number' is not assignable to type 'number'.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
         prop: strOrNumber,
         anotherP: str,
         anotherP1: num
@@ -121,6 +114,5 @@ tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(
 !!! error TS2322:     Types of property 'commonMethodDifferentReturnType' are incompatible.
 !!! error TS2322:       Type '(a: string, b: number) => string | number' is not assignable to type '(a: string, b: number) => number'.
 !!! error TS2322:         Type 'string | number' is not assignable to type 'number'.
-!!! error TS2322:           Type 'string' is not assignable to type 'number'.
         commonMethodDifferentReturnType: (a, b) => strOrNumber,
     };

--- a/tests/baselines/reference/controlFlowIterationErrors.errors.txt
+++ b/tests/baselines/reference/controlFlowIterationErrors.errors.txt
@@ -1,11 +1,9 @@
 tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(11,17): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'string'.
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(22,17): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'string'.
-  Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(34,17): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(45,17): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-  Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts (4 errors) ====
@@ -36,7 +34,6 @@ tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(45,17): error 
             x = len(x);
                     ~
 !!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'string'.
-!!! error TS2345:   Type 'number' is not assignable to type 'string'.
         }
         x;
     }
@@ -65,7 +62,6 @@ tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(45,17): error 
             x = foo(x);
                     ~
 !!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
         }
         x;
     }

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -21,7 +21,6 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(64,33): error
   Type '"size"' is not assignable to type '"name" | "width" | "height" | "visible"'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(66,24): error TS2345: Argument of type '"size"' is not assignable to parameter of type '"name" | "width" | "height" | "visible"'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(67,24): error TS2345: Argument of type '"name" | "size"' is not assignable to parameter of type '"name" | "width" | "height" | "visible"'.
-  Type '"size"' is not assignable to type '"name" | "width" | "height" | "visible"'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(72,5): error TS2536: Type 'keyof (T & U)' cannot be used to index type 'T | U'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(76,5): error TS2322: Type 'T | U' is not assignable to type 'T & U'.
   Type 'T' is not assignable to type 'T & U'.
@@ -142,7 +141,6 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(77,5): error 
         setProperty(shape, cond ? "name" : "size", 10);  // Error
                            ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '"name" | "size"' is not assignable to parameter of type '"name" | "width" | "height" | "visible"'.
-!!! error TS2345:   Type '"size"' is not assignable to type '"name" | "width" | "height" | "visible"'.
     }
     
     function f20<T, U>(k1: keyof (T | U), k2: keyof (T & U), o1: T | U, o2: T & U) {

--- a/tests/baselines/reference/mappedTypeRelationships.errors.txt
+++ b/tests/baselines/reference/mappedTypeRelationships.errors.txt
@@ -50,16 +50,15 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(40,5): error TS2
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(41,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'Partial<U>[keyof T]'.
   Type 'T[string]' is not assignable to type 'Partial<U>[keyof T]'.
     Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
-      Type 'T[string]' is not assignable to type 'U[keyof T]'.
-        Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
-          Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
-            Type 'T[string]' is not assignable to type 'U[keyof T]'.
-              Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
-                Type 'T[string]' is not assignable to type 'U[keyof T]'.
-                  Type 'T[string]' is not assignable to type 'U[string]'.
-                    Type 'T[keyof T]' is not assignable to type 'U[string]'.
-                      Type 'T[string]' is not assignable to type 'U[string]'.
-                        Type 'T' is not assignable to type 'U'.
+      Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
+        Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
+          Type 'T[string]' is not assignable to type 'U[keyof T]'.
+            Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+              Type 'T[string]' is not assignable to type 'U[keyof T]'.
+                Type 'T[string]' is not assignable to type 'U[string]'.
+                  Type 'T[keyof T]' is not assignable to type 'U[string]'.
+                    Type 'T[string]' is not assignable to type 'U[string]'.
+                      Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(45,5): error TS2322: Type 'Partial<U>[K]' is not assignable to type 'T[K]'.
   Type 'U[K] | undefined' is not assignable to type 'T[K]'.
     Type 'undefined' is not assignable to type 'T[K]'.
@@ -70,16 +69,15 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(45,5): error TS2
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(46,5): error TS2322: Type 'T[K]' is not assignable to type 'Partial<U>[K]'.
   Type 'T[string]' is not assignable to type 'Partial<U>[K]'.
     Type 'T[string]' is not assignable to type 'U[K] | undefined'.
-      Type 'T[string]' is not assignable to type 'U[K]'.
-        Type 'T[K]' is not assignable to type 'U[K] | undefined'.
-          Type 'T[string]' is not assignable to type 'U[K] | undefined'.
-            Type 'T[string]' is not assignable to type 'U[K]'.
-              Type 'T[K]' is not assignable to type 'U[K]'.
-                Type 'T[string]' is not assignable to type 'U[K]'.
-                  Type 'T[string]' is not assignable to type 'U[string]'.
-                    Type 'T[K]' is not assignable to type 'U[string]'.
-                      Type 'T[string]' is not assignable to type 'U[string]'.
-                        Type 'T' is not assignable to type 'U'.
+      Type 'T[K]' is not assignable to type 'U[K] | undefined'.
+        Type 'T[string]' is not assignable to type 'U[K] | undefined'.
+          Type 'T[string]' is not assignable to type 'U[K]'.
+            Type 'T[K]' is not assignable to type 'U[K]'.
+              Type 'T[string]' is not assignable to type 'U[K]'.
+                Type 'T[string]' is not assignable to type 'U[string]'.
+                  Type 'T[K]' is not assignable to type 'U[string]'.
+                    Type 'T[string]' is not assignable to type 'U[string]'.
+                      Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(51,5): error TS2542: Index signature in type 'Readonly<T>' only permits reading.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(56,5): error TS2542: Index signature in type 'Readonly<T>' only permits reading.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(61,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'Readonly<U>[keyof T]'.
@@ -236,16 +234,15 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
 !!! error TS2322: Type 'T[keyof T]' is not assignable to type 'Partial<U>[keyof T]'.
 !!! error TS2322:   Type 'T[string]' is not assignable to type 'Partial<U>[keyof T]'.
 !!! error TS2322:     Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
-!!! error TS2322:       Type 'T[string]' is not assignable to type 'U[keyof T]'.
-!!! error TS2322:         Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
-!!! error TS2322:           Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
-!!! error TS2322:             Type 'T[string]' is not assignable to type 'U[keyof T]'.
-!!! error TS2322:               Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
-!!! error TS2322:                 Type 'T[string]' is not assignable to type 'U[keyof T]'.
-!!! error TS2322:                   Type 'T[string]' is not assignable to type 'U[string]'.
-!!! error TS2322:                     Type 'T[keyof T]' is not assignable to type 'U[string]'.
-!!! error TS2322:                       Type 'T[string]' is not assignable to type 'U[string]'.
-!!! error TS2322:                         Type 'T' is not assignable to type 'U'.
+!!! error TS2322:       Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
+!!! error TS2322:         Type 'T[string]' is not assignable to type 'U[keyof T] | undefined'.
+!!! error TS2322:           Type 'T[string]' is not assignable to type 'U[keyof T]'.
+!!! error TS2322:             Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+!!! error TS2322:               Type 'T[string]' is not assignable to type 'U[keyof T]'.
+!!! error TS2322:                 Type 'T[string]' is not assignable to type 'U[string]'.
+!!! error TS2322:                   Type 'T[keyof T]' is not assignable to type 'U[string]'.
+!!! error TS2322:                     Type 'T[string]' is not assignable to type 'U[string]'.
+!!! error TS2322:                       Type 'T' is not assignable to type 'U'.
     }
     
     function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K) {
@@ -263,16 +260,15 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
 !!! error TS2322: Type 'T[K]' is not assignable to type 'Partial<U>[K]'.
 !!! error TS2322:   Type 'T[string]' is not assignable to type 'Partial<U>[K]'.
 !!! error TS2322:     Type 'T[string]' is not assignable to type 'U[K] | undefined'.
-!!! error TS2322:       Type 'T[string]' is not assignable to type 'U[K]'.
-!!! error TS2322:         Type 'T[K]' is not assignable to type 'U[K] | undefined'.
-!!! error TS2322:           Type 'T[string]' is not assignable to type 'U[K] | undefined'.
-!!! error TS2322:             Type 'T[string]' is not assignable to type 'U[K]'.
-!!! error TS2322:               Type 'T[K]' is not assignable to type 'U[K]'.
-!!! error TS2322:                 Type 'T[string]' is not assignable to type 'U[K]'.
-!!! error TS2322:                   Type 'T[string]' is not assignable to type 'U[string]'.
-!!! error TS2322:                     Type 'T[K]' is not assignable to type 'U[string]'.
-!!! error TS2322:                       Type 'T[string]' is not assignable to type 'U[string]'.
-!!! error TS2322:                         Type 'T' is not assignable to type 'U'.
+!!! error TS2322:       Type 'T[K]' is not assignable to type 'U[K] | undefined'.
+!!! error TS2322:         Type 'T[string]' is not assignable to type 'U[K] | undefined'.
+!!! error TS2322:           Type 'T[string]' is not assignable to type 'U[K]'.
+!!! error TS2322:             Type 'T[K]' is not assignable to type 'U[K]'.
+!!! error TS2322:               Type 'T[string]' is not assignable to type 'U[K]'.
+!!! error TS2322:                 Type 'T[string]' is not assignable to type 'U[string]'.
+!!! error TS2322:                   Type 'T[K]' is not assignable to type 'U[string]'.
+!!! error TS2322:                     Type 'T[string]' is not assignable to type 'U[string]'.
+!!! error TS2322:                       Type 'T' is not assignable to type 'U'.
     }
     
     function f20<T>(x: T, y: Readonly<T>, k: keyof T) {

--- a/tests/baselines/reference/nonPrimitiveStrictNull.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveStrictNull.errors.txt
@@ -9,7 +9,6 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(11,1): erro
   Type 'undefined' is not assignable to type 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(17,7): error TS2339: Property 'toString' does not exist on type 'never'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(21,5): error TS2322: Type 'object | null' is not assignable to type 'object'.
-  Type 'null' is not assignable to type 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(26,5): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(28,5): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(32,5): error TS2533: Object is possibly 'null' or 'undefined'.
@@ -63,7 +62,6 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(53,14): err
         a = b; // error, b is not narrowed
         ~
 !!! error TS2322: Type 'object | null' is not assignable to type 'object'.
-!!! error TS2322:   Type 'null' is not assignable to type 'object'.
     }
     
     if (typeof d === 'object') {

--- a/tests/baselines/reference/objectSpreadStrictNull.errors.txt
+++ b/tests/baselines/reference/objectSpreadStrictNull.errors.txt
@@ -5,7 +5,6 @@ tests/cases/conformance/types/spread/objectSpreadStrictNull.ts(14,9): error TS23
 tests/cases/conformance/types/spread/objectSpreadStrictNull.ts(15,9): error TS2322: Type '{ sn: number | undefined; }' is not assignable to type '{ sn: string | number; }'.
   Types of property 'sn' are incompatible.
     Type 'number | undefined' is not assignable to type 'string | number'.
-      Type 'undefined' is not assignable to type 'string | number'.
 tests/cases/conformance/types/spread/objectSpreadStrictNull.ts(18,9): error TS2322: Type '{ sn: string | number | undefined; }' is not assignable to type '{ sn: string | number | boolean; }'.
   Types of property 'sn' are incompatible.
     Type 'string | number | undefined' is not assignable to type 'string | number | boolean'.
@@ -44,7 +43,6 @@ tests/cases/conformance/types/spread/objectSpreadStrictNull.ts(42,5): error TS23
 !!! error TS2322: Type '{ sn: number | undefined; }' is not assignable to type '{ sn: string | number; }'.
 !!! error TS2322:   Types of property 'sn' are incompatible.
 !!! error TS2322:     Type 'number | undefined' is not assignable to type 'string | number'.
-!!! error TS2322:       Type 'undefined' is not assignable to type 'string | number'.
         let allUndefined: { sn: string | number | undefined } = { ...undefinedString, ...undefinedNumber };
     
         let undefinedWithOptionalContinues: { sn: string | number | boolean } = { ...definiteBoolean, ...undefinedString, ...optionalNumber };

--- a/tests/baselines/reference/stringLiteralsWithSwitchStatements03.errors.txt
+++ b/tests/baselines/reference/stringLiteralsWithSwitchStatements03.errors.txt
@@ -5,11 +5,9 @@ tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts(14
 tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts(14,11): error TS2695: Left side of comma operator is unused and has no side effects.
 tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts(14,11): error TS2695: Left side of comma operator is unused and has no side effects.
 tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts(20,10): error TS2678: Type '"bar" | "baz"' is not comparable to type '"foo"'.
-  Type '"baz"' is not comparable to type '"foo"'.
 tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts(22,10): error TS2678: Type '"bar" | "baz"' is not comparable to type '"foo"'.
   Type '"baz"' is not comparable to type '"foo"'.
 tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts(23,10): error TS2678: Type '"bar" | "baz"' is not comparable to type '"foo"'.
-  Type '"baz"' is not comparable to type '"foo"'.
 
 
 ==== tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts (8 errors) ====
@@ -46,7 +44,6 @@ tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts(23
         case (("bar" || ("baz"))):
              ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2678: Type '"bar" | "baz"' is not comparable to type '"foo"'.
-!!! error TS2678:   Type '"baz"' is not comparable to type '"foo"'.
             break;
         case z || "baz":
              ~~~~~~~~~~
@@ -55,7 +52,6 @@ tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts(23
         case "baz" || z:
              ~~~~~~~~~~
 !!! error TS2678: Type '"bar" | "baz"' is not comparable to type '"foo"'.
-!!! error TS2678:   Type '"baz"' is not comparable to type '"foo"'.
             z;
             break;
     }

--- a/tests/baselines/reference/typeArgumentsWithStringLiteralTypes01.errors.txt
+++ b/tests/baselines/reference/typeArgumentsWithStringLiteralTypes01.errors.txt
@@ -16,16 +16,13 @@ tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes0
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(74,5): error TS2322: Type '"Hello" | "World"' is not assignable to type '"Hello"'.
   Type '"World"' is not assignable to type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(76,5): error TS2322: Type '"Hello" | "World"' is not assignable to type '"Hello"'.
-  Type '"World"' is not assignable to type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(86,43): error TS2345: Argument of type '"World"' is not assignable to parameter of type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(87,43): error TS2345: Argument of type '"Hello"' is not assignable to parameter of type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(88,52): error TS2345: Argument of type '"World"' is not assignable to parameter of type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(92,5): error TS2322: Type 'string' is not assignable to type '"Hello" | "World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(96,5): error TS2322: Type 'string' is not assignable to type '"Hello" | "World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(99,25): error TS2345: Argument of type '"Hello" | "World"' is not assignable to parameter of type '"Hello"'.
-  Type '"World"' is not assignable to type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(103,25): error TS2345: Argument of type '"Hello" | "World"' is not assignable to parameter of type '"Hello"'.
-  Type '"World"' is not assignable to type '"Hello"'.
 
 
 ==== tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts (24 errors) ====
@@ -140,7 +137,6 @@ tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes0
         c = takeReturnHelloWorld(c);
         ~
 !!! error TS2322: Type '"Hello" | "World"' is not assignable to type '"Hello"'.
-!!! error TS2322:   Type '"World"' is not assignable to type '"Hello"'.
         d = takeReturnHelloWorld(d);
         e = takeReturnHelloWorld(e);
     }
@@ -176,14 +172,12 @@ tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes0
         a = takeReturnHello(a);
                             ~
 !!! error TS2345: Argument of type '"Hello" | "World"' is not assignable to parameter of type '"Hello"'.
-!!! error TS2345:   Type '"World"' is not assignable to type '"Hello"'.
         b = takeReturnHello(b);
         c = takeReturnHello(c);
         d = takeReturnHello(d);
         e = takeReturnHello(e);
                             ~
 !!! error TS2345: Argument of type '"Hello" | "World"' is not assignable to parameter of type '"Hello"'.
-!!! error TS2345:   Type '"World"' is not assignable to type '"Hello"'.
     
         // Both should be valid.
         a = takeReturnHelloWorld(a);

--- a/tests/baselines/reference/typeParameterDiamond2.errors.txt
+++ b/tests/baselines/reference/typeParameterDiamond2.errors.txt
@@ -2,7 +2,6 @@ tests/cases/compiler/typeParameterDiamond2.ts(8,13): error TS2322: Type 'T | U' 
   Type 'U' is not assignable to type 'Top'.
 tests/cases/compiler/typeParameterDiamond2.ts(10,13): error TS2322: Type 'Bottom' is not assignable to type 'Top'.
   Type 'T | U' is not assignable to type 'Top'.
-    Type 'U' is not assignable to type 'Top'.
 
 
 ==== tests/cases/compiler/typeParameterDiamond2.ts (2 errors) ====
@@ -22,7 +21,6 @@ tests/cases/compiler/typeParameterDiamond2.ts(10,13): error TS2322: Type 'Bottom
                 ~~~
 !!! error TS2322: Type 'Bottom' is not assignable to type 'Top'.
 !!! error TS2322:   Type 'T | U' is not assignable to type 'Top'.
-!!! error TS2322:     Type 'U' is not assignable to type 'Top'.
             }
         }
     }

--- a/tests/baselines/reference/typeParameterDiamond4.errors.txt
+++ b/tests/baselines/reference/typeParameterDiamond4.errors.txt
@@ -2,7 +2,6 @@ tests/cases/compiler/typeParameterDiamond4.ts(8,13): error TS2322: Type 'Top | T
   Type 'T' is not assignable to type 'Top'.
 tests/cases/compiler/typeParameterDiamond4.ts(10,13): error TS2322: Type 'Bottom' is not assignable to type 'Top'.
   Type 'Top | T | U' is not assignable to type 'Top'.
-    Type 'T' is not assignable to type 'Top'.
 
 
 ==== tests/cases/compiler/typeParameterDiamond4.ts (2 errors) ====
@@ -22,7 +21,6 @@ tests/cases/compiler/typeParameterDiamond4.ts(10,13): error TS2322: Type 'Bottom
                 ~~~
 !!! error TS2322: Type 'Bottom' is not assignable to type 'Top'.
 !!! error TS2322:   Type 'Top | T | U' is not assignable to type 'Top'.
-!!! error TS2322:     Type 'T' is not assignable to type 'Top'.
             }
         }
     }


### PR DESCRIPTION
This lifts the cache used within `recursiveTypeRelatedTo` up to `isRelatedTo` as a whole; enabling the results of comparing unions and intersections of types to be cached.

As a side effect of caching the results, this causes us to no longer duplicate elaborations for the newly cached types across multiple diagnostic messages, similarly to what we were already doing for structured types.

Combined with #17947, @sandersn and I saw significant improvements in the compilation time of some type-heavy compilations.