### PR TITLE
extractMethod: Don't try to extract an ExpressionStatement consisting of a single token

### DIFF
--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -404,6 +404,8 @@ function test(x: number) {
             "Cannot extract range containing conditional break or continue statements."
         ]);
 
+        testExtractRangeFailed("extract-method-not-for-token-expression-statement", `[#|a|]`, ["Select more than a single token."]);
+
         testExtractMethod("extractMethod1",
             `namespace A {
     let x = 1;

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -226,7 +226,7 @@ namespace ts.refactor.extractMethod {
         }
 
         function checkRootNode(node: Node): Diagnostic[] | undefined {
-            if (isToken(node)) {
+            if (isToken(isExpressionStatement(node) ? node.expression : node)) {
                 return [createDiagnosticForNode(node, Messages.InsufficientSelection)];
             }
             return undefined;

--- a/tests/cases/fourslash/extract-method-not-for-token-expression-statement.ts
+++ b/tests/cases/fourslash/extract-method-not-for-token-expression-statement.ts
@@ -1,9 +1,0 @@
-/// <reference path='fourslash.ts' />
-
-// Same as `extract-method-not-for-token, but without the `;`,
-// so the range is the entire ExpressionStatement rather than just the token it contains.
-
-/////*start*/a/*end*/
-
-goTo.select('start', 'end')
-verify.not.refactorAvailable("Extract Method");

--- a/tests/cases/fourslash/extract-method-not-for-token-expression-statement.ts
+++ b/tests/cases/fourslash/extract-method-not-for-token-expression-statement.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+// Same as `extract-method-not-for-token, but without the `;`,
+// so the range is the entire ExpressionStatement rather than just the token it contains.
+
+/////*start*/a/*end*/
+
+goTo.select('start', 'end')
+verify.not.refactorAvailable("Extract Method");


### PR DESCRIPTION
Sequel to #18090. This problem comes up  while typing; even when typing a document consisting of a single character, the editor recommends extracting it out to a function because it sees it as its own statement (because it is, so far).
