### PR TITLE
Improve insertion position of extracted methods

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -505,7 +505,7 @@ namespace ts {
         }
     }
 
-    function staticAssertNever(_: never): void {}
+    export function staticAssertNever(_: never): void {}
 
     // Gets the nearest enclosing block scope container that has the provided node
     // as a descendant, that is not the provided node.

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -500,12 +500,10 @@ namespace ts {
             case SyntaxKind.ArrowFunction:
                 return true;
             default:
-                staticAssertNever(node);
+                assertTypeIsNever(node);
                 return false;
         }
     }
-
-    export function staticAssertNever(_: never): void {}
 
     // Gets the nearest enclosing block scope container that has the provided node
     // as a descendant, that is not the provided node.

--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -224,7 +224,7 @@ namespace ts {
             testExtractRange(`
                 function f() {
                     while (true) {
-                [#| 
+                [#|
                         if (x) {
                             return;
                         } |]
@@ -234,7 +234,7 @@ namespace ts {
             testExtractRange(`
                 function f() {
                     while (true) {
-                [#| 
+                [#|
                         [$|if (x) {
                         }
                         return;|]
@@ -655,6 +655,60 @@ function test(x: number) {
     finally {
         [#|return 1;|]
     }
+}`);
+        // Extraction position - namespace
+        testExtractMethod("extractMethod23",
+            `namespace NS {
+    function M1() { }
+    function M2() {
+        [#|return 1;|]
+    }
+    function M3() { }
+}`);
+        // Extraction position - function
+        testExtractMethod("extractMethod24",
+            `function Outer() {
+    function M1() { }
+    function M2() {
+        [#|return 1;|]
+    }
+    function M3() { }
+}`);
+        // Extraction position - file
+        testExtractMethod("extractMethod25",
+            `function M1() { }
+function M2() {
+    [#|return 1;|]
+}
+function M3() { }`);
+        // Extraction position - class without ctor
+        testExtractMethod("extractMethod26",
+            `class C {
+    M1() { }
+    M2() {
+        [#|return 1;|]
+    }
+    M3() { }
+}`);
+        // Extraction position - class with ctor in middle
+        testExtractMethod("extractMethod27",
+            `class C {
+    M1() { }
+    M2() {
+        [#|return 1;|]
+    }
+    constructor() { }
+    M3() { }
+}`);
+        // Extraction position - class with ctor at end
+        testExtractMethod("extractMethod28",
+            `class C {
+    M1() { }
+    M2() {
+        [#|return 1;|]
+    }
+    M3() { }
+    constructor() { }
 }`);
     });
 

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -851,7 +851,7 @@ namespace ts.refactor.extractMethod {
                 return scope.members;
             }
             else {
-                staticAssertNever(scope);
+                assertTypeIsNever(scope);
             }
 
             return emptyArray;

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -697,8 +697,14 @@ namespace ts.refactor.extractMethod {
         }
 
         const changeTracker = textChanges.ChangeTracker.fromContext(context);
-        // insert function at the end of the scope
-        changeTracker.insertNodeBefore(context.file, scope.getLastToken(), newFunction, { prefix: context.newLineCharacter, suffix: context.newLineCharacter });
+        const minInsertionPos = (isReadonlyArray(range.range) ? lastOrUndefined(range.range) : range.range).end;
+        const nodeToInsertBefore = getNodeToInsertBefore(minInsertionPos, scope);
+        if (nodeToInsertBefore) {
+            changeTracker.insertNodeBefore(context.file, nodeToInsertBefore, newFunction, { suffix: context.newLineCharacter + context.newLineCharacter });
+        }
+        else {
+            changeTracker.insertNodeBefore(context.file, scope.getLastToken(), newFunction, { prefix: context.newLineCharacter, suffix: context.newLineCharacter });
+        }
 
         const newNodes: Node[] = [];
         // replace range with function call
@@ -829,6 +835,39 @@ namespace ts.refactor.extractMethod {
 
         function generateReturnValueProperty() {
             return "__return";
+        }
+
+        function getStatementsOrClassElements(scope: Scope): ReadonlyArray<Statement> | ReadonlyArray<ClassElement> {
+            if (isFunctionLike(scope)) {
+                const body = scope.body;
+                if (isBlock(body)) {
+                    return body.statements;
+                }
+            }
+            else if (isModuleBlock(scope) || isSourceFile(scope)) {
+                return scope.statements;
+            }
+            else if (isClassLike(scope)) {
+                return scope.members;
+            }
+            else {
+                staticAssertNever(scope);
+            }
+
+            return emptyArray;
+        }
+
+        /**
+         * If `scope` contains a function after `minPos`, then return the first such function.
+         * Otherwise, return `undefined`.
+         */
+        function getNodeToInsertBefore(minPos: number, scope: Scope): Node | undefined {
+            const children = getStatementsOrClassElements(scope);
+            for (const child of children) {
+                if (child.pos >= minPos && isFunctionLike(child) && !isConstructorDeclaration(child)) {
+                    return child;
+                }
+            }
         }
 
         function transformFunctionBody(body: Node) {

--- a/tests/baselines/reference/extractMethod/extractMethod23.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod23.ts
@@ -1,0 +1,43 @@
+// ==ORIGINAL==
+namespace NS {
+    function M1() { }
+    function M2() {
+        return 1;
+    }
+    function M3() { }
+}
+// ==SCOPE::function 'M2'==
+namespace NS {
+    function M1() { }
+    function M2() {
+        return newFunction();
+
+        function newFunction() {
+            return 1;
+        }
+    }
+    function M3() { }
+}
+// ==SCOPE::namespace 'NS'==
+namespace NS {
+    function M1() { }
+    function M2() {
+        return newFunction();
+    }
+    function newFunction() {
+        return 1;
+    }
+
+    function M3() { }
+}
+// ==SCOPE::global scope==
+namespace NS {
+    function M1() { }
+    function M2() {
+        return newFunction();
+    }
+    function M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod24.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod24.ts
@@ -1,0 +1,43 @@
+// ==ORIGINAL==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return 1;
+    }
+    function M3() { }
+}
+// ==SCOPE::function 'M2'==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return newFunction();
+
+        function newFunction() {
+            return 1;
+        }
+    }
+    function M3() { }
+}
+// ==SCOPE::function 'Outer'==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return newFunction();
+    }
+    function newFunction() {
+        return 1;
+    }
+
+    function M3() { }
+}
+// ==SCOPE::global scope==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return newFunction();
+    }
+    function M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod25.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod25.ts
@@ -1,0 +1,26 @@
+// ==ORIGINAL==
+function M1() { }
+function M2() {
+    return 1;
+}
+function M3() { }
+// ==SCOPE::function 'M2'==
+function M1() { }
+function M2() {
+    return newFunction();
+
+    function newFunction() {
+        return 1;
+    }
+}
+function M3() { }
+// ==SCOPE::global scope==
+function M1() { }
+function M2() {
+    return newFunction();
+}
+function newFunction() {
+    return 1;
+}
+
+function M3() { }

--- a/tests/baselines/reference/extractMethod/extractMethod26.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod26.ts
@@ -1,0 +1,31 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    M3() { }
+}
+// ==SCOPE::class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this.newFunction();
+    }
+    private newFunction() {
+        return 1;
+    }
+
+    M3() { }
+}
+// ==SCOPE::global scope==
+class C {
+    M1() { }
+    M2() {
+        return newFunction();
+    }
+    M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod27.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod27.ts
@@ -1,0 +1,34 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    constructor() { }
+    M3() { }
+}
+// ==SCOPE::class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this.newFunction();
+    }
+    constructor() { }
+    private newFunction() {
+        return 1;
+    }
+
+    M3() { }
+}
+// ==SCOPE::global scope==
+class C {
+    M1() { }
+    M2() {
+        return newFunction();
+    }
+    constructor() { }
+    M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod28.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod28.ts
@@ -1,0 +1,34 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    M3() { }
+    constructor() { }
+}
+// ==SCOPE::class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this.newFunction();
+    }
+    private newFunction() {
+        return 1;
+    }
+
+    M3() { }
+    constructor() { }
+}
+// ==SCOPE::global scope==
+class C {
+    M1() { }
+    M2() {
+        return newFunction();
+    }
+    M3() { }
+    constructor() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/cases/fourslash/extract-method13.ts
+++ b/tests/cases/fourslash/extract-method13.ts
@@ -16,6 +16,16 @@ edit.applyRefactor({
     actionDescription: "Extract function into class 'C'",
 });
 
+verify.currentFileContentIs(`class C {
+    static j = 1 + 1;
+    constructor(q: string = C.newFunction()) {
+    }
+
+    private static newFunction(): string {
+        return "a" + "b";
+    }
+}`);
+
 goTo.select('c', 'd');
 edit.applyRefactor({
     refactorName: "Extract Method",
@@ -28,11 +38,11 @@ verify.currentFileContentIs(`class C {
     constructor(q: string = C.newFunction()) {
     }
 
-    private static newFunction(): string {
-        return "a" + "b";
-    }
-
     private static newFunction_1() {
         return 1 + 1;
+    }
+
+    private static newFunction(): string {
+        return "a" + "b";
     }
 }`);


### PR DESCRIPTION
_Old_: End of target scope
_New_: Before the first non-constructor function following the extracted range in the target scope

TODO: I'm going to add more tests, but I know people are anxious for local builds of this change.