### PR TITLE
Improve testing of code fixes, and improve diagnostic messages

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3685,6 +3685,10 @@
         "category": "Message",
         "code": 90026
     },
+    "Declare static property '{0}'.": {
+        "category": "Message",
+        "code": 90027
+    },
 
     "Convert function to an ES2015 class": {
         "category": "Message",

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2361,11 +2361,12 @@ namespace FourSlash {
                 this.applyEdits(change.fileName, change.textChanges, /*isFormattingEdit*/ false);
             }
 
-            if (this.getRanges().length === 0) {
-                this.verifyCurrentFileContent(options.newContent);
+            if (options.newFileContent) {
+                assert(!options.newRangeContent);
+                this.verifyCurrentFileContent(options.newFileContent);
             }
             else {
-                this.verifyRangeIs(options.newContent, /*includeWhitespace*/ true);
+                this.verifyRangeIs(options.newRangeContent, /*includeWhitespace*/ true);
             }
         }
 
@@ -4398,7 +4399,9 @@ namespace FourSlashInterface {
 
     export interface VerifyCodeFixOptions {
         description: string;
-        newContent: string;
+        // One of these should be defined.
+        newFileContent?: string;
+        newRangeContent?: string;
         errorCode?: number;
         index?: number;
     }

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -156,8 +156,9 @@ namespace ts.codefix {
             const propertyChangeTracker = textChanges.ChangeTracker.fromContext(context);
             propertyChangeTracker.insertNodeAfter(classDeclarationSourceFile, classOpenBrace, property, { suffix: context.newLineCharacter });
 
-            (actions || (actions = [])).push({
-                description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Declare_property_0), [tokenName]),
+            const diag = makeStatic ? Diagnostics.Declare_static_property_0 : Diagnostics.Declare_property_0;
+            actions = append(actions, {
+                description: formatStringFromArgs(getLocaleSpecificMessage(diag), [tokenName]),
                 changes: propertyChangeTracker.getChanges()
             });
 
@@ -197,11 +198,9 @@ namespace ts.codefix {
 
                 const methodDeclarationChangeTracker = textChanges.ChangeTracker.fromContext(context);
                 methodDeclarationChangeTracker.insertNodeAfter(classDeclarationSourceFile, classOpenBrace, methodDeclaration, { suffix: context.newLineCharacter });
+                const diag = makeStatic ? Diagnostics.Declare_static_method_0 : Diagnostics.Declare_method_0;
                 return {
-                    description: formatStringFromArgs(getLocaleSpecificMessage(makeStatic ?
-                        Diagnostics.Declare_method_0 :
-                        Diagnostics.Declare_static_method_0),
-                        [tokenName]),
+                    description: formatStringFromArgs(getLocaleSpecificMessage(diag), [tokenName]),
                     changes: methodDeclarationChangeTracker.getChanges()
                 };
             }

--- a/tests/cases/fourslash/codeFixAddForgottenThis01.ts
+++ b/tests/cases/fourslash/codeFixAddForgottenThis01.ts
@@ -9,7 +9,7 @@
 
 verify.codeFix({
     description: "Add 'this.' to unresolved variable.",
-    newContent: `
+    newRangeContent: `
         this.foo = 10;
     `
 });

--- a/tests/cases/fourslash/codeFixAddForgottenThis01.ts
+++ b/tests/cases/fourslash/codeFixAddForgottenThis01.ts
@@ -7,6 +7,9 @@
 ////    |]}
 ////}
 
-verify.rangeAfterCodeFix(`
+verify.codeFix({
+    description: "Add 'this.' to unresolved variable.",
+    newContent: `
         this.foo = 10;
-    `, /*includeWhitespace*/ true);
+    `
+});

--- a/tests/cases/fourslash/codeFixAddForgottenThis02.ts
+++ b/tests/cases/fourslash/codeFixAddForgottenThis02.ts
@@ -6,4 +6,7 @@
 ////    bar() { [|foo = 10|] };
 ////}
 
-verify.rangeAfterCodeFix("this.foo = 10");
+verify.codeFix({
+    description: "Add 'this.' to unresolved variable.",
+    newContent: "this.foo = 10",
+});

--- a/tests/cases/fourslash/codeFixAddForgottenThis02.ts
+++ b/tests/cases/fourslash/codeFixAddForgottenThis02.ts
@@ -8,5 +8,5 @@
 
 verify.codeFix({
     description: "Add 'this.' to unresolved variable.",
-    newContent: "this.foo = 10",
+    newRangeContent: "this.foo = 10",
 });

--- a/tests/cases/fourslash/codeFixAddMissingMember.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember.ts
@@ -1,14 +1,19 @@
 /// <reference path='fourslash.ts' />
 
-////[|class C {
+////class C {
 ////    method() {
 ////        this.foo = 10;
 ////    }
-////}|]
+////}
 
-verify.rangeAfterCodeFix(`class C {
-    foo: number;
+verify.codeFix({
+    description: "Declare property 'foo'.",
+    index: 0,
+    // TODO: GH#18445
+    newContent: `class C {
+    foo: number;\r
     method() {
         this.foo = 10;
     }
-}`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);
+}`
+});

--- a/tests/cases/fourslash/codeFixAddMissingMember.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember.ts
@@ -10,7 +10,7 @@ verify.codeFix({
     description: "Declare property 'foo'.",
     index: 0,
     // TODO: GH#18445
-    newContent: `class C {
+    newFileContent: `class C {
     foo: number;\r
     method() {
         this.foo = 10;

--- a/tests/cases/fourslash/codeFixAddMissingMember2.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember2.ts
@@ -10,7 +10,7 @@ verify.codeFix({
     description: "Add index signature for property 'foo'.",
     index: 1,
     // TODO: GH#18445
-    newContent: `class C {
+    newFileContent: `class C {
     [x: string]: number;\r
     method() {
         this.foo = 10;

--- a/tests/cases/fourslash/codeFixAddMissingMember2.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember2.ts
@@ -1,14 +1,19 @@
 /// <reference path='fourslash.ts' />
 
-////[|class C {
+////class C {
 ////    method() {
 ////        this.foo = 10;
 ////    }
-////}|]
+////}
 
-verify.rangeAfterCodeFix(`class C {
-    [x:string]: number;
+verify.codeFix({
+    description: "Add index signature for property 'foo'.",
+    index: 1,
+    // TODO: GH#18445
+    newContent: `class C {
+    [x: string]: number;\r
     method() {
         this.foo = 10;
     }
-}`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 1);
+}`
+});

--- a/tests/cases/fourslash/codeFixAddMissingMember3.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember3.ts
@@ -10,7 +10,7 @@ verify.codeFix({
     description: "Declare static property 'foo'.",
     index: 0,
     // TODO: GH#18445
-    newContent: `class C {
+    newFileContent: `class C {
     static foo: number;\r
     static method() {
         this.foo = 10;

--- a/tests/cases/fourslash/codeFixAddMissingMember3.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember3.ts
@@ -1,14 +1,19 @@
 /// <reference path='fourslash.ts' />
 
-////[|class C {
+////class C {
 ////    static method() {
 ////        this.foo = 10;
 ////    }
-////}|]
+////}
 
-verify.rangeAfterCodeFix(`class C {
-    static foo: number;
+verify.codeFix({
+    description: "Declare static property 'foo'.",
+    index: 0,
+    // TODO: GH#18445
+    newContent: `class C {
+    static foo: number;\r
     static method() {
         this.foo = 10;
     }
-}`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);
+}`
+});

--- a/tests/cases/fourslash/codeFixAddMissingMember4.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember4.ts
@@ -4,19 +4,25 @@
 // @allowJs: true
 
 // @Filename: a.js
-////[|class C {
+////class C {
 ////    constructor() {
 ////    }
 ////    method() {
 ////        this.foo === 10;
 ////    }
-////}|]
+////}
 
-verify.rangeAfterCodeFix(`class C {
+verify.codeFix({
+    description: "Initialize property 'foo' in the constructor.",
+    index: 0,
+    // TODO: GH#18741 and GH#18445
+    newContent: `class C {
     constructor() {
-    this.foo = undefined;
+    \r
+this.foo = undefined;\r
 }
     method() {
         this.foo === 10;
     }
-}`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);
+}`
+});

--- a/tests/cases/fourslash/codeFixAddMissingMember4.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember4.ts
@@ -16,7 +16,7 @@ verify.codeFix({
     description: "Initialize property 'foo' in the constructor.",
     index: 0,
     // TODO: GH#18741 and GH#18445
-    newContent: `class C {
+    newFileContent: `class C {
     constructor() {
     \r
 this.foo = undefined;\r

--- a/tests/cases/fourslash/codeFixAddMissingMember5.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember5.ts
@@ -4,17 +4,20 @@
 // @allowJs: true
 
 // @Filename: a.js
-////[|class C {
+////class C {
 ////    static method() {
 ////        ()=>{ this.foo === 10 };
 ////    }
 ////}
-////|]
 
-verify.getAndApplyCodeFix(/*errorCode*/ undefined, /*index*/ 0);
-verify.currentFileContentIs(`class C {
+verify.codeFix({
+    description: "Initialize static property 'foo'.",
+    index: 0,
+    // TODO: GH#18743 and GH#18445
+    newContent: `class C {
     static method() {
         ()=>{ this.foo === 10 };
     }
-}
-C.foo = undefined;` + "\r\n"); // TODO: GH#18445
+}C.foo = undefined;\r
+`
+});

--- a/tests/cases/fourslash/codeFixAddMissingMember5.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember5.ts
@@ -14,7 +14,7 @@ verify.codeFix({
     description: "Initialize static property 'foo'.",
     index: 0,
     // TODO: GH#18743 and GH#18445
-    newContent: `class C {
+    newFileContent: `class C {
     static method() {
         ()=>{ this.foo === 10 };
     }

--- a/tests/cases/fourslash/codeFixAddMissingMember6.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember6.ts
@@ -14,7 +14,7 @@ verify.codeFix({
     description: "Initialize property 'foo' in the constructor.",
     index: 0,
     // TODO: GH#18741 and GH#18445
-    newContent: `class C {
+    newFileContent: `class C {
     constructor() {
     \r
 this.foo = undefined;\r

--- a/tests/cases/fourslash/codeFixAddMissingMember6.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember6.ts
@@ -4,15 +4,21 @@
 // @allowJs: true
 
 // @Filename: a.js
-////[|class C {
+////class C {
 ////    constructor() {
 ////    }
 ////    prop = ()=>{ this.foo === 10 };
-////}|]
+////}
 
-verify.rangeAfterCodeFix(`class C {
+verify.codeFix({
+    description: "Initialize property 'foo' in the constructor.",
+    index: 0,
+    // TODO: GH#18741 and GH#18445
+    newContent: `class C {
     constructor() {
-    this.foo = undefined;
-    }
+    \r
+this.foo = undefined;\r
+}
     prop = ()=>{ this.foo === 10 };
-}`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);
+}`
+});

--- a/tests/cases/fourslash/codeFixAddMissingMember7.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember7.ts
@@ -12,7 +12,7 @@ verify.codeFix({
     description: "Initialize static property 'foo'.",
     index: 2,
     // TODO: GH#18743 and GH#18445
-    newContent: `class C {
+    newFileContent: `class C {
     static p = ()=>{ this.foo === 10 };
 }C.foo = undefined;\r
 `

--- a/tests/cases/fourslash/codeFixAddMissingMember7.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember7.ts
@@ -4,13 +4,16 @@
 // @allowJs: true
 
 // @Filename: a.js
-////[|class C {
+////class C {
 ////    static p = ()=>{ this.foo === 10 };
 ////}
-////|]
 
-verify.getAndApplyCodeFix(/*errorCode*/ undefined, /*index*/ 2)
-verify.currentFileContentIs(`class C {
+verify.codeFix({
+    description: "Initialize static property 'foo'.",
+    index: 2,
+    // TODO: GH#18743 and GH#18445
+    newContent: `class C {
     static p = ()=>{ this.foo === 10 };
-}
-C.foo = undefined;` + "\r\n"); // TODO: GH#18445
+}C.foo = undefined;\r
+`
+});

--- a/tests/cases/fourslash/codeFixUndeclaredInStaticMethod.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredInStaticMethod.ts
@@ -13,7 +13,7 @@ verify.codeFix({
     description: "Declare static method 'm1'.",
     index: 0,
     // TODO: GH#18445
-    newContent: `
+    newRangeContent: `
     static m1(arg0: any, arg1: any, arg2: any): any {\r
         throw new Error("Method not implemented.");\r
     }\r
@@ -23,7 +23,7 @@ verify.codeFix({
 verify.codeFix({
     description: "Declare static method 'm2'.",
     index: 0,
-    newContent: `
+    newRangeContent: `
     static m2(arg0: any, arg1: any): any {\r
         throw new Error("Method not implemented.");\r
     }\r
@@ -36,7 +36,7 @@ verify.codeFix({
 verify.codeFix({
     description: "Declare static property 'prop1'.",
     index: 0,
-    newContent: `
+    newRangeContent: `
     static prop1: number;\r
     static m2(arg0: any, arg1: any): any {\r
         throw new Error("Method not implemented.");\r
@@ -50,7 +50,7 @@ verify.codeFix({
 verify.codeFix({
     description: "Declare static property 'prop2'.",
     index: 0,
-    newContent: `
+    newRangeContent: `
     static prop2: string;\r
     static prop1: number;\r
     static m2(arg0: any, arg1: any): any {\r

--- a/tests/cases/fourslash/codeFixUndeclaredInStaticMethod.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredInStaticMethod.ts
@@ -9,18 +9,55 @@
 ////     }
 //// }
 
-verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
-verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
-verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
-verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
+verify.codeFix({
+    description: "Declare static method 'm1'.",
+    index: 0,
+    // TODO: GH#18445
+    newContent: `
+    static m1(arg0: any, arg1: any, arg2: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    `,
+});
 
-verify.rangeIs(`
-    static prop2: string;
-    static prop1: number;
-    static m2(arg0: any, arg1: any): any {
-        throw new Error("Method not implemented.");
-    }
-    static m1(arg0: any, arg1: any, arg2: any): any {
-        throw new Error("Method not implemented.");
-    }
-`);
+verify.codeFix({
+    description: "Declare static method 'm2'.",
+    index: 0,
+    newContent: `
+    static m2(arg0: any, arg1: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    static m1(arg0: any, arg1: any, arg2: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    `,
+});
+
+verify.codeFix({
+    description: "Declare static property 'prop1'.",
+    index: 0,
+    newContent: `
+    static prop1: number;\r
+    static m2(arg0: any, arg1: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    static m1(arg0: any, arg1: any, arg2: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    `,
+});
+
+verify.codeFix({
+    description: "Declare static property 'prop2'.",
+    index: 0,
+    newContent: `
+    static prop2: string;\r
+    static prop1: number;\r
+    static m2(arg0: any, arg1: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    static m1(arg0: any, arg1: any, arg2: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    `,
+});

--- a/tests/cases/fourslash/codeFixUndeclaredMethod.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredMethod.ts
@@ -14,7 +14,7 @@ verify.codeFix({
     description: "Declare method 'foo1'.",
     index: 0,
     // TODO: GH#18445
-    newContent: `
+    newRangeContent: `
     foo1(arg0: any, arg1: any, arg2: any): any {\r
         throw new Error("Method not implemented.");\r
     }\r
@@ -24,7 +24,7 @@ verify.codeFix({
 verify.codeFix({
     description: "Declare method 'foo2'.",
     index: 0,
-    newContent: `
+    newRangeContent: `
     foo2<T, U, V, W, X, Y, Z>(): any {\r
         throw new Error("Method not implemented.");\r
     }\r
@@ -37,7 +37,7 @@ verify.codeFix({
 verify.codeFix({
     description: "Declare method 'foo3'.",
     index: 0,
-    newContent:`
+    newRangeContent:`
     foo3<T0, T1, T2, T3, T4, T5, T6, T7>(): any {\r
         throw new Error("Method not implemented.");\r
     }\r

--- a/tests/cases/fourslash/codeFixUndeclaredMethod.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredMethod.ts
@@ -10,18 +10,42 @@
 ////     }
 //// }
 
-verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
-verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
-verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
+verify.codeFix({
+    description: "Declare method 'foo1'.",
+    index: 0,
+    // TODO: GH#18445
+    newContent: `
+    foo1(arg0: any, arg1: any, arg2: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    `,
+});
 
-verify.rangeIs(`
-    foo3<T0, T1, T2, T3, T4, T5, T6, T7>(): any {
-        throw new Error("Method not implemented.");
-    }
-    foo2<T, U, V, W, X, Y, Z>(): any {
-        throw new Error("Method not implemented.");
-    }
-    foo1(arg0: any, arg1: any, arg2: any): any {
-        throw new Error("Method not implemented.");
-    }
-`);
+verify.codeFix({
+    description: "Declare method 'foo2'.",
+    index: 0,
+    newContent: `
+    foo2<T, U, V, W, X, Y, Z>(): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    foo1(arg0: any, arg1: any, arg2: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    `
+});
+
+verify.codeFix({
+    description: "Declare method 'foo3'.",
+    index: 0,
+    newContent:`
+    foo3<T0, T1, T2, T3, T4, T5, T6, T7>(): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    foo2<T, U, V, W, X, Y, Z>(): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    foo1(arg0: any, arg1: any, arg2: any): any {\r
+        throw new Error("Method not implemented.");\r
+    }\r
+    `
+});

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -155,7 +155,13 @@ declare namespace FourSlashInterface {
         implementationListIsEmpty(): void;
         isValidBraceCompletionAtPosition(openingBrace?: string): void;
         isInCommentAtPosition(onlyMultiLineDiverges?: boolean): void;
-        codeFix(options: { description: string, newContent: string, errorCode?: number, index?: number });
+        codeFix(options: {
+            description: string,
+            newFileContent?: string,
+            newRangeContent?: string,
+            errorCode?: number,
+            index?: number,
+        });
         codeFixAvailable(): void;
         applicableRefactorAvailableAtMarker(markerName: string): void;
         codeFixDiagnosticsAvailableAtMarkers(markerNames: string[], diagnosticCode?: number): void;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -155,6 +155,7 @@ declare namespace FourSlashInterface {
         implementationListIsEmpty(): void;
         isValidBraceCompletionAtPosition(openingBrace?: string): void;
         isInCommentAtPosition(onlyMultiLineDiverges?: boolean): void;
+        codeFix(options: { description: string, newContent: string, errorCode?: number, index?: number });
         codeFixAvailable(): void;
         applicableRefactorAvailableAtMarker(markerName: string): void;
         codeFixDiagnosticsAvailableAtMarkers(markerNames: string[], diagnosticCode?: number): void;


### PR DESCRIPTION
We were reporting fixes to add instance methods as static, and vice versa.
Also added a diagnostic message for adding *static* properties.
Since this resulted in no test changes, I added functionality to assert the description of code fixes; haven't applied it to every test yet but I think that would be a good idea since we've caught some bugs already.
The new tester no longer ignores whitespace, which uncovered #18741 and #18743 (and also more  #18445 errors).