### PR TITLE
Make it a parse error for an `@type` jsdoc tag to not include a type

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6137,11 +6137,11 @@ namespace ts {
             // Parses out a JSDoc type expression.
             /* @internal */
             export function parseJSDocTypeExpression(): JSDocTypeExpression;
-            export function parseJSDocTypeExpression(mayBail: true): JSDocTypeExpression | undefined;
-            export function parseJSDocTypeExpression(mayBail?: boolean): JSDocTypeExpression | undefined {
+            export function parseJSDocTypeExpression(requireBraces: true): JSDocTypeExpression | undefined;
+            export function parseJSDocTypeExpression(requireBraces?: boolean): JSDocTypeExpression | undefined {
                 const result = <JSDocTypeExpression>createNode(SyntaxKind.JSDocTypeExpression, scanner.getTokenPos());
 
-                if (!parseExpected(SyntaxKind.OpenBraceToken) && mayBail) {
+                if (!parseExpected(SyntaxKind.OpenBraceToken) && requireBraces) {
                     return undefined;
                 }
                 result.type = doInsideOfContext(NodeFlags.JSDoc, parseType);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6136,10 +6136,14 @@ namespace ts {
 
             // Parses out a JSDoc type expression.
             /* @internal */
-            export function parseJSDocTypeExpression(): JSDocTypeExpression {
+            export function parseJSDocTypeExpression(): JSDocTypeExpression;
+            export function parseJSDocTypeExpression(mayBail: true): JSDocTypeExpression | undefined;
+            export function parseJSDocTypeExpression(mayBail?: boolean): JSDocTypeExpression | undefined {
                 const result = <JSDocTypeExpression>createNode(SyntaxKind.JSDocTypeExpression, scanner.getTokenPos());
 
-                parseExpected(SyntaxKind.OpenBraceToken);
+                if (!parseExpected(SyntaxKind.OpenBraceToken) && mayBail) {
+                    return undefined;
+                }
                 result.type = doInsideOfContext(NodeFlags.JSDoc, parseType);
                 parseExpected(SyntaxKind.CloseBraceToken);
 
@@ -6602,7 +6606,7 @@ namespace ts {
                     const result = <JSDocTypeTag>createNode(SyntaxKind.JSDocTypeTag, atToken.pos);
                     result.atToken = atToken;
                     result.tagName = tagName;
-                    result.typeExpression = tryParseTypeExpression();
+                    result.typeExpression = parseJSDocTypeExpression(/*mayBail*/ true);
                     return finishNode(result);
                 }
 

--- a/src/harness/unittests/jsDocParsing.ts
+++ b/src/harness/unittests/jsDocParsing.ts
@@ -139,18 +139,17 @@ namespace ts {
                         `/**
   * @param
   */`);
+
+                parsesIncorrectly("noType",
+`/**
+* @type
+*/`);
             });
 
             describe("parsesCorrectly", () => {
                 parsesCorrectly("noLeadingAsterisk",
 `/**
     @type {number}
-  */`);
-
-
-                parsesCorrectly("noType",
-`/**
-  * @type
   */`);
 
 


### PR DESCRIPTION
Fixes #16947