### PR TITLE
Add typedef declaration space, unify typedef name gathering

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -589,14 +589,14 @@ namespace ts {
             // Binding of JsDocComment should be done before the current block scope container changes.
             // because the scope of JsDocComment should not be affected by whether the current node is a
             // container or not.
-            if (node.jsDoc) {
+            if ((node as HasJSDocNodes).jsDoc) {
                 if (isInJavaScriptFile(node)) {
-                    for (const j of node.jsDoc) {
+                    for (const j of (node as HasJSDocNodes).jsDoc) {
                         bind(j);
                     }
                 }
                 else {
-                    for (const j of node.jsDoc) {
+                    for (const j of (node as HasJSDocNodes).jsDoc) {
                         setParentPointers(node, j);
                     }
                 }
@@ -1885,7 +1885,7 @@ namespace ts {
             // Here the current node is "foo", which is a container, but the scope of "MyType" should
             // not be inside "foo". Therefore we always bind @typedef before bind the parent node,
             // and skip binding this tag later when binding all the other jsdoc tags.
-            if (isInJavaScriptFile(node)) bindJSDocTypedefTagIfAny(node);
+            if (isInJavaScriptFile(node)) bindJSDocTypedefTagIfAny(node as HasJSDocNodes);
 
             // First we bind declaration nodes to a symbol if possible. We'll both create a symbol
             // and then potentially add the symbol to an appropriate symbol table. Possible
@@ -1921,7 +1921,7 @@ namespace ts {
             inStrictMode = saveInStrictMode;
         }
 
-        function bindJSDocTypedefTagIfAny(node: Node) {
+        function bindJSDocTypedefTagIfAny(node: HasJSDocNodes) {
             if (!node.jsDoc) {
                 return;
             }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -589,14 +589,14 @@ namespace ts {
             // Binding of JsDocComment should be done before the current block scope container changes.
             // because the scope of JsDocComment should not be affected by whether the current node is a
             // container or not.
-            if ((node as HasJSDocNodes).jsDoc) {
+            if (hasJSDocNodes(node)) {
                 if (isInJavaScriptFile(node)) {
-                    for (const j of (node as HasJSDocNodes).jsDoc) {
+                    for (const j of node.jsDoc) {
                         bind(j);
                     }
                 }
                 else {
-                    for (const j of (node as HasJSDocNodes).jsDoc) {
+                    for (const j of node.jsDoc) {
                         setParentPointers(node, j);
                     }
                 }
@@ -1885,7 +1885,7 @@ namespace ts {
             // Here the current node is "foo", which is a container, but the scope of "MyType" should
             // not be inside "foo". Therefore we always bind @typedef before bind the parent node,
             // and skip binding this tag later when binding all the other jsdoc tags.
-            if (isInJavaScriptFile(node)) bindJSDocTypedefTagIfAny(node as HasJSDocNodes);
+            if (isInJavaScriptFile(node)) bindJSDocTypedefTagIfAny(node);
 
             // First we bind declaration nodes to a symbol if possible. We'll both create a symbol
             // and then potentially add the symbol to an appropriate symbol table. Possible
@@ -1921,8 +1921,8 @@ namespace ts {
             inStrictMode = saveInStrictMode;
         }
 
-        function bindJSDocTypedefTagIfAny(node: HasJSDocNodes) {
-            if (!node.jsDoc) {
+        function bindJSDocTypedefTagIfAny(node: Node) {
+            if (!hasJSDocNodes(node)) {
                 return;
             }
 

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -282,17 +282,8 @@ namespace ts {
                     const index = indexOf(functionType.parameters, node);
                     return "arg" + index as __String;
                 case SyntaxKind.JSDocTypedefTag:
-                    const parentNode = node.parent && node.parent.parent;
-                    let nameFromParentNode: __String;
-                    if (parentNode && parentNode.kind === SyntaxKind.VariableStatement) {
-                        if ((<VariableStatement>parentNode).declarationList.declarations.length > 0) {
-                            const nameIdentifier = (<VariableStatement>parentNode).declarationList.declarations[0].name;
-                            if (isIdentifier(nameIdentifier)) {
-                                nameFromParentNode = nameIdentifier.escapedText;
-                            }
-                        }
-                    }
-                    return nameFromParentNode;
+                    const name = getNameOfJSDocTypedef(node as JSDocTypedefTag);
+                    return typeof name !== "undefined" ? name.escapedText : undefined;
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19158,6 +19158,8 @@ namespace ts {
                 switch (d.kind) {
                     case SyntaxKind.InterfaceDeclaration:
                     case SyntaxKind.TypeAliasDeclaration:
+                    // A jsdoc typedef is, by definition, a type alias
+                    case SyntaxKind.JSDocTypedefTag:
                         return DeclarationSpaces.ExportType;
                     case SyntaxKind.ModuleDeclaration:
                         return isAmbientModule(d) || getModuleInstanceState(d) !== ModuleInstanceState.NonInstantiated
@@ -19827,7 +19829,7 @@ namespace ts {
                             }
                         }
                         else if (compilerOptions.noUnusedLocals) {
-                            forEach(local.declarations, d => errorUnusedLocal(getNameOfDeclaration(d) || d, unescapeLeadingUnderscores(local.escapedName)));
+                            forEach(local.declarations, d => errorUnusedLocal(d, unescapeLeadingUnderscores(local.escapedName)));
                         }
                     }
                 });
@@ -19842,7 +19844,8 @@ namespace ts {
             return false;
         }
 
-        function errorUnusedLocal(node: Node, name: string) {
+        function errorUnusedLocal(declaration: Declaration, name: string) {
+            const node = getNameOfDeclaration(declaration) || declaration;
             if (isIdentifierThatStartsWithUnderScore(node)) {
                 const declaration = getRootDeclaration(node.parent);
                 if (declaration.kind === SyntaxKind.VariableDeclaration && isForInOrOfStatement(declaration.parent.parent)) {
@@ -19909,7 +19912,7 @@ namespace ts {
                     if (!local.isReferenced && !local.exportSymbol) {
                         for (const declaration of local.declarations) {
                             if (!isAmbientModule(declaration)) {
-                                errorUnusedLocal(getNameOfDeclaration(declaration), unescapeLeadingUnderscores(local.escapedName));
+                                errorUnusedLocal(declaration, unescapeLeadingUnderscores(local.escapedName));
                             }
                         }
                     }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2441,7 +2441,7 @@ namespace ts {
             }
         }
 
-        export function fail(message?: string, stackCrawlMark?: Function): void {
+        export function fail(message?: string, stackCrawlMark?: Function): never {
             debugger;
             const e = new Error(message ? `Debug Failure. ${message}` : "Debug Failure.");
             if ((<any>Error).captureStackTrace) {
@@ -2451,8 +2451,7 @@ namespace ts {
         }
 
         export function assertNever(_member: never, message?: string, stackCrawlMark?: Function): never {
-            fail(message, stackCrawlMark || assertNever);
-            throw "Unreachable";
+            return fail(message, stackCrawlMark || assertNever);
         }
 
         export function getFunctionName(func: Function) {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2450,6 +2450,11 @@ namespace ts {
             throw e;
         }
 
+        export function assertNever(_member: never, message?: string, stackCrawlMark?: Function): never {
+            fail(message, stackCrawlMark || assertNever);
+            throw "Unreachable";
+        }
+
         export function getFunctionName(func: Function) {
             if (typeof func !== "function") {
                 return "";

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2450,8 +2450,8 @@ namespace ts {
             throw e;
         }
 
-        export function assertNever(_member: never, message?: string, stackCrawlMark?: Function): never {
-            return fail(message, stackCrawlMark || assertNever);
+        export function assertNever(member: never, message?: string, stackCrawlMark?: Function): never {
+            return fail(message || `Illegal value: ${member}`, stackCrawlMark || assertNever);
         }
 
         export function getFunctionName(func: Function) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6997,8 +6997,8 @@ namespace ts {
                 }
 
                 forEachChild(node, visitNode, visitArray);
-                if ((node as HasJSDocNodes).jsDoc) {
-                    for (const jsDocComment of (node as HasJSDocNodes).jsDoc) {
+                if (hasJSDocNodes(node)) {
+                    for (const jsDocComment of node.jsDoc) {
                         forEachChild(jsDocComment, visitNode, visitArray);
                     }
                 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -526,7 +526,7 @@ namespace ts {
         /* @internal */ contextualMapper?: TypeMapper;        // Mapper for contextual type
     }
 
-    export interface HasJSDocNodes {
+    export interface JSDocContainer {
         /* @internal */ jsDoc?: JSDoc[];                      // JSDoc that directly precedes this node
         /* @internal */ jsDocCache?: ReadonlyArray<JSDocTag>; // Cache for getJSDocTags
     }
@@ -582,7 +582,7 @@ namespace ts {
     export type EqualsToken = Token<SyntaxKind.EqualsToken>;
     export type AsteriskToken = Token<SyntaxKind.AsteriskToken>;
     export type EqualsGreaterThanToken = Token<SyntaxKind.EqualsGreaterThanToken>;
-    export type EndOfFileToken = Token<SyntaxKind.EndOfFileToken> & HasJSDocNodes;
+    export type EndOfFileToken = Token<SyntaxKind.EndOfFileToken> & JSDocContainer;
     export type AtToken = Token<SyntaxKind.AtToken>;
     export type ReadonlyToken = Token<SyntaxKind.ReadonlyKeyword>;
     export type AwaitKeywordToken = Token<SyntaxKind.AwaitKeyword>;
@@ -687,7 +687,7 @@ namespace ts {
         expression?: Expression;
     }
 
-    export interface SignatureDeclarationBase extends NamedDeclaration, HasJSDocNodes {
+    export interface SignatureDeclarationBase extends NamedDeclaration, JSDocContainer {
         kind: SignatureDeclaration["kind"];
         name?: PropertyName;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
@@ -734,7 +734,7 @@ namespace ts {
         declarations: NodeArray<VariableDeclaration>;
     }
 
-    export interface ParameterDeclaration extends NamedDeclaration, HasJSDocNodes {
+    export interface ParameterDeclaration extends NamedDeclaration, JSDocContainer {
         kind: SyntaxKind.Parameter;
         parent?: SignatureDeclaration;
         dotDotDotToken?: DotDotDotToken;    // Present on rest parameter
@@ -753,7 +753,7 @@ namespace ts {
         initializer?: Expression;           // Optional initializer
     }
 
-    export interface PropertySignature extends TypeElement, HasJSDocNodes {
+    export interface PropertySignature extends TypeElement, JSDocContainer {
         kind: SyntaxKind.PropertySignature;
         name: PropertyName;                 // Declared property name
         questionToken?: QuestionToken;      // Present on optional property
@@ -761,7 +761,7 @@ namespace ts {
         initializer?: Expression;           // Optional initializer
     }
 
-    export interface PropertyDeclaration extends ClassElement, HasJSDocNodes {
+    export interface PropertyDeclaration extends ClassElement, JSDocContainer {
         kind: SyntaxKind.PropertyDeclaration;
         questionToken?: QuestionToken;      // Present for use with reporting a grammar error
         name: PropertyName;
@@ -782,7 +782,7 @@ namespace ts {
         | AccessorDeclaration
         ;
 
-    export interface PropertyAssignment extends ObjectLiteralElement, HasJSDocNodes {
+    export interface PropertyAssignment extends ObjectLiteralElement, JSDocContainer {
         parent: ObjectLiteralExpression;
         kind: SyntaxKind.PropertyAssignment;
         name: PropertyName;
@@ -790,7 +790,7 @@ namespace ts {
         initializer: Expression;
     }
 
-    export interface ShorthandPropertyAssignment extends ObjectLiteralElement, HasJSDocNodes {
+    export interface ShorthandPropertyAssignment extends ObjectLiteralElement, JSDocContainer {
         parent: ObjectLiteralExpression;
         kind: SyntaxKind.ShorthandPropertyAssignment;
         name: Identifier;
@@ -801,7 +801,7 @@ namespace ts {
         objectAssignmentInitializer?: Expression;
     }
 
-    export interface SpreadAssignment extends ObjectLiteralElement, HasJSDocNodes {
+    export interface SpreadAssignment extends ObjectLiteralElement, JSDocContainer {
         parent: ObjectLiteralExpression;
         kind: SyntaxKind.SpreadAssignment;
         expression: Expression;
@@ -899,13 +899,13 @@ namespace ts {
     // Because of this, it may be necessary to determine what sort of MethodDeclaration you have
     // at later stages of the compiler pipeline.  In that case, you can either check the parent kind
     // of the method, or use helpers like isObjectLiteralMethodDeclaration
-    export interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, HasJSDocNodes {
+    export interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, JSDocContainer {
         kind: SyntaxKind.MethodDeclaration;
         name: PropertyName;
         body?: FunctionBody;
     }
 
-    export interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElement, HasJSDocNodes {
+    export interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElement, JSDocContainer {
         kind: SyntaxKind.Constructor;
         parent?: ClassDeclaration | ClassExpression;
         body?: FunctionBody;
@@ -919,7 +919,7 @@ namespace ts {
 
     // See the comment on MethodDeclaration for the intuition behind GetAccessorDeclaration being a
     // ClassElement and an ObjectLiteralElement.
-    export interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, HasJSDocNodes {
+    export interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, JSDocContainer {
         kind: SyntaxKind.GetAccessor;
         parent?: ClassDeclaration | ClassExpression | ObjectLiteralExpression;
         name: PropertyName;
@@ -928,7 +928,7 @@ namespace ts {
 
     // See the comment on MethodDeclaration for the intuition behind SetAccessorDeclaration being a
     // ClassElement and an ObjectLiteralElement.
-    export interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, HasJSDocNodes {
+    export interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, JSDocContainer {
         kind: SyntaxKind.SetAccessor;
         parent?: ClassDeclaration | ClassExpression | ObjectLiteralExpression;
         name: PropertyName;
@@ -1393,13 +1393,13 @@ namespace ts {
     export type FunctionBody = Block;
     export type ConciseBody = FunctionBody | Expression;
 
-    export interface FunctionExpression extends PrimaryExpression, FunctionLikeDeclarationBase, HasJSDocNodes {
+    export interface FunctionExpression extends PrimaryExpression, FunctionLikeDeclarationBase, JSDocContainer {
         kind: SyntaxKind.FunctionExpression;
         name?: Identifier;
         body: FunctionBody;  // Required, whereas the member inherited from FunctionDeclaration is optional
     }
 
-    export interface ArrowFunction extends Expression, FunctionLikeDeclarationBase, HasJSDocNodes {
+    export interface ArrowFunction extends Expression, FunctionLikeDeclarationBase, JSDocContainer {
         kind: SyntaxKind.ArrowFunction;
         equalsGreaterThanToken: EqualsGreaterThanToken;
         body: ConciseBody;
@@ -1478,7 +1478,7 @@ namespace ts {
         literal: TemplateMiddle | TemplateTail;
     }
 
-    export interface ParenthesizedExpression extends PrimaryExpression, HasJSDocNodes {
+    export interface ParenthesizedExpression extends PrimaryExpression, JSDocContainer {
         kind: SyntaxKind.ParenthesizedExpression;
         expression: Expression;
     }
@@ -1734,12 +1734,12 @@ namespace ts {
         /*@internal*/ multiLine?: boolean;
     }
 
-    export interface VariableStatement extends Statement, HasJSDocNodes {
+    export interface VariableStatement extends Statement, JSDocContainer {
         kind: SyntaxKind.VariableStatement;
         declarationList: VariableDeclarationList;
     }
 
-    export interface ExpressionStatement extends Statement, HasJSDocNodes {
+    export interface ExpressionStatement extends Statement, JSDocContainer {
         kind: SyntaxKind.ExpressionStatement;
         expression: Expression;
     }
@@ -1845,7 +1845,7 @@ namespace ts {
 
     export type CaseOrDefaultClause = CaseClause | DefaultClause;
 
-    export interface LabeledStatement extends Statement, HasJSDocNodes {
+    export interface LabeledStatement extends Statement, JSDocContainer {
         kind: SyntaxKind.LabeledStatement;
         label: Identifier;
         statement: Statement;
@@ -1872,7 +1872,7 @@ namespace ts {
 
     export type DeclarationWithTypeParameters = SignatureDeclaration | ClassLikeDeclaration | InterfaceDeclaration | TypeAliasDeclaration | JSDocTemplateTag;
 
-    export interface ClassLikeDeclarationBase extends NamedDeclaration, HasJSDocNodes {
+    export interface ClassLikeDeclarationBase extends NamedDeclaration, JSDocContainer {
         kind: SyntaxKind.ClassDeclaration | SyntaxKind.ClassExpression;
         name?: Identifier;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
@@ -1902,7 +1902,7 @@ namespace ts {
         questionToken?: QuestionToken;
     }
 
-    export interface InterfaceDeclaration extends DeclarationStatement, HasJSDocNodes {
+    export interface InterfaceDeclaration extends DeclarationStatement, JSDocContainer {
         kind: SyntaxKind.InterfaceDeclaration;
         name: Identifier;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
@@ -1917,14 +1917,14 @@ namespace ts {
         types: NodeArray<ExpressionWithTypeArguments>;
     }
 
-    export interface TypeAliasDeclaration extends DeclarationStatement, HasJSDocNodes {
+    export interface TypeAliasDeclaration extends DeclarationStatement, JSDocContainer {
         kind: SyntaxKind.TypeAliasDeclaration;
         name: Identifier;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
         type: TypeNode;
     }
 
-    export interface EnumMember extends NamedDeclaration, HasJSDocNodes {
+    export interface EnumMember extends NamedDeclaration, JSDocContainer {
         kind: SyntaxKind.EnumMember;
         parent?: EnumDeclaration;
         // This does include ComputedPropertyName, but the parser will give an error
@@ -1933,7 +1933,7 @@ namespace ts {
         initializer?: Expression;
     }
 
-    export interface EnumDeclaration extends DeclarationStatement, HasJSDocNodes {
+    export interface EnumDeclaration extends DeclarationStatement, JSDocContainer {
         kind: SyntaxKind.EnumDeclaration;
         name: Identifier;
         members: NodeArray<EnumMember>;
@@ -1943,7 +1943,7 @@ namespace ts {
 
     export type ModuleBody = NamespaceBody | JSDocNamespaceBody;
 
-    export interface ModuleDeclaration extends DeclarationStatement, HasJSDocNodes {
+    export interface ModuleDeclaration extends DeclarationStatement, JSDocContainer {
         kind: SyntaxKind.ModuleDeclaration;
         parent?: ModuleBody | SourceFile;
         name: ModuleName;
@@ -1977,7 +1977,7 @@ namespace ts {
      * - import x = require("mod");
      * - import x = M.x;
      */
-    export interface ImportEqualsDeclaration extends DeclarationStatement, HasJSDocNodes {
+    export interface ImportEqualsDeclaration extends DeclarationStatement, JSDocContainer {
         kind: SyntaxKind.ImportEqualsDeclaration;
         parent?: SourceFile | ModuleBlock;
         name: Identifier;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -531,7 +531,6 @@ namespace ts {
         /* @internal */ jsDocCache?: ReadonlyArray<JSDocTag>; // Cache for getJSDocTags
     }
 
-    /* @internal */
     export type HasJSDoc =
         | ParameterDeclaration
         | CallSignatureDeclaration

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -516,8 +516,6 @@ namespace ts {
         parent?: Node;                                        // Parent node (initialized by binding)
         /* @internal */ original?: Node;                      // The original node if this is an updated node.
         /* @internal */ startsOnNewLine?: boolean;            // Whether a synthesized node should start on a new line (used by transforms).
-        /* @internal */ jsDoc?: JSDoc[];                      // JSDoc that directly precedes this node
-        /* @internal */ jsDocCache?: ReadonlyArray<JSDocTag>; // Cache for getJSDocTags
         /* @internal */ symbol?: Symbol;                      // Symbol declared by node (initialized by binding)
         /* @internal */ locals?: SymbolTable;                 // Locals associated with node (initialized by binding)
         /* @internal */ nextContainer?: Node;                 // Next container in declaration order (initialized by binding)
@@ -527,6 +525,45 @@ namespace ts {
         /* @internal */ contextualType?: Type;                // Used to temporarily assign a contextual type during overload resolution
         /* @internal */ contextualMapper?: TypeMapper;        // Mapper for contextual type
     }
+
+    export interface HasJSDocNodes {
+        /* @internal */ jsDoc?: JSDoc[];                      // JSDoc that directly precedes this node
+        /* @internal */ jsDocCache?: ReadonlyArray<JSDocTag>; // Cache for getJSDocTags
+    }
+
+    /* @internal */
+    export type HasJSDoc =
+        | ParameterDeclaration
+        | CallSignatureDeclaration
+        | ConstructSignatureDeclaration
+        | MethodSignature
+        | PropertySignature
+        | ArrowFunction
+        | ParenthesizedExpression
+        | SpreadAssignment
+        | ShorthandPropertyAssignment
+        | PropertyAssignment
+        | FunctionExpression
+        | LabeledStatement
+        | ExpressionStatement
+        | VariableStatement
+        | FunctionDeclaration
+        | ConstructorDeclaration
+        | MethodDeclaration
+        | PropertyDeclaration
+        | AccessorDeclaration
+        | ClassLikeDeclaration
+        | InterfaceDeclaration
+        | TypeAliasDeclaration
+        | EnumMember
+        | EnumDeclaration
+        | ModuleDeclaration
+        | ImportEqualsDeclaration
+        | IndexSignatureDeclaration
+        | FunctionTypeNode
+        | ConstructorTypeNode
+        | JSDocFunctionType
+        | EndOfFileToken;
 
     /* @internal */
     export type MutableNodeArray<T extends Node> = NodeArray<T> & T[];
@@ -546,7 +583,7 @@ namespace ts {
     export type EqualsToken = Token<SyntaxKind.EqualsToken>;
     export type AsteriskToken = Token<SyntaxKind.AsteriskToken>;
     export type EqualsGreaterThanToken = Token<SyntaxKind.EqualsGreaterThanToken>;
-    export type EndOfFileToken = Token<SyntaxKind.EndOfFileToken>;
+    export type EndOfFileToken = Token<SyntaxKind.EndOfFileToken> & HasJSDocNodes;
     export type AtToken = Token<SyntaxKind.AtToken>;
     export type ReadonlyToken = Token<SyntaxKind.ReadonlyKeyword>;
     export type AwaitKeywordToken = Token<SyntaxKind.AwaitKeyword>;
@@ -651,32 +688,34 @@ namespace ts {
         expression?: Expression;
     }
 
-    export interface SignatureDeclaration extends NamedDeclaration {
-        kind: SyntaxKind.CallSignature
-            | SyntaxKind.ConstructSignature
-            | SyntaxKind.MethodSignature
-            | SyntaxKind.IndexSignature
-            | SyntaxKind.FunctionType
-            | SyntaxKind.ConstructorType
-            | SyntaxKind.JSDocFunctionType
-            | SyntaxKind.FunctionDeclaration
-            | SyntaxKind.MethodDeclaration
-            | SyntaxKind.Constructor
-            | SyntaxKind.GetAccessor
-            | SyntaxKind.SetAccessor
-            | SyntaxKind.FunctionExpression
-            | SyntaxKind.ArrowFunction;
+    export interface SignatureDeclarationBase extends NamedDeclaration, HasJSDocNodes {
+        kind: SignatureDeclaration["kind"];
         name?: PropertyName;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
         parameters: NodeArray<ParameterDeclaration>;
         type: TypeNode | undefined;
     }
 
-    export interface CallSignatureDeclaration extends SignatureDeclaration, TypeElement {
+    export type SignatureDeclaration =
+        | CallSignatureDeclaration
+        | ConstructSignatureDeclaration
+        | MethodSignature
+        | IndexSignatureDeclaration
+        | FunctionTypeNode
+        | ConstructorTypeNode
+        | JSDocFunctionType
+        | FunctionDeclaration
+        | MethodDeclaration
+        | ConstructorDeclaration
+        | AccessorDeclaration
+        | FunctionExpression
+        | ArrowFunction;
+
+    export interface CallSignatureDeclaration extends SignatureDeclarationBase, TypeElement {
         kind: SyntaxKind.CallSignature;
     }
 
-    export interface ConstructSignatureDeclaration extends SignatureDeclaration, TypeElement {
+    export interface ConstructSignatureDeclaration extends SignatureDeclarationBase, TypeElement {
         kind: SyntaxKind.ConstructSignature;
     }
 
@@ -696,7 +735,7 @@ namespace ts {
         declarations: NodeArray<VariableDeclaration>;
     }
 
-    export interface ParameterDeclaration extends NamedDeclaration {
+    export interface ParameterDeclaration extends NamedDeclaration, HasJSDocNodes {
         kind: SyntaxKind.Parameter;
         parent?: SignatureDeclaration;
         dotDotDotToken?: DotDotDotToken;    // Present on rest parameter
@@ -715,7 +754,7 @@ namespace ts {
         initializer?: Expression;           // Optional initializer
     }
 
-    export interface PropertySignature extends TypeElement {
+    export interface PropertySignature extends TypeElement, HasJSDocNodes {
         kind: SyntaxKind.PropertySignature;
         name: PropertyName;                 // Declared property name
         questionToken?: QuestionToken;      // Present on optional property
@@ -723,7 +762,7 @@ namespace ts {
         initializer?: Expression;           // Optional initializer
     }
 
-    export interface PropertyDeclaration extends ClassElement {
+    export interface PropertyDeclaration extends ClassElement, HasJSDocNodes {
         kind: SyntaxKind.PropertyDeclaration;
         questionToken?: QuestionToken;      // Present for use with reporting a grammar error
         name: PropertyName;
@@ -744,7 +783,7 @@ namespace ts {
         | AccessorDeclaration
         ;
 
-    export interface PropertyAssignment extends ObjectLiteralElement {
+    export interface PropertyAssignment extends ObjectLiteralElement, HasJSDocNodes {
         parent: ObjectLiteralExpression;
         kind: SyntaxKind.PropertyAssignment;
         name: PropertyName;
@@ -752,7 +791,7 @@ namespace ts {
         initializer: Expression;
     }
 
-    export interface ShorthandPropertyAssignment extends ObjectLiteralElement {
+    export interface ShorthandPropertyAssignment extends ObjectLiteralElement, HasJSDocNodes {
         parent: ObjectLiteralExpression;
         kind: SyntaxKind.ShorthandPropertyAssignment;
         name: Identifier;
@@ -763,7 +802,7 @@ namespace ts {
         objectAssignmentInitializer?: Expression;
     }
 
-    export interface SpreadAssignment extends ObjectLiteralElement {
+    export interface SpreadAssignment extends ObjectLiteralElement, HasJSDocNodes {
         parent: ObjectLiteralExpression;
         kind: SyntaxKind.SpreadAssignment;
         expression: Expression;
@@ -816,7 +855,7 @@ namespace ts {
      * - MethodDeclaration
      * - AccessorDeclaration
      */
-    export interface FunctionLikeDeclarationBase extends SignatureDeclaration {
+    export interface FunctionLikeDeclarationBase extends SignatureDeclarationBase {
         _functionLikeDeclarationBrand: any;
 
         asteriskToken?: AsteriskToken;
@@ -847,7 +886,7 @@ namespace ts {
         body?: FunctionBody;
     }
 
-    export interface MethodSignature extends SignatureDeclaration, TypeElement {
+    export interface MethodSignature extends SignatureDeclarationBase, TypeElement {
         kind: SyntaxKind.MethodSignature;
         name: PropertyName;
     }
@@ -861,13 +900,13 @@ namespace ts {
     // Because of this, it may be necessary to determine what sort of MethodDeclaration you have
     // at later stages of the compiler pipeline.  In that case, you can either check the parent kind
     // of the method, or use helpers like isObjectLiteralMethodDeclaration
-    export interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement {
+    export interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, HasJSDocNodes {
         kind: SyntaxKind.MethodDeclaration;
         name: PropertyName;
         body?: FunctionBody;
     }
 
-    export interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElement {
+    export interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElement, HasJSDocNodes {
         kind: SyntaxKind.Constructor;
         parent?: ClassDeclaration | ClassExpression;
         body?: FunctionBody;
@@ -881,7 +920,7 @@ namespace ts {
 
     // See the comment on MethodDeclaration for the intuition behind GetAccessorDeclaration being a
     // ClassElement and an ObjectLiteralElement.
-    export interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement {
+    export interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, HasJSDocNodes {
         kind: SyntaxKind.GetAccessor;
         parent?: ClassDeclaration | ClassExpression | ObjectLiteralExpression;
         name: PropertyName;
@@ -890,7 +929,7 @@ namespace ts {
 
     // See the comment on MethodDeclaration for the intuition behind SetAccessorDeclaration being a
     // ClassElement and an ObjectLiteralElement.
-    export interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement {
+    export interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, HasJSDocNodes {
         kind: SyntaxKind.SetAccessor;
         parent?: ClassDeclaration | ClassExpression | ObjectLiteralExpression;
         name: PropertyName;
@@ -899,7 +938,7 @@ namespace ts {
 
     export type AccessorDeclaration = GetAccessorDeclaration | SetAccessorDeclaration;
 
-    export interface IndexSignatureDeclaration extends SignatureDeclaration, ClassElement, TypeElement {
+    export interface IndexSignatureDeclaration extends SignatureDeclarationBase, ClassElement, TypeElement {
         kind: SyntaxKind.IndexSignature;
         parent?: ClassDeclaration | ClassExpression | InterfaceDeclaration | TypeLiteralNode;
     }
@@ -928,11 +967,11 @@ namespace ts {
 
     export type FunctionOrConstructorTypeNode = FunctionTypeNode | ConstructorTypeNode;
 
-    export interface FunctionTypeNode extends TypeNode, SignatureDeclaration {
+    export interface FunctionTypeNode extends TypeNode, SignatureDeclarationBase {
         kind: SyntaxKind.FunctionType;
     }
 
-    export interface ConstructorTypeNode extends TypeNode, SignatureDeclaration {
+    export interface ConstructorTypeNode extends TypeNode, SignatureDeclarationBase {
         kind: SyntaxKind.ConstructorType;
     }
 
@@ -1355,13 +1394,13 @@ namespace ts {
     export type FunctionBody = Block;
     export type ConciseBody = FunctionBody | Expression;
 
-    export interface FunctionExpression extends PrimaryExpression, FunctionLikeDeclarationBase {
+    export interface FunctionExpression extends PrimaryExpression, FunctionLikeDeclarationBase, HasJSDocNodes {
         kind: SyntaxKind.FunctionExpression;
         name?: Identifier;
         body: FunctionBody;  // Required, whereas the member inherited from FunctionDeclaration is optional
     }
 
-    export interface ArrowFunction extends Expression, FunctionLikeDeclarationBase {
+    export interface ArrowFunction extends Expression, FunctionLikeDeclarationBase, HasJSDocNodes {
         kind: SyntaxKind.ArrowFunction;
         equalsGreaterThanToken: EqualsGreaterThanToken;
         body: ConciseBody;
@@ -1440,7 +1479,7 @@ namespace ts {
         literal: TemplateMiddle | TemplateTail;
     }
 
-    export interface ParenthesizedExpression extends PrimaryExpression {
+    export interface ParenthesizedExpression extends PrimaryExpression, HasJSDocNodes {
         kind: SyntaxKind.ParenthesizedExpression;
         expression: Expression;
     }
@@ -1696,12 +1735,12 @@ namespace ts {
         /*@internal*/ multiLine?: boolean;
     }
 
-    export interface VariableStatement extends Statement {
+    export interface VariableStatement extends Statement, HasJSDocNodes {
         kind: SyntaxKind.VariableStatement;
         declarationList: VariableDeclarationList;
     }
 
-    export interface ExpressionStatement extends Statement {
+    export interface ExpressionStatement extends Statement, HasJSDocNodes {
         kind: SyntaxKind.ExpressionStatement;
         expression: Expression;
     }
@@ -1807,7 +1846,7 @@ namespace ts {
 
     export type CaseOrDefaultClause = CaseClause | DefaultClause;
 
-    export interface LabeledStatement extends Statement {
+    export interface LabeledStatement extends Statement, HasJSDocNodes {
         kind: SyntaxKind.LabeledStatement;
         label: Identifier;
         statement: Statement;
@@ -1834,7 +1873,7 @@ namespace ts {
 
     export type DeclarationWithTypeParameters = SignatureDeclaration | ClassLikeDeclaration | InterfaceDeclaration | TypeAliasDeclaration | JSDocTemplateTag;
 
-    export interface ClassLikeDeclaration extends NamedDeclaration {
+    export interface ClassLikeDeclarationBase extends NamedDeclaration, HasJSDocNodes {
         kind: SyntaxKind.ClassDeclaration | SyntaxKind.ClassExpression;
         name?: Identifier;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
@@ -1842,14 +1881,16 @@ namespace ts {
         members: NodeArray<ClassElement>;
     }
 
-    export interface ClassDeclaration extends ClassLikeDeclaration, DeclarationStatement {
+    export interface ClassDeclaration extends ClassLikeDeclarationBase, DeclarationStatement {
         kind: SyntaxKind.ClassDeclaration;
         name?: Identifier;
     }
 
-    export interface ClassExpression extends ClassLikeDeclaration, PrimaryExpression {
+    export interface ClassExpression extends ClassLikeDeclarationBase, PrimaryExpression {
         kind: SyntaxKind.ClassExpression;
     }
+
+    export type ClassLikeDeclaration = ClassDeclaration | ClassExpression;
 
     export interface ClassElement extends NamedDeclaration {
         _classElementBrand: any;
@@ -1862,7 +1903,7 @@ namespace ts {
         questionToken?: QuestionToken;
     }
 
-    export interface InterfaceDeclaration extends DeclarationStatement {
+    export interface InterfaceDeclaration extends DeclarationStatement, HasJSDocNodes {
         kind: SyntaxKind.InterfaceDeclaration;
         name: Identifier;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
@@ -1877,14 +1918,14 @@ namespace ts {
         types: NodeArray<ExpressionWithTypeArguments>;
     }
 
-    export interface TypeAliasDeclaration extends DeclarationStatement {
+    export interface TypeAliasDeclaration extends DeclarationStatement, HasJSDocNodes {
         kind: SyntaxKind.TypeAliasDeclaration;
         name: Identifier;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
         type: TypeNode;
     }
 
-    export interface EnumMember extends NamedDeclaration {
+    export interface EnumMember extends NamedDeclaration, HasJSDocNodes {
         kind: SyntaxKind.EnumMember;
         parent?: EnumDeclaration;
         // This does include ComputedPropertyName, but the parser will give an error
@@ -1893,7 +1934,7 @@ namespace ts {
         initializer?: Expression;
     }
 
-    export interface EnumDeclaration extends DeclarationStatement {
+    export interface EnumDeclaration extends DeclarationStatement, HasJSDocNodes {
         kind: SyntaxKind.EnumDeclaration;
         name: Identifier;
         members: NodeArray<EnumMember>;
@@ -1903,7 +1944,7 @@ namespace ts {
 
     export type ModuleBody = NamespaceBody | JSDocNamespaceBody;
 
-    export interface ModuleDeclaration extends DeclarationStatement {
+    export interface ModuleDeclaration extends DeclarationStatement, HasJSDocNodes {
         kind: SyntaxKind.ModuleDeclaration;
         parent?: ModuleBody | SourceFile;
         name: ModuleName;
@@ -1937,7 +1978,7 @@ namespace ts {
      * - import x = require("mod");
      * - import x = M.x;
      */
-    export interface ImportEqualsDeclaration extends DeclarationStatement {
+    export interface ImportEqualsDeclaration extends DeclarationStatement, HasJSDocNodes {
         kind: SyntaxKind.ImportEqualsDeclaration;
         parent?: SourceFile | ModuleBlock;
         name: Identifier;
@@ -2090,7 +2131,7 @@ namespace ts {
         type: TypeNode;
     }
 
-    export interface JSDocFunctionType extends JSDocType, SignatureDeclaration {
+    export interface JSDocFunctionType extends JSDocType, SignatureDeclarationBase {
         kind: SyntaxKind.JSDocFunctionType;
     }
 
@@ -2103,6 +2144,7 @@ namespace ts {
 
     export interface JSDoc extends Node {
         kind: SyntaxKind.JSDocComment;
+        parent?: HasJSDoc;
         tags: NodeArray<JSDocTag> | undefined;
         comment: string | undefined;
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1510,10 +1510,10 @@ namespace ts {
     }
 
     export function getJSDocTags(node: Node): ReadonlyArray<JSDocTag> | undefined {
-        let tags = (node as HasJSDocNodes).jsDocCache;
+        let tags = (node as JSDocContainer).jsDocCache;
         // If cache is 'null', that means we did the work of searching for JSDoc tags and came up with nothing.
         if (tags === undefined) {
-            (node as HasJSDocNodes).jsDocCache = tags = flatMap(getJSDocCommentsAndTags(node), j => isJSDoc(j) ? j.tags : j);
+            (node as JSDocContainer).jsDocCache = tags = flatMap(getJSDocCommentsAndTags(node), j => isJSDoc(j) ? j.tags : j);
         }
         return tags;
     }
@@ -5433,6 +5433,6 @@ namespace ts {
     /** True if has jsdoc nodes attached to it. */
     /* @internal */
     export function hasJSDocNodes(node: Node): node is HasJSDoc {
-        return !!(node as HasJSDocNodes).jsDoc && (node as HasJSDocNodes).jsDoc.length > 0;
+        return !!(node as JSDocContainer).jsDoc && (node as JSDocContainer).jsDoc.length > 0;
     }
 }

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -699,7 +699,8 @@ namespace ts {
                 // specially.
                 const docCommentAndDiagnostics = parseIsolatedJSDocComment(sourceFile.text, start, width);
                 if (docCommentAndDiagnostics && docCommentAndDiagnostics.jsDoc) {
-                    docCommentAndDiagnostics.jsDoc.parent = token;
+                    // TODO: This should be predicated on `token["kind"]` being compatible with `HasJSDoc["kind"]`
+                    docCommentAndDiagnostics.jsDoc.parent = token as HasJSDoc;
                     classifyJSDocComment(docCommentAndDiagnostics.jsDoc);
                     return;
                 }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1739,7 +1739,7 @@ namespace ts.Completions {
 
     /** Get the corresponding JSDocTag node if the position is in a jsDoc comment */
     function getJsDocTagAtPosition(node: Node, position: number): JSDocTag | undefined {
-        const { jsDoc } = getJsDocHavingNode(node) as HasJSDocNodes;
+        const { jsDoc } = getJsDocHavingNode(node) as JSDocContainer;
         if (!jsDoc) return undefined;
 
         for (const { pos, end, tags } of jsDoc) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1739,7 +1739,7 @@ namespace ts.Completions {
 
     /** Get the corresponding JSDocTag node if the position is in a jsDoc comment */
     function getJsDocTagAtPosition(node: Node, position: number): JSDocTag | undefined {
-        const { jsDoc } = getJsDocHavingNode(node);
+        const { jsDoc } = getJsDocHavingNode(node) as HasJSDocNodes;
         if (!jsDoc) return undefined;
 
         for (const { pos, end, tags } of jsDoc) {

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -263,13 +263,15 @@ namespace ts.NavigationBar {
                 break;
 
             default:
-                forEach(node.jsDoc, jsDoc => {
-                    forEach(jsDoc.tags, tag => {
-                        if (tag.kind === SyntaxKind.JSDocTypedefTag) {
-                            addLeafNode(tag);
-                        }
+                if (hasJSDocNodes(node)) {
+                    forEach(node.jsDoc, jsDoc => {
+                        forEach(jsDoc.tags, tag => {
+                            if (tag.kind === SyntaxKind.JSDocTypedefTag) {
+                                addLeafNode(tag);
+                            }
+                        });
                     });
-                });
+                }
 
                 forEachChild(node, addChildrenRecursively);
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2111,7 +2111,7 @@ namespace ts {
             }
 
             forEachChild(node, walk);
-            if (node.jsDoc) {
+            if (hasJSDocNodes(node)) {
                 for (const jsDoc of node.jsDoc) {
                     forEachChild(jsDoc, walk);
                 }

--- a/tests/baselines/reference/jsdocTypedefNoCrash.js
+++ b/tests/baselines/reference/jsdocTypedefNoCrash.js
@@ -1,0 +1,13 @@
+//// [export.js]
+/**
+ * @typedef {{
+ * }}
+ */
+export const foo = 5;
+
+//// [export.js]
+/**
+ * @typedef {{
+ * }}
+ */
+export const foo = 5;

--- a/tests/baselines/reference/jsdocTypedefNoCrash.symbols
+++ b/tests/baselines/reference/jsdocTypedefNoCrash.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/export.js ===
+/**
+ * @typedef {{
+ * }}
+ */
+export const foo = 5;
+>foo : Symbol(foo, Decl(export.js, 4, 12))
+

--- a/tests/baselines/reference/jsdocTypedefNoCrash.types
+++ b/tests/baselines/reference/jsdocTypedefNoCrash.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/export.js ===
+/**
+ * @typedef {{
+ * }}
+ */
+export const foo = 5;
+>foo : 5
+>5 : 5
+

--- a/tests/baselines/reference/jsdocTypedefNoCrash2.errors.txt
+++ b/tests/baselines/reference/jsdocTypedefNoCrash2.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/export.js(1,13): error TS8008: 'type aliases' can only be used in a .ts file.
+
+
+==== tests/cases/compiler/export.js (1 errors) ====
+    export type foo = 5;
+                ~~~
+!!! error TS8008: 'type aliases' can only be used in a .ts file.
+    /**
+     * @typedef {{
+     * }}
+     */
+    export const foo = 5;

--- a/tests/baselines/reference/jsdocTypedefNoCrash2.js
+++ b/tests/baselines/reference/jsdocTypedefNoCrash2.js
@@ -1,0 +1,14 @@
+//// [export.js]
+export type foo = 5;
+/**
+ * @typedef {{
+ * }}
+ */
+export const foo = 5;
+
+//// [export.js]
+/**
+ * @typedef {{
+ * }}
+ */
+export const foo = 5;

--- a/tests/cases/compiler/jsdocTypedefNoCrash.ts
+++ b/tests/cases/compiler/jsdocTypedefNoCrash.ts
@@ -1,0 +1,9 @@
+// @target: es6
+// @allowJs: true
+// @outDir: ./dist
+// @filename: export.js
+/**
+ * @typedef {{
+ * }}
+ */
+export const foo = 5;

--- a/tests/cases/compiler/jsdocTypedefNoCrash2.ts
+++ b/tests/cases/compiler/jsdocTypedefNoCrash2.ts
@@ -1,0 +1,11 @@
+// @target: es6
+// @allowJs: true
+// @outDir: ./dist
+// @filename: export.js
+
+export type foo = 5;
+/**
+ * @typedef {{
+ * }}
+ */
+export const foo = 5;


### PR DESCRIPTION
And strengthen `errorUnusedLocal` to no longer error when a declaration name cannot be found.

Fixes #18097

There were actually two separate but related crashes in that issue - one because `getDeclarationSpaces` did not contain a clause for jsdoc typedefs, and one because `getNameOfDeclaration` did not know how to find the name for a jsdoc typedef when its own `.name` field was not provided - I've unified the codepath used by the binder to get the name with the path used in `getNameOfDeclaration`, so minimally if the symbol is bound, then it should be nameable now. In doing so I found that we had some test cases which were unnameable but bound or nameable but unbound, and added clauses to the new `getNameOfJSDocTypedef` based on where I saw either naming or binding occur prior to this change, so both should always be possible in both cases now. To do this, I wanted to ensure I was being exhaustive with the nodes checked; so I've also separated the jsdoc node properties from the `Node` interface and created a `HasJSDoc` union which represents all nodes which the parser applies JSDoc to. In doing so, I actually found a few types where we could have been applying jsdoc, but were not - which we now are.