### PR TITLE
Bind logger function before using

### DIFF
--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -149,7 +149,7 @@ namespace ts.server.typingsInstaller {
             }
             const discoverTypingsResult = JsTyping.discoverTypings(
                 this.installTypingHost,
-                this.log.isEnabled() ? this.log.writeLine.bind(this.log) : undefined,
+                this.log.isEnabled() ? (s => this.log.writeLine(s)) : undefined,
                 req.fileNames,
                 req.projectRootPath,
                 this.safeList,

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -149,7 +149,7 @@ namespace ts.server.typingsInstaller {
             }
             const discoverTypingsResult = JsTyping.discoverTypings(
                 this.installTypingHost,
-                this.log.isEnabled() ? this.log.writeLine : undefined,
+                this.log.isEnabled() ? this.log.writeLine.bind(this.log) : undefined,
                 req.fileNames,
                 req.projectRootPath,
                 this.safeList,


### PR DESCRIPTION
bind log function to avoid invalid access to `this`.