### PR TITLE
Include nearest test name in uncaught errors, catch suite errors

### DIFF
--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -113,7 +113,7 @@ namespace Harness.Parallel.Host {
             child.on("message", (data: ParallelClientMessage) => {
                 switch (data.type) {
                     case "error": {
-                        console.error(`Test worker encounted unexpected error and was forced to close:
+                        console.error(`Test worker encounted unexpected error${data.payload.name ? ` during the execution of test ${data.payload.name}` : ""} and was forced to close:
         Message: ${data.payload.error}
         Stack: ${data.payload.stack}`);
                         return process.exit(2);

--- a/src/harness/parallel/shared.ts
+++ b/src/harness/parallel/shared.ts
@@ -6,7 +6,7 @@ namespace Harness.Parallel {
     export type ParallelCloseMessage = { type: "close" } | never;
     export type ParallelHostMessage = ParallelTestMessage | ParallelCloseMessage | ParallelBatchMessage;
 
-    export type ParallelErrorMessage = { type: "error", payload: { error: string, stack: string } } | never;
+    export type ParallelErrorMessage = { type: "error", payload: { error: string, stack: string, name?: string } } | never;
     export type ErrorInfo = ParallelErrorMessage["payload"] & { name: string };
     export type ParallelResultMessage = { type: "result", payload: { passing: number, errors: ErrorInfo[], duration: number, runner: TestRunnerKind, file: string } } | never;
     export type ParallelBatchProgressMessage = { type: "progress", payload: ParallelResultMessage["payload"] } | never;


### PR DESCRIPTION
Fixes #18692 - a recoverable crash error should now include the name of the nearest test; and any errors during the execution of a describe block/before block/after block are now caught and reported as test errors, rather than as process-crashing errors.
