### PR TITLE
Fix the jsdoc codefix for VariableLike declarations

### DIFF
--- a/src/services/codefixes/fixJSDocTypes.ts
+++ b/src/services/codefixes/fixJSDocTypes.ts
@@ -8,11 +8,27 @@ namespace ts.codefix {
     function getActionsForJSDocTypes(context: CodeFixContext): CodeAction[] | undefined {
         const sourceFile = context.sourceFile;
         const node = getTokenAtPosition(sourceFile, context.span.start, /*includeJsDocComment*/ false);
+
+        // NOTE: Some locations are not handled yet:
+        // MappedTypeNode.typeParameters and SignatureDeclaration.typeParameters, as well as CallExpression.typeArguments
         const decl = ts.findAncestor(node,
-                                     n => n.kind === SyntaxKind.VariableDeclaration ||
+                                     n =>
+                                     n.kind === SyntaxKind.AsExpression ||
+                                     n.kind === SyntaxKind.CallSignature ||
+                                     n.kind === SyntaxKind.ConstructSignature ||
+                                     n.kind === SyntaxKind.FunctionDeclaration ||
+                                     n.kind === SyntaxKind.GetAccessor ||
+                                     n.kind === SyntaxKind.IndexSignature ||
+                                     n.kind === SyntaxKind.MappedType ||
+                                     n.kind === SyntaxKind.MethodDeclaration ||
+                                     n.kind === SyntaxKind.MethodSignature ||
                                      n.kind === SyntaxKind.Parameter ||
                                      n.kind === SyntaxKind.PropertyDeclaration ||
-                                     n.kind === SyntaxKind.PropertyAssignment);
+                                     n.kind === SyntaxKind.PropertySignature ||
+                                     n.kind === SyntaxKind.SetAccessor ||
+                                     n.kind === SyntaxKind.TypeAliasDeclaration ||
+                                     n.kind === SyntaxKind.TypeAssertionExpression ||
+                                     n.kind === SyntaxKind.VariableDeclaration);
         if (!decl) return;
         const checker = context.program.getTypeChecker();
 

--- a/src/services/codefixes/fixJSDocTypes.ts
+++ b/src/services/codefixes/fixJSDocTypes.ts
@@ -8,11 +8,16 @@ namespace ts.codefix {
     function getActionsForJSDocTypes(context: CodeFixContext): CodeAction[] | undefined {
         const sourceFile = context.sourceFile;
         const node = getTokenAtPosition(sourceFile, context.span.start, /*includeJsDocComment*/ false);
-        const decl = ts.findAncestor(node, n => n.kind === SyntaxKind.VariableDeclaration);
+        const decl = ts.findAncestor(node,
+                                     n => n.kind === SyntaxKind.VariableDeclaration ||
+                                     n.kind === SyntaxKind.Parameter ||
+                                     n.kind === SyntaxKind.PropertyDeclaration ||
+                                     n.kind === SyntaxKind.PropertyAssignment);
         if (!decl) return;
         const checker = context.program.getTypeChecker();
 
         const jsdocType = (decl as VariableDeclaration).type;
+        if (!jsdocType) return;
         const original = getTextOfNode(jsdocType);
         const type = checker.getTypeFromTypeNode(jsdocType);
         const actions = [createAction(jsdocType, sourceFile.fileName, original, checker.typeToString(type, /*enclosingDeclaration*/ undefined, TypeFormatFlags.NoTruncation))];

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax10.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax10.ts
@@ -1,0 +1,5 @@
+// @strict: true
+/// <reference path='fourslash.ts' />
+//// function f(x: [|number?|]) {
+//// }
+verify.rangeAfterCodeFix("number | null", /*includeWhiteSpace*/ false, /*errorCode*/ 8020, 0);

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax11.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax11.ts
@@ -1,0 +1,5 @@
+// @strict: true
+/// <reference path='fourslash.ts' />
+//// var f = function f(x: [|string?|]) {
+//// }
+verify.rangeAfterCodeFix("string | null | undefined", /*includeWhiteSpace*/ false, /*errorCode*/ 8020, 1);

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax12.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax12.ts
@@ -1,0 +1,6 @@
+// @strict: true
+/// <reference path='fourslash.ts' />
+////class C {
+////    p: [|*|]
+////}
+verify.rangeAfterCodeFix("any", /*includeWhiteSpace*/ false, /*errorCode*/ 8020, 0);

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax13.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax13.ts
@@ -1,0 +1,6 @@
+// @strict: true
+/// <reference path='fourslash.ts' />
+////class C {
+////    p: [|*|] = 12
+////}
+verify.rangeAfterCodeFix("any", /*includeWhiteSpace*/ false, /*errorCode*/ 8020, 0);

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax14.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax14.ts
@@ -1,0 +1,5 @@
+// @strict: true
+/// <reference path='fourslash.ts' />
+//// var x = 12 as [|number?|];
+
+verify.rangeAfterCodeFix("number | null", /*includeWhiteSpace*/ false, /*errorCode*/ 8020, 0);

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax15.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax15.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts' />
+//// var f = <[|function(number?): number|]>(x => x);
+
+// note: without --strict, number? --> number, not number | null
+verify.rangeAfterCodeFix("(arg0: number) => number", /*includeWhiteSpace*/ false, /*errorCode*/ 8020, 0);

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax16.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax16.ts
@@ -1,0 +1,4 @@
+/// <reference path='fourslash.ts' />
+//// var f: { [K in keyof number]: [|*|] };
+
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax17.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax17.ts
@@ -1,0 +1,3 @@
+/// <reference path='fourslash.ts' />
+//// declare function index(ix: number): [|*|];
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax18.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax18.ts
@@ -1,0 +1,3 @@
+/// <reference path='fourslash.ts' />
+//// var index: { (ix: number): [|?|] };
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax19.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax19.ts
@@ -1,0 +1,3 @@
+/// <reference path='fourslash.ts' />
+//// var index: { new (ix: number): [|?|] };
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax20.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax20.ts
@@ -1,0 +1,3 @@
+/// <reference path='fourslash.ts' />
+//// var index = { get p(): [|*|] { return 12 } };
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax21.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax21.ts
@@ -1,0 +1,3 @@
+/// <reference path='fourslash.ts' />
+//// var index = { set p(x: [|*|]) { } };
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax22.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax22.ts
@@ -1,0 +1,3 @@
+/// <reference path='fourslash.ts' />
+//// var index: { [s: string]: [|*|] };
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax23.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax23.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts' />
+////class C {
+////    m(): [|*|] {
+////    }
+////}
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax24.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax24.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts' />
+////declare class C {
+////    m(): [|*|];
+////}
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax25.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax25.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts' />
+////declare class C {
+////    p: [|*|];
+////}
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax26.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax26.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts' />
+////class C {
+////    p: [|*|] = 12;
+////}
+verify.rangeAfterCodeFix("any");

--- a/tests/cases/fourslash/codeFixChangeJSDocSyntax27.ts
+++ b/tests/cases/fourslash/codeFixChangeJSDocSyntax27.ts
@@ -1,0 +1,4 @@
+// @strict: true
+/// <reference path='fourslash.ts' />
+////type T = [|...number?|];
+verify.rangeAfterCodeFix("(number | null)[]");


### PR DESCRIPTION
Provide jsdoc type code fixes for other variable-like declarations. This includes 3 SyntaxKinds I missed earlier: Parameter, PropertyDeclaration and PropertyAssignment.

Fixes #18066 
Fixes #18068