### PR TITLE
Fix 18224

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18052,7 +18052,7 @@ namespace ts {
 
         function checkParenthesizedExpression(node: ParenthesizedExpression, checkMode?: CheckMode): Type {
             if (isInJavaScriptFile(node) && node.jsDoc) {
-                const typecasts = flatMap(node.jsDoc, doc => filter(doc.tags, tag => tag.kind === SyntaxKind.JSDocTypeTag));
+                const typecasts = flatMap(node.jsDoc, doc => filter(doc.tags, tag => tag.kind === SyntaxKind.JSDocTypeTag && !!(tag as JSDocTypeTag).typeExpression && !!(tag as JSDocTypeTag).typeExpression.type));
                 if (typecasts && typecasts.length) {
                     // We should have already issued an error if there were multiple type jsdocs
                     const cast = typecasts[0] as JSDocTypeTag;

--- a/tests/baselines/reference/jsdocTypecastNoTypeNoCrash.js
+++ b/tests/baselines/reference/jsdocTypecastNoTypeNoCrash.js
@@ -1,0 +1,8 @@
+//// [index.js]
+function Foo() {}
+const a = /* @type string */(Foo);
+
+
+//// [index.js]
+function Foo() { }
+var a = (Foo);

--- a/tests/baselines/reference/jsdocTypecastNoTypeNoCrash.symbols
+++ b/tests/baselines/reference/jsdocTypecastNoTypeNoCrash.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/index.js ===
+function Foo() {}
+>Foo : Symbol(Foo, Decl(index.js, 0, 0))
+
+const a = /* @type string */(Foo);
+>a : Symbol(a, Decl(index.js, 1, 5))
+>Foo : Symbol(Foo, Decl(index.js, 0, 0))
+

--- a/tests/baselines/reference/jsdocTypecastNoTypeNoCrash.types
+++ b/tests/baselines/reference/jsdocTypecastNoTypeNoCrash.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/index.js ===
+function Foo() {}
+>Foo : () => void
+
+const a = /* @type string */(Foo);
+>a : () => void
+>(Foo) : () => void
+>Foo : () => void
+

--- a/tests/cases/compiler/jsdocTypecastNoTypeNoCrash.ts
+++ b/tests/cases/compiler/jsdocTypecastNoTypeNoCrash.ts
@@ -2,11 +2,4 @@
 // @outDir: ./out
 // @filename: index.js
 function Foo() {}
-const x = /* @type */(Foo);
-/* @type */(function() {})();
-
-const y = /* @type {} */(Foo);
-/* @type {} */(function() {})();
-
-const z = /* @type { */(Foo);
-/* @type { */(function() {})();
+const a = /* @type string */(Foo);

--- a/tests/cases/compiler/jsdocTypecastNoTypeNoCrash.ts
+++ b/tests/cases/compiler/jsdocTypecastNoTypeNoCrash.ts
@@ -1,0 +1,12 @@
+// @allowJS: true
+// @outDir: ./out
+// @filename: index.js
+function Foo() {}
+const x = /* @type */(Foo);
+/* @type */(function() {})();
+
+const y = /* @type {} */(Foo);
+/* @type {} */(function() {})();
+
+const z = /* @type { */(Foo);
+/* @type { */(function() {})();


### PR DESCRIPTION
Fixes #18224

No longer crash when we parse a jsdoc `@type` tag without an accompanying type (but still with a comment).