### PR TITLE
Remove empty intersection types in unit types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7302,7 +7302,11 @@ namespace ts {
                 if (flags & TypeFlags.Null) typeSet.containsNull = true;
                 if (!(flags & TypeFlags.ContainsWideningType)) typeSet.containsNonWideningType = true;
             }
-            else if (!(flags & TypeFlags.Never)) {
+            else if (!(flags & TypeFlags.Never || flags & TypeFlags.Intersection && every((<IntersectionType>type).types, isUnitType))) {
+                // We ignore 'never' types in unions. Likewise, we ignore intersections of unit types as they are
+                // another form of 'never' (in that they have an empty value domain). We could in theory turn
+                // intersections of unit types into 'never' upon construction, but deferring the reduction makes it
+                // easier to reason about their origin.
                 if (flags & TypeFlags.String) typeSet.containsString = true;
                 if (flags & TypeFlags.Number) typeSet.containsNumber = true;
                 if (flags & TypeFlags.StringOrNumberLiteral) typeSet.containsStringOrNumberLiteral = true;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3217,6 +3217,7 @@ namespace ts {
         /* @internal */
         Nullable = Undefined | Null,
         Literal = StringLiteral | NumberLiteral | BooleanLiteral,
+        Unit = Literal | Nullable,
         StringOrNumberLiteral = StringLiteral | NumberLiteral,
         /* @internal */
         DefinitelyFalsy = StringLiteral | NumberLiteral | BooleanLiteral | Void | Undefined | Null,

--- a/tests/baselines/reference/intersectionOfUnionOfUnitTypes.js
+++ b/tests/baselines/reference/intersectionOfUnionOfUnitTypes.js
@@ -1,0 +1,47 @@
+//// [intersectionOfUnionOfUnitTypes.ts]
+// @strict
+
+const enum E { A, B, C, D, E, F }
+
+let x0: ('a' | 'b' | 'c') & ('a' | 'b' | 'c');  // 'a' | 'b' | 'c'
+let x1: ('a' | 'b' | 'c') & ('b' | 'c' | 'd');  // 'b' | 'c'
+let x2: ('a' | 'b' | 'c') & ('c' | 'd' | 'e');  // 'c'
+let x3: ('a' | 'b' | 'c') & ('d' | 'e' | 'f');  // never
+let x4: ('a' | 'b' | 'c') & ('b' | 'c' | 'd') & ('c' | 'd' | 'e');  // 'c'
+let x5: ('a' | 'b' | 'c') & ('b' | 'c' | 'd') & ('c' | 'd' | 'e') & ('d' | 'e' | 'f');  // never
+
+let y0: (0 | 1 | 2) & (0 | 1 | 2);  // 0 | 1 | 2
+let y1: (0 | 1 | 2) & (1 | 2 | 3);  // 1 | 2
+let y2: (0 | 1 | 2) & (2 | 3 | 4);  // 2
+let y3: (0 | 1 | 2) & (3 | 4 | 5);  // never
+let y4: (0 | 1 | 2) & (1 | 2 | 3) & (2 | 3 | 4);  // 2
+let y5: (0 | 1 | 2) & (1 | 2 | 3) & (2 | 3 | 4) & (3 | 4 | 5);  // never
+
+let z0: (E.A | E.B | E.C) & (E.A | E.B | E.C);  // E.A | E.B | E.C
+let z1: (E.A | E.B | E.C) & (E.B | E.C | E.D);  // E.B | E.C
+let z2: (E.A | E.B | E.C) & (E.C | E.D | E.E);  // E.C
+let z3: (E.A | E.B | E.C) & (E.D | E.E | E.F);  // never
+let z4: (E.A | E.B | E.C) & (E.B | E.C | E.D) & (E.C | E.D | E.E);  // E.C
+let z5: (E.A | E.B | E.C) & (E.B | E.C | E.D) & (E.C | E.D | E.E) & (E.D | E.E | E.F);  // never
+
+
+//// [intersectionOfUnionOfUnitTypes.js]
+// @strict
+var x0; // 'a' | 'b' | 'c'
+var x1; // 'b' | 'c'
+var x2; // 'c'
+var x3; // never
+var x4; // 'c'
+var x5; // never
+var y0; // 0 | 1 | 2
+var y1; // 1 | 2
+var y2; // 2
+var y3; // never
+var y4; // 2
+var y5; // never
+var z0; // E.A | E.B | E.C
+var z1; // E.B | E.C
+var z2; // E.C
+var z3; // never
+var z4; // E.C
+var z5; // never

--- a/tests/baselines/reference/intersectionOfUnionOfUnitTypes.symbols
+++ b/tests/baselines/reference/intersectionOfUnionOfUnitTypes.symbols
@@ -1,0 +1,156 @@
+=== tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts ===
+// @strict
+
+const enum E { A, B, C, D, E, F }
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>A : Symbol(E.A, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 14))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+>E : Symbol(E.E, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 26))
+>F : Symbol(E.F, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 29))
+
+let x0: ('a' | 'b' | 'c') & ('a' | 'b' | 'c');  // 'a' | 'b' | 'c'
+>x0 : Symbol(x0, Decl(intersectionOfUnionOfUnitTypes.ts, 4, 3))
+
+let x1: ('a' | 'b' | 'c') & ('b' | 'c' | 'd');  // 'b' | 'c'
+>x1 : Symbol(x1, Decl(intersectionOfUnionOfUnitTypes.ts, 5, 3))
+
+let x2: ('a' | 'b' | 'c') & ('c' | 'd' | 'e');  // 'c'
+>x2 : Symbol(x2, Decl(intersectionOfUnionOfUnitTypes.ts, 6, 3))
+
+let x3: ('a' | 'b' | 'c') & ('d' | 'e' | 'f');  // never
+>x3 : Symbol(x3, Decl(intersectionOfUnionOfUnitTypes.ts, 7, 3))
+
+let x4: ('a' | 'b' | 'c') & ('b' | 'c' | 'd') & ('c' | 'd' | 'e');  // 'c'
+>x4 : Symbol(x4, Decl(intersectionOfUnionOfUnitTypes.ts, 8, 3))
+
+let x5: ('a' | 'b' | 'c') & ('b' | 'c' | 'd') & ('c' | 'd' | 'e') & ('d' | 'e' | 'f');  // never
+>x5 : Symbol(x5, Decl(intersectionOfUnionOfUnitTypes.ts, 9, 3))
+
+let y0: (0 | 1 | 2) & (0 | 1 | 2);  // 0 | 1 | 2
+>y0 : Symbol(y0, Decl(intersectionOfUnionOfUnitTypes.ts, 11, 3))
+
+let y1: (0 | 1 | 2) & (1 | 2 | 3);  // 1 | 2
+>y1 : Symbol(y1, Decl(intersectionOfUnionOfUnitTypes.ts, 12, 3))
+
+let y2: (0 | 1 | 2) & (2 | 3 | 4);  // 2
+>y2 : Symbol(y2, Decl(intersectionOfUnionOfUnitTypes.ts, 13, 3))
+
+let y3: (0 | 1 | 2) & (3 | 4 | 5);  // never
+>y3 : Symbol(y3, Decl(intersectionOfUnionOfUnitTypes.ts, 14, 3))
+
+let y4: (0 | 1 | 2) & (1 | 2 | 3) & (2 | 3 | 4);  // 2
+>y4 : Symbol(y4, Decl(intersectionOfUnionOfUnitTypes.ts, 15, 3))
+
+let y5: (0 | 1 | 2) & (1 | 2 | 3) & (2 | 3 | 4) & (3 | 4 | 5);  // never
+>y5 : Symbol(y5, Decl(intersectionOfUnionOfUnitTypes.ts, 16, 3))
+
+let z0: (E.A | E.B | E.C) & (E.A | E.B | E.C);  // E.A | E.B | E.C
+>z0 : Symbol(z0, Decl(intersectionOfUnionOfUnitTypes.ts, 18, 3))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>A : Symbol(E.A, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 14))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>A : Symbol(E.A, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 14))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+
+let z1: (E.A | E.B | E.C) & (E.B | E.C | E.D);  // E.B | E.C
+>z1 : Symbol(z1, Decl(intersectionOfUnionOfUnitTypes.ts, 19, 3))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>A : Symbol(E.A, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 14))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+
+let z2: (E.A | E.B | E.C) & (E.C | E.D | E.E);  // E.C
+>z2 : Symbol(z2, Decl(intersectionOfUnionOfUnitTypes.ts, 20, 3))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>A : Symbol(E.A, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 14))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>E : Symbol(E.E, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 26))
+
+let z3: (E.A | E.B | E.C) & (E.D | E.E | E.F);  // never
+>z3 : Symbol(z3, Decl(intersectionOfUnionOfUnitTypes.ts, 21, 3))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>A : Symbol(E.A, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 14))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>E : Symbol(E.E, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 26))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>F : Symbol(E.F, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 29))
+
+let z4: (E.A | E.B | E.C) & (E.B | E.C | E.D) & (E.C | E.D | E.E);  // E.C
+>z4 : Symbol(z4, Decl(intersectionOfUnionOfUnitTypes.ts, 22, 3))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>A : Symbol(E.A, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 14))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>E : Symbol(E.E, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 26))
+
+let z5: (E.A | E.B | E.C) & (E.B | E.C | E.D) & (E.C | E.D | E.E) & (E.D | E.E | E.F);  // never
+>z5 : Symbol(z5, Decl(intersectionOfUnionOfUnitTypes.ts, 23, 3))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>A : Symbol(E.A, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 14))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>B : Symbol(E.B, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 17))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>C : Symbol(E.C, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 20))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>E : Symbol(E.E, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 26))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>D : Symbol(E.D, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 23))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>E : Symbol(E.E, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 26))
+>E : Symbol(E, Decl(intersectionOfUnionOfUnitTypes.ts, 0, 0))
+>F : Symbol(E.F, Decl(intersectionOfUnionOfUnitTypes.ts, 2, 29))
+

--- a/tests/baselines/reference/intersectionOfUnionOfUnitTypes.types
+++ b/tests/baselines/reference/intersectionOfUnionOfUnitTypes.types
@@ -1,0 +1,156 @@
+=== tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts ===
+// @strict
+
+const enum E { A, B, C, D, E, F }
+>E : E
+>A : E.A
+>B : E.B
+>C : E.C
+>D : E.D
+>E : E.E
+>F : E.F
+
+let x0: ('a' | 'b' | 'c') & ('a' | 'b' | 'c');  // 'a' | 'b' | 'c'
+>x0 : "a" | "b" | "c"
+
+let x1: ('a' | 'b' | 'c') & ('b' | 'c' | 'd');  // 'b' | 'c'
+>x1 : "b" | "c"
+
+let x2: ('a' | 'b' | 'c') & ('c' | 'd' | 'e');  // 'c'
+>x2 : "c"
+
+let x3: ('a' | 'b' | 'c') & ('d' | 'e' | 'f');  // never
+>x3 : never
+
+let x4: ('a' | 'b' | 'c') & ('b' | 'c' | 'd') & ('c' | 'd' | 'e');  // 'c'
+>x4 : "c"
+
+let x5: ('a' | 'b' | 'c') & ('b' | 'c' | 'd') & ('c' | 'd' | 'e') & ('d' | 'e' | 'f');  // never
+>x5 : never
+
+let y0: (0 | 1 | 2) & (0 | 1 | 2);  // 0 | 1 | 2
+>y0 : 0 | 1 | 2
+
+let y1: (0 | 1 | 2) & (1 | 2 | 3);  // 1 | 2
+>y1 : 1 | 2
+
+let y2: (0 | 1 | 2) & (2 | 3 | 4);  // 2
+>y2 : 2
+
+let y3: (0 | 1 | 2) & (3 | 4 | 5);  // never
+>y3 : never
+
+let y4: (0 | 1 | 2) & (1 | 2 | 3) & (2 | 3 | 4);  // 2
+>y4 : 2
+
+let y5: (0 | 1 | 2) & (1 | 2 | 3) & (2 | 3 | 4) & (3 | 4 | 5);  // never
+>y5 : never
+
+let z0: (E.A | E.B | E.C) & (E.A | E.B | E.C);  // E.A | E.B | E.C
+>z0 : E.A | E.B | E.C
+>E : any
+>A : E.A
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>A : E.A
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+
+let z1: (E.A | E.B | E.C) & (E.B | E.C | E.D);  // E.B | E.C
+>z1 : E.B | E.C
+>E : any
+>A : E.A
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>D : E.D
+
+let z2: (E.A | E.B | E.C) & (E.C | E.D | E.E);  // E.C
+>z2 : E.C
+>E : any
+>A : E.A
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>C : E.C
+>E : any
+>D : E.D
+>E : any
+>E : E.E
+
+let z3: (E.A | E.B | E.C) & (E.D | E.E | E.F);  // never
+>z3 : never
+>E : any
+>A : E.A
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>D : E.D
+>E : any
+>E : E.E
+>E : any
+>F : E.F
+
+let z4: (E.A | E.B | E.C) & (E.B | E.C | E.D) & (E.C | E.D | E.E);  // E.C
+>z4 : E.C
+>E : any
+>A : E.A
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>D : E.D
+>E : any
+>C : E.C
+>E : any
+>D : E.D
+>E : any
+>E : E.E
+
+let z5: (E.A | E.B | E.C) & (E.B | E.C | E.D) & (E.C | E.D | E.E) & (E.D | E.E | E.F);  // never
+>z5 : never
+>E : any
+>A : E.A
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>B : E.B
+>E : any
+>C : E.C
+>E : any
+>D : E.D
+>E : any
+>C : E.C
+>E : any
+>D : E.D
+>E : any
+>E : E.E
+>E : any
+>D : E.D
+>E : any
+>E : E.E
+>E : any
+>F : E.F
+

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -205,7 +205,7 @@ type Q40 = (Shape | Options)["visible"];  // boolean | "yes" | "no"
 >Options : Options
 
 type Q41 = (Shape & Options)["visible"];  // true & "yes" | true & "no" | false & "yes" | false & "no"
->Q41 : (true & "yes") | (true & "no") | (false & "yes") | (false & "no")
+>Q41 : never
 >Shape : Shape
 >Options : Options
 

--- a/tests/baselines/reference/restUnion2.js
+++ b/tests/baselines/reference/restUnion2.js
@@ -13,7 +13,7 @@ declare const nullAndUndefinedUnion: null | undefined;
 var rest4: { };
 var {...rest4 } = nullAndUndefinedUnion;
 
-declare const unionWithIntersection: ({ n: number } & { s: string }) & undefined | null;
+declare const unionWithIntersection: ({ n: number } & { s: string }) & undefined;
 var rest5: { n: number, s: string };
 var {...rest5 } = unionWithIntersection;
 

--- a/tests/baselines/reference/restUnion2.symbols
+++ b/tests/baselines/reference/restUnion2.symbols
@@ -35,7 +35,7 @@ var {...rest4 } = nullAndUndefinedUnion;
 >rest4 : Symbol(rest4, Decl(restUnion2.ts, 11, 3), Decl(restUnion2.ts, 12, 5))
 >nullAndUndefinedUnion : Symbol(nullAndUndefinedUnion, Decl(restUnion2.ts, 10, 13))
 
-declare const unionWithIntersection: ({ n: number } & { s: string }) & undefined | null;
+declare const unionWithIntersection: ({ n: number } & { s: string }) & undefined;
 >unionWithIntersection : Symbol(unionWithIntersection, Decl(restUnion2.ts, 14, 13))
 >n : Symbol(n, Decl(restUnion2.ts, 14, 39))
 >s : Symbol(s, Decl(restUnion2.ts, 14, 55))

--- a/tests/baselines/reference/restUnion2.types
+++ b/tests/baselines/reference/restUnion2.types
@@ -37,11 +37,10 @@ var {...rest4 } = nullAndUndefinedUnion;
 >rest4 : {}
 >nullAndUndefinedUnion : null | undefined
 
-declare const unionWithIntersection: ({ n: number } & { s: string }) & undefined | null;
->unionWithIntersection : ({ n: number; } & { s: string; } & undefined) | null
+declare const unionWithIntersection: ({ n: number } & { s: string }) & undefined;
+>unionWithIntersection : { n: number; } & { s: string; } & undefined
 >n : number
 >s : string
->null : null
 
 var rest5: { n: number, s: string };
 >rest5 : { n: number; s: string; }
@@ -50,5 +49,5 @@ var rest5: { n: number, s: string };
 
 var {...rest5 } = unionWithIntersection;
 >rest5 : { n: number; s: string; }
->unionWithIntersection : ({ n: number; } & { s: string; } & undefined) | null
+>unionWithIntersection : { n: number; } & { s: string; } & undefined
 

--- a/tests/cases/compiler/restUnion2.ts
+++ b/tests/cases/compiler/restUnion2.ts
@@ -14,6 +14,6 @@ declare const nullAndUndefinedUnion: null | undefined;
 var rest4: { };
 var {...rest4 } = nullAndUndefinedUnion;
 
-declare const unionWithIntersection: ({ n: number } & { s: string }) & undefined | null;
+declare const unionWithIntersection: ({ n: number } & { s: string }) & undefined;
 var rest5: { n: number, s: string };
 var {...rest5 } = unionWithIntersection;

--- a/tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts
+++ b/tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts
@@ -1,0 +1,24 @@
+// @strict
+
+const enum E { A, B, C, D, E, F }
+
+let x0: ('a' | 'b' | 'c') & ('a' | 'b' | 'c');  // 'a' | 'b' | 'c'
+let x1: ('a' | 'b' | 'c') & ('b' | 'c' | 'd');  // 'b' | 'c'
+let x2: ('a' | 'b' | 'c') & ('c' | 'd' | 'e');  // 'c'
+let x3: ('a' | 'b' | 'c') & ('d' | 'e' | 'f');  // never
+let x4: ('a' | 'b' | 'c') & ('b' | 'c' | 'd') & ('c' | 'd' | 'e');  // 'c'
+let x5: ('a' | 'b' | 'c') & ('b' | 'c' | 'd') & ('c' | 'd' | 'e') & ('d' | 'e' | 'f');  // never
+
+let y0: (0 | 1 | 2) & (0 | 1 | 2);  // 0 | 1 | 2
+let y1: (0 | 1 | 2) & (1 | 2 | 3);  // 1 | 2
+let y2: (0 | 1 | 2) & (2 | 3 | 4);  // 2
+let y3: (0 | 1 | 2) & (3 | 4 | 5);  // never
+let y4: (0 | 1 | 2) & (1 | 2 | 3) & (2 | 3 | 4);  // 2
+let y5: (0 | 1 | 2) & (1 | 2 | 3) & (2 | 3 | 4) & (3 | 4 | 5);  // never
+
+let z0: (E.A | E.B | E.C) & (E.A | E.B | E.C);  // E.A | E.B | E.C
+let z1: (E.A | E.B | E.C) & (E.B | E.C | E.D);  // E.B | E.C
+let z2: (E.A | E.B | E.C) & (E.C | E.D | E.E);  // E.C
+let z3: (E.A | E.B | E.C) & (E.D | E.E | E.F);  // never
+let z4: (E.A | E.B | E.C) & (E.B | E.C | E.D) & (E.C | E.D | E.E);  // E.C
+let z5: (E.A | E.B | E.C) & (E.B | E.C | E.D) & (E.C | E.D | E.E) & (E.D | E.E | E.F);  // never


### PR DESCRIPTION
An intersection of distinct unit types (such as `'a' & 'b' & 'c'`) is effectively the same as `never` because it has en empty set of possible values. We allow such types to exist primarily to make it easier to discover their origin (e.g. an intersection of object types containing two properties with the same name). However, when intersecting unions of unit types, the normalization introduced by #11717 ends up making the types very noisy. For example `(0 | 1 | 2) & (1 | 2 | 3)` becomes `1 | 2 | (0 & 1) | (0 & 2) | (0 & 3) | (1 & 2) | (1 & 3) | (2 & 1) | (2 & 3)`.

Likewise, when intersecting `{ a: string } | undefined` and `{ b: number } | undefined` (similar to #18210), normalization produces a union of `{ a: string } & { b: number }`, `{ a: string } & undefined`, `undefined & { b: number }` and `undefined`. The middle two have empty sets of values, but trip up property accesses through values of the union type.

With this PR we now remove an intersection type from a union type if

* the intersection type contains more than one unit type, or
* the intersection type contains an object type and a nullable type (`null` or `undefined`).

Some examples:

```ts
type T1 = (0 | 1 | 2) & (1 | 2 | 3);  // 1 | 2
type T2 = (0 | 1 | 2) & (3 | 4 | 5);  // never
type T3 = { a: string } | undefined;
type T4 = { b: number } | undefined;
type T5 = T3 & T4;  // ({ a: string} & { b: number }) | undefined
```

We could in theory be more aggressive about removing empty intersection types, but we don't want to break code that uses intersections to "tag" primitive types.

This implements parts of what is suggested in #16386 and fixes #18210.