### PR TITLE
Change typed array constructor signature

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1743,9 +1743,8 @@ interface Int8Array {
 }
 interface Int8ArrayConstructor {
     readonly prototype: Int8Array;
-    new(length: number): Int8Array;
-    new(array: ArrayLike<number>): Int8Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int8Array;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Int8Array;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Int8Array;
 
     /**
       * The size in bytes of each element in the array.
@@ -2011,9 +2010,8 @@ interface Uint8Array {
 
 interface Uint8ArrayConstructor {
     readonly prototype: Uint8Array;
-    new(length: number): Uint8Array;
-    new(array: ArrayLike<number>): Uint8Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint8Array;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Uint8Array;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Uint8Array;
 
     /**
       * The size in bytes of each element in the array.
@@ -2278,9 +2276,8 @@ interface Uint8ClampedArray {
 
 interface Uint8ClampedArrayConstructor {
     readonly prototype: Uint8ClampedArray;
-    new(length: number): Uint8ClampedArray;
-    new(array: ArrayLike<number>): Uint8ClampedArray;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint8ClampedArray;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Uint8ClampedArray;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Uint8ClampedArray;
 
     /**
       * The size in bytes of each element in the array.
@@ -2543,9 +2540,8 @@ interface Int16Array {
 
 interface Int16ArrayConstructor {
     readonly prototype: Int16Array;
-    new(length: number): Int16Array;
-    new(array: ArrayLike<number>): Int16Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int16Array;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Int16Array;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Int16Array;
 
     /**
       * The size in bytes of each element in the array.
@@ -2811,9 +2807,8 @@ interface Uint16Array {
 
 interface Uint16ArrayConstructor {
     readonly prototype: Uint16Array;
-    new(length: number): Uint16Array;
-    new(array: ArrayLike<number>): Uint16Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint16Array;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Uint16Array;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Uint16Array;
 
     /**
       * The size in bytes of each element in the array.
@@ -3078,9 +3073,8 @@ interface Int32Array {
 
 interface Int32ArrayConstructor {
     readonly prototype: Int32Array;
-    new(length: number): Int32Array;
-    new(array: ArrayLike<number>): Int32Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int32Array;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Int32Array;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Int32Array;
 
     /**
       * The size in bytes of each element in the array.
@@ -3344,9 +3338,8 @@ interface Uint32Array {
 
 interface Uint32ArrayConstructor {
     readonly prototype: Uint32Array;
-    new(length: number): Uint32Array;
-    new(array: ArrayLike<number>): Uint32Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint32Array;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Uint32Array;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Uint32Array;
 
     /**
       * The size in bytes of each element in the array.
@@ -3611,9 +3604,8 @@ interface Float32Array {
 
 interface Float32ArrayConstructor {
     readonly prototype: Float32Array;
-    new(length: number): Float32Array;
-    new(array: ArrayLike<number>): Float32Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Float32Array;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Float32Array;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Float32Array;
 
     /**
       * The size in bytes of each element in the array.
@@ -3879,9 +3871,8 @@ interface Float64Array {
 
 interface Float64ArrayConstructor {
     readonly prototype: Float64Array;
-    new(length: number): Float64Array;
-    new(array: ArrayLike<number>): Float64Array;
-    new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Float64Array;
+    new(lengthOrArrayOrArrayBuffer: number | ArrayLike<number> | ArrayBufferLike): Float64Array;
+    new(buffer: ArrayBufferLike, byteOffset: number, length?: number): Float64Array;
 
     /**
       * The size in bytes of each element in the array.


### PR DESCRIPTION
Fixes #17962.

This PR changes the constructor definitions of the typed arrays to allow for valid code as described in #17962.