### PR TITLE
Remove unnecessary check in emitNodeList

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2415,7 +2415,7 @@ namespace ts {
                 return;
             }
 
-            const isEmpty = isUndefined || children.length === 0 || start >= children.length || count === 0;
+            const isEmpty = isUndefined || start >= children.length || count === 0;
             if (isEmpty && format & ListFormat.OptionalIfEmpty) {
                 return;
             }


### PR DESCRIPTION
We don't use a negative `start` anywhere, so if `children.length === 0` then `start >= children.length`.