### PR TITLE
Fix crash when exporting class without name

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -1204,7 +1204,7 @@ namespace ts {
             }
 
             if (hasModifier(decl, ModifierFlags.Export)) {
-                const exportName = hasModifier(decl, ModifierFlags.Default) ? createIdentifier("default") : decl.name;
+                const exportName = hasModifier(decl, ModifierFlags.Default) ? createIdentifier("default") : getDeclarationName(decl);
                 statements = appendExportStatement(statements, exportName, getLocalName(decl), /*location*/ decl);
             }
 

--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -124,7 +124,7 @@ namespace ts {
                         else {
                             // export class x { }
                             const name = (<ClassDeclaration>node).name;
-                            if (!uniqueExports.get(unescapeLeadingUnderscores(name.escapedText))) {
+                            if (name && !uniqueExports.get(unescapeLeadingUnderscores(name.escapedText))) {
                                 multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), name);
                                 uniqueExports.set(unescapeLeadingUnderscores(name.escapedText), true);
                                 exportedNames = append(exportedNames, name);

--- a/tests/baselines/reference/exportClassWithoutName.errors.txt
+++ b/tests/baselines/reference/exportClassWithoutName.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/exportClassWithoutName.ts(1,1): error TS1211: A class declaration without the 'default' modifier must have a name.
+
+
+==== tests/cases/compiler/exportClassWithoutName.ts (1 errors) ====
+    export class {
+    ~~~~~~
+!!! error TS1211: A class declaration without the 'default' modifier must have a name.
+    }

--- a/tests/baselines/reference/exportClassWithoutName.js
+++ b/tests/baselines/reference/exportClassWithoutName.js
@@ -1,0 +1,10 @@
+//// [exportClassWithoutName.ts]
+export class {
+}
+
+//// [exportClassWithoutName.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class default_1 {
+}
+exports.default_1 = default_1;

--- a/tests/cases/compiler/exportClassWithoutName.ts
+++ b/tests/cases/compiler/exportClassWithoutName.ts
@@ -1,0 +1,4 @@
+//@module: commonjs
+//@target: es2015
+export class {
+}


### PR DESCRIPTION
This fixes a compiler crash when exporting a class without a name for `--module commonjs --target es2015`.

Fixes #16681
