### PR TITLE
Make sys.watchDirectory required 

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -43,7 +43,7 @@ namespace ts {
          * use native OS file watching
          */
         watchFile?(path: string, callback: FileWatcherCallback, pollingInterval?: number): FileWatcher;
-        watchDirectory?(path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher;
+        watchDirectory(path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher;
         resolvePath(path: string): string;
         fileExists(path: string): boolean;
         directoryExists(path: string): boolean;
@@ -114,7 +114,7 @@ namespace ts {
         getDirectories(path: string): string[];
         readDirectory(path: string, extensions?: ReadonlyArray<string>, basePaths?: ReadonlyArray<string>, excludeEx?: string, includeFileEx?: string, includeDirEx?: string): string[];
         watchFile?(path: string, callback: FileWatcherCallback): FileWatcher;
-        watchDirectory?(path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher;
+        watchDirectory(path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher;
         realpath(path: string): string;
         getEnvironmentVariable?(name: string): string;
     };
@@ -505,6 +505,7 @@ namespace ts {
                 fileExists: ChakraHost.fileExists,
                 directoryExists: ChakraHost.directoryExists,
                 createDirectory: ChakraHost.createDirectory,
+                watchDirectory: ChakraHost.watchDirectory,
                 getExecutingFilePath: () => ChakraHost.executingFile,
                 getCurrentDirectory: () => ChakraHost.currentDirectory,
                 getDirectories: ChakraHost.getDirectories,

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -20,6 +20,7 @@ namespace ts.server {
         getCurrentDirectory(): string { return void 0; },
         getEnvironmentVariable(): string { return ""; },
         readDirectory() { return []; },
+        watchDirectory() { return void 0; },
         exit: noop,
         setTimeout() { return 0; },
         clearTimeout: noop,


### PR DESCRIPTION
This seems too simple, but I could find neither an implementation for ChakraHost nor even an API reference. googling `chakra readdirectory` returns nothing. https://github.com/Microsoft/TypeScript/issues/16776 was light on details.

Fixes https://github.com/Microsoft/TypeScript/issues/16776
