### PR TITLE
Only decrement activeRequestCount on SetTypings responses

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -433,23 +433,25 @@ namespace ts.server {
                 return;
             }
 
-            if (this.activeRequestCount > 0) {
-                this.activeRequestCount--;
-            }
-            else {
-                Debug.fail("Received too many responses");
-            }
-
-            while (this.requestQueue.length > 0) {
-                const queuedRequest = this.requestQueue.shift();
-                if (this.requestMap.get(queuedRequest.operationId) === queuedRequest) {
-                    this.requestMap.delete(queuedRequest.operationId);
-                    this.scheduleRequest(queuedRequest);
-                    break;
+            if (response.kind === ActionSet) {
+                if (this.activeRequestCount > 0) {
+                    this.activeRequestCount--;
+                }
+                else {
+                    Debug.fail("Received too many responses");
                 }
 
-                if (this.logger.hasLevel(LogLevel.verbose)) {
-                    this.logger.info(`Skipping defunct request for: ${queuedRequest.operationId}`);
+                while (this.requestQueue.length > 0) {
+                    const queuedRequest = this.requestQueue.shift();
+                    if (this.requestMap.get(queuedRequest.operationId) === queuedRequest) {
+                        this.requestMap.delete(queuedRequest.operationId);
+                        this.scheduleRequest(queuedRequest);
+                        break;
+                    }
+
+                    if (this.logger.hasLevel(LogLevel.verbose)) {
+                        this.logger.info(`Skipping defunct request for: ${queuedRequest.operationId}`);
+                    }
                 }
             }
 


### PR DESCRIPTION
InvalidateCache responses are triggered by file watchers, rather than by requests.

When I port this to 2.5, I plan to remove the `Debug.fail` call.
