### PR TITLE
Optimize strict generic signature checking performance

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6654,9 +6654,8 @@ namespace ts {
             // interface is instantiated with a fresh set of cloned type parameters (which we need to handle scenarios
             // where different generations of the same type parameter are in scope). This leads to a lot of new type
             // identities, and potentially a lot of work comparing those identities, so here we create an instantiation
-            // that reverts back to the original type identities for all unconstrained type parameters.
-            const canonicalTypeArguments = map(signature.typeParameters, tp => tp.target && !getConstraintOfTypeParameter(tp.target) ? tp.target : tp);
-            return instantiateSignature(signature, createTypeMapper(signature.typeParameters, canonicalTypeArguments), /*eraseTypeParameters*/ true);
+            // that uses the original type identities for all unconstrained type parameters.
+            return getSignatureInstantiation(signature, map(signature.typeParameters, tp => tp.target && !getConstraintOfTypeParameter(tp.target) ? tp.target : tp));
         }
 
         function getOrCreateTypeFromSignature(signature: Signature): ObjectType {
@@ -8493,8 +8492,8 @@ namespace ts {
                 return Ternary.False;
             }
 
-            target = getCanonicalSignature(target);
-            if (source.typeParameters) {
+            if (source.typeParameters && source.typeParameters !== target.typeParameters) {
+                target = getCanonicalSignature(target);
                 source = instantiateSignatureInContextOf(source, target, /*contextualMapper*/ undefined, compareTypes);
             }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3447,6 +3447,8 @@ namespace ts {
         /* @internal */
         erasedSignatureCache?: Signature;   // Erased version of signature (deferred)
         /* @internal */
+        canonicalSignatureCache?: Signature; // Canonical version of signature (deferred)
+        /* @internal */
         isolatedSignatureType?: ObjectType; // A manufactured type that just contains the signature for purposes of signature comparison
         /* @internal */
         typePredicate?: TypePredicate;


### PR DESCRIPTION
This PR optimizes the performance of strict generic signature checking introduced in #16368. When a generic class or interface is instantiated, each generic method in the class or interface is instantiated with a fresh set of cloned type parameters (which we need to handle scenarios where different generations of the same type parameter are in scope). This leads to a lot of new type identities, and potentially a lot of work comparing those identities in strict generic checking mode. As an optimization we now base signature comparisons on "canonical instantiations" that uses a single type identity for all unconstrained type parameters.

Projects that make heavy use of generic methods see dramatically improved type check times. For example:

* https://github.com/falsandtru/spica: From 4.24s to 1.83s.
* https://github.com/arturkulig/immview: From 18.25s to 1.35s.
* https://github.com/emmanueltouzery/prelude.ts: From 21.34s to 0.93s.

Only changes in RWC baselines are missing error elaborations due to improved sharing.

Fixes #18257.