### PR TITLE
Remove unnecessary "@internal"

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6135,7 +6135,6 @@ namespace ts {
             }
 
             // Parses out a JSDoc type expression.
-            /* @internal */
             export function parseJSDocTypeExpression(): JSDocTypeExpression {
                 const result = <JSDocTypeExpression>createNode(SyntaxKind.JSDocTypeExpression, scanner.getTokenPos());
 


### PR DESCRIPTION
`namespace Parser` is not exported, so no need to mark anything nested inside `@internal`.