### PR TITLE
union-proof the 'generic mapped type' check

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7690,7 +7690,7 @@ namespace ts {
             }
             const returnType = makeReturnType(typeParameters[0], typeParameters[1]);
             return createSignature(
-                /*declaration*/ null,
+                /*declaration*/ undefined,
                 /*typeParameters*/ typeParameters,
                 /*thisParameter*/ undefined,
                 /*parameters*/ properties,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7678,12 +7678,43 @@ namespace ts {
             return undefined;
         }
 
+        function binarySignature(makeReturnType: (a: Type, b: Type) => Type): Signature {
+            const typeParameters: TypeParameter[] = [];
+            const properties: Symbol[] = [];
+            for (let i = 0; i < 2; i++) {
+                const typeParameter = <TypeParameter>createType(TypeFlags.TypeParameter);
+                typeParameters.push(typeParameter);
+                const property = createSymbol(SymbolFlags.Property, "" + i as __String);
+                property.type = typeParameter;
+                properties.push(property);
+            }
+            const returnType = makeReturnType(typeParameters[0], typeParameters[1]);
+            return createSignature(
+                /*declaration*/ null,
+                /*typeParameters*/ typeParameters,
+                /*thisParameter*/ undefined,
+                /*parameters*/ properties,
+                /*resolvedReturnType*/ returnType,
+                /*typePredicate*/ undefined,
+                /*minArgumentCount*/ 2,
+                /*hasRestParameter*/ false,
+                /*hasLiteralTypes*/ true,
+            );
+        }
+
         function getIndexedAccessType(objectType: Type, indexType: Type, accessNode?: ElementAccessExpression | IndexedAccessTypeNode): Type {
             // If the object type is a mapped type { [P in K]: E }, where K is generic, we instantiate E using a mapper
             // that substitutes the index type for P. For example, for an index access { [P in K]: Box<T[P]> }[X], we
             // construct the type Box<T[X]>.
             if (isGenericMappedType(objectType)) {
-                return getIndexedAccessForMappedType(<MappedType>objectType, indexType, accessNode);
+                const innerType = binarySignature((a: Type, b: Type) => getIndexedAccessForMappedType(<MappedType>objectType, getUnionType([a, b])));
+                const outerType = binarySignature((a: Type, b: Type) => getUnionType([
+                    getIndexedAccessForMappedType(<MappedType>objectType, a),
+                    getIndexedAccessForMappedType(<MappedType>objectType, b),
+                ]));
+                if (compareSignaturesIdentical(innerType, outerType, /*partialMatch*/ false, /*ignoreThisTypes*/ true, /*ignoreReturnTypes*/ false, /*compareTypes*/ compareTypesIdentical)) {
+                    return getIndexedAccessForMappedType(<MappedType>objectType, indexType, accessNode);
+                }
             }
             // Otherwise, if the index type is generic, or if the object type is generic and doesn't originate in an
             // expression, we are performing a higher-order index access where we cannot meaningfully access the properties

--- a/tests/baselines/reference/keyofAndIndexedAccess.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccess.errors.txt
@@ -1,0 +1,560 @@
+tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts(524,9): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'any' has no compatible call signatures.
+
+
+==== tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts (1 errors) ====
+    class Shape {
+        name: string;
+        width: number;
+        height: number;
+        visible: boolean;
+    }
+    
+    class TaggedShape extends Shape {
+        tag: string;
+    }
+    
+    class Item {
+        name: string;
+        price: number;
+    }
+    
+    class Options {
+        visible: "yes" | "no";
+    }
+    
+    type Dictionary<T> = { [x: string]: T };
+    type NumericallyIndexed<T> = { [x: number]: T };
+    
+    const enum E { A, B, C }
+    
+    type K00 = keyof any;  // string
+    type K01 = keyof string;  // "toString" | "charAt" | ...
+    type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
+    type K03 = keyof boolean;  // "valueOf"
+    type K04 = keyof void;  // never
+    type K05 = keyof undefined;  // never
+    type K06 = keyof null;  // never
+    type K07 = keyof never;  // never
+    
+    type K10 = keyof Shape;  // "name" | "width" | "height" | "visible"
+    type K11 = keyof Shape[];  // "length" | "toString" | ...
+    type K12 = keyof Dictionary<Shape>;  // string
+    type K13 = keyof {};  // never
+    type K14 = keyof Object;  // "constructor" | "toString" | ...
+    type K15 = keyof E;  // "toString" | "toFixed" | "toExponential" | ...
+    type K16 = keyof [string, number];  // "0" | "1" | "length" | "toString" | ...
+    type K17 = keyof (Shape | Item);  // "name"
+    type K18 = keyof (Shape & Item);  // "name" | "width" | "height" | "visible" | "price"
+    type K19 = keyof NumericallyIndexed<Shape> // never
+    
+    type KeyOf<T> = keyof T;
+    
+    type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
+    type K21 = KeyOf<Dictionary<Shape>>;  // string
+    
+    type NAME = "name";
+    type WIDTH_OR_HEIGHT = "width" | "height";
+    
+    type Q10 = Shape["name"];  // string
+    type Q11 = Shape["width" | "height"];  // number
+    type Q12 = Shape["name" | "visible"];  // string | boolean
+    
+    type Q20 = Shape[NAME];  // string
+    type Q21 = Shape[WIDTH_OR_HEIGHT];  // number
+    
+    type Q30 = [string, number][0];  // string
+    type Q31 = [string, number][1];  // number
+    type Q32 = [string, number][2];  // string | number
+    type Q33 = [string, number][E.A];  // string
+    type Q34 = [string, number][E.B];  // number
+    type Q35 = [string, number][E.C];  // string | number
+    type Q36 = [string, number]["0"];  // string
+    type Q37 = [string, number]["1"];  // string
+    
+    type Q40 = (Shape | Options)["visible"];  // boolean | "yes" | "no"
+    type Q41 = (Shape & Options)["visible"];  // true & "yes" | true & "no" | false & "yes" | false & "no"
+    
+    type Q50 = Dictionary<Shape>["howdy"];  // Shape
+    type Q51 = Dictionary<Shape>[123];  // Shape
+    type Q52 = Dictionary<Shape>[E.B];  // Shape
+    
+    declare let cond: boolean;
+    
+    function getProperty<T, K extends keyof T>(obj: T, key: K) {
+        return obj[key];
+    }
+    
+    function setProperty<T, K extends keyof T>(obj: T, key: K, value: T[K]) {
+        obj[key] = value;
+    }
+    
+    function f10(shape: Shape) {
+        let name = getProperty(shape, "name");  // string
+        let widthOrHeight = getProperty(shape, cond ? "width" : "height");  // number
+        let nameOrVisible = getProperty(shape, cond ? "name" : "visible");  // string | boolean
+        setProperty(shape, "name", "rectangle");
+        setProperty(shape, cond ? "width" : "height", 10);
+        setProperty(shape, cond ? "name" : "visible", true);  // Technically not safe
+    }
+    
+    function f11(a: Shape[]) {
+        let len = getProperty(a, "length");  // number
+        setProperty(a, "length", len);
+    }
+    
+    function f12(t: [Shape, boolean]) {
+        let len = getProperty(t, "length");
+        let s2 = getProperty(t, "0");  // Shape
+        let b2 = getProperty(t, "1");  // boolean
+    }
+    
+    function f13(foo: any, bar: any) {
+        let x = getProperty(foo, "x");  // any
+        let y = getProperty(foo, "100");  // any
+        let z = getProperty(foo, bar);  // any
+    }
+    
+    class Component<PropType> {
+        props: PropType;
+        getProperty<K extends keyof PropType>(key: K) {
+            return this.props[key];
+        }
+        setProperty<K extends keyof PropType>(key: K, value: PropType[K]) {
+            this.props[key] = value;
+        }
+    }
+    
+    function f20(component: Component<Shape>) {
+        let name = component.getProperty("name");  // string
+        let widthOrHeight = component.getProperty(cond ? "width" : "height");  // number
+        let nameOrVisible = component.getProperty(cond ? "name" : "visible");  // string | boolean
+        component.setProperty("name", "rectangle");
+        component.setProperty(cond ? "width" : "height", 10)
+        component.setProperty(cond ? "name" : "visible", true);  // Technically not safe
+    }
+    
+    function pluck<T, K extends keyof T>(array: T[], key: K) {
+        return array.map(x => x[key]);
+    }
+    
+    function f30(shapes: Shape[]) {
+        let names = pluck(shapes, "name");    // string[]
+        let widths = pluck(shapes, "width");  // number[]
+        let nameOrVisibles = pluck(shapes, cond ? "name" : "visible");  // (string | boolean)[]
+    }
+    
+    function f31<K extends keyof Shape>(key: K) {
+        const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
+        return shape[key];  // Shape[K]
+    }
+    
+    function f32<K extends "width" | "height">(key: K) {
+        const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
+        return shape[key];  // Shape[K]
+    }
+    
+    function f33<S extends Shape, K extends keyof S>(shape: S, key: K) {
+        let name = getProperty(shape, "name");
+        let prop = getProperty(shape, key);
+        return prop;
+    }
+    
+    function f34(ts: TaggedShape) {
+        let tag1 = f33(ts, "tag");
+        let tag2 = getProperty(ts, "tag");
+    }
+    
+    class C {
+        public x: string;
+        protected y: string;
+        private z: string;
+    }
+    
+    // Indexed access expressions have always permitted access to private and protected members.
+    // For consistency we also permit such access in indexed access types.
+    function f40(c: C) {
+        type X = C["x"];
+        type Y = C["y"];
+        type Z = C["z"];
+        let x: X = c["x"];
+        let y: Y = c["y"];
+        let z: Z = c["z"];
+    }
+    
+    function f50<T>(k: keyof T, s: string) {
+        const x1 = s as keyof T;
+        const x2 = k as string;
+    }
+    
+    function f51<T, K extends keyof T>(k: K, s: string) {
+        const x1 = s as keyof T;
+        const x2 = k as string;
+    }
+    
+    function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {
+        const x1 = obj[s];
+        const x2 = obj[n];
+        const x3 = obj[k];
+    }
+    
+    function f53<T, K extends keyof T>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
+        const x1 = obj[s];
+        const x2 = obj[n];
+        const x3 = obj[k];
+    }
+    
+    function f54<T>(obj: T, key: keyof T) {
+        for (let s in obj[key]) {
+        }
+        const b = "foo" in obj[key];
+    }
+    
+    function f55<T, K extends keyof T>(obj: T, key: K) {
+        for (let s in obj[key]) {
+        }
+        const b = "foo" in obj[key];
+    }
+    
+    function f60<T>(source: T, target: T) {
+        for (let k in source) {
+            target[k] = source[k];
+        }
+    }
+    
+    function f70(func: <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void) {
+        func<{ a: any, b: any }, { a: any, c: any }>('a', 'a');
+        func<{ a: any, b: any }, { a: any, c: any }>('a', 'b');
+        func<{ a: any, b: any }, { a: any, c: any }>('a', 'c');
+    }
+    
+    function f71(func: <T, U>(x: T, y: U) => Partial<T & U>) {
+        let x = func({ a: 1, b: "hello" }, { c: true });
+        x.a;  // number | undefined
+        x.b;  // string | undefined
+        x.c;  // boolean | undefined
+    }
+    
+    function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T & U)[K]) {
+        let a = func({ a: 1, b: "hello" }, { c: true }, 'a');  // number
+        let b = func({ a: 1, b: "hello" }, { c: true }, 'b');  // string
+        let c = func({ a: 1, b: "hello" }, { c: true }, 'c');  // boolean
+    }
+    
+    function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[K]) {
+        let a = func({ a: 1, b: "hello" }, { c: true }, 'a');  // number
+        let b = func({ a: 1, b: "hello" }, { c: true }, 'b');  // string
+        let c = func({ a: 1, b: "hello" }, { c: true }, 'c');  // boolean
+    }
+    
+    function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[K]) {
+        let a = func({ a: 1, b: "hello" }, { a: 2, b: true }, 'a');  // number
+        let b = func({ a: 1, b: "hello" }, { a: 2, b: true }, 'b');  // string | boolean
+    }
+    
+    function f80<T extends { a: { x: any } }>(obj: T) {
+        let a1 = obj.a;  // { x: any }
+        let a2 = obj['a'];  // { x: any }
+        let a3 = obj['a'] as T['a'];  // T["a"]
+        let x1 = obj.a.x;  // any
+        let x2 = obj['a']['x'];  // any
+        let x3 = obj['a']['x'] as T['a']['x'];  // T["a"]["x"]
+    }
+    
+    function f81<T extends { a: { x: any } }>(obj: T) {
+        return obj['a']['x'] as T['a']['x'];
+    }
+    
+    function f82() {
+        let x1 = f81({ a: { x: "hello" } });  // string
+        let x2 = f81({ a: { x: 42 } });  // number
+    }
+    
+    function f83<T extends { [x: string]: { x: any } }, K extends keyof T>(obj: T, key: K) {
+        return obj[key]['x'] as T[K]['x'];
+    }
+    
+    function f84() {
+        let x1 = f83({ foo: { x: "hello" } }, "foo");  // string
+        let x2 = f83({ bar: { x: 42 } }, "bar");  // number
+    }
+    
+    class C1 {
+        x: number;
+        get<K extends keyof this>(key: K) {
+            return this[key];
+        }
+        set<K extends keyof this>(key: K, value: this[K]) {
+            this[key] = value;
+        }
+        foo() {
+            let x1 = this.x;  // number
+            let x2 = this["x"];  // number
+            let x3 = this.get("x");  // this["x"]
+            let x4 = getProperty(this, "x"); // this["x"]
+            this.x = 42;
+            this["x"] = 42;
+            this.set("x", 42);
+            setProperty(this, "x", 42);
+        }
+    }
+    
+    type S2 = {
+        a: string;
+        b: string;
+    };
+    
+    function f90<T extends S2, K extends keyof S2>(x1: S2[keyof S2], x2: T[keyof S2], x3: S2[K], x4: T[K]) {
+        x1 = x2;
+        x1 = x3;
+        x1 = x4;
+        x2 = x1;
+        x2 = x3;
+        x2 = x4;
+        x3 = x1;
+        x3 = x2;
+        x3 = x4;
+        x4 = x1;
+        x4 = x2;
+        x4 = x3;
+        x1.length;
+        x2.length;
+        x3.length;
+        x4.length;
+    }
+    
+    // Repros from #12011
+    
+    class Base {
+        get<K extends keyof this>(prop: K) {
+            return this[prop];
+        }
+        set<K extends keyof this>(prop: K, value: this[K]) {
+            this[prop] = value;
+        }
+    }
+    
+    class Person extends Base {
+        parts: number;
+        constructor(parts: number) {
+            super();
+            this.set("parts", parts);
+        }
+        getParts() {
+            return this.get("parts")
+        }
+    }
+    
+    class OtherPerson {
+        parts: number;
+        constructor(parts: number) {
+            setProperty(this, "parts", parts);
+        }
+        getParts() {
+            return getProperty(this, "parts")
+        }
+    }
+    
+    // Modified repro from #12544
+    
+    function path<T, K1 extends keyof T>(obj: T, key1: K1): T[K1];
+    function path<T, K1 extends keyof T, K2 extends keyof T[K1]>(obj: T, key1: K1, key2: K2): T[K1][K2];
+    function path<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(obj: T, key1: K1, key2: K2, key3: K3): T[K1][K2][K3];
+    function path(obj: any, ...keys: (string | number)[]): any;
+    function path(obj: any, ...keys: (string | number)[]): any {
+        let result = obj;
+        for (let k of keys) {
+            result = result[k];
+        }
+        return result;
+    }
+    
+    type Thing = {
+        a: { x: number, y: string },
+        b: boolean
+    };
+    
+    
+    function f1(thing: Thing) {
+        let x1 = path(thing, 'a');  // { x: number, y: string }
+        let x2 = path(thing, 'a', 'y');  // string
+        let x3 = path(thing, 'b');  // boolean
+        let x4 = path(thing, ...['a', 'x']);  // any
+    }
+    
+    // Repro from comment in #12114
+    
+    const assignTo2 = <T, K1 extends keyof T, K2 extends keyof T[K1]>(object: T, key1: K1, key2: K2) =>
+        (value: T[K1][K2]) => object[key1][key2] = value;
+    
+    // Modified repro from #12573
+    
+    declare function one<T>(handler: (t: T) => void): T
+    var empty = one(() => {}) // inferred as {}, expected
+    
+    type Handlers<T> = { [K in keyof T]: (t: T[K]) => void }
+    declare function on<T>(handlerHash: Handlers<T>): T
+    var hashOfEmpty1 = on({ test: () => {} });  // {}
+    var hashOfEmpty2 = on({ test: (x: boolean) => {} });  // { test: boolean }
+    
+    // Repro from #12624
+    
+    interface Options1<Data, Computed> {
+        data?: Data
+        computed?: Computed;
+    }
+    
+    declare class Component1<Data, Computed> {
+        constructor(options: Options1<Data, Computed>);
+        get<K extends keyof (Data & Computed)>(key: K): (Data & Computed)[K];
+    }
+    
+    let c1 = new Component1({
+        data: {
+            hello: ""
+        }
+    });
+    
+    c1.get("hello");
+    
+    // Repro from #12625
+    
+    interface Options2<Data, Computed> {
+        data?: Data
+        computed?: Computed;
+    }
+    
+    declare class Component2<Data, Computed> {
+        constructor(options: Options2<Data, Computed>);
+        get<K extends keyof Data | keyof Computed>(key: K): (Data & Computed)[K];
+    }
+    
+    // Repro from #12641
+    
+    interface R {
+        p: number;
+    }
+    
+    function f<K extends keyof R>(p: K) {
+        let a: any;
+        a[p].add;  // any
+    }
+    
+    // Repro from #12651
+    
+    type MethodDescriptor = {
+    	name: string;
+    	args: any[];
+    	returnValue: any;
+    }
+    
+    declare function dispatchMethod<M extends MethodDescriptor>(name: M['name'], args: M['args']): M['returnValue'];
+    
+    type SomeMethodDescriptor = {
+    	name: "someMethod";
+    	args: [string, number];
+    	returnValue: string[];
+    }
+    
+    let result = dispatchMethod<SomeMethodDescriptor>("someMethod", ["hello", 35]);
+    
+    // Repro from #13073
+    
+    type KeyTypes = "a" | "b"
+    let MyThingy: { [key in KeyTypes]: string[] };
+    
+    function addToMyThingy<S extends KeyTypes>(key: S) {
+        MyThingy[key].push("a");
+    }
+    
+    // Repro from #13102
+    
+    type Handler<T> = {
+        onChange: (name: keyof T) => void;
+    };
+    
+    function onChangeGenericFunction<T>(handler: Handler<T & {preset: number}>) {
+        handler.onChange('preset')
+    }
+    
+    // Repro from #13285
+    
+    function updateIds<T extends Record<K, string>, K extends string>(
+        obj: T,
+        idFields: K[],
+        idMapping: { [oldId: string]: string }
+    ): Record<K, string> {
+        for (const idField of idFields) {
+            const newId = idMapping[obj[idField]];
+            if (newId) {
+                obj[idField] = newId;
+            }
+        }
+        return obj;
+    }
+    
+    // Repro from #13285
+    
+    function updateIds2<T extends { [x: string]: string }, K extends keyof T>(
+        obj: T,
+        key: K,
+        stringMap: { [oldId: string]: string }
+    ) {
+        var x = obj[key];
+        stringMap[x]; // Should be OK.
+    }
+    
+    // Repro from #13514
+    
+    declare function head<T extends Array<any>>(list: T): T[0];
+    
+    // Repro from #13604
+    
+    class A<T> {
+    	props: T & { foo: string };
+    }
+    
+    class B extends A<{ x: number}> {
+    	f(p: this["props"]) {
+    		p.x;
+    	}
+    }
+    
+    // Repro from #13749
+    
+    class Form<T> {
+        private childFormFactories: {[K in keyof T]: (v: T[K]) => Form<T[K]>}
+    
+        public set<K extends keyof T>(prop: K, value: T[K]) {
+            this.childFormFactories[prop](value)
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'any' has no compatible call signatures.
+        }
+    }
+    
+    // Repro from #13787
+    
+    class SampleClass<P> {
+        public props: Readonly<P>;
+        constructor(props: P) {
+            this.props = Object.freeze(props);
+        }
+    }
+    
+    interface Foo {
+        foo: string;
+    }
+    
+    declare function merge<T, U>(obj1: T, obj2: U): T & U;
+    
+    class AnotherSampleClass<T> extends SampleClass<T & Foo> {
+        constructor(props: T) {
+            const foo: Foo = { foo: "bar" };
+            super(merge(props, foo));
+        }
+    
+        public brokenMethod() {
+            this.props.foo.concat;
+        }
+    }
+    new AnotherSampleClass({});
+    

--- a/tests/baselines/reference/unionProofGenericMappedType.errors.txt
+++ b/tests/baselines/reference/unionProofGenericMappedType.errors.txt
@@ -1,0 +1,45 @@
+tests/cases/compiler/unionProofGenericMappedType.ts(15,5): error TS2322: Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; } | { key: "bar"; value: number; }'.
+  Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; }'.
+    Types of property 'value' are incompatible.
+      Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/unionProofGenericMappedType.ts(20,5): error TS2322: Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; } | { key: "bar"; value: number; }'.
+  Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; }'.
+    Types of property 'value' are incompatible.
+      Type 'number' is not assignable to type 'string'.
+
+
+==== tests/cases/compiler/unionProofGenericMappedType.ts (2 errors) ====
+    type Pairs<T> = {
+        [TKey in keyof T]: {
+            key: TKey;
+            value: T[TKey];
+        };
+    };
+    
+    type Pair<T> = Pairs<T>[keyof T];
+    
+    type FooBar = {
+        foo: string;
+        bar: number;
+    };
+    
+    let pair1: Pair<FooBar> = {
+        ~~~~~
+!!! error TS2322: Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; } | { key: "bar"; value: number; }'.
+!!! error TS2322:   Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; }'.
+!!! error TS2322:     Types of property 'value' are incompatible.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+        key: "foo",
+        value: 3
+    }; // no compile error here
+    
+    let pair2: Pairs<FooBar>[keyof FooBar] = {
+        ~~~~~
+!!! error TS2322: Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; } | { key: "bar"; value: number; }'.
+!!! error TS2322:   Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; }'.
+!!! error TS2322:     Types of property 'value' are incompatible.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+        key: "foo",
+        value: 3
+    }; // this does cause a compile error
+    

--- a/tests/baselines/reference/unionProofGenericMappedType.js
+++ b/tests/baselines/reference/unionProofGenericMappedType.js
@@ -1,0 +1,35 @@
+//// [unionProofGenericMappedType.ts]
+type Pairs<T> = {
+    [TKey in keyof T]: {
+        key: TKey;
+        value: T[TKey];
+    };
+};
+
+type Pair<T> = Pairs<T>[keyof T];
+
+type FooBar = {
+    foo: string;
+    bar: number;
+};
+
+let pair1: Pair<FooBar> = {
+    key: "foo",
+    value: 3
+}; // no compile error here
+
+let pair2: Pairs<FooBar>[keyof FooBar] = {
+    key: "foo",
+    value: 3
+}; // this does cause a compile error
+
+
+//// [unionProofGenericMappedType.js]
+var pair1 = {
+    key: "foo",
+    value: 3
+}; // no compile error here
+var pair2 = {
+    key: "foo",
+    value: 3
+}; // this does cause a compile error

--- a/tests/cases/compiler/unionProofGenericMappedType.ts
+++ b/tests/cases/compiler/unionProofGenericMappedType.ts
@@ -1,0 +1,23 @@
+type Pairs<T> = {
+    [TKey in keyof T]: {
+        key: TKey;
+        value: T[TKey];
+    };
+};
+
+type Pair<T> = Pairs<T>[keyof T];
+
+type FooBar = {
+    foo: string;
+    bar: number;
+};
+
+let pair1: Pair<FooBar> = {
+    key: "foo",
+    value: 3
+}; // no compile error here
+
+let pair2: Pairs<FooBar>[keyof FooBar] = {
+    key: "foo",
+    value: 3
+}; // this does cause a compile error


### PR DESCRIPTION
Fixes #15756.

This incidentally also uncovered one other case (`Form` from `keyofAndIndexedAccess`) where generic mapped types had been applied in an unsound way w.r.t. union keys. That simplified heuristic worked there for the basic case of non-union types, but without it inference ended up no longer strong enough there.
That appears a piece of collateral damage here, though I'm under the impression the altered check here wasn't wrong about such reduction being unsound there.

To elaborate:
```ts
class Form<T> {
    private childFormFactories: {[K in keyof T]: (v: T[K]) => Form<T[K]>}

    public set<K extends keyof T>(prop: K, value: T[K]) {
        this.childFormFactories[prop](value)
    }
}
```

Reduction makes for `{[K in keyof T]: (v: T[K]) => Form<T[K]>}[K]` -> `(v: T[K]) => Form<T[K]>`. If one substitutes some union `A|B` for `K`, that makes for `(v: T[A|B]) => Form<T[A|B]>`, distinct from the (I believe) expected result here of `((v: T[A]) => Form<T[A]>) | ((v: T[B]) => Form<T[B]>)`. That's why I believe this reduction here was technically unsound even though it would have held for the base case of non-unions.
