### PR TITLE
Suppress errors in .ts files using '// @ts-ignore' comments

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1158,9 +1158,7 @@ namespace ts {
                 const programDiagnosticsInFile = programDiagnostics.getDiagnostics(sourceFile.fileName);
 
                 const diagnostics = bindDiagnostics.concat(checkDiagnostics, fileProcessingDiagnosticsInFile, programDiagnosticsInFile);
-                return isSourceFileJavaScript(sourceFile)
-                    ? filter(diagnostics, shouldReportDiagnostic)
-                    : diagnostics;
+                return filter(diagnostics, shouldReportDiagnostic);
             });
         }
 


### PR DESCRIPTION
We currently support suppressing errors in .js files using `// @ts-ignore` comments placed above the offending lines. With this PR we extend this support to .ts files as well. For example:

```ts
if (false) {
    // @ts-ignore: Unreachable code error
    console.log("hello");
}
```

A `// @ts-ignore` comment suppresses all errors that originate on the following line. It is recommended practice to have the remainder of the comment following `@ts-ignore` explain which error is being suppressed.

Fixes #9448.