### PR TITLE
Stop preventing extraction when a type parameter wouldn't bind correctly in a containing scope

### DIFF
--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -710,6 +710,25 @@ function M3() { }`);
     M3() { }
     constructor() { }
 }`);
+        // Shorthand property names
+        testExtractMethod("extractMethod29",
+            `interface UnaryExpression {
+    kind: "Unary";
+    operator: string;
+    operand: any;
+}
+
+function parseUnaryExpression(operator: string): UnaryExpression {
+    [#|return {
+        kind: "Unary",
+        operator,
+        operand: parsePrimaryExpression(),
+    };|]
+}
+
+function parsePrimaryExpression(): any {
+    throw "Not implemented";
+}`);
     });
 
 

--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -729,6 +729,11 @@ function parseUnaryExpression(operator: string): UnaryExpression {
 function parsePrimaryExpression(): any {
     throw "Not implemented";
 }`);
+        // Type parameter as declared type
+        testExtractMethod("extractMethod30",
+            `function F<T>() {
+    [#|let t: T;|]
+}`);
     });
 
 

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -1161,7 +1161,11 @@ namespace ts.refactor.extractMethod {
         }
 
         function recordUsagebySymbol(identifier: Identifier, usage: Usage, isTypeName: boolean) {
-            const symbol = checker.getSymbolAtLocation(identifier);
+            // If the identifier is both a property name and its value, we're only interested in its value
+            // (since the name is a declaration and will be included in the extracted range).
+            const symbol = identifier.parent && isShorthandPropertyAssignment(identifier.parent) && identifier.parent.name === identifier
+                ? checker.getShorthandAssignmentValueSymbol(identifier.parent)
+                : checker.getSymbolAtLocation(identifier);
             if (!symbol) {
                 // cannot find symbol - do nothing
                 return undefined;

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -1222,7 +1222,11 @@ namespace ts.refactor.extractMethod {
                         substitutionsPerScope[i].set(symbolId, substitution);
                     }
                     else if (isTypeName) {
-                        errorsPerScope[i].push(createDiagnosticForNode(identifier, Messages.TypeWillNotBeVisibleInTheNewScope));
+                        // If the symbol is a type parameter that won't be in scope, we'll pass it as a type argument
+                        // so there's no problem.
+                        if (!(symbol.flags & SymbolFlags.TypeParameter)) {
+                            errorsPerScope[i].push(createDiagnosticForNode(identifier, Messages.TypeWillNotBeVisibleInTheNewScope));
+                        }
                     }
                     else {
                         usagesPerScope[i].usages.set(identifier.text as string, { usage, symbol, node: identifier });

--- a/tests/baselines/reference/extractMethod/extractMethod29.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod29.ts
@@ -1,0 +1,62 @@
+// ==ORIGINAL==
+interface UnaryExpression {
+    kind: "Unary";
+    operator: string;
+    operand: any;
+}
+
+function parseUnaryExpression(operator: string): UnaryExpression {
+    return {
+        kind: "Unary",
+        operator,
+        operand: parsePrimaryExpression(),
+    };
+}
+
+function parsePrimaryExpression(): any {
+    throw "Not implemented";
+}
+// ==SCOPE::inner function in function 'parseUnaryExpression'==
+interface UnaryExpression {
+    kind: "Unary";
+    operator: string;
+    operand: any;
+}
+
+function parseUnaryExpression(operator: string): UnaryExpression {
+    return /*RENAME*/newFunction();
+
+    function newFunction() {
+        return {
+            kind: "Unary",
+            operator,
+            operand: parsePrimaryExpression(),
+        };
+    }
+}
+
+function parsePrimaryExpression(): any {
+    throw "Not implemented";
+}
+// ==SCOPE::function in global scope==
+interface UnaryExpression {
+    kind: "Unary";
+    operator: string;
+    operand: any;
+}
+
+function parseUnaryExpression(operator: string): UnaryExpression {
+    return /*RENAME*/newFunction(operator);
+}
+
+function newFunction(operator: string) {
+    return {
+        kind: "Unary",
+        operator,
+        operand: parsePrimaryExpression(),
+    };
+}
+
+function parsePrimaryExpression(): any {
+    throw "Not implemented";
+}

--- a/tests/baselines/reference/extractMethod/extractMethod30.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod30.ts
@@ -1,0 +1,19 @@
+// ==ORIGINAL==
+function F<T>() {
+    let t: T;
+}
+// ==SCOPE::inner function in function 'F'==
+function F<T>() {
+    /*RENAME*/newFunction();
+
+    function newFunction() {
+        let t: T;
+    }
+}
+// ==SCOPE::function in global scope==
+function F<T>() {
+    /*RENAME*/newFunction<T>();
+}
+function newFunction<T>() {
+    let t: T;
+}


### PR DESCRIPTION
It's not an issue because we'll just declare a corresponding type parameter on the extracted function and pass the original as a type argument.
    
Fixes #18142

Note that the first commit is actually https://github.com/Microsoft/TypeScript/pull/18423