### PR TITLE
Minor cleanup to symbolWalker

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -994,11 +994,6 @@ namespace ts {
 
     /**
      * Gets the owned, enumerable property keys of a map-like.
-     *
-     * NOTE: This is intended for use with MapLike<T> objects. For Map<T> objects, use
-     *       Object.keys instead as it offers better performance.
-     *
-     * @param map A map-like.
      */
     export function getOwnKeys<T>(map: MapLike<T>): string[] {
         const keys: string[] = [];
@@ -1009,6 +1004,17 @@ namespace ts {
         }
 
         return keys;
+    }
+
+    export function getOwnValues<T>(sparseArray: T[]): T[] {
+        const values: T[] = [];
+        for (const key in sparseArray) {
+            if (hasOwnProperty.call(sparseArray, key)) {
+                values.push(sparseArray[key]);
+            }
+        }
+
+        return values;
     }
 
     /** Shims `Array.from`. */

--- a/src/compiler/symbolWalker.ts
+++ b/src/compiler/symbolWalker.ts
@@ -73,13 +73,13 @@ namespace ts {
                     }
                 }
                 if (type.flags & TypeFlags.TypeParameter) {
-                    visitType(getConstraintFromTypeParameter(type as TypeParameter));
+                    visitTypeParameter(type as TypeParameter);
                 }
                 if (type.flags & TypeFlags.UnionOrIntersection) {
-                    forEach((type as UnionOrIntersectionType).types, visitType);
+                    visitUnionOrIntersectionType(type as UnionOrIntersectionType);
                 }
                 if (type.flags & TypeFlags.Index) {
-                    visitType((type as IndexType).type);
+                    visitIndexType(type as IndexType);
                 }
                 if (type.flags & TypeFlags.IndexedAccess) {
                     visitIndexedAccessType(type as IndexedAccessType);
@@ -89,6 +89,18 @@ namespace ts {
             function visitTypeReference(type: TypeReference): void {
                 visitType(type.target);
                 forEach(type.typeArguments, visitType);
+            }
+
+            function visitTypeParameter(type: TypeParameter): void {
+                visitType(getConstraintFromTypeParameter(type));
+            }
+
+            function visitUnionOrIntersectionType(type: UnionOrIntersectionType): void {
+                forEach(type.types, visitType);
+            }
+
+            function visitIndexType(type: IndexType): void {
+                visitType(type.type);
             }
 
             function visitIndexedAccessType(type: IndexedAccessType): void {


### PR DESCRIPTION
Instead of reviewing #17844 I thought I'd just make a pull request implementing some changes.
* Use sparse arrays for number-keyed maps.
* Clear the map after use to avoid leaving garbage around.
* Use `forEach` instead of a null check followed by `for-of`; this reduces `visitTypeList` to a single line, so inlined it.
* Inline other single-line functions that are only called once.