### PR TITLE
Simplify and correct PermittedJumps computation

### DIFF
--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -614,6 +614,13 @@ namespace A {
         return a1.x + 10;|]
     }
 }`);
+        // Write + void return
+        testExtractMethod("extractMethod21",
+            `function foo() {
+    let x = 10;
+    [#|x++;
+    return;|]
+}`);
     });
 
 

--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -647,7 +647,7 @@ function test(x: number) {
     [#|x++;
     return;|]
 }`);
-        // Write + void return
+        // Return in finally block
         testExtractMethod("extractMethod22",
             `function test() {
     try {

--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -378,6 +378,32 @@ namespace A {
             "Cannot extract range containing conditional return statement."
         ]);
 
+        testExtractRangeFailed("extractRangeFailed7",
+        `
+function test(x: number) {
+    while (x) {
+        x--;
+        [#|break;|]
+    }
+}
+        `,
+        [
+            "Cannot extract range containing conditional break or continue statements."
+        ]);
+
+        testExtractRangeFailed("extractRangeFailed8",
+        `
+function test(x: number) {
+    switch (x) {
+        case 1:
+            [#|break;|]
+    }
+}
+        `,
+        [
+            "Cannot extract range containing conditional break or continue statements."
+        ]);
+
         testExtractMethod("extractMethod1",
             `namespace A {
     let x = 1;
@@ -620,6 +646,15 @@ namespace A {
     let x = 10;
     [#|x++;
     return;|]
+}`);
+        // Write + void return
+        testExtractMethod("extractMethod22",
+            `function test() {
+    try {
+    }
+    finally {
+        [#|return 1;|]
+    }
 }`);
     });
 

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -293,14 +293,13 @@ namespace ts.refactor.extractMethod {
             }
 
             let errors: Diagnostic[];
-            let permittedJumps = PermittedJumps.Return;
             let seenLabels: Array<__String>;
 
-            visit(nodeToCheck);
+            visit(nodeToCheck, PermittedJumps.Return);
 
             return errors;
 
-            function visit(node: Node) {
+            function visit(node: Node, permittedJumps: PermittedJumps) {
                 if (errors) {
                     // already found an error - can stop now
                     return true;
@@ -351,7 +350,6 @@ namespace ts.refactor.extractMethod {
                     // do not dive into functions or classes
                     return false;
                 }
-                const savedPermittedJumps = permittedJumps;
                 if (node.parent) {
                     switch (node.parent.kind) {
                         case SyntaxKind.IfStatement:
@@ -402,7 +400,7 @@ namespace ts.refactor.extractMethod {
                         {
                             const label = (<LabeledStatement>node).label;
                             (seenLabels || (seenLabels = [])).push(label.escapedText);
-                            forEachChild(node, visit);
+                            forEachChild(node, child => visit(child, permittedJumps));
                             seenLabels.pop();
                             break;
                         }
@@ -439,11 +437,10 @@ namespace ts.refactor.extractMethod {
                         }
                         break;
                     default:
-                        forEachChild(node, visit);
+                        forEachChild(node, child => visit(child, permittedJumps));
                         break;
                 }
 
-                permittedJumps = savedPermittedJumps;
             }
         }
     }

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -350,45 +350,31 @@ namespace ts.refactor.extractMethod {
                     // do not dive into functions or classes
                     return false;
                 }
-                if (node.parent) {
-                    switch (node.parent.kind) {
-                        case SyntaxKind.IfStatement:
-                            if ((<IfStatement>node.parent).thenStatement === node || (<IfStatement>node.parent).elseStatement === node) {
-                                // forbid all jumps inside thenStatement or elseStatement
-                                permittedJumps = PermittedJumps.None;
-                            }
-                            break;
-                        case SyntaxKind.TryStatement:
-                            if ((<TryStatement>node.parent).tryBlock === node) {
-                                // forbid all jumps inside try blocks
-                                permittedJumps = PermittedJumps.None;
-                            }
-                            else if ((<TryStatement>node.parent).finallyBlock === node) {
-                                // allow unconditional returns from finally blocks
-                                permittedJumps = PermittedJumps.Return;
-                            }
-                            break;
-                        case SyntaxKind.CatchClause:
-                            if ((<CatchClause>node.parent).block === node) {
-                                // forbid all jumps inside the block of catch clause
-                                permittedJumps = PermittedJumps.None;
-                            }
-                            break;
-                        case SyntaxKind.CaseClause:
-                            if ((<CaseClause>node).expression !== node) {
-                                // allow unlabeled break inside case clauses
-                                permittedJumps |= PermittedJumps.Break;
-                            }
-                            break;
-                        default:
-                            if (isIterationStatement(node.parent, /*lookInLabeledStatements*/ false)) {
-                                if ((<IterationStatement>node.parent).statement === node) {
-                                    // allow unlabeled break/continue inside loops
-                                    permittedJumps |= PermittedJumps.Break | PermittedJumps.Continue;
-                                }
-                            }
-                            break;
-                    }
+
+                switch (node.kind) {
+                    case SyntaxKind.IfStatement:
+                        permittedJumps = PermittedJumps.None;
+                        break;
+                    case SyntaxKind.TryStatement:
+                        // forbid all jumps inside try blocks
+                        permittedJumps = PermittedJumps.None;
+                        break;
+                    case SyntaxKind.Block:
+                        if (node.parent && node.parent.kind === SyntaxKind.TryStatement && (<TryStatement>node).finallyBlock === node) {
+                            // allow unconditional returns from finally blocks
+                            permittedJumps = PermittedJumps.Return;
+                        }
+                        break;
+                    case SyntaxKind.CaseClause:
+                        // allow unlabeled break inside case clauses
+                        permittedJumps |= PermittedJumps.Break;
+                        break;
+                    default:
+                        if (isIterationStatement(node, /*lookInLabeledStatements*/ false)) {
+                            // allow unlabeled break/continue inside loops
+                            permittedJumps |= PermittedJumps.Break | PermittedJumps.Continue;
+                        }
+                        break;
                 }
 
                 switch (node.kind) {

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -748,6 +748,10 @@ namespace ts.refactor.extractMethod {
                 }
                 else {
                     newNodes.push(createStatement(createBinary(assignments[0].name, SyntaxKind.EqualsToken, call)));
+
+                    if (range.facts & RangeFacts.HasReturn) {
+                        newNodes.push(createReturn());
+                    }
                 }
             }
             else {

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -293,13 +293,14 @@ namespace ts.refactor.extractMethod {
             }
 
             let errors: Diagnostic[];
+            let permittedJumps = PermittedJumps.Return;
             let seenLabels: Array<__String>;
 
-            visit(nodeToCheck, PermittedJumps.Return);
+            visit(nodeToCheck);
 
             return errors;
 
-            function visit(node: Node, permittedJumps: PermittedJumps) {
+            function visit(node: Node) {
                 if (errors) {
                     // already found an error - can stop now
                     return true;
@@ -350,6 +351,7 @@ namespace ts.refactor.extractMethod {
                     // do not dive into functions or classes
                     return false;
                 }
+                const savedPermittedJumps = permittedJumps;
 
                 switch (node.kind) {
                     case SyntaxKind.IfStatement:
@@ -386,7 +388,7 @@ namespace ts.refactor.extractMethod {
                         {
                             const label = (<LabeledStatement>node).label;
                             (seenLabels || (seenLabels = [])).push(label.escapedText);
-                            forEachChild(node, child => visit(child, permittedJumps));
+                            forEachChild(node, visit);
                             seenLabels.pop();
                             break;
                         }
@@ -423,10 +425,11 @@ namespace ts.refactor.extractMethod {
                         }
                         break;
                     default:
-                        forEachChild(node, child => visit(child, permittedJumps));
+                        forEachChild(node, visit);
                         break;
                 }
 
+                permittedJumps = savedPermittedJumps;
             }
         }
     }

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -417,7 +417,7 @@ namespace ts.refactor.extractMethod {
                                 }
                             }
                             else {
-                                if (!(permittedJumps & (SyntaxKind.BreakStatement ? PermittedJumps.Break : PermittedJumps.Continue))) {
+                                if (!(permittedJumps & (node.kind === SyntaxKind.BreakStatement ? PermittedJumps.Break : PermittedJumps.Continue))) {
                                     // attempt to break or continue in a forbidden context
                                     (errors || (errors = [])).push(createDiagnosticForNode(node, Messages.CannotExtractRangeContainingConditionalBreakOrContinueStatements));
                                 }

--- a/tests/baselines/reference/extractMethod/extractMethod21.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod21.ts
@@ -1,0 +1,26 @@
+// ==ORIGINAL==
+function foo() {
+    let x = 10;
+    x++;
+    return;
+}
+// ==SCOPE::function 'foo'==
+function foo() {
+    let x = 10;
+    return newFunction();
+
+    function newFunction() {
+        x++;
+        return;
+    }
+}
+// ==SCOPE::global scope==
+function foo() {
+    let x = 10;
+    x = newFunction(x);
+    return;
+}
+function newFunction(x: number) {
+    x++;
+    return x;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod22.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod22.ts
@@ -1,0 +1,31 @@
+// ==ORIGINAL==
+function test() {
+    try {
+    }
+    finally {
+        return 1;
+    }
+}
+// ==SCOPE::function 'test'==
+function test() {
+    try {
+    }
+    finally {
+        return newFunction();
+    }
+
+    function newFunction() {
+        return 1;
+    }
+}
+// ==SCOPE::global scope==
+function test() {
+    try {
+    }
+    finally {
+        return newFunction();
+    }
+}
+function newFunction() {
+    return 1;
+}


### PR DESCRIPTION
1. It was looking at the parent which wasn't guaranteed to be in the extracted range.
2. It was checking direct, rather than indirect containment - apparently to avoid applying the rules to certain expressions (which can't contain jumps anyway, unless they're in anonymous functions, in which case they're fine).

Fixes #18144

Note that this is built on top of https://github.com/Microsoft/TypeScript/pull/18164.  They're independent, but git would report a merge conflict between their newly introduced tests.  Reviewers can ignore https://github.com/amcasey/TypeScript/commit/e8ff2052eb35d4228e82bf91dc55907ea396d21e.