### PR TITLE
Change "scroll" event from UIEvent to Event

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -2599,7 +2599,7 @@ interface DocumentEventMap extends GlobalEventHandlersEventMap {
     "ratechange": Event;
     "readystatechange": Event;
     "reset": Event;
-    "scroll": UIEvent;
+    "scroll": Event;
     "seeked": Event;
     "seeking": Event;
     "select": UIEvent;
@@ -4237,7 +4237,7 @@ interface HTMLBodyElementEventMap extends HTMLElementEventMap {
     "pageshow": PageTransitionEvent;
     "popstate": PopStateEvent;
     "resize": UIEvent;
-    "scroll": UIEvent;
+    "scroll": Event;
     "storage": StorageEvent;
     "unload": Event;
 }
@@ -4554,7 +4554,7 @@ interface HTMLElementEventMap extends ElementEventMap {
     "progress": ProgressEvent;
     "ratechange": Event;
     "reset": Event;
-    "scroll": UIEvent;
+    "scroll": Event;
     "seeked": Event;
     "seeking": Event;
     "select": UIEvent;
@@ -4962,7 +4962,7 @@ interface HTMLFrameSetElementEventMap extends HTMLElementEventMap {
     "pageshow": PageTransitionEvent;
     "popstate": PopStateEvent;
     "resize": UIEvent;
-    "scroll": UIEvent;
+    "scroll": Event;
     "storage": StorageEvent;
     "unload": Event;
 }
@@ -11312,7 +11312,7 @@ interface SVGSVGElementEventMap extends SVGElementEventMap {
     "SVGAbort": Event;
     "SVGError": Event;
     "resize": UIEvent;
-    "scroll": UIEvent;
+    "scroll": Event;
     "SVGUnload": Event;
     "SVGZoom": SVGZoomEvent;
 }
@@ -13113,7 +13113,7 @@ interface WindowEventMap extends GlobalEventHandlersEventMap {
     "readystatechange": ProgressEvent;
     "reset": Event;
     "resize": UIEvent;
-    "scroll": UIEvent;
+    "scroll": Event;
     "seeked": Event;
     "seeking": Event;
     "select": UIEvent;


### PR DESCRIPTION
See https://github.com/w3c/uievents/issues/47 for details.

I ran into this because on Chrome 60 `event.view` is undefined for scroll events. On digging further into this, it seems like declaring it as UIEvent is quite dangerous, as according to #w3c/uievents/47 most browsers implement it as an Event.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
