### PR TITLE
Apply "array-type" lint rule

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1462,7 +1462,7 @@ namespace ts {
 
             // file.imports may not be undefined if there exists dynamic import
             let imports: StringLiteral[];
-            let moduleAugmentations: Array<StringLiteral | Identifier>;
+            let moduleAugmentations: (StringLiteral | Identifier)[];
             let ambientModules: string[];
 
             // If we are importing helpers, we need to add a synthetic reference to resolve the

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1514,7 +1514,7 @@ namespace ts {
     }
 
     export function getJSDocCommentsAndTags(node: Node): (JSDoc | JSDocTag)[] {
-        let result: Array<JSDoc | JSDocTag> | undefined;
+        let result: (JSDoc | JSDocTag)[] | undefined;
         getJSDocCommentsAndTagsWorker(node);
         return result || emptyArray;
 

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1003,7 +1003,7 @@ namespace FourSlash {
             }
         }
 
-        public verifyReferenceGroups(startRanges: Range | Range[], parts: Array<{ definition: string, ranges: Range[] }>): void {
+        public verifyReferenceGroups(startRanges: Range | Range[], parts: FourSlashInterface.ReferenceGroup[]): void {
             const fullExpected = ts.map(parts, ({ definition, ranges }) => ({ definition, ranges: ranges.map(rangeToReferenceEntry) }));
 
             for (const startRange of toArray(startRanges)) {
@@ -3833,7 +3833,7 @@ namespace FourSlashInterface {
             this.state.verifyReferencesOf(start, references);
         }
 
-        public referenceGroups(startRanges: FourSlash.Range[], parts: Array<{ definition: string, ranges: FourSlash.Range[] }>) {
+        public referenceGroups(startRanges: FourSlash.Range[], parts: ReferenceGroup[]) {
             this.state.verifyReferenceGroups(startRanges, parts);
         }
 
@@ -4342,6 +4342,11 @@ namespace FourSlashInterface {
             const textSpan = position === undefined ? undefined : { start: position, end: position + text.length };
             return { classificationType, text, textSpan };
         }
+    }
+
+    export interface ReferenceGroup {
+        definition: string;
+        ranges: FourSlash.Range[];
     }
 
     export interface ApplyRefactorOptions {

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -509,7 +509,7 @@ namespace ts.server {
         class InProcClient {
             private server: InProcSession;
             private seq = 0;
-            private callbacks: Array<(resp: protocol.Response) => void> = [];
+            private callbacks: ((resp: protocol.Response) => void)[] = [];
             private eventHandlers = createMap<(args: any) => void>();
 
             handle(msg: protocol.Message): void {

--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -10,7 +10,7 @@ interface Array<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    find(predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): T | undefined;
+    find(predicate: (value: T, index: number, obj: T[]) => boolean, thisArg?: any): T | undefined;
 
     /**
      * Returns the index of the first element in the array where predicate is true, and -1
@@ -21,7 +21,7 @@ interface Array<T> {
      * @param thisArg If provided, it will be used as the this value for each invocation of
      * predicate. If it is not provided, undefined is used instead.
      */
-    findIndex(predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: T, index: number, obj: T[]) => boolean, thisArg?: any): number;
 
     /**
      * Returns the this object after filling the section identified by start and end with value
@@ -52,13 +52,13 @@ interface ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T, U = T>(arrayLike: ArrayLike<T>, mapfn?: (v: T, k: number) => U, thisArg?: any): Array<U>;
+    from<T, U = T>(arrayLike: ArrayLike<T>, mapfn?: (v: T, k: number) => U, thisArg?: any): U[];
 
     /**
      * Returns a new array from a set of elements.
      * @param items A set of elements to include in the new array object.
      */
-    of<T>(...items: T[]): Array<T>;
+    of<T>(...items: T[]): T[];
 }
 
 interface DateConstructor {

--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -54,7 +54,7 @@ interface ArrayConstructor {
      * @param mapfn A mapping function to call on every element of the array.
      * @param thisArg Value of 'this' used to invoke the mapfn.
      */
-    from<T, U = T>(iterable: Iterable<T>, mapfn?: (v: T, k: number) => U, thisArg?: any): Array<U>;
+    from<T, U = T>(iterable: Iterable<T>, mapfn?: (v: T, k: number) => U, thisArg?: any): U[];
 }
 
 interface ReadonlyArray<T> {

--- a/src/lib/es2015.reflect.d.ts
+++ b/src/lib/es2015.reflect.d.ts
@@ -8,7 +8,7 @@ declare namespace Reflect {
     function getPrototypeOf(target: object): object;
     function has(target: object, propertyKey: PropertyKey): boolean;
     function isExtensible(target: object): boolean;
-    function ownKeys(target: object): Array<PropertyKey>;
+    function ownKeys(target: object): PropertyKey[];
     function preventExtensions(target: object): boolean;
     function set(target: object, propertyKey: PropertyKey, value: any, receiver?: any): boolean;
     function setPrototypeOf(target: object, proto: any): boolean;

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -84,7 +84,7 @@ namespace ts.server {
     }
 
     export interface SafeList {
-        [name: string]: { match: RegExp, exclude?: Array<Array<string | number>>, types?: string[] };
+        [name: string]: { match: RegExp, exclude?: (string | number)[][], types?: string[] };
     }
 
     function prepareConvertersForEnumLikeCompilerOptions(commandLineOptions: CommandLineOption[]): Map<Map<number>> {
@@ -1780,7 +1780,7 @@ namespace ts.server {
 
                         if (rule.exclude) {
                             for (const exclude of rule.exclude) {
-                                const processedRule = root.replace(rule.match, (...groups: Array<string>) => {
+                                const processedRule = root.replace(rule.match, (...groups: string[]) => {
                                     return exclude.map(groupNumberOrString => {
                                         // RegExp group numbers are 1-based, but the first element in groups
                                         // is actually the original string, so it all works out in the end.

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -515,7 +515,7 @@ namespace ts.FindAllReferences.Core {
         }
 
         // Source file ID → symbol ID → Whether the symbol has been searched for in the source file.
-        private readonly sourceFileToSeenSymbols: Array<Array<true>> = [];
+        private readonly sourceFileToSeenSymbols: true[][] = [];
         /** Returns `true` the first time we search for a symbol in a file and `false` afterwards. */
         markSearchedSymbol(sourceFile: SourceFile, symbol: Symbol): boolean {
             const sourceId = getNodeId(sourceFile);

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -3,7 +3,7 @@
 namespace ts.FindAllReferences {
     export interface ImportsResult {
         /** For every import of the symbol, the location and local symbol for the import. */
-        importSearches: Array<[Identifier, Symbol]>;
+        importSearches: [Identifier, Symbol][];
         /** For rename imports/exports `{ foo as bar }`, `foo` is not a local, so it may be added as a reference immediately without further searching. */
         singleReferences: Identifier[];
         /** List of source files that may (or may not) use the symbol via a namespace. (For UMD modules this is every file.) */
@@ -180,7 +180,7 @@ namespace ts.FindAllReferences {
      * But re-exports will be placed in 'singleReferences' since they cannot be locally referenced.
      */
     function getSearchesFromDirectImports(directImports: Importer[], exportSymbol: Symbol, exportKind: ExportKind, checker: TypeChecker, isForRename: boolean): Pick<ImportsResult, "importSearches" | "singleReferences"> {
-        const importSearches: Array<[Identifier, Symbol]> = [];
+        const importSearches: [Identifier, Symbol][] = [];
         const singleReferences: Identifier[] = [];
         function addSearch(location: Identifier, symbol: Symbol): void {
             importSearches.push([location, symbol]);

--- a/src/services/refactors/extractMethod.ts
+++ b/src/services/refactors/extractMethod.ts
@@ -286,7 +286,7 @@ namespace ts.refactor.extractMethod {
 
             let errors: Diagnostic[];
             let permittedJumps = PermittedJumps.Return;
-            let seenLabels: Array<__String>;
+            let seenLabels: __String[];
 
             visit(nodeToCheck);
 

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -568,11 +568,18 @@ namespace ts {
         }
     }
 
-    export function realizeDiagnostics(diagnostics: ReadonlyArray<Diagnostic>, newLine: string): { message: string; start: number; length: number; category: string; code: number; }[] {
+    interface RealizedDiagnostic {
+        message: string;
+        start: number;
+        length: number;
+        category: string;
+        code: number;
+    }
+    export function realizeDiagnostics(diagnostics: ReadonlyArray<Diagnostic>, newLine: string): RealizedDiagnostic[] {
         return diagnostics.map(d => realizeDiagnostic(d, newLine));
     }
 
-    function realizeDiagnostic(diagnostic: Diagnostic, newLine: string): { message: string; start: number; length: number; category: string; code: number; } {
+    function realizeDiagnostic(diagnostic: Diagnostic, newLine: string): RealizedDiagnostic {
         return {
             message: flattenDiagnosticMessageText(diagnostic.messageText, newLine),
             start: diagnostic.start,

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1100,7 +1100,7 @@ namespace ts {
 
     /** Returns `true` the first time it encounters a node and `false` afterwards. */
     export function nodeSeenTracker<T extends Node>(): (node: T) => boolean {
-        const seen: Array<true> = [];
+        const seen: true[] = [];
         return node => {
             const id = getNodeId(node);
             return !seen[id] && (seen[id] = true);

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
     "rulesDirectory": "built/local/tslint/rules",
     "rules": {
+        "array-type": [true, "array"],
         "boolean-trivia": true,
         "class-name": true,
         "comment-format": [true,


### PR DESCRIPTION
Most of the instances of `Array<T>` appear to have been written by myself. Everyone else has been using `T[]`.