### PR TITLE
Allow template string with no substitutions to be used as a string literal type

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -773,13 +773,13 @@ namespace ts {
             : node;
     }
 
-    export function createLiteralTypeNode(literal: Expression) {
+    export function createLiteralTypeNode(literal: LiteralTypeNode["literal"]) {
         const node = createSynthesizedNode(SyntaxKind.LiteralType) as LiteralTypeNode;
         node.literal = literal;
         return node;
     }
 
-    export function updateLiteralTypeNode(node: LiteralTypeNode, literal: Expression) {
+    export function updateLiteralTypeNode(node: LiteralTypeNode, literal: LiteralTypeNode["literal"]) {
         return node.literal !== literal
             ? updateNode(createLiteralTypeNode(literal), node)
             : node;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2621,16 +2621,9 @@ namespace ts {
                 unaryMinusExpression.operator = SyntaxKind.MinusToken;
                 nextToken();
             }
-            let expression: UnaryExpression;
-            switch (token()) {
-                case SyntaxKind.StringLiteral:
-                case SyntaxKind.NumericLiteral:
-                    expression = parseLiteralLikeNode(token()) as LiteralExpression;
-                    break;
-                case SyntaxKind.TrueKeyword:
-                case SyntaxKind.FalseKeyword:
-                    expression = parseTokenNode();
-            }
+            let expression: BooleanLiteral | LiteralExpression | PrefixUnaryExpression = token() === SyntaxKind.TrueKeyword || token() === SyntaxKind.FalseKeyword
+                ? parseTokenNode<BooleanLiteral>()
+                : parseLiteralLikeNode(token()) as LiteralExpression;
             if (negative) {
                 unaryMinusExpression.operand = expression;
                 finishNode(unaryMinusExpression);
@@ -2666,6 +2659,7 @@ namespace ts {
                     return parseJSDocNodeWithType(SyntaxKind.JSDocVariadicType);
                 case SyntaxKind.ExclamationToken:
                     return parseJSDocNodeWithType(SyntaxKind.JSDocNonNullableType);
+                case SyntaxKind.NoSubstitutionTemplateLiteral:
                 case SyntaxKind.StringLiteral:
                 case SyntaxKind.NumericLiteral:
                 case SyntaxKind.TrueKeyword:

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1049,7 +1049,7 @@ namespace ts {
 
     export interface LiteralTypeNode extends TypeNode {
         kind: SyntaxKind.LiteralType;
-        literal: Expression;
+        literal: BooleanLiteral | LiteralExpression | PrefixUnaryExpression;
     }
 
     export interface StringLiteral extends LiteralExpression {

--- a/tests/baselines/reference/noSubstitutionTemplateStringLiteralTypes.js
+++ b/tests/baselines/reference/noSubstitutionTemplateStringLiteralTypes.js
@@ -1,0 +1,6 @@
+//// [noSubstitutionTemplateStringLiteralTypes.ts]
+const x: `foo` = "foo";
+
+
+//// [noSubstitutionTemplateStringLiteralTypes.js]
+var x = "foo";

--- a/tests/baselines/reference/noSubstitutionTemplateStringLiteralTypes.symbols
+++ b/tests/baselines/reference/noSubstitutionTemplateStringLiteralTypes.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/noSubstitutionTemplateStringLiteralTypes.ts ===
+const x: `foo` = "foo";
+>x : Symbol(x, Decl(noSubstitutionTemplateStringLiteralTypes.ts, 0, 5))
+

--- a/tests/baselines/reference/noSubstitutionTemplateStringLiteralTypes.types
+++ b/tests/baselines/reference/noSubstitutionTemplateStringLiteralTypes.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/noSubstitutionTemplateStringLiteralTypes.ts ===
+const x: `foo` = "foo";
+>x : "foo"
+>`foo` : "foo"
+>"foo" : "foo"
+

--- a/tests/cases/compiler/noSubstitutionTemplateStringLiteralTypes.ts
+++ b/tests/cases/compiler/noSubstitutionTemplateStringLiteralTypes.ts
@@ -1,0 +1,1 @@
+const x: `foo` = "foo";


### PR DESCRIPTION
Fixes #16592

Allows to write:
```ts
let x: `foo`;
```

Sequel of sorts to  #17704

