### PR TITLE
Fix emit comments on system export default expressions

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2519,7 +2519,7 @@ namespace ts {
                 //          2
                 //          /* end of element 2 */
                 //       ];
-                if (previousSibling && delimiter && previousSibling.end !== parentNode.end) {
+                if (previousSibling && delimiter && previousSibling.end !== parentNode.end && !(getEmitFlags(previousSibling) & EmitFlags.NoTrailingComments)) {
                     emitLeadingCommentsOfPosition(previousSibling.end);
                 }
 

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -1132,7 +1132,8 @@ namespace ts {
          */
         function createExportExpression(name: Identifier | StringLiteral, value: Expression) {
             const exportName = isIdentifier(name) ? createLiteral(name) : name;
-            return createCall(exportFunction, /*typeArguments*/ undefined, [exportName, value]);
+            setEmitFlags(value, getEmitFlags(value) | EmitFlags.NoComments);
+            return setCommentRange(createCall(exportFunction, /*typeArguments*/ undefined, [exportName, value]), value);
         }
 
         //

--- a/tests/baselines/reference/systemDefaultExportCommentValidity.js
+++ b/tests/baselines/reference/systemDefaultExportCommentValidity.js
@@ -1,0 +1,20 @@
+//// [systemDefaultExportCommentValidity.ts]
+const Home = {}
+
+export default Home
+// There is intentionally no semicolon on the prior line, this comment should not break emit
+
+//// [systemDefaultExportCommentValidity.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var Home;
+    return {
+        setters: [],
+        execute: function () {
+            Home = {};
+            exports_1("default", Home);
+            // There is intentionally no semicolon on the prior line, this comment should not break emit 
+        }
+    };
+});

--- a/tests/baselines/reference/systemDefaultExportCommentValidity.symbols
+++ b/tests/baselines/reference/systemDefaultExportCommentValidity.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/systemDefaultExportCommentValidity.ts ===
+const Home = {}
+>Home : Symbol(Home, Decl(systemDefaultExportCommentValidity.ts, 0, 5))
+
+export default Home
+>Home : Symbol(Home, Decl(systemDefaultExportCommentValidity.ts, 0, 5))
+
+// There is intentionally no semicolon on the prior line, this comment should not break emit

--- a/tests/baselines/reference/systemDefaultExportCommentValidity.types
+++ b/tests/baselines/reference/systemDefaultExportCommentValidity.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/systemDefaultExportCommentValidity.ts ===
+const Home = {}
+>Home : {}
+>{} : {}
+
+export default Home
+>Home : {}
+
+// There is intentionally no semicolon on the prior line, this comment should not break emit

--- a/tests/cases/compiler/systemDefaultExportCommentValidity.ts
+++ b/tests/cases/compiler/systemDefaultExportCommentValidity.ts
@@ -1,0 +1,5 @@
+// @module: system
+const Home = {}
+
+export default Home
+// There is intentionally no semicolon on the prior line, this comment should not break emit


### PR DESCRIPTION
We now emit them on the surrounding export call expression instead.

Fixes #17665
