### PR TITLE
Fixes to emit / format for codeFix

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2417,6 +2417,12 @@ namespace ts {
 
             const isEmpty = isUndefined || start >= children.length || count === 0;
             if (isEmpty && format & ListFormat.OptionalIfEmpty) {
+                if (onBeforeEmitNodeArray) {
+                    onBeforeEmitNodeArray(children);
+                }
+                if (onAfterEmitNodeArray) {
+                    onAfterEmitNodeArray(children);
+                }
                 return;
             }
 

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -3500,7 +3500,7 @@ ${code}
             expected = makeWhitespaceVisible(expected);
             actual = makeWhitespaceVisible(actual);
         }
-        return `Expected:\n${expected}\nActual:${actual}`;
+        return `Expected:\n${expected}\nActual:\n${actual}`;
     }
 
     function differOnlyByWhitespace(a: string, b: string) {

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -755,9 +755,8 @@ namespace ts.formatting {
                     return true;
                 case SyntaxKind.Block: {
                     const blockParent = context.currentTokenParent.parent;
-                    if (blockParent.kind !== SyntaxKind.ArrowFunction &&
-                        blockParent.kind !== SyntaxKind.FunctionExpression
-                    ) {
+                    // In a codefix scenario, we can't rely on parents being set. So just always return true.
+                    if (!blockParent || blockParent.kind !== SyntaxKind.ArrowFunction && blockParent.kind !== SyntaxKind.FunctionExpression) {
                         return true;
                     }
                 }

--- a/tests/cases/fourslash/convertFunctionToEs6Class3.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class3.ts
@@ -2,14 +2,14 @@
 
 // @allowNonTsExtensions: true
 // @Filename: test123.js
-//// [|var bar = 10, /*1*/foo = function() { };
+//// var bar = 10, /*1*/foo = function() { };
 //// /*2*/foo.prototype.instanceMethod1 = function() { return "this is name"; };
 //// /*3*/foo.prototype.instanceMethod2 = () => { return "this is name"; };
 //// /*4*/foo.prototype.instanceProp1 = "hello";
 //// /*5*/foo.prototype.instanceProp2 = undefined;
 //// /*6*/foo.staticProp = "world";
 //// /*7*/foo.staticMethod1 = function() { return "this is static name"; };
-//// /*8*/foo.staticMethod2 = () => "this is static name";|]
+//// /*8*/foo.staticMethod2 = () => "this is static name";
 
 
 ['1', '2', '3', '4', '5', '6', '7', '8'].forEach(m => verify.applicableRefactorAvailableAtMarker(m));

--- a/tests/cases/fourslash/convertFunctionToEs6Class_emptySwitchCase.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class_emptySwitchCase.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: /a.js
+////function /**/MyClass() {
+////}
+////MyClass.prototype.f = function(x) {
+////    switch (x) {
+////        case 0:
+////    }
+////}
+
+verify.applicableRefactorAvailableAtMarker("");
+verify.fileAfterApplyingRefactorAtMarker("",
+`class MyClass {
+    constructor() {
+    }
+    f(x) {
+        switch (x) {
+            case 0:
+        }
+    }
+}
+`,
+'Convert to ES2015 class', 'convert');

--- a/tests/cases/fourslash/convertFunctionToEs6Class_objectLiteralInArrowFunction.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class_objectLiteralInArrowFunction.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: /a.js
+////function /**/MyClass() {
+////}
+////MyClass.prototype.foo = function() {
+////    ({ bar: () => { } })
+////}
+
+verify.applicableRefactorAvailableAtMarker("");
+verify.fileAfterApplyingRefactorAtMarker("",
+`class MyClass {
+    constructor() {
+    }
+    foo() {
+        ({ bar: () => { } });
+    }
+}
+`,
+'Convert to ES2015 class', 'convert');


### PR DESCRIPTION
Fixes #18437
Fixes #18434

This is basically a sequel to #18284 -- we need to remember to call callbacks for an empty list (e.g. from an empty `case` statement). We also can't look assume that `parent` exists in formatting rules, because synthesized nodes don't have parents.

@mhegazy This might be a good idea to get in for 2.5.3.