### PR TITLE
Add support for custom outlining regions

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2037,10 +2037,6 @@ namespace ts {
         end: -1;
     }
 
-    export interface RegionRange extends TextRange {
-        name?: string;
-    }
-
     // represents a top level: { type } expression in a JSDoc comment.
     export interface JSDocTypeExpression extends TypeNode {
         kind: SyntaxKind.JSDocTypeExpression;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2037,6 +2037,10 @@ namespace ts {
         end: -1;
     }
 
+    export interface RegionRange extends TextRange {
+        name?: string;
+    }
+
     // represents a top level: { type } expression in a JSDoc comment.
     export interface JSDocTypeExpression extends TypeNode {
         kind: SyntaxKind.JSDocTypeExpression;

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -107,26 +107,28 @@ namespace ts.OutliningElementsCollector {
         }
 
         function isRegionStart(start: number, end: number) {
-            const comment = sourceFile.text.substring(start, end);
-            const result = comment.match(regionStart);
+            if (!ts.formatting.getRangeOfEnclosingComment(sourceFile, start, /*onlyMultiLine*/ true)) {
+                const comment = sourceFile.text.substring(start, end);
+                const result = comment.match(regionStart);
 
-            if (result && result.length > 0) {
-                const sections = result[0].split(" ").filter(function (s) { return s !== ""; });
+                if (result && result.length > 0) {
+                    const sections = result[0].split(" ").filter(function (s) { return s !== ""; });
 
-                if (sections[0] === "//") {
-                    if (sections.length > 2) {
-                        return result[0].substring(result[0].indexOf(sections[2]));
+                    if (sections[0] === "//") {
+                        if (sections.length > 2) {
+                            return result[0].substring(result[0].indexOf(sections[2]));
+                        }
+                        else {
+                            return regionText;
+                        }
                     }
                     else {
-                        return regionText;
-                    }
-                }
-                else {
-                    if (sections.length > 1) {
-                        return result[0].substring(result[0].indexOf(sections[1]));
-                    }
-                    else {
-                        return regionText;
+                        if (sections.length > 1) {
+                            return result[0].substring(result[0].indexOf(sections[1]));
+                        }
+                        else {
+                            return regionText;
+                        }
                     }
                 }
             }
@@ -134,8 +136,11 @@ namespace ts.OutliningElementsCollector {
         }
 
         function isRegionEnd(start: number, end: number) {
-            const comment = sourceFile.text.substring(start, end);
-            return comment.match(regionEnd);
+            if (!ts.formatting.getRangeOfEnclosingComment(sourceFile, start, /*onlyMultiLine*/ true)) {
+                const comment = sourceFile.text.substring(start, end);
+                return comment.match(regionEnd);
+            }
+            return undefined;
         }
 
         function gatherRegions(): void {

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -6,6 +6,10 @@ namespace ts.OutliningElementsCollector {
     const regionStart = new RegExp("^//\\s*#region(\\s+.*)?$");
     const regionEnd = new RegExp("^//\\s*#endregion(\\s|$)");
 
+    interface RegionRange extends TextRange {
+        name?: string;
+    }
+
     export function collectElements(sourceFile: SourceFile, cancellationToken: CancellationToken): OutliningSpan[] {
         const elements: OutliningSpan[] = [];
         let depth = 0;

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -8,8 +8,8 @@ namespace ts.OutliningElementsCollector {
         let depth = 0;
         const regions: RegionRange[] = [];
         const regionText = "#region";
-        const regionStart = new RegExp("//\\s*#region(\\s+.*)?$", "gm");
-        const regionEnd = new RegExp("//\\s*#endregion(\\s|$)", "gm");
+        const regionStart = new RegExp("^\\s*//\\s*#region(\\s+.*)?$", "gm");
+        const regionEnd = new RegExp("^\\s*//\\s*#endregion(\\s|$)", "gm");
 
         walk(sourceFile);
         gatherRegions();

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -8,8 +8,8 @@ namespace ts.OutliningElementsCollector {
         let depth = 0;
         const regions: RegionRange[] = [];
         const regionText = "#region";
-        const regionStart = new RegExp("// #region( .+| *)", "g");
-        const regionEnd = new RegExp("// #endregion *");
+        const regionStart = new RegExp("//\\s*#region(\\s+.*)?$", "gm");
+        const regionEnd = new RegExp("//\\s*#endregion(\\s|$)", "gm");
 
         walk(sourceFile);
         gatherRegions();
@@ -165,12 +165,23 @@ namespace ts.OutliningElementsCollector {
             const result = comment.match(regionStart);
 
             if (result && result.length > 0) {
-                const name = result[0].substring(10).trim();
-                if (name) {
-                    return name;
+                const sections = result[0].split(" ").filter(function (s) { return s !== ""; });
+
+                if (sections[0] === "//") {
+                    if (sections.length > 2) {
+                        return result[0].substring(result[0].indexOf(sections[2]));
+                    }
+                    else {
+                        return regionText;
+                    }
                 }
                 else {
-                    return regionText;
+                    if (sections.length > 1) {
+                        return result[0].substring(result[0].indexOf(sections[1]));
+                    }
+                    else {
+                        return regionText;
+                    }
                 }
             }
             return "";

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -3,7 +3,7 @@ namespace ts.OutliningElementsCollector {
     const collapseText = "...";
     const maxDepth = 20;
     const defaultLabel = "#region";
-    const regionMatch = new RegExp("^\\s*//\\s*(#region|#endregion)(?:\\s+(.*))?$");
+    const regionMatch = new RegExp("^\\s*//\\s*#(end)?region(?:\\s+(.*))?$");
 
     export function collectElements(sourceFile: SourceFile, cancellationToken: CancellationToken): OutliningSpan[] {
         const elements: OutliningSpan[] = [];
@@ -103,7 +103,7 @@ namespace ts.OutliningElementsCollector {
                 const result = comment.match(regionMatch);
 
                 if (result && !isInComment(sourceFile, currentLineStart)) {
-                    if (result[1] === "#region") {
+                    if (!result[1]) {
                         const start = sourceFile.getFullText().indexOf("//", currentLineStart);
                         const textSpan = createTextSpanFromBounds(start, lineEnd);
                         const region: OutliningSpan = {
@@ -117,9 +117,8 @@ namespace ts.OutliningElementsCollector {
                     else {
                         const region = regions.pop();
                         if (region) {
-                            const newTextSpan = createTextSpanFromBounds(region.textSpan.start, lineEnd);
-                            region.textSpan = newTextSpan;
-                            region.hintSpan = newTextSpan;
+                            region.textSpan.length = lineEnd - region.textSpan.start;
+                            region.hintSpan.length = lineEnd - region.textSpan.start;
                             elements.push(region);
                         }
                     }

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -13,7 +13,7 @@ namespace ts.OutliningElementsCollector {
 
         walk(sourceFile);
         gatherRegions();
-        return elements;
+        return elements.sort((span1, span2) => span1.textSpan.start - span2.textSpan.start);
 
         /** If useFullStart is true, then the collapsing span includes leading whitespace, including linebreaks. */
         function addOutliningSpan(hintSpanNode: Node, startElement: Node, endElement: Node, autoCollapse: boolean, useFullStart: boolean) {

--- a/tests/cases/fourslash/getOutliningSpansForRegions.ts
+++ b/tests/cases/fourslash/getOutliningSpansForRegions.ts
@@ -1,0 +1,46 @@
+/// <reference path="fourslash.ts"/>
+
+////// basic region
+////[|// #region
+////
+////// #endregion|]
+////
+////// region with label
+////[|// #region label1
+////
+////// #endregion|]
+////
+////// region with extra whitespace in all valid locations
+////[|             //              #region          label2    label3
+////
+////        //        #endregion|]
+////
+////// No space before directive
+////[|//#region label4
+////
+//////#endregion|]
+////
+////// Nested regions
+////[|// #region outer
+////
+////[|// #region inner
+////
+////// #endregion inner|]
+////
+////// #endregion outer|]
+////
+////// region delimiters not valid when preceding text on line
+//// test // #region invalid1
+////
+////test // #endregion
+////
+////// region delimiters not valid when in multiline comment
+/////*
+////// #region invalid2
+////*/
+////
+/////*
+////// #endregion
+////*/
+
+verify.outliningSpansInCurrentFile(test.ranges());

--- a/tests/cases/fourslash/getOutliningSpansForRegions.ts
+++ b/tests/cases/fourslash/getOutliningSpansForRegions.ts
@@ -1,6 +1,6 @@
 /// <reference path="fourslash.ts"/>
 
-////// basic region
+////// region without label
 ////[|// #region
 ////
 ////// #endregion|]
@@ -29,7 +29,7 @@
 ////
 ////// #endregion outer|]
 ////
-////// region delimiters not valid when preceding text on line
+////// region delimiters not valid when there is preceding text on line
 //// test // #region invalid1
 ////
 ////test // #endregion

--- a/tests/cases/fourslash/getOutliningSpansForRegions.ts
+++ b/tests/cases/fourslash/getOutliningSpansForRegions.ts
@@ -5,6 +5,11 @@
 ////
 ////// #endregion|]
 ////
+////// region without label with trailing spaces
+////[|// #region  
+////
+////// #endregion|]
+////
 ////// region with label
 ////[|// #region label1
 ////

--- a/tests/cases/fourslash/getOutliningSpansForRegions.ts
+++ b/tests/cases/fourslash/getOutliningSpansForRegions.ts
@@ -11,7 +11,7 @@
 ////// #endregion|]
 ////
 ////// region with extra whitespace in all valid locations
-////[|             //              #region          label2    label3
+////             [|//              #region          label2    label3
 ////
 ////        //        #endregion|]
 ////

--- a/tests/cases/fourslash/getOutliningSpansForUnbalancedEndRegion.ts
+++ b/tests/cases/fourslash/getOutliningSpansForUnbalancedEndRegion.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts"/>
+
+////// bottom-heavy region balance
+////[|// #region matched
+////
+////// #endregion matched|]
+////
+////// #endregion unmatched
+
+verify.outliningSpansInCurrentFile(test.ranges());

--- a/tests/cases/fourslash/getOutliningSpansForUnbalancedRegion.ts
+++ b/tests/cases/fourslash/getOutliningSpansForUnbalancedRegion.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts"/>
+
+////// top-heavy region balance
+////// #region unmatched
+////
+////[|// #region matched
+////
+////// #endregion matched|]
+
+debugger;
+verify.outliningSpansInCurrentFile(test.ranges());


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
Fixes #11073.

This update enables support for custom outlining regions of the following form

```
// #region label

...code...

// #endregion
```

Region delimiters may not be preceded by any non-whitespace text, and they are not valid if they occur within a multiline comment.
