### PR TITLE
Make formatOptions optional in GetEditsForRefactorRequestArgs

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -494,7 +494,7 @@ namespace ts.server.protocol {
         refactor: string;
         /* The 'name' property from the refactoring action */
         action: string;
-        formatOptions: FormatCodeSettings,
+        formatOptions?: FormatCodeSettings,
     };
 
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1488,7 +1488,7 @@ namespace ts.server {
 
             const result = project.getLanguageService().getEditsForRefactor(
                 file,
-                convertFormatOptions(args.formatOptions),
+                args.formatOptions ? convertFormatOptions(args.formatOptions) : this.projectService.getFormatCodeOptions(),
                 position || textRange,
                 args.refactor,
                 args.action


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/commit/d96dfeb708bfec850031a85cc197dfd5732bd52a#commitcomment-24315710
