### PR TITLE
ThisKeyword is not a type, only ThisType is

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2507,7 +2507,7 @@ namespace ts {
                             context.encounteredError = true;
                         }
                     }
-                    return createThis();
+                    return createThisTypeNode();
                 }
 
                 const objectFlags = getObjectFlags(type);
@@ -8040,7 +8040,6 @@ namespace ts {
                 case SyntaxKind.ObjectKeyword:
                     return node.flags & NodeFlags.JavaScriptFile ? anyType : nonPrimitiveType;
                 case SyntaxKind.ThisType:
-                case SyntaxKind.ThisKeyword:
                     return getTypeFromThisTypeNode(node as ThisExpression | ThisTypeNode);
                 case SyntaxKind.LiteralType:
                     return getTypeFromLiteralTypeNode(<LiteralTypeNode>node);

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -285,9 +285,13 @@ namespace ts {
     }
 
     const tokenStrings = makeReverseMap(textToToken);
+    // "this" maps to SyntaxKind.ThisKeyword normally, so can't be in textToToken. But can put it in tokenStrings.
+    tokenStrings[SyntaxKind.ThisType] = "this";
 
     export function tokenToString(t: SyntaxKind): string | undefined {
-        return tokenStrings[t];
+        const res = tokenStrings[t];
+        Debug.assert(!!res);
+        return res;
     }
 
     /* @internal */

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -289,9 +289,7 @@ namespace ts {
     tokenStrings[SyntaxKind.ThisType] = "this";
 
     export function tokenToString(t: SyntaxKind): string | undefined {
-        const res = tokenStrings[t];
-        Debug.assert(!!res);
-        return res;
+        return tokenStrings[t];
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -157,6 +157,7 @@ namespace ts {
         SuperKeyword,
         SwitchKeyword,
         ThisKeyword,
+        ThisType, // Same as ThisKeyword, but parsed from a type context.
         ThrowKeyword,
         TrueKeyword,
         TryKeyword,
@@ -235,7 +236,6 @@ namespace ts {
         UnionType,
         IntersectionType,
         ParenthesizedType,
-        ThisType,
         TypeOperator,
         IndexedAccessType,
         MappedType,
@@ -953,7 +953,6 @@ namespace ts {
             | SyntaxKind.BooleanKeyword
             | SyntaxKind.StringKeyword
             | SyntaxKind.SymbolKeyword
-            | SyntaxKind.ThisKeyword
             | SyntaxKind.VoidKeyword
             | SyntaxKind.UndefinedKeyword
             | SyntaxKind.NullKeyword
@@ -1138,7 +1137,7 @@ namespace ts {
         kind: SyntaxKind.TrueKeyword | SyntaxKind.FalseKeyword;
     }
 
-    export interface ThisExpression extends PrimaryExpression, KeywordTypeNode {
+    export interface ThisExpression extends PrimaryExpression {
         kind: SyntaxKind.ThisKeyword;
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5012,7 +5012,7 @@ namespace ts {
             || kind === SyntaxKind.BooleanKeyword
             || kind === SyntaxKind.StringKeyword
             || kind === SyntaxKind.SymbolKeyword
-            || kind === SyntaxKind.ThisKeyword
+            || kind === SyntaxKind.ThisType
             || kind === SyntaxKind.VoidKeyword
             || kind === SyntaxKind.UndefinedKeyword
             || kind === SyntaxKind.NullKeyword

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1674,6 +1674,10 @@ namespace ts.Completions {
         function getAllKeywordCompletions() {
             const allKeywordsCompletions: CompletionEntry[] = [];
             for (let i = SyntaxKind.FirstKeyword; i <= SyntaxKind.LastKeyword; i++) {
+                if (i === SyntaxKind.ThisType) {
+                    // handled by SyntaxKind.ThisKeyword
+                    continue;
+                }
                 allKeywordsCompletions.push({
                     name: tokenToString(i),
                     kind: ScriptElementKind.keyword,

--- a/tests/cases/fourslash/quickInfoOnThis.ts
+++ b/tests/cases/fourslash/quickInfoOnThis.ts
@@ -23,7 +23,7 @@
 ////}
 
 verify.quickInfos({
-    0: "this: this",
+    0: "class Foo",
     1: "this: void",
     2: "this: this",
     3: "(parameter) this: Restricted",


### PR DESCRIPTION
Replaces #15686
Ensures that we're always using `ThisType` for `this` in a type position, not `ThisKeyword`.