### PR TITLE
Always use case-insensitive fs operartions for RWC

### DIFF
--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -70,6 +70,7 @@ interface IOLog {
         depth: number,
         result: ReadonlyArray<string>,
     }[];
+    useCaseSensitiveFileNames?: boolean;
 }
 
 interface PlaybackControl {
@@ -151,7 +152,7 @@ namespace Playback {
         wrapper.startRecord = (fileNameBase) => {
             recordLogFileNameBase = fileNameBase;
             recordLog = createEmptyLog();
-
+            recordLog.useCaseSensitiveFileNames = typeof underlying.useCaseSensitiveFileNames === "function" ? underlying.useCaseSensitiveFileNames() : underlying.useCaseSensitiveFileNames;
             if (typeof underlying.args !== "function") {
                 recordLog.arguments = underlying.args;
             }
@@ -249,6 +250,8 @@ namespace Playback {
             }
             underlying.exit(exitCode);
         };
+
+        wrapper.useCaseSensitiveFileNames = () => !!recordLog.useCaseSensitiveFileNames;
     }
 
     function recordReplay<T extends Function>(original: T, underlying: any) {

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -79,7 +79,7 @@ namespace RWC {
                         tsconfigFiles.push({ unitName: tsconfigFile.path, content: tsconfigFileContents.content });
                         const parsedTsconfigFileContents = ts.parseJsonText(tsconfigFile.path, tsconfigFileContents.content);
                         const configParseHost: ts.ParseConfigHost = {
-                            useCaseSensitiveFileNames: Harness.IO.useCaseSensitiveFileNames(),
+                            useCaseSensitiveFileNames: false,
                             fileExists: Harness.IO.fileExists,
                             readDirectory: Harness.IO.readDirectory,
                             readFile: Harness.IO.readFile

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -79,7 +79,7 @@ namespace RWC {
                         tsconfigFiles.push({ unitName: tsconfigFile.path, content: tsconfigFileContents.content });
                         const parsedTsconfigFileContents = ts.parseJsonText(tsconfigFile.path, tsconfigFileContents.content);
                         const configParseHost: ts.ParseConfigHost = {
-                            useCaseSensitiveFileNames: false,
+                            useCaseSensitiveFileNames: Harness.IO.useCaseSensitiveFileNames(),
                             fileExists: Harness.IO.fileExists,
                             readDirectory: Harness.IO.readDirectory,
                             readFile: Harness.IO.readFile


### PR DESCRIPTION
@sandersn Noted that on linux many RWC tests fail due to using the system case-sensitivity, rather than the sensitivity used when capturing the test. For now, we just assume all tests were captured on a case-insensitive file system, which should allow our linux developers to run the tests without spurious failures.
