### PR TITLE
Fix javascript signature instantiation

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1325,11 +1325,11 @@ namespace ts {
         return isInJavaScriptFile(file);
     }
 
-    export function isInJavaScriptFile(node: Node): boolean {
+    export function isInJavaScriptFile(node: Node | undefined): boolean {
         return node && !!(node.flags & NodeFlags.JavaScriptFile);
     }
 
-    export function isInJSDoc(node: Node): boolean {
+    export function isInJSDoc(node: Node | undefined): boolean {
         return node && !!(node.flags & NodeFlags.JSDoc);
     }
 

--- a/tests/baselines/reference/fillInMissingTypeArgsOnJSConstructCalls.errors.txt
+++ b/tests/baselines/reference/fillInMissingTypeArgsOnJSConstructCalls.errors.txt
@@ -1,0 +1,48 @@
+tests/cases/compiler/BaseB.js(2,24): error TS8004: 'type parameter declarations' can only be used in a .ts file.
+tests/cases/compiler/BaseB.js(2,25): error TS1005: ',' expected.
+tests/cases/compiler/BaseB.js(3,14): error TS2304: Cannot find name 'Class'.
+tests/cases/compiler/BaseB.js(3,14): error TS8010: 'types' can only be used in a .ts file.
+tests/cases/compiler/BaseB.js(4,25): error TS2304: Cannot find name 'Class'.
+tests/cases/compiler/BaseB.js(4,25): error TS8010: 'types' can only be used in a .ts file.
+tests/cases/compiler/SubB.js(3,41): error TS8011: 'type arguments' can only be used in a .ts file.
+
+
+==== tests/cases/compiler/BaseA.js (0 errors) ====
+    // regression test for #18254
+    export default class BaseA {
+    }
+==== tests/cases/compiler/SubA.js (0 errors) ====
+    import BaseA from './BaseA';
+    export default class SubA extends BaseA {
+    }
+==== tests/cases/compiler/BaseB.js (6 errors) ====
+    import BaseA from './BaseA';
+    export default class B<T: BaseA> {
+                           ~~~~~~~~
+!!! error TS8004: 'type parameter declarations' can only be used in a .ts file.
+                            ~
+!!! error TS1005: ',' expected.
+        _AClass: Class<T>;
+                 ~~~~~
+!!! error TS2304: Cannot find name 'Class'.
+                 ~~~~~~~~
+!!! error TS8010: 'types' can only be used in a .ts file.
+        constructor(AClass: Class<T>) {
+                            ~~~~~
+!!! error TS2304: Cannot find name 'Class'.
+                            ~~~~~~~~
+!!! error TS8010: 'types' can only be used in a .ts file.
+            this._AClass = AClass;
+        }
+    }
+==== tests/cases/compiler/SubB.js (1 errors) ====
+    import SubA from './SubA';
+    import BaseB from './BaseB';
+    export default class SubB extends BaseB<SubA> {
+                                            ~~~~
+!!! error TS8011: 'type arguments' can only be used in a .ts file.
+        constructor() {
+            super(SubA);
+        }
+    }
+    

--- a/tests/cases/compiler/fillInMissingTypeArgsOnJSConstructCalls.ts
+++ b/tests/cases/compiler/fillInMissingTypeArgsOnJSConstructCalls.ts
@@ -1,0 +1,27 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// regression test for #18254
+// @Filename: BaseA.js
+export default class BaseA {
+}
+// @Filename: SubA.js
+import BaseA from './BaseA';
+export default class SubA extends BaseA {
+}
+// @Filename: BaseB.js
+import BaseA from './BaseA';
+export default class B<T: BaseA> {
+    _AClass: Class<T>;
+    constructor(AClass: Class<T>) {
+        this._AClass = AClass;
+    }
+}
+// @Filename: SubB.js
+import SubA from './SubA';
+import BaseB from './BaseB';
+export default class SubB extends BaseB<SubA> {
+    constructor() {
+        super(SubA);
+    }
+}


### PR DESCRIPTION
Fixes #18254

`getSignatureInstantation` takes a parameter that tells whether the signature comes from Javascript and therefore is allowed to pass fewer than the required number of type arguments. (Defaults are chosen if this is the case.)

Previously, `getInstantiatedConstructorsForTypeArguments` forgot to provide this argument, and constructors with insufficient type arguments would cause a crash because `getSignatureInstantiation` would not know to fill in the missing type arguments.