### PR TITLE
Use getPropertyOfObjectType to get a superclass property

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14732,7 +14732,7 @@ namespace ts {
                 if (!classType) {
                     return false;
                 }
-                const superProperty = getPropertyOfType(classType, prop.escapedName);
+                const superProperty = getPropertyOfObjectType(classType, prop.escapedName);
                 if (superProperty && superProperty.valueDeclaration) {
                     return true;
                 }


### PR DESCRIPTION
We don't need the full complexity of `getPropertyOfType`, just `getPropertyOfObjectType`.
Ref: #17910