### PR TITLE
Properly report external filenames

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1659,7 +1659,7 @@ namespace ts {
     }
 
     export function isRootedDiskPath(path: string) {
-        return getRootLength(path) !== 0;
+        return path && getRootLength(path) !== 0;
     }
 
     export function convertToRelativePath(absoluteOrRelativePath: string, basePath: string, getCanonicalFileName: (path: string) => string): string {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1191,7 +1191,8 @@ namespace ts.server {
                 projectOptions.compileOnSave === undefined ? false : projectOptions.compileOnSave);
 
             this.addFilesToProjectAndUpdateGraph(project, projectOptions.files, fileNamePropertyReader, clientFileName, projectOptions.typeAcquisition, configFileErrors);
-
+            this.addFilesToProjectAndUpdateGraph(project, project.getExternalFiles(), fileNamePropertyReader, clientFileName, projectOptions.typeAcquisition, configFileErrors);
+            
             project.watchConfigFile(project => this.onConfigChangedForConfiguredProject(project));
             if (!sizeLimitExceeded) {
                 this.watchConfigDirectoryForProject(project, projectOptions);
@@ -1210,7 +1211,7 @@ namespace ts.server {
             }
         }
 
-        private addFilesToProjectAndUpdateGraph<T>(project: ConfiguredProject | ExternalProject, files: T[], propertyReader: FilePropertyReader<T>, clientFileName: string, typeAcquisition: TypeAcquisition, configFileErrors: ReadonlyArray<Diagnostic>): void {
+        private addFilesToProjectAndUpdateGraph<T>(project: ConfiguredProject | ExternalProject, files: ReadonlyArray<T>, propertyReader: FilePropertyReader<T>, clientFileName: string, typeAcquisition: TypeAcquisition, configFileErrors: ReadonlyArray<Diagnostic>): void {
             let errors: Diagnostic[];
             for (const f of files) {
                 const rootFileName = propertyReader.getFileName(f);

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1190,9 +1190,9 @@ namespace ts.server {
                 /*languageServiceEnabled*/ !sizeLimitExceeded,
                 projectOptions.compileOnSave === undefined ? false : projectOptions.compileOnSave);
 
-            this.addFilesToProjectAndUpdateGraph(project, projectOptions.files, fileNamePropertyReader, clientFileName, projectOptions.typeAcquisition, configFileErrors);
-            this.addFilesToProjectAndUpdateGraph(project, project.getExternalFiles(), fileNamePropertyReader, clientFileName, projectOptions.typeAcquisition, configFileErrors);
-            
+            const filesToAdd = projectOptions.files.concat(project.getExternalFiles());
+            this.addFilesToProjectAndUpdateGraph(project, filesToAdd, fileNamePropertyReader, clientFileName, projectOptions.typeAcquisition, configFileErrors);
+
             project.watchConfigFile(project => this.onConfigChangedForConfiguredProject(project));
             if (!sizeLimitExceeded) {
                 this.watchConfigDirectoryForProject(project, projectOptions);

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -747,7 +747,8 @@ namespace ts.server {
                 }
                 // compute and return the difference
                 const lastReportedFileNames = this.lastReportedFileNames;
-                const currentFiles = arrayToSet(this.getFileNames());
+                const externalFiles = this.getExternalFiles().map(f => toNormalizedPath(f));
+                const currentFiles = arrayToSet(this.getFileNames().concat(externalFiles));
 
                 const added: string[] = [];
                 const removed: string[] = [];
@@ -770,7 +771,8 @@ namespace ts.server {
             else {
                 // unknown version - return everything
                 const projectFileNames = this.getFileNames();
-                this.lastReportedFileNames = arrayToSet(projectFileNames);
+                const externalFiles = this.getExternalFiles().map(f => toNormalizedPath(f));
+                this.lastReportedFileNames = arrayToSet(projectFileNames.concat(externalFiles));
                 this.lastReportedVersion = this.projectStructureVersion;
                 return { info, files: projectFileNames, projectErrors: this.getGlobalProjectErrors() };
             }
@@ -1085,6 +1087,9 @@ namespace ts.server {
                 }
                 catch (e) {
                     this.projectService.logger.info(`A plugin threw an exception in getExternalFiles: ${e}`);
+                    if (e.stack) {
+                        this.projectService.logger.info(e.stack);
+                    }
                 }
             }));
         }


### PR DESCRIPTION
We need to list external files during project synchronization for VS to realize they're part of a TS project