### PR TITLE
Changed "Duplicate Identifier" to "enum cannot be merged..."

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -390,6 +390,10 @@ namespace ts {
                             ? Diagnostics.Cannot_redeclare_block_scoped_variable_0
                             : Diagnostics.Duplicate_identifier_0;
 
+                        if (symbol.flags & SymbolFlags.Enum || includes & SymbolFlags.Enum) {
+                            message = Diagnostics.Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations;
+                        }
+
                         if (symbol.declarations && symbol.declarations.length) {
                             // If the current node is a default export of some sort, then check if
                             // there are any other default exports that we need to error on.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -847,13 +847,11 @@ namespace ts {
                 error(getNameOfDeclaration(source.declarations[0]), Diagnostics.Cannot_augment_module_0_with_value_exports_because_it_resolves_to_a_non_module_entity, symbolToString(target));
             }
             else {
-                let message = Diagnostics.Duplicate_identifier_0;
-                if (target.flags & SymbolFlags.Enum || source.flags & SymbolFlags.Enum) {
-                    message = Diagnostics.Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations;
-                }
-                if (target.flags & SymbolFlags.BlockScopedVariable || source.flags & SymbolFlags.BlockScopedVariable) {
-                    message = Diagnostics.Cannot_redeclare_block_scoped_variable_0;
-                }
+                const message = target.flags & SymbolFlags.Enum || source.flags & SymbolFlags.Enum
+                    ? Diagnostics.Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations
+                    : target.flags & SymbolFlags.BlockScopedVariable || source.flags & SymbolFlags.BlockScopedVariable
+                        ? Diagnostics.Cannot_redeclare_block_scoped_variable_0
+                        : Diagnostics.Duplicate_identifier_0;
                 forEach(source.declarations, node => {
                     error(getNameOfDeclaration(node) || node, message, symbolToString(source));
                 });

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -847,8 +847,13 @@ namespace ts {
                 error(getNameOfDeclaration(source.declarations[0]), Diagnostics.Cannot_augment_module_0_with_value_exports_because_it_resolves_to_a_non_module_entity, symbolToString(target));
             }
             else {
-                const message = target.flags & SymbolFlags.BlockScopedVariable || source.flags & SymbolFlags.BlockScopedVariable
-                    ? Diagnostics.Cannot_redeclare_block_scoped_variable_0 : Diagnostics.Duplicate_identifier_0;
+                let message = Diagnostics.Duplicate_identifier_0;
+                if (target.flags & SymbolFlags.Enum || source.flags & SymbolFlags.Enum) {
+                    message = Diagnostics.Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations;
+                }
+                if (target.flags & SymbolFlags.BlockScopedVariable || source.flags & SymbolFlags.BlockScopedVariable) {
+                    message = Diagnostics.Cannot_redeclare_block_scoped_variable_0;
+                }
                 forEach(source.declarations, node => {
                     error(getNameOfDeclaration(node) || node, message, symbolToString(source));
                 });

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1980,6 +1980,11 @@
         "category": "Error",
         "code": 2566
     },
+    "Enum declarations can only merge with namespace or other enum declarations.": {
+        "category": "Error",
+        "code": 2567
+    },
+
     "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",
         "code": 2600

--- a/tests/baselines/reference/augmentedTypesClass.errors.txt
+++ b/tests/baselines/reference/augmentedTypesClass.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/augmentedTypesClass.ts(2,7): error TS2300: Duplicate identifier 'c1'.
 tests/cases/compiler/augmentedTypesClass.ts(3,5): error TS2300: Duplicate identifier 'c1'.
-tests/cases/compiler/augmentedTypesClass.ts(6,7): error TS2300: Duplicate identifier 'c4'.
-tests/cases/compiler/augmentedTypesClass.ts(7,6): error TS2300: Duplicate identifier 'c4'.
+tests/cases/compiler/augmentedTypesClass.ts(6,7): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesClass.ts(7,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 
 
 ==== tests/cases/compiler/augmentedTypesClass.ts (4 errors) ====
@@ -16,7 +16,7 @@ tests/cases/compiler/augmentedTypesClass.ts(7,6): error TS2300: Duplicate identi
     //// class then enum
     class c4 { public foo() { } }
           ~~
-!!! error TS2300: Duplicate identifier 'c4'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     enum c4 { One } // error
          ~~
-!!! error TS2300: Duplicate identifier 'c4'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.

--- a/tests/baselines/reference/augmentedTypesClass2.errors.txt
+++ b/tests/baselines/reference/augmentedTypesClass2.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/augmentedTypesClass2.ts(16,7): error TS2300: Duplicate identifier 'c33'.
-tests/cases/compiler/augmentedTypesClass2.ts(21,6): error TS2300: Duplicate identifier 'c33'.
+tests/cases/compiler/augmentedTypesClass2.ts(16,7): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesClass2.ts(21,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 
 
 ==== tests/cases/compiler/augmentedTypesClass2.ts (2 errors) ====
@@ -20,14 +20,14 @@ tests/cases/compiler/augmentedTypesClass2.ts(21,6): error TS2300: Duplicate iden
     // class then enum 
     class c33 {
           ~~~
-!!! error TS2300: Duplicate identifier 'c33'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
         foo() {
             return 1;
         }
     }
     enum c33 { One };
          ~~~
-!!! error TS2300: Duplicate identifier 'c33'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     // class then import
     class c44 {

--- a/tests/baselines/reference/augmentedTypesEnum.errors.txt
+++ b/tests/baselines/reference/augmentedTypesEnum.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/augmentedTypesEnum.ts(2,6): error TS2300: Duplicate identifier 'e1111'.
-tests/cases/compiler/augmentedTypesEnum.ts(3,5): error TS2300: Duplicate identifier 'e1111'.
-tests/cases/compiler/augmentedTypesEnum.ts(6,6): error TS2300: Duplicate identifier 'e2'.
-tests/cases/compiler/augmentedTypesEnum.ts(7,10): error TS2300: Duplicate identifier 'e2'.
-tests/cases/compiler/augmentedTypesEnum.ts(9,6): error TS2300: Duplicate identifier 'e3'.
-tests/cases/compiler/augmentedTypesEnum.ts(10,5): error TS2300: Duplicate identifier 'e3'.
-tests/cases/compiler/augmentedTypesEnum.ts(13,6): error TS2300: Duplicate identifier 'e4'.
-tests/cases/compiler/augmentedTypesEnum.ts(14,7): error TS2300: Duplicate identifier 'e4'.
+tests/cases/compiler/augmentedTypesEnum.ts(2,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum.ts(3,5): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum.ts(6,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum.ts(7,10): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum.ts(9,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum.ts(10,5): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum.ts(13,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum.ts(14,7): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 tests/cases/compiler/augmentedTypesEnum.ts(18,11): error TS2432: In an enum with multiple declarations, only one declaration can omit an initializer for its first enum element.
 tests/cases/compiler/augmentedTypesEnum.ts(20,12): error TS2300: Duplicate identifier 'One'.
 tests/cases/compiler/augmentedTypesEnum.ts(21,12): error TS2300: Duplicate identifier 'One'.
@@ -16,33 +16,33 @@ tests/cases/compiler/augmentedTypesEnum.ts(21,12): error TS2432: In an enum with
     // enum then var
     enum e1111 { One } // error
          ~~~~~
-!!! error TS2300: Duplicate identifier 'e1111'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     var e1111 = 1; // error
         ~~~~~
-!!! error TS2300: Duplicate identifier 'e1111'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     // enum then function
     enum e2 { One } // error
          ~~
-!!! error TS2300: Duplicate identifier 'e2'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     function e2() { } // error
              ~~
-!!! error TS2300: Duplicate identifier 'e2'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     enum e3 { One } // error
          ~~
-!!! error TS2300: Duplicate identifier 'e3'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     var e3 = () => { } // error
         ~~
-!!! error TS2300: Duplicate identifier 'e3'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     // enum then class
     enum e4 { One } // error
          ~~
-!!! error TS2300: Duplicate identifier 'e4'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     class e4 { public foo() { } } // error
           ~~
-!!! error TS2300: Duplicate identifier 'e4'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     // enum then enum
     enum e5 { One }

--- a/tests/baselines/reference/augmentedTypesEnum2.errors.txt
+++ b/tests/baselines/reference/augmentedTypesEnum2.errors.txt
@@ -1,18 +1,18 @@
-tests/cases/compiler/augmentedTypesEnum2.ts(2,6): error TS2300: Duplicate identifier 'e1'.
-tests/cases/compiler/augmentedTypesEnum2.ts(4,11): error TS2300: Duplicate identifier 'e1'.
-tests/cases/compiler/augmentedTypesEnum2.ts(11,6): error TS2300: Duplicate identifier 'e2'.
-tests/cases/compiler/augmentedTypesEnum2.ts(12,7): error TS2300: Duplicate identifier 'e2'.
+tests/cases/compiler/augmentedTypesEnum2.ts(2,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum2.ts(4,11): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum2.ts(11,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesEnum2.ts(12,7): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 
 
 ==== tests/cases/compiler/augmentedTypesEnum2.ts (4 errors) ====
     // enum then interface
     enum e1 { One } // error
          ~~
-!!! error TS2300: Duplicate identifier 'e1'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     interface e1 { // error
               ~~
-!!! error TS2300: Duplicate identifier 'e1'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
         foo(): void;
     }
     
@@ -21,10 +21,10 @@ tests/cases/compiler/augmentedTypesEnum2.ts(12,7): error TS2300: Duplicate ident
     // enum then class
     enum e2 { One }; // error
          ~~
-!!! error TS2300: Duplicate identifier 'e2'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     class e2 { // error
           ~~
-!!! error TS2300: Duplicate identifier 'e2'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
         foo() {
             return 1;
         }

--- a/tests/baselines/reference/augmentedTypesFunction.errors.txt
+++ b/tests/baselines/reference/augmentedTypesFunction.errors.txt
@@ -8,8 +8,8 @@ tests/cases/compiler/augmentedTypesFunction.ts(13,10): error TS2300: Duplicate i
 tests/cases/compiler/augmentedTypesFunction.ts(14,7): error TS2300: Duplicate identifier 'y3'.
 tests/cases/compiler/augmentedTypesFunction.ts(16,10): error TS2300: Duplicate identifier 'y3a'.
 tests/cases/compiler/augmentedTypesFunction.ts(17,7): error TS2300: Duplicate identifier 'y3a'.
-tests/cases/compiler/augmentedTypesFunction.ts(20,10): error TS2300: Duplicate identifier 'y4'.
-tests/cases/compiler/augmentedTypesFunction.ts(21,6): error TS2300: Duplicate identifier 'y4'.
+tests/cases/compiler/augmentedTypesFunction.ts(20,10): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesFunction.ts(21,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 
 
 ==== tests/cases/compiler/augmentedTypesFunction.ts (12 errors) ====
@@ -54,10 +54,10 @@ tests/cases/compiler/augmentedTypesFunction.ts(21,6): error TS2300: Duplicate id
     // function then enum
     function y4() { } // error
              ~~
-!!! error TS2300: Duplicate identifier 'y4'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     enum y4 { One } // error
          ~~
-!!! error TS2300: Duplicate identifier 'y4'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     // function then internal module
     function y5() { }

--- a/tests/baselines/reference/augmentedTypesInterface.errors.txt
+++ b/tests/baselines/reference/augmentedTypesInterface.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/augmentedTypesInterface.ts(23,11): error TS2300: Duplicate identifier 'i3'.
-tests/cases/compiler/augmentedTypesInterface.ts(26,6): error TS2300: Duplicate identifier 'i3'.
+tests/cases/compiler/augmentedTypesInterface.ts(23,11): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesInterface.ts(26,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 
 
 ==== tests/cases/compiler/augmentedTypesInterface.ts (2 errors) ====
@@ -27,12 +27,12 @@ tests/cases/compiler/augmentedTypesInterface.ts(26,6): error TS2300: Duplicate i
     // interface then enum
     interface i3 { // error
               ~~
-!!! error TS2300: Duplicate identifier 'i3'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
         foo(): void;
     }
     enum i3 { One }; // error
          ~~
-!!! error TS2300: Duplicate identifier 'i3'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     // interface then import
     interface i4 {

--- a/tests/baselines/reference/augmentedTypesVar.errors.txt
+++ b/tests/baselines/reference/augmentedTypesVar.errors.txt
@@ -5,8 +5,8 @@ tests/cases/compiler/augmentedTypesVar.ts(13,5): error TS2300: Duplicate identif
 tests/cases/compiler/augmentedTypesVar.ts(14,7): error TS2300: Duplicate identifier 'x4'.
 tests/cases/compiler/augmentedTypesVar.ts(16,5): error TS2300: Duplicate identifier 'x4a'.
 tests/cases/compiler/augmentedTypesVar.ts(17,7): error TS2300: Duplicate identifier 'x4a'.
-tests/cases/compiler/augmentedTypesVar.ts(20,5): error TS2300: Duplicate identifier 'x5'.
-tests/cases/compiler/augmentedTypesVar.ts(21,6): error TS2300: Duplicate identifier 'x5'.
+tests/cases/compiler/augmentedTypesVar.ts(20,5): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/augmentedTypesVar.ts(21,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 tests/cases/compiler/augmentedTypesVar.ts(27,5): error TS2300: Duplicate identifier 'x6a'.
 tests/cases/compiler/augmentedTypesVar.ts(28,8): error TS2300: Duplicate identifier 'x6a'.
 tests/cases/compiler/augmentedTypesVar.ts(30,5): error TS2300: Duplicate identifier 'x6b'.
@@ -49,10 +49,10 @@ tests/cases/compiler/augmentedTypesVar.ts(31,8): error TS2300: Duplicate identif
     // var then enum
     var x5 = 1;
         ~~
-!!! error TS2300: Duplicate identifier 'x5'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     enum x5 { One } // error
          ~~
-!!! error TS2300: Duplicate identifier 'x5'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     
     // var then module
     var x6 = 1;

--- a/tests/baselines/reference/constEnumErrors.errors.txt
+++ b/tests/baselines/reference/constEnumErrors.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/constEnumErrors.ts(1,12): error TS2300: Duplicate identifier 'E'.
-tests/cases/compiler/constEnumErrors.ts(5,8): error TS2300: Duplicate identifier 'E'.
+tests/cases/compiler/constEnumErrors.ts(1,12): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/constEnumErrors.ts(5,8): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 tests/cases/compiler/constEnumErrors.ts(12,9): error TS2651: A member initializer in a enum declaration cannot reference members declared after it, including members defined in other enums.
 tests/cases/compiler/constEnumErrors.ts(14,9): error TS2474: In 'const' enum declarations member initializer must be constant expression.
 tests/cases/compiler/constEnumErrors.ts(15,10): error TS2474: In 'const' enum declarations member initializer must be constant expression.
@@ -16,13 +16,13 @@ tests/cases/compiler/constEnumErrors.ts(42,9): error TS2478: 'const' enum member
 ==== tests/cases/compiler/constEnumErrors.ts (13 errors) ====
     const enum E {
                ~
-!!! error TS2300: Duplicate identifier 'E'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
         A
     }
     
     module E {
            ~
-!!! error TS2300: Duplicate identifier 'E'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
         var x = 1;
     }
     

--- a/tests/baselines/reference/duplicateIdentifierEnum.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierEnum.errors.txt
@@ -1,0 +1,69 @@
+tests/cases/compiler/duplicateIdentifierEnum_A.ts(2,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_A.ts(5,7): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_A.ts(9,11): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_A.ts(12,12): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_A.ts(16,12): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_A.ts(19,10): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_A.ts(23,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_A.ts(26,7): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_B.ts(1,10): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/duplicateIdentifierEnum_B.ts(4,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+
+
+==== tests/cases/compiler/duplicateIdentifierEnum_A.ts (8 errors) ====
+    // Test the error message when attempting to merge an enum with a class, an interface, or a function.
+    enum A {
+         ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        bar
+    }
+    class A {
+          ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        foo: number;
+    }
+    
+    interface B {
+              ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        foo: number;
+    }
+    const enum B {
+               ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        bar
+    }
+    
+    const enum C {
+               ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+    
+    }
+    function C() {
+             ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        return 0;
+    }
+    
+    enum D {
+         ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        bar
+    }
+    class E {
+          ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        foo: number;
+    }
+    // also make sure the error appears when trying to merge an enum in a separate file.
+==== tests/cases/compiler/duplicateIdentifierEnum_B.ts (2 errors) ====
+    function D() {
+             ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        return 0;
+    }
+    enum E {
+         ~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+        bar
+    }

--- a/tests/baselines/reference/duplicateIdentifierEnum.js
+++ b/tests/baselines/reference/duplicateIdentifierEnum.js
@@ -1,0 +1,72 @@
+//// [tests/cases/compiler/duplicateIdentifierEnum.ts] ////
+
+//// [duplicateIdentifierEnum_A.ts]
+// Test the error message when attempting to merge an enum with a class, an interface, or a function.
+enum A {
+    bar
+}
+class A {
+    foo: number;
+}
+
+interface B {
+    foo: number;
+}
+const enum B {
+    bar
+}
+
+const enum C {
+
+}
+function C() {
+    return 0;
+}
+
+enum D {
+    bar
+}
+class E {
+    foo: number;
+}
+// also make sure the error appears when trying to merge an enum in a separate file.
+//// [duplicateIdentifierEnum_B.ts]
+function D() {
+    return 0;
+}
+enum E {
+    bar
+}
+
+//// [duplicateIdentifierEnum_A.js]
+// Test the error message when attempting to merge an enum with a class, an interface, or a function.
+var A;
+(function (A) {
+    A[A["bar"] = 0] = "bar";
+})(A || (A = {}));
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+function C() {
+    return 0;
+}
+var D;
+(function (D) {
+    D[D["bar"] = 0] = "bar";
+})(D || (D = {}));
+var E = /** @class */ (function () {
+    function E() {
+    }
+    return E;
+}());
+// also make sure the error appears when trying to merge an enum in a separate file.
+//// [duplicateIdentifierEnum_B.js]
+function D() {
+    return 0;
+}
+var E;
+(function (E) {
+    E[E["bar"] = 0] = "bar";
+})(E || (E = {}));

--- a/tests/baselines/reference/duplicateIdentifierEnum.symbols
+++ b/tests/baselines/reference/duplicateIdentifierEnum.symbols
@@ -1,0 +1,63 @@
+=== tests/cases/compiler/duplicateIdentifierEnum_A.ts ===
+// Test the error message when attempting to merge an enum with a class, an interface, or a function.
+enum A {
+>A : Symbol(A, Decl(duplicateIdentifierEnum_A.ts, 0, 0))
+
+    bar
+>bar : Symbol(A.bar, Decl(duplicateIdentifierEnum_A.ts, 1, 8))
+}
+class A {
+>A : Symbol(A, Decl(duplicateIdentifierEnum_A.ts, 3, 1))
+
+    foo: number;
+>foo : Symbol(A.foo, Decl(duplicateIdentifierEnum_A.ts, 4, 9))
+}
+
+interface B {
+>B : Symbol(B, Decl(duplicateIdentifierEnum_A.ts, 6, 1))
+
+    foo: number;
+>foo : Symbol(B.foo, Decl(duplicateIdentifierEnum_A.ts, 8, 13))
+}
+const enum B {
+>B : Symbol(B, Decl(duplicateIdentifierEnum_A.ts, 10, 1))
+
+    bar
+>bar : Symbol(B.bar, Decl(duplicateIdentifierEnum_A.ts, 11, 14))
+}
+
+const enum C {
+>C : Symbol(C, Decl(duplicateIdentifierEnum_A.ts, 13, 1))
+
+}
+function C() {
+>C : Symbol(C, Decl(duplicateIdentifierEnum_A.ts, 17, 1))
+
+    return 0;
+}
+
+enum D {
+>D : Symbol(D, Decl(duplicateIdentifierEnum_A.ts, 20, 1))
+
+    bar
+>bar : Symbol(D.bar, Decl(duplicateIdentifierEnum_A.ts, 22, 8))
+}
+class E {
+>E : Symbol(E, Decl(duplicateIdentifierEnum_A.ts, 24, 1))
+
+    foo: number;
+>foo : Symbol(E.foo, Decl(duplicateIdentifierEnum_A.ts, 25, 9))
+}
+// also make sure the error appears when trying to merge an enum in a separate file.
+=== tests/cases/compiler/duplicateIdentifierEnum_B.ts ===
+function D() {
+>D : Symbol(D, Decl(duplicateIdentifierEnum_B.ts, 0, 0))
+
+    return 0;
+}
+enum E {
+>E : Symbol(E, Decl(duplicateIdentifierEnum_B.ts, 2, 1))
+
+    bar
+>bar : Symbol(E.bar, Decl(duplicateIdentifierEnum_B.ts, 3, 8))
+}

--- a/tests/baselines/reference/duplicateIdentifierEnum.types
+++ b/tests/baselines/reference/duplicateIdentifierEnum.types
@@ -1,0 +1,65 @@
+=== tests/cases/compiler/duplicateIdentifierEnum_A.ts ===
+// Test the error message when attempting to merge an enum with a class, an interface, or a function.
+enum A {
+>A : A
+
+    bar
+>bar : A
+}
+class A {
+>A : A
+
+    foo: number;
+>foo : number
+}
+
+interface B {
+>B : B
+
+    foo: number;
+>foo : number
+}
+const enum B {
+>B : B
+
+    bar
+>bar : B
+}
+
+const enum C {
+>C : C
+
+}
+function C() {
+>C : () => number
+
+    return 0;
+>0 : 0
+}
+
+enum D {
+>D : D
+
+    bar
+>bar : D
+}
+class E {
+>E : E
+
+    foo: number;
+>foo : number
+}
+// also make sure the error appears when trying to merge an enum in a separate file.
+=== tests/cases/compiler/duplicateIdentifierEnum_B.ts ===
+function D() {
+>D : () => number
+
+    return 0;
+>0 : 0
+}
+enum E {
+>E : E
+
+    bar
+>bar : E
+}

--- a/tests/baselines/reference/enumGenericTypeClash.errors.txt
+++ b/tests/baselines/reference/enumGenericTypeClash.errors.txt
@@ -1,12 +1,12 @@
-tests/cases/compiler/enumGenericTypeClash.ts(1,7): error TS2300: Duplicate identifier 'X'.
-tests/cases/compiler/enumGenericTypeClash.ts(2,6): error TS2300: Duplicate identifier 'X'.
+tests/cases/compiler/enumGenericTypeClash.ts(1,7): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+tests/cases/compiler/enumGenericTypeClash.ts(2,6): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 
 
 ==== tests/cases/compiler/enumGenericTypeClash.ts (2 errors) ====
     class X<A,B,C> { }
           ~
-!!! error TS2300: Duplicate identifier 'X'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     enum X { MyVal }
          ~
-!!! error TS2300: Duplicate identifier 'X'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
     

--- a/tests/baselines/reference/reservedWords2.errors.txt
+++ b/tests/baselines/reference/reservedWords2.errors.txt
@@ -3,6 +3,7 @@ tests/cases/compiler/reservedWords2.ts(1,14): error TS1005: '(' expected.
 tests/cases/compiler/reservedWords2.ts(1,16): error TS2304: Cannot find name 'require'.
 tests/cases/compiler/reservedWords2.ts(1,31): error TS1005: ')' expected.
 tests/cases/compiler/reservedWords2.ts(2,12): error TS2300: Duplicate identifier '(Missing)'.
+tests/cases/compiler/reservedWords2.ts(2,12): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 tests/cases/compiler/reservedWords2.ts(2,14): error TS1003: Identifier expected.
 tests/cases/compiler/reservedWords2.ts(2,20): error TS1005: '(' expected.
 tests/cases/compiler/reservedWords2.ts(2,20): error TS2304: Cannot find name 'from'.
@@ -10,6 +11,7 @@ tests/cases/compiler/reservedWords2.ts(2,25): error TS1005: ')' expected.
 tests/cases/compiler/reservedWords2.ts(4,5): error TS1134: Variable declaration expected.
 tests/cases/compiler/reservedWords2.ts(4,12): error TS1109: Expression expected.
 tests/cases/compiler/reservedWords2.ts(5,9): error TS2300: Duplicate identifier '(Missing)'.
+tests/cases/compiler/reservedWords2.ts(5,9): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 tests/cases/compiler/reservedWords2.ts(5,10): error TS1003: Identifier expected.
 tests/cases/compiler/reservedWords2.ts(5,18): error TS1005: '=>' expected.
 tests/cases/compiler/reservedWords2.ts(6,1): error TS2304: Cannot find name 'module'.
@@ -27,11 +29,11 @@ tests/cases/compiler/reservedWords2.ts(9,6): error TS1181: Array element destruc
 tests/cases/compiler/reservedWords2.ts(9,14): error TS1005: ';' expected.
 tests/cases/compiler/reservedWords2.ts(9,18): error TS1005: '(' expected.
 tests/cases/compiler/reservedWords2.ts(9,20): error TS1128: Declaration or statement expected.
-tests/cases/compiler/reservedWords2.ts(10,5): error TS2300: Duplicate identifier '(Missing)'.
+tests/cases/compiler/reservedWords2.ts(10,5): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
 tests/cases/compiler/reservedWords2.ts(10,6): error TS1003: Identifier expected.
 
 
-==== tests/cases/compiler/reservedWords2.ts (31 errors) ====
+==== tests/cases/compiler/reservedWords2.ts (33 errors) ====
     import while = require("dfdf");
            ~~~~~
 !!! error TS1109: Expression expected.
@@ -44,6 +46,8 @@ tests/cases/compiler/reservedWords2.ts(10,6): error TS1003: Identifier expected.
     import * as  while from "foo"
                
 !!! error TS2300: Duplicate identifier '(Missing)'.
+               
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
                  ~~~~~
 !!! error TS1003: Identifier expected.
                        ~~~~
@@ -61,6 +65,8 @@ tests/cases/compiler/reservedWords2.ts(10,6): error TS1003: Identifier expected.
     function throw() {}
             
 !!! error TS2300: Duplicate identifier '(Missing)'.
+            
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
              ~~~~~
 !!! error TS1003: Identifier expected.
                      ~
@@ -101,7 +107,7 @@ tests/cases/compiler/reservedWords2.ts(10,6): error TS1003: Identifier expected.
 !!! error TS1128: Declaration or statement expected.
     enum void {}
         
-!!! error TS2300: Duplicate identifier '(Missing)'.
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
          ~~~~
 !!! error TS1003: Identifier expected.
     

--- a/tests/cases/compiler/duplicateIdentifierEnum.ts
+++ b/tests/cases/compiler/duplicateIdentifierEnum.ts
@@ -1,0 +1,37 @@
+// Test the error message when attempting to merge an enum with a class, an interface, or a function.
+// @Filename: duplicateIdentifierEnum_A.ts
+enum A {
+    bar
+}
+class A {
+    foo: number;
+}
+
+interface B {
+    foo: number;
+}
+const enum B {
+    bar
+}
+
+const enum C {
+
+}
+function C() {
+    return 0;
+}
+
+enum D {
+    bar
+}
+class E {
+    foo: number;
+}
+// also make sure the error appears when trying to merge an enum in a separate file.
+// @Filename: duplicateIdentifierEnum_B.ts
+function D() {
+    return 0;
+}
+enum E {
+    bar
+}


### PR DESCRIPTION
when either declaration of the identifier is an enum.

Partial (?) fix for #529