### PR TITLE
Support accessing enum types from JSDoc

### DIFF
--- a/tests/baselines/reference/jsdocAccessEnumType.symbols
+++ b/tests/baselines/reference/jsdocAccessEnumType.symbols
@@ -1,0 +1,16 @@
+=== /a.ts ===
+export enum E { A }
+>E : Symbol(E, Decl(a.ts, 0, 0))
+>A : Symbol(E.A, Decl(a.ts, 0, 15))
+
+=== /b.js ===
+import { E } from "./a";
+>E : Symbol(E, Decl(b.js, 0, 8))
+
+/** @type {E} */
+const e = E.A;
+>e : Symbol(e, Decl(b.js, 2, 5))
+>E.A : Symbol(E.A, Decl(a.ts, 0, 15))
+>E : Symbol(E, Decl(b.js, 0, 8))
+>A : Symbol(E.A, Decl(a.ts, 0, 15))
+

--- a/tests/baselines/reference/jsdocAccessEnumType.types
+++ b/tests/baselines/reference/jsdocAccessEnumType.types
@@ -1,0 +1,16 @@
+=== /a.ts ===
+export enum E { A }
+>E : E
+>A : E
+
+=== /b.js ===
+import { E } from "./a";
+>E : typeof E
+
+/** @type {E} */
+const e = E.A;
+>e : E
+>E.A : E
+>E : typeof E
+>A : E
+

--- a/tests/cases/compiler/jsdocAccessEnumType.ts
+++ b/tests/cases/compiler/jsdocAccessEnumType.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /a.ts
+export enum E { A }
+
+// @Filename: /b.js
+import { E } from "./a";
+/** @type {E} */
+const e = E.A;


### PR DESCRIPTION
Fixes #18205

The error was that we did not try `getDeclaredTypeOfSymbol` before assuming it was a JSDoc value access. `getDeclaredTypeOfSymbol` handled enums, we we should try doing it first, and only if it fails do special JSDoc stuff.