### PR TITLE
In `isInPropertyInitializer`, don't bail out at a `PropertyAssignment`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14753,7 +14753,7 @@ namespace ts {
                 return;
             }
 
-            if (findAncestor(node, node => node.kind === SyntaxKind.PropertyDeclaration ? true : isExpression(node) ? false : "quit") &&
+            if (isInPropertyInitializer(node) &&
                 !isBlockScopedNameDeclaredBeforeUse(valueDeclaration, right)
                 && !isPropertyDeclaredInAncestorClass(prop)) {
                 error(right, Diagnostics.Block_scoped_variable_0_used_before_its_declaration, unescapeLeadingUnderscores(right.escapedText));
@@ -14764,6 +14764,20 @@ namespace ts {
                 !isBlockScopedNameDeclaredBeforeUse(valueDeclaration, right)) {
                 error(right, Diagnostics.Class_0_used_before_its_declaration, unescapeLeadingUnderscores(right.escapedText));
             }
+        }
+
+        function isInPropertyInitializer(node: Node): boolean {
+            return !!findAncestor(node, node => {
+                switch (node.kind) {
+                    case SyntaxKind.PropertyDeclaration:
+                        return true;
+                    case SyntaxKind.PropertyAssignment:
+                        // We might be in `a = { b: this.b }`, so keep looking. See `tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts`.
+                        return false;
+                    default:
+                        return isPartOfExpression(node) ? false : "quit";
+                }
+            });
         }
 
         /**

--- a/tests/baselines/reference/useBeforeDeclaration_propertyAssignment.errors.txt
+++ b/tests/baselines/reference/useBeforeDeclaration_propertyAssignment.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts(2,27): error TS2448: Block-scoped variable 'b' used before its declaration.
+
+
+==== tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts (1 errors) ====
+    export class C {
+        public a =  { b: this.b };
+                              ~
+!!! error TS2448: Block-scoped variable 'b' used before its declaration.
+        private b = 0;
+    }
+    

--- a/tests/baselines/reference/useBeforeDeclaration_propertyAssignment.js
+++ b/tests/baselines/reference/useBeforeDeclaration_propertyAssignment.js
@@ -1,0 +1,18 @@
+//// [useBeforeDeclaration_propertyAssignment.ts]
+export class C {
+    public a =  { b: this.b };
+    private b = 0;
+}
+
+
+//// [useBeforeDeclaration_propertyAssignment.js]
+"use strict";
+exports.__esModule = true;
+var C = /** @class */ (function () {
+    function C() {
+        this.a = { b: this.b };
+        this.b = 0;
+    }
+    return C;
+}());
+exports.C = C;

--- a/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
+++ b/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
@@ -1,0 +1,4 @@
+export class C {
+    public a =  { b: this.b };
+    private b = 0;
+}


### PR DESCRIPTION
Fixes #18352

In #17910 I had replaced `isInPropertyAssignment` with a `forEachAncestor` loop that bailed out on any non-`Expression`; however, a `PropertyAssignment` may appear in an expression, but `isPartOfExpression` returns `false` for it.
Are there any other nodes like this? Should we just make `isPartOfExpression` return true for a `PropertyAssignment`?