### PR TITLE
Consider underscore for type parameters in unused-local checks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20019,7 +20019,7 @@ namespace ts {
                         return;
                     }
                     for (const typeParameter of node.typeParameters) {
-                        if (!getMergedSymbol(typeParameter.symbol).isReferenced && !parameterNameStartsWithUnderscore(typeParameter.name)) {
+                        if (!getMergedSymbol(typeParameter.symbol).isReferenced && !isIdentifierThatStartsWithUnderScore(typeParameter.name)) {
                             error(typeParameter.name, Diagnostics._0_is_declared_but_its_value_is_never_read, unescapeLeadingUnderscores(typeParameter.symbol.escapedName));
                         }
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19968,7 +19968,8 @@ namespace ts {
             const node = getNameOfDeclaration(declaration) || declaration;
             if (isIdentifierThatStartsWithUnderScore(node)) {
                 const declaration = getRootDeclaration(node.parent);
-                if (declaration.kind === SyntaxKind.VariableDeclaration && isForInOrOfStatement(declaration.parent.parent)) {
+                if ((declaration.kind === SyntaxKind.VariableDeclaration && isForInOrOfStatement(declaration.parent.parent)) ||
+                  declaration.kind === SyntaxKind.TypeParameter) {
                     return;
                 }
             }
@@ -20018,7 +20019,7 @@ namespace ts {
                         return;
                     }
                     for (const typeParameter of node.typeParameters) {
-                        if (!getMergedSymbol(typeParameter.symbol).isReferenced) {
+                        if (!getMergedSymbol(typeParameter.symbol).isReferenced && !parameterNameStartsWithUnderscore(typeParameter.name)) {
                             error(typeParameter.name, Diagnostics._0_is_declared_but_its_value_is_never_read, unescapeLeadingUnderscores(typeParameter.symbol.escapedName));
                         }
                     }

--- a/tests/baselines/reference/unusedTypeParametersWithUnderscore.errors.txt
+++ b/tests/baselines/reference/unusedTypeParametersWithUnderscore.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(1,16): error TS6133: 'U' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(3,12): error TS6133: 'U' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(5,17): error TS6133: 'U' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(7,13): error TS6133: 'U' is declared but its value is never read.
+
+
+==== tests/cases/compiler/unusedTypeParametersWithUnderscore.ts (4 errors) ====
+    function f<_T, U>() { }
+                   ~
+!!! error TS6133: 'U' is declared but its value is never read.
+    
+    type T<_T, U> = { };
+               ~
+!!! error TS6133: 'U' is declared but its value is never read.
+    
+    interface I<_T, U> { };
+                    ~
+!!! error TS6133: 'U' is declared but its value is never read.
+    
+    class C<_T, U> { };
+                ~
+!!! error TS6133: 'U' is declared but its value is never read.
+    

--- a/tests/baselines/reference/unusedTypeParametersWithUnderscore.js
+++ b/tests/baselines/reference/unusedTypeParametersWithUnderscore.js
@@ -1,0 +1,19 @@
+//// [unusedTypeParametersWithUnderscore.ts]
+function f<_T, U>() { }
+
+type T<_T, U> = { };
+
+interface I<_T, U> { };
+
+class C<_T, U> { };
+
+
+//// [unusedTypeParametersWithUnderscore.js]
+function f() { }
+;
+var C = /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());
+;

--- a/tests/cases/compiler/unusedTypeParametersWithUnderscore.ts
+++ b/tests/cases/compiler/unusedTypeParametersWithUnderscore.ts
@@ -1,0 +1,9 @@
+//@noUnusedLocals:true
+
+function f<_T, U>() { }
+
+type T<_T, U> = { };
+
+interface I<_T, U> { };
+
+class C<_T, U> { };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #18420
