### PR TITLE
Check for jsconfig.json when running tsc

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -160,6 +160,10 @@ namespace ts {
             if (!fileOrDirectory /* current directory "." */ || sys.directoryExists(fileOrDirectory)) {
                 configFileName = combinePaths(fileOrDirectory, "tsconfig.json");
                 if (!sys.fileExists(configFileName)) {
+                    configFileName = combinePaths(fileOrDirectory, "jsconfig.json");
+                }
+
+                if (!sys.fileExists(configFileName)) {
                     reportDiagnostic(createCompilerDiagnostic(Diagnostics.Cannot_find_a_tsconfig_json_file_at_the_specified_directory_Colon_0, commandLine.options.project), /* host */ undefined);
                     return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
                 }


### PR DESCRIPTION
This patch checks for `jsconfig.json` in addition to `tsconfig.json` if no configuration file is specified.

Fixes #18235
