### PR TITLE
ts.server.ProjectService.closeConfiguredProject returns true on success.

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1686,11 +1686,13 @@ namespace ts.server {
             }
         }
 
-        private closeConfiguredProject(configFile: NormalizedPath): void {
+        private closeConfiguredProject(configFile: NormalizedPath): boolean {
             const configuredProject = this.findConfiguredProjectByProjectName(configFile);
             if (configuredProject && configuredProject.deleteOpenRef() === 0) {
                 this.removeProject(configuredProject);
+                return true;
             }
+            return false;
         }
 
         closeExternalProject(uncheckedFileName: string, suppressRefresh = false): void {


### PR DESCRIPTION
Fixes #17892
The if condition around the return value of that method in closeExternalProject indicates that this was the expected behavior.

I didn't find any tests (I searched for `ts.server` in path tests/cases). If one is required, where would it go?