### PR TITLE
Rework computed property name + decorator emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12528,7 +12528,7 @@ namespace ts {
                 // must instead be rewritten to point to a temporary variable to avoid issues with the double-bind
                 // behavior of class names in ES6.
                 if (declaration.kind === SyntaxKind.ClassDeclaration
-                    && nodeIsDecorated(declaration)) {
+                    && nodeIsDecorated(declaration as ClassDeclaration)) {
                     let container = getContainingClass(node);
                     while (container !== undefined) {
                         if (container === declaration && container.name !== node) {
@@ -20017,7 +20017,7 @@ namespace ts {
 
             // skip this check for nodes that cannot have decorators. These should have already had an error reported by
             // checkGrammarDecorators.
-            if (!nodeCanBeDecorated(node)) {
+            if (!nodeCanBeDecorated(node, node.parent, node.parent.parent)) {
                 return;
             }
 
@@ -24394,7 +24394,7 @@ namespace ts {
             if (!node.decorators) {
                 return false;
             }
-            if (!nodeCanBeDecorated(node)) {
+            if (!nodeCanBeDecorated(node, node.parent, node.parent.parent)) {
                 if (node.kind === SyntaxKind.MethodDeclaration && !ts.nodeIsPresent((<MethodDeclaration>node).body)) {
                     return grammarErrorOnFirstToken(node, Diagnostics.A_decorator_can_only_decorate_a_method_implementation_not_an_overload);
                 }

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1155,14 +1155,15 @@ namespace ts {
             if (!node.members) return;
             const result: PropertyDeclaration[] = [];
             for (let member of node.members) {
-                if (!isStatic && isComputedNameWhichRequiresHoisting(member, isStatic)) {
+                if (!isStatic && hasComputedNameWhichRequiresHoisting(member)) {
+                    const memberProp = member as PropertyDeclaration;
                     const tempId = getGeneratedNameForNode(member);
                     const hoistedExpression = createAssignment(tempId, (member.name as ComputedPropertyName).expression);
-                    member = updateProperty(member, member.decorators, member.modifiers, createComputedPropertyName(tempId), member.questionToken, member.type, member.initializer);
+                    member = updateProperty(memberProp, member.decorators, member.modifiers, createComputedPropertyName(tempId), memberProp.questionToken, memberProp.type, memberProp.initializer);
                     hoistedComputedNames.push(hoistedExpression);
                 }
                 if (isInitializedProperty(member, isStatic)) {
-                    result.push(member);
+                    result.push(member as PropertyDeclaration);
                 }
                 if (isDecoratedClassElement(member, node, isStatic)) {
                     decoratedMembers.push(member);
@@ -1176,7 +1177,7 @@ namespace ts {
          *
          * @param member The class element node.
          */
-        function isInstanceInitializedProperty(member: ClassElement): member is PropertyDeclaration {
+        function isInstanceInitializedProperty(member: ClassElement) {
             return isInitializedProperty(member, /*isStatic*/ false);
         }
 
@@ -1186,15 +1187,15 @@ namespace ts {
          * @param member The class element node.
          * @param isStatic A value indicating whether the member should be a static or instance member.
          */
-        function isInitializedProperty(member: ClassElement, isStatic: boolean): member is PropertyDeclaration {
+        function isInitializedProperty(member: ClassElement, isStatic: boolean) {
             return member.kind === SyntaxKind.PropertyDeclaration
                 && isStatic === hasModifier(member, ModifierFlags.Static)
                 && (<PropertyDeclaration>member).initializer !== undefined;
         }
 
-        function isComputedNameWhichRequiresHoisting(member: ClassElement, isStatic: boolean): member is PropertyDeclaration {
+        function hasComputedNameWhichRequiresHoisting(member: ClassElement) {
             return member.kind === SyntaxKind.PropertyDeclaration
-                && isStatic === hasModifier(member, ModifierFlags.Static)
+                && !hasModifier(member, ModifierFlags.Static)
                 && isComputedPropertyName(member.name)
                 && !isSimpleComputedPropertyName(member.name.expression);
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1159,7 +1159,7 @@ namespace ts {
         return (<CallExpression | Decorator>node).expression;
     }
 
-    export function nodeCanBeDecorated(node: Node): boolean {
+    export function nodeCanBeDecorated(node: Node, parent: Node = node.parent, grandparent: Node = parent.parent): boolean {
         switch (node.kind) {
             case SyntaxKind.ClassDeclaration:
                 // classes are valid targets
@@ -1167,43 +1167,43 @@ namespace ts {
 
             case SyntaxKind.PropertyDeclaration:
                 // property declarations are valid if their parent is a class declaration.
-                return node.parent.kind === SyntaxKind.ClassDeclaration;
+                return parent.kind === SyntaxKind.ClassDeclaration;
 
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
             case SyntaxKind.MethodDeclaration:
                 // if this method has a body and its parent is a class declaration, this is a valid target.
                 return (<FunctionLikeDeclaration>node).body !== undefined
-                    && node.parent.kind === SyntaxKind.ClassDeclaration;
+                    && parent.kind === SyntaxKind.ClassDeclaration;
 
             case SyntaxKind.Parameter:
                 // if the parameter's parent has a body and its grandparent is a class declaration, this is a valid target;
-                return (<FunctionLikeDeclaration>node.parent).body !== undefined
-                    && (node.parent.kind === SyntaxKind.Constructor
-                        || node.parent.kind === SyntaxKind.MethodDeclaration
-                        || node.parent.kind === SyntaxKind.SetAccessor)
-                    && node.parent.parent.kind === SyntaxKind.ClassDeclaration;
+                return (<FunctionLikeDeclaration>parent).body !== undefined
+                    && (parent.kind === SyntaxKind.Constructor
+                        || parent.kind === SyntaxKind.MethodDeclaration
+                        || parent.kind === SyntaxKind.SetAccessor)
+                    && grandparent.kind === SyntaxKind.ClassDeclaration;
         }
 
         return false;
     }
 
-    export function nodeIsDecorated(node: Node): boolean {
+    export function nodeIsDecorated(node: Node, parent?: Node, grandparent?: Node): boolean {
         return node.decorators !== undefined
-            && nodeCanBeDecorated(node);
+            && nodeCanBeDecorated(node, parent, grandparent);
     }
 
-    export function nodeOrChildIsDecorated(node: Node): boolean {
-        return nodeIsDecorated(node) || childIsDecorated(node);
+    export function nodeOrChildIsDecorated(node: Node, parent?: Node, grandparent?: Node): boolean {
+        return nodeIsDecorated(node, parent, grandparent) || childIsDecorated(node, parent);
     }
 
-    export function childIsDecorated(node: Node): boolean {
+    export function childIsDecorated(node: Node, parent?: Node): boolean {
         switch (node.kind) {
             case SyntaxKind.ClassDeclaration:
-                return forEach((<ClassDeclaration>node).members, nodeOrChildIsDecorated);
+                return forEach((<ClassDeclaration>node).members, m => nodeOrChildIsDecorated(m, node, parent));
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.SetAccessor:
-                return forEach((<FunctionLikeDeclaration>node).parameters, nodeIsDecorated);
+                return forEach((<FunctionLikeDeclaration>node).parameters, p => nodeIsDecorated(p, node, parent));
         }
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1159,7 +1159,10 @@ namespace ts {
         return (<CallExpression | Decorator>node).expression;
     }
 
-    export function nodeCanBeDecorated(node: Node, parent: Node = node.parent, grandparent: Node = parent.parent): boolean {
+    export function nodeCanBeDecorated(node: ClassDeclaration): true;
+    export function nodeCanBeDecorated(node: ClassElement, parent: Node): boolean;
+    export function nodeCanBeDecorated(node: Node, parent: Node, grandparent: Node): boolean;
+    export function nodeCanBeDecorated(node: Node, parent?: Node, grandparent?: Node): boolean {
         switch (node.kind) {
             case SyntaxKind.ClassDeclaration:
                 // classes are valid targets
@@ -1188,15 +1191,23 @@ namespace ts {
         return false;
     }
 
+    export function nodeIsDecorated(node: ClassDeclaration): boolean;
+    export function nodeIsDecorated(node: ClassElement, parent: Node): boolean;
+    export function nodeIsDecorated(node: Node, parent: Node, grandparent: Node): boolean;
     export function nodeIsDecorated(node: Node, parent?: Node, grandparent?: Node): boolean {
         return node.decorators !== undefined
             && nodeCanBeDecorated(node, parent, grandparent);
     }
 
+    export function nodeOrChildIsDecorated(node: ClassDeclaration): boolean;
+    export function nodeOrChildIsDecorated(node: ClassElement, parent: Node): boolean;
+    export function nodeOrChildIsDecorated(node: Node, parent: Node, grandparent: Node): boolean;
     export function nodeOrChildIsDecorated(node: Node, parent?: Node, grandparent?: Node): boolean {
         return nodeIsDecorated(node, parent, grandparent) || childIsDecorated(node, parent);
     }
 
+    export function childIsDecorated(node: ClassDeclaration): boolean;
+    export function childIsDecorated(node: Node, parent: Node): boolean;
     export function childIsDecorated(node: Node, parent?: Node): boolean {
         switch (node.kind) {
             case SyntaxKind.ClassDeclaration:

--- a/tests/baselines/reference/capturedParametersInInitializers2.js
+++ b/tests/baselines/reference/capturedParametersInInitializers2.js
@@ -19,11 +19,14 @@ function foo(y, x) {
     var _a;
 }
 function foo2(y, x) {
-    if (y === void 0) { y = /** @class */ (function () {
-        function class_2() {
-            this[x] = x;
-        }
-        return class_2;
-    }()); }
+    if (y === void 0) { y = (_a = x,
+        _b = /** @class */ (function () {
+                function class_2() {
+                    this[_a] = x;
+                }
+                return class_2;
+            }()),
+        _b); }
     if (x === void 0) { x = 1; }
+    var _b;
 }

--- a/tests/baselines/reference/capturedParametersInInitializers2.js
+++ b/tests/baselines/reference/capturedParametersInInitializers2.js
@@ -28,5 +28,5 @@ function foo2(y, x) {
             }()),
         _b); }
     if (x === void 0) { x = 1; }
-    var _b;
+    var _a, _b;
 }

--- a/tests/baselines/reference/computedPropertyNames12_ES5.js
+++ b/tests/baselines/reference/computedPropertyNames12_ES5.js
@@ -20,10 +20,11 @@ class C {
 var s;
 var n;
 var a;
+var _a = s, _b = n, _c = s + n, _d = +s, _e = a;
 var C = /** @class */ (function () {
     function C() {
-        this[n] = n;
-        this[s + n] = 2;
+        this[_b] = n;
+        this[_c] = 2;
         this["hello bye"] = 0;
     }
     C["hello " + a + " bye"] = 0;

--- a/tests/baselines/reference/computedPropertyNames12_ES6.js
+++ b/tests/baselines/reference/computedPropertyNames12_ES6.js
@@ -20,10 +20,11 @@ class C {
 var s;
 var n;
 var a;
+var _a = s, _b = n, _c = s + n, _d = +s, _e = a;
 class C {
     constructor() {
-        this[n] = n;
-        this[s + n] = 2;
+        this[_b] = n;
+        this[_c] = 2;
         this[`hello bye`] = 0;
     }
 }

--- a/tests/baselines/reference/decoratorOnClassMethod13.js
+++ b/tests/baselines/reference/decoratorOnClassMethod13.js
@@ -14,13 +14,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 class C {
-    [_a = "1"]() { }
-    [_b = "b"]() { }
+    ["1"]() { }
+    ["b"]() { }
 }
 __decorate([
     dec
-], C.prototype, _a, null);
+], C.prototype, "1", null);
 __decorate([
     dec
-], C.prototype, _b, null);
-var _a, _b;
+], C.prototype, "b", null);

--- a/tests/baselines/reference/decoratorOnClassMethod4.js
+++ b/tests/baselines/reference/decoratorOnClassMethod4.js
@@ -13,9 +13,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 class C {
-    [_a = "method"]() { }
+    ["method"]() { }
 }
 __decorate([
     dec
-], C.prototype, _a, null);
-var _a;
+], C.prototype, "method", null);

--- a/tests/baselines/reference/decoratorOnClassMethod5.js
+++ b/tests/baselines/reference/decoratorOnClassMethod5.js
@@ -13,9 +13,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 class C {
-    [_a = "method"]() { }
+    ["method"]() { }
 }
 __decorate([
     dec()
-], C.prototype, _a, null);
-var _a;
+], C.prototype, "method", null);

--- a/tests/baselines/reference/decoratorOnClassMethod6.js
+++ b/tests/baselines/reference/decoratorOnClassMethod6.js
@@ -13,9 +13,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 class C {
-    [_a = "method"]() { }
+    ["method"]() { }
 }
 __decorate([
     dec
-], C.prototype, _a, null);
-var _a;
+], C.prototype, "method", null);

--- a/tests/baselines/reference/decoratorOnClassMethod7.js
+++ b/tests/baselines/reference/decoratorOnClassMethod7.js
@@ -13,9 +13,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 class C {
-    [_a = "method"]() { }
+    ["method"]() { }
 }
 __decorate([
     dec
-], C.prototype, _a, null);
-var _a;
+], C.prototype, "method", null);

--- a/tests/baselines/reference/decoratorsOnComputedProperties.errors.txt
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.errors.txt
@@ -1,0 +1,93 @@
+tests/cases/compiler/decoratorsOnComputedProperties.ts(18,5): error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(19,8): error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(20,8): error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(21,5): error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(22,8): error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(23,8): error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(27,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(28,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(29,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(30,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(35,5): error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(36,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(37,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(38,5): error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(39,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(40,5): error TS1206: Decorators are not valid here.
+
+
+==== tests/cases/compiler/decoratorsOnComputedProperties.ts (16 errors) ====
+    function x(o: object, k: PropertyKey) { }
+    let i = 0;
+    function foo(): string { return ++i + ""; }
+    
+    const fieldNameA: string = "fieldName1";
+    const fieldNameB: string = "fieldName2";
+    const fieldNameC: string = "fieldName3";
+    
+    class A {
+        @x ["property"]: any;
+        @x [Symbol.toStringTag]: any;
+        @x ["property2"]: any = 2;
+        @x [Symbol.iterator]: any = null;
+        ["property3"]: any;
+        [Symbol.isConcatSpreadable]: any;
+        ["property4"]: any = 2;
+        [Symbol.match]: any = null;
+        [foo()]: any;
+        ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+        @x [foo()]: any;
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+        @x [foo()]: any = null;
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+        [fieldNameA]: any;
+        ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+        @x [fieldNameB]: any;
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+        @x [fieldNameC]: any = null;
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+    }
+    
+    void class B {
+        @x ["property"]: any;
+        ~
+!!! error TS1206: Decorators are not valid here.
+        @x [Symbol.toStringTag]: any;
+        ~
+!!! error TS1206: Decorators are not valid here.
+        @x ["property2"]: any = 2;
+        ~
+!!! error TS1206: Decorators are not valid here.
+        @x [Symbol.iterator]: any = null;
+        ~
+!!! error TS1206: Decorators are not valid here.
+        ["property3"]: any;
+        [Symbol.isConcatSpreadable]: any;
+        ["property4"]: any = 2;
+        [Symbol.match]: any = null;
+        [foo()]: any;
+        ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+        @x [foo()]: any;
+        ~
+!!! error TS1206: Decorators are not valid here.
+        @x [foo()]: any = null;
+        ~
+!!! error TS1206: Decorators are not valid here.
+        [fieldNameA]: any;
+        ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must directly refer to a built-in symbol.
+        @x [fieldNameB]: any;
+        ~
+!!! error TS1206: Decorators are not valid here.
+        @x [fieldNameC]: any = null;
+        ~
+!!! error TS1206: Decorators are not valid here.
+    };
+    

--- a/tests/baselines/reference/decoratorsOnComputedProperties.js
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.js
@@ -1,0 +1,105 @@
+//// [decoratorsOnComputedProperties.ts]
+function x(o: object, k: PropertyKey) { }
+let i = 0;
+function foo(): string { return ++i + ""; }
+
+const fieldNameA: string = "fieldName1";
+const fieldNameB: string = "fieldName2";
+const fieldNameC: string = "fieldName3";
+
+class A {
+    @x ["property"]: any;
+    @x [Symbol.toStringTag]: any;
+    @x ["property2"]: any = 2;
+    @x [Symbol.iterator]: any = null;
+    ["property3"]: any;
+    [Symbol.isConcatSpreadable]: any;
+    ["property4"]: any = 2;
+    [Symbol.match]: any = null;
+    [foo()]: any;
+    @x [foo()]: any;
+    @x [foo()]: any = null;
+    [fieldNameA]: any;
+    @x [fieldNameB]: any;
+    @x [fieldNameC]: any = null;
+}
+
+void class B {
+    @x ["property"]: any;
+    @x [Symbol.toStringTag]: any;
+    @x ["property2"]: any = 2;
+    @x [Symbol.iterator]: any = null;
+    ["property3"]: any;
+    [Symbol.isConcatSpreadable]: any;
+    ["property4"]: any = 2;
+    [Symbol.match]: any = null;
+    [foo()]: any;
+    @x [foo()]: any;
+    @x [foo()]: any = null;
+    [fieldNameA]: any;
+    @x [fieldNameB]: any;
+    @x [fieldNameC]: any = null;
+};
+
+
+//// [decoratorsOnComputedProperties.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+function x(o, k) { }
+let i = 0;
+function foo() { return ++i + ""; }
+const fieldNameA = "fieldName1";
+const fieldNameB = "fieldName2";
+const fieldNameC = "fieldName3";
+var _a = foo(), _b = foo(), _c = foo(), _d = fieldNameA, _e = fieldNameB, _f = fieldNameC;
+class A {
+    constructor() {
+        this["property2"] = 2;
+        this[Symbol.iterator] = null;
+        this["property4"] = 2;
+        this[Symbol.match] = null;
+        this[_c] = null;
+        this[_f] = null;
+    }
+}
+__decorate([
+    x
+], A.prototype, "property", void 0);
+__decorate([
+    x
+], A.prototype, Symbol.toStringTag, void 0);
+__decorate([
+    x
+], A.prototype, "property2", void 0);
+__decorate([
+    x
+], A.prototype, Symbol.iterator, void 0);
+__decorate([
+    x
+], A.prototype, _b, void 0);
+__decorate([
+    x
+], A.prototype, _c, void 0);
+__decorate([
+    x
+], A.prototype, _e, void 0);
+__decorate([
+    x
+], A.prototype, _f, void 0);
+void (_g = foo(), _h = foo(), _j = foo(), _k = fieldNameA, _l = fieldNameB, _m = fieldNameC,
+    _o = class B {
+            constructor() {
+                this["property2"] = 2;
+                this[Symbol.iterator] = null;
+                this["property4"] = 2;
+                this[Symbol.match] = null;
+                this[_j] = null;
+                this[_m] = null;
+            }
+        },
+    _o);
+var _o;

--- a/tests/baselines/reference/decoratorsOnComputedProperties.js
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.js
@@ -102,4 +102,4 @@ void (_g = foo(), _h = foo(), _j = foo(), _k = fieldNameA, _l = fieldNameB, _m =
             }
         },
     _o);
-var _o;
+var _g, _h, _j, _k, _l, _m, _o;

--- a/tests/baselines/reference/decoratorsOnComputedProperties.symbols
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.symbols
@@ -1,0 +1,148 @@
+=== tests/cases/compiler/decoratorsOnComputedProperties.ts ===
+function x(o: object, k: PropertyKey) { }
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>o : Symbol(o, Decl(decoratorsOnComputedProperties.ts, 0, 11))
+>k : Symbol(k, Decl(decoratorsOnComputedProperties.ts, 0, 21))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.es2015.core.d.ts, --, --))
+
+let i = 0;
+>i : Symbol(i, Decl(decoratorsOnComputedProperties.ts, 1, 3))
+
+function foo(): string { return ++i + ""; }
+>foo : Symbol(foo, Decl(decoratorsOnComputedProperties.ts, 1, 10))
+>i : Symbol(i, Decl(decoratorsOnComputedProperties.ts, 1, 3))
+
+const fieldNameA: string = "fieldName1";
+>fieldNameA : Symbol(fieldNameA, Decl(decoratorsOnComputedProperties.ts, 4, 5))
+
+const fieldNameB: string = "fieldName2";
+>fieldNameB : Symbol(fieldNameB, Decl(decoratorsOnComputedProperties.ts, 5, 5))
+
+const fieldNameC: string = "fieldName3";
+>fieldNameC : Symbol(fieldNameC, Decl(decoratorsOnComputedProperties.ts, 6, 5))
+
+class A {
+>A : Symbol(A, Decl(decoratorsOnComputedProperties.ts, 6, 40))
+
+    @x ["property"]: any;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>"property" : Symbol(A[["property"]], Decl(decoratorsOnComputedProperties.ts, 8, 9))
+
+    @x [Symbol.toStringTag]: any;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    @x ["property2"]: any = 2;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>"property2" : Symbol(A[["property2"]], Decl(decoratorsOnComputedProperties.ts, 10, 33))
+
+    @x [Symbol.iterator]: any = null;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+
+    ["property3"]: any;
+>"property3" : Symbol(A[["property3"]], Decl(decoratorsOnComputedProperties.ts, 12, 37))
+
+    [Symbol.isConcatSpreadable]: any;
+>Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    ["property4"]: any = 2;
+>"property4" : Symbol(A[["property4"]], Decl(decoratorsOnComputedProperties.ts, 14, 37))
+
+    [Symbol.match]: any = null;
+>Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    [foo()]: any;
+>foo : Symbol(foo, Decl(decoratorsOnComputedProperties.ts, 1, 10))
+
+    @x [foo()]: any;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>foo : Symbol(foo, Decl(decoratorsOnComputedProperties.ts, 1, 10))
+
+    @x [foo()]: any = null;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>foo : Symbol(foo, Decl(decoratorsOnComputedProperties.ts, 1, 10))
+
+    [fieldNameA]: any;
+>fieldNameA : Symbol(fieldNameA, Decl(decoratorsOnComputedProperties.ts, 4, 5))
+
+    @x [fieldNameB]: any;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>fieldNameB : Symbol(fieldNameB, Decl(decoratorsOnComputedProperties.ts, 5, 5))
+
+    @x [fieldNameC]: any = null;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>fieldNameC : Symbol(fieldNameC, Decl(decoratorsOnComputedProperties.ts, 6, 5))
+}
+
+void class B {
+>B : Symbol(B, Decl(decoratorsOnComputedProperties.ts, 25, 4))
+
+    @x ["property"]: any;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>"property" : Symbol(B[["property"]], Decl(decoratorsOnComputedProperties.ts, 25, 14))
+
+    @x [Symbol.toStringTag]: any;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    @x ["property2"]: any = 2;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>"property2" : Symbol(B[["property2"]], Decl(decoratorsOnComputedProperties.ts, 27, 33))
+
+    @x [Symbol.iterator]: any = null;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+
+    ["property3"]: any;
+>"property3" : Symbol(B[["property3"]], Decl(decoratorsOnComputedProperties.ts, 29, 37))
+
+    [Symbol.isConcatSpreadable]: any;
+>Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    ["property4"]: any = 2;
+>"property4" : Symbol(B[["property4"]], Decl(decoratorsOnComputedProperties.ts, 31, 37))
+
+    [Symbol.match]: any = null;
+>Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    [foo()]: any;
+>foo : Symbol(foo, Decl(decoratorsOnComputedProperties.ts, 1, 10))
+
+    @x [foo()]: any;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>foo : Symbol(foo, Decl(decoratorsOnComputedProperties.ts, 1, 10))
+
+    @x [foo()]: any = null;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>foo : Symbol(foo, Decl(decoratorsOnComputedProperties.ts, 1, 10))
+
+    [fieldNameA]: any;
+>fieldNameA : Symbol(fieldNameA, Decl(decoratorsOnComputedProperties.ts, 4, 5))
+
+    @x [fieldNameB]: any;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>fieldNameB : Symbol(fieldNameB, Decl(decoratorsOnComputedProperties.ts, 5, 5))
+
+    @x [fieldNameC]: any = null;
+>x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
+>fieldNameC : Symbol(fieldNameC, Decl(decoratorsOnComputedProperties.ts, 6, 5))
+
+};
+

--- a/tests/baselines/reference/decoratorsOnComputedProperties.types
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.types
@@ -1,0 +1,175 @@
+=== tests/cases/compiler/decoratorsOnComputedProperties.ts ===
+function x(o: object, k: PropertyKey) { }
+>x : (o: object, k: PropertyKey) => void
+>o : object
+>k : PropertyKey
+>PropertyKey : PropertyKey
+
+let i = 0;
+>i : number
+>0 : 0
+
+function foo(): string { return ++i + ""; }
+>foo : () => string
+>++i + "" : string
+>++i : number
+>i : number
+>"" : ""
+
+const fieldNameA: string = "fieldName1";
+>fieldNameA : string
+>"fieldName1" : "fieldName1"
+
+const fieldNameB: string = "fieldName2";
+>fieldNameB : string
+>"fieldName2" : "fieldName2"
+
+const fieldNameC: string = "fieldName3";
+>fieldNameC : string
+>"fieldName3" : "fieldName3"
+
+class A {
+>A : A
+
+    @x ["property"]: any;
+>x : (o: object, k: PropertyKey) => void
+>"property" : "property"
+
+    @x [Symbol.toStringTag]: any;
+>x : (o: object, k: PropertyKey) => void
+>Symbol.toStringTag : symbol
+>Symbol : SymbolConstructor
+>toStringTag : symbol
+
+    @x ["property2"]: any = 2;
+>x : (o: object, k: PropertyKey) => void
+>"property2" : "property2"
+>2 : 2
+
+    @x [Symbol.iterator]: any = null;
+>x : (o: object, k: PropertyKey) => void
+>Symbol.iterator : symbol
+>Symbol : SymbolConstructor
+>iterator : symbol
+>null : null
+
+    ["property3"]: any;
+>"property3" : "property3"
+
+    [Symbol.isConcatSpreadable]: any;
+>Symbol.isConcatSpreadable : symbol
+>Symbol : SymbolConstructor
+>isConcatSpreadable : symbol
+
+    ["property4"]: any = 2;
+>"property4" : "property4"
+>2 : 2
+
+    [Symbol.match]: any = null;
+>Symbol.match : symbol
+>Symbol : SymbolConstructor
+>match : symbol
+>null : null
+
+    [foo()]: any;
+>foo() : string
+>foo : () => string
+
+    @x [foo()]: any;
+>x : (o: object, k: PropertyKey) => void
+>foo() : string
+>foo : () => string
+
+    @x [foo()]: any = null;
+>x : (o: object, k: PropertyKey) => void
+>foo() : string
+>foo : () => string
+>null : null
+
+    [fieldNameA]: any;
+>fieldNameA : string
+
+    @x [fieldNameB]: any;
+>x : (o: object, k: PropertyKey) => void
+>fieldNameB : string
+
+    @x [fieldNameC]: any = null;
+>x : (o: object, k: PropertyKey) => void
+>fieldNameC : string
+>null : null
+}
+
+void class B {
+>void class B {    @x ["property"]: any;    @x [Symbol.toStringTag]: any;    @x ["property2"]: any = 2;    @x [Symbol.iterator]: any = null;    ["property3"]: any;    [Symbol.isConcatSpreadable]: any;    ["property4"]: any = 2;    [Symbol.match]: any = null;    [foo()]: any;    @x [foo()]: any;    @x [foo()]: any = null;    [fieldNameA]: any;    @x [fieldNameB]: any;    @x [fieldNameC]: any = null;} : undefined
+>class B {    @x ["property"]: any;    @x [Symbol.toStringTag]: any;    @x ["property2"]: any = 2;    @x [Symbol.iterator]: any = null;    ["property3"]: any;    [Symbol.isConcatSpreadable]: any;    ["property4"]: any = 2;    [Symbol.match]: any = null;    [foo()]: any;    @x [foo()]: any;    @x [foo()]: any = null;    [fieldNameA]: any;    @x [fieldNameB]: any;    @x [fieldNameC]: any = null;} : typeof B
+>B : typeof B
+
+    @x ["property"]: any;
+>x : (o: object, k: PropertyKey) => void
+>"property" : "property"
+
+    @x [Symbol.toStringTag]: any;
+>x : (o: object, k: PropertyKey) => void
+>Symbol.toStringTag : symbol
+>Symbol : SymbolConstructor
+>toStringTag : symbol
+
+    @x ["property2"]: any = 2;
+>x : (o: object, k: PropertyKey) => void
+>"property2" : "property2"
+>2 : 2
+
+    @x [Symbol.iterator]: any = null;
+>x : (o: object, k: PropertyKey) => void
+>Symbol.iterator : symbol
+>Symbol : SymbolConstructor
+>iterator : symbol
+>null : null
+
+    ["property3"]: any;
+>"property3" : "property3"
+
+    [Symbol.isConcatSpreadable]: any;
+>Symbol.isConcatSpreadable : symbol
+>Symbol : SymbolConstructor
+>isConcatSpreadable : symbol
+
+    ["property4"]: any = 2;
+>"property4" : "property4"
+>2 : 2
+
+    [Symbol.match]: any = null;
+>Symbol.match : symbol
+>Symbol : SymbolConstructor
+>match : symbol
+>null : null
+
+    [foo()]: any;
+>foo() : string
+>foo : () => string
+
+    @x [foo()]: any;
+>x : (o: object, k: PropertyKey) => void
+>foo() : string
+>foo : () => string
+
+    @x [foo()]: any = null;
+>x : (o: object, k: PropertyKey) => void
+>foo() : string
+>foo : () => string
+>null : null
+
+    [fieldNameA]: any;
+>fieldNameA : string
+
+    @x [fieldNameB]: any;
+>x : (o: object, k: PropertyKey) => void
+>fieldNameB : string
+
+    @x [fieldNameC]: any = null;
+>x : (o: object, k: PropertyKey) => void
+>fieldNameC : string
+>null : null
+
+};
+

--- a/tests/baselines/reference/parserComputedPropertyName10.js
+++ b/tests/baselines/reference/parserComputedPropertyName10.js
@@ -4,8 +4,9 @@ class C {
 }
 
 //// [parserComputedPropertyName10.js]
+var _a = e;
 class C {
     constructor() {
-        this[e] = 1;
+        this[_a] = 1;
     }
 }

--- a/tests/baselines/reference/parserComputedPropertyName25.js
+++ b/tests/baselines/reference/parserComputedPropertyName25.js
@@ -6,9 +6,10 @@ class C {
 }
 
 //// [parserComputedPropertyName25.js]
+var _a = e;
 class C {
     constructor() {
         // No ASI
-        this[e] = 0[e2] = 1;
+        this[_a] = 0[e2] = 1;
     }
 }

--- a/tests/baselines/reference/parserComputedPropertyName27.js
+++ b/tests/baselines/reference/parserComputedPropertyName27.js
@@ -6,9 +6,10 @@ class C {
 }
 
 //// [parserComputedPropertyName27.js]
+var _a = e;
 class C {
     constructor() {
         // No ASI
-        this[e] = 0[e2];
+        this[_a] = 0[e2];
     }
 }

--- a/tests/baselines/reference/parserComputedPropertyName28.js
+++ b/tests/baselines/reference/parserComputedPropertyName28.js
@@ -5,8 +5,9 @@ class C {
 }
 
 //// [parserComputedPropertyName28.js]
+var _a = e, _b = e2;
 class C {
     constructor() {
-        this[e] = 0;
+        this[_a] = 0;
     }
 }

--- a/tests/baselines/reference/parserComputedPropertyName29.js
+++ b/tests/baselines/reference/parserComputedPropertyName29.js
@@ -6,9 +6,10 @@ class C {
 }
 
 //// [parserComputedPropertyName29.js]
+var _a = e, _b = e2;
 class C {
     constructor() {
         // yes ASI
-        this[e] = id++;
+        this[_a] = id++;
     }
 }

--- a/tests/baselines/reference/parserComputedPropertyName33.js
+++ b/tests/baselines/reference/parserComputedPropertyName33.js
@@ -6,10 +6,11 @@ class C {
 }
 
 //// [parserComputedPropertyName33.js]
+var _a = e;
 class C {
     constructor() {
         // No ASI
-        this[e] = 0[e2]();
+        this[_a] = 0[e2]();
     }
 }
 { }

--- a/tests/baselines/reference/parserES5ComputedPropertyName10.js
+++ b/tests/baselines/reference/parserES5ComputedPropertyName10.js
@@ -4,9 +4,10 @@ class C {
 }
 
 //// [parserES5ComputedPropertyName10.js]
+var _a = e;
 var C = /** @class */ (function () {
     function C() {
-        this[e] = 1;
+        this[_a] = 1;
     }
     return C;
 }());

--- a/tests/baselines/reference/symbolProperty7.js
+++ b/tests/baselines/reference/symbolProperty7.js
@@ -9,9 +9,10 @@ class C {
 }
 
 //// [symbolProperty7.js]
+var _a = Symbol(), _b = Symbol();
 class C {
     constructor() {
-        this[Symbol()] = 0;
+        this[_a] = 0;
     }
     [Symbol()]() { }
     get [Symbol()]() {

--- a/tests/cases/compiler/decoratorsOnComputedProperties.ts
+++ b/tests/cases/compiler/decoratorsOnComputedProperties.ts
@@ -1,0 +1,43 @@
+// @target: es6
+// @experimentalDecorators: true
+function x(o: object, k: PropertyKey) { }
+let i = 0;
+function foo(): string { return ++i + ""; }
+
+const fieldNameA: string = "fieldName1";
+const fieldNameB: string = "fieldName2";
+const fieldNameC: string = "fieldName3";
+
+class A {
+    @x ["property"]: any;
+    @x [Symbol.toStringTag]: any;
+    @x ["property2"]: any = 2;
+    @x [Symbol.iterator]: any = null;
+    ["property3"]: any;
+    [Symbol.isConcatSpreadable]: any;
+    ["property4"]: any = 2;
+    [Symbol.match]: any = null;
+    [foo()]: any;
+    @x [foo()]: any;
+    @x [foo()]: any = null;
+    [fieldNameA]: any;
+    @x [fieldNameB]: any;
+    @x [fieldNameC]: any = null;
+}
+
+void class B {
+    @x ["property"]: any;
+    @x [Symbol.toStringTag]: any;
+    @x ["property2"]: any = 2;
+    @x [Symbol.iterator]: any = null;
+    ["property3"]: any;
+    [Symbol.isConcatSpreadable]: any;
+    ["property4"]: any = 2;
+    [Symbol.match]: any = null;
+    [foo()]: any;
+    @x [foo()]: any;
+    @x [foo()]: any = null;
+    [fieldNameA]: any;
+    @x [fieldNameB]: any;
+    @x [fieldNameC]: any = null;
+};


### PR DESCRIPTION
Fixes #17028

Computed property names for properties were being elided if uninitialized, or, if initialized, run within the constructor of the class. This is incorrect - for reference, computed property names for methods/getters/setters execute outside the class, and only once. This change makes a computed property name be hoisted to outside of the class declaration if it is not "simple" (and could have observable side effects from being invoked multiple times on each construction of the class). Then, if hoisted, the hoisted identifier is used in the decorator emit if need be. If not hoisted, but still decorated (if the expression is simple), then the simple expression is duplicated into the decorator emit. As an added bonus, we also no longer omit a computed property name expression whose execution may have observable side effects if there is no initializer.

We issue errors on the usage of most complex expressions in computed property names today, but this brings the property computed name emit (when it could matter) in-line with the method/getter/setter computed name runtime behavior. This shouldn't be considered a breaking change, since we issue an error on computed names on properties which are not directly a string/number/symbol; but should now have correct emit for if/when we allow it as part of allowing local symbol types as computed property names or other proposals around expanding what we allow for computed property names. 

As of now, a "simple" computed property is defined as a numeric literal, a string literal, a no substitution template literal, a keyword, or a syntactically well-known symbol - it is possible that there is room to expand this if anyone has further suggestions.