### PR TITLE
Compare shapes of objects before comparing contained types

### DIFF
--- a/tests/baselines/reference/arityAndOrderCompatibility01.errors.txt
+++ b/tests/baselines/reference/arityAndOrderCompatibility01.errors.txt
@@ -3,14 +3,11 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(14,12): erro
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(15,5): error TS2461: Type '{ 0: string; 1: number; }' is not an array type.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(15,12): error TS2460: Type '{ 0: string; 1: number; }' has no property '2'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(16,5): error TS2322: Type '[string, number]' is not assignable to type '[number, number, number]'.
-  Types of property '0' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+  Property '2' is missing in type '[string, number]'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(17,5): error TS2322: Type 'StrNum' is not assignable to type '[number, number, number]'.
-  Types of property '0' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+  Property '2' is missing in type 'StrNum'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(18,5): error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[number, number, number]'.
-  Types of property '0' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+  Property '2' is missing in type '{ 0: string; 1: number; }'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(19,5): error TS2322: Type '[string, number]' is not assignable to type '[string, number, number]'.
   Property '2' is missing in type '[string, number]'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(20,5): error TS2322: Type 'StrNum' is not assignable to type '[string, number, number]'.
@@ -24,8 +21,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(23,5): error
   Types of property '0' are incompatible.
     Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(24,5): error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[number]'.
-  Types of property '0' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+  Property 'length' is missing in type '{ 0: string; 1: number; }'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(25,5): error TS2322: Type '[string, number]' is not assignable to type '[string]'.
   Types of property 'pop' are incompatible.
     Type '() => string | number' is not assignable to type '() => string'.
@@ -44,8 +40,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(29,5): error
   Types of property '0' are incompatible.
     Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(30,5): error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[number, string]'.
-  Types of property '0' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+  Property 'length' is missing in type '{ 0: string; 1: number; }'.
 
 
 ==== tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts (19 errors) ====
@@ -75,18 +70,15 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(30,5): error
     var j1: [number, number, number] = x;
         ~~
 !!! error TS2322: Type '[string, number]' is not assignable to type '[number, number, number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Property '2' is missing in type '[string, number]'.
     var j2: [number, number, number] = y;
         ~~
 !!! error TS2322: Type 'StrNum' is not assignable to type '[number, number, number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Property '2' is missing in type 'StrNum'.
     var j3: [number, number, number] = z;
         ~~
 !!! error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[number, number, number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Property '2' is missing in type '{ 0: string; 1: number; }'.
     var k1: [string, number, number] = x;
         ~~
 !!! error TS2322: Type '[string, number]' is not assignable to type '[string, number, number]'.
@@ -112,8 +104,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(30,5): error
     var l3: [number] = z;
         ~~
 !!! error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Property 'length' is missing in type '{ 0: string; 1: number; }'.
     var m1: [string] = x;
         ~~
 !!! error TS2322: Type '[string, number]' is not assignable to type '[string]'.
@@ -144,8 +135,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(30,5): error
     var n3: [number, string] = z;
         ~~
 !!! error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[number, string]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Property 'length' is missing in type '{ 0: string; 1: number; }'.
     var o1: [string, number] = x;
     var o2: [string, number] = y;
     var o3: [string, number] = y;

--- a/tests/baselines/reference/contextualTypeWithUnionTypeObjectLiteral.errors.txt
+++ b/tests/baselines/reference/contextualTypeWithUnionTypeObjectLiteral.errors.txt
@@ -15,9 +15,7 @@ tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(
         Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(25,5): error TS2322: Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: string; anotherP: string; } | { prop: number; anotherP1: number; }'.
   Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: number; anotherP1: number; }'.
-    Types of property 'prop' are incompatible.
-      Type 'string | number' is not assignable to type 'number'.
-        Type 'string' is not assignable to type 'number'.
+    Property 'anotherP1' is missing in type '{ prop: string | number; anotherP: string; }'.
 tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(29,5): error TS2322: Type '{ prop: string | number; anotherP: string; anotherP1: number; }' is not assignable to type '{ prop: string; anotherP: string; } | { prop: number; anotherP1: number; }'.
   Type '{ prop: string | number; anotherP: string; anotherP1: number; }' is not assignable to type '{ prop: number; anotherP1: number; }'.
     Types of property 'prop' are incompatible.
@@ -78,9 +76,7 @@ tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts(
         ~~~~~~~~~~~~
 !!! error TS2322: Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: string; anotherP: string; } | { prop: number; anotherP1: number; }'.
 !!! error TS2322:   Type '{ prop: string | number; anotherP: string; }' is not assignable to type '{ prop: number; anotherP1: number; }'.
-!!! error TS2322:     Types of property 'prop' are incompatible.
-!!! error TS2322:       Type 'string | number' is not assignable to type 'number'.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Property 'anotherP1' is missing in type '{ prop: string | number; anotherP: string; }'.
         prop: strOrNumber,
         anotherP: str
     };

--- a/tests/baselines/reference/promisePermutations.errors.txt
+++ b/tests/baselines/reference/promisePermutations.errors.txt
@@ -48,11 +48,7 @@ tests/cases/compiler/promisePermutations.ts(144,35): error TS2345: Argument of t
   Type 'IPromise<string>' is not assignable to type 'IPromise<number>'.
 tests/cases/compiler/promisePermutations.ts(152,36): error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
   Type 'IPromise<string>' is not assignable to type 'Promise<number>'.
-    Types of property 'then' are incompatible.
-      Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '{ <TResult1 = number, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-        Types of parameters 'success' and 'onfulfilled' are incompatible.
-          Types of parameters 'value' and 'value' are incompatible.
-            Type 'string' is not assignable to type 'number'.
+    Property 'catch' is missing in type 'IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(156,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'IPromise<number>' is not assignable to type 'IPromise<string>'.
     Type 'number' is not assignable to type 'string'.
@@ -302,11 +298,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
                                        ~~~~~~~~~
 !!! error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
 !!! error TS2345:   Type 'IPromise<string>' is not assignable to type 'Promise<number>'.
-!!! error TS2345:     Types of property 'then' are incompatible.
-!!! error TS2345:       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '{ <TResult1 = number, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-!!! error TS2345:         Types of parameters 'success' and 'onfulfilled' are incompatible.
-!!! error TS2345:           Types of parameters 'value' and 'value' are incompatible.
-!!! error TS2345:             Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Property 'catch' is missing in type 'IPromise<string>'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     
     var r11: IPromise<number>;

--- a/tests/baselines/reference/promisePermutations2.errors.txt
+++ b/tests/baselines/reference/promisePermutations2.errors.txt
@@ -48,11 +48,7 @@ tests/cases/compiler/promisePermutations2.ts(143,35): error TS2345: Argument of 
   Type 'IPromise<string>' is not assignable to type 'IPromise<number>'.
 tests/cases/compiler/promisePermutations2.ts(151,36): error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
   Type 'IPromise<string>' is not assignable to type 'Promise<number>'.
-    Types of property 'then' are incompatible.
-      Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '{ <TResult1 = number, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-        Types of parameters 'success' and 'onfulfilled' are incompatible.
-          Types of parameters 'value' and 'value' are incompatible.
-            Type 'string' is not assignable to type 'number'.
+    Property 'catch' is missing in type 'IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(155,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'IPromise<number>' is not assignable to type 'IPromise<string>'.
     Type 'number' is not assignable to type 'string'.
@@ -301,11 +297,7 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
                                        ~~~~~~~~~
 !!! error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
 !!! error TS2345:   Type 'IPromise<string>' is not assignable to type 'Promise<number>'.
-!!! error TS2345:     Types of property 'then' are incompatible.
-!!! error TS2345:       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '{ <TResult1 = number, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-!!! error TS2345:         Types of parameters 'success' and 'onfulfilled' are incompatible.
-!!! error TS2345:           Types of parameters 'value' and 'value' are incompatible.
-!!! error TS2345:             Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Property 'catch' is missing in type 'IPromise<string>'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     
     var r11: IPromise<number>;

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -51,11 +51,7 @@ tests/cases/compiler/promisePermutations3.ts(143,35): error TS2345: Argument of 
   Type 'IPromise<string>' is not assignable to type 'IPromise<number>'.
 tests/cases/compiler/promisePermutations3.ts(151,36): error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
   Type 'IPromise<string>' is not assignable to type 'Promise<number>'.
-    Types of property 'then' are incompatible.
-      Type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <TResult1 = number, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-        Types of parameters 'success' and 'onfulfilled' are incompatible.
-          Types of parameters 'value' and 'value' are incompatible.
-            Type 'string' is not assignable to type 'number'.
+    Property 'catch' is missing in type 'IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(155,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'IPromise<number>' is not assignable to type 'IPromise<string>'.
     Type 'number' is not assignable to type 'string'.
@@ -73,9 +69,7 @@ tests/cases/compiler/promisePermutations3.ts(159,21): error TS2345: Argument of 
             Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of type '{ <T>(x: T): IPromise<T>; <T>(x: T, y: T): Promise<T>; }' is not assignable to parameter of type '(value: (x: any) => any) => Promise<any>'.
   Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
-    Types of property 'then' are incompatible.
-      Type '<U>(success?: (value: any) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <TResult1 = any, TResult2 = never>(onfulfilled?: (value: any) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>; <U>(success?: (value: any) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-        Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
+    Property 'catch' is missing in type 'IPromise<any>'.
 
 
 ==== tests/cases/compiler/promisePermutations3.ts (35 errors) ====
@@ -313,11 +307,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                                        ~~~~~~~~~
 !!! error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
 !!! error TS2345:   Type 'IPromise<string>' is not assignable to type 'Promise<number>'.
-!!! error TS2345:     Types of property 'then' are incompatible.
-!!! error TS2345:       Type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <TResult1 = number, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-!!! error TS2345:         Types of parameters 'success' and 'onfulfilled' are incompatible.
-!!! error TS2345:           Types of parameters 'value' and 'value' are incompatible.
-!!! error TS2345:             Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Property 'catch' is missing in type 'IPromise<string>'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     
     var r11: IPromise<number>;
@@ -354,7 +344,5 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                         ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ <T>(x: T): IPromise<T>; <T>(x: T, y: T): Promise<T>; }' is not assignable to parameter of type '(value: (x: any) => any) => Promise<any>'.
 !!! error TS2345:   Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
-!!! error TS2345:     Types of property 'then' are incompatible.
-!!! error TS2345:       Type '<U>(success?: (value: any) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <TResult1 = any, TResult2 = never>(onfulfilled?: (value: any) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2>; <U>(success?: (value: any) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-!!! error TS2345:         Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
+!!! error TS2345:     Property 'catch' is missing in type 'IPromise<any>'.
     var s12c = s12.then(testFunction12P, testFunction12, testFunction12); // ok

--- a/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter2.errors.txt
+++ b/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter2.errors.txt
@@ -3,8 +3,7 @@ tests/cases/conformance/jsx/file.tsx(13,9): error TS2322: Type '{}' is not assig
     Property 'a' is missing in type '{}'.
 tests/cases/conformance/jsx/file.tsx(14,18): error TS2322: Type '{ a: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
   Type '{ a: "hi"; }' is not assignable to type 'Prop'.
-    Types of property 'a' are incompatible.
-      Type '"hi"' is not assignable to type 'number'.
+    Property 'b' is missing in type '{ a: "hi"; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -29,5 +28,4 @@ tests/cases/conformance/jsx/file.tsx(14,18): error TS2322: Type '{ a: "hi"; }' i
                      ~~~~~~
 !!! error TS2322: Type '{ a: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{ a: "hi"; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'a' are incompatible.
-!!! error TS2322:       Type '"hi"' is not assignable to type 'number'.
+!!! error TS2322:     Property 'b' is missing in type '{ a: "hi"; }'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -30,12 +30,10 @@ tests/cases/conformance/jsx/file.tsx(34,29): error TS2322: Type '{ y1: "hello"; 
       Type '"hello"' is not assignable to type 'boolean'.
 tests/cases/conformance/jsx/file.tsx(35,29): error TS2322: Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
   Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-    Types of property 'y1' are incompatible.
-      Type '"hello"' is not assignable to type 'boolean'.
+    Property 'y3' is missing in type '{ y1: "hello"; y2: 1000; children: "hi"; }'.
 tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
   Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-    Types of property 'y1' are incompatible.
-      Type '"hello"' is not assignable to type 'boolean'.
+    Property 'y3' is missing in type '{ y1: "hello"; y2: 1000; children: string; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (11 errors) ====
@@ -116,12 +114,10 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; 
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
 !!! error TS2322:   Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:     Types of property 'y1' are incompatible.
-!!! error TS2322:       Type '"hello"' is not assignable to type 'boolean'.
+!!! error TS2322:     Property 'y3' is missing in type '{ y1: "hello"; y2: 1000; children: "hi"; }'.
     const e4 = <TestingOptional y1="hello" y2={1000}>Hi</TestingOptional>
                                 ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
 !!! error TS2322:   Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:     Types of property 'y1' are incompatible.
-!!! error TS2322:       Type '"hello"' is not assignable to type 'boolean'.
+!!! error TS2322:     Property 'y3' is missing in type '{ y1: "hello"; y2: 1000; children: string; }'.
     


### PR DESCRIPTION
With this PR, when comparing two object types we first check that the source type contains all properties required by the target type. Only when that is the case do we then proceed to compare the types of the properties. Previously we'd do both of these things in the same pass which could cause us to needlessly drill into the (possibly deep) types of matching properties only to later discover that other properties are missing (meaning that the types are not related).

As can be seen from the baseline differences, we now bail out quicker when types are not related. This reduces noise in error messages and should also help performance.