### PR TITLE
Support JS baselines in Extract Method unit tests

### DIFF
--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -641,7 +641,7 @@ function test(x: number) {
     [#|v.toString()|];
 }`);
 
-        testExtractMethod("extractMethod20", [Extension.Ts],
+        testExtractMethod("extractMethod20", [Extension.Ts, Extension.Js],
         `const _ = class {
     a() {
         [#|let a1 = { x: 1 };
@@ -649,14 +649,14 @@ function test(x: number) {
     }
 }`);
         // Write + void return
-        testExtractMethod("extractMethod21", [Extension.Ts],
+        testExtractMethod("extractMethod21", [Extension.Ts, Extension.Js],
             `function foo() {
     let x = 10;
     [#|x++;
     return;|]
 }`);
         // Return in finally block
-        testExtractMethod("extractMethod22", [Extension.Ts],
+        testExtractMethod("extractMethod22", [Extension.Ts, Extension.Js],
             `function test() {
     try {
     }
@@ -674,7 +674,7 @@ function test(x: number) {
     function M3() { }
 }`);
         // Extraction position - function
-        testExtractMethod("extractMethod24", [Extension.Ts],
+        testExtractMethod("extractMethod24", [Extension.Ts, Extension.Js],
             `function Outer() {
     function M1() { }
     function M2() {
@@ -683,14 +683,14 @@ function test(x: number) {
     function M3() { }
 }`);
         // Extraction position - file
-        testExtractMethod("extractMethod25", [Extension.Ts],
+        testExtractMethod("extractMethod25", [Extension.Ts, Extension.Js],
             `function M1() { }
 function M2() {
     [#|return 1;|]
 }
 function M3() { }`);
         // Extraction position - class without ctor
-        testExtractMethod("extractMethod26", [Extension.Ts],
+        testExtractMethod("extractMethod26", [Extension.Ts, Extension.Js],
             `class C {
     M1() { }
     M2() {
@@ -699,7 +699,7 @@ function M3() { }`);
     M3() { }
 }`);
         // Extraction position - class with ctor in middle
-        testExtractMethod("extractMethod27", [Extension.Ts],
+        testExtractMethod("extractMethod27", [Extension.Ts, Extension.Js],
             `class C {
     M1() { }
     M2() {
@@ -709,7 +709,7 @@ function M3() { }`);
     M3() { }
 }`);
         // Extraction position - class with ctor at end
-        testExtractMethod("extractMethod28", [Extension.Ts],
+        testExtractMethod("extractMethod28", [Extension.Ts, Extension.Js],
             `class C {
     M1() { }
     M2() {
@@ -738,12 +738,12 @@ function parsePrimaryExpression(): any {
     throw "Not implemented";
 }`);
         // Type parameter as declared type
-        testExtractMethod("extractMethod30", [Extension.Ts],
+        testExtractMethod("extractMethod30", [Extension.Ts, Extension.Js],
             `function F<T>() {
     [#|let t: T;|]
 }`);
         // Return in nested function
-        testExtractMethod("extractMethod31", [Extension.Ts],
+        testExtractMethod("extractMethod31", [Extension.Ts, Extension.Js],
             `namespace N {
 
     export const value = 1;
@@ -756,7 +756,7 @@ function parsePrimaryExpression(): any {
     }
 }`);
         // Return in nested class
-        testExtractMethod("extractMethod32", [Extension.Ts],
+        testExtractMethod("extractMethod32", [Extension.Ts, Extension.Js],
             `namespace N {
 
     export const value = 1;
@@ -770,7 +770,7 @@ function parsePrimaryExpression(): any {
     }
 }`);
         // Selection excludes leading trivia of declaration
-        testExtractMethod("extractMethod33", [Extension.Ts],
+        testExtractMethod("extractMethod33", [Extension.Ts, Extension.Js],
             `function F() {
     [#|function G() { }|]
 }`);

--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -412,7 +412,7 @@ function test(x: number) {
 
         testExtractRangeFailed("extract-method-not-for-token-expression-statement", `[#|a|]`, ["Select more than a single identifier."]);
 
-        testExtractMethod("extractMethod1",
+        testExtractMethod("extractMethod1", [Extension.Ts],
             `namespace A {
     let x = 1;
     function foo() {
@@ -428,7 +428,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod2",
+        testExtractMethod("extractMethod2", [Extension.Ts],
             `namespace A {
     let x = 1;
     function foo() {
@@ -442,7 +442,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod3",
+        testExtractMethod("extractMethod3", [Extension.Ts],
             `namespace A {
     function foo() {
     }
@@ -455,7 +455,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod4",
+        testExtractMethod("extractMethod4", [Extension.Ts],
             `namespace A {
     function foo() {
     }
@@ -470,7 +470,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod5",
+        testExtractMethod("extractMethod5", [Extension.Ts],
             `namespace A {
     let x = 1;
     export function foo() {
@@ -486,7 +486,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod6",
+        testExtractMethod("extractMethod6", [Extension.Ts],
             `namespace A {
     let x = 1;
     export function foo() {
@@ -502,7 +502,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod7",
+        testExtractMethod("extractMethod7", [Extension.Ts],
             `namespace A {
     let x = 1;
     export namespace C {
@@ -520,7 +520,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod8",
+        testExtractMethod("extractMethod8", [Extension.Ts],
             `namespace A {
     let x = 1;
     namespace B {
@@ -530,7 +530,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod9",
+        testExtractMethod("extractMethod9", [Extension.Ts],
             `namespace A {
     export interface I { x: number };
     namespace B {
@@ -540,7 +540,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod10",
+        testExtractMethod("extractMethod10", [Extension.Ts],
             `namespace A {
     export interface I { x: number };
     class C {
@@ -551,7 +551,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod11",
+        testExtractMethod("extractMethod11", [Extension.Ts],
             `namespace A {
     let y = 1;
     class C {
@@ -564,7 +564,7 @@ function test(x: number) {
         }
     }
 }`);
-        testExtractMethod("extractMethod12",
+        testExtractMethod("extractMethod12", [Extension.Ts],
             `namespace A {
     let y = 1;
     class C {
@@ -584,7 +584,7 @@ function test(x: number) {
         // In all cases, we could use type inference, rather than passing explicit type arguments.
         // Note the inclusion of arrow functions to ensure that some type parameters are not from
         //   targetable scopes.
-        testExtractMethod("extractMethod13",
+        testExtractMethod("extractMethod13", [Extension.Ts],
             `<U1a, U1b>(u1a: U1a, u1b: U1b) => {
     function F1<T1a, T1b>(t1a: T1a, t1b: T1b) {
         <U2a, U2b>(u2a: U2a, u2b: U2b) => {
@@ -602,7 +602,7 @@ function test(x: number) {
 }`);
         // This test is descriptive, rather than normative.  The current implementation
         // doesn't handle type parameter shadowing.
-        testExtractMethod("extractMethod14",
+        testExtractMethod("extractMethod14", [Extension.Ts],
             `function F<T>(t1: T) {
     function F<T>(t2: T) {
         [#|t1.toString();
@@ -610,38 +610,38 @@ function test(x: number) {
     }
 }`);
         // Confirm that the constraint is preserved.
-        testExtractMethod("extractMethod15",
+        testExtractMethod("extractMethod15", [Extension.Ts],
             `function F<T>(t1: T) {
     function F<U extends T[]>(t2: U) {
         [#|t2.toString();|]
     }
 }`);
         // Confirm that the contextual type of an extracted expression counts as a use.
-        testExtractMethod("extractMethod16",
+        testExtractMethod("extractMethod16", [Extension.Ts],
             `function F<T>() {
     const array: T[] = [#|[]|];
 }`);
         // Class type parameter
-        testExtractMethod("extractMethod17",
+        testExtractMethod("extractMethod17", [Extension.Ts],
             `class C<T1, T2> {
     M(t1: T1, t2: T2) {
         [#|t1.toString()|];
     }
 }`);
         // Method type parameter
-        testExtractMethod("extractMethod18",
+        testExtractMethod("extractMethod18", [Extension.Ts],
             `class C {
     M<T1, T2>(t1: T1, t2: T2) {
         [#|t1.toString()|];
     }
 }`);
         // Coupled constraints
-        testExtractMethod("extractMethod19",
+        testExtractMethod("extractMethod19", [Extension.Ts],
             `function F<T, U extends T[], V extends U[]>(v: V) {
     [#|v.toString()|];
 }`);
 
-        testExtractMethod("extractMethod20",
+        testExtractMethod("extractMethod20", [Extension.Ts],
         `const _ = class {
     a() {
         [#|let a1 = { x: 1 };
@@ -649,14 +649,14 @@ function test(x: number) {
     }
 }`);
         // Write + void return
-        testExtractMethod("extractMethod21",
+        testExtractMethod("extractMethod21", [Extension.Ts],
             `function foo() {
     let x = 10;
     [#|x++;
     return;|]
 }`);
         // Return in finally block
-        testExtractMethod("extractMethod22",
+        testExtractMethod("extractMethod22", [Extension.Ts],
             `function test() {
     try {
     }
@@ -665,7 +665,7 @@ function test(x: number) {
     }
 }`);
         // Extraction position - namespace
-        testExtractMethod("extractMethod23",
+        testExtractMethod("extractMethod23", [Extension.Ts],
             `namespace NS {
     function M1() { }
     function M2() {
@@ -674,7 +674,7 @@ function test(x: number) {
     function M3() { }
 }`);
         // Extraction position - function
-        testExtractMethod("extractMethod24",
+        testExtractMethod("extractMethod24", [Extension.Ts],
             `function Outer() {
     function M1() { }
     function M2() {
@@ -683,14 +683,14 @@ function test(x: number) {
     function M3() { }
 }`);
         // Extraction position - file
-        testExtractMethod("extractMethod25",
+        testExtractMethod("extractMethod25", [Extension.Ts],
             `function M1() { }
 function M2() {
     [#|return 1;|]
 }
 function M3() { }`);
         // Extraction position - class without ctor
-        testExtractMethod("extractMethod26",
+        testExtractMethod("extractMethod26", [Extension.Ts],
             `class C {
     M1() { }
     M2() {
@@ -699,7 +699,7 @@ function M3() { }`);
     M3() { }
 }`);
         // Extraction position - class with ctor in middle
-        testExtractMethod("extractMethod27",
+        testExtractMethod("extractMethod27", [Extension.Ts],
             `class C {
     M1() { }
     M2() {
@@ -709,7 +709,7 @@ function M3() { }`);
     M3() { }
 }`);
         // Extraction position - class with ctor at end
-        testExtractMethod("extractMethod28",
+        testExtractMethod("extractMethod28", [Extension.Ts],
             `class C {
     M1() { }
     M2() {
@@ -719,7 +719,7 @@ function M3() { }`);
     constructor() { }
 }`);
         // Shorthand property names
-        testExtractMethod("extractMethod29",
+        testExtractMethod("extractMethod29", [Extension.Ts],
             `interface UnaryExpression {
     kind: "Unary";
     operator: string;
@@ -738,12 +738,12 @@ function parsePrimaryExpression(): any {
     throw "Not implemented";
 }`);
         // Type parameter as declared type
-        testExtractMethod("extractMethod30",
+        testExtractMethod("extractMethod30", [Extension.Ts],
             `function F<T>() {
     [#|let t: T;|]
 }`);
         // Return in nested function
-        testExtractMethod("extractMethod31",
+        testExtractMethod("extractMethod31", [Extension.Ts],
             `namespace N {
 
     export const value = 1;
@@ -756,7 +756,7 @@ function parsePrimaryExpression(): any {
     }
 }`);
         // Return in nested class
-        testExtractMethod("extractMethod32",
+        testExtractMethod("extractMethod32", [Extension.Ts],
             `namespace N {
 
     export const value = 1;
@@ -770,21 +770,22 @@ function parsePrimaryExpression(): any {
     }
 }`);
         // Selection excludes leading trivia of declaration
-        testExtractMethod("extractMethod33",
+        testExtractMethod("extractMethod33", [Extension.Ts],
             `function F() {
     [#|function G() { }|]
 }`);
     });
 
 
-    function testExtractMethod(caption: string, text: string) {
+    function testExtractMethod(caption: string, extensions: Extension[], text: string) {
         const t = extractTest(text);
         const selectionRange = t.ranges.get("selection");
         if (!selectionRange) {
             throw new Error(`Test ${caption} does not specify selection range`);
         }
 
-        it(caption, () => runBaseline(Extension.Ts));
+        extensions.forEach(extension =>
+            it(`${caption} [${extension}]`, () => runBaseline(extension)));
 
         function runBaseline(extension: Extension) {
             Harness.Baseline.runBaseline(`extractMethod/${caption}${extension}`, () => {

--- a/src/harness/unittests/extractMethods.ts
+++ b/src/harness/unittests/extractMethods.ts
@@ -778,15 +778,18 @@ function parsePrimaryExpression(): any {
 
 
     function testExtractMethod(caption: string, text: string) {
-        it(caption, () => {
-            Harness.Baseline.runBaseline(`extractMethod/${caption}.ts`, () => {
-                const t = extractTest(text);
-                const selectionRange = t.ranges.get("selection");
-                if (!selectionRange) {
-                    throw new Error(`Test ${caption} does not specify selection range`);
-                }
+        const t = extractTest(text);
+        const selectionRange = t.ranges.get("selection");
+        if (!selectionRange) {
+            throw new Error(`Test ${caption} does not specify selection range`);
+        }
+
+        it(caption, () => runBaseline(Extension.Ts));
+
+        function runBaseline(extension: Extension) {
+            Harness.Baseline.runBaseline(`extractMethod/${caption}${extension}`, () => {
                 const f = {
-                    path: "/a.ts",
+                    path: "/a" + extension,
                     content: t.source
                 };
                 const host = projectSystem.createServerHost([f, projectSystem.libFile]);
@@ -818,6 +821,6 @@ function parsePrimaryExpression(): any {
                 }
                 return data.join(newLineCharacter);
             });
-        });
+        }
     }
 }

--- a/tests/baselines/reference/extractMethod/extractMethod20.js
+++ b/tests/baselines/reference/extractMethod/extractMethod20.js
@@ -1,0 +1,28 @@
+// ==ORIGINAL==
+const _ = class {
+    a() {
+        let a1 = { x: 1 };
+        return a1.x + 10;
+    }
+}
+// ==SCOPE::method in anonymous class expression==
+const _ = class {
+    a() {
+        return this./*RENAME*/newFunction();
+    }
+
+    newFunction() {
+        let a1 = { x: 1 };
+        return a1.x + 10;
+    }
+}
+// ==SCOPE::function in global scope==
+const _ = class {
+    a() {
+        return /*RENAME*/newFunction();
+    }
+}
+function newFunction() {
+    let a1 = { x: 1 };
+    return a1.x + 10;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod21.js
+++ b/tests/baselines/reference/extractMethod/extractMethod21.js
@@ -1,0 +1,26 @@
+// ==ORIGINAL==
+function foo() {
+    let x = 10;
+    x++;
+    return;
+}
+// ==SCOPE::inner function in function 'foo'==
+function foo() {
+    let x = 10;
+    return /*RENAME*/newFunction();
+
+    function newFunction() {
+        x++;
+        return;
+    }
+}
+// ==SCOPE::function in global scope==
+function foo() {
+    let x = 10;
+    x = /*RENAME*/newFunction(x);
+    return;
+}
+function newFunction(x) {
+    x++;
+    return x;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod22.js
+++ b/tests/baselines/reference/extractMethod/extractMethod22.js
@@ -1,0 +1,31 @@
+// ==ORIGINAL==
+function test() {
+    try {
+    }
+    finally {
+        return 1;
+    }
+}
+// ==SCOPE::inner function in function 'test'==
+function test() {
+    try {
+    }
+    finally {
+        return /*RENAME*/newFunction();
+    }
+
+    function newFunction() {
+        return 1;
+    }
+}
+// ==SCOPE::function in global scope==
+function test() {
+    try {
+    }
+    finally {
+        return /*RENAME*/newFunction();
+    }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod24.js
+++ b/tests/baselines/reference/extractMethod/extractMethod24.js
@@ -1,0 +1,43 @@
+// ==ORIGINAL==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return 1;
+    }
+    function M3() { }
+}
+// ==SCOPE::inner function in function 'M2'==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return /*RENAME*/newFunction();
+
+        function newFunction() {
+            return 1;
+        }
+    }
+    function M3() { }
+}
+// ==SCOPE::inner function in function 'Outer'==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return /*RENAME*/newFunction();
+    }
+    function newFunction() {
+        return 1;
+    }
+
+    function M3() { }
+}
+// ==SCOPE::function in global scope==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return /*RENAME*/newFunction();
+    }
+    function M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod25.js
+++ b/tests/baselines/reference/extractMethod/extractMethod25.js
@@ -1,0 +1,26 @@
+// ==ORIGINAL==
+function M1() { }
+function M2() {
+    return 1;
+}
+function M3() { }
+// ==SCOPE::inner function in function 'M2'==
+function M1() { }
+function M2() {
+    return /*RENAME*/newFunction();
+
+    function newFunction() {
+        return 1;
+    }
+}
+function M3() { }
+// ==SCOPE::function in global scope==
+function M1() { }
+function M2() {
+    return /*RENAME*/newFunction();
+}
+function newFunction() {
+    return 1;
+}
+
+function M3() { }

--- a/tests/baselines/reference/extractMethod/extractMethod26.js
+++ b/tests/baselines/reference/extractMethod/extractMethod26.js
@@ -1,0 +1,31 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    M3() { }
+}
+// ==SCOPE::method in class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this./*RENAME*/newFunction();
+    }
+    newFunction() {
+        return 1;
+    }
+
+    M3() { }
+}
+// ==SCOPE::function in global scope==
+class C {
+    M1() { }
+    M2() {
+        return /*RENAME*/newFunction();
+    }
+    M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod27.js
+++ b/tests/baselines/reference/extractMethod/extractMethod27.js
@@ -1,0 +1,34 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    constructor() { }
+    M3() { }
+}
+// ==SCOPE::method in class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this./*RENAME*/newFunction();
+    }
+    constructor() { }
+    newFunction() {
+        return 1;
+    }
+
+    M3() { }
+}
+// ==SCOPE::function in global scope==
+class C {
+    M1() { }
+    M2() {
+        return /*RENAME*/newFunction();
+    }
+    constructor() { }
+    M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod28.js
+++ b/tests/baselines/reference/extractMethod/extractMethod28.js
@@ -1,0 +1,34 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    M3() { }
+    constructor() { }
+}
+// ==SCOPE::method in class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this./*RENAME*/newFunction();
+    }
+    newFunction() {
+        return 1;
+    }
+
+    M3() { }
+    constructor() { }
+}
+// ==SCOPE::function in global scope==
+class C {
+    M1() { }
+    M2() {
+        return /*RENAME*/newFunction();
+    }
+    M3() { }
+    constructor() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod30.js
+++ b/tests/baselines/reference/extractMethod/extractMethod30.js
@@ -1,0 +1,19 @@
+// ==ORIGINAL==
+function F<T>() {
+    let t: T;
+}
+// ==SCOPE::inner function in function 'F'==
+function F<T>() {
+    /*RENAME*/newFunction();
+
+    function newFunction() {
+        let t: T;
+    }
+}
+// ==SCOPE::function in global scope==
+function F<T>() {
+    /*RENAME*/newFunction<T>();
+}
+function newFunction<T>() {
+    let t: T;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod31.js
+++ b/tests/baselines/reference/extractMethod/extractMethod31.js
@@ -1,0 +1,45 @@
+// ==ORIGINAL==
+namespace N {
+
+    export const value = 1;
+
+    () => {
+        var f: () => number;
+        f = function (): number {
+            return value;
+        }
+    }
+}
+// ==SCOPE::function in namespace 'N'==
+namespace N {
+
+    export const value = 1;
+
+    () => {
+        var f: () => number;
+        f = /*RENAME*/newFunction(f);
+    }
+
+    function newFunction(f) {
+        f = function(): number {
+            return value;
+        };
+        return f;
+    }
+}
+// ==SCOPE::function in global scope==
+namespace N {
+
+    export const value = 1;
+
+    () => {
+        var f: () => number;
+        f = /*RENAME*/newFunction(f);
+    }
+}
+function newFunction(f) {
+    f = function(): number {
+        return N.value;
+    };
+    return f;
+}

--- a/tests/baselines/reference/extractMethod/extractMethod32.js
+++ b/tests/baselines/reference/extractMethod/extractMethod32.js
@@ -1,0 +1,46 @@
+// ==ORIGINAL==
+namespace N {
+
+    export const value = 1;
+
+    () => {
+        var c = class {
+            M() {
+                return value;
+            }
+        }
+    }
+}
+// ==SCOPE::function in namespace 'N'==
+namespace N {
+
+    export const value = 1;
+
+    () => {
+        /*RENAME*/newFunction();
+    }
+
+    function newFunction() {
+        var c = class {
+            M() {
+                return value;
+            }
+        };
+    }
+}
+// ==SCOPE::function in global scope==
+namespace N {
+
+    export const value = 1;
+
+    () => {
+        /*RENAME*/newFunction();
+    }
+}
+function newFunction() {
+    var c = class {
+        M() {
+            return N.value;
+        }
+    };
+}

--- a/tests/baselines/reference/extractMethod/extractMethod33.js
+++ b/tests/baselines/reference/extractMethod/extractMethod33.js
@@ -1,0 +1,19 @@
+// ==ORIGINAL==
+function F() {
+    function G() { }
+}
+// ==SCOPE::inner function in function 'F'==
+function F() {
+    /*RENAME*/newFunction();
+
+    function newFunction() {
+        function G() { }
+    }
+}
+// ==SCOPE::function in global scope==
+function F() {
+    /*RENAME*/newFunction();
+}
+function newFunction() {
+    function G() { }
+}


### PR DESCRIPTION
I basically just eyeballed the existing tests and picked the ones that looked like JS.

Note that we could actually get JS baselines for the other tests too, but I didn't see much benefit to doing so.