### PR TITLE
Fix get adjusted start position on first line

### DIFF
--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -152,7 +152,9 @@ namespace ts.textChanges {
             return position === Position.Start ? start : fullStart;
         }
         // get start position of the line following the line that contains fullstart position
-        let adjustedStartPosition = getStartPositionOfLine(getLineOfLocalPosition(sourceFile, fullStartLine) + (fullStart > 0 ? 1 : 0), sourceFile);
+        // (but only if the fullstart isn't the very beginning of the file)
+        const nextLineStart = fullStart > 0 ? 1 : 0;
+        let adjustedStartPosition = getStartPositionOfLine(getLineOfLocalPosition(sourceFile, fullStartLine) + nextLineStart, sourceFile);
         // skip whitespaces/newlines
         adjustedStartPosition = skipWhitespacesAndLineBreaks(sourceFile.text, adjustedStartPosition);
         return getStartPositionOfLine(getLineOfLocalPosition(sourceFile, adjustedStartPosition), sourceFile);

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -152,7 +152,7 @@ namespace ts.textChanges {
             return position === Position.Start ? start : fullStart;
         }
         // get start position of the line following the line that contains fullstart position
-        let adjustedStartPosition = getStartPositionOfLine(getLineOfLocalPosition(sourceFile, fullStartLine) + 1, sourceFile);
+        let adjustedStartPosition = getStartPositionOfLine(getLineOfLocalPosition(sourceFile, fullStartLine) + (fullStart > 0 ? 1 : 0), sourceFile);
         // skip whitespaces/newlines
         adjustedStartPosition = skipWhitespacesAndLineBreaks(sourceFile.text, adjustedStartPosition);
         return getStartPositionOfLine(getLineOfLocalPosition(sourceFile, adjustedStartPosition), sourceFile);

--- a/tests/cases/fourslash/extract-method-uniqueName.ts
+++ b/tests/cases/fourslash/extract-method-uniqueName.ts
@@ -9,8 +9,7 @@ edit.applyRefactor({
     actionName: "scope_0",
     actionDescription: "Extract to function in global scope",
     newContent:
-`// newFunction
-/*RENAME*/newFunction_1();
+`/*RENAME*/newFunction_1();
 
 function newFunction_1() {
     // newFunction

--- a/tests/cases/fourslash/extract-method-uniqueName.ts
+++ b/tests/cases/fourslash/extract-method-uniqueName.ts
@@ -3,6 +3,8 @@
 ////// newFunction
 /////*start*/1 + 1/*end*/;
 
+// NOTE: '// newFunction' should be included, but due to incorrect handling of trivia,
+// it's omitted right now.
 goTo.select('start', 'end')
 edit.applyRefactor({
     refactorName: "Extract Method",

--- a/tests/cases/fourslash/server/convertFunctionToEs6Class-server.ts
+++ b/tests/cases/fourslash/server/convertFunctionToEs6Class-server.ts
@@ -12,6 +12,8 @@
 //// }
 
 verify.applicableRefactorAvailableAtMarker('1');
+// NOTE: '// Comment' should be included, but due to incorrect handling of trivia,
+// it's omitted right now.
 verify.fileAfterApplyingRefactorAtMarker('1',
 `class fn {
     constructor() {

--- a/tests/cases/fourslash/server/convertFunctionToEs6Class-server.ts
+++ b/tests/cases/fourslash/server/convertFunctionToEs6Class-server.ts
@@ -13,8 +13,7 @@
 
 verify.applicableRefactorAvailableAtMarker('1');
 verify.fileAfterApplyingRefactorAtMarker('1',
-`// Comment
-class fn {
+`class fn {
     constructor() {
         this.baz = 10;
     }


### PR DESCRIPTION
getAdjustedStartPosition shouldn't skip to next line when on 1st line when calculating adjustedStartPosition.

Note that the baseline update resulting from this fix is not good because we would not like to lose the leading comments. It should be fixed when
(1) trivia-handling issues are fixed or (2) the refactorings themselves
add a workaround. The workaround is unlikely to be completely correct, though &mdash; this is a known problem with Extract Method.