### PR TITLE
Ensure that emitter calls callbacks for empty blocks

### DIFF
--- a/tests/cases/fourslash/convertToEs6Class_emptyCatchClause.ts
+++ b/tests/cases/fourslash/convertToEs6Class_emptyCatchClause.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: /a.js
+////function /**/MyClass() {}
+////MyClass.prototype.foo = function() {
+////    try {} catch() {}
+////}
+
+verify.applicableRefactorAvailableAtMarker("");
+verify.fileAfterApplyingRefactorAtMarker("",
+`class MyClass {
+    constructor() { }
+    foo() {
+        try { }
+        catch () { }
+    }
+}
+`,
+'Convert to ES2015 class', 'convert');

--- a/tests/cases/fourslash/extract-method-empty-namespace.ts
+++ b/tests/cases/fourslash/extract-method-empty-namespace.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// TODO: GH#18546
+// For now this tests that at least we don't crash.
+
+////function f() {
+////    /*start*/namespace N {}/*end*/
+////}
+
+goTo.select('start', 'end')
+edit.applyRefactor({
+    refactorName: "Extract Method",
+    actionName: "scope_1",
+    actionDescription: "Extract to function in global scope",
+    newContent: `function f() {
+    /*RENAME*/newFunction(N);
+}
+function newFunction(N: any) {
+    namespace N { }
+}
+`
+});


### PR DESCRIPTION
Fixes  #18541
Another sequel to #18284 and #18484

Discovered #18546; does not fix the bug, but we will no longer crash.
