### PR TITLE
Update `fromCodeFixContext`

### DIFF
--- a/src/services/codefixes/correctQualifiedNameToIndexedAccessType.ts
+++ b/src/services/codefixes/correctQualifiedNameToIndexedAccessType.ts
@@ -15,7 +15,7 @@ namespace ts.codefix {
             const replacement = createIndexedAccessTypeNode(
                 createTypeReferenceNode(qualifiedName.left, /*typeArguments*/ undefined),
                 createLiteralTypeNode(createLiteral(rightText)));
-            const changeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+            const changeTracker = textChanges.ChangeTracker.fromContext(context);
             changeTracker.replaceNode(sourceFile, qualifiedName, replacement);
 
             return [{

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -87,7 +87,7 @@ namespace ts.codefix {
                     createPropertyAccess(createIdentifier(className), tokenName),
                     createIdentifier("undefined")));
 
-                const staticInitializationChangeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+                const staticInitializationChangeTracker = textChanges.ChangeTracker.fromContext(context);
                 staticInitializationChangeTracker.insertNodeAfter(
                     classDeclarationSourceFile,
                     classDeclaration,
@@ -111,7 +111,7 @@ namespace ts.codefix {
                     createPropertyAccess(createThis(), tokenName),
                     createIdentifier("undefined")));
 
-                const propertyInitializationChangeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+                const propertyInitializationChangeTracker = textChanges.ChangeTracker.fromContext(context);
                 propertyInitializationChangeTracker.insertNodeAt(
                     classDeclarationSourceFile,
                     classConstructor.body.getEnd() - 1,
@@ -153,7 +153,7 @@ namespace ts.codefix {
                 /*questionToken*/ undefined,
                 typeNode,
                 /*initializer*/ undefined);
-            const propertyChangeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+            const propertyChangeTracker = textChanges.ChangeTracker.fromContext(context);
             propertyChangeTracker.insertNodeAfter(classDeclarationSourceFile, classOpenBrace, property, { suffix: context.newLineCharacter });
 
             (actions || (actions = [])).push({
@@ -178,7 +178,7 @@ namespace ts.codefix {
                     [indexingParameter],
                     typeNode);
 
-                const indexSignatureChangeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+                const indexSignatureChangeTracker = textChanges.ChangeTracker.fromContext(context);
                 indexSignatureChangeTracker.insertNodeAfter(classDeclarationSourceFile, classOpenBrace, indexSignature, { suffix: context.newLineCharacter });
 
                 actions.push({
@@ -195,7 +195,7 @@ namespace ts.codefix {
                 const callExpression = <CallExpression>token.parent.parent;
                 const methodDeclaration = createMethodFromCallExpression(callExpression, tokenName, includeTypeScriptSyntax, makeStatic);
 
-                const methodDeclarationChangeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+                const methodDeclarationChangeTracker = textChanges.ChangeTracker.fromContext(context);
                 methodDeclarationChangeTracker.insertNodeAfter(classDeclarationSourceFile, classOpenBrace, methodDeclaration, { suffix: context.newLineCharacter });
                 return {
                     description: formatStringFromArgs(getLocaleSpecificMessage(makeStatic ?

--- a/src/services/codefixes/fixClassSuperMustPrecedeThisAccess.ts
+++ b/src/services/codefixes/fixClassSuperMustPrecedeThisAccess.ts
@@ -26,7 +26,7 @@ namespace ts.codefix {
                     }
                 }
             }
-            const changeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+            const changeTracker = textChanges.ChangeTracker.fromContext(context);
             changeTracker.insertNodeAfter(sourceFile, getOpenBrace(<ConstructorDeclaration>constructor, sourceFile), superCall, { suffix: context.newLineCharacter });
             changeTracker.deleteNode(sourceFile, superCall);
 

--- a/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
+++ b/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
@@ -10,7 +10,7 @@ namespace ts.codefix {
                 return undefined;
             }
 
-            const changeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+            const changeTracker = textChanges.ChangeTracker.fromContext(context);
             const superCall = createStatement(createCall(createSuper(), /*typeArguments*/ undefined, /*argumentsArray*/ emptyArray));
             changeTracker.insertNodeAfter(sourceFile, getOpenBrace(<ConstructorDeclaration>token.parent, sourceFile), superCall, { suffix: context.newLineCharacter });
 

--- a/src/services/codefixes/fixExtendsInterfaceBecomesImplements.ts
+++ b/src/services/codefixes/fixExtendsInterfaceBecomesImplements.ts
@@ -21,7 +21,7 @@ namespace ts.codefix {
                 return undefined;
             }
 
-            const changeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+            const changeTracker = textChanges.ChangeTracker.fromContext(context);
             changeTracker.replaceNode(sourceFile, extendsToken, createToken(SyntaxKind.ImplementsKeyword));
 
             // We replace existing keywords with commas.

--- a/src/services/codefixes/fixForgottenThisPropertyAccess.ts
+++ b/src/services/codefixes/fixForgottenThisPropertyAccess.ts
@@ -8,7 +8,7 @@ namespace ts.codefix {
             if (token.kind !== SyntaxKind.Identifier) {
                 return undefined;
             }
-            const changeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+            const changeTracker = textChanges.ChangeTracker.fromContext(context);
             changeTracker.replaceNode(sourceFile, token, createPropertyAccess(createThis(), <Identifier>token));
 
             return [{

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -175,23 +175,23 @@ namespace ts.codefix {
             }
 
             function deleteNode(n: Node) {
-                return makeChange(textChanges.ChangeTracker.fromCodeFixContext(context).deleteNode(sourceFile, n));
+                return makeChange(textChanges.ChangeTracker.fromContext(context).deleteNode(sourceFile, n));
             }
 
             function deleteRange(range: TextRange) {
-                return makeChange(textChanges.ChangeTracker.fromCodeFixContext(context).deleteRange(sourceFile, range));
+                return makeChange(textChanges.ChangeTracker.fromContext(context).deleteRange(sourceFile, range));
             }
 
             function deleteNodeInList(n: Node) {
-                return makeChange(textChanges.ChangeTracker.fromCodeFixContext(context).deleteNodeInList(sourceFile, n));
+                return makeChange(textChanges.ChangeTracker.fromContext(context).deleteNodeInList(sourceFile, n));
             }
 
             function deleteNodeRange(start: Node, end: Node) {
-                return makeChange(textChanges.ChangeTracker.fromCodeFixContext(context).deleteNodeRange(sourceFile, start, end));
+                return makeChange(textChanges.ChangeTracker.fromContext(context).deleteNodeRange(sourceFile, start, end));
             }
 
             function replaceNode(n: Node, newNode: Node) {
-                return makeChange(textChanges.ChangeTracker.fromCodeFixContext(context).replaceNode(sourceFile, n, newNode));
+                return makeChange(textChanges.ChangeTracker.fromContext(context).replaceNode(sourceFile, n, newNode));
             }
 
             function makeChange(changeTracker: textChanges.ChangeTracker): CodeAction {

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -4,7 +4,7 @@ namespace ts.codefix {
     export function newNodesToChanges(newNodes: Node[], insertAfter: Node, context: CodeFixContext) {
         const sourceFile = context.sourceFile;
 
-        const changeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+        const changeTracker = textChanges.ChangeTracker.fromContext(context);
 
         for (const newNode of newNodes) {
             changeTracker.insertNodeAfter(sourceFile, insertAfter, newNode, { suffix: context.newLineCharacter });

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -692,7 +692,7 @@ namespace ts.codefix {
         }
 
         function createChangeTracker() {
-            return textChanges.ChangeTracker.fromCodeFixContext(context);
+            return textChanges.ChangeTracker.fromContext(context);
         }
 
         function createCodeAction(

--- a/src/services/refactors/convertFunctionToEs6Class.ts
+++ b/src/services/refactors/convertFunctionToEs6Class.ts
@@ -63,7 +63,7 @@ namespace ts.refactor.convertFunctionToES6Class {
         }
 
         const ctorDeclaration = ctorSymbol.valueDeclaration;
-        const changeTracker = textChanges.ChangeTracker.fromCodeFixContext(context as { newLineCharacter: string, rulesProvider: formatting.RulesProvider });
+        const changeTracker = textChanges.ChangeTracker.fromContext(context);
 
         let precedingNode: Node;
         let newClassDeclaration: ClassDeclaration;

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -708,7 +708,7 @@ namespace ts.refactor.extractMethod {
             );
         }
 
-        const changeTracker = textChanges.ChangeTracker.fromCodeFixContext(context);
+        const changeTracker = textChanges.ChangeTracker.fromContext(context);
         // insert function at the end of the scope
         changeTracker.insertNodeBefore(context.file, scope.getLastToken(), newFunction, { prefix: context.newLineCharacter, suffix: context.newLineCharacter });
 

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -186,7 +186,7 @@ namespace ts.textChanges {
         private changes: Change[] = [];
         private readonly newLineCharacter: string;
 
-        public static fromCodeFixContext(context: { newLineCharacter: string, rulesProvider?: formatting.RulesProvider }) {
+        public static fromContext(context: RefactorContext | CodeFixContext) {
             return new ChangeTracker(getNewlineKind(context), context.rulesProvider);
         }
 


### PR DESCRIPTION
* Update to take `RefactorContext | CodeFixContext` instead of its own object literal type; before this, finding references on `RefactorContext#rulesProvider` made it look like it was only used for `context.rulesProvider.getFormatOptions().newLineCharacter`.
* Takes either a `RefactorContext` or a `CodeFixContext`, so update name.
