### PR TITLE
Increase max depth for outlining spans

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -3096,7 +3096,7 @@ ${code}
         let currentFileSize = getFileSize();
 
         function getFileSize() {
-            const stats = _fs.statSync(fileName);
+            const stats = _fs.statSync("." + fileName);
             return stats.size;
         }
 

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -20,6 +20,8 @@
 /// <reference path="fourslashRunner.ts" />
 
 namespace FourSlash {
+    const _fs = require("fs");
+
     ts.disableIncrementalParsing = false;
 
     // Represents a parsed source file with metadata
@@ -27,6 +29,7 @@ namespace FourSlash {
         // The contents of the file (with markers, etc stripped out)
         content: string;
         fileName: string;
+        fileSize: number;
         version: number;
         // File-specific options (name/value pairs)
         fileOptions: Harness.TestCaseParser.CompilerSettings;
@@ -2249,7 +2252,7 @@ namespace FourSlash {
         }
 
         public verifyOutliningSpans(spans: TextSpan[]) {
-            const actual = this.languageService.getOutliningSpans(this.activeFile.fileName);
+            const actual = this.languageService.getOutliningSpans(this.activeFile.fileName, this.activeFile.fileSize);
 
             if (actual.length !== spans.length) {
                 this.raiseError(`verifyOutliningSpans failed - expected total spans to be ${spans.length}, but was ${actual.length}`);
@@ -3090,11 +3093,18 @@ ${code}
         let currentFileContent: string = undefined;
         let currentFileName = fileName;
         let currentFileOptions: { [s: string]: string } = {};
+        let currentFileSize = getFileSize();
+
+        function getFileSize() {
+            const stats = _fs.statSync(fileName);
+            return stats.size;
+        }
 
         function resetLocalData() {
             currentFileContent = undefined;
             currentFileOptions = {};
             currentFileName = fileName;
+            currentFileSize = getFileSize();
         }
 
         for (let line of lines) {
@@ -3135,7 +3145,7 @@ ${code}
                         if (fileMetadataNamesIndex === fileMetadataNames.indexOf(metadataOptionNames.fileName)) {
                             // Found an @FileName directive, if this is not the first then create a new subfile
                             if (currentFileContent) {
-                                const file = parseFileContent(currentFileContent, currentFileName, markerPositions, markers, ranges);
+                                const file = parseFileContent(currentFileContent, currentFileName, currentFileSize, markerPositions, markers, ranges);
                                 file.fileOptions = currentFileOptions;
 
                                 // Store result file
@@ -3161,7 +3171,7 @@ ${code}
             else {
                 // Empty line or code line, terminate current subfile if there is one
                 if (currentFileContent) {
-                    const file = parseFileContent(currentFileContent, currentFileName, markerPositions, markers, ranges);
+                    const file = parseFileContent(currentFileContent, currentFileName, currentFileSize, markerPositions, markers, ranges);
                     file.fileOptions = currentFileOptions;
 
                     // Store result file
@@ -3270,7 +3280,7 @@ ${code}
         }
     }
 
-    function parseFileContent(content: string, fileName: string, markerMap: ts.Map<Marker>, markers: Marker[], ranges: Range[]): FourSlashFile {
+    function parseFileContent(content: string, fileName: string, fileSize: number, markerMap: ts.Map<Marker>, markers: Marker[], ranges: Range[]): FourSlashFile {
         content = chompLeadingSpace(content);
 
         // Any slash-star comment with a character not in this string is not a marker.
@@ -3461,6 +3471,7 @@ ${code}
             fileOptions: {},
             version: 0,
             fileName,
+            fileSize
         };
     }
 

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -460,8 +460,8 @@ namespace Harness.LanguageService {
             return unwrapJSONCallResult(this.shim.getNavigationTree(fileName));
         }
 
-        getOutliningSpans(fileName: string): ts.OutliningSpan[] {
-            return unwrapJSONCallResult(this.shim.getOutliningSpans(fileName));
+        getOutliningSpans(fileName: string, fileSize: number): ts.OutliningSpan[] {
+            return unwrapJSONCallResult(this.shim.getOutliningSpans(fileName, fileSize));
         }
         getTodoComments(fileName: string, descriptors: ts.TodoCommentDescriptor[]): ts.TodoComment[] {
             return unwrapJSONCallResult(this.shim.getTodoComments(fileName, JSON.stringify(descriptors)));

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2126,10 +2126,10 @@ namespace ts.projectSystem {
             const projectService = createProjectService(host, { useSingleInferredProject: true });
             projectService.setCompilerOptionsForInferredProjects({ target: ScriptTarget.ES5, allowJs: false });
             projectService.openClientFile(file1.path);
-            projectService.inferredProjects[0].getLanguageService(/*ensureSynchronized*/ false).getOutliningSpans(file1.path);
+            projectService.inferredProjects[0].getLanguageService(/*ensureSynchronized*/ false).getOutliningSpans(file1.path, 9);
             projectService.setCompilerOptionsForInferredProjects({ target: ScriptTarget.ES5, allowJs: true });
             projectService.getScriptInfo(file1.path).editContent(0, 0, " ");
-            projectService.inferredProjects[0].getLanguageService(/*ensureSynchronized*/ false).getOutliningSpans(file1.path);
+            projectService.inferredProjects[0].getLanguageService(/*ensureSynchronized*/ false).getOutliningSpans(file1.path, 10);
             projectService.closeClientFile(file1.path);
         });
 

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -203,6 +203,13 @@ namespace ts.server.protocol {
         projectFileName?: string;
     }
 
+    export interface FileAndSizeRequestArgs extends FileRequestArgs {
+        /**
+         * The size of the requested file
+         */
+        size: number;
+    }
+
     /**
      * Requests a JS Doc comment template for a given position
      */
@@ -394,6 +401,13 @@ namespace ts.server.protocol {
      */
     export interface FileRequest extends Request {
         arguments: FileRequestArgs;
+    }
+
+    /**
+     * Request containing a file name and the size of that file (in bytes).
+     */
+    export interface FileAndSizeRequest extends Request {
+        arguments: FileAndSizeRequestArgs;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1010,7 +1010,8 @@ namespace ts.server {
 
         private getOutliningSpans(args: protocol.FileAndSizeRequestArgs) {
             const { file, project } = this.getFileAndProjectWithoutRefreshingInferredProjects(args);
-            return project.getLanguageService(/*ensureSynchronized*/ false).getOutliningSpans(file, args.size);
+            const size = args.size || 200000; // check due to protocol change
+            return project.getLanguageService(/*ensureSynchronized*/ false).getOutliningSpans(file, size);
         }
 
         private getTodoComments(args: protocol.TodoCommentRequestArgs) {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1008,9 +1008,9 @@ namespace ts.server {
             return { file, project };
         }
 
-        private getOutliningSpans(args: protocol.FileRequestArgs) {
+        private getOutliningSpans(args: protocol.FileAndSizeRequestArgs) {
             const { file, project } = this.getFileAndProjectWithoutRefreshingInferredProjects(args);
-            return project.getLanguageService(/*ensureSynchronized*/ false).getOutliningSpans(file);
+            return project.getLanguageService(/*ensureSynchronized*/ false).getOutliningSpans(file, args.size);
         }
 
         private getTodoComments(args: protocol.TodoCommentRequestArgs) {
@@ -1752,7 +1752,7 @@ namespace ts.server {
             [CommandNames.QuickinfoFull]: (request: protocol.QuickInfoRequest) => {
                 return this.requiredResponse(this.getQuickInfoWorker(request.arguments, /*simplifiedResult*/ false));
             },
-            [CommandNames.OutliningSpans]: (request: protocol.FileRequest) => {
+            [CommandNames.OutliningSpans]: (request: protocol.FileAndSizeRequest) => {
                 return this.requiredResponse(this.getOutliningSpans(request.arguments));
             },
             [CommandNames.TodoComments]: (request: protocol.TodoCommentRequest) => {

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -1,11 +1,11 @@
 /* @internal */
 namespace ts.OutliningElementsCollector {
     const collapseText = "...";
-    const maxDepth = 20;
 
-    export function collectElements(sourceFile: SourceFile, cancellationToken: CancellationToken): OutliningSpan[] {
+    export function collectElements(sourceFile: SourceFile, fileSize: number, cancellationToken: CancellationToken): OutliningSpan[] {
         const elements: OutliningSpan[] = [];
         let depth = 0;
+        const maxDepth = fileSize > 100000 ? 50 : 20;
 
         walk(sourceFile);
         return elements;

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -5,7 +5,7 @@ namespace ts.OutliningElementsCollector {
     export function collectElements(sourceFile: SourceFile, fileSize: number, cancellationToken: CancellationToken): OutliningSpan[] {
         const elements: OutliningSpan[] = [];
         let depth = 0;
-        const maxDepth = fileSize > 100000 ? 50 : 20;
+        const maxDepth = fileSize < 100000 ? 50 : 20;
 
         walk(sourceFile);
         return elements;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1707,10 +1707,10 @@ namespace ts {
             return ts.getEncodedSyntacticClassifications(cancellationToken, syntaxTreeCache.getCurrentSourceFile(fileName), span);
         }
 
-        function getOutliningSpans(fileName: string): OutliningSpan[] {
+        function getOutliningSpans(fileName: string, fileSize: number): OutliningSpan[] {
             // doesn't use compiler - no need to synchronize with host
             const sourceFile = syntaxTreeCache.getCurrentSourceFile(fileName);
-            return OutliningElementsCollector.collectElements(sourceFile, cancellationToken);
+            return OutliningElementsCollector.collectElements(sourceFile, fileSize, cancellationToken);
         }
 
         function getBraceMatchingAtPosition(fileName: string, position: number) {

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -231,7 +231,7 @@ namespace ts {
          * Returns a JSON-encoded value of the type:
          * { textSpan: { start: number, length: number }; hintSpan: { start: number, length: number }; bannerText: string; autoCollapse: boolean } [] = [];
          */
-        getOutliningSpans(fileName: string): string;
+        getOutliningSpans(fileName: string, fileSize: number): string;
 
         getTodoComments(fileName: string, todoCommentDescriptors: string): string;
 
@@ -951,10 +951,10 @@ namespace ts {
             );
         }
 
-        public getOutliningSpans(fileName: string): string {
+        public getOutliningSpans(fileName: string, fileSize: number): string {
             return this.forwardJSONCall(
-                `getOutliningSpans('${fileName}')`,
-                () => this.languageService.getOutliningSpans(fileName)
+                `getOutliningSpans('${fileName}', ${fileSize})`,
+                () => this.languageService.getOutliningSpans(fileName, fileSize)
             );
         }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -257,7 +257,7 @@ namespace ts {
         getNavigationBarItems(fileName: string): NavigationBarItem[];
         getNavigationTree(fileName: string): NavigationTree;
 
-        getOutliningSpans(fileName: string): OutliningSpan[];
+        getOutliningSpans(fileName: string, fileSize: number): OutliningSpan[];
         getTodoComments(fileName: string, descriptors: TodoCommentDescriptor[]): TodoComment[];
         getBraceMatchingAtPosition(fileName: string, position: number): TextSpan[];
         getIndentationAtPosition(fileName: string, position: number, options: EditorOptions | EditorSettings): number;

--- a/tests/cases/fourslash/getOutliningSpans.ts
+++ b/tests/cases/fourslash/getOutliningSpans.ts
@@ -89,12 +89,12 @@
 ////                            module m8[| {
 ////                                module m9[| {
 ////                                    module m10[| {
-////                                        module m11 {
-////                                            module m12 {
-////                                                export interface IFoo {
-////                                                }
-////                                            }
-////                                        }
+////                                        module m11[| {
+////                                            module m12[| {
+////                                                export interface IFoo[| {
+////                                                }|]
+////                                            }|]
+////                                        }|]
 ////                                    }|]
 ////                                }|]
 ////                            }|]

--- a/tests/cases/fourslash/getOutliningSpansInLargeFile.ts
+++ b/tests/cases/fourslash/getOutliningSpansInLargeFile.ts
@@ -1,0 +1,2457 @@
+/// <reference path='fourslash.ts' />
+
+//////outline with deep nesting
+////module m1[|{
+////    module m2[| {
+////        module m3[| {
+////            module m4[| {
+////                module m5[| {
+////                    module m6[| {
+////                        module m7[| {
+////                            module m8[| {
+////                                module m9[| {
+////                                    module m10[| {
+////                                        module m11 {
+////                                            module m12 {
+////                                                export interface IFoo {
+////                                                }
+////                                            }
+////                                        }
+////                                    }|]
+////                                }|]
+////                            }|]
+////                        }|]
+////                    }|]
+////                }|]
+////            }|]
+////        }|]
+////    }|]
+////}|]
+////
+//////outline after a deeply nested node
+////class AfterNestedNodes[| {
+////}|]
+
+verify.outliningSpansInCurrentFile(test.ranges());
+
+// need this file to be over 100KB to trigger outlining change
+// no meaningful test information after this point
+
+// /////** this is signature 1*/
+// ////function /*1*/f1(/**param a*/a: number): number;
+// ////function /*2*/f1(b: string): number;
+// ////function /*3*/f1(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*4q*/1(/*4*/"hello");
+// ////f/*o4q*/1(/*o4*/10);
+// ////function /*5*/f2(/**param a*/a: number): number;
+// /////** this is signature 2*/
+// ////function /*6*/f2(b: string): number;
+// /////** this is f2 var comment*/
+// ////function /*7*/f2(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*8q*/2(/*8*/"hello");
+// ////f/*o8q*/2(/*o8*/10);
+// ////function /*9*/f3(a: number): number;
+// ////function /*10*/f3(b: string): number;
+// ////function /*11*/f3(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*12q*/3(/*12*/"hello");
+// ////f/*o12q*/3(/*o12*/10);
+// /////** this is signature 4 - with number parameter*/
+// ////function /*13*/f4(/**param a*/a: number): number;
+// /////** this is signature 4 - with string parameter*/
+// ////function /*14*/f4(b: string): number;
+// ////function /*15*/f4(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*16q*/4(/*16*/"hello");
+// ////f/*o16q*/4(/*o16*/10);
+// /////*17*/
+// ////interface i1 {
+// ////    /**this signature 1*/
+// ////    (/**param a*/ a: number): number;
+// ////    /**this is signature 2*/
+// ////    (b: string): number;
+// ////    /** foo 1*/
+// ////    foo(a: number): number;
+// ////    /** foo 2*/
+// ////    foo(b: string): number;
+// ////    foo2(a: number): number;
+// ////    /** foo2 2*/
+// ////    foo2(b: string): number;
+// ////    foo3(a: number): number;
+// ////    foo3(b: string): number;
+// ////    /** foo4 1*/
+// ////    foo4(a: number): number;
+// ////    foo4(b: string): number;
+// ////    /** new 1*/
+// ////    new (a: string);
+// ////    new (b: number);
+// ////}
+// ////var i1_i: i1;
+// ////interface i2 {
+// ////    new (a: string);
+// ////    /** new 2*/
+// ////    new (b: number);
+// ////    (a: number): number;
+// ////    /**this is signature 2*/
+// ////    (b: string): number;
+// ////}
+// ////var i2_i: i2;
+// ////interface i3 {
+// ////    /** new 1*/
+// ////    new (a: string);
+// ////    /** new 2*/
+// ////    new (b: number);
+// ////    /**this is signature 1*/
+// ////    (a: number): number;
+// ////    (b: string): number;
+// ////}
+// ////var i3_i: i3;
+// ////interface i4 {
+// ////    new (a: string);
+// ////    new (b: number);
+// ////    (a: number): number;
+// ////    (b: string): number;
+// ////}
+// ////var i4_i: i4;
+// ////new /*18*/i1/*19q*/_i(/*19*/10);
+// ////new i/*20q*/1_i(/*20*/"Hello");
+// ////i/*21q*/1_i(/*21*/10);
+// ////i/*22q*/1_i(/*22*/"hello");
+// ////i1_i./*23*/f/*24q*/oo(/*24*/10);
+// ////i1_i.f/*25q*/oo(/*25*/"hello");
+// ////i1_i.fo/*26q*/o2(/*26*/10);
+// ////i1_i.fo/*27q*/o2(/*27*/"hello");
+// ////i1_i.fo/*28q*/o3(/*28*/10);
+// ////i1_i.fo/*29q*/o3(/*29*/"hello");
+// ////i1_i.fo/*30q*/o4(/*30*/10);
+// ////i1_i.fo/*31q*/o4(/*31*/"hello");
+// ////new i2/*32q*/_i(/*32*/10);
+// ////new i2/*33q*/_i(/*33*/"Hello");
+// ////i/*34q*/2_i(/*34*/10);
+// ////i2/*35q*/_i(/*35*/"hello");
+// ////new i/*36q*/3_i(/*36*/10);
+// ////new i3/*37q*/_i(/*37*/"Hello");
+// ////i3/*38q*/_i(/*38*/10);
+// ////i3/*39q*/_i(/*39*/"hello");
+// ////new i4/*40q*/_i(/*40*/10);
+// ////new i/*41q*/4_i(/*41*/"Hello");
+// ////i4/*42q*/_i(/*42*/10);
+// ////i4/*43q*/_i(/*43*/"hello");
+// ////class c {
+// ////    public /*93*/prop1(a: number): number;
+// ////    public /*94*/prop1(b: string): number;
+// ////    public /*95*/prop1(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop2 1*/
+// ////    public /*96*/prop2(a: number): number;
+// ////    public /*97*/prop2(b: string): number;
+// ////    public /*98*/prop2(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    public /*99*/prop3(a: number): number;
+// ////    /** prop3 2*/
+// ////    public /*100*/prop3(b: string): number;
+// ////    public /*101*/prop3(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop4 1*/
+// ////    public /*102*/prop4(a: number): number;
+// ////    /** prop4 2*/
+// ////    public /*103*/prop4(b: string): number;
+// ////    public /*104*/prop4(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop5 1*/
+// ////    public /*105*/prop5(a: number): number;
+// ////    /** prop5 2*/
+// ////    public /*106*/prop5(b: string): number;
+// ////    /** Prop5 implementaion*/
+// ////    public /*107*/prop5(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////}
+// ////class c1 {
+// ////    /*78*/constructor(a: number);
+// ////    /*79*/constructor(b: string);
+// ////    /*80*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c2 {
+// ////    /** c2 1*/
+// ////    /*81*/constructor(a: number);
+// ////    /*82*/constructor(b: string);
+// ////    /*83*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c3 {
+// ////    /*84*/constructor(a: number);
+// ////    /** c3 2*/
+// ////    /*85*/constructor(b: string);
+// ////    /*86*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c4 {
+// ////    /** c4 1*/
+// ////    /*87*/constructor(a: number);
+// ////    /** c4 2*/
+// ////    /*88*/constructor(b: string);
+// ////    /*89*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c5 {
+// ////    /** c5 1*/
+// ////    /*90*/constructor(a: number);
+// ////    /** c5 2*/
+// ////    /*91*/constructor(b: string);
+// ////    /** c5 implementation*/
+// ////    /*92*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////var c_i = new c();
+// ////c_i./*44*/pro/*45q*/p1(/*45*/10);
+// ////c_i.pr/*46q*/op1(/*46*/"hello");
+// ////c_i.pr/*47q*/op2(/*47*/10);
+// ////c_i.pr/*48q*/op2(/*48*/"hello");
+// ////c_i.pro/*49q*/p3(/*49*/10);
+// ////c_i.pr/*50q*/op3(/*50*/"hello");
+// ////c_i.pr/*51q*/op4(/*51*/10);
+// ////c_i.pr/*52q*/op4(/*52*/"hello");
+// ////c_i.pr/*53q*/op5(/*53*/10);
+// ////c_i.pr/*54q*/op5(/*54*/"hello");
+// ////var c1/*66*/_i_1 = new c/*55q*/1(/*55*/10);
+// ////var c1_i_2 = new c/*56q*/1(/*56*/"hello");
+// ////var c2_i_1 = new c/*57q*/2(/*57*/10);
+// ////var c/*67*/2_i_2 = new c/*58q*/2(/*58*/"hello");
+// ////var c3_i_1 = new c/*59q*/3(/*59*/10);
+// ////var c/*68*/3_i_2 = new c/*60q*/3(/*60*/"hello");
+// ////var c4/*69*/_i_1 = new c/*61q*/4(/*61*/10);
+// ////var c4_i_2 = new c/*62q*/4(/*62*/"hello");
+// ////var c/*70*/5_i_1 = new c/*63q*/5(/*63*/10);
+// ////var c5_i_2 = new c/*64q*/5(/*64*/"hello");
+// /////** This is multiOverload F1 1*/
+// ////function multiOverload(a: number): string;
+// /////** This is multiOverload F1 2*/
+// ////function multiOverload(b: string): string;
+// /////** This is multiOverload F1 3*/
+// ////function multiOverload(c: boolean): string;
+// /////** This is multiOverload Implementation */
+// ////function multiOverload(d): string {
+// ////    return "Hello";
+// ////}
+// ////multiOverl/*71*/oad(10);
+// ////multiOverl/*72*/oad("hello");
+// ////multiOverl/*73*/oad(true);
+// /////** This is ambient F1 1*/
+// ////declare function ambientF1(a: number): string;
+// /////** This is ambient F1 2*/
+// ////declare function ambientF1(b: string): string;
+// /////** This is ambient F1 3*/
+// ////declare function ambientF1(c: boolean): boolean;
+// /////*65*/
+// ////ambient/*74*/F1(10);
+// ////ambient/*75*/F1("hello");
+// ////ambient/*76*/F1(true);
+// ////function foo(a/*77*/a: i3) {
+// ////}
+// ////foo(null);
+
+// verify.quickInfos({
+//     1: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+//     2: "function f1(b: string): number (+1 overload)",
+//     3: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+//     "4q": "function f1(b: string): number (+1 overload)",
+//     o4q: ["function f1(a: number): number (+1 overload)", "this is signature 1"]
+// });
+
+// goTo.marker('4');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// goTo.marker('o4');
+// verify.currentSignatureHelpDocCommentIs("this is signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// verify.quickInfos({
+//     5: "function f2(a: number): number (+1 overload)",
+//     6: ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+//     7: "function f2(a: number): number (+1 overload)",
+//     "8q": ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+//     o8q: "function f2(a: number): number (+1 overload)"
+// });
+
+// goTo.marker('8');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o8');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// verify.quickInfos({
+//     9: "function f3(a: number): number (+1 overload)",
+//     10: "function f3(b: string): number (+1 overload)",
+//     11: "function f3(a: number): number (+1 overload)",
+//     "12q": "function f3(b: string): number (+1 overload)",
+//     o12q: "function f3(a: number): number (+1 overload)"
+// });
+
+// goTo.marker('12');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o12');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// verify.quickInfos({
+//     13: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+//     14: ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+//     15: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+//     "16q": ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+//     o16q: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"]
+// });
+
+// goTo.marker('16');
+// verify.currentSignatureHelpDocCommentIs("this is signature 4 - with string parameter");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o16');
+// verify.currentSignatureHelpDocCommentIs("this is signature 4 - with number parameter");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// goTo.marker('17');
+// verify.completionListContains('f1', 'function f1(a: number): number (+1 overload)', 'this is signature 1');
+// verify.completionListContains('f2', 'function f2(a: number): number (+1 overload)', '');
+// verify.completionListContains('f3', 'function f3(a: number): number (+1 overload)', '');
+// verify.completionListContains('f4', 'function f4(a: number): number (+1 overload)', 'this is signature 4 - with number parameter');
+
+// goTo.marker('18');
+// verify.not.completionListContains('i1', 'interface i1', '');
+// verify.completionListContains('i1_i', 'var i1_i: new i1(b: number) => any (+1 overload)', '');
+// verify.not.completionListContains('i2', 'interface i2', '');
+// verify.completionListContains('i2_i', 'var i2_i: new i2(a: string) => any (+1 overload)', '');
+// verify.not.completionListContains('i3', 'interface i3', '');
+// verify.completionListContains('i3_i', 'var i3_i: new i3(a: string) => any (+1 overload)', 'new 1');
+// verify.not.completionListContains('i4', 'interface i4', '');
+// verify.completionListContains('i4_i', 'var i4_i: new i4(a: string) => any (+1 overload)', '');
+
+// goTo.marker('19');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("19q", "var i1_i: new i1(b: number) => any (+1 overload)");
+
+// goTo.marker('20');
+// verify.currentSignatureHelpDocCommentIs("new 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("20q", "var i1_i: new i1(a: string) => any (+1 overload)", "new 1");
+
+// goTo.marker('21');
+// verify.currentSignatureHelpDocCommentIs("this signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+// verify.quickInfoAt("21q", "var i1_i: i1(a: number) => number (+1 overload)", "this signature 1");
+
+// goTo.marker('22');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// goTo.marker('22q');
+// verify.quickInfoAt("22q", "var i1_i: i1(b: string) => number (+1 overload)", "this is signature 2");
+
+// goTo.marker('23');
+// verify.completionListContains('foo', '(method) i1.foo(a: number): number (+1 overload)', 'foo 1');
+// verify.completionListContains('foo2', '(method) i1.foo2(a: number): number (+1 overload)', '');
+// verify.completionListContains('foo3', '(method) i1.foo3(a: number): number (+1 overload)', '');
+// verify.completionListContains('foo4', '(method) i1.foo4(a: number): number (+1 overload)', 'foo4 1');
+
+// goTo.marker('24');
+// verify.currentSignatureHelpDocCommentIs("foo 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("24q", "(method) i1.foo(a: number): number (+1 overload)", "foo 1");
+
+// goTo.marker('25');
+// verify.currentSignatureHelpDocCommentIs("foo 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("25q", "(method) i1.foo(b: string): number (+1 overload)", "foo 2");
+
+// goTo.marker('26');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("26q", "(method) i1.foo2(a: number): number (+1 overload)");
+
+// goTo.marker('27');
+// verify.currentSignatureHelpDocCommentIs("foo2 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("27q", "(method) i1.foo2(b: string): number (+1 overload)", "foo2 2");
+
+// goTo.marker('28');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("28q", "(method) i1.foo3(a: number): number (+1 overload)");
+
+// goTo.marker('29');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("29q", "(method) i1.foo3(b: string): number (+1 overload)");
+
+// goTo.marker('30');
+// verify.currentSignatureHelpDocCommentIs("foo4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("30q", "(method) i1.foo4(a: number): number (+1 overload)", "foo4 1");
+
+// goTo.marker('31');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("31q", "(method) i1.foo4(b: string): number (+1 overload)");
+
+// goTo.marker('32');
+// verify.currentSignatureHelpDocCommentIs("new 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("32q", "var i2_i: new i2(b: number) => any (+1 overload)", "new 2");
+
+// goTo.marker('33');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("33q", "var i2_i: new i2(a: string) => any (+1 overload)");
+
+// goTo.marker('34');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("34q", "var i2_i: i2(a: number) => number (+1 overload)");
+
+// goTo.marker('35');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("35q", "var i2_i: i2(b: string) => number (+1 overload)", "this is signature 2");
+
+// goTo.marker('36');
+// verify.currentSignatureHelpDocCommentIs("new 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("36q", "var i3_i: new i3(b: number) => any (+1 overload)", "new 2");
+
+// goTo.marker('37');
+// verify.currentSignatureHelpDocCommentIs("new 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("37q", "var i3_i: new i3(a: string) => any (+1 overload)", "new 1");
+
+// goTo.marker('38');
+// verify.currentSignatureHelpDocCommentIs("this is signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("38q", "var i3_i: i3(a: number) => number (+1 overload)", "this is signature 1");
+
+// goTo.marker('39');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("39q", "var i3_i: i3(b: string) => number (+1 overload)");
+
+// goTo.marker('40');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("40q", "var i4_i: new i4(b: number) => any (+1 overload)");
+
+// goTo.marker('41');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("41q", "var i4_i: new i4(a: string) => any (+1 overload)");
+
+// goTo.marker('42');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("42q", "var i4_i: i4(a: number) => number (+1 overload)");
+
+// goTo.marker('43');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("43q", "var i4_i: i4(b: string) => number (+1 overload)");
+
+// goTo.marker('44');
+// verify.completionListContains('prop1', '(method) c.prop1(a: number): number (+1 overload)', '');
+// verify.completionListContains('prop2', '(method) c.prop2(a: number): number (+1 overload)', 'prop2 1');
+// verify.completionListContains('prop3', '(method) c.prop3(a: number): number (+1 overload)', '');
+// verify.completionListContains('prop4', '(method) c.prop4(a: number): number (+1 overload)', 'prop4 1');
+// verify.completionListContains('prop5', '(method) c.prop5(a: number): number (+1 overload)', 'prop5 1');
+
+// goTo.marker('45');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("45q", "(method) c.prop1(a: number): number (+1 overload)");
+
+// goTo.marker('46');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("46q", "(method) c.prop1(b: string): number (+1 overload)");
+
+// goTo.marker('47');
+// verify.currentSignatureHelpDocCommentIs("prop2 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("47q", "(method) c.prop2(a: number): number (+1 overload)", "prop2 1");
+
+// goTo.marker('48');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("48q", "(method) c.prop2(b: string): number (+1 overload)");
+
+// goTo.marker('49');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("49q", "(method) c.prop3(a: number): number (+1 overload)");
+
+// goTo.marker('50');
+// verify.currentSignatureHelpDocCommentIs("prop3 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("50q", "(method) c.prop3(b: string): number (+1 overload)", "prop3 2");
+
+// goTo.marker('51');
+// verify.currentSignatureHelpDocCommentIs("prop4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("51q", "(method) c.prop4(a: number): number (+1 overload)", "prop4 1");
+
+// goTo.marker('52');
+// verify.currentSignatureHelpDocCommentIs("prop4 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("52q", "(method) c.prop4(b: string): number (+1 overload)", "prop4 2");
+
+// goTo.marker('53');
+// verify.currentSignatureHelpDocCommentIs("prop5 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("53q", "(method) c.prop5(a: number): number (+1 overload)", "prop5 1");
+
+// goTo.marker('54');
+// verify.currentSignatureHelpDocCommentIs("prop5 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("54q", "(method) c.prop5(b: string): number (+1 overload)", "prop5 2");
+
+// goTo.marker('55');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("55q", "constructor c1(a: number): c1 (+1 overload)");
+
+// goTo.marker('56');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("56q", "constructor c1(b: string): c1 (+1 overload)");
+
+// goTo.marker('57');
+// verify.currentSignatureHelpDocCommentIs("c2 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("57q", "constructor c2(a: number): c2 (+1 overload)", "c2 1");
+
+// goTo.marker('58');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("58q", "constructor c2(b: string): c2 (+1 overload)");
+
+// goTo.marker('59');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("59q", "constructor c3(a: number): c3 (+1 overload)");
+
+// goTo.marker('60');
+// verify.currentSignatureHelpDocCommentIs("c3 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("60q", "constructor c3(b: string): c3 (+1 overload)", "c3 2");
+
+// goTo.marker('61');
+// verify.currentSignatureHelpDocCommentIs("c4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("61q", "constructor c4(a: number): c4 (+1 overload)", "c4 1");
+
+// goTo.marker('62');
+// verify.currentSignatureHelpDocCommentIs("c4 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("62q", "constructor c4(b: string): c4 (+1 overload)", "c4 2");
+
+// goTo.marker('63');
+// verify.currentSignatureHelpDocCommentIs("c5 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("63q", "constructor c5(a: number): c5 (+1 overload)", "c5 1");
+
+// goTo.marker('64');
+// verify.currentSignatureHelpDocCommentIs("c5 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("64q", "constructor c5(b: string): c5 (+1 overload)", "c5 2");
+
+// goTo.marker('65');
+// verify.completionListContains("c", "class c", "");
+// verify.completionListContains("c1", "class c1", "");
+// verify.completionListContains("c2", "class c2", "");
+// verify.completionListContains("c3", "class c3", "");
+// verify.completionListContains("c4", "class c4", "");
+// verify.completionListContains("c5", "class c5", "");
+// verify.completionListContains("c_i", "var c_i: c", "");
+// verify.completionListContains("c1_i_1", "var c1_i_1: c1", "");
+// verify.completionListContains("c2_i_1", "var c2_i_1: c2", "");
+// verify.completionListContains("c3_i_1", "var c3_i_1: c3", "");
+// verify.completionListContains("c4_i_1", "var c4_i_1: c4", "");
+// verify.completionListContains("c5_i_1", "var c5_i_1: c5", "");
+// verify.completionListContains("c1_i_2", "var c1_i_2: c1", "");
+// verify.completionListContains("c2_i_2", "var c2_i_2: c2", "");
+// verify.completionListContains("c3_i_2", "var c3_i_2: c3", "");
+// verify.completionListContains("c4_i_2", "var c4_i_2: c4", "");
+// verify.completionListContains("c5_i_2", "var c5_i_2: c5", "");
+// verify.completionListContains('multiOverload', 'function multiOverload(a: number): string (+2 overloads)', 'This is multiOverload F1 1');
+// verify.completionListContains('ambientF1', 'function ambientF1(a: number): string (+2 overloads)', 'This is ambient F1 1');
+
+// verify.quickInfos({
+//     66: "var c1_i_1: c1",
+//     67: "var c2_i_2: c2",
+//     68: "var c3_i_2: c3",
+//     69: "var c4_i_1: c4",
+//     70: "var c5_i_1: c5",
+//     71: ["function multiOverload(a: number): string (+2 overloads)", "This is multiOverload F1 1"],
+//     72: ["function multiOverload(b: string): string (+2 overloads)", "This is multiOverload F1 2"],
+//     73: ["function multiOverload(c: boolean): string (+2 overloads)", "This is multiOverload F1 3"],
+//     74: ["function ambientF1(a: number): string (+2 overloads)", "This is ambient F1 1"],
+//     75: ["function ambientF1(b: string): string (+2 overloads)", "This is ambient F1 2"],
+//     76: ["function ambientF1(c: boolean): boolean (+2 overloads)", "This is ambient F1 3"],
+//     77: "(parameter) aa: i3",
+//     78: "constructor c1(a: number): c1 (+1 overload)",
+//     79: "constructor c1(b: string): c1 (+1 overload)",
+//     80: "constructor c1(a: number): c1 (+1 overload)",
+//     81: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+//     82: "constructor c2(b: string): c2 (+1 overload)",
+//     83: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+//     84: "constructor c3(a: number): c3 (+1 overload)",
+//     85: ["constructor c3(b: string): c3 (+1 overload)", "c3 2"],
+//     86: "constructor c3(a: number): c3 (+1 overload)",
+//     87: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+//     88: ["constructor c4(b: string): c4 (+1 overload)", "c4 2"],
+//     89: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+//     90: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+//     91: ["constructor c5(b: string): c5 (+1 overload)", "c5 2"],
+//     92: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+//     93: "(method) c.prop1(a: number): number (+1 overload)",
+//     94: "(method) c.prop1(b: string): number (+1 overload)",
+//     95: "(method) c.prop1(a: number): number (+1 overload)",
+//     96: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+//     97: "(method) c.prop2(b: string): number (+1 overload)",
+//     98: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+//     99: "(method) c.prop3(a: number): number (+1 overload)",
+//     100: ["(method) c.prop3(b: string): number (+1 overload)", "prop3 2"],
+//     101: "(method) c.prop3(a: number): number (+1 overload)",
+//     102: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+//     103: ["(method) c.prop4(b: string): number (+1 overload)", "prop4 2"],
+//     104: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+//     105: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"],
+//     106: ["(method) c.prop5(b: string): number (+1 overload)", "prop5 2"],
+//     107: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"]
+// });
+// /// <reference path='fourslash.ts' />
+
+// /////** this is signature 1*/
+// ////function /*1*/f1(/**param a*/a: number): number;
+// ////function /*2*/f1(b: string): number;
+// ////function /*3*/f1(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*4q*/1(/*4*/"hello");
+// ////f/*o4q*/1(/*o4*/10);
+// ////function /*5*/f2(/**param a*/a: number): number;
+// /////** this is signature 2*/
+// ////function /*6*/f2(b: string): number;
+// /////** this is f2 var comment*/
+// ////function /*7*/f2(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*8q*/2(/*8*/"hello");
+// ////f/*o8q*/2(/*o8*/10);
+// ////function /*9*/f3(a: number): number;
+// ////function /*10*/f3(b: string): number;
+// ////function /*11*/f3(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*12q*/3(/*12*/"hello");
+// ////f/*o12q*/3(/*o12*/10);
+// /////** this is signature 4 - with number parameter*/
+// ////function /*13*/f4(/**param a*/a: number): number;
+// /////** this is signature 4 - with string parameter*/
+// ////function /*14*/f4(b: string): number;
+// ////function /*15*/f4(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*16q*/4(/*16*/"hello");
+// ////f/*o16q*/4(/*o16*/10);
+// /////*17*/
+// ////interface i1 {
+// ////    /**this signature 1*/
+// ////    (/**param a*/ a: number): number;
+// ////    /**this is signature 2*/
+// ////    (b: string): number;
+// ////    /** foo 1*/
+// ////    foo(a: number): number;
+// ////    /** foo 2*/
+// ////    foo(b: string): number;
+// ////    foo2(a: number): number;
+// ////    /** foo2 2*/
+// ////    foo2(b: string): number;
+// ////    foo3(a: number): number;
+// ////    foo3(b: string): number;
+// ////    /** foo4 1*/
+// ////    foo4(a: number): number;
+// ////    foo4(b: string): number;
+// ////    /** new 1*/
+// ////    new (a: string);
+// ////    new (b: number);
+// ////}
+// ////var i1_i: i1;
+// ////interface i2 {
+// ////    new (a: string);
+// ////    /** new 2*/
+// ////    new (b: number);
+// ////    (a: number): number;
+// ////    /**this is signature 2*/
+// ////    (b: string): number;
+// ////}
+// ////var i2_i: i2;
+// ////interface i3 {
+// ////    /** new 1*/
+// ////    new (a: string);
+// ////    /** new 2*/
+// ////    new (b: number);
+// ////    /**this is signature 1*/
+// ////    (a: number): number;
+// ////    (b: string): number;
+// ////}
+// ////var i3_i: i3;
+// ////interface i4 {
+// ////    new (a: string);
+// ////    new (b: number);
+// ////    (a: number): number;
+// ////    (b: string): number;
+// ////}
+// ////var i4_i: i4;
+// ////new /*18*/i1/*19q*/_i(/*19*/10);
+// ////new i/*20q*/1_i(/*20*/"Hello");
+// ////i/*21q*/1_i(/*21*/10);
+// ////i/*22q*/1_i(/*22*/"hello");
+// ////i1_i./*23*/f/*24q*/oo(/*24*/10);
+// ////i1_i.f/*25q*/oo(/*25*/"hello");
+// ////i1_i.fo/*26q*/o2(/*26*/10);
+// ////i1_i.fo/*27q*/o2(/*27*/"hello");
+// ////i1_i.fo/*28q*/o3(/*28*/10);
+// ////i1_i.fo/*29q*/o3(/*29*/"hello");
+// ////i1_i.fo/*30q*/o4(/*30*/10);
+// ////i1_i.fo/*31q*/o4(/*31*/"hello");
+// ////new i2/*32q*/_i(/*32*/10);
+// ////new i2/*33q*/_i(/*33*/"Hello");
+// ////i/*34q*/2_i(/*34*/10);
+// ////i2/*35q*/_i(/*35*/"hello");
+// ////new i/*36q*/3_i(/*36*/10);
+// ////new i3/*37q*/_i(/*37*/"Hello");
+// ////i3/*38q*/_i(/*38*/10);
+// ////i3/*39q*/_i(/*39*/"hello");
+// ////new i4/*40q*/_i(/*40*/10);
+// ////new i/*41q*/4_i(/*41*/"Hello");
+// ////i4/*42q*/_i(/*42*/10);
+// ////i4/*43q*/_i(/*43*/"hello");
+// ////class c {
+// ////    public /*93*/prop1(a: number): number;
+// ////    public /*94*/prop1(b: string): number;
+// ////    public /*95*/prop1(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop2 1*/
+// ////    public /*96*/prop2(a: number): number;
+// ////    public /*97*/prop2(b: string): number;
+// ////    public /*98*/prop2(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    public /*99*/prop3(a: number): number;
+// ////    /** prop3 2*/
+// ////    public /*100*/prop3(b: string): number;
+// ////    public /*101*/prop3(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop4 1*/
+// ////    public /*102*/prop4(a: number): number;
+// ////    /** prop4 2*/
+// ////    public /*103*/prop4(b: string): number;
+// ////    public /*104*/prop4(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop5 1*/
+// ////    public /*105*/prop5(a: number): number;
+// ////    /** prop5 2*/
+// ////    public /*106*/prop5(b: string): number;
+// ////    /** Prop5 implementaion*/
+// ////    public /*107*/prop5(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////}
+// ////class c1 {
+// ////    /*78*/constructor(a: number);
+// ////    /*79*/constructor(b: string);
+// ////    /*80*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c2 {
+// ////    /** c2 1*/
+// ////    /*81*/constructor(a: number);
+// ////    /*82*/constructor(b: string);
+// ////    /*83*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c3 {
+// ////    /*84*/constructor(a: number);
+// ////    /** c3 2*/
+// ////    /*85*/constructor(b: string);
+// ////    /*86*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c4 {
+// ////    /** c4 1*/
+// ////    /*87*/constructor(a: number);
+// ////    /** c4 2*/
+// ////    /*88*/constructor(b: string);
+// ////    /*89*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c5 {
+// ////    /** c5 1*/
+// ////    /*90*/constructor(a: number);
+// ////    /** c5 2*/
+// ////    /*91*/constructor(b: string);
+// ////    /** c5 implementation*/
+// ////    /*92*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////var c_i = new c();
+// ////c_i./*44*/pro/*45q*/p1(/*45*/10);
+// ////c_i.pr/*46q*/op1(/*46*/"hello");
+// ////c_i.pr/*47q*/op2(/*47*/10);
+// ////c_i.pr/*48q*/op2(/*48*/"hello");
+// ////c_i.pro/*49q*/p3(/*49*/10);
+// ////c_i.pr/*50q*/op3(/*50*/"hello");
+// ////c_i.pr/*51q*/op4(/*51*/10);
+// ////c_i.pr/*52q*/op4(/*52*/"hello");
+// ////c_i.pr/*53q*/op5(/*53*/10);
+// ////c_i.pr/*54q*/op5(/*54*/"hello");
+// ////var c1/*66*/_i_1 = new c/*55q*/1(/*55*/10);
+// ////var c1_i_2 = new c/*56q*/1(/*56*/"hello");
+// ////var c2_i_1 = new c/*57q*/2(/*57*/10);
+// ////var c/*67*/2_i_2 = new c/*58q*/2(/*58*/"hello");
+// ////var c3_i_1 = new c/*59q*/3(/*59*/10);
+// ////var c/*68*/3_i_2 = new c/*60q*/3(/*60*/"hello");
+// ////var c4/*69*/_i_1 = new c/*61q*/4(/*61*/10);
+// ////var c4_i_2 = new c/*62q*/4(/*62*/"hello");
+// ////var c/*70*/5_i_1 = new c/*63q*/5(/*63*/10);
+// ////var c5_i_2 = new c/*64q*/5(/*64*/"hello");
+// /////** This is multiOverload F1 1*/
+// ////function multiOverload(a: number): string;
+// /////** This is multiOverload F1 2*/
+// ////function multiOverload(b: string): string;
+// /////** This is multiOverload F1 3*/
+// ////function multiOverload(c: boolean): string;
+// /////** This is multiOverload Implementation */
+// ////function multiOverload(d): string {
+// ////    return "Hello";
+// ////}
+// ////multiOverl/*71*/oad(10);
+// ////multiOverl/*72*/oad("hello");
+// ////multiOverl/*73*/oad(true);
+// /////** This is ambient F1 1*/
+// ////declare function ambientF1(a: number): string;
+// /////** This is ambient F1 2*/
+// ////declare function ambientF1(b: string): string;
+// /////** This is ambient F1 3*/
+// ////declare function ambientF1(c: boolean): boolean;
+// /////*65*/
+// ////ambient/*74*/F1(10);
+// ////ambient/*75*/F1("hello");
+// ////ambient/*76*/F1(true);
+// ////function foo(a/*77*/a: i3) {
+// ////}
+// ////foo(null);
+
+// verify.quickInfos({
+//     1: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+//     2: "function f1(b: string): number (+1 overload)",
+//     3: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+//     "4q": "function f1(b: string): number (+1 overload)",
+//     o4q: ["function f1(a: number): number (+1 overload)", "this is signature 1"]
+// });
+
+// goTo.marker('4');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// goTo.marker('o4');
+// verify.currentSignatureHelpDocCommentIs("this is signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// verify.quickInfos({
+//     5: "function f2(a: number): number (+1 overload)",
+//     6: ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+//     7: "function f2(a: number): number (+1 overload)",
+//     "8q": ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+//     o8q: "function f2(a: number): number (+1 overload)"
+// });
+
+// goTo.marker('8');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o8');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// verify.quickInfos({
+//     9: "function f3(a: number): number (+1 overload)",
+//     10: "function f3(b: string): number (+1 overload)",
+//     11: "function f3(a: number): number (+1 overload)",
+//     "12q": "function f3(b: string): number (+1 overload)",
+//     o12q: "function f3(a: number): number (+1 overload)"
+// });
+
+// goTo.marker('12');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o12');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// verify.quickInfos({
+//     13: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+//     14: ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+//     15: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+//     "16q": ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+//     o16q: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"]
+// });
+
+// goTo.marker('16');
+// verify.currentSignatureHelpDocCommentIs("this is signature 4 - with string parameter");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o16');
+// verify.currentSignatureHelpDocCommentIs("this is signature 4 - with number parameter");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// goTo.marker('17');
+// verify.completionListContains('f1', 'function f1(a: number): number (+1 overload)', 'this is signature 1');
+// verify.completionListContains('f2', 'function f2(a: number): number (+1 overload)', '');
+// verify.completionListContains('f3', 'function f3(a: number): number (+1 overload)', '');
+// verify.completionListContains('f4', 'function f4(a: number): number (+1 overload)', 'this is signature 4 - with number parameter');
+
+// goTo.marker('18');
+// verify.not.completionListContains('i1', 'interface i1', '');
+// verify.completionListContains('i1_i', 'var i1_i: new i1(b: number) => any (+1 overload)', '');
+// verify.not.completionListContains('i2', 'interface i2', '');
+// verify.completionListContains('i2_i', 'var i2_i: new i2(a: string) => any (+1 overload)', '');
+// verify.not.completionListContains('i3', 'interface i3', '');
+// verify.completionListContains('i3_i', 'var i3_i: new i3(a: string) => any (+1 overload)', 'new 1');
+// verify.not.completionListContains('i4', 'interface i4', '');
+// verify.completionListContains('i4_i', 'var i4_i: new i4(a: string) => any (+1 overload)', '');
+
+// goTo.marker('19');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("19q", "var i1_i: new i1(b: number) => any (+1 overload)");
+
+// goTo.marker('20');
+// verify.currentSignatureHelpDocCommentIs("new 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("20q", "var i1_i: new i1(a: string) => any (+1 overload)", "new 1");
+
+// goTo.marker('21');
+// verify.currentSignatureHelpDocCommentIs("this signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+// verify.quickInfoAt("21q", "var i1_i: i1(a: number) => number (+1 overload)", "this signature 1");
+
+// goTo.marker('22');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// goTo.marker('22q');
+// verify.quickInfoAt("22q", "var i1_i: i1(b: string) => number (+1 overload)", "this is signature 2");
+
+// goTo.marker('23');
+// verify.completionListContains('foo', '(method) i1.foo(a: number): number (+1 overload)', 'foo 1');
+// verify.completionListContains('foo2', '(method) i1.foo2(a: number): number (+1 overload)', '');
+// verify.completionListContains('foo3', '(method) i1.foo3(a: number): number (+1 overload)', '');
+// verify.completionListContains('foo4', '(method) i1.foo4(a: number): number (+1 overload)', 'foo4 1');
+
+// goTo.marker('24');
+// verify.currentSignatureHelpDocCommentIs("foo 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("24q", "(method) i1.foo(a: number): number (+1 overload)", "foo 1");
+
+// goTo.marker('25');
+// verify.currentSignatureHelpDocCommentIs("foo 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("25q", "(method) i1.foo(b: string): number (+1 overload)", "foo 2");
+
+// goTo.marker('26');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("26q", "(method) i1.foo2(a: number): number (+1 overload)");
+
+// goTo.marker('27');
+// verify.currentSignatureHelpDocCommentIs("foo2 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("27q", "(method) i1.foo2(b: string): number (+1 overload)", "foo2 2");
+
+// goTo.marker('28');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("28q", "(method) i1.foo3(a: number): number (+1 overload)");
+
+// goTo.marker('29');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("29q", "(method) i1.foo3(b: string): number (+1 overload)");
+
+// goTo.marker('30');
+// verify.currentSignatureHelpDocCommentIs("foo4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("30q", "(method) i1.foo4(a: number): number (+1 overload)", "foo4 1");
+
+// goTo.marker('31');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("31q", "(method) i1.foo4(b: string): number (+1 overload)");
+
+// goTo.marker('32');
+// verify.currentSignatureHelpDocCommentIs("new 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("32q", "var i2_i: new i2(b: number) => any (+1 overload)", "new 2");
+
+// goTo.marker('33');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("33q", "var i2_i: new i2(a: string) => any (+1 overload)");
+
+// goTo.marker('34');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("34q", "var i2_i: i2(a: number) => number (+1 overload)");
+
+// goTo.marker('35');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("35q", "var i2_i: i2(b: string) => number (+1 overload)", "this is signature 2");
+
+// goTo.marker('36');
+// verify.currentSignatureHelpDocCommentIs("new 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("36q", "var i3_i: new i3(b: number) => any (+1 overload)", "new 2");
+
+// goTo.marker('37');
+// verify.currentSignatureHelpDocCommentIs("new 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("37q", "var i3_i: new i3(a: string) => any (+1 overload)", "new 1");
+
+// goTo.marker('38');
+// verify.currentSignatureHelpDocCommentIs("this is signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("38q", "var i3_i: i3(a: number) => number (+1 overload)", "this is signature 1");
+
+// goTo.marker('39');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("39q", "var i3_i: i3(b: string) => number (+1 overload)");
+
+// goTo.marker('40');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("40q", "var i4_i: new i4(b: number) => any (+1 overload)");
+
+// goTo.marker('41');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("41q", "var i4_i: new i4(a: string) => any (+1 overload)");
+
+// goTo.marker('42');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("42q", "var i4_i: i4(a: number) => number (+1 overload)");
+
+// goTo.marker('43');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("43q", "var i4_i: i4(b: string) => number (+1 overload)");
+
+// goTo.marker('44');
+// verify.completionListContains('prop1', '(method) c.prop1(a: number): number (+1 overload)', '');
+// verify.completionListContains('prop2', '(method) c.prop2(a: number): number (+1 overload)', 'prop2 1');
+// verify.completionListContains('prop3', '(method) c.prop3(a: number): number (+1 overload)', '');
+// verify.completionListContains('prop4', '(method) c.prop4(a: number): number (+1 overload)', 'prop4 1');
+// verify.completionListContains('prop5', '(method) c.prop5(a: number): number (+1 overload)', 'prop5 1');
+
+// goTo.marker('45');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("45q", "(method) c.prop1(a: number): number (+1 overload)");
+
+// goTo.marker('46');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("46q", "(method) c.prop1(b: string): number (+1 overload)");
+
+// goTo.marker('47');
+// verify.currentSignatureHelpDocCommentIs("prop2 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("47q", "(method) c.prop2(a: number): number (+1 overload)", "prop2 1");
+
+// goTo.marker('48');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("48q", "(method) c.prop2(b: string): number (+1 overload)");
+
+// goTo.marker('49');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("49q", "(method) c.prop3(a: number): number (+1 overload)");
+
+// goTo.marker('50');
+// verify.currentSignatureHelpDocCommentIs("prop3 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("50q", "(method) c.prop3(b: string): number (+1 overload)", "prop3 2");
+
+// goTo.marker('51');
+// verify.currentSignatureHelpDocCommentIs("prop4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("51q", "(method) c.prop4(a: number): number (+1 overload)", "prop4 1");
+
+// goTo.marker('52');
+// verify.currentSignatureHelpDocCommentIs("prop4 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("52q", "(method) c.prop4(b: string): number (+1 overload)", "prop4 2");
+
+// goTo.marker('53');
+// verify.currentSignatureHelpDocCommentIs("prop5 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("53q", "(method) c.prop5(a: number): number (+1 overload)", "prop5 1");
+
+// goTo.marker('54');
+// verify.currentSignatureHelpDocCommentIs("prop5 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("54q", "(method) c.prop5(b: string): number (+1 overload)", "prop5 2");
+
+// goTo.marker('55');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("55q", "constructor c1(a: number): c1 (+1 overload)");
+
+// goTo.marker('56');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("56q", "constructor c1(b: string): c1 (+1 overload)");
+
+// goTo.marker('57');
+// verify.currentSignatureHelpDocCommentIs("c2 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("57q", "constructor c2(a: number): c2 (+1 overload)", "c2 1");
+
+// goTo.marker('58');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("58q", "constructor c2(b: string): c2 (+1 overload)");
+
+// goTo.marker('59');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("59q", "constructor c3(a: number): c3 (+1 overload)");
+
+// goTo.marker('60');
+// verify.currentSignatureHelpDocCommentIs("c3 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("60q", "constructor c3(b: string): c3 (+1 overload)", "c3 2");
+
+// goTo.marker('61');
+// verify.currentSignatureHelpDocCommentIs("c4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("61q", "constructor c4(a: number): c4 (+1 overload)", "c4 1");
+
+// goTo.marker('62');
+// verify.currentSignatureHelpDocCommentIs("c4 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("62q", "constructor c4(b: string): c4 (+1 overload)", "c4 2");
+
+// goTo.marker('63');
+// verify.currentSignatureHelpDocCommentIs("c5 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("63q", "constructor c5(a: number): c5 (+1 overload)", "c5 1");
+
+// goTo.marker('64');
+// verify.currentSignatureHelpDocCommentIs("c5 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("64q", "constructor c5(b: string): c5 (+1 overload)", "c5 2");
+
+// goTo.marker('65');
+// verify.completionListContains("c", "class c", "");
+// verify.completionListContains("c1", "class c1", "");
+// verify.completionListContains("c2", "class c2", "");
+// verify.completionListContains("c3", "class c3", "");
+// verify.completionListContains("c4", "class c4", "");
+// verify.completionListContains("c5", "class c5", "");
+// verify.completionListContains("c_i", "var c_i: c", "");
+// verify.completionListContains("c1_i_1", "var c1_i_1: c1", "");
+// verify.completionListContains("c2_i_1", "var c2_i_1: c2", "");
+// verify.completionListContains("c3_i_1", "var c3_i_1: c3", "");
+// verify.completionListContains("c4_i_1", "var c4_i_1: c4", "");
+// verify.completionListContains("c5_i_1", "var c5_i_1: c5", "");
+// verify.completionListContains("c1_i_2", "var c1_i_2: c1", "");
+// verify.completionListContains("c2_i_2", "var c2_i_2: c2", "");
+// verify.completionListContains("c3_i_2", "var c3_i_2: c3", "");
+// verify.completionListContains("c4_i_2", "var c4_i_2: c4", "");
+// verify.completionListContains("c5_i_2", "var c5_i_2: c5", "");
+// verify.completionListContains('multiOverload', 'function multiOverload(a: number): string (+2 overloads)', 'This is multiOverload F1 1');
+// verify.completionListContains('ambientF1', 'function ambientF1(a: number): string (+2 overloads)', 'This is ambient F1 1');
+
+// verify.quickInfos({
+//     66: "var c1_i_1: c1",
+//     67: "var c2_i_2: c2",
+//     68: "var c3_i_2: c3",
+//     69: "var c4_i_1: c4",
+//     70: "var c5_i_1: c5",
+//     71: ["function multiOverload(a: number): string (+2 overloads)", "This is multiOverload F1 1"],
+//     72: ["function multiOverload(b: string): string (+2 overloads)", "This is multiOverload F1 2"],
+//     73: ["function multiOverload(c: boolean): string (+2 overloads)", "This is multiOverload F1 3"],
+//     74: ["function ambientF1(a: number): string (+2 overloads)", "This is ambient F1 1"],
+//     75: ["function ambientF1(b: string): string (+2 overloads)", "This is ambient F1 2"],
+//     76: ["function ambientF1(c: boolean): boolean (+2 overloads)", "This is ambient F1 3"],
+//     77: "(parameter) aa: i3",
+//     78: "constructor c1(a: number): c1 (+1 overload)",
+//     79: "constructor c1(b: string): c1 (+1 overload)",
+//     80: "constructor c1(a: number): c1 (+1 overload)",
+//     81: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+//     82: "constructor c2(b: string): c2 (+1 overload)",
+//     83: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+//     84: "constructor c3(a: number): c3 (+1 overload)",
+//     85: ["constructor c3(b: string): c3 (+1 overload)", "c3 2"],
+//     86: "constructor c3(a: number): c3 (+1 overload)",
+//     87: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+//     88: ["constructor c4(b: string): c4 (+1 overload)", "c4 2"],
+//     89: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+//     90: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+//     91: ["constructor c5(b: string): c5 (+1 overload)", "c5 2"],
+//     92: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+//     93: "(method) c.prop1(a: number): number (+1 overload)",
+//     94: "(method) c.prop1(b: string): number (+1 overload)",
+//     95: "(method) c.prop1(a: number): number (+1 overload)",
+//     96: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+//     97: "(method) c.prop2(b: string): number (+1 overload)",
+//     98: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+//     99: "(method) c.prop3(a: number): number (+1 overload)",
+//     100: ["(method) c.prop3(b: string): number (+1 overload)", "prop3 2"],
+//     101: "(method) c.prop3(a: number): number (+1 overload)",
+//     102: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+//     103: ["(method) c.prop4(b: string): number (+1 overload)", "prop4 2"],
+//     104: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+//     105: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"],
+//     106: ["(method) c.prop5(b: string): number (+1 overload)", "prop5 2"],
+//     107: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"]
+// });
+// /// <reference path='fourslash.ts' />
+
+// /////** this is signature 1*/
+// ////function /*1*/f1(/**param a*/a: number): number;
+// ////function /*2*/f1(b: string): number;
+// ////function /*3*/f1(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*4q*/1(/*4*/"hello");
+// ////f/*o4q*/1(/*o4*/10);
+// ////function /*5*/f2(/**param a*/a: number): number;
+// /////** this is signature 2*/
+// ////function /*6*/f2(b: string): number;
+// /////** this is f2 var comment*/
+// ////function /*7*/f2(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*8q*/2(/*8*/"hello");
+// ////f/*o8q*/2(/*o8*/10);
+// ////function /*9*/f3(a: number): number;
+// ////function /*10*/f3(b: string): number;
+// ////function /*11*/f3(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*12q*/3(/*12*/"hello");
+// ////f/*o12q*/3(/*o12*/10);
+// /////** this is signature 4 - with number parameter*/
+// ////function /*13*/f4(/**param a*/a: number): number;
+// /////** this is signature 4 - with string parameter*/
+// ////function /*14*/f4(b: string): number;
+// ////function /*15*/f4(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*16q*/4(/*16*/"hello");
+// ////f/*o16q*/4(/*o16*/10);
+// /////*17*/
+// ////interface i1 {
+// ////    /**this signature 1*/
+// ////    (/**param a*/ a: number): number;
+// ////    /**this is signature 2*/
+// ////    (b: string): number;
+// ////    /** foo 1*/
+// ////    foo(a: number): number;
+// ////    /** foo 2*/
+// ////    foo(b: string): number;
+// ////    foo2(a: number): number;
+// ////    /** foo2 2*/
+// ////    foo2(b: string): number;
+// ////    foo3(a: number): number;
+// ////    foo3(b: string): number;
+// ////    /** foo4 1*/
+// ////    foo4(a: number): number;
+// ////    foo4(b: string): number;
+// ////    /** new 1*/
+// ////    new (a: string);
+// ////    new (b: number);
+// ////}
+// ////var i1_i: i1;
+// ////interface i2 {
+// ////    new (a: string);
+// ////    /** new 2*/
+// ////    new (b: number);
+// ////    (a: number): number;
+// ////    /**this is signature 2*/
+// ////    (b: string): number;
+// ////}
+// ////var i2_i: i2;
+// ////interface i3 {
+// ////    /** new 1*/
+// ////    new (a: string);
+// ////    /** new 2*/
+// ////    new (b: number);
+// ////    /**this is signature 1*/
+// ////    (a: number): number;
+// ////    (b: string): number;
+// ////}
+// ////var i3_i: i3;
+// ////interface i4 {
+// ////    new (a: string);
+// ////    new (b: number);
+// ////    (a: number): number;
+// ////    (b: string): number;
+// ////}
+// ////var i4_i: i4;
+// ////new /*18*/i1/*19q*/_i(/*19*/10);
+// ////new i/*20q*/1_i(/*20*/"Hello");
+// ////i/*21q*/1_i(/*21*/10);
+// ////i/*22q*/1_i(/*22*/"hello");
+// ////i1_i./*23*/f/*24q*/oo(/*24*/10);
+// ////i1_i.f/*25q*/oo(/*25*/"hello");
+// ////i1_i.fo/*26q*/o2(/*26*/10);
+// ////i1_i.fo/*27q*/o2(/*27*/"hello");
+// ////i1_i.fo/*28q*/o3(/*28*/10);
+// ////i1_i.fo/*29q*/o3(/*29*/"hello");
+// ////i1_i.fo/*30q*/o4(/*30*/10);
+// ////i1_i.fo/*31q*/o4(/*31*/"hello");
+// ////new i2/*32q*/_i(/*32*/10);
+// ////new i2/*33q*/_i(/*33*/"Hello");
+// ////i/*34q*/2_i(/*34*/10);
+// ////i2/*35q*/_i(/*35*/"hello");
+// ////new i/*36q*/3_i(/*36*/10);
+// ////new i3/*37q*/_i(/*37*/"Hello");
+// ////i3/*38q*/_i(/*38*/10);
+// ////i3/*39q*/_i(/*39*/"hello");
+// ////new i4/*40q*/_i(/*40*/10);
+// ////new i/*41q*/4_i(/*41*/"Hello");
+// ////i4/*42q*/_i(/*42*/10);
+// ////i4/*43q*/_i(/*43*/"hello");
+// ////class c {
+// ////    public /*93*/prop1(a: number): number;
+// ////    public /*94*/prop1(b: string): number;
+// ////    public /*95*/prop1(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop2 1*/
+// ////    public /*96*/prop2(a: number): number;
+// ////    public /*97*/prop2(b: string): number;
+// ////    public /*98*/prop2(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    public /*99*/prop3(a: number): number;
+// ////    /** prop3 2*/
+// ////    public /*100*/prop3(b: string): number;
+// ////    public /*101*/prop3(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop4 1*/
+// ////    public /*102*/prop4(a: number): number;
+// ////    /** prop4 2*/
+// ////    public /*103*/prop4(b: string): number;
+// ////    public /*104*/prop4(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop5 1*/
+// ////    public /*105*/prop5(a: number): number;
+// ////    /** prop5 2*/
+// ////    public /*106*/prop5(b: string): number;
+// ////    /** Prop5 implementaion*/
+// ////    public /*107*/prop5(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////}
+// ////class c1 {
+// ////    /*78*/constructor(a: number);
+// ////    /*79*/constructor(b: string);
+// ////    /*80*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c2 {
+// ////    /** c2 1*/
+// ////    /*81*/constructor(a: number);
+// ////    /*82*/constructor(b: string);
+// ////    /*83*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c3 {
+// ////    /*84*/constructor(a: number);
+// ////    /** c3 2*/
+// ////    /*85*/constructor(b: string);
+// ////    /*86*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c4 {
+// ////    /** c4 1*/
+// ////    /*87*/constructor(a: number);
+// ////    /** c4 2*/
+// ////    /*88*/constructor(b: string);
+// ////    /*89*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c5 {
+// ////    /** c5 1*/
+// ////    /*90*/constructor(a: number);
+// ////    /** c5 2*/
+// ////    /*91*/constructor(b: string);
+// ////    /** c5 implementation*/
+// ////    /*92*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////var c_i = new c();
+// ////c_i./*44*/pro/*45q*/p1(/*45*/10);
+// ////c_i.pr/*46q*/op1(/*46*/"hello");
+// ////c_i.pr/*47q*/op2(/*47*/10);
+// ////c_i.pr/*48q*/op2(/*48*/"hello");
+// ////c_i.pro/*49q*/p3(/*49*/10);
+// ////c_i.pr/*50q*/op3(/*50*/"hello");
+// ////c_i.pr/*51q*/op4(/*51*/10);
+// ////c_i.pr/*52q*/op4(/*52*/"hello");
+// ////c_i.pr/*53q*/op5(/*53*/10);
+// ////c_i.pr/*54q*/op5(/*54*/"hello");
+// ////var c1/*66*/_i_1 = new c/*55q*/1(/*55*/10);
+// ////var c1_i_2 = new c/*56q*/1(/*56*/"hello");
+// ////var c2_i_1 = new c/*57q*/2(/*57*/10);
+// ////var c/*67*/2_i_2 = new c/*58q*/2(/*58*/"hello");
+// ////var c3_i_1 = new c/*59q*/3(/*59*/10);
+// ////var c/*68*/3_i_2 = new c/*60q*/3(/*60*/"hello");
+// ////var c4/*69*/_i_1 = new c/*61q*/4(/*61*/10);
+// ////var c4_i_2 = new c/*62q*/4(/*62*/"hello");
+// ////var c/*70*/5_i_1 = new c/*63q*/5(/*63*/10);
+// ////var c5_i_2 = new c/*64q*/5(/*64*/"hello");
+// /////** This is multiOverload F1 1*/
+// ////function multiOverload(a: number): string;
+// /////** This is multiOverload F1 2*/
+// ////function multiOverload(b: string): string;
+// /////** This is multiOverload F1 3*/
+// ////function multiOverload(c: boolean): string;
+// /////** This is multiOverload Implementation */
+// ////function multiOverload(d): string {
+// ////    return "Hello";
+// ////}
+// ////multiOverl/*71*/oad(10);
+// ////multiOverl/*72*/oad("hello");
+// ////multiOverl/*73*/oad(true);
+// /////** This is ambient F1 1*/
+// ////declare function ambientF1(a: number): string;
+// /////** This is ambient F1 2*/
+// ////declare function ambientF1(b: string): string;
+// /////** This is ambient F1 3*/
+// ////declare function ambientF1(c: boolean): boolean;
+// /////*65*/
+// ////ambient/*74*/F1(10);
+// ////ambient/*75*/F1("hello");
+// ////ambient/*76*/F1(true);
+// ////function foo(a/*77*/a: i3) {
+// ////}
+// ////foo(null);
+
+// verify.quickInfos({
+//     1: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+//     2: "function f1(b: string): number (+1 overload)",
+//     3: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+//     "4q": "function f1(b: string): number (+1 overload)",
+//     o4q: ["function f1(a: number): number (+1 overload)", "this is signature 1"]
+// });
+
+// goTo.marker('4');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// goTo.marker('o4');
+// verify.currentSignatureHelpDocCommentIs("this is signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// verify.quickInfos({
+//     5: "function f2(a: number): number (+1 overload)",
+//     6: ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+//     7: "function f2(a: number): number (+1 overload)",
+//     "8q": ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+//     o8q: "function f2(a: number): number (+1 overload)"
+// });
+
+// goTo.marker('8');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o8');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// verify.quickInfos({
+//     9: "function f3(a: number): number (+1 overload)",
+//     10: "function f3(b: string): number (+1 overload)",
+//     11: "function f3(a: number): number (+1 overload)",
+//     "12q": "function f3(b: string): number (+1 overload)",
+//     o12q: "function f3(a: number): number (+1 overload)"
+// });
+
+// goTo.marker('12');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o12');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// verify.quickInfos({
+//     13: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+//     14: ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+//     15: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+//     "16q": ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+//     o16q: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"]
+// });
+
+// goTo.marker('16');
+// verify.currentSignatureHelpDocCommentIs("this is signature 4 - with string parameter");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o16');
+// verify.currentSignatureHelpDocCommentIs("this is signature 4 - with number parameter");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// goTo.marker('17');
+// verify.completionListContains('f1', 'function f1(a: number): number (+1 overload)', 'this is signature 1');
+// verify.completionListContains('f2', 'function f2(a: number): number (+1 overload)', '');
+// verify.completionListContains('f3', 'function f3(a: number): number (+1 overload)', '');
+// verify.completionListContains('f4', 'function f4(a: number): number (+1 overload)', 'this is signature 4 - with number parameter');
+
+// goTo.marker('18');
+// verify.not.completionListContains('i1', 'interface i1', '');
+// verify.completionListContains('i1_i', 'var i1_i: new i1(b: number) => any (+1 overload)', '');
+// verify.not.completionListContains('i2', 'interface i2', '');
+// verify.completionListContains('i2_i', 'var i2_i: new i2(a: string) => any (+1 overload)', '');
+// verify.not.completionListContains('i3', 'interface i3', '');
+// verify.completionListContains('i3_i', 'var i3_i: new i3(a: string) => any (+1 overload)', 'new 1');
+// verify.not.completionListContains('i4', 'interface i4', '');
+// verify.completionListContains('i4_i', 'var i4_i: new i4(a: string) => any (+1 overload)', '');
+
+// goTo.marker('19');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("19q", "var i1_i: new i1(b: number) => any (+1 overload)");
+
+// goTo.marker('20');
+// verify.currentSignatureHelpDocCommentIs("new 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("20q", "var i1_i: new i1(a: string) => any (+1 overload)", "new 1");
+
+// goTo.marker('21');
+// verify.currentSignatureHelpDocCommentIs("this signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+// verify.quickInfoAt("21q", "var i1_i: i1(a: number) => number (+1 overload)", "this signature 1");
+
+// goTo.marker('22');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// goTo.marker('22q');
+// verify.quickInfoAt("22q", "var i1_i: i1(b: string) => number (+1 overload)", "this is signature 2");
+
+// goTo.marker('23');
+// verify.completionListContains('foo', '(method) i1.foo(a: number): number (+1 overload)', 'foo 1');
+// verify.completionListContains('foo2', '(method) i1.foo2(a: number): number (+1 overload)', '');
+// verify.completionListContains('foo3', '(method) i1.foo3(a: number): number (+1 overload)', '');
+// verify.completionListContains('foo4', '(method) i1.foo4(a: number): number (+1 overload)', 'foo4 1');
+
+// goTo.marker('24');
+// verify.currentSignatureHelpDocCommentIs("foo 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("24q", "(method) i1.foo(a: number): number (+1 overload)", "foo 1");
+
+// goTo.marker('25');
+// verify.currentSignatureHelpDocCommentIs("foo 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("25q", "(method) i1.foo(b: string): number (+1 overload)", "foo 2");
+
+// goTo.marker('26');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("26q", "(method) i1.foo2(a: number): number (+1 overload)");
+
+// goTo.marker('27');
+// verify.currentSignatureHelpDocCommentIs("foo2 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("27q", "(method) i1.foo2(b: string): number (+1 overload)", "foo2 2");
+
+// goTo.marker('28');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("28q", "(method) i1.foo3(a: number): number (+1 overload)");
+
+// goTo.marker('29');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("29q", "(method) i1.foo3(b: string): number (+1 overload)");
+
+// goTo.marker('30');
+// verify.currentSignatureHelpDocCommentIs("foo4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("30q", "(method) i1.foo4(a: number): number (+1 overload)", "foo4 1");
+
+// goTo.marker('31');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("31q", "(method) i1.foo4(b: string): number (+1 overload)");
+
+// goTo.marker('32');
+// verify.currentSignatureHelpDocCommentIs("new 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("32q", "var i2_i: new i2(b: number) => any (+1 overload)", "new 2");
+
+// goTo.marker('33');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("33q", "var i2_i: new i2(a: string) => any (+1 overload)");
+
+// goTo.marker('34');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("34q", "var i2_i: i2(a: number) => number (+1 overload)");
+
+// goTo.marker('35');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("35q", "var i2_i: i2(b: string) => number (+1 overload)", "this is signature 2");
+
+// goTo.marker('36');
+// verify.currentSignatureHelpDocCommentIs("new 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("36q", "var i3_i: new i3(b: number) => any (+1 overload)", "new 2");
+
+// goTo.marker('37');
+// verify.currentSignatureHelpDocCommentIs("new 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("37q", "var i3_i: new i3(a: string) => any (+1 overload)", "new 1");
+
+// goTo.marker('38');
+// verify.currentSignatureHelpDocCommentIs("this is signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("38q", "var i3_i: i3(a: number) => number (+1 overload)", "this is signature 1");
+
+// goTo.marker('39');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("39q", "var i3_i: i3(b: string) => number (+1 overload)");
+
+// goTo.marker('40');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("40q", "var i4_i: new i4(b: number) => any (+1 overload)");
+
+// goTo.marker('41');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("41q", "var i4_i: new i4(a: string) => any (+1 overload)");
+
+// goTo.marker('42');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("42q", "var i4_i: i4(a: number) => number (+1 overload)");
+
+// goTo.marker('43');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("43q", "var i4_i: i4(b: string) => number (+1 overload)");
+
+// goTo.marker('44');
+// verify.completionListContains('prop1', '(method) c.prop1(a: number): number (+1 overload)', '');
+// verify.completionListContains('prop2', '(method) c.prop2(a: number): number (+1 overload)', 'prop2 1');
+// verify.completionListContains('prop3', '(method) c.prop3(a: number): number (+1 overload)', '');
+// verify.completionListContains('prop4', '(method) c.prop4(a: number): number (+1 overload)', 'prop4 1');
+// verify.completionListContains('prop5', '(method) c.prop5(a: number): number (+1 overload)', 'prop5 1');
+
+// goTo.marker('45');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("45q", "(method) c.prop1(a: number): number (+1 overload)");
+
+// goTo.marker('46');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("46q", "(method) c.prop1(b: string): number (+1 overload)");
+
+// goTo.marker('47');
+// verify.currentSignatureHelpDocCommentIs("prop2 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("47q", "(method) c.prop2(a: number): number (+1 overload)", "prop2 1");
+
+// goTo.marker('48');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("48q", "(method) c.prop2(b: string): number (+1 overload)");
+
+// goTo.marker('49');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("49q", "(method) c.prop3(a: number): number (+1 overload)");
+
+// goTo.marker('50');
+// verify.currentSignatureHelpDocCommentIs("prop3 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("50q", "(method) c.prop3(b: string): number (+1 overload)", "prop3 2");
+
+// goTo.marker('51');
+// verify.currentSignatureHelpDocCommentIs("prop4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("51q", "(method) c.prop4(a: number): number (+1 overload)", "prop4 1");
+
+// goTo.marker('52');
+// verify.currentSignatureHelpDocCommentIs("prop4 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("52q", "(method) c.prop4(b: string): number (+1 overload)", "prop4 2");
+
+// goTo.marker('53');
+// verify.currentSignatureHelpDocCommentIs("prop5 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("53q", "(method) c.prop5(a: number): number (+1 overload)", "prop5 1");
+
+// goTo.marker('54');
+// verify.currentSignatureHelpDocCommentIs("prop5 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("54q", "(method) c.prop5(b: string): number (+1 overload)", "prop5 2");
+
+// goTo.marker('55');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("55q", "constructor c1(a: number): c1 (+1 overload)");
+
+// goTo.marker('56');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("56q", "constructor c1(b: string): c1 (+1 overload)");
+
+// goTo.marker('57');
+// verify.currentSignatureHelpDocCommentIs("c2 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("57q", "constructor c2(a: number): c2 (+1 overload)", "c2 1");
+
+// goTo.marker('58');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("58q", "constructor c2(b: string): c2 (+1 overload)");
+
+// goTo.marker('59');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("59q", "constructor c3(a: number): c3 (+1 overload)");
+
+// goTo.marker('60');
+// verify.currentSignatureHelpDocCommentIs("c3 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("60q", "constructor c3(b: string): c3 (+1 overload)", "c3 2");
+
+// goTo.marker('61');
+// verify.currentSignatureHelpDocCommentIs("c4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("61q", "constructor c4(a: number): c4 (+1 overload)", "c4 1");
+
+// goTo.marker('62');
+// verify.currentSignatureHelpDocCommentIs("c4 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("62q", "constructor c4(b: string): c4 (+1 overload)", "c4 2");
+
+// goTo.marker('63');
+// verify.currentSignatureHelpDocCommentIs("c5 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("63q", "constructor c5(a: number): c5 (+1 overload)", "c5 1");
+
+// goTo.marker('64');
+// verify.currentSignatureHelpDocCommentIs("c5 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("64q", "constructor c5(b: string): c5 (+1 overload)", "c5 2");
+
+// goTo.marker('65');
+// verify.completionListContains("c", "class c", "");
+// verify.completionListContains("c1", "class c1", "");
+// verify.completionListContains("c2", "class c2", "");
+// verify.completionListContains("c3", "class c3", "");
+// verify.completionListContains("c4", "class c4", "");
+// verify.completionListContains("c5", "class c5", "");
+// verify.completionListContains("c_i", "var c_i: c", "");
+// verify.completionListContains("c1_i_1", "var c1_i_1: c1", "");
+// verify.completionListContains("c2_i_1", "var c2_i_1: c2", "");
+// verify.completionListContains("c3_i_1", "var c3_i_1: c3", "");
+// verify.completionListContains("c4_i_1", "var c4_i_1: c4", "");
+// verify.completionListContains("c5_i_1", "var c5_i_1: c5", "");
+// verify.completionListContains("c1_i_2", "var c1_i_2: c1", "");
+// verify.completionListContains("c2_i_2", "var c2_i_2: c2", "");
+// verify.completionListContains("c3_i_2", "var c3_i_2: c3", "");
+// verify.completionListContains("c4_i_2", "var c4_i_2: c4", "");
+// verify.completionListContains("c5_i_2", "var c5_i_2: c5", "");
+// verify.completionListContains('multiOverload', 'function multiOverload(a: number): string (+2 overloads)', 'This is multiOverload F1 1');
+// verify.completionListContains('ambientF1', 'function ambientF1(a: number): string (+2 overloads)', 'This is ambient F1 1');
+
+// verify.quickInfos({
+//     66: "var c1_i_1: c1",
+//     67: "var c2_i_2: c2",
+//     68: "var c3_i_2: c3",
+//     69: "var c4_i_1: c4",
+//     70: "var c5_i_1: c5",
+//     71: ["function multiOverload(a: number): string (+2 overloads)", "This is multiOverload F1 1"],
+//     72: ["function multiOverload(b: string): string (+2 overloads)", "This is multiOverload F1 2"],
+//     73: ["function multiOverload(c: boolean): string (+2 overloads)", "This is multiOverload F1 3"],
+//     74: ["function ambientF1(a: number): string (+2 overloads)", "This is ambient F1 1"],
+//     75: ["function ambientF1(b: string): string (+2 overloads)", "This is ambient F1 2"],
+//     76: ["function ambientF1(c: boolean): boolean (+2 overloads)", "This is ambient F1 3"],
+//     77: "(parameter) aa: i3",
+//     78: "constructor c1(a: number): c1 (+1 overload)",
+//     79: "constructor c1(b: string): c1 (+1 overload)",
+//     80: "constructor c1(a: number): c1 (+1 overload)",
+//     81: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+//     82: "constructor c2(b: string): c2 (+1 overload)",
+//     83: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+//     84: "constructor c3(a: number): c3 (+1 overload)",
+//     85: ["constructor c3(b: string): c3 (+1 overload)", "c3 2"],
+//     86: "constructor c3(a: number): c3 (+1 overload)",
+//     87: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+//     88: ["constructor c4(b: string): c4 (+1 overload)", "c4 2"],
+//     89: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+//     90: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+//     91: ["constructor c5(b: string): c5 (+1 overload)", "c5 2"],
+//     92: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+//     93: "(method) c.prop1(a: number): number (+1 overload)",
+//     94: "(method) c.prop1(b: string): number (+1 overload)",
+//     95: "(method) c.prop1(a: number): number (+1 overload)",
+//     96: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+//     97: "(method) c.prop2(b: string): number (+1 overload)",
+//     98: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+//     99: "(method) c.prop3(a: number): number (+1 overload)",
+//     100: ["(method) c.prop3(b: string): number (+1 overload)", "prop3 2"],
+//     101: "(method) c.prop3(a: number): number (+1 overload)",
+//     102: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+//     103: ["(method) c.prop4(b: string): number (+1 overload)", "prop4 2"],
+//     104: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+//     105: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"],
+//     106: ["(method) c.prop5(b: string): number (+1 overload)", "prop5 2"],
+//     107: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"]
+// });
+// /// <reference path='fourslash.ts' />
+
+// /////** this is signature 1*/
+// ////function /*1*/f1(/**param a*/a: number): number;
+// ////function /*2*/f1(b: string): number;
+// ////function /*3*/f1(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*4q*/1(/*4*/"hello");
+// ////f/*o4q*/1(/*o4*/10);
+// ////function /*5*/f2(/**param a*/a: number): number;
+// /////** this is signature 2*/
+// ////function /*6*/f2(b: string): number;
+// /////** this is f2 var comment*/
+// ////function /*7*/f2(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*8q*/2(/*8*/"hello");
+// ////f/*o8q*/2(/*o8*/10);
+// ////function /*9*/f3(a: number): number;
+// ////function /*10*/f3(b: string): number;
+// ////function /*11*/f3(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*12q*/3(/*12*/"hello");
+// ////f/*o12q*/3(/*o12*/10);
+// /////** this is signature 4 - with number parameter*/
+// ////function /*13*/f4(/**param a*/a: number): number;
+// /////** this is signature 4 - with string parameter*/
+// ////function /*14*/f4(b: string): number;
+// ////function /*15*/f4(aOrb: any) {
+// ////    return 10;
+// ////}
+// ////f/*16q*/4(/*16*/"hello");
+// ////f/*o16q*/4(/*o16*/10);
+// /////*17*/
+// ////interface i1 {
+// ////    /**this signature 1*/
+// ////    (/**param a*/ a: number): number;
+// ////    /**this is signature 2*/
+// ////    (b: string): number;
+// ////    /** foo 1*/
+// ////    foo(a: number): number;
+// ////    /** foo 2*/
+// ////    foo(b: string): number;
+// ////    foo2(a: number): number;
+// ////    /** foo2 2*/
+// ////    foo2(b: string): number;
+// ////    foo3(a: number): number;
+// ////    foo3(b: string): number;
+// ////    /** foo4 1*/
+// ////    foo4(a: number): number;
+// ////    foo4(b: string): number;
+// ////    /** new 1*/
+// ////    new (a: string);
+// ////    new (b: number);
+// ////}
+// ////var i1_i: i1;
+// ////interface i2 {
+// ////    new (a: string);
+// ////    /** new 2*/
+// ////    new (b: number);
+// ////    (a: number): number;
+// ////    /**this is signature 2*/
+// ////    (b: string): number;
+// ////}
+// ////var i2_i: i2;
+// ////interface i3 {
+// ////    /** new 1*/
+// ////    new (a: string);
+// ////    /** new 2*/
+// ////    new (b: number);
+// ////    /**this is signature 1*/
+// ////    (a: number): number;
+// ////    (b: string): number;
+// ////}
+// ////var i3_i: i3;
+// ////interface i4 {
+// ////    new (a: string);
+// ////    new (b: number);
+// ////    (a: number): number;
+// ////    (b: string): number;
+// ////}
+// ////var i4_i: i4;
+// ////new /*18*/i1/*19q*/_i(/*19*/10);
+// ////new i/*20q*/1_i(/*20*/"Hello");
+// ////i/*21q*/1_i(/*21*/10);
+// ////i/*22q*/1_i(/*22*/"hello");
+// ////i1_i./*23*/f/*24q*/oo(/*24*/10);
+// ////i1_i.f/*25q*/oo(/*25*/"hello");
+// ////i1_i.fo/*26q*/o2(/*26*/10);
+// ////i1_i.fo/*27q*/o2(/*27*/"hello");
+// ////i1_i.fo/*28q*/o3(/*28*/10);
+// ////i1_i.fo/*29q*/o3(/*29*/"hello");
+// ////i1_i.fo/*30q*/o4(/*30*/10);
+// ////i1_i.fo/*31q*/o4(/*31*/"hello");
+// ////new i2/*32q*/_i(/*32*/10);
+// ////new i2/*33q*/_i(/*33*/"Hello");
+// ////i/*34q*/2_i(/*34*/10);
+// ////i2/*35q*/_i(/*35*/"hello");
+// ////new i/*36q*/3_i(/*36*/10);
+// ////new i3/*37q*/_i(/*37*/"Hello");
+// ////i3/*38q*/_i(/*38*/10);
+// ////i3/*39q*/_i(/*39*/"hello");
+// ////new i4/*40q*/_i(/*40*/10);
+// ////new i/*41q*/4_i(/*41*/"Hello");
+// ////i4/*42q*/_i(/*42*/10);
+// ////i4/*43q*/_i(/*43*/"hello");
+// ////class c {
+// ////    public /*93*/prop1(a: number): number;
+// ////    public /*94*/prop1(b: string): number;
+// ////    public /*95*/prop1(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop2 1*/
+// ////    public /*96*/prop2(a: number): number;
+// ////    public /*97*/prop2(b: string): number;
+// ////    public /*98*/prop2(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    public /*99*/prop3(a: number): number;
+// ////    /** prop3 2*/
+// ////    public /*100*/prop3(b: string): number;
+// ////    public /*101*/prop3(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop4 1*/
+// ////    public /*102*/prop4(a: number): number;
+// ////    /** prop4 2*/
+// ////    public /*103*/prop4(b: string): number;
+// ////    public /*104*/prop4(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////    /** prop5 1*/
+// ////    public /*105*/prop5(a: number): number;
+// ////    /** prop5 2*/
+// ////    public /*106*/prop5(b: string): number;
+// ////    /** Prop5 implementaion*/
+// ////    public /*107*/prop5(aorb: any) {
+// ////        return 10;
+// ////    }
+// ////}
+// ////class c1 {
+// ////    /*78*/constructor(a: number);
+// ////    /*79*/constructor(b: string);
+// ////    /*80*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c2 {
+// ////    /** c2 1*/
+// ////    /*81*/constructor(a: number);
+// ////    /*82*/constructor(b: string);
+// ////    /*83*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c3 {
+// ////    /*84*/constructor(a: number);
+// ////    /** c3 2*/
+// ////    /*85*/constructor(b: string);
+// ////    /*86*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c4 {
+// ////    /** c4 1*/
+// ////    /*87*/constructor(a: number);
+// ////    /** c4 2*/
+// ////    /*88*/constructor(b: string);
+// ////    /*89*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////class c5 {
+// ////    /** c5 1*/
+// ////    /*90*/constructor(a: number);
+// ////    /** c5 2*/
+// ////    /*91*/constructor(b: string);
+// ////    /** c5 implementation*/
+// ////    /*92*/constructor(aorb: any) {
+// ////    }
+// ////}
+// ////var c_i = new c();
+// ////c_i./*44*/pro/*45q*/p1(/*45*/10);
+// ////c_i.pr/*46q*/op1(/*46*/"hello");
+// ////c_i.pr/*47q*/op2(/*47*/10);
+// ////c_i.pr/*48q*/op2(/*48*/"hello");
+// ////c_i.pro/*49q*/p3(/*49*/10);
+// ////c_i.pr/*50q*/op3(/*50*/"hello");
+// ////c_i.pr/*51q*/op4(/*51*/10);
+// ////c_i.pr/*52q*/op4(/*52*/"hello");
+// ////c_i.pr/*53q*/op5(/*53*/10);
+// ////c_i.pr/*54q*/op5(/*54*/"hello");
+// ////var c1/*66*/_i_1 = new c/*55q*/1(/*55*/10);
+// ////var c1_i_2 = new c/*56q*/1(/*56*/"hello");
+// ////var c2_i_1 = new c/*57q*/2(/*57*/10);
+// ////var c/*67*/2_i_2 = new c/*58q*/2(/*58*/"hello");
+// ////var c3_i_1 = new c/*59q*/3(/*59*/10);
+// ////var c/*68*/3_i_2 = new c/*60q*/3(/*60*/"hello");
+// ////var c4/*69*/_i_1 = new c/*61q*/4(/*61*/10);
+// ////var c4_i_2 = new c/*62q*/4(/*62*/"hello");
+// ////var c/*70*/5_i_1 = new c/*63q*/5(/*63*/10);
+// ////var c5_i_2 = new c/*64q*/5(/*64*/"hello");
+// /////** This is multiOverload F1 1*/
+// ////function multiOverload(a: number): string;
+// /////** This is multiOverload F1 2*/
+// ////function multiOverload(b: string): string;
+// /////** This is multiOverload F1 3*/
+// ////function multiOverload(c: boolean): string;
+// /////** This is multiOverload Implementation */
+// ////function multiOverload(d): string {
+// ////    return "Hello";
+// ////}
+// ////multiOverl/*71*/oad(10);
+// ////multiOverl/*72*/oad("hello");
+// ////multiOverl/*73*/oad(true);
+// /////** This is ambient F1 1*/
+// ////declare function ambientF1(a: number): string;
+// /////** This is ambient F1 2*/
+// ////declare function ambientF1(b: string): string;
+// /////** This is ambient F1 3*/
+// ////declare function ambientF1(c: boolean): boolean;
+// /////*65*/
+// ////ambient/*74*/F1(10);
+// ////ambient/*75*/F1("hello");
+// ////ambient/*76*/F1(true);
+// ////function foo(a/*77*/a: i3) {
+// ////}
+// ////foo(null);
+
+// verify.quickInfos({
+//     1: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+//     2: "function f1(b: string): number (+1 overload)",
+//     3: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+//     "4q": "function f1(b: string): number (+1 overload)",
+//     o4q: ["function f1(a: number): number (+1 overload)", "this is signature 1"]
+// });
+
+// goTo.marker('4');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// goTo.marker('o4');
+// verify.currentSignatureHelpDocCommentIs("this is signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// verify.quickInfos({
+//     5: "function f2(a: number): number (+1 overload)",
+//     6: ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+//     7: "function f2(a: number): number (+1 overload)",
+//     "8q": ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+//     o8q: "function f2(a: number): number (+1 overload)"
+// });
+
+// goTo.marker('8');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o8');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// verify.quickInfos({
+//     9: "function f3(a: number): number (+1 overload)",
+//     10: "function f3(b: string): number (+1 overload)",
+//     11: "function f3(a: number): number (+1 overload)",
+//     "12q": "function f3(b: string): number (+1 overload)",
+//     o12q: "function f3(a: number): number (+1 overload)"
+// });
+
+// goTo.marker('12');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o12');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// verify.quickInfos({
+//     13: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+//     14: ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+//     15: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+//     "16q": ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+//     o16q: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"]
+// });
+
+// goTo.marker('16');
+// verify.currentSignatureHelpDocCommentIs("this is signature 4 - with string parameter");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+
+// goTo.marker('o16');
+// verify.currentSignatureHelpDocCommentIs("this is signature 4 - with number parameter");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+
+// goTo.marker('17');
+// verify.completionListContains('f1', 'function f1(a: number): number (+1 overload)', 'this is signature 1');
+// verify.completionListContains('f2', 'function f2(a: number): number (+1 overload)', '');
+// verify.completionListContains('f3', 'function f3(a: number): number (+1 overload)', '');
+// verify.completionListContains('f4', 'function f4(a: number): number (+1 overload)', 'this is signature 4 - with number parameter');
+
+// goTo.marker('18');
+// verify.not.completionListContains('i1', 'interface i1', '');
+// verify.completionListContains('i1_i', 'var i1_i: new i1(b: number) => any (+1 overload)', '');
+// verify.not.completionListContains('i2', 'interface i2', '');
+// verify.completionListContains('i2_i', 'var i2_i: new i2(a: string) => any (+1 overload)', '');
+// verify.not.completionListContains('i3', 'interface i3', '');
+// verify.completionListContains('i3_i', 'var i3_i: new i3(a: string) => any (+1 overload)', 'new 1');
+// verify.not.completionListContains('i4', 'interface i4', '');
+// verify.completionListContains('i4_i', 'var i4_i: new i4(a: string) => any (+1 overload)', '');
+
+// goTo.marker('19');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("19q", "var i1_i: new i1(b: number) => any (+1 overload)");
+
+// goTo.marker('20');
+// verify.currentSignatureHelpDocCommentIs("new 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("20q", "var i1_i: new i1(a: string) => any (+1 overload)", "new 1");
+
+// goTo.marker('21');
+// verify.currentSignatureHelpDocCommentIs("this signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("param a");
+// verify.quickInfoAt("21q", "var i1_i: i1(a: number) => number (+1 overload)", "this signature 1");
+
+// goTo.marker('22');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// goTo.marker('22q');
+// verify.quickInfoAt("22q", "var i1_i: i1(b: string) => number (+1 overload)", "this is signature 2");
+
+// goTo.marker('23');
+// verify.completionListContains('foo', '(method) i1.foo(a: number): number (+1 overload)', 'foo 1');
+// verify.completionListContains('foo2', '(method) i1.foo2(a: number): number (+1 overload)', '');
+// verify.completionListContains('foo3', '(method) i1.foo3(a: number): number (+1 overload)', '');
+// verify.completionListContains('foo4', '(method) i1.foo4(a: number): number (+1 overload)', 'foo4 1');
+
+// goTo.marker('24');
+// verify.currentSignatureHelpDocCommentIs("foo 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("24q", "(method) i1.foo(a: number): number (+1 overload)", "foo 1");
+
+// goTo.marker('25');
+// verify.currentSignatureHelpDocCommentIs("foo 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("25q", "(method) i1.foo(b: string): number (+1 overload)", "foo 2");
+
+// goTo.marker('26');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("26q", "(method) i1.foo2(a: number): number (+1 overload)");
+
+// goTo.marker('27');
+// verify.currentSignatureHelpDocCommentIs("foo2 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("27q", "(method) i1.foo2(b: string): number (+1 overload)", "foo2 2");
+
+// goTo.marker('28');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("28q", "(method) i1.foo3(a: number): number (+1 overload)");
+
+// goTo.marker('29');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("29q", "(method) i1.foo3(b: string): number (+1 overload)");
+
+// goTo.marker('30');
+// verify.currentSignatureHelpDocCommentIs("foo4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("30q", "(method) i1.foo4(a: number): number (+1 overload)", "foo4 1");
+
+// goTo.marker('31');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("31q", "(method) i1.foo4(b: string): number (+1 overload)");
+
+// goTo.marker('32');
+// verify.currentSignatureHelpDocCommentIs("new 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("32q", "var i2_i: new i2(b: number) => any (+1 overload)", "new 2");
+
+// goTo.marker('33');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("33q", "var i2_i: new i2(a: string) => any (+1 overload)");
+
+// goTo.marker('34');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("34q", "var i2_i: i2(a: number) => number (+1 overload)");
+
+// goTo.marker('35');
+// verify.currentSignatureHelpDocCommentIs("this is signature 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("35q", "var i2_i: i2(b: string) => number (+1 overload)", "this is signature 2");
+
+// goTo.marker('36');
+// verify.currentSignatureHelpDocCommentIs("new 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("36q", "var i3_i: new i3(b: number) => any (+1 overload)", "new 2");
+
+// goTo.marker('37');
+// verify.currentSignatureHelpDocCommentIs("new 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("37q", "var i3_i: new i3(a: string) => any (+1 overload)", "new 1");
+
+// goTo.marker('38');
+// verify.currentSignatureHelpDocCommentIs("this is signature 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("38q", "var i3_i: i3(a: number) => number (+1 overload)", "this is signature 1");
+
+// goTo.marker('39');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("39q", "var i3_i: i3(b: string) => number (+1 overload)");
+
+// goTo.marker('40');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("40q", "var i4_i: new i4(b: number) => any (+1 overload)");
+
+// goTo.marker('41');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("41q", "var i4_i: new i4(a: string) => any (+1 overload)");
+
+// goTo.marker('42');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("42q", "var i4_i: i4(a: number) => number (+1 overload)");
+
+// goTo.marker('43');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("43q", "var i4_i: i4(b: string) => number (+1 overload)");
+
+// goTo.marker('44');
+// verify.completionListContains('prop1', '(method) c.prop1(a: number): number (+1 overload)', '');
+// verify.completionListContains('prop2', '(method) c.prop2(a: number): number (+1 overload)', 'prop2 1');
+// verify.completionListContains('prop3', '(method) c.prop3(a: number): number (+1 overload)', '');
+// verify.completionListContains('prop4', '(method) c.prop4(a: number): number (+1 overload)', 'prop4 1');
+// verify.completionListContains('prop5', '(method) c.prop5(a: number): number (+1 overload)', 'prop5 1');
+
+// goTo.marker('45');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("45q", "(method) c.prop1(a: number): number (+1 overload)");
+
+// goTo.marker('46');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("46q", "(method) c.prop1(b: string): number (+1 overload)");
+
+// goTo.marker('47');
+// verify.currentSignatureHelpDocCommentIs("prop2 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("47q", "(method) c.prop2(a: number): number (+1 overload)", "prop2 1");
+
+// goTo.marker('48');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("48q", "(method) c.prop2(b: string): number (+1 overload)");
+
+// goTo.marker('49');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("49q", "(method) c.prop3(a: number): number (+1 overload)");
+
+// goTo.marker('50');
+// verify.currentSignatureHelpDocCommentIs("prop3 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("50q", "(method) c.prop3(b: string): number (+1 overload)", "prop3 2");
+
+// goTo.marker('51');
+// verify.currentSignatureHelpDocCommentIs("prop4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("51q", "(method) c.prop4(a: number): number (+1 overload)", "prop4 1");
+
+// goTo.marker('52');
+// verify.currentSignatureHelpDocCommentIs("prop4 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("52q", "(method) c.prop4(b: string): number (+1 overload)", "prop4 2");
+
+// goTo.marker('53');
+// verify.currentSignatureHelpDocCommentIs("prop5 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("53q", "(method) c.prop5(a: number): number (+1 overload)", "prop5 1");
+
+// goTo.marker('54');
+// verify.currentSignatureHelpDocCommentIs("prop5 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("54q", "(method) c.prop5(b: string): number (+1 overload)", "prop5 2");
+
+// goTo.marker('55');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("55q", "constructor c1(a: number): c1 (+1 overload)");
+
+// goTo.marker('56');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("56q", "constructor c1(b: string): c1 (+1 overload)");
+
+// goTo.marker('57');
+// verify.currentSignatureHelpDocCommentIs("c2 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("57q", "constructor c2(a: number): c2 (+1 overload)", "c2 1");
+
+// goTo.marker('58');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("58q", "constructor c2(b: string): c2 (+1 overload)");
+
+// goTo.marker('59');
+// verify.currentSignatureHelpDocCommentIs("");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("59q", "constructor c3(a: number): c3 (+1 overload)");
+
+// goTo.marker('60');
+// verify.currentSignatureHelpDocCommentIs("c3 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("60q", "constructor c3(b: string): c3 (+1 overload)", "c3 2");
+
+// goTo.marker('61');
+// verify.currentSignatureHelpDocCommentIs("c4 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("61q", "constructor c4(a: number): c4 (+1 overload)", "c4 1");
+
+// goTo.marker('62');
+// verify.currentSignatureHelpDocCommentIs("c4 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("62q", "constructor c4(b: string): c4 (+1 overload)", "c4 2");
+
+// goTo.marker('63');
+// verify.currentSignatureHelpDocCommentIs("c5 1");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("63q", "constructor c5(a: number): c5 (+1 overload)", "c5 1");
+
+// goTo.marker('64');
+// verify.currentSignatureHelpDocCommentIs("c5 2");
+// verify.currentParameterHelpArgumentDocCommentIs("");
+// verify.quickInfoAt("64q", "constructor c5(b: string): c5 (+1 overload)", "c5 2");
+
+// goTo.marker('65');
+// verify.completionListContains("c", "class c", "");
+// verify.completionListContains("c1", "class c1", "");
+// verify.completionListContains("c2", "class c2", "");
+// verify.completionListContains("c3", "class c3", "");
+// verify.completionListContains("c4", "class c4", "");
+// verify.completionListContains("c5", "class c5", "");
+// verify.completionListContains("c_i", "var c_i: c", "");
+// verify.completionListContains("c1_i_1", "var c1_i_1: c1", "");
+// verify.completionListContains("c2_i_1", "var c2_i_1: c2", "");
+// verify.completionListContains("c3_i_1", "var c3_i_1: c3", "");
+// verify.completionListContains("c4_i_1", "var c4_i_1: c4", "");
+// verify.completionListContains("c5_i_1", "var c5_i_1: c5", "");
+// verify.completionListContains("c1_i_2", "var c1_i_2: c1", "");
+// verify.completionListContains("c2_i_2", "var c2_i_2: c2", "");
+// verify.completionListContains("c3_i_2", "var c3_i_2: c3", "");
+// verify.completionListContains("c4_i_2", "var c4_i_2: c4", "");
+// verify.completionListContains("c5_i_2", "var c5_i_2: c5", "");
+// verify.completionListContains('multiOverload', 'function multiOverload(a: number): string (+2 overloads)', 'This is multiOverload F1 1');
+// verify.completionListContains('ambientF1', 'function ambientF1(a: number): string (+2 overloads)', 'This is ambient F1 1');
+
+// verify.quickInfos({
+//     66: "var c1_i_1: c1",
+//     67: "var c2_i_2: c2",
+//     68: "var c3_i_2: c3",
+//     69: "var c4_i_1: c4",
+//     70: "var c5_i_1: c5",
+//     71: ["function multiOverload(a: number): string (+2 overloads)", "This is multiOverload F1 1"],
+//     72: ["function multiOverload(b: string): string (+2 overloads)", "This is multiOverload F1 2"],
+//     73: ["function multiOverload(c: boolean): string (+2 overloads)", "This is multiOverload F1 3"],
+//     74: ["function ambientF1(a: number): string (+2 overloads)", "This is ambient F1 1"],
+//     75: ["function ambientF1(b: string): string (+2 overloads)", "This is ambient F1 2"],
+//     76: ["function ambientF1(c: boolean): boolean (+2 overloads)", "This is ambient F1 3"],
+//     77: "(parameter) aa: i3",
+//     78: "constructor c1(a: number): c1 (+1 overload)",
+//     79: "constructor c1(b: string): c1 (+1 overload)",
+//     80: "constructor c1(a: number): c1 (+1 overload)",
+//     81: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+//     82: "constructor c2(b: string): c2 (+1 overload)",
+//     83: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+//     84: "constructor c3(a: number): c3 (+1 overload)",
+//     85: ["constructor c3(b: string): c3 (+1 overload)", "c3 2"],
+//     86: "constructor c3(a: number): c3 (+1 overload)",
+//     87: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+//     88: ["constructor c4(b: string): c4 (+1 overload)", "c4 2"],
+//     89: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+//     90: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+//     91: ["constructor c5(b: string): c5 (+1 overload)", "c5 2"],
+//     92: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+//     93: "(method) c.prop1(a: number): number (+1 overload)",
+//     94: "(method) c.prop1(b: string): number (+1 overload)",
+//     95: "(method) c.prop1(a: number): number (+1 overload)",
+//     96: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+//     97: "(method) c.prop2(b: string): number (+1 overload)",
+//     98: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+//     99: "(method) c.prop3(a: number): number (+1 overload)",
+//     100: ["(method) c.prop3(b: string): number (+1 overload)", "prop3 2"],
+//     101: "(method) c.prop3(a: number): number (+1 overload)",
+//     102: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+//     103: ["(method) c.prop4(b: string): number (+1 overload)", "prop4 2"],
+//     104: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+//     105: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"],
+//     106: ["(method) c.prop5(b: string): number (+1 overload)", "prop5 2"],
+//     107: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"]
+// });

--- a/tests/cases/fourslash/shims-pp/getOutliningSpans.ts
+++ b/tests/cases/fourslash/shims-pp/getOutliningSpans.ts
@@ -89,12 +89,12 @@
 ////                            module m8[| {
 ////                                module m9[| {
 ////                                    module m10[| {
-////                                        module m11 {
-////                                            module m12 {
-////                                                export interface IFoo {
-////                                                }
-////                                            }
-////                                        }
+////                                        module m11[| {
+////                                            module m12[| {
+////                                                export interface IFoo[| {
+////                                                }|]
+////                                            }|]
+////                                        }|]
 ////                                    }|]
 ////                                }|]
 ////                            }|]

--- a/tests/cases/fourslash/shims/getOutliningSpans.ts
+++ b/tests/cases/fourslash/shims/getOutliningSpans.ts
@@ -89,12 +89,12 @@
 ////                            module m8[| {
 ////                                module m9[| {
 ////                                    module m10[| {
-////                                        module m11 {
-////                                            module m12 {
-////                                                export interface IFoo {
-////                                                }
-////                                            }
-////                                        }
+////                                        module m11[| {
+////                                            module m12[| {
+////                                                export interface IFoo[| {
+////                                                }|]
+////                                            }|]
+////                                        }|]
 ////                                    }|]
 ////                                }|]
 ////                            }|]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This change increases the maximum depth to which we traverse the AST of a file looking for outlining spans. Because this is a noticeable operation on larger files, this is conditional on the file size being smaller than 100KB. Otherwise, we leave the max depth at the previous value.
This involves a protocol change for GetOutliningSpans.