### PR TITLE
Split rwc input files

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -978,8 +978,9 @@ gulp.task(instrumenterJsPath, /*help*/ false, [servicesFile], () => {
         .pipe(gulp.dest(builtLocalDirectory));
 });
 
-gulp.task("tsc-instrumented", "Builds an instrumented tsc.js", ["local", loggedIOJsPath, instrumenterJsPath, servicesFile], (done) => {
-    exec(host, [instrumenterJsPath, "record", "iocapture", builtLocalCompiler], done, done);
+gulp.task("tsc-instrumented", "Builds an instrumented tsc.js - run with --test=[testname]", ["local", loggedIOJsPath, instrumenterJsPath, servicesFile], (done) => {
+    const test = cmdLineOptions["tests"] || "iocapture";
+    exec(host, [instrumenterJsPath, "record", test, builtLocalCompiler], done, done);
 });
 
 gulp.task("update-sublime", "Updates the sublime plugin's tsserver", ["local", serverFile], () => {

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -1104,9 +1104,10 @@ var instrumenterPath = harnessDirectory + 'instrumenter.ts';
 var instrumenterJsPath = builtLocalDirectory + 'instrumenter.js';
 compileFile(instrumenterJsPath, [instrumenterPath], [tscFile, instrumenterPath].concat(libraryTargets), [], /*useBuiltCompiler*/ true, { lib: "es6", types: ["node"], noOutFile: true, outDir: builtLocalDirectory });
 
-desc("Builds an instrumented tsc.js");
+desc("Builds an instrumented tsc.js - run with test=[testname]");
 task('tsc-instrumented', [loggedIOJsPath, instrumenterJsPath, tscFile], function () {
-    var cmd = host + ' ' + instrumenterJsPath + ' record iocapture ' + builtLocalDirectory + compilerFilename;
+    var test = process.env.test || process.env.tests || process.env.t || "iocapture";
+    var cmd = host + ' ' + instrumenterJsPath + " record " + test + " " + builtLocalDirectory + compilerFilename;
     console.log(cmd);
     var ex = jake.createExec([cmd]);
     ex.addListener("cmdEnd", function () {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1717,8 +1717,12 @@ namespace Harness {
             return resultName;
         }
 
-        function sanitizeTestFilePath(name: string) {
-            return ts.toPath(ts.normalizeSlashes(name.replace(/[\^<>:"|?*%]/g, "_")).replace(/\.\.\//g, "__dotdot/"), "", Utils.canonicalizeForHarness);
+        export function sanitizeTestFilePath(name: string) {
+            const path = ts.toPath(ts.normalizeSlashes(name.replace(/[\^<>:"|?*%]/g, "_")).replace(/\.\.\//g, "__dotdot/"), "", Utils.canonicalizeForHarness);
+            if (ts.startsWith(path, "/")) {
+                return path.substring(1);
+            }
+            return path;
         }
 
         // This does not need to exist strictly speaking, but many tests will need to be updated if it's removed
@@ -2068,7 +2072,7 @@ namespace Harness {
                 for (let {done, value} = gen.next(); !done; { done, value } = gen.next()) {
                     const [name, content, count] = value as [string, string, number | undefined];
                     if (count === 0) continue; // Allow error reporter to skip writing files without errors
-                    const relativeFileName = relativeFileBase + (ts.startsWith(name, "/") ? "" : "/") + name + extension;
+                    const relativeFileName = relativeFileBase + "/" + name + extension;
                     const actualFileName = localPath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
                     const comparison = compareToBaseline(content, relativeFileName, opts);
                     try {

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -206,10 +206,10 @@ namespace Playback {
             (<any>wrapper)[prop] = (<any>underlying)[prop];
         });
 
-        wrapper.startReplayFromString = (logString) => {
+        wrapper.startReplayFromString = logString => {
             wrapper.startReplayFromData(JSON.parse(logString));
         };
-        wrapper.startReplayFromData = (log) => {
+        wrapper.startReplayFromData = log => {
             replayLog = log;
             // Remove non-found files from the log (shouldn't really need them, but we still record them for diagnostic purposes)
             replayLog.filesRead = replayLog.filesRead.filter(f => f.result.contents !== undefined);

--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -60,12 +60,12 @@ namespace Harness.Parallel.Host {
                     try {
                         size = statSync(file).size;
                     }
-                    catch (e) {
+                    catch {
                         // May be a directory
                         try {
                             size = Harness.IO.listFiles(file, /.*/g, { recursive: true }).reduce((acc, elem) => acc + statSync(elem).size, 0);
                         }
-                        catch (e2) {
+                        catch {
                             // Unknown test kind, just return 0 and let the historical analysis take over after one run
                             size = 0;
                         }

--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -57,8 +57,19 @@ namespace Harness.Parallel.Host {
             for (const file of files) {
                 let size: number;
                 if (!perfData) {
-                    size = statSync(file).size;
-
+                    try {
+                        size = statSync(file).size;
+                    }
+                    catch (e) {
+                        // May be a directory
+                        try {
+                            size = Harness.IO.listFiles(file, /.*/g, { recursive: true }).reduce((acc, elem) => acc + statSync(elem).size, 0);
+                        }
+                        catch (e2) {
+                            // Unknown test kind, just return 0 and let the historical analysis take over after one run
+                            size = 0;
+                        }
+                    }
                 }
                 else {
                     const hashedName = hashName(runner.kind(), file);

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -173,16 +173,6 @@ function handleTestConfig() {
                         break;
                     case "rwc":
                         runners.push(new RWCRunner());
-                        const documents = Harness.IO.readDirectory("internal/cases/rwc", [".json"], [], [], 1);
-                        for (const doc of documents) {
-                            console.log(`Migrating ${doc} to new test format...`);
-                            const baseName = ts.getBaseFileName(doc);
-                            const name = baseName.substring(0, baseName.length - 5);
-                            const log = JSON.parse(Harness.IO.readFile(doc));
-                            const newFile = Playback.oldStyleLogIntoNewStyleLog(log, (path, string) => Harness.IO.writeFile(`./internal/cases/rwc/${path}`, string), name);
-                            Harness.IO.writeFile(`internal/cases/rwc/${name}/test.json`, JSON.stringify(newFile, null, 4)); // tslint:disable-line:no-null-keyword
-                            Harness.IO.deleteFile(doc);
-                        }
                         break;
                     case "test262":
                         runners.push(new Test262BaselineRunner());

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -173,6 +173,16 @@ function handleTestConfig() {
                         break;
                     case "rwc":
                         runners.push(new RWCRunner());
+                        const documents = Harness.IO.readDirectory("internal/cases/rwc", [".json"], [], [], 1);
+                        for (const doc of documents) {
+                            console.log(`Migrating ${doc} to new test format...`);
+                            const baseName = ts.getBaseFileName(doc);
+                            const name = baseName.substring(0, baseName.length - 5);
+                            const log = JSON.parse(Harness.IO.readFile(doc));
+                            const newFile = Playback.oldStyleLogIntoNewStyleLog(log, (path, string) => Harness.IO.writeFile(`./internal/cases/rwc/${path}`, string), name);
+                            Harness.IO.writeFile(`internal/cases/rwc/${name}/test.json`, JSON.stringify(newFile, null, 4)); // tslint:disable-line:no-null-keyword
+                            Harness.IO.deleteFile(doc);
+                        }
                         break;
                     case "test262":
                         runners.push(new Test262BaselineRunner());

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -36,13 +36,7 @@ namespace RWC {
                 Subfolder: "rwc",
                 Baselinefolder: "internal/baselines"
             };
-            let baseName: string;
-            if (ts.endsWith(jsonPath, ".json")) {
-                baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
-            }
-            else {
-                baseName = ts.getBaseFileName(jsonPath);
-            }
+            const baseName = ts.getBaseFileName(jsonPath);
             let currentDirectory: string;
             let useCustomLibraryFile: boolean;
             let skipTypeAndSymbolbaselines = false;
@@ -67,7 +61,7 @@ namespace RWC {
                 this.timeout(800000); // Allow long timeouts for RWC compilations
                 let opts: ts.ParsedCommandLine;
 
-                const ioLog: IOLog = Harness.IO.fileExists(jsonPath) ? JSON.parse(Harness.IO.readFile(jsonPath)) : Playback.newStyleLogIntoOldStyleLog(JSON.parse(Harness.IO.readFile(`internal/cases/rwc/${jsonPath}/test.json`)), Harness.IO, `internal/cases/rwc/${baseName}`);
+                const ioLog: IOLog = Playback.newStyleLogIntoOldStyleLog(JSON.parse(Harness.IO.readFile(`internal/cases/rwc/${jsonPath}/test.json`)), Harness.IO, `internal/cases/rwc/${baseName}`);
                 currentDirectory = ioLog.currentDirectory;
                 useCustomLibraryFile = ioLog.useCustomLibraryFile;
                 skipTypeAndSymbolbaselines = ioLog.filesRead.reduce((acc, elem) => (elem && elem.result && elem.result.contents) ? acc + elem.result.contents.length : acc, 0) > typeAndSymbolSizeLimit;
@@ -259,9 +253,7 @@ namespace RWC {
 
 class RWCRunner extends RunnerBase {
     public enumerateTestFiles() {
-        const legacyTests = Harness.IO.listFiles("internal/cases/rwc/", /.+\.json$/);
-        const newTests = Harness.IO.getDirectories("internal/cases/rwc/");
-        return [...legacyTests || [], ...newTests || []];
+        return Harness.IO.getDirectories("internal/cases/rwc/");
     }
 
     public kind(): TestRunnerKind {

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -36,7 +36,13 @@ namespace RWC {
                 Subfolder: "rwc",
                 Baselinefolder: "internal/baselines"
             };
-            const baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
+            let baseName: string;
+            if (ts.endsWith(jsonPath, ".json")) {
+                baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
+            }
+            else {
+                baseName = ts.getBaseFileName(jsonPath);
+            }
             let currentDirectory: string;
             let useCustomLibraryFile: boolean;
             let skipTypeAndSymbolbaselines = false;
@@ -61,7 +67,7 @@ namespace RWC {
                 this.timeout(800000); // Allow long timeouts for RWC compilations
                 let opts: ts.ParsedCommandLine;
 
-                const ioLog: IOLog = JSON.parse(Harness.IO.readFile(jsonPath));
+                const ioLog: IOLog = Harness.IO.fileExists(jsonPath) ? JSON.parse(Harness.IO.readFile(jsonPath)) : Playback.newStyleLogIntoOldStyleLog(JSON.parse(Harness.IO.readFile(`internal/cases/rwc/${jsonPath}/test.json`)), Harness.IO, `internal/cases/rwc/${baseName}`);
                 currentDirectory = ioLog.currentDirectory;
                 useCustomLibraryFile = ioLog.useCustomLibraryFile;
                 skipTypeAndSymbolbaselines = ioLog.filesRead.reduce((acc, elem) => (elem && elem.result && elem.result.contents) ? acc + elem.result.contents.length : acc, 0) > typeAndSymbolSizeLimit;
@@ -253,7 +259,9 @@ namespace RWC {
 
 class RWCRunner extends RunnerBase {
     public enumerateTestFiles() {
-        return Harness.IO.listFiles("internal/cases/rwc/", /.+\.json$/);
+        const legacyTests = Harness.IO.listFiles("internal/cases/rwc/", /.+\.json$/);
+        const newTests = Harness.IO.getDirectories("internal/cases/rwc/");
+        return [...legacyTests || [], ...newTests || []];
     }
 
     public kind(): TestRunnerKind {


### PR DESCRIPTION
The last stage of the internal RWC format revision (prior to any rewrites for public consumption), this splits our RWC test definitions into a tree of files and a test definition json file. There is a linked internal PR with updated test definitions.

For anyone not familiar with this effort: this change should both make it much easier for us to audit changes to RWC tests when we recapture them (as we can review individual units of code), and also allows us to inspect the project structure on disk with our usual tools without a separate extraction step (though some projects may require extra local configuration to be navigable if they, for example, read their test settings from a response file) when debugging issues found by RWC tests.