### PR TITLE
Add `Object.getOwnPropertyDescriptors` definition (2nd attempt)

### DIFF
--- a/src/lib/es2017.object.d.ts
+++ b/src/lib/es2017.object.d.ts
@@ -22,4 +22,10 @@ interface ObjectConstructor {
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
     entries(o: any): [string, any][];
+
+    /**
+     * Returns an object containing all own property descriptors of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    getOwnPropertyDescriptors<T>(o: T): {[P in keyof T]: TypedPropertyDescriptor<T[P]>} & { [x: string]: PropertyDescriptor };
 }


### PR DESCRIPTION
Original PR #15280

Made changes as per https://github.com/Microsoft/TypeScript/pull/15280/files/26150d97951039a1a4bd2c9ac4f9145325154716#r113041822

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15280