### PR TITLE
Fix fourslash baselines

### DIFF
--- a/tests/baselines/reference/extractMethod/extractMethod23.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod23.ts
@@ -6,7 +6,7 @@ namespace NS {
     }
     function M3() { }
 }
-// ==SCOPE::function 'M2'==
+// ==SCOPE::inner function in function 'M2'==
 namespace NS {
     function M1() { }
     function M2() {
@@ -18,7 +18,7 @@ namespace NS {
     }
     function M3() { }
 }
-// ==SCOPE::namespace 'NS'==
+// ==SCOPE::function in namespace 'NS'==
 namespace NS {
     function M1() { }
     function M2() {
@@ -30,7 +30,7 @@ namespace NS {
 
     function M3() { }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 namespace NS {
     function M1() { }
     function M2() {

--- a/tests/baselines/reference/extractMethod/extractMethod24.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod24.ts
@@ -6,7 +6,7 @@ function Outer() {
     }
     function M3() { }
 }
-// ==SCOPE::function 'M2'==
+// ==SCOPE::inner function in function 'M2'==
 function Outer() {
     function M1() { }
     function M2() {
@@ -18,7 +18,7 @@ function Outer() {
     }
     function M3() { }
 }
-// ==SCOPE::function 'Outer'==
+// ==SCOPE::inner function in function 'Outer'==
 function Outer() {
     function M1() { }
     function M2() {
@@ -30,7 +30,7 @@ function Outer() {
 
     function M3() { }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 function Outer() {
     function M1() { }
     function M2() {

--- a/tests/baselines/reference/extractMethod/extractMethod25.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod25.ts
@@ -4,7 +4,7 @@ function M2() {
     return 1;
 }
 function M3() { }
-// ==SCOPE::function 'M2'==
+// ==SCOPE::inner function in function 'M2'==
 function M1() { }
 function M2() {
     return newFunction();
@@ -14,7 +14,7 @@ function M2() {
     }
 }
 function M3() { }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 function M1() { }
 function M2() {
     return newFunction();

--- a/tests/baselines/reference/extractMethod/extractMethod26.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod26.ts
@@ -6,7 +6,7 @@ class C {
     }
     M3() { }
 }
-// ==SCOPE::class 'C'==
+// ==SCOPE::method in class 'C'==
 class C {
     M1() { }
     M2() {
@@ -18,7 +18,7 @@ class C {
 
     M3() { }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 class C {
     M1() { }
     M2() {

--- a/tests/baselines/reference/extractMethod/extractMethod27.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod27.ts
@@ -7,7 +7,7 @@ class C {
     constructor() { }
     M3() { }
 }
-// ==SCOPE::class 'C'==
+// ==SCOPE::method in class 'C'==
 class C {
     M1() { }
     M2() {
@@ -20,7 +20,7 @@ class C {
 
     M3() { }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 class C {
     M1() { }
     M2() {

--- a/tests/baselines/reference/extractMethod/extractMethod28.ts
+++ b/tests/baselines/reference/extractMethod/extractMethod28.ts
@@ -7,7 +7,7 @@ class C {
     M3() { }
     constructor() { }
 }
-// ==SCOPE::class 'C'==
+// ==SCOPE::method in class 'C'==
 class C {
     M1() { }
     M2() {
@@ -20,7 +20,7 @@ class C {
     M3() { }
     constructor() { }
 }
-// ==SCOPE::global scope==
+// ==SCOPE::function in global scope==
 class C {
     M1() { }
     M2() {


### PR DESCRIPTION
40e459117aeb0b792a23d6805af884b594dd42c4 was out of date in a way that
didn't register as a conflict.