### PR TITLE
Let the RWC harness iterate over files instead of building one big file

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -769,15 +769,16 @@ function exec(cmd, completeHandler, errorHandler) {
     ex.run();
 }
 
+const del = require("del");
 function cleanTestDirs() {
     // Clean the local baselines directory
     if (fs.existsSync(localBaseline)) {
-        jake.rmRf(localBaseline);
+        del.sync(localBaseline);
     }
 
     // Clean the local Rwc baselines directory
     if (fs.existsSync(localRwcBaseline)) {
-        jake.rmRf(localRwcBaseline);
+        del.sync(localRwcBaseline);
     }
 
     jake.mkdirP(localRwcBaseline);
@@ -1042,6 +1043,7 @@ function acceptBaseline(sourceFolder, targetFolder) {
                     if (fs.existsSync(target)) {
                         fs.unlinkSync(target);
                     }
+                    jake.mkdirP(path.dirname(target));
                     fs.renameSync(path.join(sourceFolder, filename), target);
                 }
             }

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -170,29 +170,29 @@ namespace RWC {
 
 
             it("has the expected emitted code", () => {
-                Harness.Baseline.runBaseline(`${baseName}.output.js`, () => {
-                    return Harness.Compiler.collateOutputs(compilerResult.files);
-                }, baselineOpts);
+                Harness.Baseline.runMultifileBaseline(baseName, "", () => {
+                    return Harness.Compiler.iterateOutputs(compilerResult.files);
+                }, baselineOpts, [".js", ".jsx"]);
             });
 
             it("has the expected declaration file content", () => {
-                Harness.Baseline.runBaseline(`${baseName}.d.ts`, () => {
+                Harness.Baseline.runMultifileBaseline(baseName, "", () => {
                     if (!compilerResult.declFilesCode.length) {
                         return null;
                     }
 
-                    return Harness.Compiler.collateOutputs(compilerResult.declFilesCode);
-                }, baselineOpts);
+                    return Harness.Compiler.iterateOutputs(compilerResult.declFilesCode);
+                }, baselineOpts, [".d.ts"]);
             });
 
             it("has the expected source maps", () => {
-                Harness.Baseline.runBaseline(`${baseName}.map`, () => {
+                Harness.Baseline.runMultifileBaseline(baseName, "", () => {
                     if (!compilerResult.sourceMaps.length) {
                         return null;
                     }
 
-                    return Harness.Compiler.collateOutputs(compilerResult.sourceMaps);
-                }, baselineOpts);
+                    return Harness.Compiler.iterateOutputs(compilerResult.sourceMaps);
+                }, baselineOpts, [".map"]);
             });
 
             /*it("has correct source map record", () => {
@@ -204,14 +204,14 @@ namespace RWC {
             });*/
 
             it("has the expected errors", () => {
-                Harness.Baseline.runBaseline(`${baseName}.errors.txt`, () => {
+                Harness.Baseline.runMultifileBaseline(baseName, ".errors.txt", () => {
                     if (compilerResult.errors.length === 0) {
                         return null;
                     }
                     // Do not include the library in the baselines to avoid noise
                     const baselineFiles = tsconfigFiles.concat(inputFiles, otherFiles).filter(f => !Harness.isDefaultLibraryFile(f.unitName));
                     const errors = compilerResult.errors.filter(e => !e.file || !Harness.isDefaultLibraryFile(e.file.fileName));
-                    return Harness.Compiler.getErrorBaseline(baselineFiles, errors);
+                    return Harness.Compiler.iterateErrorBaseline(baselineFiles, errors);
                 }, baselineOpts);
             });
 
@@ -220,14 +220,14 @@ namespace RWC {
                 Harness.Compiler.doTypeAndSymbolBaseline(baseName, compilerResult, inputFiles
                     .concat(otherFiles)
                     .filter(file => !!compilerResult.program.getSourceFile(file.unitName))
-                    .filter(e => !Harness.isDefaultLibraryFile(e.unitName)), baselineOpts);
+                    .filter(e => !Harness.isDefaultLibraryFile(e.unitName)), baselineOpts, /*multifile*/ true);
             });
 
             // Ideally, a generated declaration file will have no errors. But we allow generated
             // declaration file errors as part of the baseline.
             it("has the expected errors in generated declaration files", () => {
                 if (compilerOptions.declaration && !compilerResult.errors.length) {
-                    Harness.Baseline.runBaseline(`${baseName}.dts.errors.txt`, () => {
+                    Harness.Baseline.runMultifileBaseline(baseName, ".dts.errors.txt", () => {
                         if (compilerResult.errors.length === 0) {
                             return null;
                         }
@@ -239,9 +239,7 @@ namespace RWC {
                         compilerResult = undefined;
                         const declFileCompilationResult = Harness.Compiler.compileDeclarationFiles(declContext);
 
-                        return Harness.Compiler.minimalDiagnosticsToString(declFileCompilationResult.declResult.errors) +
-                            Harness.IO.newLine() + Harness.IO.newLine() +
-                            Harness.Compiler.getErrorBaseline(tsconfigFiles.concat(declFileCompilationResult.declInputFiles, declFileCompilationResult.declOtherFiles), declFileCompilationResult.declResult.errors);
+                        return Harness.Compiler.iterateErrorBaseline(tsconfigFiles.concat(declFileCompilationResult.declInputFiles, declFileCompilationResult.declOtherFiles), declFileCompilationResult.declResult.errors);
                     }, baselineOpts);
                 }
             });


### PR DESCRIPTION
@mhegazy mentioned yesterday that he'd like it more if our RWC inputs and outputs were split into more files, such that they were easier to review changes to. This does that. There is a PR on our internal tracker with corresponding baseline updates.
