### PR TITLE
Fix instrumenter target + deprecation warning

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -968,7 +968,7 @@ const instrumenterPath = path.join(harnessDirectory, "instrumenter.ts");
 const instrumenterJsPath = path.join(builtLocalDirectory, "instrumenter.js");
 gulp.task(instrumenterJsPath, /*help*/ false, [servicesFile], () => {
     const settings: tsc.Settings = getCompilerSettings({
-        outFile: instrumenterJsPath,
+        module: "commonjs",
         target: "es5",
         lib: [
             "es6",
@@ -980,8 +980,8 @@ gulp.task(instrumenterJsPath, /*help*/ false, [servicesFile], () => {
         .pipe(newer(instrumenterJsPath))
         .pipe(sourcemaps.init())
         .pipe(tsc(settings))
-        .pipe(sourcemaps.write("."))
-        .pipe(gulp.dest("."));
+        .pipe(sourcemaps.write(builtLocalDirectory))
+        .pipe(gulp.dest(builtLocalDirectory));
 });
 
 gulp.task("tsc-instrumented", "Builds an instrumented tsc.js", ["local", loggedIOJsPath, instrumenterJsPath, servicesFile], (done) => {

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -1086,7 +1086,7 @@ file(loggedIOJsPath, [builtLocalDirectory, loggedIOpath], function () {
 
 var instrumenterPath = harnessDirectory + 'instrumenter.ts';
 var instrumenterJsPath = builtLocalDirectory + 'instrumenter.js';
-compileFile(instrumenterJsPath, [instrumenterPath], [tscFile, instrumenterPath].concat(libraryTargets), [], /*useBuiltCompiler*/ true, { lib: "es6", types: ["node"] });
+compileFile(instrumenterJsPath, [instrumenterPath], [tscFile, instrumenterPath].concat(libraryTargets), [], /*useBuiltCompiler*/ true, { lib: "es6", types: ["node"], noOutFile: true, outDir: builtLocalDirectory });
 
 desc("Builds an instrumented tsc.js");
 task('tsc-instrumented', [loggedIOJsPath, instrumenterJsPath, tscFile], function () {

--- a/src/harness/instrumenter.ts
+++ b/src/harness/instrumenter.ts
@@ -1,5 +1,5 @@
-const fs: any = require("fs");
-const path: any = require("path");
+import fs = require("fs");
+import path = require("path");
 
 function instrumentForRecording(fn: string, tscPath: string) {
     instrument(tscPath, `
@@ -38,7 +38,9 @@ function instrument(tscPath: string, prepareCode: string, cleanupCode = "") {
 
                     const index2 = index1 + invocationLine.length;
                     const newContent = tscContent.substr(0, index1) + loggerContent + prepareCode + invocationLine + cleanupCode + tscContent.substr(index2) + "\r\n";
-                    fs.writeFile(tscPath, newContent);
+                    fs.writeFile(tscPath, newContent, err => {
+                        if (err) throw err;
+                    });
                 });
             });
         });


### PR DESCRIPTION
`instrumenter.js` was not building using the `Jakefile`, and had a deprecation warning about calling async functions without a callback in the execution on new versions of node. This fixes that.
