### PR TITLE
Allow bang+dotdotdot as start of type

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2722,6 +2722,8 @@ namespace ts {
                 case SyntaxKind.ObjectKeyword:
                 case SyntaxKind.AsteriskToken:
                 case SyntaxKind.QuestionToken:
+                case SyntaxKind.ExclamationToken:
+                case SyntaxKind.DotDotDotToken:
                     return true;
                 case SyntaxKind.MinusToken:
                     return lookAhead(nextTokenIsNumericLiteral);

--- a/tests/baselines/reference/jsdocDisallowedInTypescript.errors.txt
+++ b/tests/baselines/reference/jsdocDisallowedInTypescript.errors.txt
@@ -12,9 +12,13 @@ tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(17,11): error TS802
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(18,17): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(19,5): error TS2322: Type 'undefined' is not assignable to type 'number | null'.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(19,17): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(21,16): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(22,16): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(23,17): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(24,17): error TS8020: JSDoc types can only be used inside documentation comments.
 
 
-==== tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts (14 errors) ====
+==== tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts (18 errors) ====
     // grammar error from checker
     var ara: Array.<number> = [1,2,3];
                   ~
@@ -62,4 +66,18 @@ tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(19,17): error TS802
 !!! error TS2322: Type 'undefined' is not assignable to type 'number | null'.
                     ~~~~~~~
 !!! error TS8020: JSDoc types can only be used inside documentation comments.
+    
+    var nns: Array<?number>;
+                   ~~~~~~~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+    var dns: Array<!number>;
+                   ~~~~~~~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+    var anys: Array<*>;
+                    ~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+    var vars: Array<...number>;
+                    ~~~~~~~~~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+    
     

--- a/tests/baselines/reference/jsdocDisallowedInTypescript.js
+++ b/tests/baselines/reference/jsdocDisallowedInTypescript.js
@@ -19,6 +19,12 @@ var most: !string = 'definite';
 var postfixdef: number! = 101;
 var postfixopt: number? = undefined;
 
+var nns: Array<?number>;
+var dns: Array<!number>;
+var anys: Array<*>;
+var vars: Array<...number>;
+
+
 
 //// [jsdocDisallowedInTypescript.js]
 "use strict";
@@ -40,3 +46,7 @@ var variadic = [true, false, true];
 var most = 'definite';
 var postfixdef = 101;
 var postfixopt = undefined;
+var nns;
+var dns;
+var anys;
+var vars;

--- a/tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts
+++ b/tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts
@@ -19,3 +19,9 @@ var variadic: ...boolean = [true, false, true];
 var most: !string = 'definite';
 var postfixdef: number! = 101;
 var postfixopt: number? = undefined;
+
+var nns: Array<?number>;
+var dns: Array<!number>;
+var anys: Array<*>;
+var vars: Array<...number>;
+


### PR DESCRIPTION
Followup to #17994; I realised that some other jsdoc types were also incorrectly disallowed in type argument lists.