### PR TITLE
Handle unixy paths in RWC tests

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -2077,10 +2077,9 @@ namespace Harness {
                 for (let {done, value} = gen.next(); !done; { done, value } = gen.next()) {
                     const [name, content, count] = value as [string, string, number | undefined];
                     if (count === 0) continue; // Allow error reporter to skip writing files without errors
-                    const relativeFileName = ts.combinePaths(relativeFileBase, name) + extension;
+                    const relativeFileName = relativeFileBase + (ts.startsWith(name, "/") ? "" : "/") + name + extension;
                     const actualFileName = localPath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
-                    const actual = content;
-                    const comparison = compareToBaseline(actual, relativeFileName, opts);
+                    const comparison = compareToBaseline(content, relativeFileName, opts);
                     try {
                         writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName);
                     }


### PR DESCRIPTION
Fixes an issue @sandersn was seeing with rooted unix paths outputting in the wrong directory. The issue was that `combinePaths` drops the LHS operand when the RHS is rooted (which is not what was desired here) - this never happens with windows-captured baselines as the paths are preprocessed to remove the root (by replacing the colon).

Fixes #18561