### PR TITLE
Move browser-resolve to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@types/run-sequence": "latest",
         "@types/through2": "latest",
         "browserify": "latest",
+        "browser-resolve": "^1.11.2",
         "chai": "latest",
         "convert-source-map": "latest",
         "del": "latest",
@@ -93,8 +94,5 @@
         "fs": false,
         "os": false,
         "path": false
-    },
-    "dependencies": {
-        "browser-resolve": "^1.11.2"
     }
 }


### PR DESCRIPTION
This was added in #17468 and is only used as part of a build script.