### PR TITLE
Handle undefined `symbol.declarations` in `cloneSymbol`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -577,7 +577,7 @@ namespace ts {
 
         function cloneSymbol(symbol: Symbol): Symbol {
             const result = createSymbol(symbol.flags, symbol.escapedName);
-            result.declarations = symbol.declarations.slice(0);
+            result.declarations = symbol.declarations ? symbol.declarations.slice() : [];
             result.parent = symbol.parent;
             if (symbol.valueDeclaration) result.valueDeclaration = symbol.valueDeclaration;
             if (symbol.constEnumOnlyModule) result.constEnumOnlyModule = true;

--- a/tests/baselines/reference/mergedClassWithNamespacePrototype.errors.txt
+++ b/tests/baselines/reference/mergedClassWithNamespacePrototype.errors.txt
@@ -1,0 +1,15 @@
+/b.ts(2,15): error TS2300: Duplicate identifier 'prototype'.
+
+
+==== /a.d.ts (0 errors) ====
+    declare class Foo {}
+    
+==== /b.ts (1 errors) ====
+    declare namespace Foo {
+        namespace prototype {
+                  ~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'prototype'.
+            function f(): void;
+        }
+    }
+    

--- a/tests/baselines/reference/mergedClassWithNamespacePrototype.js
+++ b/tests/baselines/reference/mergedClassWithNamespacePrototype.js
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/mergedClassWithNamespacePrototype.ts] ////
+
+//// [a.d.ts]
+declare class Foo {}
+
+//// [b.ts]
+declare namespace Foo {
+    namespace prototype {
+        function f(): void;
+    }
+}
+
+
+//// [b.js]

--- a/tests/cases/compiler/mergedClassWithNamespacePrototype.ts
+++ b/tests/cases/compiler/mergedClassWithNamespacePrototype.ts
@@ -1,0 +1,9 @@
+// @Filename: /a.d.ts
+declare class Foo {}
+
+// @Filename: /b.ts
+declare namespace Foo {
+    namespace prototype {
+        function f(): void;
+    }
+}


### PR DESCRIPTION
Alternative to #18455 (fixing #18356)

This avoids changing the operation order of symbol merging and just handles `undefined` here.