### PR TITLE
Actually be able to run RWC tests in parallel

### DIFF
--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -216,8 +216,8 @@ if (taskConfigsFolder) {
 
     for (let i = 0; i < workerCount; i++) {
         const config = workerConfigs[i];
-        // use last worker to run unit tests
-        config.runUnitTests = i === workerCount - 1;
+        // use last worker to run unit tests if we're not just running a single specific runner
+        config.runUnitTests = runners.length !== 1 && i === workerCount - 1;
         Harness.IO.writeFile(ts.combinePaths(taskConfigsFolder, `task-config${i}.json`), JSON.stringify(workerConfigs[i]));
     }
 }

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -263,7 +263,7 @@ class RWCRunner extends RunnerBase {
      */
     public initializeTests(): void {
         // Read in and evaluate the test list
-        const testList = this.enumerateTestFiles();
+        const testList = this.tests && this.tests.length ? this.tests : this.enumerateTestFiles();
         for (let i = 0; i < testList.length; i++) {
             this.runTest(testList[i]);
         }


### PR DESCRIPTION
Our RWC harness was running all tests on all threads under `runtests-parallel`, which was not particularly helpful. With this, each thread only runs the work it has been partitioned.

This can let you get RWC results faster; however it's still a bit suboptimal, as _certain_ RWC tests take up more than 1/8th of the test CPU cycles on their own; so the balance is a little off and some threads finish a few minutes before the slowest one. In any case, this is a nice improvement for now; until we get around to making them take work from a shared queue rather than a preallocated partition.