### PR TITLE
Correct JSON.parse types 

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -956,7 +956,7 @@ interface JSON {
       * @param reviver A function that transforms the results. This function is called for each member of the object.
       * If a member contains nested objects, the nested objects are transformed before the parent object is.
       */
-    parse(text: string, reviver?: (key: any, value: any) => any): any;
+    parse(text: string | null | boolean | number, reviver?: (key: any, value: any) => any): any;
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
       * @param value A JavaScript value, usually an object or array, to be converted.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

It looks like you can use boolean and number in this method.
![2017-09-15 19 30 45](https://user-images.githubusercontent.com/6794386/30493342-65fdecbc-9a4c-11e7-941b-dd17be2dbebb.png)

My case:
```
phoneModels: JSON.parse(window.localStorage.getItem('phoneModel')) || null
```

spec - http://www.ecma-international.org/ecma-262/5.1/#sec-5.1.5
