### PR TITLE
Don't normalize whitespace in fourslash tests

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -500,7 +500,8 @@ namespace Harness {
     export let IO: IO;
 
     // harness always uses one kind of new line
-    const harnessNewLine = "\r\n";
+    // But note that `parseTestData` in `fourslash.ts` uses "\n"
+    export const harnessNewLine = "\r\n";
 
     // Root for file paths that are stored in a virtual file system
     export const virtualFileSystemRoot = "/";

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -130,7 +130,7 @@ namespace Harness.LanguageService {
         }
 
         public getNewLine(): string {
-            return "\r\n";
+            return harnessNewLine;
         }
 
         public getFilenames(): string[] {

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -573,7 +573,7 @@ namespace ts.server {
 
         getEditsForRefactor(
             fileName: string,
-            _formatOptions: FormatCodeSettings,
+            formatOptions: FormatCodeSettings,
             positionOrRange: number | TextRange,
             refactorName: string,
             actionName: string): RefactorEditInfo {
@@ -581,6 +581,7 @@ namespace ts.server {
             const args = this.createFileLocationOrRangeRequestArgs(positionOrRange, fileName) as protocol.GetEditsForRefactorRequestArgs;
             args.refactor = refactorName;
             args.action = actionName;
+            args.formatOptions = formatOptions;
 
             const request = this.processRequest<protocol.GetEditsForRefactorRequest>(CommandNames.GetEditsForRefactor, args);
             const response = this.processResponse<protocol.GetEditsForRefactorResponse>(request);

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -494,6 +494,7 @@ namespace ts.server.protocol {
         refactor: string;
         /* The 'name' property from the refactoring action */
         action: string;
+        formatOptions: FormatCodeSettings,
     };
 
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1488,7 +1488,7 @@ namespace ts.server {
 
             const result = project.getLanguageService().getEditsForRefactor(
                 file,
-                this.projectService.getFormatCodeOptions(),
+                convertFormatOptions(args.formatOptions),
                 position || textRange,
                 args.refactor,
                 args.action

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2019,7 +2019,7 @@ namespace ts {
                 startPosition,
                 endPosition,
                 program: getProgram(),
-                newLineCharacter: host.getNewLine(),
+                newLineCharacter: formatOptions ? formatOptions.newLineCharacter : host.getNewLine(),
                 rulesProvider: getRuleProvider(formatOptions),
                 cancellationToken
             };

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -184,16 +184,12 @@ namespace ts.textChanges {
         return s;
     }
 
-    function getNewlineKind(context: { newLineCharacter: string }) {
-        return context.newLineCharacter === "\n" ? NewLineKind.LineFeed : NewLineKind.CarriageReturnLineFeed;
-    }
-
     export class ChangeTracker {
         private changes: Change[] = [];
         private readonly newLineCharacter: string;
 
         public static fromContext(context: RefactorContext | CodeFixContext) {
-            return new ChangeTracker(getNewlineKind(context), context.rulesProvider);
+            return new ChangeTracker(context.newLineCharacter === "\n" ? NewLineKind.LineFeed : NewLineKind.CarriageReturnLineFeed, context.rulesProvider);
         }
 
         constructor(

--- a/tests/cases/fourslash/codeFixAddMissingMember5.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember5.ts
@@ -17,5 +17,4 @@ verify.currentFileContentIs(`class C {
         ()=>{ this.foo === 10 };
     }
 }
-C.foo = undefined;
-`);
+C.foo = undefined;` + "\r\n"); // TODO: GH#18445

--- a/tests/cases/fourslash/codeFixAddMissingMember7.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember7.ts
@@ -13,5 +13,4 @@ verify.getAndApplyCodeFix(/*errorCode*/ undefined, /*index*/ 2)
 verify.currentFileContentIs(`class C {
     static p = ()=>{ this.foo === 10 };
 }
-C.foo = undefined;
-`);
+C.foo = undefined;` + "\r\n"); // TODO: GH#18445

--- a/tests/cases/fourslash/codeFixSuperAfterThis.ts
+++ b/tests/cases/fourslash/codeFixSuperAfterThis.ts
@@ -9,7 +9,8 @@
 ////        super();
 ////    |]}
 ////}
+// TODO: GH#18445
 verify.rangeAfterCodeFix(`
-        super();
+        super();\r
         this.a = 12;
     `, /*includeWhiteSpace*/ true);

--- a/tests/cases/fourslash/codeFixSuperCall.ts
+++ b/tests/cases/fourslash/codeFixSuperCall.ts
@@ -6,6 +6,7 @@
 ////    constructor() {[|
 ////    |]}
 ////}
+// TODO: GH#18445
 verify.rangeAfterCodeFix(`
-        super();
+        super();\r
     `, /*includeWhitespace*/ true);

--- a/tests/cases/fourslash/extract-method14.ts
+++ b/tests/cases/fourslash/extract-method14.ts
@@ -19,7 +19,7 @@ edit.applyRefactor({
 `function foo() {
     var i = 10;
     var __return: any;
-    ({ __return, i } = n/*RENAME*/ewFunction(i));
+    ({ __return, i } = /*RENAME*/newFunction(i));
     return __return;
 }
 function newFunction(i) {

--- a/tests/cases/fourslash/formatConflictDiff3Marker1.ts
+++ b/tests/cases/fourslash/formatConflictDiff3Marker1.ts
@@ -11,12 +11,12 @@
 ////}
 
 format.document();
-verify.currentFileContentIs("class C {\r\n\
-<<<<<<< HEAD\r\n\
-    v = 1;\r\n\
-||||||| merged common ancestors\r\n\
-v = 3;\r\n\
-=======\r\n\
-v = 2;\r\n\
->>>>>>> Branch - a\r\n\
-}");
+verify.currentFileContentIs(`class C {
+<<<<<<< HEAD
+    v = 1;
+||||||| merged common ancestors
+v = 3;
+=======
+v = 2;
+>>>>>>> Branch - a
+}`);

--- a/tests/cases/fourslash/formatConflictMarker1.ts
+++ b/tests/cases/fourslash/formatConflictMarker1.ts
@@ -9,10 +9,10 @@
 ////}
 
 format.document();
-verify.currentFileContentIs("class C {\r\n\
-<<<<<<< HEAD\r\n\
-    v = 1;\r\n\
-=======\r\n\
-v = 2;\r\n\
->>>>>>> Branch - a\r\n\
-}");
+verify.currentFileContentIs(`class C {
+<<<<<<< HEAD
+    v = 1;
+=======
+v = 2;
+>>>>>>> Branch - a
+}`);

--- a/tests/cases/fourslash/importNameCodeFixReExport.ts
+++ b/tests/cases/fourslash/importNameCodeFixReExport.ts
@@ -10,7 +10,8 @@
 ////x;|]
 
 goTo.file("/b.ts");
-verify.rangeAfterCodeFix(`import { x } from "./a";
-
+// TODO:GH#18445
+verify.rangeAfterCodeFix(`import { x } from "./a";\r
+\r
 export { x } from "./a";
 x;`, /*includeWhiteSpace*/ true);


### PR DESCRIPTION
Fixes #18349

The problem was that the test runner had code to normalize newlines, but it didn't change the index; so it thought that the new cursor was 1 character further along than it really was.

Changed fourslash tests to no longer normalize newlines; discovered a few bugs along the way (#18445) where CRLF characters are inserted into LF documents. (Fourslash tests are parsed with LF newlines even if the test file itself uses CRLF.)

Also had to fix an error related to #18291 where formatting options were being ignored due to an unused parameter.

Since this is just a test fix I don't think it needs a TS2.5 port.

