### PR TITLE
Add `debugName` property to `Rule`

### DIFF
--- a/src/services/formatting/rule.ts
+++ b/src/services/formatting/rule.ts
@@ -3,16 +3,12 @@
 /* @internal */
 namespace ts.formatting {
     export class Rule {
+        // Used for debugging to identify each rule based on the property name it's assigned to.
+        public debugName?: string;
         constructor(
-            public Descriptor: RuleDescriptor,
-            public Operation: RuleOperation,
-            public Flag: RuleFlags = RuleFlags.None) {
-        }
-
-        public toString() {
-            return "[desc=" + this.Descriptor + "," +
-                "operation=" + this.Operation + "," +
-                "flag=" + this.Flag + "]";
+            readonly Descriptor: RuleDescriptor,
+            readonly Operation: RuleOperation,
+            readonly Flag: RuleFlags = RuleFlags.None) {
         }
     }
 }

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -3,18 +3,6 @@
 /* @internal */
 namespace ts.formatting {
     export class Rules {
-        public getRuleName(rule: Rule) {
-            const o: ts.MapLike<any> = <any>this;
-            for (const name in o) {
-                if (o[name] === rule) {
-                    return name;
-                }
-            }
-            throw new Error("Unknown rule");
-        }
-
-        [name: string]: any;
-
         public IgnoreBeforeComment: Rule;
         public IgnoreAfterLineComment: Rule;
 
@@ -569,6 +557,16 @@ namespace ts.formatting {
                 this.SpaceAfterSemicolon,
                 this.SpaceBetweenStatements, this.SpaceAfterTryFinally
             ];
+
+            if (Debug.isDebugging) {
+                const o: ts.MapLike<any> = <any>this;
+                for (const name in o) {
+                    const rule = o[name];
+                    if (rule instanceof Rule) {
+                        rule.debugName = name;
+                    }
+                }
+            }
         }
 
         ///

--- a/src/services/formatting/rulesProvider.ts
+++ b/src/services/formatting/rulesProvider.ts
@@ -9,16 +9,8 @@ namespace ts.formatting {
 
         constructor() {
             this.globalRules = new Rules();
-            const activeRules = this.globalRules.HighPriorityCommonRules.slice(0).concat(this.globalRules.UserConfigurableRules).concat(this.globalRules.LowPriorityCommonRules);
+            const activeRules = this.globalRules.HighPriorityCommonRules.concat(this.globalRules.UserConfigurableRules).concat(this.globalRules.LowPriorityCommonRules);
             this.rulesMap = RulesMap.create(activeRules);
-        }
-
-        public getRuleName(rule: Rule): string {
-            return this.globalRules.getRuleName(rule);
-        }
-
-        public getRuleByName(name: string): Rule {
-            return this.globalRules[name];
         }
 
         public getRulesMap() {


### PR DESCRIPTION
This helps when stepping through the formatter and seeing an unknown rule applied; this tells us what property name it was assigned to in `rules.ts`.
This replaces `Rules#getRuleName` which wasn't very convenient to access while debugging; it's easier if the rule itself has all the information needed. Removed some unused methods from `rulesProvider` that used that.

Also removed `toString()` which isn't used anywhere and isn't any more useful than a normal debug inspection.
