### PR TITLE
Fix forEachChild jsdoc `@typedef` tag

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -438,8 +438,10 @@ namespace ts {
                         visitNode(cbNode, (<JSDocTypedefTag>node).typeExpression);
                 }
             case SyntaxKind.JSDocTypeLiteral:
-                for (const tag of (node as JSDocTypeLiteral).jsDocPropertyTags) {
-                    visitNode(cbNode, tag);
+                if ((node as JSDocTypeLiteral).jsDocPropertyTags) {
+                    for (const tag of (node as JSDocTypeLiteral).jsDocPropertyTags) {
+                        visitNode(cbNode, tag);
+                    }
                 }
                 return;
             case SyntaxKind.PartiallyEmittedExpression:
@@ -6672,19 +6674,18 @@ namespace ts {
                     if (!typeExpression || isObjectOrObjectArrayTypeReference(typeExpression.type)) {
                         let child: JSDocTypeTag | JSDocPropertyTag | false;
                         let jsdocTypeLiteral: JSDocTypeLiteral;
-                        let alreadyHasTypeTag = false;
+                        let childTypeTag: JSDocTypeTag;
                         const start = scanner.getStartPos();
                         while (child = tryParse(() => parseChildParameterOrPropertyTag(PropertyLikeParse.Property))) {
                             if (!jsdocTypeLiteral) {
                                 jsdocTypeLiteral = <JSDocTypeLiteral>createNode(SyntaxKind.JSDocTypeLiteral, start);
                             }
                             if (child.kind === SyntaxKind.JSDocTypeTag) {
-                                if (alreadyHasTypeTag) {
+                                if (childTypeTag) {
                                     break;
                                 }
                                 else {
-                                    jsdocTypeLiteral.jsDocTypeTag = child;
-                                    alreadyHasTypeTag = true;
+                                    childTypeTag = child;
                                 }
                             }
                             else {
@@ -6698,7 +6699,8 @@ namespace ts {
                             if (typeExpression && typeExpression.type.kind === SyntaxKind.ArrayType) {
                                 jsdocTypeLiteral.isArrayType = true;
                             }
-                            typedefTag.typeExpression = finishNode(jsdocTypeLiteral);
+                            const useChildTypeTagAsType = childTypeTag && !isObjectOrObjectArrayTypeReference(childTypeTag.typeExpression.type);
+                            typedefTag.typeExpression = useChildTypeTagAsType ? childTypeTag.typeExpression : finishNode(jsdocTypeLiteral);
                         }
                     }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6699,8 +6699,9 @@ namespace ts {
                             if (typeExpression && typeExpression.type.kind === SyntaxKind.ArrayType) {
                                 jsdocTypeLiteral.isArrayType = true;
                             }
-                            const useChildTypeTagAsType = childTypeTag && !isObjectOrObjectArrayTypeReference(childTypeTag.typeExpression.type);
-                            typedefTag.typeExpression = useChildTypeTagAsType ? childTypeTag.typeExpression : finishNode(jsdocTypeLiteral);
+                            typedefTag.typeExpression = childTypeTag && !isObjectOrObjectArrayTypeReference(childTypeTag.typeExpression.type) ?
+                                childTypeTag.typeExpression :
+                                finishNode(jsdocTypeLiteral);
                         }
                     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2211,7 +2211,6 @@ namespace ts {
     export interface JSDocTypeLiteral extends JSDocType {
         kind: SyntaxKind.JSDocTypeLiteral;
         jsDocPropertyTags?: ReadonlyArray<JSDocPropertyLikeTag>;
-        jsDocTypeTag?: JSDocTypeTag;
         /** If true, then this type literal represents an *array* of its type. */
         isArrayType?: boolean;
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
@@ -34,38 +34,6 @@
                 "kind": "JSDocTypeLiteral",
                 "pos": 26,
                 "end": 98,
-                "jsDocTypeTag": {
-                    "kind": "JSDocTypeTag",
-                    "pos": 28,
-                    "end": 42,
-                    "atToken": {
-                        "kind": "AtToken",
-                        "pos": 28,
-                        "end": 29
-                    },
-                    "tagName": {
-                        "kind": "Identifier",
-                        "pos": 29,
-                        "end": 33,
-                        "escapedText": "type"
-                    },
-                    "typeExpression": {
-                        "kind": "JSDocTypeExpression",
-                        "pos": 34,
-                        "end": 42,
-                        "type": {
-                            "kind": "TypeReference",
-                            "pos": 35,
-                            "end": 41,
-                            "typeName": {
-                                "kind": "Identifier",
-                                "pos": 35,
-                                "end": 41,
-                                "escapedText": "Object"
-                            }
-                        }
-                    }
-                },
                 "jsDocPropertyTags": [
                     {
                         "kind": "JSDocPropertyTag",

--- a/tests/baselines/reference/jsdocTwoLineTypedef.js
+++ b/tests/baselines/reference/jsdocTwoLineTypedef.js
@@ -1,0 +1,10 @@
+//// [jsdocTwoLineTypedef.ts]
+// Regression from #18301
+/**
+ * @typedef LoadCallback
+ * @type {function}
+ */
+type LoadCallback = void;
+
+
+//// [jsdocTwoLineTypedef.js]

--- a/tests/baselines/reference/jsdocTwoLineTypedef.symbols
+++ b/tests/baselines/reference/jsdocTwoLineTypedef.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/jsdocTwoLineTypedef.ts ===
+// Regression from #18301
+/**
+ * @typedef LoadCallback
+ * @type {function}
+ */
+type LoadCallback = void;
+>LoadCallback : Symbol(LoadCallback, Decl(jsdocTwoLineTypedef.ts, 0, 0))
+

--- a/tests/baselines/reference/jsdocTwoLineTypedef.types
+++ b/tests/baselines/reference/jsdocTwoLineTypedef.types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/jsdocTwoLineTypedef.ts ===
+// Regression from #18301
+/**
+ * @typedef LoadCallback
+ * @type {function}
+ */
+type LoadCallback = void;
+>LoadCallback : void
+

--- a/tests/cases/conformance/jsdoc/jsdocTwoLineTypedef.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTwoLineTypedef.ts
@@ -1,0 +1,6 @@
+// Regression from #18301
+/**
+ * @typedef LoadCallback
+ * @type {function}
+ */
+type LoadCallback = void;


### PR DESCRIPTION
1. Remove JSDocTypeLiteral.jsdocTypeTag, which made no sense since it was only useful when storing information for its parent `@typedef` tag.
2. Also only visit jsdocPropertyTags if they exist, to mirror the behaviour of `visitNodes`.

Fixes #18301
