### PR TITLE
Call getShorthandAssignmentValueSymbol rather than getSymbolAtLocation

### DIFF
--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -710,6 +710,25 @@ function M3() { }`);
     M3() { }
     constructor() { }
 }`);
+        // Shorthand property names
+        testExtractMethod("extractMethod29",
+            `interface UnaryExpression {
+    kind: "Unary";
+    operator: string;
+    operand: any;
+}
+
+function parseUnaryExpression(operator: string): UnaryExpression {
+    [#|return {
+        kind: "Unary",
+        operator,
+        operand: parsePrimaryExpression(),
+    };|]
+}
+
+function parsePrimaryExpression(): any {
+    throw "Not implemented";
+}`);
     });
 
 

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -1161,7 +1161,11 @@ namespace ts.refactor.extractMethod {
         }
 
         function recordUsagebySymbol(identifier: Identifier, usage: Usage, isTypeName: boolean) {
-            const symbol = checker.getSymbolAtLocation(identifier);
+            // If the identifier is both a property name and its value, we're only interested in its value
+            // (since the name is a declaration and will be included in the extracted range).
+            const symbol = identifier.parent && isShorthandPropertyAssignment(identifier.parent) && identifier.parent.name === identifier
+                ? checker.getShorthandAssignmentValueSymbol(identifier.parent)
+                : checker.getSymbolAtLocation(identifier);
             if (!symbol) {
                 // cannot find symbol - do nothing
                 return undefined;

--- a/tests/baselines/reference/extractMethod/extractMethod29.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod29.ts
@@ -1,0 +1,62 @@
+// ==ORIGINAL==
+interface UnaryExpression {
+    kind: "Unary";
+    operator: string;
+    operand: any;
+}
+
+function parseUnaryExpression(operator: string): UnaryExpression {
+    return {
+        kind: "Unary",
+        operator,
+        operand: parsePrimaryExpression(),
+    };
+}
+
+function parsePrimaryExpression(): any {
+    throw "Not implemented";
+}
+// ==SCOPE::inner function in function 'parseUnaryExpression'==
+interface UnaryExpression {
+    kind: "Unary";
+    operator: string;
+    operand: any;
+}
+
+function parseUnaryExpression(operator: string): UnaryExpression {
+    return /*RENAME*/newFunction();
+
+    function newFunction() {
+        return {
+            kind: "Unary",
+            operator,
+            operand: parsePrimaryExpression(),
+        };
+    }
+}
+
+function parsePrimaryExpression(): any {
+    throw "Not implemented";
+}
+// ==SCOPE::function in global scope==
+interface UnaryExpression {
+    kind: "Unary";
+    operator: string;
+    operand: any;
+}
+
+function parseUnaryExpression(operator: string): UnaryExpression {
+    return /*RENAME*/newFunction(operator);
+}
+
+function newFunction(operator: string) {
+    return {
+        kind: "Unary",
+        operator,
+        operand: parsePrimaryExpression(),
+    };
+}
+
+function parsePrimaryExpression(): any {
+    throw "Not implemented";
+}


### PR DESCRIPTION
...for shorthand property assignment names when collecting usages.

Fixes #18188