### PR TITLE
Add Symbol.species to ArrayConstructor, MapConstructor, SetConstructo…

### DIFF
--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -150,7 +150,7 @@ interface Promise<T> {
 }
 
 interface PromiseConstructor {
-    readonly [Symbol.species]: Function;
+    readonly [Symbol.species]: PromiseConstructor;
 }
 
 interface RegExp {
@@ -202,7 +202,7 @@ interface RegExp {
 }
 
 interface RegExpConstructor {
-    [Symbol.species](): RegExpConstructor;
+    readonly [Symbol.species]: RegExpConstructor;
 }
 
 interface String {
@@ -282,4 +282,17 @@ interface Float32Array {
 
 interface Float64Array {
     readonly [Symbol.toStringTag]: "Float64Array";
+}
+
+interface ArrayConstructor {
+    readonly [Symbol.species]: ArrayConstructor;
+}
+interface MapConstructor {
+    readonly [Symbol.species]: MapConstructor;
+}
+interface SetConstructor {
+    readonly [Symbol.species]: SetConstructor;
+}
+interface ArrayBufferConstructor {
+    readonly [Symbol.species]: ArrayBufferConstructor;
 }


### PR DESCRIPTION
…r, ArrayBufferConstructor.

Fix Symbol.species in RegExpConstructor and PromiseConstructor.

See https://github.com/Microsoft/TypeScript/issues/2881 .
