### PR TITLE
Add `never` helper function

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1686,7 +1686,7 @@ namespace ts {
                     undefined;
             }
             else {
-                never(name);
+                Debug.assertNever(name, "Unknown entity name kind.");
             }
             Debug.assert((getCheckFlags(symbol) & CheckFlags.Instantiated) === 0, "Should never get an instantiated symbol here.");
             return (symbol.flags & meaning) || dontResolveAlias ? symbol : resolveAlias(symbol);
@@ -16342,7 +16342,7 @@ namespace ts {
                     // This code-path is called by language service
                     return resolveStatelessJsxOpeningLikeElement(<JsxOpeningLikeElement>node, checkExpression((<JsxOpeningLikeElement>node).tagName), candidatesOutArray);
             }
-            never(node);
+            Debug.assertNever(node, "Branch in 'resolveSignature' should be unreachable.");
         }
 
         /**
@@ -24514,7 +24514,7 @@ namespace ts {
                     currentKind = SetAccessor;
                 }
                 else {
-                    never(prop);
+                    Debug.assertNever(prop, "Unexpected syntax kind:" + (<Node>prop).kind);
                 }
 
                 const effectiveName = getPropertyNameForPropertyNameNode(name);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1686,7 +1686,7 @@ namespace ts {
                     undefined;
             }
             else {
-                Debug.fail("Unknown entity name kind.");
+                never(name);
             }
             Debug.assert((getCheckFlags(symbol) & CheckFlags.Instantiated) === 0, "Should never get an instantiated symbol here.");
             return (symbol.flags & meaning) || dontResolveAlias ? symbol : resolveAlias(symbol);
@@ -16342,7 +16342,7 @@ namespace ts {
                     // This code-path is called by language service
                     return resolveStatelessJsxOpeningLikeElement(<JsxOpeningLikeElement>node, checkExpression((<JsxOpeningLikeElement>node).tagName), candidatesOutArray);
             }
-            Debug.fail("Branch in 'resolveSignature' should be unreachable.");
+            never(node);
         }
 
         /**
@@ -24514,7 +24514,7 @@ namespace ts {
                     currentKind = SetAccessor;
                 }
                 else {
-                    Debug.fail("Unexpected syntax kind:" + (<Node>prop).kind);
+                    never(prop);
                 }
 
                 const effectiveName = getPropertyNameForPropertyNameNode(name);

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2422,6 +2422,10 @@ namespace ts {
             }
         }
 
+        export function assertNever(never: never, message?: string, stackCrawlMark?: Function): never {
+            throw fail(message || `Illegal value: ${never}`, stackCrawlMark || assertNever);
+        }
+
         export function assertEqual<T>(a: T, b: T, msg?: string, msg2?: string): void {
             if (a !== b) {
                 const message = msg ? msg2 ? `${msg} ${msg2}` : msg : "";
@@ -2627,9 +2631,5 @@ namespace ts {
 
     export function and<T>(f: (arg: T) => boolean, g: (arg: T) => boolean) {
         return (arg: T) => f(arg) && g(arg);
-    }
-
-    export function never(never: never): never {
-        throw new Error(`Illegal value: ${never}`);
     }
 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2628,4 +2628,8 @@ namespace ts {
     export function and<T>(f: (arg: T) => boolean, g: (arg: T) => boolean) {
         return (arg: T) => f(arg) && g(arg);
     }
+
+    export function never(never: never): never {
+        throw new Error(`Illegal value: ${never}`);
+    }
 }


### PR DESCRIPTION
Moved out of #18154.
This would add a `never` function which both:
* At compile-time, asserts that the type of the value is `never`.
* At runtime, throws an error.

#18154 uses a function `assertTypeIsNever` but handles the value regardless.
I think @weswigham was going to add a similar function in one of his PRs.