### PR TITLE
Unify duplicate `getNameOfSymbol` functions

### DIFF
--- a/tests/baselines/reference/declarationQuotedMembers.types
+++ b/tests/baselines/reference/declarationQuotedMembers.types
@@ -1,9 +1,9 @@
 === tests/cases/compiler/declarationQuotedMembers.ts ===
 export declare const mapped: { [K in 'a-b-c']: number }
->mapped : { a-b-c: number; }
+>mapped : { "a-b-c": number; }
 >K : K
 
 export const example = mapped;
->example : { a-b-c: number; }
->mapped : { a-b-c: number; }
+>example : { "a-b-c": number; }
+>mapped : { "a-b-c": number; }
 


### PR DESCRIPTION
These have basically the same content with the exception of `context`. Looks like it was copy-pasted at some point. Also, a bug was apparently fixed in one version but not in the other.