### PR TITLE
Fix issue #16803 Do not report exports error on getters/setters

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2626,4 +2626,8 @@ namespace ts {
     export function isCheckJsEnabledForFile(sourceFile: SourceFile, compilerOptions: CompilerOptions) {
         return sourceFile.checkJsDirective ? sourceFile.checkJsDirective.enabled : compilerOptions.checkJs;
     }
+
+    export function and<T>(f: (arg: T) => boolean, g: (arg: T) => boolean) {
+        return (arg: T) => f(arg) && g(arg);
+    }
 }

--- a/tests/baselines/reference/exportEqualsClassNoRedeclarationError.js
+++ b/tests/baselines/reference/exportEqualsClassNoRedeclarationError.js
@@ -1,0 +1,19 @@
+//// [exportEqualsClassNoRedeclarationError.ts]
+class SomeClass {
+    static get someProp(): number {
+        return 0;
+    }
+
+    static set someProp(value: number) {}
+}
+export = SomeClass;
+
+//// [exportEqualsClassNoRedeclarationError.js]
+"use strict";
+class SomeClass {
+    static get someProp() {
+        return 0;
+    }
+    static set someProp(value) { }
+}
+module.exports = SomeClass;

--- a/tests/baselines/reference/exportEqualsClassNoRedeclarationError.symbols
+++ b/tests/baselines/reference/exportEqualsClassNoRedeclarationError.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/exportEqualsClassNoRedeclarationError.ts ===
+class SomeClass {
+>SomeClass : Symbol(SomeClass, Decl(exportEqualsClassNoRedeclarationError.ts, 0, 0))
+
+    static get someProp(): number {
+>someProp : Symbol(SomeClass.someProp, Decl(exportEqualsClassNoRedeclarationError.ts, 0, 17), Decl(exportEqualsClassNoRedeclarationError.ts, 3, 5))
+
+        return 0;
+    }
+
+    static set someProp(value: number) {}
+>someProp : Symbol(SomeClass.someProp, Decl(exportEqualsClassNoRedeclarationError.ts, 0, 17), Decl(exportEqualsClassNoRedeclarationError.ts, 3, 5))
+>value : Symbol(value, Decl(exportEqualsClassNoRedeclarationError.ts, 5, 24))
+}
+export = SomeClass;
+>SomeClass : Symbol(SomeClass, Decl(exportEqualsClassNoRedeclarationError.ts, 0, 0))
+

--- a/tests/baselines/reference/exportEqualsClassNoRedeclarationError.types
+++ b/tests/baselines/reference/exportEqualsClassNoRedeclarationError.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/exportEqualsClassNoRedeclarationError.ts ===
+class SomeClass {
+>SomeClass : SomeClass
+
+    static get someProp(): number {
+>someProp : number
+
+        return 0;
+>0 : 0
+    }
+
+    static set someProp(value: number) {}
+>someProp : number
+>value : number
+}
+export = SomeClass;
+>SomeClass : SomeClass
+

--- a/tests/baselines/reference/exportEqualsClassRedeclarationError.errors.txt
+++ b/tests/baselines/reference/exportEqualsClassRedeclarationError.errors.txt
@@ -1,0 +1,21 @@
+tests/cases/compiler/exportEqualsClassRedeclarationError.ts(2,16): error TS2300: Duplicate identifier 'someProp'.
+tests/cases/compiler/exportEqualsClassRedeclarationError.ts(6,16): error TS2300: Duplicate identifier 'someProp'.
+tests/cases/compiler/exportEqualsClassRedeclarationError.ts(7,16): error TS2300: Duplicate identifier 'someProp'.
+
+
+==== tests/cases/compiler/exportEqualsClassRedeclarationError.ts (3 errors) ====
+    class SomeClass {
+        static get someProp(): number {
+                   ~~~~~~~~
+!!! error TS2300: Duplicate identifier 'someProp'.
+            return 0;
+        }
+    
+        static set someProp(value: number) {}
+                   ~~~~~~~~
+!!! error TS2300: Duplicate identifier 'someProp'.
+        static set someProp(value: number) {}
+                   ~~~~~~~~
+!!! error TS2300: Duplicate identifier 'someProp'.
+    }
+    export = SomeClass;

--- a/tests/baselines/reference/exportEqualsClassRedeclarationError.js
+++ b/tests/baselines/reference/exportEqualsClassRedeclarationError.js
@@ -1,0 +1,21 @@
+//// [exportEqualsClassRedeclarationError.ts]
+class SomeClass {
+    static get someProp(): number {
+        return 0;
+    }
+
+    static set someProp(value: number) {}
+    static set someProp(value: number) {}
+}
+export = SomeClass;
+
+//// [exportEqualsClassRedeclarationError.js]
+"use strict";
+class SomeClass {
+    static get someProp() {
+        return 0;
+    }
+    static set someProp(value) { }
+    static set someProp(value) { }
+}
+module.exports = SomeClass;

--- a/tests/cases/compiler/exportEqualsClassNoRedeclarationError.ts
+++ b/tests/cases/compiler/exportEqualsClassNoRedeclarationError.ts
@@ -1,0 +1,10 @@
+// @target: es6
+// @module: commonjs
+class SomeClass {
+    static get someProp(): number {
+        return 0;
+    }
+
+    static set someProp(value: number) {}
+}
+export = SomeClass;

--- a/tests/cases/compiler/exportEqualsClassRedeclarationError.ts
+++ b/tests/cases/compiler/exportEqualsClassRedeclarationError.ts
@@ -1,0 +1,11 @@
+// @target: es6
+// @module: commonjs
+class SomeClass {
+    static get someProp(): number {
+        return 0;
+    }
+
+    static set someProp(value: number) {}
+    static set someProp(value: number) {}
+}
+export = SomeClass;


### PR DESCRIPTION
Fixes #16803 

Simply excludes accessors from the declaration count - any location where they may be part of a module's exports would already have a duplicate identifier error reported were they repeated.
