### PR TITLE
JavaScript: handle lack of modifiers on extracted method

### DIFF
--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -650,7 +650,7 @@ namespace ts.refactor.extractMethod {
             }
             newFunction = createMethod(
                 /*decorators*/ undefined,
-                modifiers,
+                modifiers.length ? modifiers : undefined,
                 range.facts & RangeFacts.IsGenerator ? createToken(SyntaxKind.AsteriskToken) : undefined,
                 functionName,
                 /*questionToken*/ undefined,

--- a/tests/cases/fourslash/extract-method26.ts
+++ b/tests/cases/fourslash/extract-method26.ts
@@ -1,0 +1,30 @@
+/// <reference path='fourslash.ts' />
+
+// Handle having zero modifiers on a method.
+
+// @allowNonTsExtensions: true
+// @Filename: file1.js
+//// class C {
+////     M() {
+////         const q = /*a*/1 + 2/*b*/;
+////         q.toString();
+////     }
+//// }
+
+goTo.select('a', 'b')
+edit.applyRefactor({
+    refactorName: "Extract Method",
+    actionName: "scope_0",
+    actionDescription: "Extract function into class 'C'",
+    newContent:
+`class C {
+    M() {
+        const q = this./*RENAME*/newFunction();
+        q.toString();
+    }
+
+    newFunction() {
+        return 1 + 2;
+    }
+}`
+});


### PR DESCRIPTION
The emitter expects undefined, rather than empty.  This only affects JS, because TS applies `private` to all extracted methods.

TODO: port to `master`.