### PR TITLE
Fix extract method for anon class expressions

### DIFF
--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -606,6 +606,14 @@ namespace A {
             `function F<T, U extends T[], V extends U[]>(v: V) {
     [#|v.toString()|];
 }`);
+
+        testExtractMethod("extractMethod20",
+        `const _ = class {
+    a() {
+        [#|let a1 = { x: 1 };
+        return a1.x + 10;|]
+    }
+}`);
     });
 
 

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -584,7 +584,7 @@ namespace ts.refactor.extractMethod {
         else if (isClassLike(scope)) {
             return scope.kind === SyntaxKind.ClassDeclaration
                 ? `class '${scope.name.text}'`
-                : scope.name.text
+                : scope.name && scope.name.text
                     ? `class expression '${scope.name.text}'`
                     : "anonymous class expression";
         }

--- a/tests/baselines/reference/extractMethod/extractMethod20.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod20.ts
@@ -1,0 +1,28 @@
+// ==ORIGINAL==
+const _ = class {
+    a() {
+        let a1 = { x: 1 };
+        return a1.x + 10;
+    }
+}
+// ==SCOPE::anonymous class expression==
+const _ = class {
+    a() {
+        return this.newFunction();
+    }
+
+    private newFunction() {
+        let a1 = { x: 1 };
+        return a1.x + 10;
+    }
+}
+// ==SCOPE::global scope==
+const _ = class {
+    a() {
+        return newFunction();
+    }
+}
+function newFunction() {
+    let a1 = { x: 1 };
+    return a1.x + 10;
+}


### PR DESCRIPTION
Check `scope.name` when trying to extract from an anon class

Fixes #18166
