### PR TITLE
Fix formatting when keyword is parsed as part of a JSX identifier (e.g. `module-layout`)

### DIFF
--- a/src/services/formatting/formattingScanner.ts
+++ b/src/services/formatting/formattingScanner.ts
@@ -125,7 +125,8 @@ namespace ts.formatting {
                     case SyntaxKind.JsxOpeningElement:
                     case SyntaxKind.JsxClosingElement:
                     case SyntaxKind.JsxSelfClosingElement:
-                        return node.kind === SyntaxKind.Identifier;
+                        // May parse an identifier like `module-layout`; that will be scanned as a keyword at first, but we should parse the whole thing to get an identifier.
+                        return isKeyword(node.kind) || node.kind === SyntaxKind.Identifier;
                 }
             }
 
@@ -209,7 +210,7 @@ namespace ts.formatting {
                 currentToken = scanner.reScanTemplateToken();
                 lastScanAction = ScanAction.RescanTemplateToken;
             }
-            else if (expectedScanAction === ScanAction.RescanJsxIdentifier && currentToken === SyntaxKind.Identifier) {
+            else if (expectedScanAction === ScanAction.RescanJsxIdentifier) {
                 currentToken = scanner.scanJsxIdentifier();
                 lastScanAction = ScanAction.RescanJsxIdentifier;
             }

--- a/tests/cases/fourslash/formatJsxWithKeywordInIdentifier.ts
+++ b/tests/cases/fourslash/formatJsxWithKeywordInIdentifier.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+// Test that we don't crash when encountering a keyword in a JSX identifier.
+
+// @Filename: /a.tsx
+////<div module-layout=""></div>
+
+format.document();
+verify.currentFileContentIs(`<div module-layout=""></div>`);


### PR DESCRIPTION
Fixes #17128
