### PR TITLE
Expand type references recursively in cache key

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9782,8 +9782,8 @@ namespace ts {
             return type.flags & TypeFlags.TypeParameter && !getConstraintFromTypeParameter(<TypeParameter>type);
         }
 
-        function isTypeReferenceWithGenericArguments(type: Type) {
-            return getObjectFlags(type) & ObjectFlags.Reference && some((<TypeReference>type).typeArguments, isUnconstrainedTypeParameter);
+        function isTypeReferenceWithGenericArguments(type: Type): type is TypeReference {
+            return getObjectFlags(type) & ObjectFlags.Reference && some((<TypeReference>type).typeArguments, t => isUnconstrainedTypeParameter(t) || isTypeReferenceWithGenericArguments(t));
         }
 
         /**
@@ -9800,6 +9800,9 @@ namespace ts {
                         typeParameters.push(t);
                     }
                     result += "=" + index;
+                }
+                else if (isTypeReferenceWithGenericArguments(t)) {
+                    result += "<" + getTypeReferenceId(t, typeParameters) + ">";
                 }
                 else {
                     result += "-" + t.id;
@@ -10050,7 +10053,7 @@ namespace ts {
                 getUnionType(types, /*subtypeReduction*/ true);
         }
 
-        function isArrayType(type: Type): boolean {
+        function isArrayType(type: Type): type is TypeReference {
             return getObjectFlags(type) & ObjectFlags.Reference && (<TypeReference>type).target === globalArrayType;
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9781,7 +9781,7 @@ namespace ts {
             return type.flags & TypeFlags.TypeParameter && !getConstraintFromTypeParameter(<TypeParameter>type);
         }
 
-        function isTypeReferenceWithGenericArguments(type: Type): type is TypeReference {
+        function isTypeReferenceWithGenericArguments(type: Type): boolean {
             return getObjectFlags(type) & ObjectFlags.Reference && some((<TypeReference>type).typeArguments, t => isUnconstrainedTypeParameter(t) || isTypeReferenceWithGenericArguments(t));
         }
 
@@ -9801,7 +9801,7 @@ namespace ts {
                     result += "=" + index;
                 }
                 else if (depth < 4 && isTypeReferenceWithGenericArguments(t)) {
-                    result += "<" + getTypeReferenceId(t, typeParameters, depth + 1) + ">";
+                    result += "<" + getTypeReferenceId(t as TypeReference, typeParameters, depth + 1) + ">";
                 }
                 else {
                     result += "-" + t.id;
@@ -10052,7 +10052,7 @@ namespace ts {
                 getUnionType(types, /*subtypeReduction*/ true);
         }
 
-        function isArrayType(type: Type): type is TypeReference {
+        function isArrayType(type: Type): boolean {
             return getObjectFlags(type) & ObjectFlags.Reference && (<TypeReference>type).target === globalArrayType;
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9790,7 +9790,7 @@ namespace ts {
          * getTypeReferenceId(A<T, number, U>) returns "111=0-12=1"
          *   where A.id=111 and number.id=12
          */
-        function getTypeReferenceId(type: TypeReference, typeParameters: Type[]) {
+        function getTypeReferenceId(type: TypeReference, typeParameters: Type[], depth = 0) {
             let result = "" + type.target.id;
             for (const t of type.typeArguments) {
                 if (isUnconstrainedTypeParameter(t)) {
@@ -9801,8 +9801,8 @@ namespace ts {
                     }
                     result += "=" + index;
                 }
-                else if (isTypeReferenceWithGenericArguments(t)) {
-                    result += "<" + getTypeReferenceId(t, typeParameters) + ">";
+                else if (depth < 4 && isTypeReferenceWithGenericArguments(t)) {
+                    result += "<" + getTypeReferenceId(t, typeParameters, depth + 1) + ">";
                 }
                 else {
                     result += "-" + t.id;


### PR DESCRIPTION
This means that `A<B<T, C<U>>>` will include the keys for `B` and `C` now.

Fixes the secondary cause of #17716 &mdash; when comparing `Bluebird<string>` to `Bluebird<string>`, the compilation ends up using two versions of Bluebird. And it turns out Bluebird is a very large type, and nearly every method returns another instance of Bluebird. This causes the compiler to run out of memory and crash. With this fix, compilation finishes in 2.9 seconds compared to 0.9 seconds when package deduping work correctly, skipping the structural `Bluebird <-> Bluebird` comparison.

The fix works because many of Bluebird's methods return `Bluebird<T[]>`. So extending `getTypeReferenceId` to understand arrays allows caching to perform better. The intuition is that if we don't learn anything by relating `A<T> ==> B<T>` when already relating `A<U> ==> B<U>`, then we also don't learn anything by relating `A<T[]> ==> B<T[]>` when already relating `A<U[]> ==> B<U[]>`.

This technique, in fact, generalises to any depth of nested type references. that is a type argument of a type reference. So if we are already relating `Foo<Bar<T, Baz<V>>> ==> Qux<Quid<T, Quam<V>>>` then we will skip `Foo<Bar<U, Baz<W>>> ==> Qux<Quid<U, Quam<W>>>`. 

This works by generating the same key in `getTypeReferenceId`. I add one additional case that checks if a type argument is itself a type reference with generic arguments. If so, then `getTypeReferenceId` calls itself recursively on that type argument.

Note that we could limit the depth of the expansion when generating the key by adding a depth parameter to `getTypeReferenceId`.