### PR TITLE
Allow trailing newline to have fake position

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -268,7 +268,7 @@ namespace ts {
         return s;
     }
 
-    export function formatDiagnosticsWithColorAndContext(diagnostics: Diagnostic[], host: FormatDiagnosticsHost): string {
+    export function formatDiagnosticsWithColorAndContext(diagnostics: ReadonlyArray<Diagnostic>, host: FormatDiagnosticsHost): string {
         let output = "";
         for (const diagnostic of diagnostics) {
             if (diagnostic.file) {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -284,12 +284,12 @@ namespace ts {
                     gutterWidth = Math.max(ellipsis.length, gutterWidth);
                 }
 
-                output += sys.newLine;
+                output += host.getNewLine();
                 for (let i = firstLine; i <= lastLine; i++) {
                     // If the error spans over 5 lines, we'll only show the first 2 and last 2 lines,
                     // so we'll skip ahead to the second-to-last line.
                     if (hasMoreThanFiveLines && firstLine + 1 < i && i < lastLine - 1) {
-                        output += formatAndReset(padLeft(ellipsis, gutterWidth), gutterStyleSequence) + gutterSeparator + sys.newLine;
+                        output += formatAndReset(padLeft(ellipsis, gutterWidth), gutterStyleSequence) + gutterSeparator + host.getNewLine();
                         i = lastLine - 1;
                     }
 
@@ -301,7 +301,7 @@ namespace ts {
 
                     // Output the gutter and the actual contents of the line.
                     output += formatAndReset(padLeft(i + 1 + "", gutterWidth), gutterStyleSequence) + gutterSeparator;
-                    output += lineContent + sys.newLine;
+                    output += lineContent + host.getNewLine();
 
                     // Output the gutter and the error span for the line using tildes.
                     output += formatAndReset(padLeft("", gutterWidth), gutterStyleSequence) + gutterSeparator;
@@ -323,17 +323,17 @@ namespace ts {
                     }
                     output += resetEscapeSequence;
 
-                    output += sys.newLine;
+                    output += host.getNewLine();
                 }
 
-                output += sys.newLine;
+                output += host.getNewLine();
                 output += `${ relativeFileName }(${ firstLine + 1 },${ firstLineChar + 1 }): `;
             }
 
             const categoryColor = getCategoryFormat(diagnostic.category);
             const category = DiagnosticCategory[diagnostic.category].toLowerCase();
-            output += `${ formatAndReset(category, categoryColor) } TS${ diagnostic.code }: ${ flattenDiagnosticMessageText(diagnostic.messageText, sys.newLine) }`;
-            output += sys.newLine;
+            output += `${ formatAndReset(category, categoryColor) } TS${ diagnostic.code }: ${ flattenDiagnosticMessageText(diagnostic.messageText, host.getNewLine()) }`;
+            output += host.getNewLine();
         }
         return output;
     }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -337,6 +337,9 @@ namespace ts {
             Debug.assert(res < lineStarts[line + 1]);
         }
         else if (debugText !== undefined) {
+            if (res === debugText.length) {
+                return res; // Allow single character overflow for trailing newline
+            }
             Debug.assert(res < debugText.length);
         }
         return res;

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -337,10 +337,7 @@ namespace ts {
             Debug.assert(res < lineStarts[line + 1]);
         }
         else if (debugText !== undefined) {
-            if (res === debugText.length) {
-                return res; // Allow single character overflow for trailing newline
-            }
-            Debug.assert(res < debugText.length);
+            Debug.assert(res <= debugText.length); // Allow single character overflow for trailing newline
         }
         return res;
     }

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -141,7 +141,7 @@ class CompilerBaselineRunner extends RunnerBase {
 
             // check errors
             it("Correct errors for " + fileName, () => {
-                Harness.Compiler.doErrorBaseline(justName, tsConfigFiles.concat(toBeCompiled, otherFiles), result.errors);
+                Harness.Compiler.doErrorBaseline(justName, tsConfigFiles.concat(toBeCompiled, otherFiles), result.errors, !!options.pretty);
             });
 
             it (`Correct module resolution tracing for ${fileName}`, () => {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1284,11 +1284,12 @@ namespace Harness {
             return normalized;
         }
 
-        export function minimalDiagnosticsToString(diagnostics: ReadonlyArray<ts.Diagnostic>) {
-            return ts.formatDiagnostics(diagnostics, { getCanonicalFileName, getCurrentDirectory: () => "", getNewLine: () => Harness.IO.newLine() });
+        export function minimalDiagnosticsToString(diagnostics: ReadonlyArray<ts.Diagnostic>, pretty?: boolean) {
+            const host = { getCanonicalFileName, getCurrentDirectory: () => "", getNewLine: () => Harness.IO.newLine() };
+            return (pretty ? ts.formatDiagnosticsWithColorAndContext : ts.formatDiagnostics)(diagnostics, host);
         }
 
-        export function getErrorBaseline(inputFiles: ReadonlyArray<TestFile>, diagnostics: ReadonlyArray<ts.Diagnostic>) {
+        export function getErrorBaseline(inputFiles: ReadonlyArray<TestFile>, diagnostics: ReadonlyArray<ts.Diagnostic>, pretty?: boolean) {
             diagnostics = diagnostics.slice().sort(ts.compareDiagnostics);
             let outputLines = "";
             // Count up all errors that were found in files other than lib.d.ts so we don't miss any
@@ -1408,18 +1409,18 @@ namespace Harness {
             // Verify we didn't miss any errors in total
             assert.equal(totalErrorsReportedInNonLibraryFiles + numLibraryDiagnostics + numTest262HarnessDiagnostics, diagnostics.length, "total number of errors");
 
-            return minimalDiagnosticsToString(diagnostics) +
+            return minimalDiagnosticsToString(diagnostics, pretty) +
                 Harness.IO.newLine() + Harness.IO.newLine() + outputLines;
         }
 
-        export function doErrorBaseline(baselinePath: string, inputFiles: TestFile[], errors: ts.Diagnostic[]) {
+        export function doErrorBaseline(baselinePath: string, inputFiles: TestFile[], errors: ts.Diagnostic[], pretty?: boolean) {
             Harness.Baseline.runBaseline(baselinePath.replace(/\.tsx?$/, ".errors.txt"), (): string => {
                 if (!errors || (errors.length === 0)) {
                     /* tslint:disable:no-null-keyword */
                     return null;
                     /* tslint:enable:no-null-keyword */
                 }
-                return getErrorBaseline(inputFiles, errors);
+                return getErrorBaseline(inputFiles, errors, pretty);
             });
         }
 

--- a/tests/baselines/reference/prettyContextNotDebugAssertion.errors.txt
+++ b/tests/baselines/reference/prettyContextNotDebugAssertion.errors.txt
@@ -1,0 +1,12 @@
+
+[100;30m2[0m 
+[100;30m [0m [91m[0m
+
+tests/cases/compiler/index.ts(2,1): [91merror[0m TS1005: '}' expected.
+
+
+==== tests/cases/compiler/index.ts (1 errors) ====
+    if (true) {
+    
+    
+!!! error TS1005: '}' expected.

--- a/tests/baselines/reference/prettyContextNotDebugAssertion.js
+++ b/tests/baselines/reference/prettyContextNotDebugAssertion.js
@@ -1,0 +1,7 @@
+//// [index.ts]
+if (true) {
+
+
+//// [index.js]
+if (true) {
+}

--- a/tests/cases/compiler/prettyContextNotDebugAssertion.ts
+++ b/tests/cases/compiler/prettyContextNotDebugAssertion.ts
@@ -1,0 +1,3 @@
+// @pretty: true
+// @filename: index.ts
+if (true) {


### PR DESCRIPTION
In #17121, an assertion was added to catch when we calculated a position outside a file's bounds; however the `pretty` diagnostic printer relies on the fact that for a trailing newline we calculate a position one after the actual bounds of the file as the position for the first (nonexistant) character on that last line. An alternative was to adjust `computeLineStarts` to not include trailing newlines in the list of things calculated, then also adjust the baseline code to not consider trailing newlines as lines for writing errors on, then updating all the baselines; but that seemed a little less elegant than just allowing the one-character overflow; seeing as the calculated position always works as intended with `substring`.

Also modifies the test harness a little bit to allow it to baseline `pretty`-formatted diagnostics. They don't look terribly pretty in the baseline since they have ANSI escapes, but so be it.

Fixes #18216 
