### PR TITLE
Change wording of scope description

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3696,7 +3696,7 @@
         "code": 95003
     },
 
-    "Extract function into {0}": {
+    "Extract to {0}": {
         "category": "Message",
         "code": 95004
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4829,16 +4829,29 @@ namespace ts {
     }
 
     /* @internal */
-    export function isFunctionLikeKind(kind: SyntaxKind): boolean {
+    export function isFunctionLikeDeclaration(node: Node): node is FunctionLikeDeclaration {
+        return node && isFunctionLikeDeclarationKind(node.kind);
+    }
+
+    function isFunctionLikeDeclarationKind(kind: SyntaxKind): boolean {
         switch (kind) {
-            case SyntaxKind.Constructor:
-            case SyntaxKind.FunctionExpression:
             case SyntaxKind.FunctionDeclaration:
-            case SyntaxKind.ArrowFunction:
             case SyntaxKind.MethodDeclaration:
-            case SyntaxKind.MethodSignature:
+            case SyntaxKind.Constructor:
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
+            case SyntaxKind.FunctionExpression:
+            case SyntaxKind.ArrowFunction:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /* @internal */
+    export function isFunctionLikeKind(kind: SyntaxKind): boolean {
+        switch (kind) {
+            case SyntaxKind.MethodSignature:
             case SyntaxKind.CallSignature:
             case SyntaxKind.ConstructSignature:
             case SyntaxKind.IndexSignature:
@@ -4846,9 +4859,9 @@ namespace ts {
             case SyntaxKind.JSDocFunctionType:
             case SyntaxKind.ConstructorType:
                 return true;
+            default:
+                return isFunctionLikeDeclarationKind(kind);
         }
-
-        return false;
     }
 
     // Classes

--- a/tests/baselines/reference/extractMethod/extractMethod1.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod1.ts
@@ -14,7 +14,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     let x = 1;
     function foo() {
@@ -34,7 +34,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     let x = 1;
     function foo() {
@@ -55,7 +55,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     let x = 1;
     function foo() {
@@ -76,7 +76,7 @@ namespace A {
         return a;
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     let x = 1;
     function foo() {

--- a/tests/baselines/reference/extractMethod/extractMethod10.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod10.ts
@@ -9,7 +9,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::class 'C'==
+// ==SCOPE::method in class 'C'==
 namespace A {
     export interface I { x: number };
     class C {
@@ -24,7 +24,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     export interface I { x: number };
     class C {
@@ -39,7 +39,7 @@ namespace A {
         return a1.x + 10;
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     export interface I { x: number };
     class C {

--- a/tests/baselines/reference/extractMethod/extractMethod11.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod11.ts
@@ -11,7 +11,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::class 'C'==
+// ==SCOPE::method in class 'C'==
 namespace A {
     let y = 1;
     class C {
@@ -30,7 +30,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     let y = 1;
     class C {
@@ -49,7 +49,7 @@ namespace A {
         return { __return: a1.x + 10, z };
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     let y = 1;
     class C {

--- a/tests/baselines/reference/extractMethod/extractMethod12.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod12.ts
@@ -13,7 +13,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::class 'C'==
+// ==SCOPE::method in class 'C'==
 namespace A {
     let y = 1;
     class C {

--- a/tests/baselines/reference/extractMethod/extractMethod13.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod13.ts
@@ -14,7 +14,7 @@
         }
     }
 }
-// ==SCOPE::function 'F2'==
+// ==SCOPE::inner function in function 'F2'==
 <U1a, U1b>(u1a: U1a, u1b: U1b) => {
     function F1<T1a, T1b>(t1a: T1a, t1b: T1b) {
         <U2a, U2b>(u2a: U2a, u2b: U2b) => {
@@ -34,7 +34,7 @@
         }
     }
 }
-// ==SCOPE::function 'F1'==
+// ==SCOPE::inner function in function 'F1'==
 <U1a, U1b>(u1a: U1a, u1b: U1b) => {
     function F1<T1a, T1b>(t1a: T1a, t1b: T1b) {
         <U2a, U2b>(u2a: U2a, u2b: U2b) => {
@@ -54,7 +54,7 @@
         }
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 <U1a, U1b>(u1a: U1a, u1b: U1b) => {
     function F1<T1a, T1b>(t1a: T1a, t1b: T1b) {
         <U2a, U2b>(u2a: U2a, u2b: U2b) => {

--- a/tests/baselines/reference/extractMethod/extractMethod14.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod14.ts
@@ -5,7 +5,7 @@ function F<T>(t1: T) {
         t2.toString();
     }
 }
-// ==SCOPE::function 'F'==
+// ==SCOPE::inner function in function 'F'==
 function F<T>(t1: T) {
     function F<T>(t2: T) {
         newFunction();
@@ -16,7 +16,7 @@ function F<T>(t1: T) {
         }
     }
 }
-// ==SCOPE::function 'F'==
+// ==SCOPE::inner function in function 'F'==
 function F<T>(t1: T) {
     function F<T>(t2: T) {
         newFunction<T>(t2);
@@ -27,7 +27,7 @@ function F<T>(t1: T) {
         t2.toString();
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 function F<T>(t1: T) {
     function F<T>(t2: T) {
         newFunction<T, T>(t1, t2);

--- a/tests/baselines/reference/extractMethod/extractMethod15.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod15.ts
@@ -4,7 +4,7 @@ function F<T>(t1: T) {
         t2.toString();
     }
 }
-// ==SCOPE::function 'F'==
+// ==SCOPE::inner function in function 'F'==
 function F<T>(t1: T) {
     function F<U extends T[]>(t2: U) {
         newFunction();
@@ -14,7 +14,7 @@ function F<T>(t1: T) {
         }
     }
 }
-// ==SCOPE::function 'F'==
+// ==SCOPE::inner function in function 'F'==
 function F<T>(t1: T) {
     function F<U extends T[]>(t2: U) {
         newFunction<U>(t2);
@@ -24,7 +24,7 @@ function F<T>(t1: T) {
         t2.toString();
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 function F<T>(t1: T) {
     function F<U extends T[]>(t2: U) {
         newFunction<T, U>(t2);

--- a/tests/baselines/reference/extractMethod/extractMethod16.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod16.ts
@@ -2,7 +2,7 @@
 function F<T>() {
     const array: T[] = [];
 }
-// ==SCOPE::function 'F'==
+// ==SCOPE::inner function in function 'F'==
 function F<T>() {
     const array: T[] = newFunction();
 
@@ -10,7 +10,7 @@ function F<T>() {
         return [];
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 function F<T>() {
     const array: T[] = newFunction<T>();
 }

--- a/tests/baselines/reference/extractMethod/extractMethod17.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod17.ts
@@ -4,7 +4,7 @@ class C<T1, T2> {
         t1.toString();
     }
 }
-// ==SCOPE::class 'C'==
+// ==SCOPE::method in class 'C'==
 class C<T1, T2> {
     M(t1: T1, t2: T2) {
         this.newFunction(t1);
@@ -14,7 +14,7 @@ class C<T1, T2> {
         t1.toString();
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 class C<T1, T2> {
     M(t1: T1, t2: T2) {
         newFunction<T1>(t1);

--- a/tests/baselines/reference/extractMethod/extractMethod18.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod18.ts
@@ -4,7 +4,7 @@ class C {
         t1.toString();
     }
 }
-// ==SCOPE::class 'C'==
+// ==SCOPE::method in class 'C'==
 class C {
     M<T1, T2>(t1: T1, t2: T2) {
         this.newFunction<T1>(t1);
@@ -14,7 +14,7 @@ class C {
         t1.toString();
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 class C {
     M<T1, T2>(t1: T1, t2: T2) {
         newFunction<T1>(t1);

--- a/tests/baselines/reference/extractMethod/extractMethod19.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod19.ts
@@ -2,7 +2,7 @@
 function F<T, U extends T[], V extends U[]>(v: V) {
     v.toString();
 }
-// ==SCOPE::function 'F'==
+// ==SCOPE::inner function in function 'F'==
 function F<T, U extends T[], V extends U[]>(v: V) {
     newFunction();
 
@@ -10,7 +10,7 @@ function F<T, U extends T[], V extends U[]>(v: V) {
         v.toString();
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 function F<T, U extends T[], V extends U[]>(v: V) {
     newFunction<T, U, V>(v);
 }

--- a/tests/baselines/reference/extractMethod/extractMethod2.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod2.ts
@@ -12,7 +12,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     let x = 1;
     function foo() {
@@ -30,7 +30,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     let x = 1;
     function foo() {
@@ -48,7 +48,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     let x = 1;
     function foo() {
@@ -66,7 +66,7 @@ namespace A {
         return foo();
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     let x = 1;
     function foo() {

--- a/tests/baselines/reference/extractMethod/extractMethod20.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod20.ts
@@ -5,7 +5,7 @@ const _ = class {
         return a1.x + 10;
     }
 }
-// ==SCOPE::anonymous class expression==
+// ==SCOPE::method in anonymous class expression==
 const _ = class {
     a() {
         return this.newFunction();
@@ -16,7 +16,7 @@ const _ = class {
         return a1.x + 10;
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 const _ = class {
     a() {
         return newFunction();

--- a/tests/baselines/reference/extractMethod/extractMethod21.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod21.ts
@@ -4,7 +4,7 @@ function foo() {
     x++;
     return;
 }
-// ==SCOPE::function 'foo'==
+// ==SCOPE::inner function in function 'foo'==
 function foo() {
     let x = 10;
     return newFunction();
@@ -14,7 +14,7 @@ function foo() {
         return;
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 function foo() {
     let x = 10;
     x = newFunction(x);

--- a/tests/baselines/reference/extractMethod/extractMethod22.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod22.ts
@@ -6,7 +6,7 @@ function test() {
         return 1;
     }
 }
-// ==SCOPE::function 'test'==
+// ==SCOPE::inner function in function 'test'==
 function test() {
     try {
     }
@@ -18,7 +18,7 @@ function test() {
         return 1;
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 function test() {
     try {
     }

--- a/tests/baselines/reference/extractMethod/extractMethod3.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod3.ts
@@ -11,7 +11,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     function foo() {
     }
@@ -28,7 +28,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     function foo() {
     }
@@ -45,7 +45,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     function foo() {
     }
@@ -62,7 +62,7 @@ namespace A {
         return foo();
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     function foo() {
     }

--- a/tests/baselines/reference/extractMethod/extractMethod4.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod4.ts
@@ -13,7 +13,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     function foo() {
     }
@@ -32,7 +32,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     function foo() {
     }
@@ -51,7 +51,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     function foo() {
     }
@@ -70,7 +70,7 @@ namespace A {
         return foo();
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     function foo() {
     }

--- a/tests/baselines/reference/extractMethod/extractMethod5.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod5.ts
@@ -14,7 +14,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     let x = 1;
     export function foo() {
@@ -34,7 +34,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     let x = 1;
     export function foo() {
@@ -55,7 +55,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     let x = 1;
     export function foo() {
@@ -76,7 +76,7 @@ namespace A {
         return a;
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     let x = 1;
     export function foo() {

--- a/tests/baselines/reference/extractMethod/extractMethod6.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod6.ts
@@ -14,7 +14,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     let x = 1;
     export function foo() {
@@ -34,7 +34,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     let x = 1;
     export function foo() {
@@ -56,7 +56,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     let x = 1;
     export function foo() {
@@ -78,7 +78,7 @@ namespace A {
         return { __return: foo(), a };
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     let x = 1;
     export function foo() {

--- a/tests/baselines/reference/extractMethod/extractMethod7.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod7.ts
@@ -16,7 +16,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     let x = 1;
     export namespace C {
@@ -38,7 +38,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     let x = 1;
     export namespace C {
@@ -62,7 +62,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     let x = 1;
     export namespace C {
@@ -86,7 +86,7 @@ namespace A {
         return { __return: C.foo(), a };
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     let x = 1;
     export namespace C {

--- a/tests/baselines/reference/extractMethod/extractMethod8.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod8.ts
@@ -8,7 +8,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     let x = 1;
     namespace B {
@@ -22,7 +22,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     let x = 1;
     namespace B {
@@ -36,7 +36,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     let x = 1;
     namespace B {
@@ -50,7 +50,7 @@ namespace A {
         return 1 + a1 + x;
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     let x = 1;
     namespace B {

--- a/tests/baselines/reference/extractMethod/extractMethod9.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod9.ts
@@ -8,7 +8,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::function 'a'==
+// ==SCOPE::inner function in function 'a'==
 namespace A {
     export interface I { x: number };
     namespace B {
@@ -22,7 +22,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'B'==
+// ==SCOPE::function in namespace 'B'==
 namespace A {
     export interface I { x: number };
     namespace B {
@@ -36,7 +36,7 @@ namespace A {
         }
     }
 }
-// ==SCOPE::namespace 'A'==
+// ==SCOPE::function in namespace 'A'==
 namespace A {
     export interface I { x: number };
     namespace B {
@@ -50,7 +50,7 @@ namespace A {
         return a1.x + 10;
     }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace A {
     export interface I { x: number };
     namespace B {

--- a/tests/cases/fourslash/extract-method-formatting.ts
+++ b/tests/cases/fourslash/extract-method-formatting.ts
@@ -9,7 +9,7 @@ goTo.select('start', 'end')
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_1",
-    actionDescription: "Extract function into global scope",
+    actionDescription: "Extract to function in global scope",
 });
 verify.currentFileContentIs(
 `function f(x: number): number {

--- a/tests/cases/fourslash/extract-method1.ts
+++ b/tests/cases/fourslash/extract-method1.ts
@@ -16,7 +16,7 @@ goTo.select('start', 'end')
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_0",
-    actionDescription: "Extract function into class 'Foo'",
+    actionDescription: "Extract to method in class 'Foo'",
 });
 verify.currentFileContentIs(
 `class Foo {

--- a/tests/cases/fourslash/extract-method10.ts
+++ b/tests/cases/fourslash/extract-method10.ts
@@ -7,5 +7,5 @@ goTo.select('1', '2');
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: 'scope_0',
-    actionDescription: "Extract function into module scope",
+    actionDescription: "Extract to function in module scope",
 });

--- a/tests/cases/fourslash/extract-method13.ts
+++ b/tests/cases/fourslash/extract-method13.ts
@@ -13,14 +13,14 @@ goTo.select('a', 'b');
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_0",
-    actionDescription: "Extract function into class 'C'",
+    actionDescription: "Extract to method in class 'C'",
 });
 
 goTo.select('c', 'd');
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_0",
-    actionDescription: "Extract function into class 'C'",
+    actionDescription: "Extract to method in class 'C'",
 });
 
 verify.currentFileContentIs(`class C {

--- a/tests/cases/fourslash/extract-method14.ts
+++ b/tests/cases/fourslash/extract-method14.ts
@@ -14,7 +14,7 @@ goTo.select('a', 'b');
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_1",
-    actionDescription: "Extract function into global scope",
+    actionDescription: "Extract to function in global scope",
 });
 verify.currentFileContentIs(`function foo() {
     var i = 10;

--- a/tests/cases/fourslash/extract-method15.ts
+++ b/tests/cases/fourslash/extract-method15.ts
@@ -12,7 +12,7 @@ goTo.select('a', 'b');
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_1",
-    actionDescription: "Extract function into global scope",
+    actionDescription: "Extract to function in global scope",
 });
 
 verify.currentFileContentIs(`function foo() {

--- a/tests/cases/fourslash/extract-method18.ts
+++ b/tests/cases/fourslash/extract-method18.ts
@@ -12,7 +12,7 @@ goTo.select('a', 'b')
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_1",
-    actionDescription: "Extract function into global scope",
+    actionDescription: "Extract to function in global scope",
 });
 verify.currentFileContentIs(`function fn() {
     const x = { m: 1 };

--- a/tests/cases/fourslash/extract-method19.ts
+++ b/tests/cases/fourslash/extract-method19.ts
@@ -12,7 +12,7 @@ goTo.select('a', 'b')
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_0",
-    actionDescription: "Extract function into function 'fn'",
+    actionDescription: "Extract to inner function in function 'fn'",
 });
 verify.currentFileContentIs(`function fn() {
     newFunction_1();

--- a/tests/cases/fourslash/extract-method2.ts
+++ b/tests/cases/fourslash/extract-method2.ts
@@ -13,7 +13,7 @@ goTo.select('start', 'end')
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_2",
-    actionDescription: "Extract function into global scope",
+    actionDescription: "Extract to function in global scope",
 });
 verify.currentFileContentIs(
 `namespace NS {

--- a/tests/cases/fourslash/extract-method21.ts
+++ b/tests/cases/fourslash/extract-method21.ts
@@ -15,7 +15,7 @@ verify.refactorAvailable('Extract Method');
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_0",
-    actionDescription: "Extract function into class 'Foo'",
+    actionDescription: "Extract to method in class 'Foo'",
 });
 
 verify.currentFileContentIs(`class Foo {

--- a/tests/cases/fourslash/extract-method24.ts
+++ b/tests/cases/fourslash/extract-method24.ts
@@ -10,7 +10,7 @@ goTo.select('a', 'b')
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_1",
-    actionDescription: "Extract function into global scope",
+    actionDescription: "Extract to function in global scope",
 });
 verify.currentFileContentIs(`function M() {
     let a = [1,2,3];

--- a/tests/cases/fourslash/extract-method25.ts
+++ b/tests/cases/fourslash/extract-method25.ts
@@ -11,7 +11,7 @@ goTo.select('a', 'b')
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_0",
-    actionDescription: "Extract function into function 'fn'",
+    actionDescription: "Extract to inner function in function 'fn'",
 });
 verify.currentFileContentIs(`function fn() {
     var q = newFunction()

--- a/tests/cases/fourslash/extract-method5.ts
+++ b/tests/cases/fourslash/extract-method5.ts
@@ -12,7 +12,7 @@ goTo.select('start', 'end');
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_0",
-    actionDescription: "Extract function into function 'f'",
+    actionDescription: "Extract to inner function in function 'f'",
 });
 // TODO: GH#18091 (fix formatting to use `2 ? 1 :` and not `2?1:`)
 verify.currentFileContentIs(

--- a/tests/cases/fourslash/extract-method7.ts
+++ b/tests/cases/fourslash/extract-method7.ts
@@ -10,7 +10,7 @@ goTo.select('a', 'b');
 edit.applyRefactor({
     refactorName: "Extract Method",
     actionName: "scope_0",
-    actionDescription: "Extract function into global scope",
+    actionDescription: "Extract to function in global scope",
 });
 verify.currentFileContentIs(`function fn(x = newFunction()) {
 }


### PR DESCRIPTION
Fixes #18176
The test baseline changes do a pretty good job of describing what this change does. The new wording describes what the result will be, e.g. `method in class 'C'`, whereas the old wording just described what the parent node of the result would be, e.g. `class 'C'`.