### PR TITLE
Handle the combination of a write and a void return

### DIFF
--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -614,6 +614,13 @@ namespace A {
         return a1.x + 10;|]
     }
 }`);
+        // Write + void return
+        testExtractMethod("extractMethod21",
+            `function foo() {
+    let x = 10;
+    [#|x++;
+    return;|]
+}`);
     });
 
 

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -748,6 +748,10 @@ namespace ts.refactor.extractMethod {
                 }
                 else {
                     newNodes.push(createStatement(createBinary(assignments[0].name, SyntaxKind.EqualsToken, call)));
+
+                    if (range.facts & RangeFacts.HasReturn) {
+                        newNodes.push(createReturn());
+                    }
                 }
             }
             else {

--- a/tests/baselines/reference/extractMethod/extractMethod21.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod21.ts
@@ -1,0 +1,26 @@
+// ==ORIGINAL==
+function foo() {
+    let x = 10;
+    x++;
+    return;
+}
+// ==SCOPE::function 'foo'==
+function foo() {
+    let x = 10;
+    return newFunction();
+
+    function newFunction() {
+        x++;
+        return;
+    }
+}
+// ==SCOPE::global scope==
+function foo() {
+    let x = 10;
+    x = newFunction(x);
+    return;
+}
+function newFunction(x: number) {
+    x++;
+    return x;
+}


### PR DESCRIPTION
When the return type is void, there's no `returnValueProperty`, but that
doesn't mean we don't need a `return` at the call site.

Fixes #18140.