### PR TITLE
Actually capture oldTranspile baselines

### DIFF
--- a/src/harness/unittests/transpile.ts
+++ b/src/harness/unittests/transpile.ts
@@ -17,32 +17,33 @@ namespace ts {
                 let oldTranspileResult: string;
                 let oldTranspileDiagnostics: Diagnostic[];
 
+                transpileOptions = testSettings.options || {};
+                if (!transpileOptions.compilerOptions) {
+                    transpileOptions.compilerOptions = {};
+                }
+
+                if (transpileOptions.compilerOptions.newLine === undefined) {
+                    // use \r\n as default new line
+                    transpileOptions.compilerOptions.newLine = ts.NewLineKind.CarriageReturnLineFeed;
+                }
+
+                transpileOptions.compilerOptions.sourceMap = true;
+
+                if (!transpileOptions.fileName) {
+                    transpileOptions.fileName = transpileOptions.compilerOptions.jsx ? "file.tsx" : "file.ts";
+                }
+
+                transpileOptions.reportDiagnostics = true;
+
+                justName = "transpile/" + name.replace(/[^a-z0-9\-. ]/ig, "") + (transpileOptions.compilerOptions.jsx ? Extension.Tsx : Extension.Ts);
+                toBeCompiled = [{
+                    unitName: transpileOptions.fileName,
+                    content: input
+                }];
+
+                canUseOldTranspile = !transpileOptions.renamedDependencies;
+
                 before(() => {
-                    transpileOptions = testSettings.options || {};
-                    if (!transpileOptions.compilerOptions) {
-                        transpileOptions.compilerOptions = {};
-                    }
-
-                    if (transpileOptions.compilerOptions.newLine === undefined) {
-                        // use \r\n as default new line
-                        transpileOptions.compilerOptions.newLine = ts.NewLineKind.CarriageReturnLineFeed;
-                    }
-
-                    transpileOptions.compilerOptions.sourceMap = true;
-
-                    if (!transpileOptions.fileName) {
-                        transpileOptions.fileName = transpileOptions.compilerOptions.jsx ? "file.tsx" : "file.ts";
-                    }
-
-                    transpileOptions.reportDiagnostics = true;
-
-                    justName = "transpile/" + name.replace(/[^a-z0-9\-. ]/ig, "") + (transpileOptions.compilerOptions.jsx ? Extension.Tsx : Extension.Ts);
-                    toBeCompiled = [{
-                        unitName: transpileOptions.fileName,
-                        content: input
-                    }];
-
-                    canUseOldTranspile = !transpileOptions.renamedDependencies;
                     transpileResult = transpileModule(input, transpileOptions);
 
                     if (canUseOldTranspile) {
@@ -52,10 +53,6 @@ namespace ts {
                 });
 
                 after(() => {
-                    justName = undefined;
-                    transpileOptions = undefined;
-                    canUseOldTranspile = undefined;
-                    toBeCompiled = undefined;
                     transpileResult = undefined;
                     oldTranspileResult = undefined;
                     oldTranspileDiagnostics = undefined;

--- a/tests/baselines/reference/transpile/Accepts string as enum values for compile-options.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Accepts string as enum values for compile-options.oldTranspile.js
@@ -1,0 +1,2 @@
+export const x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Correctly serialize metadata when transpile with CommonJS option.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Correctly serialize metadata when transpile with CommonJS option.oldTranspile.js
@@ -1,0 +1,24 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var ng = require("angular2/core");
+var MyClass1 = /** @class */ (function () {
+    function MyClass1(_elementRef) {
+        this._elementRef = _elementRef;
+    }
+    MyClass1 = __decorate([
+        fooexport,
+        __metadata("design:paramtypes", [typeof (_a = (typeof ng !== "undefined" && ng).ElementRef) === "function" && _a || Object])
+    ], MyClass1);
+    return MyClass1;
+    var _a;
+}());
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Correctly serialize metadata when transpile with System option.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Correctly serialize metadata when transpile with System option.oldTranspile.js
@@ -1,0 +1,35 @@
+System.register(["angular2/core"], function (exports_1, context_1) {
+    "use strict";
+    var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+    var __metadata = (this && this.__metadata) || function (k, v) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+    };
+    var __moduleName = context_1 && context_1.id;
+    var ng, MyClass1;
+    return {
+        setters: [
+            function (ng_1) {
+                ng = ng_1;
+            }
+        ],
+        execute: function () {
+            MyClass1 = /** @class */ (function () {
+                function MyClass1(_elementRef) {
+                    this._elementRef = _elementRef;
+                }
+                MyClass1 = __decorate([
+                    fooexport,
+                    __metadata("design:paramtypes", [typeof (_a = (typeof ng !== "undefined" && ng).ElementRef) === "function" && _a || Object])
+                ], MyClass1);
+                return MyClass1;
+                var _a;
+            }());
+        }
+    };
+});
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics.oldTranspile.js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.oldTranspile.errors.txt
@@ -1,0 +1,7 @@
+file.ts(1,3): error TS1005: ';' expected.
+
+
+==== file.ts (1 errors) ====
+    a b
+      ~
+!!! error TS1005: ';' expected.

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.oldTranspile.js
@@ -1,0 +1,3 @@
+a;
+b;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates module output.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates module output.oldTranspile.js
@@ -1,0 +1,5 @@
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var x = 0;
+});
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.oldTranspile.js
@@ -1,0 +1,3 @@
+/// <reference path="file2.ts" />
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports.oldTranspile.js
@@ -1,0 +1,3 @@
+"use strict";
+exports.__esModule = true;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.oldTranspile.js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/No extra errors for file without extension.oldTranspile.js
+++ b/tests/baselines/reference/transpile/No extra errors for file without extension.oldTranspile.js
@@ -1,0 +1,3 @@
+"use strict";
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
+
+
+!!! error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
+==== file.ts (0 errors) ====
+    

--- a/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.oldTranspile.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
+
+
+!!! error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
+==== file.ts (0 errors) ====
+    

--- a/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.oldTranspile.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Sets module name.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Sets module name.oldTranspile.js
@@ -1,0 +1,11 @@
+System.register("NamedModule", [], function (exports_1, context_1) {
+    var __moduleName = context_1 && context_1.id;
+    var x;
+    return {
+        setters: [],
+        execute: function () {
+            x = 1;
+        }
+    };
+});
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Support options with lib values.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Support options with lib values.oldTranspile.js
@@ -1,0 +1,2 @@
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Support options with types values.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Support options with types values.oldTranspile.js
@@ -1,0 +1,2 @@
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports backslashes in file name.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports backslashes in file name.oldTranspile.js
@@ -1,0 +1,2 @@
+var x;
+//# sourceMappingURL=b.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowJs.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting allowJs.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowUnreachableCode.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting allowUnreachableCode.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowUnusedLabels.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting allowUnusedLabels.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting alwaysStrict.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting alwaysStrict.oldTranspile.js
@@ -1,0 +1,3 @@
+"use strict";
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting baseUrl.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting baseUrl.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting charset.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting charset.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting declaration.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting declaration.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting declarationDir.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting declarationDir.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting emitBOM.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting emitBOM.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting experimentalDecorators.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting experimentalDecorators.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting isolatedModules.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting isolatedModules.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsx.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting jsx.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsxFactory.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting jsxFactory.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting lib.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting lib.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting locale.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting locale.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting module.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting module.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting moduleResolution.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting moduleResolution.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting newLine.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting newLine.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmit.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmit.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmitHelpers.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmitHelpers.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmitOnError.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmitOnError.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noErrorTruncation.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noErrorTruncation.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitReturns.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitReturns.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitThis.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitThis.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noLib.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noLib.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noResolve.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noResolve.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting out.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting out.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting outDir.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting outDir.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting outFile.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting outFile.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting paths.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting paths.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting preserveConstEnums.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting preserveConstEnums.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting reactNamespace.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting reactNamespace.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting removeComments.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting removeComments.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting rootDir.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting rootDir.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting rootDirs.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting rootDirs.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting skipLibCheck.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting skipLibCheck.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting strictNullChecks.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting strictNullChecks.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting stripInternal.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting stripInternal.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting target.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting target.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting typeRoots.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting typeRoots.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting types.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting types.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports urls in file name.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports urls in file name.oldTranspile.js
@@ -1,0 +1,2 @@
+var x;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Transpile with emit decorators and emit metadata.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Transpile with emit decorators and emit metadata.oldTranspile.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var db_1 = require("./db");
+function someDecorator(target) {
+    return target;
+}
+var MyClass = /** @class */ (function () {
+    function MyClass(db) {
+        this.db = db;
+        this.db.doSomething();
+    }
+    MyClass = __decorate([
+        someDecorator,
+        __metadata("design:paramtypes", [typeof (_a = typeof db_1.db !== "undefined" && db_1.db) === "function" && _a || Object])
+    ], MyClass);
+    return MyClass;
+    var _a;
+}());
+exports.MyClass = MyClass;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Uses correct newLine character.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Uses correct newLine character.oldTranspile.js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/transpile .js files.oldTranspile.js
+++ b/tests/baselines/reference/transpile/transpile .js files.oldTranspile.js
@@ -1,0 +1,2 @@
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.oldTranspile.js
+++ b/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.oldTranspile.js
@@ -1,0 +1,2 @@
+var x = React.createElement("div", null);
+//# sourceMappingURL=file.js.map


### PR DESCRIPTION
While working on adjusting the execution order in #18583; I noticed that there was a variant which caused these baselines to be captured, whereas normally they were not. The original intent was clearly to capture them; however `canUseOldTranspile` was only being set within `before`, and thus was not set during test definition time; causing the tests to never be defined/executed.