### PR TITLE
Changed error for setter when emitting declaration with private param…

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -1429,45 +1429,40 @@ namespace ts {
             function getAccessorDeclarationTypeVisibilityError(symbolAccessibilityResult: SymbolAccessibilityResult): SymbolAccessibilityDiagnostic {
                 let diagnosticMessage: DiagnosticMessage;
                 if (accessorWithTypeAnnotation.kind === SyntaxKind.SetAccessor) {
-                    // Setters have to have type named and cannot infer it so, the type should always be named
-                    if (hasModifier(accessorWithTypeAnnotation.parent, ModifierFlags.Static)) {
+                    // Getters can infer the return type from the returned expression, but setters cannot, so the
+                    // "_from_external_module_1_but_cannot_be_named" case cannot occur.
+                    if (hasModifier(accessorWithTypeAnnotation, ModifierFlags.Static)) {
                         diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                            Diagnostics.Parameter_0_of_public_static_property_setter_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                            Diagnostics.Parameter_0_of_public_static_property_setter_from_exported_class_has_or_is_using_private_name_1;
+                            Diagnostics.Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
+                            Diagnostics.Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_private_name_1;
                     }
                     else {
                         diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                            Diagnostics.Parameter_0_of_public_property_setter_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                            Diagnostics.Parameter_0_of_public_property_setter_from_exported_class_has_or_is_using_private_name_1;
+                            Diagnostics.Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
+                            Diagnostics.Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_private_name_1;
                     }
-                    return {
-                        diagnosticMessage,
-                        errorNode: <Node>accessorWithTypeAnnotation.parameters[0],
-                        // TODO(jfreeman): Investigate why we are passing node.name instead of node.parameters[0].name
-                        typeName: accessorWithTypeAnnotation.name
-                    };
                 }
                 else {
                     if (hasModifier(accessorWithTypeAnnotation, ModifierFlags.Static)) {
                         diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
                             symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                                Diagnostics.Return_type_of_public_static_property_getter_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named :
-                                Diagnostics.Return_type_of_public_static_property_getter_from_exported_class_has_or_is_using_name_0_from_private_module_1 :
-                            Diagnostics.Return_type_of_public_static_property_getter_from_exported_class_has_or_is_using_private_name_0;
+                                Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
+                                Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
+                            Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_private_name_1;
                     }
                     else {
                         diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
                             symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                                Diagnostics.Return_type_of_public_property_getter_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named :
-                                Diagnostics.Return_type_of_public_property_getter_from_exported_class_has_or_is_using_name_0_from_private_module_1 :
-                            Diagnostics.Return_type_of_public_property_getter_from_exported_class_has_or_is_using_private_name_0;
+                            Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
+                            Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
+                        Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_private_name_1;
                     }
-                    return {
-                        diagnosticMessage,
-                        errorNode: <Node>accessorWithTypeAnnotation.name,
-                        typeName: undefined
-                    };
                 }
+                return {
+                    diagnosticMessage,
+                    errorNode: <Node>accessorWithTypeAnnotation.name,
+                    typeName: accessorWithTypeAnnotation.name
+                };
             }
         }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2309,43 +2309,43 @@
         "category": "Error",
         "code": 4033
     },
-    "Parameter '{0}' of public static property setter from exported class has or is using name '{1}' from private module '{2}'.": {
+    "Parameter type of public static setter '{0}' from exported class has or is using name '{1}' from private module '{2}'.": {
         "category": "Error",
         "code": 4034
     },
-    "Parameter '{0}' of public static property setter from exported class has or is using private name '{1}'.": {
+    "Parameter type of public static setter '{0}' from exported class has or is using private name '{1}'.": {
         "category": "Error",
         "code": 4035
     },
-    "Parameter '{0}' of public property setter from exported class has or is using name '{1}' from private module '{2}'.": {
+    "Parameter type of public setter '{0}' from exported class has or is using name '{1}' from private module '{2}'.": {
         "category": "Error",
         "code": 4036
     },
-    "Parameter '{0}' of public property setter from exported class has or is using private name '{1}'.": {
+    "Parameter type of public setter '{0}' from exported class has or is using private name '{1}'.": {
         "category": "Error",
         "code": 4037
     },
-    "Return type of public static property getter from exported class has or is using name '{0}' from external module {1} but cannot be named.": {
+    "Return type of public static getter '{0}' from exported class has or is using name '{1}' from external module {2} but cannot be named.": {
         "category": "Error",
         "code": 4038
     },
-    "Return type of public static property getter from exported class has or is using name '{0}' from private module '{1}'.": {
+    "Return type of public static getter '{0}' from exported class has or is using name '{1}' from private module '{2}'.": {
         "category": "Error",
         "code": 4039
     },
-    "Return type of public static property getter from exported class has or is using private name '{0}'.": {
+    "Return type of public static getter '{0}' from exported class has or is using private name '{1}'.": {
         "category": "Error",
         "code": 4040
     },
-    "Return type of public property getter from exported class has or is using name '{0}' from external module {1} but cannot be named.": {
+    "Return type of public getter '{0}' from exported class has or is using name '{1}' from external module {2} but cannot be named.": {
         "category": "Error",
         "code": 4041
     },
-    "Return type of public property getter from exported class has or is using name '{0}' from private module '{1}'.": {
+    "Return type of public getter '{0}' from exported class has or is using name '{1}' from private module '{2}'.": {
         "category": "Error",
         "code": 4042
     },
-    "Return type of public property getter from exported class has or is using private name '{0}'.": {
+    "Return type of public getter '{0}' from exported class has or is using private name '{1}'.": {
         "category": "Error",
         "code": 4043
     },

--- a/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorAccessors.errors.txt
+++ b/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorAccessors.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(15,21): error TS4043: Return type of public property getter from exported class has or is using private name 'private1'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(20,13): error TS4043: Return type of public property getter from exported class has or is using private name 'private1'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(25,25): error TS4037: Parameter 'foo3' of public property setter from exported class has or is using private name 'private1'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(32,25): error TS4037: Parameter 'foo4' of public property setter from exported class has or is using private name 'private1'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(36,21): error TS4043: Return type of public property getter from exported class has or is using private name 'private1'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(71,23): error TS4043: Return type of public property getter from exported class has or is using private name 'm2'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(76,13): error TS4042: Return type of public property getter from exported class has or is using name 'm2.public2' from private module 'm2'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(81,27): error TS4037: Parameter 'foo113' of public property setter from exported class has or is using private name 'm2'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(88,27): error TS4037: Parameter 'foo114' of public property setter from exported class has or is using private name 'm2'.
-tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(92,23): error TS4043: Return type of public property getter from exported class has or is using private name 'm2'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(15,21): error TS4043: Return type of public getter 'foo1' from exported class has or is using private name 'private1'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(20,13): error TS4043: Return type of public getter 'foo2' from exported class has or is using private name 'private1'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(25,25): error TS4037: Parameter type of public setter 'foo3' from exported class has or is using private name 'private1'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(32,25): error TS4037: Parameter type of public setter 'foo4' from exported class has or is using private name 'private1'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(36,21): error TS4043: Return type of public getter 'foo5' from exported class has or is using private name 'private1'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(71,23): error TS4043: Return type of public getter 'foo111' from exported class has or is using private name 'm2'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(76,13): error TS4042: Return type of public getter 'foo112' from exported class has or is using name 'm2.public2' from private module 'm2'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(81,27): error TS4037: Parameter type of public setter 'foo113' from exported class has or is using private name 'm2'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(88,27): error TS4037: Parameter type of public setter 'foo114' from exported class has or is using private name 'm2'.
+tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(92,23): error TS4043: Return type of public getter 'foo115' from exported class has or is using private name 'm2'.
 
 
 ==== tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts (10 errors) ====
@@ -22,26 +22,26 @@ tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(92,23): e
             export class public2 {
             }
         }
-        
+    
         export class c {
             // getter with annotation
             get foo1(): private1 {
                         ~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'private1'.
+!!! error TS4043: Return type of public getter 'foo1' from exported class has or is using private name 'private1'.
                 return;
             }
     
             // getter without annotation
             get foo2() {
                 ~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'private1'.
+!!! error TS4043: Return type of public getter 'foo2' from exported class has or is using private name 'private1'.
                 return new private1();
             }
     
             // setter with annotation
             set foo3(param: private1) {
                             ~~~~~~~~
-!!! error TS4037: Parameter 'foo3' of public property setter from exported class has or is using private name 'private1'.
+!!! error TS4037: Parameter type of public setter 'foo3' from exported class has or is using private name 'private1'.
             }
     
             // Both - getter without annotation, setter with annotation
@@ -50,18 +50,18 @@ tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(92,23): e
             }
             set foo4(param: private1) {
                             ~~~~~~~~
-!!! error TS4037: Parameter 'foo4' of public property setter from exported class has or is using private name 'private1'.
+!!! error TS4037: Parameter type of public setter 'foo4' from exported class has or is using private name 'private1'.
             }
     
             // Both - with annotation
             get foo5(): private1 {
                         ~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'private1'.
+!!! error TS4043: Return type of public getter 'foo5' from exported class has or is using private name 'private1'.
                 return;
             }
             set foo5(param: private1) {
             }
-        
+    
             // getter with annotation
             get foo11(): public1 {
                 return;
@@ -93,21 +93,21 @@ tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(92,23): e
             // getter with annotation
             get foo111(): m2.public2 {
                           ~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'm2'.
+!!! error TS4043: Return type of public getter 'foo111' from exported class has or is using private name 'm2'.
                 return;
             }
     
             // getter without annotation
             get foo112() {
                 ~~~~~~
-!!! error TS4042: Return type of public property getter from exported class has or is using name 'm2.public2' from private module 'm2'.
+!!! error TS4042: Return type of public getter 'foo112' from exported class has or is using name 'm2.public2' from private module 'm2'.
                 return new m2.public2();
             }
     
             // setter with annotation
             set foo113(param: m2.public2) {
                               ~~
-!!! error TS4037: Parameter 'foo113' of public property setter from exported class has or is using private name 'm2'.
+!!! error TS4037: Parameter type of public setter 'foo113' from exported class has or is using private name 'm2'.
             }
     
             // Both - getter without annotation, setter with annotation
@@ -116,13 +116,13 @@ tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts(92,23): e
             }
             set foo114(param: m2.public2) {
                               ~~
-!!! error TS4037: Parameter 'foo114' of public property setter from exported class has or is using private name 'm2'.
+!!! error TS4037: Parameter type of public setter 'foo114' from exported class has or is using private name 'm2'.
             }
     
             // Both - with annotation
             get foo115(): m2.public2 {
                           ~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'm2'.
+!!! error TS4043: Return type of public getter 'foo115' from exported class has or is using private name 'm2'.
                 return;
             }
             set foo115(param: m2.public2) {

--- a/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorAccessors.js
+++ b/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorAccessors.js
@@ -10,7 +10,7 @@ module m {
         export class public2 {
         }
     }
-    
+
     export class c {
         // getter with annotation
         get foo1(): private1 {
@@ -39,7 +39,7 @@ module m {
         }
         set foo5(param: private1) {
         }
-    
+
         // getter with annotation
         get foo11(): public1 {
             return;

--- a/tests/baselines/reference/privacyAccessorDeclFile.errors.txt
+++ b/tests/baselines/reference/privacyAccessorDeclFile.errors.txt
@@ -1,39 +1,39 @@
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(253,44): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(259,31): error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(265,20): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(271,13): error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(361,48): error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(365,35): error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(405,44): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(408,31): error TS4043: Return type of public property getter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(411,20): error TS4039: Return type of public static property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(414,13): error TS4042: Return type of public property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(420,48): error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(422,35): error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(8,40): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(14,27): error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(20,16): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(26,9): error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(116,44): error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(120,31): error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(160,40): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(163,27): error TS4043: Return type of public property getter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(166,16): error TS4039: Return type of public static property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(169,9): error TS4042: Return type of public property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(175,44): error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(177,31): error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(210,44): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(216,31): error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(222,20): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(228,13): error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(318,48): error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(322,35): error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateClass'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(362,44): error TS4040: Return type of public static property getter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(365,31): error TS4043: Return type of public property getter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(368,20): error TS4039: Return type of public static property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(371,13): error TS4042: Return type of public property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(377,48): error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateModule'.
-tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(253,44): error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(259,31): error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(265,20): error TS4040: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(271,13): error TS4043: Return type of public getter 'myPublicMethod1' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(361,48): error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(365,35): error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(405,44): error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(408,31): error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(411,20): error TS4039: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(414,13): error TS4042: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(420,48): error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_GlobalFile.ts(422,35): error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(8,40): error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(14,27): error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(20,16): error TS4040: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(26,9): error TS4043: Return type of public getter 'myPublicMethod1' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(116,44): error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(120,31): error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(160,40): error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(163,27): error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(166,16): error TS4039: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(169,9): error TS4042: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(175,44): error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(177,31): error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(210,44): error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(216,31): error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(222,20): error TS4040: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(228,13): error TS4043: Return type of public getter 'myPublicMethod1' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(318,48): error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(322,35): error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(362,44): error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(365,31): error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(368,20): error TS4039: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(371,13): error TS4042: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(377,48): error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
+tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
 
 
 ==== tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts (24 errors) ====
@@ -46,7 +46,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
     export class publicClassWithWithPrivateGetAccessorTypes {
         static get myPublicStaticMethod(): privateClass { // Error
                                            ~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
             return null;
         }
         private static get myPrivateStaticMethod(): privateClass {
@@ -54,7 +54,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         }
         get myPublicMethod(): privateClass { // Error
                               ~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
             return null;
         }
         private get myPrivateMethod(): privateClass {
@@ -62,7 +62,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         }
         static get myPublicStaticMethod1() { // Error
                    ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using private name 'privateClass'.
             return new privateClass();
         }
         private static get myPrivateStaticMethod1() {
@@ -70,7 +70,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         }
         get myPublicMethod1() { // Error
             ~~~~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4043: Return type of public getter 'myPublicMethod1' from exported class has or is using private name 'privateClass'.
             return new privateClass();
         }
         private get myPrivateMethod1() {
@@ -162,13 +162,13 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
     export class publicClassWithWithPrivateSetAccessorTypes {
         static set myPublicStaticMethod(param: privateClass) { // Error
                                                ~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateClass'.
+!!! error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
         }
         private static set myPrivateStaticMethod(param: privateClass) {
         }
         set myPublicMethod(param: privateClass) { // Error
                                   ~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateClass'.
+!!! error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
         }
         private set myPrivateMethod(param: privateClass) {
         }
@@ -210,22 +210,22 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
     export class publicClassWithPrivateModuleGetAccessorTypes {
         static get myPublicStaticMethod(): privateModule.publicClass { // Error
                                            ~~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateModule'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
             return null;
         }
         get myPublicMethod(): privateModule.publicClass { // Error
                               ~~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateModule'.
+!!! error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
             return null;
         }
         static get myPublicStaticMethod1() { // Error
                    ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4039: Return type of public static property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+!!! error TS4039: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
             return new privateModule.publicClass();
         }
         get myPublicMethod1() { // Error
             ~~~~~~~~~~~~~~~
-!!! error TS4042: Return type of public property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+!!! error TS4042: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
             return new privateModule.publicClass();
         }
     }
@@ -233,11 +233,11 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
     export class publicClassWithPrivateModuleSetAccessorTypes {
         static set myPublicStaticMethod(param: privateModule.publicClass) { // Error
                                                ~~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateModule'.
+!!! error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
         }
         set myPublicMethod(param: privateModule.publicClass) { // Error
                                   ~~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateModule'.
+!!! error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
         }
     }
     
@@ -272,7 +272,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         export class publicClassWithWithPrivateGetAccessorTypes {
             static get myPublicStaticMethod(): privateClass { // Error
                                                ~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
                 return null;
             }
             private static get myPrivateStaticMethod(): privateClass {
@@ -280,7 +280,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
             }
             get myPublicMethod(): privateClass { // Error
                                   ~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
                 return null;
             }
             private get myPrivateMethod(): privateClass {
@@ -288,7 +288,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
             }
             static get myPublicStaticMethod1() { // Error
                        ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using private name 'privateClass'.
                 return new privateClass();
             }
             private static get myPrivateStaticMethod1() {
@@ -296,7 +296,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
             }
             get myPublicMethod1() { // Error
                 ~~~~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4043: Return type of public getter 'myPublicMethod1' from exported class has or is using private name 'privateClass'.
                 return new privateClass();
             }
             private get myPrivateMethod1() {
@@ -388,13 +388,13 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         export class publicClassWithWithPrivateSetAccessorTypes {
             static set myPublicStaticMethod(param: privateClass) { // Error
                                                    ~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateClass'.
+!!! error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
             }
             private static set myPrivateStaticMethod(param: privateClass) {
             }
             set myPublicMethod(param: privateClass) { // Error
                                       ~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateClass'.
+!!! error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
             }
             private set myPrivateMethod(param: privateClass) {
             }
@@ -436,22 +436,22 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         export class publicClassWithPrivateModuleGetAccessorTypes {
             static get myPublicStaticMethod(): privateModule.publicClass { // Error
                                                ~~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateModule'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
                 return null;
             }
             get myPublicMethod(): privateModule.publicClass { // Error
                                   ~~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateModule'.
+!!! error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
                 return null;
             }
             static get myPublicStaticMethod1() { // Error
                        ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4039: Return type of public static property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+!!! error TS4039: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
                 return new privateModule.publicClass();
             }
             get myPublicMethod1() { // Error
                 ~~~~~~~~~~~~~~~
-!!! error TS4042: Return type of public property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+!!! error TS4042: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
                 return new privateModule.publicClass();
             }
         }
@@ -459,11 +459,11 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         export class publicClassWithPrivateModuleSetAccessorTypes {
             static set myPublicStaticMethod(param: privateModule.publicClass) { // Error
                                                    ~~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateModule'.
+!!! error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
             }
             set myPublicMethod(param: privateModule.publicClass) { // Error
                                       ~~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateModule'.
+!!! error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
             }
         }
     
@@ -948,7 +948,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         export class publicClassWithWithPrivateGetAccessorTypes {
             static get myPublicStaticMethod(): privateClass { // Error
                                                ~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
                 return null;
             }
             private static get myPrivateStaticMethod(): privateClass {
@@ -956,7 +956,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
             }
             get myPublicMethod(): privateClass { // Error
                                   ~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
                 return null;
             }
             private get myPrivateMethod(): privateClass {
@@ -964,7 +964,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
             }
             static get myPublicStaticMethod1() { // Error
                        ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using private name 'privateClass'.
                 return new privateClass();
             }
             private static get myPrivateStaticMethod1() {
@@ -972,7 +972,7 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
             }
             get myPublicMethod1() { // Error
                 ~~~~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateClass'.
+!!! error TS4043: Return type of public getter 'myPublicMethod1' from exported class has or is using private name 'privateClass'.
                 return new privateClass();
             }
             private get myPrivateMethod1() {
@@ -1064,13 +1064,13 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         export class publicClassWithWithPrivateSetAccessorTypes {
             static set myPublicStaticMethod(param: privateClass) { // Error
                                                    ~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateClass'.
+!!! error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateClass'.
             }
             private static set myPrivateStaticMethod(param: privateClass) {
             }
             set myPublicMethod(param: privateClass) { // Error
                                       ~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateClass'.
+!!! error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateClass'.
             }
             private set myPrivateMethod(param: privateClass) {
             }
@@ -1112,22 +1112,22 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         export class publicClassWithPrivateModuleGetAccessorTypes {
             static get myPublicStaticMethod(): privateModule.publicClass { // Error
                                                ~~~~~~~~~~~~~
-!!! error TS4040: Return type of public static property getter from exported class has or is using private name 'privateModule'.
+!!! error TS4040: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
                 return null;
             }
             get myPublicMethod(): privateModule.publicClass { // Error
                                   ~~~~~~~~~~~~~
-!!! error TS4043: Return type of public property getter from exported class has or is using private name 'privateModule'.
+!!! error TS4043: Return type of public getter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
                 return null;
             }
             static get myPublicStaticMethod1() { // Error
                        ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4039: Return type of public static property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+!!! error TS4039: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
                 return new privateModule.publicClass();
             }
             get myPublicMethod1() { // Error
                 ~~~~~~~~~~~~~~~
-!!! error TS4042: Return type of public property getter from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
+!!! error TS4042: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'privateModule.publicClass' from private module 'privateModule'.
                 return new privateModule.publicClass();
             }
         }
@@ -1135,11 +1135,11 @@ tests/cases/compiler/privacyAccessorDeclFile_externalModule.ts(379,35): error TS
         export class publicClassWithPrivateModuleSetAccessorTypes {
             static set myPublicStaticMethod(param: privateModule.publicClass) { // Error
                                                    ~~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicStaticMethod' of public property setter from exported class has or is using private name 'privateModule'.
+!!! error TS4035: Parameter type of public static setter 'myPublicStaticMethod' from exported class has or is using private name 'privateModule'.
             }
             set myPublicMethod(param: privateModule.publicClass) { // Error
                                       ~~~~~~~~~~~~~
-!!! error TS4037: Parameter 'myPublicMethod' of public property setter from exported class has or is using private name 'privateModule'.
+!!! error TS4037: Parameter type of public setter 'myPublicMethod' from exported class has or is using private name 'privateModule'.
             }
         }
     

--- a/tests/baselines/reference/privacyCannotNameAccessorDeclFile.errors.txt
+++ b/tests/baselines/reference/privacyCannotNameAccessorDeclFile.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(3,16): error TS4038: Return type of public static property getter from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
-tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(9,9): error TS4041: Return type of public property getter from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
-tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(15,16): error TS4038: Return type of public static property getter from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
-tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(21,9): error TS4041: Return type of public property getter from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
-tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(57,16): error TS4038: Return type of public static property getter from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
-tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(60,9): error TS4041: Return type of public property getter from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
-tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(63,16): error TS4038: Return type of public static property getter from exported class has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
-tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(66,9): error TS4041: Return type of public property getter from exported class has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
+tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(3,16): error TS4038: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
+tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(9,9): error TS4041: Return type of public getter 'myPublicMethod' from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
+tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(15,16): error TS4038: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
+tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(21,9): error TS4041: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
+tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(57,16): error TS4038: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
+tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(60,9): error TS4041: Return type of public getter 'myPublicMethod' from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
+tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(63,16): error TS4038: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
+tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(66,9): error TS4041: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
 
 
 ==== tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts (8 errors) ====
@@ -13,7 +13,7 @@ tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(66,9): error 
     export class publicClassWithWithPrivateGetAccessorTypes {
         static get myPublicStaticMethod() { // Error
                    ~~~~~~~~~~~~~~~~~~~~
-!!! error TS4038: Return type of public static property getter from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
+!!! error TS4038: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
             return exporter.createExportedWidget1();
         }
         private static get myPrivateStaticMethod() {
@@ -21,7 +21,7 @@ tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(66,9): error 
         }
         get myPublicMethod() { // Error
             ~~~~~~~~~~~~~~
-!!! error TS4041: Return type of public property getter from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
+!!! error TS4041: Return type of public getter 'myPublicMethod' from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
             return exporter.createExportedWidget1();
         }
         private get myPrivateMethod() {
@@ -29,7 +29,7 @@ tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(66,9): error 
         }
         static get myPublicStaticMethod1() { // Error
                    ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4038: Return type of public static property getter from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
+!!! error TS4038: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
             return exporter.createExportedWidget3();
         }
         private static get myPrivateStaticMethod1() {
@@ -37,7 +37,7 @@ tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(66,9): error 
         }
         get myPublicMethod1() { // Error
             ~~~~~~~~~~~~~~~
-!!! error TS4041: Return type of public property getter from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
+!!! error TS4041: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
             return exporter.createExportedWidget3();
         }
         private get myPrivateMethod1() {
@@ -75,22 +75,22 @@ tests/cases/compiler/privacyCannotNameAccessorDeclFile_consumer.ts(66,9): error 
     export class publicClassWithPrivateModuleGetAccessorTypes {
         static get myPublicStaticMethod() { // Error
                    ~~~~~~~~~~~~~~~~~~~~
-!!! error TS4038: Return type of public static property getter from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
+!!! error TS4038: Return type of public static getter 'myPublicStaticMethod' from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
             return exporter.createExportedWidget2();
         }
         get myPublicMethod() { // Error
             ~~~~~~~~~~~~~~
-!!! error TS4041: Return type of public property getter from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
+!!! error TS4041: Return type of public getter 'myPublicMethod' from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyCannotNameAccessorDeclFile_Widgets" but cannot be named.
             return exporter.createExportedWidget2();
         }
         static get myPublicStaticMethod1() { // Error
                    ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS4038: Return type of public static property getter from exported class has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
+!!! error TS4038: Return type of public static getter 'myPublicStaticMethod1' from exported class has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
             return exporter.createExportedWidget4();
         }
         get myPublicMethod1() { // Error
             ~~~~~~~~~~~~~~~
-!!! error TS4041: Return type of public property getter from exported class has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
+!!! error TS4041: Return type of public getter 'myPublicMethod1' from exported class has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
             return exporter.createExportedWidget4();
         }
     }

--- a/tests/baselines/reference/symbolDeclarationEmit12.errors.txt
+++ b/tests/baselines/reference/symbolDeclarationEmit12.errors.txt
@@ -4,7 +4,7 @@ tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(5,33): error TS40
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(6,40): error TS4055: Return type of public method from exported class has or is using private name 'I'.
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(9,13): error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,13): error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
-tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,37): error TS4037: Parameter '[Symbol.toPrimitive]' of public property setter from exported class has or is using private name 'I'.
+tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,37): error TS4037: Parameter type of public setter '[Symbol.toPrimitive]' from exported class has or is using private name 'I'.
 
 
 ==== tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts (7 errors) ====
@@ -31,6 +31,6 @@ tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,37): error TS4
                 ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
                                         ~
-!!! error TS4037: Parameter '[Symbol.toPrimitive]' of public property setter from exported class has or is using private name 'I'.
+!!! error TS4037: Parameter type of public setter '[Symbol.toPrimitive]' from exported class has or is using private name 'I'.
         }
     }

--- a/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts
+++ b/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts
@@ -13,7 +13,7 @@ module m {
         export class public2 {
         }
     }
-    
+
     export class c {
         // getter with annotation
         get foo1(): private1 {
@@ -42,7 +42,7 @@ module m {
         }
         set foo5(param: private1) {
         }
-    
+
         // getter with annotation
         get foo11(): public1 {
             return;


### PR DESCRIPTION
… type

so that error message refers to prop name instead of param name.

Changed getter errors for similar case so they also refer to prop name.

Fixed bug where static getters wouldn't output their specific error.

Fixes #1976

