### PR TITLE
Simplify return type parsing

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1316,14 +1316,12 @@ namespace ts {
 
     export function createFileDiagnostic(file: SourceFile, start: number, length: number, message: DiagnosticMessage, ...args: (string | number)[]): Diagnostic;
     export function createFileDiagnostic(file: SourceFile, start: number, length: number, message: DiagnosticMessage): Diagnostic {
-        const end = start + length;
-
         Debug.assertGreaterThanOrEqual(start, 0);
         Debug.assertGreaterThanOrEqual(length, 0);
 
         if (file) {
             Debug.assertLessThanOrEqual(start, file.text.length);
-            Debug.assertLessThanOrEqual(end, file.text.length);
+            Debug.assertLessThanOrEqual(start + length, file.text.length);
         }
 
         let text = getLocaleSpecificMessage(message);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2294,20 +2294,23 @@ namespace ts {
         }
 
         function parseReturnType(returnToken: SyntaxKind.ColonToken | SyntaxKind.EqualsGreaterThanToken, isType: boolean): TypeNode | undefined {
+            return shouldParseReturnType(returnToken, isType) ? parseTypeOrTypePredicate() : undefined;
+        }
+        function shouldParseReturnType(returnToken: SyntaxKind.ColonToken | SyntaxKind.EqualsGreaterThanToken, isType: boolean): boolean {
             if (returnToken === SyntaxKind.EqualsGreaterThanToken) {
-                // return token required
-                parseExpected(SyntaxKind.EqualsGreaterThanToken);
+                parseExpected(returnToken);
+                return true;
             }
-            else if (parseOptional(SyntaxKind.ColonToken)) {}
+            else if (parseOptional(SyntaxKind.ColonToken)) {
+                return true;
+            }
             else if (isType && token() === SyntaxKind.EqualsGreaterThanToken) {
                 // This is easy to get backward, especially in type contexts, so parse the type anyway
                 parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.ColonToken));
                 nextToken();
+                return true;
             }
-            else {
-                return undefined;
-            }
-            return parseTypeOrTypePredicate();
+            return false;
         }
 
         function parseParameterList(flags: SignatureFlags) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -668,7 +668,7 @@ namespace ts {
         name?: PropertyName;
         typeParameters?: NodeArray<TypeParameterDeclaration>;
         parameters: NodeArray<ParameterDeclaration>;
-        type?: TypeNode;
+        type: TypeNode | undefined;
     }
 
     export interface CallSignatureDeclaration extends SignatureDeclaration, TypeElement {


### PR DESCRIPTION
There was some dead code around due to checking `returnToken` after it had already been checked.