### PR TITLE
Fixes to @augments handling

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4882,7 +4882,16 @@ namespace ts {
         }
 
         function getBaseTypeNodeOfClass(type: InterfaceType): ExpressionWithTypeArguments {
-            return getClassExtendsHeritageClauseElement(<ClassLikeDeclaration>type.symbol.valueDeclaration);
+            const decl = <ClassLikeDeclaration>type.symbol.valueDeclaration;
+            if (isInJavaScriptFile(decl)) {
+                // Prefer an @augments tag because it may have type parameters.
+                const tag = getJSDocAugmentsTag(decl);
+                if (tag) {
+                    return tag.class;
+                }
+            }
+
+            return getClassExtendsHeritageClauseElement(decl);
         }
 
         function getConstructorsForTypeArguments(type: Type, typeArgumentNodes: ReadonlyArray<TypeNode>, location: Node): Signature[] {
@@ -4986,15 +4995,6 @@ namespace ts {
                 baseType = getReturnTypeOfSignature(constructors[0]);
             }
 
-            // In a JS file, you can use the @augments jsdoc tag to specify a base type with type parameters
-            const valueDecl = type.symbol.valueDeclaration;
-            if (valueDecl && isInJavaScriptFile(valueDecl)) {
-                const augTag = getJSDocAugmentsTag(type.symbol.valueDeclaration);
-                if (augTag && augTag.typeExpression && augTag.typeExpression.type) {
-                    baseType = getTypeFromTypeNode(augTag.typeExpression.type);
-                }
-            }
-
             if (baseType === unknownType) {
                 return;
             }
@@ -5003,7 +5003,7 @@ namespace ts {
                 return;
             }
             if (type === baseType || hasBaseType(baseType, type)) {
-                error(valueDecl, Diagnostics.Type_0_recursively_references_itself_as_a_base_type,
+                error(type.symbol.valueDeclaration, Diagnostics.Type_0_recursively_references_itself_as_a_base_type,
                     typeToString(type, /*enclosingDeclaration*/ undefined, TypeFormatFlags.WriteArrayAsGenericType));
                 return;
             }
@@ -19789,6 +19789,36 @@ namespace ts {
             }
         }
 
+        function checkJSDocAugmentsTag(node: JSDocAugmentsTag): void {
+            const cls = getNodeCommentedByJSDocTag(node);
+            if (!isClassDeclaration(cls) && !isClassExpression(cls)) {
+                error(cls, Diagnostics.JSDoc_augments_tag_will_be_ignored_if_not_attached_to_a_class_declaration);
+                return;
+            }
+
+            const name = node.class.expression.kind === SyntaxKind.PropertyAccessExpression ? node.class.expression.name : node.class.expression;
+            const extend = getClassExtendsHeritageClauseElement(cls);
+            if (extend) {
+                const className = getClassName(extend.expression);
+                if (className && name.escapedText !== className.escapedText) {
+                    error(name, Diagnostics.JSDoc_augments_tag_declares_to_extend_0_but_actual_class_augments_1,
+                        unescapeLeadingUnderscores(name.escapedText),
+                        unescapeLeadingUnderscores(className.escapedText));
+                }
+            }
+        }
+
+        function getClassName(node: Expression): Identifier | undefined {
+            switch (node.kind) {
+                case SyntaxKind.Identifier:
+                    return node as Identifier;
+                case SyntaxKind.PropertyAccessExpression:
+                    return (node as PropertyAccessExpression).name;
+                default:
+                    return undefined;
+            }
+        }
+
         function checkFunctionOrMethodDeclaration(node: FunctionDeclaration | MethodDeclaration): void {
             checkDecorators(node);
             checkSignatureDeclaration(node);
@@ -22483,6 +22513,8 @@ namespace ts {
                 case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.TypeOperator:
                     return checkSourceElement((<ParenthesizedTypeNode | TypeOperatorNode>node).type);
+                case SyntaxKind.JSDocAugmentsTag:
+                    return checkJSDocAugmentsTag(node as JSDocAugmentsTag);
                 case SyntaxKind.JSDocTypedefTag:
                     return checkJSDocTypedefTag(node as JSDocTypedefTag);
                 case SyntaxKind.JSDocParameterTag:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19790,25 +19790,27 @@ namespace ts {
         }
 
         function checkJSDocAugmentsTag(node: JSDocAugmentsTag): void {
-            const cls = getNodeCommentedByJSDocTag(node);
+            const cls = getJSDocHost(node);
             if (!isClassDeclaration(cls) && !isClassExpression(cls)) {
-                error(cls, Diagnostics.JSDoc_augments_tag_will_be_ignored_if_not_attached_to_a_class_declaration);
+                error(cls, Diagnostics.JSDoc_augments_is_not_attached_to_a_class_declaration);
                 return;
             }
 
-            const name = node.class.expression.kind === SyntaxKind.PropertyAccessExpression ? node.class.expression.name : node.class.expression;
+            const name = getIdentifierFromEntityNameExpression(node.class.expression);
             const extend = getClassExtendsHeritageClauseElement(cls);
             if (extend) {
-                const className = getClassName(extend.expression);
+                const className = getIdentifierFromEntityNameExpression(extend.expression);
                 if (className && name.escapedText !== className.escapedText) {
-                    error(name, Diagnostics.JSDoc_augments_tag_declares_to_extend_0_but_actual_class_augments_1,
+                    error(name, Diagnostics.JSDoc_augments_0_does_not_match_the_extends_1_clause,
                         unescapeLeadingUnderscores(name.escapedText),
                         unescapeLeadingUnderscores(className.escapedText));
                 }
             }
         }
 
-        function getClassName(node: Expression): Identifier | undefined {
+        function getIdentifierFromEntityNameExpression(node: Identifier | PropertyAccessExpression): Identifier;
+        function getIdentifierFromEntityNameExpression(node: Expression): Identifier | undefined;
+        function getIdentifierFromEntityNameExpression(node: Expression): Identifier | undefined {
             switch (node.kind) {
                 case SyntaxKind.Identifier:
                     return node as Identifier;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3511,6 +3511,14 @@
         "category": "Error",
         "code": 8021
     },
+    "JSDoc '@augments' tag will be ignored if not attached to a class declaration.": {
+        "category": "Error",
+        "code": 8022
+    },
+    "JSDoc '@augments' tag declares to extend '{0}', but actual class augments '{1}'.": {
+        "category": "Error",
+        "code": 8023
+    },
     "Only identifiers/qualified-names with optional type arguments are currently supported in a class 'extends' clause.": {
         "category": "Error",
         "code": 9002

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3511,11 +3511,11 @@
         "category": "Error",
         "code": 8021
     },
-    "JSDoc '@augments' tag will be ignored if not attached to a class declaration.": {
+    "JSDoc '@augments' is not attached to a class declaration.": {
         "category": "Error",
         "code": 8022
     },
-    "JSDoc '@augments' tag declares to extend '{0}', but actual class augments '{1}'.": {
+    "JSDoc '@augments {0}' does not match the 'extends {1}' clause.": {
         "category": "Error",
         "code": 8023
     },

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6610,11 +6610,11 @@ namespace ts {
                     const result = <JSDocAugmentsTag>createNode(SyntaxKind.JSDocAugmentsTag, atToken.pos);
                     result.atToken = atToken;
                     result.tagName = tagName;
-                    result.class = parseValidExpressionWithTypeArguments();
+                    result.class = parseExpressionWithTypeArgumentsForAugments();
                     return finishNode(result);
                 }
 
-                function parseValidExpressionWithTypeArguments(): ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression } {
+                function parseExpressionWithTypeArgumentsForAugments(): ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression } {
                     const usedBrace = parseOptional(SyntaxKind.OpenBraceToken);
                     const node = createNode(SyntaxKind.ExpressionWithTypeArguments) as ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression };
                     node.expression = parsePropertyAccessEntityNameExpression();

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1856,6 +1856,12 @@ namespace ts {
                 case CharacterCodes.closeBracket:
                     pos++;
                     return token = SyntaxKind.CloseBracketToken;
+                case CharacterCodes.lessThan:
+                    pos++;
+                    return token = SyntaxKind.LessThanToken;
+                case CharacterCodes.greaterThan:
+                    pos++;
+                    return token = SyntaxKind.GreaterThanToken;
                 case CharacterCodes.equals:
                     pos++;
                     return token = SyntaxKind.EqualsToken;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2161,7 +2161,7 @@ namespace ts {
 
     export interface JSDocAugmentsTag extends JSDocTag {
         kind: SyntaxKind.JSDocAugmentsTag;
-        typeExpression: JSDocTypeExpression;
+        class: ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression };
     }
 
     export interface JSDocClassTag extends JSDocTag {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1581,14 +1581,18 @@ namespace ts {
             return undefined;
         }
         const name = node.name.escapedText;
-        Debug.assert(node.parent!.kind === SyntaxKind.JSDocComment);
-        const func = node.parent!.parent!;
+        const func = getNodeCommentedByJSDocTag(node);
         if (!isFunctionLike(func)) {
             return undefined;
         }
         const parameter = find(func.parameters, p =>
             p.name.kind === SyntaxKind.Identifier && p.name.escapedText === name);
         return parameter && parameter.symbol;
+    }
+
+    export function getNodeCommentedByJSDocTag(node: JSDocTag): Node {
+        Debug.assert(node.parent!.kind === SyntaxKind.JSDocComment);
+        return node.parent!.parent!;
     }
 
     export function getTypeParameterFromJsDoc(node: TypeParameterDeclaration & { parent: JSDocTemplateTag }): TypeParameterDeclaration | undefined {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1590,7 +1590,7 @@ namespace ts {
         return parameter && parameter.symbol;
     }
 
-    export function getJSDocHost(node: JSDocTag): Node {
+    export function getJSDocHost(node: JSDocTag): HasJSDoc {
         Debug.assert(node.parent!.kind === SyntaxKind.JSDocComment);
         return node.parent!.parent!;
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1581,7 +1581,7 @@ namespace ts {
             return undefined;
         }
         const name = node.name.escapedText;
-        const func = getNodeCommentedByJSDocTag(node);
+        const func = getJSDocHost(node);
         if (!isFunctionLike(func)) {
             return undefined;
         }
@@ -1590,7 +1590,7 @@ namespace ts {
         return parameter && parameter.symbol;
     }
 
-    export function getNodeCommentedByJSDocTag(node: JSDocTag): Node {
+    export function getJSDocHost(node: JSDocTag): Node {
         Debug.assert(node.parent!.kind === SyntaxKind.JSDocComment);
         return node.parent!.parent!;
     }

--- a/src/harness/unittests/jsDocParsing.ts
+++ b/src/harness/unittests/jsDocParsing.ts
@@ -300,6 +300,11 @@ namespace ts {
   * @property {number} age
   * @property {string} name
   */`);
+                parsesCorrectly("<> characters",
+`/**
+ * @param x hi
+< > still part of the previous comment
+ */`);
             });
         });
         describe("getFirstToken", () => {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -581,11 +581,10 @@ namespace ts.Completions {
 
         return { symbols, isGlobalCompletion, isMemberCompletion, allowStringLiteral, isNewIdentifierLocation, location, isRightOfDot: (isRightOfDot || isRightOfOpenTag), request, keywordFilters };
 
-        type JSDocTagWithTypeExpression = JSDocAugmentsTag | JSDocParameterTag | JSDocPropertyTag | JSDocReturnTag | JSDocTypeTag | JSDocTypedefTag;
+        type JSDocTagWithTypeExpression = JSDocParameterTag | JSDocPropertyTag | JSDocReturnTag | JSDocTypeTag | JSDocTypedefTag;
 
         function isTagWithTypeExpression(tag: JSDocTag): tag is JSDocTagWithTypeExpression {
             switch (tag.kind) {
-                case SyntaxKind.JSDocAugmentsTag:
                 case SyntaxKind.JSDocParameterTag:
                 case SyntaxKind.JSDocPropertyTag:
                 case SyntaxKind.JSDocReturnTag:

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.<> characters.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.<> characters.json
@@ -1,0 +1,35 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 61,
+    "tags": {
+        "0": {
+            "kind": "JSDocParameterTag",
+            "pos": 7,
+            "end": 16,
+            "atToken": {
+                "kind": "AtToken",
+                "pos": 7,
+                "end": 8
+            },
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 8,
+                "end": 13,
+                "escapedText": "param"
+            },
+            "name": {
+                "kind": "Identifier",
+                "pos": 14,
+                "end": 15,
+                "escapedText": "x"
+            },
+            "isNameFirst": true,
+            "isBracketed": false,
+            "comment": "hi\n< > still part of the previous comment"
+        },
+        "length": 1,
+        "pos": 7,
+        "end": 16
+    }
+}

--- a/tests/baselines/reference/jsdocAugmentsMissingType.errors.txt
+++ b/tests/baselines/reference/jsdocAugmentsMissingType.errors.txt
@@ -1,14 +1,20 @@
-/a.js(2,14): error TS1005: '{' expected.
+/a.js(2,14): error TS1003: Identifier expected.
+/a.js(2,14): error TS8023: JSDoc '@augments' tag declares to extend '', but actual class augments 'A'.
+/a.js(5,14): error TS2339: Property 'x' does not exist on type 'B'.
 
 
-==== /a.js (1 errors) ====
+==== /a.js (3 errors) ====
     class A { constructor() { this.x = 0; } }
     /** @augments */
-                 ~
-!!! error TS1005: '{' expected.
+                 
+!!! error TS1003: Identifier expected.
+                 
+!!! error TS8023: JSDoc '@augments' tag declares to extend '', but actual class augments 'A'.
     class B extends A {
         m() {
             this.x
+                 ~
+!!! error TS2339: Property 'x' does not exist on type 'B'.
         }
     }
     

--- a/tests/baselines/reference/jsdocAugmentsMissingType.errors.txt
+++ b/tests/baselines/reference/jsdocAugmentsMissingType.errors.txt
@@ -1,5 +1,5 @@
 /a.js(2,14): error TS1003: Identifier expected.
-/a.js(2,14): error TS8023: JSDoc '@augments' tag declares to extend '', but actual class augments 'A'.
+/a.js(2,14): error TS8023: JSDoc '@augments ' does not match the 'extends A' clause.
 /a.js(5,14): error TS2339: Property 'x' does not exist on type 'B'.
 
 
@@ -9,7 +9,7 @@
                  
 !!! error TS1003: Identifier expected.
                  
-!!! error TS8023: JSDoc '@augments' tag declares to extend '', but actual class augments 'A'.
+!!! error TS8023: JSDoc '@augments ' does not match the 'extends A' clause.
     class B extends A {
         m() {
             this.x

--- a/tests/baselines/reference/jsdocAugmentsMissingType.symbols
+++ b/tests/baselines/reference/jsdocAugmentsMissingType.symbols
@@ -14,9 +14,7 @@ class B extends A {
 >m : Symbol(B.m, Decl(a.js, 2, 19))
 
         this.x
->this.x : Symbol(A.x, Decl(a.js, 0, 25))
 >this : Symbol(B, Decl(a.js, 0, 41))
->x : Symbol(A.x, Decl(a.js, 0, 25))
     }
 }
 

--- a/tests/baselines/reference/jsdocAugments_nameMismatch.errors.txt
+++ b/tests/baselines/reference/jsdocAugments_nameMismatch.errors.txt
@@ -1,0 +1,12 @@
+/b.js(4,15): error TS8023: JSDoc '@augments' tag declares to extend 'A', but actual class augments 'B'.
+
+
+==== /b.js (1 errors) ====
+    class A {}
+    class B {}
+    
+    /** @augments A */
+                  ~
+!!! error TS8023: JSDoc '@augments' tag declares to extend 'A', but actual class augments 'B'.
+    class C extends B {}
+    

--- a/tests/baselines/reference/jsdocAugments_nameMismatch.errors.txt
+++ b/tests/baselines/reference/jsdocAugments_nameMismatch.errors.txt
@@ -1,4 +1,4 @@
-/b.js(4,15): error TS8023: JSDoc '@augments' tag declares to extend 'A', but actual class augments 'B'.
+/b.js(4,15): error TS8023: JSDoc '@augments A' does not match the 'extends B' clause.
 
 
 ==== /b.js (1 errors) ====
@@ -7,6 +7,6 @@
     
     /** @augments A */
                   ~
-!!! error TS8023: JSDoc '@augments' tag declares to extend 'A', but actual class augments 'B'.
+!!! error TS8023: JSDoc '@augments A' does not match the 'extends B' clause.
     class C extends B {}
     

--- a/tests/baselines/reference/jsdocAugments_nameMismatch.symbols
+++ b/tests/baselines/reference/jsdocAugments_nameMismatch.symbols
@@ -1,0 +1,12 @@
+=== /b.js ===
+class A {}
+>A : Symbol(A, Decl(b.js, 0, 0))
+
+class B {}
+>B : Symbol(B, Decl(b.js, 0, 10))
+
+/** @augments A */
+class C extends B {}
+>C : Symbol(C, Decl(b.js, 1, 10))
+>B : Symbol(B, Decl(b.js, 0, 10))
+

--- a/tests/baselines/reference/jsdocAugments_nameMismatch.types
+++ b/tests/baselines/reference/jsdocAugments_nameMismatch.types
@@ -1,0 +1,12 @@
+=== /b.js ===
+class A {}
+>A : A
+
+class B {}
+>B : B
+
+/** @augments A */
+class C extends B {}
+>C : C
+>B : A
+

--- a/tests/baselines/reference/jsdocAugments_noExtends.symbols
+++ b/tests/baselines/reference/jsdocAugments_noExtends.symbols
@@ -1,0 +1,21 @@
+=== /b.js ===
+class A { constructor() { this.x = 0; } }
+>A : Symbol(A, Decl(b.js, 0, 0))
+>this.x : Symbol(A.x, Decl(b.js, 0, 25))
+>this : Symbol(A, Decl(b.js, 0, 0))
+>x : Symbol(A.x, Decl(b.js, 0, 25))
+
+/** @augments A */
+class B {
+>B : Symbol(B, Decl(b.js, 0, 41))
+
+    m() {
+>m : Symbol(B.m, Decl(b.js, 3, 9))
+
+        return this.x;
+>this.x : Symbol(A.x, Decl(b.js, 0, 25))
+>this : Symbol(B, Decl(b.js, 0, 41))
+>x : Symbol(A.x, Decl(b.js, 0, 25))
+    }
+}
+

--- a/tests/baselines/reference/jsdocAugments_noExtends.types
+++ b/tests/baselines/reference/jsdocAugments_noExtends.types
@@ -1,4 +1,4 @@
-=== /a.js ===
+=== /b.js ===
 class A { constructor() { this.x = 0; } }
 >A : A
 >this.x = 0 : 0
@@ -7,18 +7,17 @@ class A { constructor() { this.x = 0; } }
 >x : number
 >0 : 0
 
-/** @augments */
-class B extends A {
+/** @augments A */
+class B {
 >B : B
->A : typeof A
 
     m() {
->m : () => void
+>m : () => number
 
-        this.x
->this.x : any
+        return this.x;
+>this.x : number
 >this : this
->x : any
+>x : number
     }
 }
 

--- a/tests/baselines/reference/jsdocAugments_notAClass.errors.txt
+++ b/tests/baselines/reference/jsdocAugments_notAClass.errors.txt
@@ -1,0 +1,10 @@
+/b.js(3,10): error TS8022: JSDoc '@augments' tag will be ignored if not attached to a class declaration.
+
+
+==== /b.js (1 errors) ====
+    class A {}
+    /** @augments A */
+    function b() {}
+             ~
+!!! error TS8022: JSDoc '@augments' tag will be ignored if not attached to a class declaration.
+    

--- a/tests/baselines/reference/jsdocAugments_notAClass.errors.txt
+++ b/tests/baselines/reference/jsdocAugments_notAClass.errors.txt
@@ -1,4 +1,4 @@
-/b.js(3,10): error TS8022: JSDoc '@augments' tag will be ignored if not attached to a class declaration.
+/b.js(3,10): error TS8022: JSDoc '@augments' is not attached to a class declaration.
 
 
 ==== /b.js (1 errors) ====
@@ -6,5 +6,5 @@
     /** @augments A */
     function b() {}
              ~
-!!! error TS8022: JSDoc '@augments' tag will be ignored if not attached to a class declaration.
+!!! error TS8022: JSDoc '@augments' is not attached to a class declaration.
     

--- a/tests/baselines/reference/jsdocAugments_notAClass.symbols
+++ b/tests/baselines/reference/jsdocAugments_notAClass.symbols
@@ -1,0 +1,8 @@
+=== /b.js ===
+class A {}
+>A : Symbol(A, Decl(b.js, 0, 0))
+
+/** @augments A */
+function b() {}
+>b : Symbol(b, Decl(b.js, 0, 10))
+

--- a/tests/baselines/reference/jsdocAugments_notAClass.types
+++ b/tests/baselines/reference/jsdocAugments_notAClass.types
@@ -1,0 +1,8 @@
+=== /b.js ===
+class A {}
+>A : A
+
+/** @augments A */
+function b() {}
+>b : () => void
+

--- a/tests/baselines/reference/jsdocAugments_withTypeParameter.symbols
+++ b/tests/baselines/reference/jsdocAugments_withTypeParameter.symbols
@@ -1,0 +1,23 @@
+=== /a.d.ts ===
+declare class A<T> { x: T }
+>A : Symbol(A, Decl(a.d.ts, 0, 0))
+>T : Symbol(T, Decl(a.d.ts, 0, 16))
+>x : Symbol(A.x, Decl(a.d.ts, 0, 20))
+>T : Symbol(T, Decl(a.d.ts, 0, 16))
+
+=== /b.js ===
+/** @augments A<number> */
+class B extends A {
+>B : Symbol(B, Decl(b.js, 0, 0))
+>A : Symbol(A, Decl(a.d.ts, 0, 0))
+
+    m() {
+>m : Symbol(B.m, Decl(b.js, 1, 19))
+
+        return this.x;
+>this.x : Symbol(A.x, Decl(a.d.ts, 0, 20))
+>this : Symbol(B, Decl(b.js, 0, 0))
+>x : Symbol(A.x, Decl(a.d.ts, 0, 20))
+    }
+}
+

--- a/tests/baselines/reference/jsdocAugments_withTypeParameter.types
+++ b/tests/baselines/reference/jsdocAugments_withTypeParameter.types
@@ -1,0 +1,23 @@
+=== /a.d.ts ===
+declare class A<T> { x: T }
+>A : A<T>
+>T : T
+>x : T
+>T : T
+
+=== /b.js ===
+/** @augments A<number> */
+class B extends A {
+>B : B
+>A : A<number>
+
+    m() {
+>m : () => number
+
+        return this.x;
+>this.x : number
+>this : this
+>x : number
+    }
+}
+

--- a/tests/cases/compiler/jsdocAugments_nameMismatch.ts
+++ b/tests/cases/compiler/jsdocAugments_nameMismatch.ts
@@ -1,0 +1,10 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /b.js
+class A {}
+class B {}
+
+/** @augments A */
+class C extends B {}

--- a/tests/cases/compiler/jsdocAugments_noExtends.ts
+++ b/tests/cases/compiler/jsdocAugments_noExtends.ts
@@ -1,0 +1,13 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /b.js
+class A { constructor() { this.x = 0; } }
+
+/** @augments A */
+class B {
+    m() {
+        return this.x;
+    }
+}

--- a/tests/cases/compiler/jsdocAugments_notAClass.ts
+++ b/tests/cases/compiler/jsdocAugments_notAClass.ts
@@ -1,0 +1,8 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /b.js
+class A {}
+/** @augments A */
+function b() {}

--- a/tests/cases/compiler/jsdocAugments_withTypeParameter.ts
+++ b/tests/cases/compiler/jsdocAugments_withTypeParameter.ts
@@ -1,0 +1,14 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /a.d.ts
+declare class A<T> { x: T }
+
+// @Filename: /b.js
+/** @augments A<number> */
+class B extends A {
+    m() {
+        return this.x;
+    }
+}

--- a/tests/cases/fourslash/jsDocAugments.ts
+++ b/tests/cases/fourslash/jsDocAugments.ts
@@ -15,7 +15,7 @@
 
 // @Filename: declarations.d.ts
 //// declare class Thing<T> {
-////     mine: T;    
+////     mine: T;
 //// }
 
 goTo.marker();


### PR DESCRIPTION
Fixes #18740

We will now get a superclass from `@augments` even if there is no `extends`.

Allows us to parse `/** @augments A */` without the curly braces, because that [seems](http://usejsdoc.org/tags-augments.html) to be the style.

We will no longer parse arbitrary types, only a class (qualified) name followed by type arguments. So you can't declare to inherit from `() => void` without parse errors.

Adds errors for:
* `@augments` tag not on a class
* `@augments A` but `extends B`