### PR TITLE
 Change the type of Diagnostic.file from SourceFile to SourceMapSource.

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -325,7 +325,7 @@ namespace ts {
         return result;
     }
 
-    export function getPositionOfLineAndCharacter(sourceFile: SourceFile, line: number, character: number): number {
+    export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: number, character: number): number {
         return computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text);
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3607,8 +3607,12 @@ namespace ts {
         next?: DiagnosticMessageChain;
     }
 
+    export interface SourceMapSource extends SourceFileLike {
+        fileName: string;
+    }
+
     export interface Diagnostic {
-        file: SourceFile | undefined;
+        file: SourceMapSource | undefined;
         start: number | undefined;
         length: number | undefined;
         messageText: string | DiagnosticMessageChain;


### PR DESCRIPTION
Add interface SourceMapSource extends SourceFileLike { fileName: string }

Fixes https://github.com/Microsoft/TypeScript/issues/18013
