### PR TITLE
Fix crash when attempting to merge an import with a local declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19151,6 +19151,8 @@ namespace ts {
                             : DeclarationSpaces.ExportNamespace;
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.EnumDeclaration:
+                    // A NamespaceImport declares an Alias, which is allowed to merge with other values within the module
+                    case SyntaxKind.NamespaceImport:
                         return DeclarationSpaces.ExportType | DeclarationSpaces.ExportValue;
                     case SyntaxKind.ImportEqualsDeclaration:
                         let result = DeclarationSpaces.None;

--- a/tests/baselines/reference/noCrashOnImportShadowing.errors.txt
+++ b/tests/baselines/reference/noCrashOnImportShadowing.errors.txt
@@ -11,6 +11,10 @@ tests/cases/compiler/index.ts(9,10): error TS2304: Cannot find name 'OriginalB'.
     interface B {
         x: string;
     }
+    
+    const x: B = { x: "" };
+    B.zzz;
+    
     export { B };
     
 ==== tests/cases/compiler/index.ts (2 errors) ====

--- a/tests/baselines/reference/noCrashOnImportShadowing.errors.txt
+++ b/tests/baselines/reference/noCrashOnImportShadowing.errors.txt
@@ -1,0 +1,29 @@
+tests/cases/compiler/index.ts(4,1): error TS2693: 'B' only refers to a type, but is being used as a value here.
+tests/cases/compiler/index.ts(9,10): error TS2304: Cannot find name 'OriginalB'.
+
+
+==== tests/cases/compiler/b.ts (0 errors) ====
+    export const zzz = 123;
+    
+==== tests/cases/compiler/a.ts (0 errors) ====
+    import * as B from "./b";
+    
+    interface B {
+        x: string;
+    }
+    export { B };
+    
+==== tests/cases/compiler/index.ts (2 errors) ====
+    import { B } from "./a";
+    
+    const x: B = { x: "" };
+    B.zzz;
+    ~
+!!! error TS2693: 'B' only refers to a type, but is being used as a value here.
+    
+    import * as OriginalB from "./b";
+    OriginalB.zzz;
+    
+    const y: OriginalB = x;
+             ~~~~~~~~~
+!!! error TS2304: Cannot find name 'OriginalB'.

--- a/tests/baselines/reference/noCrashOnImportShadowing.js
+++ b/tests/baselines/reference/noCrashOnImportShadowing.js
@@ -9,6 +9,10 @@ import * as B from "./b";
 interface B {
     x: string;
 }
+
+const x: B = { x: "" };
+B.zzz;
+
 export { B };
 
 //// [index.ts]
@@ -29,6 +33,9 @@ exports.zzz = 123;
 //// [a.js]
 "use strict";
 exports.__esModule = true;
+var B = require("./b");
+var x = { x: "" };
+B.zzz;
 //// [index.js]
 "use strict";
 exports.__esModule = true;

--- a/tests/baselines/reference/noCrashOnImportShadowing.js
+++ b/tests/baselines/reference/noCrashOnImportShadowing.js
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/noCrashOnImportShadowing.ts] ////
+
+//// [b.ts]
+export const zzz = 123;
+
+//// [a.ts]
+import * as B from "./b";
+
+interface B {
+    x: string;
+}
+export { B };
+
+//// [index.ts]
+import { B } from "./a";
+
+const x: B = { x: "" };
+B.zzz;
+
+import * as OriginalB from "./b";
+OriginalB.zzz;
+
+const y: OriginalB = x;
+
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+exports.zzz = 123;
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var x = { x: "" };
+B.zzz;
+var OriginalB = require("./b");
+OriginalB.zzz;
+var y = x;

--- a/tests/cases/compiler/noCrashOnImportShadowing.ts
+++ b/tests/cases/compiler/noCrashOnImportShadowing.ts
@@ -7,6 +7,10 @@ import * as B from "./b";
 interface B {
     x: string;
 }
+
+const x: B = { x: "" };
+B.zzz;
+
 export { B };
 
 // @filename: index.ts

--- a/tests/cases/compiler/noCrashOnImportShadowing.ts
+++ b/tests/cases/compiler/noCrashOnImportShadowing.ts
@@ -1,0 +1,21 @@
+// @filename: b.ts
+export const zzz = 123;
+
+// @filename: a.ts
+import * as B from "./b";
+
+interface B {
+    x: string;
+}
+export { B };
+
+// @filename: index.ts
+import { B } from "./a";
+
+const x: B = { x: "" };
+B.zzz;
+
+import * as OriginalB from "./b";
+OriginalB.zzz;
+
+const y: OriginalB = x;


### PR DESCRIPTION
Somewhere around #7591, we decided to allow aliases to merge with other symbols. A `NamespaceImport` is an alias symbol, so is able to merge with another symbol in the file. We no longer crash when you attempt this, as we now handle `NamespaceImport` in `getDeclarationSpaces`.

Fixes #17982
