### PR TITLE
Use isPartOfExpression in extractMethod, not isExpression

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4955,6 +4955,7 @@ namespace ts {
     export function isLeftHandSideExpression(node: Node): node is LeftHandSideExpression {
         return isLeftHandSideExpressionKind(skipPartiallyEmittedExpressions(node).kind);
     }
+
     function isLeftHandSideExpressionKind(kind: SyntaxKind): boolean {
         switch (kind) {
             case SyntaxKind.PropertyAccessExpression:
@@ -4993,6 +4994,7 @@ namespace ts {
     export function isUnaryExpression(node: Node): node is UnaryExpression {
         return isUnaryExpressionKind(skipPartiallyEmittedExpressions(node).kind);
     }
+
     function isUnaryExpressionKind(kind: SyntaxKind): boolean {
         switch (kind) {
             case SyntaxKind.PrefixUnaryExpression:
@@ -5029,6 +5031,7 @@ namespace ts {
     export function isExpression(node: Node): node is Expression {
         return isExpressionKind(skipPartiallyEmittedExpressions(node).kind);
     }
+
     function isExpressionKind(kind: SyntaxKind): boolean {
         switch (kind) {
             case SyntaxKind.ConditionalExpression:

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4953,7 +4953,10 @@ namespace ts {
 
     /* @internal */
     export function isLeftHandSideExpression(node: Node): node is LeftHandSideExpression {
-        switch (node.kind) {
+        return isLeftHandSideExpressionKind(skipPartiallyEmittedExpressions(node).kind);
+    }
+    function isLeftHandSideExpressionKind(kind: SyntaxKind): boolean {
+        switch (kind) {
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ElementAccessExpression:
             case SyntaxKind.NewExpression:
@@ -4979,11 +4982,8 @@ namespace ts {
             case SyntaxKind.SuperKeyword:
             case SyntaxKind.NonNullExpression:
             case SyntaxKind.MetaProperty:
+            case SyntaxKind.ImportKeyword: // technically this is only an Expression if it's in a CallExpression
                 return true;
-            case SyntaxKind.PartiallyEmittedExpression:
-                return isLeftHandSideExpression((node as PartiallyEmittedExpression).expression);
-            case SyntaxKind.ImportKeyword:
-                return node.parent.kind === SyntaxKind.CallExpression;
             default:
                 return false;
         }
@@ -4991,7 +4991,10 @@ namespace ts {
 
     /* @internal */
     export function isUnaryExpression(node: Node): node is UnaryExpression {
-        switch (node.kind) {
+        return isUnaryExpressionKind(skipPartiallyEmittedExpressions(node).kind);
+    }
+    function isUnaryExpressionKind(kind: SyntaxKind): boolean {
+        switch (kind) {
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
             case SyntaxKind.DeleteExpression:
@@ -5000,10 +5003,8 @@ namespace ts {
             case SyntaxKind.AwaitExpression:
             case SyntaxKind.TypeAssertionExpression:
                 return true;
-            case SyntaxKind.PartiallyEmittedExpression:
-                return isUnaryExpression((node as PartiallyEmittedExpression).expression);
             default:
-                return isLeftHandSideExpression(node);
+                return isLeftHandSideExpressionKind(kind);
         }
     }
 
@@ -5021,8 +5022,15 @@ namespace ts {
     }
 
     /* @internal */
+    /**
+     * Determines whether a node is an expression based only on its kind.
+     * Use `isPartOfExpression` if not in transforms.
+     */
     export function isExpression(node: Node): node is Expression {
-        switch (node.kind) {
+        return isExpressionKind(skipPartiallyEmittedExpressions(node).kind);
+    }
+    function isExpressionKind(kind: SyntaxKind): boolean {
+        switch (kind) {
             case SyntaxKind.ConditionalExpression:
             case SyntaxKind.YieldExpression:
             case SyntaxKind.ArrowFunction:
@@ -5034,7 +5042,7 @@ namespace ts {
             case SyntaxKind.PartiallyEmittedExpression:
                 return true;
             default:
-                return isUnaryExpression(node);
+                return isUnaryExpressionKind(kind);
         }
     }
 

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -278,7 +278,7 @@ namespace ts.refactor.extractMethod {
                 Continue = 1 << 1,
                 Return = 1 << 2
             }
-            if (!isStatement(nodeToCheck) && !(isExpression(nodeToCheck) && isExtractableExpression(nodeToCheck))) {
+            if (!isStatement(nodeToCheck) && !(isPartOfExpression(nodeToCheck) && isExtractableExpression(nodeToCheck))) {
                 return [createDiagnosticForNode(nodeToCheck, Messages.StatementOrExpressionExpected)];
             }
 
@@ -452,12 +452,12 @@ namespace ts.refactor.extractMethod {
         if (isStatement(node)) {
             return [node];
         }
-        else if (isExpression(node)) {
+        else if (isPartOfExpression(node)) {
             // If our selection is the expression in an ExpressionStatement, expand
             // the selection to include the enclosing Statement (this stops us
             // from trying to care about the return value of the extracted function
             // and eliminates double semicolon insertion in certain scenarios)
-            return isExpressionStatement(node.parent) ? [node.parent] : node;
+            return isExpressionStatement(node.parent) ? [node.parent] : node as Expression;
         }
         return undefined;
     }


### PR DESCRIPTION
This reverts the changes to `isExpression` from #18025. @rbuckton pointed out that we should be using `isPartOfExpression` outside of transforms, not `isExpression`, since `isExpression` shouldn't look at `node.parent`.