### PR TITLE
Conditional declaration of globally visible describe/it in runner

### DIFF
--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -1,7 +1,7 @@
-// tslint:disable-next-line
-var describe: Mocha.IContextDefinition; // If launched without mocha for parallel mode, we still need a global describe visible to satisfy the parsing of the unit tests
-// tslint:disable-next-line
-var it: Mocha.ITestDefinition;
+if (typeof describe === "undefined") {
+    (global as any).describe = undefined; // If launched without mocha for parallel mode, we still need a global describe visible to satisfy the parsing of the unit tests
+    (global as any).it = undefined;
+}
 namespace Harness.Parallel.Host {
 
     interface ChildProcessPartial {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #18505. The `var` declarations were hiding mocha's own `describe`/`it` if present. 🐱 
