### PR TITLE
Properly resolve JS-only scoped packages with defined entry points (release-2.5)

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -986,7 +986,20 @@ namespace ts {
 
     function getNameOfTopDirectory(name: string): { top: string, rest: string } {
         const idx = name.indexOf(directorySeparator);
-        return idx === -1 ? { top: name, rest: "" } : { top: name.slice(0, idx), rest: name.slice(idx + 1) };
+        if (idx === -1) {
+            return { top: name, rest: "" };
+        }
+        else {
+            const top = name.slice(0, idx);
+            const rest = name.slice(idx + 1);
+            // Scoped packages should be treated as a distinct unit
+            if (top[0] === '@') {
+                return { top: name, rest: "" };
+            }
+            else {
+                return { top, rest };
+            }
+        }
     }
 
     function loadModuleFromNodeModules(extensions: Extensions, moduleName: string, directory: string, failedLookupLocations: Push<string>, state: ModuleResolutionState, cache: NonRelativeModuleNameResolutionCache): SearchResult<Resolved> {

--- a/tests/baselines/reference/scopedPackages.trace.json
+++ b/tests/baselines/reference/scopedPackages.trace.json
@@ -2,7 +2,7 @@
     "======== Resolving module '@cow/boy' from '/a.ts'. ========",
     "Module resolution kind is not specified, using 'NodeJs'.",
     "Loading module '@cow/boy' from 'node_modules' folder, target file type 'TypeScript'.",
-    "File '/node_modules/@cow/package.json' does not exist.",
+    "File '/node_modules/@cow/boy/package.json' does not exist.",
     "File '/node_modules/@cow/boy.ts' does not exist.",
     "File '/node_modules/@cow/boy.tsx' does not exist.",
     "File '/node_modules/@cow/boy.d.ts' does not exist.",


### PR DESCRIPTION
Fixes #18630 which regressed at #18326.

When we look for a node module of the form `foo/bar` it's correct to look in `foo` for a `package.json` but *not* `foo/bar/package.json`. This is *not* the case for `@foo/bar`; we *do* need to look for `@foo/bar/package.json`.

Essentially any scoped package name `@foo/bar` needs to be treated as if they are fully atomic, hence the change in `getNameOfTopDirectory`