### PR TITLE
Share object literal types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13711,7 +13711,7 @@ namespace ts {
                 // signatures, is not in a destructuring pattern, doesn't have more than 10 properties, and doesn't
                 // have property names containing colons (which we use as a separator in the cache key).
                 if (!isInferredTypeOfVariable(node) && !hasMethodsOrAccessors && !stringIndexInfo && !numberIndexInfo && !inDestructuringPattern &&
-                    propertiesArray.length <= 10 && !forEach(propertiesArray, symbolNameContainsColon)) {
+                    propertiesArray.length <= 10 && every(propertiesArray, propertyNameIsValidKey)) {
                     return getObjectLiteralType(typeFlags, node.symbol, propertiesTable, propertiesArray);
                 }
                 const result = makeObjectLiteralType(typeFlags, node.symbol, propertiesTable, stringIndexInfo, numberIndexInfo);
@@ -13733,8 +13733,8 @@ namespace ts {
             return isVariableLike(parent) && !parent.type && parent.initializer === node;
         }
 
-        function symbolNameContainsColon(symbol: Symbol) {
-            return (<string>symbol.escapedName).indexOf(":") >= 0;
+        function propertyNameIsValidKey(symbol: Symbol) {
+            return (<string>symbol.escapedName).indexOf(":") < 0;
         }
 
         function getObjectLiteralType(flags: TypeFlags, symbol: Symbol, members: SymbolTable, properties: Symbol[]): ResolvedType {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9070,7 +9070,7 @@ namespace ts {
                                         const propDeclaration = prop.valueDeclaration as ObjectLiteralElementLike;
                                         Debug.assertNode(propDeclaration, isObjectLiteralElementLike);
 
-                                        if (getContainingStatement(errorNode) === getContainingStatement(propDeclaration)) {
+                                        if (findAncestor(errorNode, isStatement) === findAncestor(propDeclaration, isStatement)) {
                                             errorNode = propDeclaration;
                                         }
 
@@ -12813,13 +12813,6 @@ namespace ts {
                 func.kind === SyntaxKind.SetAccessor) && func.parent.kind === SyntaxKind.ObjectLiteralExpression ? <ObjectLiteralExpression>func.parent :
                 func.kind === SyntaxKind.FunctionExpression && func.parent.kind === SyntaxKind.PropertyAssignment ? <ObjectLiteralExpression>func.parent.parent :
                     undefined;
-        }
-
-        function getContainingStatement(node: Node): Node {
-            while (node && !isStatement(node)) {
-                node = node.parent;
-            }
-            return node;
         }
 
         function getThisTypeArgument(type: Type): Type {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13708,10 +13708,10 @@ namespace ts {
                 // We used a cached object literal type if the object literal is not the inferred type of a variable
                 // (otherwise Go To Definition on the variable's members wouldn't work properly), has no methods or
                 // accessors (we may cause circularities when obtaining the types of those members), has no index
-                // signatures, is not in a destructuring pattern, doesn't have more than 50 properties, and doesn't
+                // signatures, is not in a destructuring pattern, doesn't have more than 10 properties, and doesn't
                 // have property names containing colons (which we use as a separator in the cache key).
                 if (!isInferredTypeOfVariable(node) && !hasMethodsOrAccessors && !stringIndexInfo && !numberIndexInfo && !inDestructuringPattern &&
-                    propertiesArray.length <= 50 && !forEach(propertiesArray, symbolNameContainsColon)) {
+                    propertiesArray.length <= 10 && !forEach(propertiesArray, symbolNameContainsColon)) {
                     return getObjectLiteralType(typeFlags, node.symbol, propertiesTable, propertiesArray);
                 }
                 const result = makeObjectLiteralType(typeFlags, node.symbol, propertiesTable, stringIndexInfo, numberIndexInfo);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3171,6 +3171,7 @@ namespace ts {
         UnionOrIntersection = Union | Intersection,
         StructuredType = Object | Union | Intersection,
         StructuredOrTypeVariable = StructuredType | TypeParameter | Index | IndexedAccess,
+        ObjectOrTypeVariable = Object | TypeParameter | Index | IndexedAccess,
         TypeVariable = TypeParameter | IndexedAccess,
 
         // 'Narrowable' types are types where narrowing actually narrows.

--- a/tests/baselines/reference/arrayLiteralComments.types
+++ b/tests/baselines/reference/arrayLiteralComments.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/arrayLiteralComments.ts ===
 var testArrayWithFunc = [
 >testArrayWithFunc : (string | number | (() => void) | number[] | { a: number; })[]
->[    // Function comment    function() {        let x = 1;    },    // String comment    '1',    // Numeric comment    2,    // Object comment    { a: 1 },    // Array comment    [1, 2, 3]] : (string | number | (() => void) | number[] | { a: number; })[]
+>[    // Function comment    function() {        let x = 1;    },    // String comment    '1',    // Numeric comment    2,    // Object comment    { a: 1 },    // Array comment    [1, 2, 3]] : (string | number | (() => void) | { a: number; } | number[])[]
 
     // Function comment
     function() {

--- a/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
+++ b/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2322: Type '({
   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type 'Action'.
     Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
       Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
-tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(29,5): error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
       Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
@@ -43,13 +43,13 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '({
     ]
     
     var z1: { id: number }[] =
-        [
-            { id: 2, trueness: false },
-                     ~~~~~~~~~~~~~~~
+        ~~
 !!! error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:       Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
+        [
+            { id: 2, trueness: false },
             { id: 3, name: "three" }
         ]
     

--- a/tests/baselines/reference/assignmentCompatBug2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug2.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/assignmentCompatBug2.ts(1,27): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
-tests/cases/compiler/assignmentCompatBug2.ts(3,8): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(3,1): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(5,13): error TS2322: Type '{ b: number; a: number; }' is not assignable to type '{ b: number; }'.
   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
@@ -19,7 +19,7 @@ tests/cases/compiler/assignmentCompatBug2.ts(33,1): error TS2322: Type '{ f: (n:
 !!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     b2 = { a: 0 }; // error
-           ~~~~
+    ~~
 !!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     

--- a/tests/baselines/reference/assignmentCompatability_checking-apply-member-off-of-function-interface.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability_checking-apply-member-off-of-function-interface.errors.txt
@@ -8,7 +8,6 @@ tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-functi
 tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts(23,4): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'Applicable'.
 tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts(24,4): error TS2345: Argument of type '4' is not assignable to parameter of type 'Applicable'.
 tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts(25,4): error TS2345: Argument of type '{}' is not assignable to parameter of type 'Applicable'.
-  Property 'apply' is missing in type '{}'.
 
 
 ==== tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts (8 errors) ====
@@ -55,7 +54,6 @@ tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-functi
     fn({});
        ~~
 !!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'Applicable'.
-!!! error TS2345:   Property 'apply' is missing in type '{}'.
     
     
     // Should work

--- a/tests/baselines/reference/assignmentCompatability_checking-call-member-off-of-function-interface.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability_checking-call-member-off-of-function-interface.errors.txt
@@ -8,7 +8,6 @@ tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-functio
 tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts(23,4): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'Callable'.
 tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts(24,4): error TS2345: Argument of type '4' is not assignable to parameter of type 'Callable'.
 tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts(25,4): error TS2345: Argument of type '{}' is not assignable to parameter of type 'Callable'.
-  Property 'call' is missing in type '{}'.
 
 
 ==== tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts (8 errors) ====
@@ -55,7 +54,6 @@ tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-functio
     fn({});
        ~~
 !!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'Callable'.
-!!! error TS2345:   Property 'call' is missing in type '{}'.
     
     
     // Should work

--- a/tests/baselines/reference/assignmentToParenthesizedIdentifiers.errors.txt
+++ b/tests/baselines/reference/assignmentToParenthesizedIdentifiers.errors.txt
@@ -10,11 +10,7 @@ tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesize
   Types of property 'x' are incompatible.
     Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(32,1): error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(33,1): error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(37,1): error TS2539: Cannot assign to 'fn' because it is not a variable.
 tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(38,2): error TS2539: Cannot assign to 'fn' because it is not a variable.
 tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesizedIdentifiers.ts(43,5): error TS2322: Type '""' is not assignable to type 'number'.
@@ -85,13 +81,9 @@ tests/cases/conformance/expressions/valuesAndReferences/assignmentToParenthesize
     (M2).M3 = { x: '' }; // Error
     ~~~~~~~
 !!! error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     (M2.M3) = { x: '' }; // Error
     ~~~~~~~
 !!! error TS2322: Type '{ x: string; }' is not assignable to type 'typeof M3'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     
     
     function fn() { }

--- a/tests/baselines/reference/conditionalOperatorWithIdenticalBCT.types
+++ b/tests/baselines/reference/conditionalOperatorWithIdenticalBCT.types
@@ -131,7 +131,7 @@ true ? 1 : {};
 >{} : {}
 
 true ? { a: 2, b: 'string' } : { a: 1 };
->true ? { a: 2, b: 'string' } : { a: 1 } : { a: number; b: string; } | { a: number; }
+>true ? { a: 2, b: 'string' } : { a: 1 } : { a: number; } | { a: number; b: string; }
 >true : true
 >{ a: 2, b: 'string' } : { a: number; b: string; }
 >a : number
@@ -150,8 +150,8 @@ var result6 = true ? 1 : {};
 >{} : {}
 
 var result7 = true ? { a: 2, b: 'string' } : { a: 1 };
->result7 : { a: number; b: string; } | { a: number; }
->true ? { a: 2, b: 'string' } : { a: 1 } : { a: number; b: string; } | { a: number; }
+>result7 : { a: number; } | { a: number; b: string; }
+>true ? { a: 2, b: 'string' } : { a: 1 } : { a: number; } | { a: number; b: string; }
 >true : true
 >{ a: 2, b: 'string' } : { a: number; b: string; }
 >a : number

--- a/tests/baselines/reference/genericCallWithObjectLiteralArguments1.errors.txt
+++ b/tests/baselines/reference/genericCallWithObjectLiteralArguments1.errors.txt
@@ -2,8 +2,6 @@ tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts(3,13): error TS23
   Types of property 'y' are incompatible.
     Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts(4,22): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type '{ x: number; y: number; }'.
-  Types of property 'y' are incompatible.
-    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts(5,22): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type '{ x: string; y: string; }'.
   Types of property 'x' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -26,8 +24,6 @@ tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts(7,22): error TS23
     var x2 = foo<number>({ x: 3, y: "" }, 4); 
                          ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type '{ x: number; y: number; }'.
-!!! error TS2345:   Types of property 'y' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var x3 = foo<string>({ x: 3, y: "" }, 4); 
                          ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type '{ x: string; y: string; }'.

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -20,7 +20,7 @@ tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2345: Argument of type 
       Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/incompatibleTypes.ts(49,7): error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
   Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
-tests/cases/compiler/incompatibleTypes.ts(66,47): error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
+tests/cases/compiler/incompatibleTypes.ts(66,5): error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
   Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(72,5): error TS2322: Type '5' is not assignable to type '() => string'.
 tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) => number' is not assignable to type '() => any'.
@@ -121,7 +121,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     }
     
     var o1: { a: { a: string; }; b: string; } = { e: 0, f: 0 };
-                                                  ~~~~
+        ~~
 !!! error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
     

--- a/tests/baselines/reference/mappedTypeErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors.errors.txt
@@ -24,7 +24,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(75,45): error TS2345: A
   Property 'y' is missing in type '{ x: number; }'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(77,59): error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Readonly<{ x: number; y: number; }>'.
   Object literal may only specify known properties, and 'z' does not exist in type 'Readonly<{ x: number; y: number; }>'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(83,58): error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Partial<{ x: number; y: number; }>'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(83,44): error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Partial<{ x: number; y: number; }>'.
   Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(105,15): error TS2345: Argument of type '{ a: undefined; }' is not assignable to parameter of type 'Pick<Foo, "a">'.
   Types of property 'a' are incompatible.
@@ -32,9 +32,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(105,15): error TS2345: 
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(106,17): error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
   Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(123,12): error TS2345: Argument of type '{ a: undefined; }' is not assignable to parameter of type 'Pick<Foo, "a">'.
-  Types of property 'a' are incompatible.
-    Type 'undefined' is not assignable to type 'string'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(124,14): error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(124,12): error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
   Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(128,5): error TS2322: Type '{ a: string; }' is not assignable to type 'T2'.
   Types of property 'a' are incompatible.
@@ -175,7 +173,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,21): error TS2536: 
         let x1 = objAndPartial({ x: 0, y: 0 }, { x: 1 });
         let x2 = objAndPartial({ x: 0, y: 0 }, { x: 1, y: 1 });
         let x3 = objAndPartial({ x: 0, y: 0 }, { x: 1, y: 1, z: 1 });  // Error
-                                                             ~~~~
+                                               ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Partial<{ x: number; y: number; }>'.
 !!! error TS2345:   Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
     }
@@ -227,10 +225,8 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,21): error TS2536: 
     c.setState({ a: undefined });  // Error
                ~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ a: undefined; }' is not assignable to parameter of type 'Pick<Foo, "a">'.
-!!! error TS2345:   Types of property 'a' are incompatible.
-!!! error TS2345:     Type 'undefined' is not assignable to type 'string'.
     c.setState({ c: true });  // Error
-                 ~~~~~~~
+               ~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
 !!! error TS2345:   Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
     

--- a/tests/baselines/reference/mappedTypeIndexedAccess.errors.txt
+++ b/tests/baselines/reference/mappedTypeIndexedAccess.errors.txt
@@ -4,8 +4,6 @@ tests/cases/compiler/mappedTypeIndexedAccess.ts(18,5): error TS2322: Type '{ key
       Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/mappedTypeIndexedAccess.ts(24,5): error TS2322: Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; } | { key: "bar"; value: number; }'.
   Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; }'.
-    Types of property 'value' are incompatible.
-      Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/mappedTypeIndexedAccess.ts (2 errors) ====
@@ -41,8 +39,6 @@ tests/cases/compiler/mappedTypeIndexedAccess.ts(24,5): error TS2322: Type '{ key
         ~~~~~
 !!! error TS2322: Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; } | { key: "bar"; value: number; }'.
 !!! error TS2322:   Type '{ key: "foo"; value: number; }' is not assignable to type '{ key: "foo"; value: string; }'.
-!!! error TS2322:     Types of property 'value' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
         key: "foo",
         value: 3
     };

--- a/tests/baselines/reference/nonPrimitiveUnionIntersection.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveUnionIntersection.errors.txt
@@ -4,7 +4,7 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(3,5)
   Type '123' is not assignable to type 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(4,1): error TS2322: Type 'string' is not assignable to type 'object & string'.
   Type 'string' is not assignable to type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(8,38): error TS2322: Type '{ bar: string; }' is not assignable to type 'object & { err: string; }'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(8,7): error TS2322: Type '{ bar: string; }' is not assignable to type 'object & { err: string; }'.
   Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
 
 
@@ -26,7 +26,7 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(8,38
     
     const foo: object & {} = {bar: 'bar'}; // ok
     const bar: object & {err: string} = {bar: 'bar'}; // error
-                                         ~~~~~~~~~~
+          ~~~
 !!! error TS2322: Type '{ bar: string; }' is not assignable to type 'object & { err: string; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
     

--- a/tests/baselines/reference/orderMattersForSignatureGroupIdentity.errors.txt
+++ b/tests/baselines/reference/orderMattersForSignatureGroupIdentity.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(19,5): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
 tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(22,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'w' must be of type 'A', but here has type 'C'.
-tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
+tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,3): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
 
 
@@ -35,6 +35,6 @@ tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS234
 !!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'w' must be of type 'A', but here has type 'C'.
     
     w({ s: "", n: 0 }).toLowerCase();
-        ~~~~~
+      ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
 !!! error TS2345:   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.

--- a/tests/baselines/reference/shorthandPropertyAssignmentsInDestructuring.errors.txt
+++ b/tests/baselines/reference/shorthandPropertyAssignmentsInDestructuring.errors.txt
@@ -12,13 +12,14 @@ tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts(80,13): erro
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts(85,8): error TS2322: Type '5' is not assignable to type 'string'.
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts(85,8): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts(85,19): error TS2322: Type '{ x: number; }' is not assignable to type '{ x: string; }'.
+tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts(85,19): error TS2322: Type '{ x: number; }' is not assignable to type '{ x: string; }'.
   Types of property 'x' are incompatible.
     Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts(111,12): error TS2304: Cannot find name 's'.
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts(111,14): error TS1312: '=' can only be used in an object literal property inside a destructuring assignment.
 
 
-==== tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts (14 errors) ====
+==== tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts (15 errors) ====
     (function() {
     	var s0;
     	for ({ s0 = 5 } of [{ s0: 1 }]) {
@@ -128,6 +129,8 @@ tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts(111,14): err
 !!! error TS2322: Type '5' is not assignable to type 'string'.
     	      ~~
 !!! error TS2322: Type 'number' is not assignable to type 'string'.
+    	                 ~~
+!!! error TS2322: Type '{ x: number; }' is not assignable to type '{ x: string; }'.
     	                 ~~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type '{ x: string; }'.
 !!! error TS2322:   Types of property 'x' are incompatible.

--- a/tests/baselines/reference/shorthandPropertyAssignmentsInDestructuring_ES6.errors.txt
+++ b/tests/baselines/reference/shorthandPropertyAssignmentsInDestructuring_ES6.errors.txt
@@ -12,13 +12,14 @@ tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts(80,13): 
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts(85,8): error TS2322: Type '5' is not assignable to type 'string'.
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts(85,8): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts(85,19): error TS2322: Type '{ x: number; }' is not assignable to type '{ x: string; }'.
+tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts(85,19): error TS2322: Type '{ x: number; }' is not assignable to type '{ x: string; }'.
   Types of property 'x' are incompatible.
     Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts(111,12): error TS2304: Cannot find name 's'.
 tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts(111,14): error TS1312: '=' can only be used in an object literal property inside a destructuring assignment.
 
 
-==== tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts (14 errors) ====
+==== tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts (15 errors) ====
     (function() {
     	var s0;
     	for ({ s0 = 5 } of [{ s0: 1 }]) {
@@ -128,6 +129,8 @@ tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts(111,14):
 !!! error TS2322: Type '5' is not assignable to type 'string'.
     	      ~~
 !!! error TS2322: Type 'number' is not assignable to type 'string'.
+    	                 ~~
+!!! error TS2322: Type '{ x: number; }' is not assignable to type '{ x: string; }'.
     	                 ~~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type '{ x: string; }'.
 !!! error TS2322:   Types of property 'x' are incompatible.

--- a/tests/baselines/reference/sourceMapValidationDestructuringForOfObjectBindingPattern.symbols
+++ b/tests/baselines/reference/sourceMapValidationDestructuringForOfObjectBindingPattern.symbols
@@ -93,7 +93,7 @@ for (let {name: nameA } of getRobots()) {
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 31, 10))
 }
 for (let {name: nameA } of [{ name: "mower", skill: "mowing" }, { name: "trimmer", skill: "trimming" }]) {
->name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 34, 29))
+>name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 16, 24))
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 34, 10))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 34, 29))
 >skill : Symbol(skill, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 34, 44))
@@ -135,10 +135,10 @@ for (let { skills: { primary: primaryA, secondary: secondaryA } } of getMultiRob
 >primaryA : Symbol(primaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 40, 20))
 }
 for (let { skills: { primary: primaryA, secondary: secondaryA } } of [{ name: "mower", skills: { primary: "mowing", secondary: "none" } },
->skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 86))
->primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 96))
+>skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 17, 49))
+>primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 17, 59))
 >primaryA : Symbol(primaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 20))
->secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 115))
+>secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 17, 78))
 >secondaryA : Symbol(secondaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 39))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 71))
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 43, 86))
@@ -185,9 +185,9 @@ for (let {name: nameA, skill: skillA } of getRobots()) {
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 51, 10))
 }
 for (let {name: nameA, skill: skillA } of [{ name: "mower", skill: "mowing" }, { name: "trimmer", skill: "trimming" }]) {
->name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 54, 44))
+>name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 16, 24))
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 54, 10))
->skill : Symbol(skill, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 54, 59))
+>skill : Symbol(skill, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 16, 39))
 >skillA : Symbol(skillA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 54, 22))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 54, 44))
 >skill : Symbol(skill, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 54, 59))
@@ -233,12 +233,12 @@ for (let {name: nameA, skills: { primary: primaryA, secondary: secondaryA } } of
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 60, 10))
 }
 for (let {name: nameA, skills: { primary: primaryA, secondary: secondaryA } } of [{ name: "mower", skills: { primary: "mowing", secondary: "none" } },
->name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 83))
+>name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 17, 34))
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 10))
->skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 98))
->primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 108))
+>skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 17, 49))
+>primary : Symbol(primary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 17, 59))
 >primaryA : Symbol(primaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 32))
->secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 127))
+>secondary : Symbol(secondary, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 17, 78))
 >secondaryA : Symbol(secondaryA, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 51))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 83))
 >skills : Symbol(skills, Decl(sourceMapValidationDestructuringForOfObjectBindingPattern.ts, 63, 98))

--- a/tests/baselines/reference/sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.symbols
+++ b/tests/baselines/reference/sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.symbols
@@ -93,7 +93,7 @@ for (let {name: nameA = "noName" } of getRobots()) {
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 31, 10))
 }
 for (let {name: nameA = "noName" } of [{ name: "mower", skill: "mowing" }, { name: "trimmer", skill: "trimming" }]) {
->name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 34, 40))
+>name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 16, 24))
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 34, 10))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 34, 40))
 >skill : Symbol(skill, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 34, 55))
@@ -200,9 +200,9 @@ for (let {name: nameA = "noName", skill: skillA = "noSkill"  } of getRobots()) {
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 55, 10))
 }
 for (let {name: nameA = "noName", skill: skillA = "noSkill"  } of [{ name: "mower", skill: "mowing" }, { name: "trimmer", skill: "trimming" }]) {
->name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 58, 68))
+>name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 16, 24))
 >nameA : Symbol(nameA, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 58, 10))
->skill : Symbol(skill, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 58, 83))
+>skill : Symbol(skill, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 16, 39))
 >skillA : Symbol(skillA, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 58, 33))
 >name : Symbol(name, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 58, 68))
 >skill : Symbol(skill, Decl(sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts, 58, 83))

--- a/tests/baselines/reference/thisTypeInObjectLiterals2.symbols
+++ b/tests/baselines/reference/thisTypeInObjectLiterals2.symbols
@@ -460,13 +460,13 @@ let x2 = makeObject2({
 >dy : Symbol(dy, Decl(thisTypeInObjectLiterals2.ts, 144, 26))
 
             this.x += dx;  // Strongly typed this
->this.x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 142, 11))
->x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 142, 11))
+>this.x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 122, 11))
+>x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 122, 11))
 >dx : Symbol(dx, Decl(thisTypeInObjectLiterals2.ts, 144, 15))
 
             this.y += dy;  // Strongly typed this
->this.y : Symbol(y, Decl(thisTypeInObjectLiterals2.ts, 142, 17))
->y : Symbol(y, Decl(thisTypeInObjectLiterals2.ts, 142, 17))
+>this.y : Symbol(y, Decl(thisTypeInObjectLiterals2.ts, 122, 17))
+>y : Symbol(y, Decl(thisTypeInObjectLiterals2.ts, 122, 17))
 >dy : Symbol(dy, Decl(thisTypeInObjectLiterals2.ts, 144, 26))
         }
     }
@@ -725,8 +725,8 @@ let vue = new Vue({
 >x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 218, 10))
 
             return this.x;
->this.x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 216, 18))
->x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 216, 18))
+>this.x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 122, 11))
+>x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 122, 11))
         }
     },
     computed: {
@@ -736,8 +736,8 @@ let vue = new Vue({
 >test : Symbol(test, Decl(thisTypeInObjectLiterals2.ts, 222, 15))
 
             return this.x;
->this.x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 216, 18))
->x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 216, 18))
+>this.x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 122, 11))
+>x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 122, 11))
 
         },
         hello: {
@@ -760,9 +760,9 @@ vue;
 >vue : Symbol(vue, Decl(thisTypeInObjectLiterals2.ts, 215, 3))
 
 vue.x;
->vue.x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 216, 18))
+>vue.x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 122, 11))
 >vue : Symbol(vue, Decl(thisTypeInObjectLiterals2.ts, 215, 3))
->x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 216, 18))
+>x : Symbol(x, Decl(thisTypeInObjectLiterals2.ts, 122, 11))
 
 vue.f("abc");
 >vue.f : Symbol(f, Decl(thisTypeInObjectLiterals2.ts, 217, 14))

--- a/tests/baselines/reference/typeArgumentInference.errors.txt
+++ b/tests/baselines/reference/typeArgumentInference.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(68,29): error TS2345: Argument of type '0' is not assignable to parameter of type '""'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(82,69): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type '{ x: number; z: Date; }'.
   Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,74): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,66): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
@@ -95,7 +95,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,74
 !!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
     var a9e: {};
     var a9f = someGenerics9<A92>(undefined, { x: 6, z: new Date() }, { x: 6, y: '' });
-                                                                             ~~~~~
+                                                                     ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
 !!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;

--- a/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
@@ -15,7 +15,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(120,69): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type '{ x: number; z: any; }'.
   Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,56): error TS2304: Cannot find name 'window'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,74): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,66): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
@@ -169,7 +169,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
     var a9f = new someGenerics9<A92>(undefined, { x: 6, z: window }, { x: 6, y: '' });
                                                            ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
-                                                                             ~~~~~
+                                                                     ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
 !!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;

--- a/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
@@ -20,7 +20,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(87,65): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type '{ x: number; z: any; }'.
   Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,52): error TS2304: Cannot find name 'window'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,70): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,62): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
@@ -151,7 +151,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
     var a9f = someGenerics9<A92>(undefined, { x: 6, z: window }, { x: 6, y: '' });
                                                        ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
-                                                                         ~~~~~
+                                                                 ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
 !!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;


### PR DESCRIPTION
With this PR we share object literal type instances whenever possible. Previously we would always generate a new type object for every object literal expression. This optimization reduces the number of redundant type objects in codebases with large numbers of object literals of similar shape. For example, it reduces the check time and overall compile time for the Monaco project by 8% and 3% respectively.