### PR TITLE
Object literals computed property names allow literal-typed expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13526,6 +13526,7 @@ namespace ts {
             for (let i = 0; i < node.properties.length; i++) {
                 const memberDecl = node.properties[i];
                 let member = memberDecl.symbol;
+                let literalName: __String | undefined;
                 if (memberDecl.kind === SyntaxKind.PropertyAssignment ||
                     memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment ||
                     isObjectLiteralMethod(memberDecl)) {
@@ -13536,6 +13537,12 @@ namespace ts {
 
                     let type: Type;
                     if (memberDecl.kind === SyntaxKind.PropertyAssignment) {
+                        if (memberDecl.name.kind === SyntaxKind.ComputedPropertyName) {
+                            const t = checkComputedPropertyName(<ComputedPropertyName>memberDecl.name);
+                            if (t.flags & TypeFlags.Literal) {
+                                literalName = escapeLeadingUnderscores("" + (t as LiteralType).value);
+                            }
+                        }
                         type = checkPropertyAssignment(<PropertyAssignment>memberDecl, checkMode);
                     }
                     else if (memberDecl.kind === SyntaxKind.MethodDeclaration) {
@@ -13552,7 +13559,7 @@ namespace ts {
                     }
 
                     typeFlags |= type.flags;
-                    const prop = createSymbol(SymbolFlags.Property | member.flags, member.escapedName);
+                    const prop = createSymbol(SymbolFlags.Property | member.flags, literalName || member.escapedName);
                     if (inDestructuringPattern) {
                         // If object literal is an assignment pattern and if the assignment pattern specifies a default value
                         // for the property, make the property optional.
@@ -13562,7 +13569,7 @@ namespace ts {
                         if (isOptional) {
                             prop.flags |= SymbolFlags.Optional;
                         }
-                        if (hasDynamicName(memberDecl)) {
+                        if (!literalName && hasDynamicName(memberDecl)) {
                             patternWithComputedProperties = true;
                         }
                     }
@@ -13620,7 +13627,7 @@ namespace ts {
                     checkNodeDeferred(memberDecl);
                 }
 
-                if (hasDynamicName(memberDecl)) {
+                if (!literalName && hasDynamicName(memberDecl)) {
                     if (isNumericName(memberDecl.name)) {
                         hasComputedNumberProperty = true;
                     }

--- a/tests/baselines/reference/computedPropertyNames46_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames46_ES5.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/computedProperties/computedPropertyNames46_ES5.ts ===
 var o = {
->o : { [x: number]: number; }
->{    ["" || 0]: 0} : { [x: number]: number; }
+>o : { ["" || 0]: number; }
+>{    ["" || 0]: 0} : { ["" || 0]: number; }
 
     ["" || 0]: 0
 >"" || 0 : 0

--- a/tests/baselines/reference/computedPropertyNames46_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames46_ES6.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/computedProperties/computedPropertyNames46_ES6.ts ===
 var o = {
->o : { [x: number]: number; }
->{    ["" || 0]: 0} : { [x: number]: number; }
+>o : { ["" || 0]: number; }
+>{    ["" || 0]: 0} : { ["" || 0]: number; }
 
     ["" || 0]: 0
 >"" || 0 : 0

--- a/tests/baselines/reference/computedPropertyNames47_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames47_ES5.types
@@ -8,8 +8,8 @@ enum E2 { x }
 >x : E2
 
 var o = {
->o : { [x: number]: number; }
->{    [E1.x || E2.x]: 0} : { [x: number]: number; }
+>o : { [E1.x || E2.x]: number; }
+>{    [E1.x || E2.x]: 0} : { [E1.x || E2.x]: number; }
 
     [E1.x || E2.x]: 0
 >E1.x || E2.x : E2

--- a/tests/baselines/reference/computedPropertyNames47_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames47_ES6.types
@@ -8,8 +8,8 @@ enum E2 { x }
 >x : E2
 
 var o = {
->o : { [x: number]: number; }
->{    [E1.x || E2.x]: 0} : { [x: number]: number; }
+>o : { [E1.x || E2.x]: number; }
+>{    [E1.x || E2.x]: 0} : { [E1.x || E2.x]: number; }
 
     [E1.x || E2.x]: 0
 >E1.x || E2.x : E2

--- a/tests/baselines/reference/computedPropertyNames48_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames48_ES5.types
@@ -28,7 +28,7 @@ extractIndexer({
 extractIndexer({
 >extractIndexer({    [E.x]: ""}) : string
 >extractIndexer : <T>(p: { [n: number]: T; }) => T
->{    [E.x]: ""} : { [x: number]: string; }
+>{    [E.x]: ""} : { [E.x]: string; }
 
     [E.x]: ""
 >E.x : E
@@ -41,7 +41,7 @@ extractIndexer({
 extractIndexer({
 >extractIndexer({    ["" || 0]: ""}) : string
 >extractIndexer : <T>(p: { [n: number]: T; }) => T
->{    ["" || 0]: ""} : { [x: number]: string; }
+>{    ["" || 0]: ""} : { ["" || 0]: string; }
 
     ["" || 0]: ""
 >"" || 0 : 0

--- a/tests/baselines/reference/computedPropertyNames48_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames48_ES6.types
@@ -28,7 +28,7 @@ extractIndexer({
 extractIndexer({
 >extractIndexer({    [E.x]: ""}) : string
 >extractIndexer : <T>(p: { [n: number]: T; }) => T
->{    [E.x]: ""} : { [x: number]: string; }
+>{    [E.x]: ""} : { [E.x]: string; }
 
     [E.x]: ""
 >E.x : E
@@ -41,7 +41,7 @@ extractIndexer({
 extractIndexer({
 >extractIndexer({    ["" || 0]: ""}) : string
 >extractIndexer : <T>(p: { [n: number]: T; }) => T
->{    ["" || 0]: ""} : { [x: number]: string; }
+>{    ["" || 0]: ""} : { ["" || 0]: string; }
 
     ["" || 0]: ""
 >"" || 0 : 0

--- a/tests/baselines/reference/computedPropertyNames4_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames4_ES5.types
@@ -9,8 +9,8 @@ var a: any;
 >a : any
 
 var v = {
->v : { [x: string]: string | number; [x: number]: string | number; [""]: number; [0]: number; }
->{    [s]: 0,    [n]: n,    [s + s]: 1,    [s + n]: 2,    [+s]: s,    [""]: 0,    [0]: 0,    [a]: 1,    [<any>true]: 0,    [`hello bye`]: 0,    [`hello ${a} bye`]: 0} : { [x: string]: string | number; [x: number]: string | number; [""]: number; [0]: number; }
+>v : { [x: string]: string | number; [x: number]: string | number; [""]: number; [0]: number; [`hello bye`]: number; }
+>{    [s]: 0,    [n]: n,    [s + s]: 1,    [s + n]: 2,    [+s]: s,    [""]: 0,    [0]: 0,    [a]: 1,    [<any>true]: 0,    [`hello bye`]: 0,    [`hello ${a} bye`]: 0} : { [x: string]: string | number; [x: number]: string | number; [""]: number; [0]: number; [`hello bye`]: number; }
 
     [s]: 0,
 >s : string

--- a/tests/baselines/reference/computedPropertyNames4_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames4_ES6.types
@@ -9,8 +9,8 @@ var a: any;
 >a : any
 
 var v = {
->v : { [x: string]: string | number; [x: number]: string | number; [""]: number; [0]: number; }
->{    [s]: 0,    [n]: n,    [s + s]: 1,    [s + n]: 2,    [+s]: s,    [""]: 0,    [0]: 0,    [a]: 1,    [<any>true]: 0,    [`hello bye`]: 0,    [`hello ${a} bye`]: 0} : { [x: string]: string | number; [x: number]: string | number; [""]: number; [0]: number; }
+>v : { [x: string]: string | number; [x: number]: string | number; [""]: number; [0]: number; [`hello bye`]: number; }
+>{    [s]: 0,    [n]: n,    [s + s]: 1,    [s + n]: 2,    [+s]: s,    [""]: 0,    [0]: 0,    [a]: 1,    [<any>true]: 0,    [`hello bye`]: 0,    [`hello ${a} bye`]: 0} : { [x: string]: string | number; [x: number]: string | number; [""]: number; [0]: number; [`hello bye`]: number; }
 
     [s]: 0,
 >s : string

--- a/tests/baselines/reference/computedPropertyNames7_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames7_ES5.types
@@ -6,8 +6,8 @@ enum E {
 >member : E
 }
 var v = {
->v : { [x: number]: number; }
->{    [E.member]: 0} : { [x: number]: number; }
+>v : { [E.member]: number; }
+>{    [E.member]: 0} : { [E.member]: number; }
 
     [E.member]: 0
 >E.member : E

--- a/tests/baselines/reference/computedPropertyNames7_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames7_ES6.types
@@ -6,8 +6,8 @@ enum E {
 >member : E
 }
 var v = {
->v : { [x: number]: number; }
->{    [E.member]: 0} : { [x: number]: number; }
+>v : { [E.member]: number; }
+>{    [E.member]: 0} : { [E.member]: number; }
 
     [E.member]: 0
 >E.member : E

--- a/tests/baselines/reference/objectLiteralEnumPropertyNames.js
+++ b/tests/baselines/reference/objectLiteralEnumPropertyNames.js
@@ -1,0 +1,108 @@
+//// [objectLiteralEnumPropertyNames.ts]
+// Fixes #16887
+enum Strs {
+    A = 'a',
+    B = 'b'
+}
+type TestStrs = { [key in Strs]: string }
+const x: TestStrs = {
+    [Strs.A]: 'xo',
+    [Strs.B]: 'xe'
+}
+const ux = {
+    [Strs.A]: 'xo',
+    [Strs.B]: 'xe'
+}
+const y: TestStrs = {
+    ['a']: 'yo',
+    ['b']: 'ye'
+}
+const a = 'a';
+const b = 'b';
+const z: TestStrs = {
+    [a]: 'zo',
+    [b]: 'ze'
+}
+const uz = {
+    [a]: 'zo',
+    [b]: 'ze'
+}
+
+enum Nums {
+    A,
+    B
+}
+type TestNums = { 0: number, 1: number }
+const n: TestNums = {
+    [Nums.A]: 1,
+    [Nums.B]: 2
+}
+const un = {
+    [Nums.A]: 3,
+    [Nums.B]: 4
+}
+const an = 0;
+const bn = 1;
+const m: TestNums = {
+    [an]: 5,
+    [bn]: 6
+}
+const um = {
+    [an]: 7,
+    [bn]: 8
+}
+
+
+//// [objectLiteralEnumPropertyNames.js]
+// Fixes #16887
+var Strs;
+(function (Strs) {
+    Strs["A"] = "a";
+    Strs["B"] = "b";
+})(Strs || (Strs = {}));
+var x = (_a = {},
+    _a[Strs.A] = 'xo',
+    _a[Strs.B] = 'xe',
+    _a);
+var ux = (_b = {},
+    _b[Strs.A] = 'xo',
+    _b[Strs.B] = 'xe',
+    _b);
+var y = (_c = {},
+    _c['a'] = 'yo',
+    _c['b'] = 'ye',
+    _c);
+var a = 'a';
+var b = 'b';
+var z = (_d = {},
+    _d[a] = 'zo',
+    _d[b] = 'ze',
+    _d);
+var uz = (_e = {},
+    _e[a] = 'zo',
+    _e[b] = 'ze',
+    _e);
+var Nums;
+(function (Nums) {
+    Nums[Nums["A"] = 0] = "A";
+    Nums[Nums["B"] = 1] = "B";
+})(Nums || (Nums = {}));
+var n = (_f = {},
+    _f[Nums.A] = 1,
+    _f[Nums.B] = 2,
+    _f);
+var un = (_g = {},
+    _g[Nums.A] = 3,
+    _g[Nums.B] = 4,
+    _g);
+var an = 0;
+var bn = 1;
+var m = (_h = {},
+    _h[an] = 5,
+    _h[bn] = 6,
+    _h);
+var um = (_j = {},
+    _j[an] = 7,
+    _j[bn] = 8,
+    _j);
+var _a, _b, _c, _d, _e, _f, _g, _h, _j;

--- a/tests/baselines/reference/objectLiteralEnumPropertyNames.symbols
+++ b/tests/baselines/reference/objectLiteralEnumPropertyNames.symbols
@@ -1,0 +1,144 @@
+=== tests/cases/compiler/objectLiteralEnumPropertyNames.ts ===
+// Fixes #16887
+enum Strs {
+>Strs : Symbol(Strs, Decl(objectLiteralEnumPropertyNames.ts, 0, 0))
+
+    A = 'a',
+>A : Symbol(Strs.A, Decl(objectLiteralEnumPropertyNames.ts, 1, 11))
+
+    B = 'b'
+>B : Symbol(Strs.B, Decl(objectLiteralEnumPropertyNames.ts, 2, 12))
+}
+type TestStrs = { [key in Strs]: string }
+>TestStrs : Symbol(TestStrs, Decl(objectLiteralEnumPropertyNames.ts, 4, 1))
+>key : Symbol(key, Decl(objectLiteralEnumPropertyNames.ts, 5, 19))
+>Strs : Symbol(Strs, Decl(objectLiteralEnumPropertyNames.ts, 0, 0))
+
+const x: TestStrs = {
+>x : Symbol(x, Decl(objectLiteralEnumPropertyNames.ts, 6, 5))
+>TestStrs : Symbol(TestStrs, Decl(objectLiteralEnumPropertyNames.ts, 4, 1))
+
+    [Strs.A]: 'xo',
+>Strs.A : Symbol(Strs.A, Decl(objectLiteralEnumPropertyNames.ts, 1, 11))
+>Strs : Symbol(Strs, Decl(objectLiteralEnumPropertyNames.ts, 0, 0))
+>A : Symbol(Strs.A, Decl(objectLiteralEnumPropertyNames.ts, 1, 11))
+
+    [Strs.B]: 'xe'
+>Strs.B : Symbol(Strs.B, Decl(objectLiteralEnumPropertyNames.ts, 2, 12))
+>Strs : Symbol(Strs, Decl(objectLiteralEnumPropertyNames.ts, 0, 0))
+>B : Symbol(Strs.B, Decl(objectLiteralEnumPropertyNames.ts, 2, 12))
+}
+const ux = {
+>ux : Symbol(ux, Decl(objectLiteralEnumPropertyNames.ts, 10, 5))
+
+    [Strs.A]: 'xo',
+>Strs.A : Symbol(Strs.A, Decl(objectLiteralEnumPropertyNames.ts, 1, 11))
+>Strs : Symbol(Strs, Decl(objectLiteralEnumPropertyNames.ts, 0, 0))
+>A : Symbol(Strs.A, Decl(objectLiteralEnumPropertyNames.ts, 1, 11))
+
+    [Strs.B]: 'xe'
+>Strs.B : Symbol(Strs.B, Decl(objectLiteralEnumPropertyNames.ts, 2, 12))
+>Strs : Symbol(Strs, Decl(objectLiteralEnumPropertyNames.ts, 0, 0))
+>B : Symbol(Strs.B, Decl(objectLiteralEnumPropertyNames.ts, 2, 12))
+}
+const y: TestStrs = {
+>y : Symbol(y, Decl(objectLiteralEnumPropertyNames.ts, 14, 5))
+>TestStrs : Symbol(TestStrs, Decl(objectLiteralEnumPropertyNames.ts, 4, 1))
+
+    ['a']: 'yo',
+>'a' : Symbol(['a'], Decl(objectLiteralEnumPropertyNames.ts, 14, 21))
+
+    ['b']: 'ye'
+>'b' : Symbol(['b'], Decl(objectLiteralEnumPropertyNames.ts, 15, 16))
+}
+const a = 'a';
+>a : Symbol(a, Decl(objectLiteralEnumPropertyNames.ts, 18, 5))
+
+const b = 'b';
+>b : Symbol(b, Decl(objectLiteralEnumPropertyNames.ts, 19, 5))
+
+const z: TestStrs = {
+>z : Symbol(z, Decl(objectLiteralEnumPropertyNames.ts, 20, 5))
+>TestStrs : Symbol(TestStrs, Decl(objectLiteralEnumPropertyNames.ts, 4, 1))
+
+    [a]: 'zo',
+>a : Symbol(a, Decl(objectLiteralEnumPropertyNames.ts, 18, 5))
+
+    [b]: 'ze'
+>b : Symbol(b, Decl(objectLiteralEnumPropertyNames.ts, 19, 5))
+}
+const uz = {
+>uz : Symbol(uz, Decl(objectLiteralEnumPropertyNames.ts, 24, 5))
+
+    [a]: 'zo',
+>a : Symbol(a, Decl(objectLiteralEnumPropertyNames.ts, 18, 5))
+
+    [b]: 'ze'
+>b : Symbol(b, Decl(objectLiteralEnumPropertyNames.ts, 19, 5))
+}
+
+enum Nums {
+>Nums : Symbol(Nums, Decl(objectLiteralEnumPropertyNames.ts, 27, 1))
+
+    A,
+>A : Symbol(Nums.A, Decl(objectLiteralEnumPropertyNames.ts, 29, 11))
+
+    B
+>B : Symbol(Nums.B, Decl(objectLiteralEnumPropertyNames.ts, 30, 6))
+}
+type TestNums = { 0: number, 1: number }
+>TestNums : Symbol(TestNums, Decl(objectLiteralEnumPropertyNames.ts, 32, 1))
+
+const n: TestNums = {
+>n : Symbol(n, Decl(objectLiteralEnumPropertyNames.ts, 34, 5))
+>TestNums : Symbol(TestNums, Decl(objectLiteralEnumPropertyNames.ts, 32, 1))
+
+    [Nums.A]: 1,
+>Nums.A : Symbol(Nums.A, Decl(objectLiteralEnumPropertyNames.ts, 29, 11))
+>Nums : Symbol(Nums, Decl(objectLiteralEnumPropertyNames.ts, 27, 1))
+>A : Symbol(Nums.A, Decl(objectLiteralEnumPropertyNames.ts, 29, 11))
+
+    [Nums.B]: 2
+>Nums.B : Symbol(Nums.B, Decl(objectLiteralEnumPropertyNames.ts, 30, 6))
+>Nums : Symbol(Nums, Decl(objectLiteralEnumPropertyNames.ts, 27, 1))
+>B : Symbol(Nums.B, Decl(objectLiteralEnumPropertyNames.ts, 30, 6))
+}
+const un = {
+>un : Symbol(un, Decl(objectLiteralEnumPropertyNames.ts, 38, 5))
+
+    [Nums.A]: 3,
+>Nums.A : Symbol(Nums.A, Decl(objectLiteralEnumPropertyNames.ts, 29, 11))
+>Nums : Symbol(Nums, Decl(objectLiteralEnumPropertyNames.ts, 27, 1))
+>A : Symbol(Nums.A, Decl(objectLiteralEnumPropertyNames.ts, 29, 11))
+
+    [Nums.B]: 4
+>Nums.B : Symbol(Nums.B, Decl(objectLiteralEnumPropertyNames.ts, 30, 6))
+>Nums : Symbol(Nums, Decl(objectLiteralEnumPropertyNames.ts, 27, 1))
+>B : Symbol(Nums.B, Decl(objectLiteralEnumPropertyNames.ts, 30, 6))
+}
+const an = 0;
+>an : Symbol(an, Decl(objectLiteralEnumPropertyNames.ts, 42, 5))
+
+const bn = 1;
+>bn : Symbol(bn, Decl(objectLiteralEnumPropertyNames.ts, 43, 5))
+
+const m: TestNums = {
+>m : Symbol(m, Decl(objectLiteralEnumPropertyNames.ts, 44, 5))
+>TestNums : Symbol(TestNums, Decl(objectLiteralEnumPropertyNames.ts, 32, 1))
+
+    [an]: 5,
+>an : Symbol(an, Decl(objectLiteralEnumPropertyNames.ts, 42, 5))
+
+    [bn]: 6
+>bn : Symbol(bn, Decl(objectLiteralEnumPropertyNames.ts, 43, 5))
+}
+const um = {
+>um : Symbol(um, Decl(objectLiteralEnumPropertyNames.ts, 48, 5))
+
+    [an]: 7,
+>an : Symbol(an, Decl(objectLiteralEnumPropertyNames.ts, 42, 5))
+
+    [bn]: 8
+>bn : Symbol(bn, Decl(objectLiteralEnumPropertyNames.ts, 43, 5))
+}
+

--- a/tests/baselines/reference/objectLiteralEnumPropertyNames.types
+++ b/tests/baselines/reference/objectLiteralEnumPropertyNames.types
@@ -1,0 +1,177 @@
+=== tests/cases/compiler/objectLiteralEnumPropertyNames.ts ===
+// Fixes #16887
+enum Strs {
+>Strs : Strs
+
+    A = 'a',
+>A : Strs.A
+>'a' : "a"
+
+    B = 'b'
+>B : Strs.B
+>'b' : "b"
+}
+type TestStrs = { [key in Strs]: string }
+>TestStrs : TestStrs
+>key : key
+>Strs : Strs
+
+const x: TestStrs = {
+>x : TestStrs
+>TestStrs : TestStrs
+>{    [Strs.A]: 'xo',    [Strs.B]: 'xe'} : { [Strs.A]: string; [Strs.B]: string; }
+
+    [Strs.A]: 'xo',
+>Strs.A : Strs.A
+>Strs : typeof Strs
+>A : Strs.A
+>'xo' : "xo"
+
+    [Strs.B]: 'xe'
+>Strs.B : Strs.B
+>Strs : typeof Strs
+>B : Strs.B
+>'xe' : "xe"
+}
+const ux = {
+>ux : { [Strs.A]: string; [Strs.B]: string; }
+>{    [Strs.A]: 'xo',    [Strs.B]: 'xe'} : { [Strs.A]: string; [Strs.B]: string; }
+
+    [Strs.A]: 'xo',
+>Strs.A : Strs.A
+>Strs : typeof Strs
+>A : Strs.A
+>'xo' : "xo"
+
+    [Strs.B]: 'xe'
+>Strs.B : Strs.B
+>Strs : typeof Strs
+>B : Strs.B
+>'xe' : "xe"
+}
+const y: TestStrs = {
+>y : TestStrs
+>TestStrs : TestStrs
+>{    ['a']: 'yo',    ['b']: 'ye'} : { ['a']: string; ['b']: string; }
+
+    ['a']: 'yo',
+>'a' : "a"
+>'yo' : "yo"
+
+    ['b']: 'ye'
+>'b' : "b"
+>'ye' : "ye"
+}
+const a = 'a';
+>a : "a"
+>'a' : "a"
+
+const b = 'b';
+>b : "b"
+>'b' : "b"
+
+const z: TestStrs = {
+>z : TestStrs
+>TestStrs : TestStrs
+>{    [a]: 'zo',    [b]: 'ze'} : { [a]: string; [b]: string; }
+
+    [a]: 'zo',
+>a : "a"
+>'zo' : "zo"
+
+    [b]: 'ze'
+>b : "b"
+>'ze' : "ze"
+}
+const uz = {
+>uz : { [a]: string; [b]: string; }
+>{    [a]: 'zo',    [b]: 'ze'} : { [a]: string; [b]: string; }
+
+    [a]: 'zo',
+>a : "a"
+>'zo' : "zo"
+
+    [b]: 'ze'
+>b : "b"
+>'ze' : "ze"
+}
+
+enum Nums {
+>Nums : Nums
+
+    A,
+>A : Nums.A
+
+    B
+>B : Nums.B
+}
+type TestNums = { 0: number, 1: number }
+>TestNums : TestNums
+
+const n: TestNums = {
+>n : TestNums
+>TestNums : TestNums
+>{    [Nums.A]: 1,    [Nums.B]: 2} : { [Nums.A]: number; [Nums.B]: number; }
+
+    [Nums.A]: 1,
+>Nums.A : Nums.A
+>Nums : typeof Nums
+>A : Nums.A
+>1 : 1
+
+    [Nums.B]: 2
+>Nums.B : Nums.B
+>Nums : typeof Nums
+>B : Nums.B
+>2 : 2
+}
+const un = {
+>un : { [Nums.A]: number; [Nums.B]: number; }
+>{    [Nums.A]: 3,    [Nums.B]: 4} : { [Nums.A]: number; [Nums.B]: number; }
+
+    [Nums.A]: 3,
+>Nums.A : Nums.A
+>Nums : typeof Nums
+>A : Nums.A
+>3 : 3
+
+    [Nums.B]: 4
+>Nums.B : Nums.B
+>Nums : typeof Nums
+>B : Nums.B
+>4 : 4
+}
+const an = 0;
+>an : 0
+>0 : 0
+
+const bn = 1;
+>bn : 1
+>1 : 1
+
+const m: TestNums = {
+>m : TestNums
+>TestNums : TestNums
+>{    [an]: 5,    [bn]: 6} : { [an]: number; [bn]: number; }
+
+    [an]: 5,
+>an : 0
+>5 : 5
+
+    [bn]: 6
+>bn : 1
+>6 : 6
+}
+const um = {
+>um : { [an]: number; [bn]: number; }
+>{    [an]: 7,    [bn]: 8} : { [an]: number; [bn]: number; }
+
+    [an]: 7,
+>an : 0
+>7 : 7
+
+    [bn]: 8
+>bn : 1
+>8 : 8
+}
+

--- a/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
+++ b/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
@@ -1,0 +1,52 @@
+// Fixes #16887
+enum Strs {
+    A = 'a',
+    B = 'b'
+}
+type TestStrs = { [key in Strs]: string }
+const x: TestStrs = {
+    [Strs.A]: 'xo',
+    [Strs.B]: 'xe'
+}
+const ux = {
+    [Strs.A]: 'xo',
+    [Strs.B]: 'xe'
+}
+const y: TestStrs = {
+    ['a']: 'yo',
+    ['b']: 'ye'
+}
+const a = 'a';
+const b = 'b';
+const z: TestStrs = {
+    [a]: 'zo',
+    [b]: 'ze'
+}
+const uz = {
+    [a]: 'zo',
+    [b]: 'ze'
+}
+
+enum Nums {
+    A,
+    B
+}
+type TestNums = { 0: number, 1: number }
+const n: TestNums = {
+    [Nums.A]: 1,
+    [Nums.B]: 2
+}
+const un = {
+    [Nums.A]: 3,
+    [Nums.B]: 4
+}
+const an = 0;
+const bn = 1;
+const m: TestNums = {
+    [an]: 5,
+    [bn]: 6
+}
+const um = {
+    [an]: 7,
+    [bn]: 8
+}


### PR DESCRIPTION
This is a late-stage name replacement in `checkObjectLiteral`, so it's a special-case of Ron's upcoming dynamic names change.

Fixes #16687 
