### PR TITLE
Optimize array operations to reduce memory footprint

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -203,9 +203,11 @@ namespace ts {
             node.symbol = symbol;
 
             if (!symbol.declarations) {
-                symbol.declarations = [];
+                symbol.declarations = [node];
             }
-            symbol.declarations.push(node);
+            else {
+                symbol.declarations.push(node);
+            }
 
             if (symbolFlags & SymbolFlags.HasExports && !symbol.exports) {
                 symbol.exports = createSymbolTable();


### PR DESCRIPTION
With this PR we optimize array operations in the parser and binder to reduce overall memory consumption of syntax trees and binding information. Specifically, since arrays are often constructed by starting with an empty array and repeatedly calling `push()`, arrays may not have an optimal memory layout. We now invoke `slice()` for small arrays (1 to 4 elements) to give the VM a chance to allocate an optimal representation.

These optimizations reduce the overall size of syntax trees and binding information by ~10%. For example, memory consumption of the syntax trees and binding information for the Monaco project is reduced from 162 Mb to 145 Mb.