### PR TITLE
WIP: type call spreads

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3358,6 +3358,7 @@ namespace ts {
             case SyntaxKind.TypeLiteral:
             case SyntaxKind.ArrayType:
             case SyntaxKind.TupleType:
+            case SyntaxKind.TypeSpread:
             case SyntaxKind.UnionType:
             case SyntaxKind.IntersectionType:
             case SyntaxKind.ParenthesizedType:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7626,7 +7626,13 @@ namespace ts {
 
         function getTypeFromTypeCallNode(node: TypeCallTypeNode): Type {
             const fn = typeNodeToExpression(node.type);
-            const args = map(node.arguments, typeNodeToExpression);
+            const args = map(node.arguments, (type: TypeNode) => {
+                if (type.kind === SyntaxKind.TypeSpread) {
+                    return createSpread(typeNodeToExpression((type as TypeSpreadTypeNode).type));
+                } else {
+                    return typeNodeToExpression(type);
+                }
+            });
             const callExpr = createCall(fn, node.typeArguments, args);
             return checkExpression(callExpr);
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6799,7 +6799,7 @@ namespace ts {
                 const typeArguments = concatenate(type.outerTypeParameters, fillMissingTypeArguments(typeArgs, typeParameters, minTypeArgumentCount, node));
                 return createTypeReference(<GenericType>type, typeArguments);
             }
-            if (node.typeArguments) {
+            if (node.typeArguments　&& node.typeArguments.length) {
                 error(node, Diagnostics.Type_0_is_not_generic, typeToString(type));
                 return unknownType;
             }
@@ -6841,7 +6841,7 @@ namespace ts {
                 }
                 return getTypeAliasInstantiation(symbol, typeArguments);
             }
-            if (node.typeArguments) {
+            if (node.typeArguments　&& node.typeArguments.length) {
                 error(node, Diagnostics.Type_0_is_not_generic, symbolToString(symbol));
                 return unknownType;
             }
@@ -6852,7 +6852,7 @@ namespace ts {
          * Get type from reference to named type that cannot be generic (enum or type parameter)
          */
         function getTypeFromNonGenericTypeReference(node: TypeReferenceType, symbol: Symbol): Type {
-            if (node.typeArguments) {
+            if (node.typeArguments　&& node.typeArguments.length) {
                 error(node, Diagnostics.Type_0_is_not_generic, symbolToString(symbol));
                 return unknownType;
             }
@@ -7553,6 +7553,18 @@ namespace ts {
             return links.resolvedType;
         }
 
+        function getTypeFromTypeCallNode(node: TypeCallTypeNode): Type {
+            const fn = typeNodeToExpression(node.type);
+            const args = map(node.arguments, typeNodeToExpression);
+            const callExpr = createCall(fn, node.typeArguments, args);
+            return checkExpression(callExpr);
+        }
+
+        // null! as type
+        function typeNodeToExpression(type: TypeNode): Expression {
+            return createAsExpression(createNonNullExpression(createNull()), type);
+        }
+
         function createIndexedAccessType(objectType: Type, indexType: Type) {
             const type = <IndexedAccessType>createType(TypeFlags.IndexedAccess);
             type.objectType = objectType;
@@ -8010,6 +8022,8 @@ namespace ts {
                     return getTypeFromTypeLiteralOrFunctionOrConstructorTypeNode(node);
                 case SyntaxKind.TypeOperator:
                     return getTypeFromTypeOperatorNode(<TypeOperatorNode>node);
+                case SyntaxKind.TypeCall:
+                    return getTypeFromTypeCallNode(<TypeCallTypeNode>node);
                 case SyntaxKind.IndexedAccessType:
                     return getTypeFromIndexedAccessTypeNode(<IndexedAccessTypeNode>node);
                 case SyntaxKind.MappedType:
@@ -13247,7 +13261,7 @@ namespace ts {
                 return node.contextualType;
             }
             const parent = node.parent;
-            switch (parent.kind) {
+            switch (parent && parent.kind) {
                 case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.Parameter:
                 case SyntaxKind.PropertyDeclaration:
@@ -18782,7 +18796,7 @@ namespace ts {
             }
             const type = getTypeFromTypeReference(node);
             if (type !== unknownType) {
-                if (node.typeArguments) {
+                if (node.typeArguments　&& node.typeArguments.length) {
                     // Do type argument local checks only if referenced type is successfully resolved
                     forEach(node.typeArguments, checkSourceElement);
                     if (produceDiagnostics) {
@@ -24338,7 +24352,7 @@ namespace ts {
 
         function checkGrammarTypeArguments(node: Node, typeArguments: NodeArray<TypeNode>): boolean {
             return checkGrammarForDisallowedTrailingComma(typeArguments) ||
-                checkGrammarForAtLeastOneTypeArgument(node, typeArguments);
+                false && checkGrammarForAtLeastOneTypeArgument(node, typeArguments);
         }
 
         function checkGrammarForOmittedArgument(args: NodeArray<Expression>): boolean {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2208,6 +2208,10 @@
         "category": "Error",
         "code": 2713
     },
+    "Tuple type spreads may only be created from tuple types.": {
+        "category": "Error",
+        "code": 2714
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -753,6 +753,8 @@ namespace ts {
                     return emitPropertyAccessExpression(<PropertyAccessExpression>node);
                 case SyntaxKind.ElementAccessExpression:
                     return emitElementAccessExpression(<ElementAccessExpression>node);
+                case SyntaxKind.TypeCall:
+                    return emitTypeCall(<TypeCallTypeNode>node);
                 case SyntaxKind.CallExpression:
                     return emitCallExpression(<CallExpression>node);
                 case SyntaxKind.NewExpression:
@@ -1238,6 +1240,12 @@ namespace ts {
             write("[");
             emitExpression(node.argumentExpression);
             write("]");
+        }
+
+        function emitTypeCall(node: TypeCallTypeNode) {
+            emit(node.type);
+            emitTypeArguments(node, node.typeArguments);
+            emitList(node, node.arguments, ListFormat.CallExpressionArguments);
         }
 
         function emitCallExpression(node: CallExpression) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -697,6 +697,8 @@ namespace ts {
                     return emitShorthandPropertyAssignment(<ShorthandPropertyAssignment>node);
                 case SyntaxKind.SpreadAssignment:
                     return emitSpreadAssignment(node as SpreadAssignment);
+                case SyntaxKind.TypeSpread:
+                    return emitTypeSpread(node as TypeSpreadTypeNode);
 
                 // Enum
                 case SyntaxKind.EnumMember:
@@ -2198,6 +2200,13 @@ namespace ts {
             if (node.expression) {
                 write("...");
                 emitExpression(node.expression);
+            }
+        }
+
+        function emitTypeSpread(node: TypeSpreadTypeNode) {
+            if (node.type) {
+                write("...");
+                emit(node.type);
             }
         }
 

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2201,6 +2201,19 @@ namespace ts {
             : node;
     }
 
+    export function createTypeSpread(type: TypeNode) {
+        console.log("createTypeSpread");
+        const node = <TypeSpreadTypeNode>createSynthesizedNode(SyntaxKind.TypeSpread);
+        node.type = type !== undefined ? parenthesizeElementTypeMember(type) : undefined;
+        return node;
+    }
+
+    export function updateTypeSpread(node: TypeSpreadTypeNode, type: TypeNode) {
+        return node.type !== type
+            ? updateNode(createTypeSpread(type), node)
+            : node;
+    }
+
     // Enum
 
     export function createEnumMember(name: string | PropertyName, initializer?: Expression) {

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -888,6 +888,22 @@ namespace ts {
             : node;
     }
 
+    export function createTypeCall(type: TypeNode, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<TypeNode>) {
+        const node = <TypeCallTypeNode>createSynthesizedNode(SyntaxKind.TypeCall);
+        node.type = parenthesizeElementTypeMember(type);
+        node.typeArguments = asNodeArray(typeArguments);
+        node.arguments = parenthesizeElementTypeMembers(createNodeArray(argumentsArray));
+        return node;
+    }
+
+    export function updateTypeCall(node: TypeCallTypeNode, type: TypeNode, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<TypeNode>) {
+        return node.type !== type
+            || node.typeArguments !== typeArguments
+            || node.arguments !== argumentsArray
+            ? updateNode(createTypeCall(type, typeArguments, argumentsArray), node)
+            : node;
+    }
+
     export function createCall(expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression>) {
         const node = <CallExpression>createSynthesizedNode(SyntaxKind.CallExpression);
         node.expression = parenthesizeForAccess(expression);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4283,7 +4283,7 @@ namespace ts {
 
         function parseTypeArgumentList() {
             parseExpected(SyntaxKind.OpenParenToken);
-            const result = parseDelimitedList(ParsingContext.TypeArguments, parseType);
+            const result = parseDelimitedList(ParsingContext.TypeArguments, parseTupleElement);
             parseExpected(SyntaxKind.CloseParenToken);
             return result;
         }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -170,6 +170,10 @@ namespace ts {
             case SyntaxKind.ElementAccessExpression:
                 return visitNode(cbNode, (<ElementAccessExpression>node).expression) ||
                     visitNode(cbNode, (<ElementAccessExpression>node).argumentExpression);
+            case SyntaxKind.TypeCall:
+                return visitNode(cbNode, (<TypeCallTypeNode>node).type) ||
+                    visitNodes(cbNode, cbNodes, (<TypeCallTypeNode>node).typeArguments) ||
+                    visitNodes(cbNode, cbNodes, (<TypeCallTypeNode>node).arguments);
             case SyntaxKind.CallExpression:
             case SyntaxKind.NewExpression:
                 return visitNode(cbNode, (<CallExpression>node).expression) ||
@@ -2739,8 +2743,8 @@ namespace ts {
             return token() === SyntaxKind.CloseParenToken || isStartOfParameter() || isStartOfType();
         }
 
-        function parseJSDocPostfixTypeOrHigher(): TypeNode {
-            const type = parseNonArrayType();
+        function parseJSDocPostfixTypeOrHigher(typeNode?: TypeNode): TypeNode {
+            const type = typeNode || parseNonArrayType();
             const kind = getKind(token());
             if (!kind) return type;
             nextToken();
@@ -2762,8 +2766,8 @@ namespace ts {
             }
         }
 
-        function parseArrayTypeOrHigher(): TypeNode {
-            let type = parseJSDocPostfixTypeOrHigher();
+        function parseArrayTypeOrHigher(typeNode?: TypeNode): TypeNode {
+            let type = parseJSDocPostfixTypeOrHigher(typeNode);
             while (!scanner.hasPrecedingLineBreak() && parseOptional(SyntaxKind.OpenBracketToken)) {
                 if (isStartOfType()) {
                     const node = <IndexedAccessTypeNode>createNode(SyntaxKind.IndexedAccessType, type.pos);
@@ -2795,7 +2799,7 @@ namespace ts {
                 case SyntaxKind.KeyOfKeyword:
                     return parseTypeOperator(SyntaxKind.KeyOfKeyword);
             }
-            return parseArrayTypeOrHigher();
+            return parseTypeCallRest();
         }
 
         function parseUnionOrIntersectionType(kind: SyntaxKind.UnionType | SyntaxKind.IntersectionType, parseConstituentType: () => TypeNode, operator: SyntaxKind.BarToken | SyntaxKind.AmpersandToken): TypeNode {
@@ -4239,6 +4243,46 @@ namespace ts {
 
                 return <MemberExpression>expression;
             }
+        }
+
+        // type equivalent of parseCallExpressionRest
+        function parseTypeCallRest(type?: TypeNode): TypeNode {
+            while (true) {
+                type = parseArrayTypeOrHigher(type);
+                if (token() === SyntaxKind.LessThanToken) {
+                    // See if this is the start of a generic invocation.  If so, consume it and
+                    // keep checking for postfix expressions.  Otherwise, it's just a '<' that's
+                    // part of an arithmetic expression.  Break out so we consume it higher in the
+                    // stack.
+                    const typeArguments = tryParse(parseTypeArgumentsInExpression);
+                    if (!typeArguments) {
+                        return type;
+                    }
+
+                    const callExpr = <TypeCallTypeNode>createNode(SyntaxKind.TypeCall, type.pos);
+                    callExpr.type = type;
+                    callExpr.typeArguments = typeArguments;
+                    callExpr.arguments = parseTypeArgumentList();
+                    type = finishNode(callExpr);
+                    continue;
+                }
+                else if (token() === SyntaxKind.OpenParenToken) {
+                    const callExpr = <TypeCallTypeNode>createNode(SyntaxKind.TypeCall, type.pos);
+                    callExpr.type = type;
+                    callExpr.arguments = parseTypeArgumentList();
+                    type = finishNode(callExpr);
+                    continue;
+                }
+
+                return type;
+            }
+        }
+
+        function parseTypeArgumentList() {
+            parseExpected(SyntaxKind.OpenParenToken);
+            const result = parseDelimitedList(ParsingContext.TypeArguments, parseType);
+            parseExpected(SyntaxKind.CloseParenToken);
+            return result;
         }
 
         function parseCallExpressionRest(expression: LeftHandSideExpression): LeftHandSideExpression {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -85,6 +85,8 @@ namespace ts {
                     visitNode(cbNode, (<ShorthandPropertyAssignment>node).objectAssignmentInitializer);
             case SyntaxKind.SpreadAssignment:
                 return visitNode(cbNode, (<SpreadAssignment>node).expression);
+            case SyntaxKind.TypeSpread:
+                return visitNode(cbNode, (<TypeSpreadTypeNode>node).type);
             case SyntaxKind.Parameter:
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.PropertySignature:
@@ -1382,8 +1384,9 @@ namespace ts {
                 case ParsingContext.Parameters:
                     return isStartOfParameter();
                 case ParsingContext.TypeArguments:
-                case ParsingContext.TupleElementTypes:
                     return token() === SyntaxKind.CommaToken || isStartOfType();
+                case ParsingContext.TupleElementTypes:
+                    return token() === SyntaxKind.CommaToken || token() === SyntaxKind.DotDotDotToken || isStartOfType();
                 case ParsingContext.HeritageClauses:
                     return isHeritageClause();
                 case ParsingContext.ImportOrExportSpecifiers:
@@ -2589,7 +2592,7 @@ namespace ts {
 
         function parseTupleType(): TupleTypeNode {
             const node = <TupleTypeNode>createNode(SyntaxKind.TupleType);
-            node.elementTypes = parseBracketedList(ParsingContext.TupleElementTypes, parseType, SyntaxKind.OpenBracketToken, SyntaxKind.CloseBracketToken);
+            node.elementTypes = parseBracketedList(ParsingContext.TupleElementTypes, parseTupleElement, SyntaxKind.OpenBracketToken, SyntaxKind.CloseBracketToken);
             return finishNode(node);
         }
 
@@ -5202,6 +5205,19 @@ namespace ts {
             node.dotDotDotToken = parseOptionalToken(SyntaxKind.DotDotDotToken);
             node.name = parseIdentifierOrPattern();
             node.initializer = parseBindingElementInitializer(/*inParameter*/ false);
+            return finishNode(node);
+        }
+
+        function parseTupleElement(): TypeSpreadTypeNode | TypeNode {
+            return (token() === SyntaxKind.DotDotDotToken) ?
+                parseTypeSpread() :
+                parseType();
+        }
+
+        function parseTypeSpread(): TypeSpreadTypeNode {
+            const node = <TypeSpreadTypeNode>createNode(SyntaxKind.TypeSpread);
+            parseExpected(SyntaxKind.DotDotDotToken);
+            node.type = parseTypeOperatorOrHigher();
             return finishNode(node);
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -344,6 +344,7 @@ namespace ts {
         PropertyAssignment,
         ShorthandPropertyAssignment,
         SpreadAssignment,
+        TypeSpread,
 
         // Enum
         EnumMember,
@@ -951,7 +952,12 @@ namespace ts {
 
     export interface TupleTypeNode extends TypeNode {
         kind: SyntaxKind.TupleType;
-        elementTypes: NodeArray<TypeNode>;
+        elementTypes: NodeArray<TypeNode | TypeSpreadTypeNode>;
+    }
+
+    export interface TypeSpreadTypeNode extends TypeNode {
+        kind: SyntaxKind.TypeSpread;
+        type: TypeNode;
     }
 
     export type UnionOrIntersectionTypeNode = UnionTypeNode | IntersectionTypeNode;
@@ -3158,6 +3164,7 @@ namespace ts {
         NonPrimitive            = 1 << 24,  // intrinsic object type
         /* @internal */
         JsxAttributes           = 1 << 25,  // Jsx attributes type
+        TypeSpread              = 1 << 26,  // spread in tuple types
 
         /* @internal */
         Nullable = Undefined | Null,
@@ -3404,6 +3411,11 @@ namespace ts {
         objectType: Type;
         indexType: Type;
         constraint?: Type;
+    }
+
+    // type spread types (TypeFlags.TypeSpread)
+    export interface TypeSpreadType extends TypeVariable {
+        type: Type;
     }
 
     // keyof T types (TypeFlags.Index)

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -240,6 +240,7 @@ namespace ts {
         IndexedAccessType,
         MappedType,
         LiteralType,
+        TypeCall,
         // Binding patterns
         ObjectBindingPattern,
         ArrayBindingPattern,
@@ -398,7 +399,7 @@ namespace ts {
         FirstFutureReservedWord = ImplementsKeyword,
         LastFutureReservedWord = YieldKeyword,
         FirstTypeNode = TypePredicate,
-        LastTypeNode = LiteralType,
+        LastTypeNode = TypeCall,
         FirstPunctuation = OpenBraceToken,
         LastPunctuation = CaretEqualsToken,
         FirstToken = Unknown,
@@ -1493,6 +1494,13 @@ namespace ts {
         expression: LeftHandSideExpression;
         typeArguments?: NodeArray<TypeNode>;
         arguments: NodeArray<Expression>;
+    }
+
+    export interface TypeCallTypeNode extends TypeNode {
+        kind: SyntaxKind.TypeCall;
+        type: TypeNode;
+        typeArguments?: NodeArray<TypeNode>;
+        arguments: NodeArray<TypeNode>;
     }
 
     // see: https://tc39.github.io/ecma262/#prod-SuperCall

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4506,6 +4506,10 @@ namespace ts {
         return node.kind === SyntaxKind.SpreadAssignment;
     }
 
+    export function isTypeSpread(node: Node): node is TypeSpreadTypeNode {
+        return node.kind === SyntaxKind.TypeSpread;
+    }
+
     // Enum
 
     export function isEnumMember(node: Node): node is EnumMember {

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -446,6 +446,12 @@ namespace ts {
                     visitNode((<ElementAccessExpression>node).expression, visitor, isExpression),
                     visitNode((<ElementAccessExpression>node).argumentExpression, visitor, isExpression));
 
+            case SyntaxKind.TypeCall:
+                return updateTypeCall(<TypeCallTypeNode>node,
+                    visitNode((<TypeCallTypeNode>node).type, visitor, isTypeNode),
+                    nodesVisitor((<TypeCallTypeNode>node).typeArguments, visitor, isTypeNode),
+                    nodesVisitor((<TypeCallTypeNode>node).arguments, visitor, isTypeNode));
+
             case SyntaxKind.CallExpression:
                 return updateCall(<CallExpression>node,
                     visitNode((<CallExpression>node).expression, visitor, isExpression),
@@ -1389,6 +1395,10 @@ namespace ts {
 
             case SyntaxKind.SpreadAssignment:
                 result = reduceNode((<SpreadAssignment>node).expression, cbNode, result);
+                break;
+
+            case SyntaxKind.TypeCall:
+                result = reduceNode((<TypeCallTypeNode>node).type, cbNode, result);
                 break;
 
             // Enum

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -875,6 +875,10 @@ namespace ts {
                 return updateSpreadAssignment(<SpreadAssignment>node,
                     visitNode((<SpreadAssignment>node).expression, visitor, isExpression));
 
+            case SyntaxKind.TypeSpread:
+                return updateTypeSpread(<TypeSpreadTypeNode>node,
+                    visitNode((<TypeSpreadTypeNode>node).type, visitor, isTypeNode));
+
             // Enum
             case SyntaxKind.EnumMember:
                 return updateEnumMember(<EnumMember>node,
@@ -1399,6 +1403,10 @@ namespace ts {
 
             case SyntaxKind.TypeCall:
                 result = reduceNode((<TypeCallTypeNode>node).type, cbNode, result);
+                break;
+
+            case SyntaxKind.TypeSpread:
+                result = reduceNode((<TypeSpreadTypeNode>node).type, cbNode, result);
                 break;
 
             // Enum

--- a/tests/baselines/reference/arrayTypeOfTypeOf.errors.txt
+++ b/tests/baselines/reference/arrayTypeOfTypeOf.errors.txt
@@ -1,28 +1,16 @@
-tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts(6,5): error TS2322: Type 'number' is not assignable to type 'ArrayConstructor'.
-tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts(6,22): error TS1005: '=' expected.
-tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts(6,30): error TS1109: Expression expected.
-tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts(7,5): error TS2322: Type 'number' is not assignable to type 'ArrayConstructor'.
-tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts(7,22): error TS1005: '=' expected.
-tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts(7,32): error TS1109: Expression expected.
+tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts(6,30): error TS1005: '(' expected.
+tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts(7,32): error TS1005: '(' expected.
 
 
-==== tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts (6 errors) ====
+==== tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayTypeOfTypeOf.ts (2 errors) ====
     // array type cannot use typeof.
     
     var x = 1;
     var xs: typeof x[];  // Not an error.  This is equivalent to Array<typeof x>
     var xs2: typeof Array;
     var xs3: typeof Array<number>;
-        ~~~
-!!! error TS2322: Type 'number' is not assignable to type 'ArrayConstructor'.
-                         ~
-!!! error TS1005: '=' expected.
                                  ~
-!!! error TS1109: Expression expected.
+!!! error TS1005: '(' expected.
     var xs4: typeof Array<typeof x>;
-        ~~~
-!!! error TS2322: Type 'number' is not assignable to type 'ArrayConstructor'.
-                         ~
-!!! error TS1005: '=' expected.
                                    ~
-!!! error TS1109: Expression expected.
+!!! error TS1005: '(' expected.

--- a/tests/baselines/reference/arrayTypeOfTypeOf.js
+++ b/tests/baselines/reference/arrayTypeOfTypeOf.js
@@ -12,5 +12,5 @@ var xs4: typeof Array<typeof x>;
 var x = 1;
 var xs; // Not an error.  This is equivalent to Array<typeof x>
 var xs2;
-var xs3 = ;
-var xs4 = ;
+var xs3;
+var xs4;

--- a/tests/baselines/reference/invalidTypeOfTarget.errors.txt
+++ b/tests/baselines/reference/invalidTypeOfTarget.errors.txt
@@ -1,6 +1,8 @@
 tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(1,16): error TS1003: Identifier expected.
 tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(2,16): error TS1003: Identifier expected.
-tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(2,24): error TS1005: '=>' expected.
+tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(2,18): error TS1005: ',' expected.
+tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(2,20): error TS1134: Variable declaration expected.
+tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(2,24): error TS1109: Expression expected.
 tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(3,16): error TS1003: Identifier expected.
 tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(4,16): error TS1003: Identifier expected.
 tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(5,16): error TS1003: Identifier expected.
@@ -12,15 +14,19 @@ tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts
 tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts(8,16): error TS1003: Identifier expected.
 
 
-==== tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts (12 errors) ====
+==== tests/cases/conformance/types/specifyingTypes/typeQueries/invalidTypeOfTarget.ts (14 errors) ====
     var x1: typeof {};
                    ~
 !!! error TS1003: Identifier expected.
     var x2: typeof (): void;
                    ~
 !!! error TS1003: Identifier expected.
+                     ~
+!!! error TS1005: ',' expected.
+                       ~~~~
+!!! error TS1134: Variable declaration expected.
                            ~
-!!! error TS1005: '=>' expected.
+!!! error TS1109: Expression expected.
     var x3: typeof 1;
                    ~
 !!! error TS1003: Identifier expected.

--- a/tests/baselines/reference/invalidTypeOfTarget.js
+++ b/tests/baselines/reference/invalidTypeOfTarget.js
@@ -10,7 +10,8 @@ var x8: typeof /123/;
 
 //// [invalidTypeOfTarget.js]
 var x1 = {};
-var x2 = function () { return ; };
+var x2;
+void ;
 var x3 = 1;
 var x4 = '';
 var x5;

--- a/tests/baselines/reference/overloadSelection.js
+++ b/tests/baselines/reference/overloadSelection.js
@@ -1,0 +1,12 @@
+//// [overloadSelection.ts]
+interface Match {
+  (o: object): 0;
+  (o: any): 1;
+}
+type Wrap = <T = RegExp>(v: T) => Match(T);
+type A = Wrap(RegExp);
+// falls thru to 1, `object` checked not with generic val `RegExp` but with its constraint (generic `any`)
+
+
+//// [overloadSelection.js]
+// falls thru to 1, `object` checked not with generic val `RegExp` but with its constraint (generic `any`)

--- a/tests/baselines/reference/overloadSelection.symbols
+++ b/tests/baselines/reference/overloadSelection.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/overloadSelection.ts ===
+interface Match {
+>Match : Symbol(Match, Decl(overloadSelection.ts, 0, 0))
+
+  (o: object): 0;
+>o : Symbol(o, Decl(overloadSelection.ts, 1, 3))
+
+  (o: any): 1;
+>o : Symbol(o, Decl(overloadSelection.ts, 2, 3))
+}
+type Wrap = <T = RegExp>(v: T) => Match(T);
+>Wrap : Symbol(Wrap, Decl(overloadSelection.ts, 3, 1))
+>T : Symbol(T, Decl(overloadSelection.ts, 4, 13))
+>RegExp : Symbol(RegExp, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>v : Symbol(v, Decl(overloadSelection.ts, 4, 25))
+>T : Symbol(T, Decl(overloadSelection.ts, 4, 13))
+>Match : Symbol(Match, Decl(overloadSelection.ts, 0, 0))
+>T : Symbol(T, Decl(overloadSelection.ts, 4, 13))
+
+type A = Wrap(RegExp);
+>A : Symbol(A, Decl(overloadSelection.ts, 4, 43))
+>Wrap : Symbol(Wrap, Decl(overloadSelection.ts, 3, 1))
+>RegExp : Symbol(RegExp, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+// falls thru to 1, `object` checked not with generic val `RegExp` but with its constraint (generic `any`)
+

--- a/tests/baselines/reference/overloadSelection.types
+++ b/tests/baselines/reference/overloadSelection.types
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/overloadSelection.ts ===
+interface Match {
+>Match : Match
+
+  (o: object): 0;
+>o : object
+
+  (o: any): 1;
+>o : any
+}
+type Wrap = <T = RegExp>(v: T) => Match(T);
+>Wrap : Wrap
+>T : T
+>RegExp : RegExp
+>v : T
+>T : T
+>Match : Match
+>T : T
+
+type A = Wrap(RegExp);
+>A : 1
+>Wrap : Wrap
+>RegExp : RegExp
+
+// falls thru to 1, `object` checked not with generic val `RegExp` but with its constraint (generic `any`)
+

--- a/tests/baselines/reference/parserObjectType5.errors.txt
+++ b/tests/baselines/reference/parserObjectType5.errors.txt
@@ -1,13 +1,16 @@
 tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType5.ts(2,7): error TS2304: Cannot find name 'B'.
+tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType5.ts(3,5): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType5.ts(3,7): error TS1005: '(' expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType5.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType5.ts (3 errors) ====
     var v: {
        A: B
           ~
 !!! error TS2304: Cannot find name 'B'.
        <T>;
+        ~
+!!! error TS2304: Cannot find name 'T'.
           ~
 !!! error TS1005: '(' expected.
     };

--- a/tests/baselines/reference/parserTypeQuery8.errors.txt
+++ b/tests/baselines/reference/parserTypeQuery8.errors.txt
@@ -1,16 +1,13 @@
 tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts(1,15): error TS2304: Cannot find name 'A'.
-tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts(1,16): error TS1005: '=' expected.
 tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts(1,17): error TS2304: Cannot find name 'B'.
-tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts(1,19): error TS1109: Expression expected.
+tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts(1,19): error TS1005: '(' expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts (4 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts (3 errors) ====
     var v: typeof A<B>
                   ~
 !!! error TS2304: Cannot find name 'A'.
-                   ~
-!!! error TS1005: '=' expected.
                     ~
 !!! error TS2304: Cannot find name 'B'.
                       
-!!! error TS1109: Expression expected.
+!!! error TS1005: '(' expected.

--- a/tests/baselines/reference/parserTypeQuery8.js
+++ b/tests/baselines/reference/parserTypeQuery8.js
@@ -2,4 +2,4 @@
 var v: typeof A<B>
 
 //// [parserTypeQuery8.js]
-var v = ;
+var v;

--- a/tests/baselines/reference/tupleTypeSpread.js
+++ b/tests/baselines/reference/tupleTypeSpread.js
@@ -1,0 +1,7 @@
+//// [tupleTypeSpread.ts]
+type a = [1, ...[2]];
+type Combine<Head, Tail extends any[]> = [Head, ...Tail];
+type b = Combine<1, [2, 3]>;
+
+
+//// [tupleTypeSpread.js]

--- a/tests/baselines/reference/tupleTypeSpread.symbols
+++ b/tests/baselines/reference/tupleTypeSpread.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/tupleTypeSpread.ts ===
+type a = [1, ...[2]];
+>a : Symbol(a, Decl(tupleTypeSpread.ts, 0, 0))
+
+type Combine<Head, Tail extends any[]> = [Head, ...Tail];
+>Combine : Symbol(Combine, Decl(tupleTypeSpread.ts, 0, 21))
+>Head : Symbol(Head, Decl(tupleTypeSpread.ts, 1, 13))
+>Tail : Symbol(Tail, Decl(tupleTypeSpread.ts, 1, 18))
+>Head : Symbol(Head, Decl(tupleTypeSpread.ts, 1, 13))
+>Tail : Symbol(Tail, Decl(tupleTypeSpread.ts, 1, 18))
+
+type b = Combine<1, [2, 3]>;
+>b : Symbol(b, Decl(tupleTypeSpread.ts, 1, 57))
+>Combine : Symbol(Combine, Decl(tupleTypeSpread.ts, 0, 21))
+

--- a/tests/baselines/reference/tupleTypeSpread.types
+++ b/tests/baselines/reference/tupleTypeSpread.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/tupleTypeSpread.ts ===
+type a = [1, ...[2]];
+>a : [1, 2]
+
+type Combine<Head, Tail extends any[]> = [Head, ...Tail];
+>Combine : [Head, ...Tail]
+>Head : Head
+>Tail : Tail
+>Head : Head
+>Tail : Tail
+
+type b = Combine<1, [2, 3]>;
+>b : [1, ...Tail]
+>Combine : [Head, ...Tail]
+

--- a/tests/baselines/reference/typeCall.js
+++ b/tests/baselines/reference/typeCall.js
@@ -1,0 +1,69 @@
+//// [typeCall.ts]
+type F1 = () => 1;
+type a = F1();
+
+type F2 = (a: string) => 1;
+type b = F2('foo');
+
+interface F3 {
+    (): 1;
+    (a: number): 2;
+    (a: string): 3;
+}
+type c = F3();
+type d = F3(123);
+type e = F3('foo');
+
+declare function f4(a: string): 1;
+let a = 'foo';
+type f = typeof f4(typeof a);
+
+type g = (() => 1)();
+
+type Id = <T>(v: T) => T;
+type h = Id(123);
+
+type Wrap<T> = Id(T);
+type i = Wrap<123>;
+
+type F5 = () => () => { a: () => 1; };
+type j = F5()()['a']();
+
+type k1 = Id<string>('foo'); // `any`, `<string>` is part of the type reference, not the function call
+type k2 = Id<><string>('foo'); // ok, `string`
+
+declare function id<T>(v: T): T;
+let l = id<string>('foo');
+
+interface IsPrimitive {
+  (o: object): '0';
+  (o: any): '1';
+}
+type stringIsPrimitive = IsPrimitive(string); // '1', ok
+type regexpIsPrimitive = IsPrimitive(RegExp); // '0', ok
+
+// explicit type arguments need to go after the type arguments of the type reference, empty `<>` if n/a
+type genericIsPrimitive = <T>() => IsPrimitive(T);
+type stringIsPrimitive2 = genericIsPrimitive<><string>(); // '1', ok
+type regexpIsPrimitive2 = genericIsPrimitive<><RegExp>();
+// FAILS!, '1' instead of '0', should delay overload selection until type argument is known
+
+// alternative, pass as parameters
+type genericIsPrimitive3 = <T>(v: T) => IsPrimitive(T);
+type stringIsPrimitive3 = genericIsPrimitive3(string); // '1', ok
+type regexpIsPrimitive3 = genericIsPrimitive3(RegExp)
+// FAILS!, '1' instead of '0', should delay overload selection until type argument is known
+
+type map = <Fn extends Function, O extends object>(fn: Fn, obj: O) => { [P in keyof O]: Fn(P) }; // Fn(O[P])
+type z = map(<T>(v: T) => [T], { a: 1, b: 2, c: 3 });
+
+// binary function composition, still fails
+type Fn1<T extends number> = (v: T[]) => { [k: string]: T };
+type Fn2<T> = (v: { [k: string]: T }) => ReadonlyArray<T>;
+type Fn3<T> = (v: T) => Fn2(Fn1(T));
+type Fn4 = Fn3(1);
+
+
+//// [typeCall.js]
+var a = 'foo';
+var l = id('foo');

--- a/tests/baselines/reference/typeCall.symbols
+++ b/tests/baselines/reference/typeCall.symbols
@@ -1,0 +1,213 @@
+=== tests/cases/compiler/typeCall.ts ===
+type F1 = () => 1;
+>F1 : Symbol(F1, Decl(typeCall.ts, 0, 0))
+
+type a = F1();
+>a : Symbol(a, Decl(typeCall.ts, 0, 18), Decl(typeCall.ts, 16, 3))
+>F1 : Symbol(F1, Decl(typeCall.ts, 0, 0))
+
+type F2 = (a: string) => 1;
+>F2 : Symbol(F2, Decl(typeCall.ts, 1, 14))
+>a : Symbol(a, Decl(typeCall.ts, 3, 11))
+
+type b = F2('foo');
+>b : Symbol(b, Decl(typeCall.ts, 3, 27))
+>F2 : Symbol(F2, Decl(typeCall.ts, 1, 14))
+
+interface F3 {
+>F3 : Symbol(F3, Decl(typeCall.ts, 4, 19))
+
+    (): 1;
+    (a: number): 2;
+>a : Symbol(a, Decl(typeCall.ts, 8, 5))
+
+    (a: string): 3;
+>a : Symbol(a, Decl(typeCall.ts, 9, 5))
+}
+type c = F3();
+>c : Symbol(c, Decl(typeCall.ts, 10, 1))
+>F3 : Symbol(F3, Decl(typeCall.ts, 4, 19))
+
+type d = F3(123);
+>d : Symbol(d, Decl(typeCall.ts, 11, 14))
+>F3 : Symbol(F3, Decl(typeCall.ts, 4, 19))
+
+type e = F3('foo');
+>e : Symbol(e, Decl(typeCall.ts, 12, 17))
+>F3 : Symbol(F3, Decl(typeCall.ts, 4, 19))
+
+declare function f4(a: string): 1;
+>f4 : Symbol(f4, Decl(typeCall.ts, 13, 19))
+>a : Symbol(a, Decl(typeCall.ts, 15, 20))
+
+let a = 'foo';
+>a : Symbol(a, Decl(typeCall.ts, 0, 18), Decl(typeCall.ts, 16, 3))
+
+type f = typeof f4(typeof a);
+>f : Symbol(f, Decl(typeCall.ts, 16, 14))
+>f4 : Symbol(f4, Decl(typeCall.ts, 13, 19))
+>a : Symbol(a, Decl(typeCall.ts, 0, 18), Decl(typeCall.ts, 16, 3))
+
+type g = (() => 1)();
+>g : Symbol(g, Decl(typeCall.ts, 17, 29))
+
+type Id = <T>(v: T) => T;
+>Id : Symbol(Id, Decl(typeCall.ts, 19, 21))
+>T : Symbol(T, Decl(typeCall.ts, 21, 11))
+>v : Symbol(v, Decl(typeCall.ts, 21, 14))
+>T : Symbol(T, Decl(typeCall.ts, 21, 11))
+>T : Symbol(T, Decl(typeCall.ts, 21, 11))
+
+type h = Id(123);
+>h : Symbol(h, Decl(typeCall.ts, 21, 25))
+>Id : Symbol(Id, Decl(typeCall.ts, 19, 21))
+
+type Wrap<T> = Id(T);
+>Wrap : Symbol(Wrap, Decl(typeCall.ts, 22, 17))
+>T : Symbol(T, Decl(typeCall.ts, 24, 10))
+>Id : Symbol(Id, Decl(typeCall.ts, 19, 21))
+>T : Symbol(T, Decl(typeCall.ts, 24, 10))
+
+type i = Wrap<123>;
+>i : Symbol(i, Decl(typeCall.ts, 24, 21))
+>Wrap : Symbol(Wrap, Decl(typeCall.ts, 22, 17))
+
+type F5 = () => () => { a: () => 1; };
+>F5 : Symbol(F5, Decl(typeCall.ts, 25, 19))
+>a : Symbol(a, Decl(typeCall.ts, 27, 23))
+
+type j = F5()()['a']();
+>j : Symbol(j, Decl(typeCall.ts, 27, 38))
+>F5 : Symbol(F5, Decl(typeCall.ts, 25, 19))
+
+type k1 = Id<string>('foo'); // `any`, `<string>` is part of the type reference, not the function call
+>k1 : Symbol(k1, Decl(typeCall.ts, 28, 23))
+>Id : Symbol(Id, Decl(typeCall.ts, 19, 21))
+
+type k2 = Id<><string>('foo'); // ok, `string`
+>k2 : Symbol(k2, Decl(typeCall.ts, 30, 28))
+>Id : Symbol(Id, Decl(typeCall.ts, 19, 21))
+
+declare function id<T>(v: T): T;
+>id : Symbol(id, Decl(typeCall.ts, 31, 30))
+>T : Symbol(T, Decl(typeCall.ts, 33, 20))
+>v : Symbol(v, Decl(typeCall.ts, 33, 23))
+>T : Symbol(T, Decl(typeCall.ts, 33, 20))
+>T : Symbol(T, Decl(typeCall.ts, 33, 20))
+
+let l = id<string>('foo');
+>l : Symbol(l, Decl(typeCall.ts, 34, 3))
+>id : Symbol(id, Decl(typeCall.ts, 31, 30))
+
+interface IsPrimitive {
+>IsPrimitive : Symbol(IsPrimitive, Decl(typeCall.ts, 34, 26))
+
+  (o: object): '0';
+>o : Symbol(o, Decl(typeCall.ts, 37, 3))
+
+  (o: any): '1';
+>o : Symbol(o, Decl(typeCall.ts, 38, 3))
+}
+type stringIsPrimitive = IsPrimitive(string); // '1', ok
+>stringIsPrimitive : Symbol(stringIsPrimitive, Decl(typeCall.ts, 39, 1))
+>IsPrimitive : Symbol(IsPrimitive, Decl(typeCall.ts, 34, 26))
+
+type regexpIsPrimitive = IsPrimitive(RegExp); // '0', ok
+>regexpIsPrimitive : Symbol(regexpIsPrimitive, Decl(typeCall.ts, 40, 45))
+>IsPrimitive : Symbol(IsPrimitive, Decl(typeCall.ts, 34, 26))
+>RegExp : Symbol(RegExp, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+// explicit type arguments need to go after the type arguments of the type reference, empty `<>` if n/a
+type genericIsPrimitive = <T>() => IsPrimitive(T);
+>genericIsPrimitive : Symbol(genericIsPrimitive, Decl(typeCall.ts, 41, 45))
+>T : Symbol(T, Decl(typeCall.ts, 44, 27))
+>IsPrimitive : Symbol(IsPrimitive, Decl(typeCall.ts, 34, 26))
+>T : Symbol(T, Decl(typeCall.ts, 44, 27))
+
+type stringIsPrimitive2 = genericIsPrimitive<><string>(); // '1', ok
+>stringIsPrimitive2 : Symbol(stringIsPrimitive2, Decl(typeCall.ts, 44, 50))
+>genericIsPrimitive : Symbol(genericIsPrimitive, Decl(typeCall.ts, 41, 45))
+
+type regexpIsPrimitive2 = genericIsPrimitive<><RegExp>();
+>regexpIsPrimitive2 : Symbol(regexpIsPrimitive2, Decl(typeCall.ts, 45, 57))
+>genericIsPrimitive : Symbol(genericIsPrimitive, Decl(typeCall.ts, 41, 45))
+>RegExp : Symbol(RegExp, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+// FAILS!, '1' instead of '0', should delay overload selection until type argument is known
+
+// alternative, pass as parameters
+type genericIsPrimitive3 = <T>(v: T) => IsPrimitive(T);
+>genericIsPrimitive3 : Symbol(genericIsPrimitive3, Decl(typeCall.ts, 46, 57))
+>T : Symbol(T, Decl(typeCall.ts, 50, 28))
+>v : Symbol(v, Decl(typeCall.ts, 50, 31))
+>T : Symbol(T, Decl(typeCall.ts, 50, 28))
+>IsPrimitive : Symbol(IsPrimitive, Decl(typeCall.ts, 34, 26))
+>T : Symbol(T, Decl(typeCall.ts, 50, 28))
+
+type stringIsPrimitive3 = genericIsPrimitive3(string); // '1', ok
+>stringIsPrimitive3 : Symbol(stringIsPrimitive3, Decl(typeCall.ts, 50, 55))
+>genericIsPrimitive3 : Symbol(genericIsPrimitive3, Decl(typeCall.ts, 46, 57))
+
+type regexpIsPrimitive3 = genericIsPrimitive3(RegExp)
+>regexpIsPrimitive3 : Symbol(regexpIsPrimitive3, Decl(typeCall.ts, 51, 54))
+>genericIsPrimitive3 : Symbol(genericIsPrimitive3, Decl(typeCall.ts, 46, 57))
+>RegExp : Symbol(RegExp, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+// FAILS!, '1' instead of '0', should delay overload selection until type argument is known
+
+type map = <Fn extends Function, O extends object>(fn: Fn, obj: O) => { [P in keyof O]: Fn(P) }; // Fn(O[P])
+>map : Symbol(map, Decl(typeCall.ts, 52, 53))
+>Fn : Symbol(Fn, Decl(typeCall.ts, 55, 12))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>O : Symbol(O, Decl(typeCall.ts, 55, 32))
+>fn : Symbol(fn, Decl(typeCall.ts, 55, 51))
+>Fn : Symbol(Fn, Decl(typeCall.ts, 55, 12))
+>obj : Symbol(obj, Decl(typeCall.ts, 55, 58))
+>O : Symbol(O, Decl(typeCall.ts, 55, 32))
+>P : Symbol(P, Decl(typeCall.ts, 55, 73))
+>O : Symbol(O, Decl(typeCall.ts, 55, 32))
+>Fn : Symbol(Fn, Decl(typeCall.ts, 55, 12))
+>P : Symbol(P, Decl(typeCall.ts, 55, 73))
+
+type z = map(<T>(v: T) => [T], { a: 1, b: 2, c: 3 });
+>z : Symbol(z, Decl(typeCall.ts, 55, 96))
+>map : Symbol(map, Decl(typeCall.ts, 52, 53))
+>T : Symbol(T, Decl(typeCall.ts, 56, 14))
+>v : Symbol(v, Decl(typeCall.ts, 56, 17))
+>T : Symbol(T, Decl(typeCall.ts, 56, 14))
+>T : Symbol(T, Decl(typeCall.ts, 56, 14))
+>a : Symbol(a, Decl(typeCall.ts, 56, 32))
+>b : Symbol(b, Decl(typeCall.ts, 56, 38))
+>c : Symbol(c, Decl(typeCall.ts, 56, 44))
+
+// binary function composition, still fails
+type Fn1<T extends number> = (v: T[]) => { [k: string]: T };
+>Fn1 : Symbol(Fn1, Decl(typeCall.ts, 56, 53))
+>T : Symbol(T, Decl(typeCall.ts, 59, 9))
+>v : Symbol(v, Decl(typeCall.ts, 59, 30))
+>T : Symbol(T, Decl(typeCall.ts, 59, 9))
+>k : Symbol(k, Decl(typeCall.ts, 59, 44))
+>T : Symbol(T, Decl(typeCall.ts, 59, 9))
+
+type Fn2<T> = (v: { [k: string]: T }) => ReadonlyArray<T>;
+>Fn2 : Symbol(Fn2, Decl(typeCall.ts, 59, 60))
+>T : Symbol(T, Decl(typeCall.ts, 60, 9))
+>v : Symbol(v, Decl(typeCall.ts, 60, 15))
+>k : Symbol(k, Decl(typeCall.ts, 60, 21))
+>T : Symbol(T, Decl(typeCall.ts, 60, 9))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(typeCall.ts, 60, 9))
+
+type Fn3<T> = (v: T) => Fn2(Fn1(T));
+>Fn3 : Symbol(Fn3, Decl(typeCall.ts, 60, 58))
+>T : Symbol(T, Decl(typeCall.ts, 61, 9))
+>v : Symbol(v, Decl(typeCall.ts, 61, 15))
+>T : Symbol(T, Decl(typeCall.ts, 61, 9))
+>Fn2 : Symbol(Fn2, Decl(typeCall.ts, 59, 60))
+>Fn1 : Symbol(Fn1, Decl(typeCall.ts, 56, 53))
+>T : Symbol(T, Decl(typeCall.ts, 61, 9))
+
+type Fn4 = Fn3(1);
+>Fn4 : Symbol(Fn4, Decl(typeCall.ts, 61, 36))
+>Fn3 : Symbol(Fn3, Decl(typeCall.ts, 60, 58))
+

--- a/tests/baselines/reference/typeCall.types
+++ b/tests/baselines/reference/typeCall.types
@@ -1,0 +1,216 @@
+=== tests/cases/compiler/typeCall.ts ===
+type F1 = () => 1;
+>F1 : F1
+
+type a = F1();
+>a : 1
+>F1 : F1
+
+type F2 = (a: string) => 1;
+>F2 : F2
+>a : string
+
+type b = F2('foo');
+>b : 1
+>F2 : F2
+
+interface F3 {
+>F3 : F3
+
+    (): 1;
+    (a: number): 2;
+>a : number
+
+    (a: string): 3;
+>a : string
+}
+type c = F3();
+>c : 1
+>F3 : F3
+
+type d = F3(123);
+>d : 2
+>F3 : F3
+
+type e = F3('foo');
+>e : 3
+>F3 : F3
+
+declare function f4(a: string): 1;
+>f4 : (a: string) => 1
+>a : string
+
+let a = 'foo';
+>a : string
+>'foo' : "foo"
+
+type f = typeof f4(typeof a);
+>f : 1
+>f4 : (a: string) => 1
+>a : string
+
+type g = (() => 1)();
+>g : 1
+
+type Id = <T>(v: T) => T;
+>Id : Id
+>T : T
+>v : T
+>T : T
+>T : T
+
+type h = Id(123);
+>h : 123
+>Id : Id
+
+type Wrap<T> = Id(T);
+>Wrap : T
+>T : T
+>Id : Id
+>T : T
+
+type i = Wrap<123>;
+>i : 123
+>Wrap : T
+
+type F5 = () => () => { a: () => 1; };
+>F5 : F5
+>a : () => 1
+
+type j = F5()()['a']();
+>j : 1
+>F5 : F5
+
+type k1 = Id<string>('foo'); // `any`, `<string>` is part of the type reference, not the function call
+>k1 : any
+>Id : Id
+
+type k2 = Id<><string>('foo'); // ok, `string`
+>k2 : string
+>Id : Id
+
+declare function id<T>(v: T): T;
+>id : <T>(v: T) => T
+>T : T
+>v : T
+>T : T
+>T : T
+
+let l = id<string>('foo');
+>l : string
+>id<string>('foo') : string
+>id : <T>(v: T) => T
+>'foo' : "foo"
+
+interface IsPrimitive {
+>IsPrimitive : IsPrimitive
+
+  (o: object): '0';
+>o : object
+
+  (o: any): '1';
+>o : any
+}
+type stringIsPrimitive = IsPrimitive(string); // '1', ok
+>stringIsPrimitive : "1"
+>IsPrimitive : IsPrimitive
+
+type regexpIsPrimitive = IsPrimitive(RegExp); // '0', ok
+>regexpIsPrimitive : "1"
+>IsPrimitive : IsPrimitive
+>RegExp : RegExp
+
+// explicit type arguments need to go after the type arguments of the type reference, empty `<>` if n/a
+type genericIsPrimitive = <T>() => IsPrimitive(T);
+>genericIsPrimitive : genericIsPrimitive
+>T : T
+>IsPrimitive : IsPrimitive
+>T : T
+
+type stringIsPrimitive2 = genericIsPrimitive<><string>(); // '1', ok
+>stringIsPrimitive2 : "1"
+>genericIsPrimitive : genericIsPrimitive
+
+type regexpIsPrimitive2 = genericIsPrimitive<><RegExp>();
+>regexpIsPrimitive2 : "1"
+>genericIsPrimitive : genericIsPrimitive
+>RegExp : RegExp
+
+// FAILS!, '1' instead of '0', should delay overload selection until type argument is known
+
+// alternative, pass as parameters
+type genericIsPrimitive3 = <T>(v: T) => IsPrimitive(T);
+>genericIsPrimitive3 : genericIsPrimitive3
+>T : T
+>v : T
+>T : T
+>IsPrimitive : IsPrimitive
+>T : T
+
+type stringIsPrimitive3 = genericIsPrimitive3(string); // '1', ok
+>stringIsPrimitive3 : "1"
+>genericIsPrimitive3 : genericIsPrimitive3
+
+type regexpIsPrimitive3 = genericIsPrimitive3(RegExp)
+>regexpIsPrimitive3 : "1"
+>genericIsPrimitive3 : genericIsPrimitive3
+>RegExp : RegExp
+
+// FAILS!, '1' instead of '0', should delay overload selection until type argument is known
+
+type map = <Fn extends Function, O extends object>(fn: Fn, obj: O) => { [P in keyof O]: Fn(P) }; // Fn(O[P])
+>map : map
+>Fn : Fn
+>Function : Function
+>O : O
+>fn : Fn
+>Fn : Fn
+>obj : O
+>O : O
+>P : P
+>O : O
+>Fn : Fn
+>P : P
+
+type z = map(<T>(v: T) => [T], { a: 1, b: 2, c: 3 });
+>z : { a: any; b: any; c: any; }
+>map : map
+>T : T
+>v : T
+>T : T
+>T : T
+>a : 1
+>b : 2
+>c : 3
+
+// binary function composition, still fails
+type Fn1<T extends number> = (v: T[]) => { [k: string]: T };
+>Fn1 : Fn1<T>
+>T : T
+>v : T[]
+>T : T
+>k : string
+>T : T
+
+type Fn2<T> = (v: { [k: string]: T }) => ReadonlyArray<T>;
+>Fn2 : Fn2<T>
+>T : T
+>v : { [k: string]: T; }
+>k : string
+>T : T
+>ReadonlyArray : ReadonlyArray<T>
+>T : T
+
+type Fn3<T> = (v: T) => Fn2(Fn1(T));
+>Fn3 : Fn3<T>
+>T : T
+>v : T
+>T : T
+>Fn2 : Fn2<T>
+>Fn1 : Fn1<T>
+>T : T
+
+type Fn4 = Fn3(1);
+>Fn4 : any
+>Fn3 : Fn3<T>
+

--- a/tests/baselines/reference/typeCallSpreads.errors.txt
+++ b/tests/baselines/reference/typeCallSpreads.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/typeCallSpreads.ts(2,13): error TS1005: ')' expected.
+tests/cases/compiler/typeCallSpreads.ts(2,19): error TS1005: ';' expected.
+
+
+==== tests/cases/compiler/typeCallSpreads.ts (2 errors) ====
+    type Fn = <T>(v: T) => T;
+    type a = Fn(...[1]);
+                ~~~
+!!! error TS1005: ')' expected.
+                      ~
+!!! error TS1005: ';' expected.
+    

--- a/tests/baselines/reference/typeCallSpreads.js
+++ b/tests/baselines/reference/typeCallSpreads.js
@@ -1,0 +1,8 @@
+//// [typeCallSpreads.ts]
+type Fn = <T>(v: T) => T;
+type a = Fn(...[1]);
+
+
+//// [typeCallSpreads.js]
+[1];
+;

--- a/tests/cases/compiler/overloadSelection.ts
+++ b/tests/cases/compiler/overloadSelection.ts
@@ -1,0 +1,9 @@
+// @allowSyntheticDefaultImports: true
+
+interface Match {
+  (o: object): 0;
+  (o: any): 1;
+}
+type Wrap = <T = RegExp>(v: T) => Match(T);
+type A = Wrap(RegExp);
+// falls thru to 1, `object` checked not with generic val `RegExp` but with its constraint (generic `any`)

--- a/tests/cases/compiler/tupleTypeSpread.ts
+++ b/tests/cases/compiler/tupleTypeSpread.ts
@@ -1,0 +1,4 @@
+// @allowSyntheticDefaultImports: true
+type a = [1, ...[2]];
+type Combine<Head, Tail extends any[]> = [Head, ...Tail];
+type b = Combine<1, [2, 3]>;

--- a/tests/cases/compiler/typeCall.ts
+++ b/tests/cases/compiler/typeCall.ts
@@ -1,0 +1,65 @@
+// @allowSyntheticDefaultImports: true
+
+type F1 = () => 1;
+type a = F1();
+
+type F2 = (a: string) => 1;
+type b = F2('foo');
+
+interface F3 {
+    (): 1;
+    (a: number): 2;
+    (a: string): 3;
+}
+type c = F3();
+type d = F3(123);
+type e = F3('foo');
+
+declare function f4(a: string): 1;
+let a = 'foo';
+type f = typeof f4(typeof a);
+
+type g = (() => 1)();
+
+type Id = <T>(v: T) => T;
+type h = Id(123);
+
+type Wrap<T> = Id(T);
+type i = Wrap<123>;
+
+type F5 = () => () => { a: () => 1; };
+type j = F5()()['a']();
+
+type k1 = Id<string>('foo'); // `any`, `<string>` is part of the type reference, not the function call
+type k2 = Id<><string>('foo'); // ok, `string`
+
+declare function id<T>(v: T): T;
+let l = id<string>('foo');
+
+interface IsPrimitive {
+  (o: object): '0';
+  (o: any): '1';
+}
+type stringIsPrimitive = IsPrimitive(string); // '1', ok
+type regexpIsPrimitive = IsPrimitive(RegExp); // '0', ok
+
+// explicit type arguments need to go after the type arguments of the type reference, empty `<>` if n/a
+type genericIsPrimitive = <T>() => IsPrimitive(T);
+type stringIsPrimitive2 = genericIsPrimitive<><string>(); // '1', ok
+type regexpIsPrimitive2 = genericIsPrimitive<><RegExp>();
+// FAILS!, '1' instead of '0', should delay overload selection until type argument is known
+
+// alternative, pass as parameters
+type genericIsPrimitive3 = <T>(v: T) => IsPrimitive(T);
+type stringIsPrimitive3 = genericIsPrimitive3(string); // '1', ok
+type regexpIsPrimitive3 = genericIsPrimitive3(RegExp)
+// FAILS!, '1' instead of '0', should delay overload selection until type argument is known
+
+type map = <Fn extends Function, O extends object>(fn: Fn, obj: O) => { [P in keyof O]: Fn(P) }; // Fn(O[P])
+type z = map(<T>(v: T) => [T], { a: 1, b: 2, c: 3 });
+
+// binary function composition, still fails
+type Fn1<T extends number> = (v: T[]) => { [k: string]: T };
+type Fn2<T> = (v: { [k: string]: T }) => ReadonlyArray<T>;
+type Fn3<T> = (v: T) => Fn2(Fn1(T));
+type Fn4 = Fn3(1);

--- a/tests/cases/compiler/typeCallSpreads.ts
+++ b/tests/cases/compiler/typeCallSpreads.ts
@@ -1,0 +1,2 @@
+type Fn = <T>(v: T) => T;
+type a = Fn(...[1]);


### PR DESCRIPTION
This addresses the last sub-problem of #5453, `Fn(...Args)`, needed to effectively type `Function.prototype.bind`, `curry`, and `compose`.

Unlike my earlier PRs, this one is not independent: it hinges on #17961 (type calls), #17884 (type spread) and #18004 (tuple spread). The first 2/3 are included, so changes will look more cluttered here though new changes just span 10 lines over 2 functions.

I'll properly re-test this when those are ready -- now still broken.