### PR TITLE
expose isExternalModuleNameRelative and moduleHasNonRelativeName

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -16,11 +16,6 @@ namespace ts {
         // Update: We also consider a path like `C:\foo.ts` "relative" because we do not search for it in `node_modules` or treat it as an ambient module.
         return pathIsRelative(moduleName) || isRootedDiskPath(moduleName);
     }
-
-    /** @deprecated Use `!isExternalModuleNameRelative(moduleName)` instead. */
-    export function moduleHasNonRelativeName(moduleName: string): boolean {
-        return !isExternalModuleNameRelative(moduleName);
-    }
 }
 
 /* @internal */
@@ -1595,6 +1590,11 @@ namespace ts {
 
     export function pathIsRelative(path: string): boolean {
         return /^\.\.?($|[\\/])/.test(path);
+    }
+
+    /** @deprecated Use `!isExternalModuleNameRelative(moduleName)` instead. */
+    export function moduleHasNonRelativeName(moduleName: string): boolean {
+        return !isExternalModuleNameRelative(moduleName);
     }
 
     export function getEmitScriptTarget(compilerOptions: CompilerOptions) {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -9,6 +9,20 @@ namespace ts {
     export const version = `${versionMajorMinor}.0`;
 }
 
+namespace ts {
+    export function isExternalModuleNameRelative(moduleName: string): boolean {
+        // TypeScript 1.0 spec (April 2014): 11.2.1
+        // An external module name is "relative" if the first term is "." or "..".
+        // Update: We also consider a path like `C:\foo.ts` "relative" because we do not search for it in `node_modules` or treat it as an ambient module.
+        return pathIsRelative(moduleName) || isRootedDiskPath(moduleName);
+    }
+
+    /** @deprecated Use `!isExternalModuleNameRelative(moduleName)` instead. */
+    export function moduleHasNonRelativeName(moduleName: string): boolean {
+        return !isExternalModuleNameRelative(moduleName);
+    }
+}
+
 /* @internal */
 namespace ts {
 
@@ -40,7 +54,6 @@ namespace ts {
         return new MapCtr<T>() as UnderscoreEscapedMap<T>;
     }
 
-    /* @internal */
     export function createSymbolTable(symbols?: ReadonlyArray<Symbol>): SymbolTable {
         const result = createMap<Symbol>() as SymbolTable;
         if (symbols) {
@@ -1580,21 +1593,8 @@ namespace ts {
         return path && !isRootedDiskPath(path) && path.indexOf("://") !== -1;
     }
 
-    /* @internal */
     export function pathIsRelative(path: string): boolean {
         return /^\.\.?($|[\\/])/.test(path);
-    }
-
-    export function isExternalModuleNameRelative(moduleName: string): boolean {
-        // TypeScript 1.0 spec (April 2014): 11.2.1
-        // An external module name is "relative" if the first term is "." or "..".
-        // Update: We also consider a path like `C:\foo.ts` "relative" because we do not search for it in `node_modules` or treat it as an ambient module.
-        return pathIsRelative(moduleName) || isRootedDiskPath(moduleName);
-    }
-
-    /** @deprecated Use `!isExternalModuleNameRelative(moduleName)` instead. */
-    export function moduleHasNonRelativeName(moduleName: string): boolean {
-        return !isExternalModuleNameRelative(moduleName);
     }
 
     export function getEmitScriptTarget(compilerOptions: CompilerOptions) {
@@ -1615,7 +1615,6 @@ namespace ts {
         return moduleResolution;
     }
 
-    /* @internal */
     export function hasZeroOrOneAsteriskCharacter(str: string): boolean {
         let seenAsterisk = false;
         for (let i = 0; i < str.length; i++) {
@@ -1840,17 +1839,14 @@ namespace ts {
         return true;
     }
 
-    /* @internal */
     export function startsWith(str: string, prefix: string): boolean {
         return str.lastIndexOf(prefix, 0) === 0;
     }
 
-    /* @internal */
     export function removePrefix(str: string, prefix: string): string {
         return startsWith(str, prefix) ? str.substr(prefix.length) : str;
     }
 
-    /* @internal */
     export function endsWith(str: string, suffix: string): boolean {
         const expectedPos = str.length - suffix.length;
         return expectedPos >= 0 && str.indexOf(suffix, expectedPos) === expectedPos;
@@ -1864,7 +1860,6 @@ namespace ts {
         return path.length > extension.length && endsWith(path, extension);
     }
 
-    /* @internal */
     export function fileExtensionIsOneOf(path: string, extensions: ReadonlyArray<string>): boolean {
         for (const extension of extensions) {
             if (fileExtensionIs(path, extension)) {
@@ -1881,7 +1876,6 @@ namespace ts {
     const reservedCharacterPattern = /[^\w\s\/]/g;
     const wildcardCharCodes = [CharacterCodes.asterisk, CharacterCodes.question];
 
-    /* @internal */
     export const commonPackageFolders: ReadonlyArray<string> = ["node_modules", "bower_components", "jspm_packages"];
 
     const implicitExcludePathRegexPattern = `(?!(${commonPackageFolders.join("|")})(/|$))`;
@@ -2499,7 +2493,6 @@ namespace ts {
      * Return an exact match if possible, or a pattern match, or undefined.
      * (These are verified by verifyCompilerOptions to have 0 or 1 "*" characters.)
      */
-    /* @internal */
     export function matchPatternOrExact(patternStrings: ReadonlyArray<string>, candidate: string): string | Pattern | undefined {
         const patterns: Pattern[] = [];
         for (const patternString of patternStrings) {
@@ -2516,7 +2509,6 @@ namespace ts {
         return findBestPatternMatch(patterns, _ => _, candidate);
     }
 
-    /* @internal */
     export function patternText({prefix, suffix}: Pattern): string {
         return `${prefix}*${suffix}`;
     }
@@ -2525,14 +2517,12 @@ namespace ts {
      * Given that candidate matches pattern, returns the text matching the '*'.
      * E.g.: matchedText(tryParsePattern("foo*baz"), "foobarbaz") === "bar"
      */
-    /* @internal */
     export function matchedText(pattern: Pattern, candidate: string): string {
         Debug.assert(isPatternMatch(pattern, candidate));
         return candidate.substr(pattern.prefix.length, candidate.length - pattern.suffix.length);
     }
 
     /** Return the object corresponding to the best pattern to match `candidate`. */
-    /* @internal */
     export function findBestPatternMatch<T>(values: ReadonlyArray<T>, getPattern: (value: T) => Pattern, candidate: string): T | undefined {
         let matchedValue: T | undefined = undefined;
         // use length of prefix as betterness criteria
@@ -2555,7 +2545,6 @@ namespace ts {
             endsWith(candidate, suffix);
     }
 
-    /* @internal */
     export function tryParsePattern(pattern: string): Pattern | undefined {
         // This should be verified outside of here and a proper error thrown.
         Debug.assert(hasZeroOrOneAsteriskCharacter(pattern));


### PR DESCRIPTION
Fixes: #17890

I created a new non-internal `namespace ts` and added both functions. I wasn't sure if I am allowed to modify the first namespace, because of this comment:

> // WARNING: The script `configureNightly.ts` uses a regexp to parse out these values.
>    // If changing the text in this section, be sure to test `configureNightly` too.

This PR also removes all redundant `@internal` comments from the internal namespace.

When this PR lands, I'd like to backport it to 2.5