### PR TITLE
Support for the ECMAScript 'throw' operator

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3255,6 +3255,10 @@ namespace ts {
         let excludeFlags = TransformFlags.NodeExcludes;
 
         switch (kind) {
+            case SyntaxKind.ThrowExpression:
+                transformFlags |= TransformFlags.AssertESNext;
+                break;
+
             case SyntaxKind.AsyncKeyword:
             case SyntaxKind.AwaitExpression:
                 // async/await is ES2017 syntax, but may be ESNext syntax (for async generators)

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17179,6 +17179,10 @@ namespace ts {
         }
 
         function checkThrowExpression(node: ThrowExpression): Type {
+            if (!compilerOptions.experimentalThrowExpressions) {
+                error(node, Diagnostics.Experimental_support_for_throw_expressions_is_a_feature_that_is_subject_to_change_in_a_future_release_Set_the_experimentalThrowExpressions_option_to_remove_this_warning);
+            }
+
             checkExpression(node.expression);
             return neverType;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17178,6 +17178,11 @@ namespace ts {
             return booleanType;
         }
 
+        function checkThrowExpression(node: ThrowExpression): Type {
+            checkExpression(node.expression);
+            return neverType;
+        }
+
         function checkTypeOfExpression(node: TypeOfExpression): Type {
             checkExpression(node.expression);
             return typeofType;
@@ -18140,6 +18145,8 @@ namespace ts {
                     return checkMetaProperty(<MetaProperty>node);
                 case SyntaxKind.DeleteExpression:
                     return checkDeleteExpression(<DeleteExpression>node);
+                case SyntaxKind.ThrowExpression:
+                    return checkThrowExpression(<ThrowExpression>node);
                 case SyntaxKind.VoidExpression:
                     return checkVoidExpression(<VoidExpression>node);
                 case SyntaxKind.AwaitExpression:

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -433,6 +433,12 @@ namespace ts {
             category: Diagnostics.Experimental_Options,
             description: Diagnostics.Enables_experimental_support_for_emitting_type_metadata_for_decorators
         },
+        {
+            name: "experimentalThrowExpressions",
+            type: "boolean",
+            category: Diagnostics.Experimental_Options,
+            description: Diagnostics.Enables_experimental_support_for_ECMAScript_Stage_2_throw_expressions
+        },
 
         // Advanced
         {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -907,6 +907,10 @@
         "category": "Error",
         "code": 1328
     },
+    "Experimental support for 'throw' expressions is a feature that is subject to change in a future release. Set the 'experimentalThrowExpressions' option to remove this warning.": {
+        "category": "Error",
+        "code": 1329
+    },
 
     "Duplicate identifier '{0}'.": {
         "category": "Error",
@@ -3314,6 +3318,11 @@
         "category": "Message",
         "code": 6185
     },
+    "Enables experimental support for ECMAScript Stage-2 'throw' expressions.": {
+        "category": "Message",
+        "code": 6186
+    },
+
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -784,6 +784,8 @@ namespace ts {
                     return emitArrowFunction(<ArrowFunction>node);
                 case SyntaxKind.DeleteExpression:
                     return emitDeleteExpression(<DeleteExpression>node);
+                case SyntaxKind.ThrowExpression:
+                    return emitThrowExpression(<ThrowExpression>node);
                 case SyntaxKind.TypeOfExpression:
                     return emitTypeOfExpression(<TypeOfExpression>node);
                 case SyntaxKind.VoidExpression:
@@ -1297,6 +1299,11 @@ namespace ts {
 
         function emitDeleteExpression(node: DeleteExpression) {
             write("delete ");
+            emitExpression(node.expression);
+        }
+
+        function emitThrowExpression(node: ThrowExpression) {
+            write("throw ");
             emitExpression(node.expression);
         }
 

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -1074,6 +1074,18 @@ namespace ts {
             : node;
     }
 
+    export function createThrowExpression(expression: Expression) {
+        const node = <ThrowExpression>createSynthesizedNode(SyntaxKind.ThrowExpression);
+        node.expression = parenthesizePrefixOperand(expression);
+        return node;
+    }
+
+    export function updateThrowExpression(node: ThrowExpression, expression: Expression) {
+        return node.expression !== expression
+            ? updateNode(createThrowExpression(expression), node)
+            : node;
+    }
+
     export function createTypeOf(expression: Expression) {
         const node = <TypeOfExpression>createSynthesizedNode(SyntaxKind.TypeOfExpression);
         node.expression = parenthesizePrefixOperand(expression);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -185,6 +185,8 @@ namespace ts {
                 return visitNode(cbNode, (<ParenthesizedExpression>node).expression);
             case SyntaxKind.DeleteExpression:
                 return visitNode(cbNode, (<DeleteExpression>node).expression);
+            case SyntaxKind.ThrowExpression:
+                return visitNode(cbNode, (<ThrowExpression>node).expression);
             case SyntaxKind.TypeOfExpression:
                 return visitNode(cbNode, (<TypeOfExpression>node).expression);
             case SyntaxKind.VoidExpression:
@@ -2962,6 +2964,7 @@ namespace ts {
                 case SyntaxKind.ExclamationToken:
                 case SyntaxKind.DeleteKeyword:
                 case SyntaxKind.TypeOfKeyword:
+                case SyntaxKind.ThrowKeyword:
                 case SyntaxKind.VoidKeyword:
                 case SyntaxKind.PlusPlusToken:
                 case SyntaxKind.MinusMinusToken:
@@ -2986,11 +2989,21 @@ namespace ts {
         }
 
         function isStartOfExpressionStatement(): boolean {
-            // As per the grammar, none of '{' or 'function' or 'class' can start an expression statement.
+            // As per the grammar, none of '{', 'function', 'async [no LineTerminator here] function', 'class', 'let [', or 'throw' can start an expression statement:
+            //
+            // An |ExpressionStatement| cannot start with a U+007B (LEFT CURLY BRACKET) because that might make it ambiguous with a |Block|.
+            // An |ExpressionStatement| cannot start with the `function` or `class` keywords because that would make it ambiguous with a |FunctionDeclaration|, a |GeneratorDeclaration|, or a |ClassDeclaration|.
+            // An |ExpressionStatement| cannot start with `async` `function` because that would make it ambiguous with an |AsyncFunctionDeclaration|.
+            // An |ExpressionStatement| cannot start with the two token sequence `let` `[` because that would make it ambiguous with a `let` |LexicalDeclaration| whose first |LexicalBinding| was an |ArrayBindingPattern|.
+            // An |ExpressionStatement| cannot start with `throw` because that would make it ambiguous with a |ThrowStatement|.
+            //
             return token() !== SyntaxKind.OpenBraceToken &&
                 token() !== SyntaxKind.FunctionKeyword &&
                 token() !== SyntaxKind.ClassKeyword &&
+                token() !== SyntaxKind.ThrowKeyword &&
                 token() !== SyntaxKind.AtToken &&
+                (token() !== SyntaxKind.AsyncKeyword || !lookAhead(nextTokenIsFunctionKeywordOnSameLine)) &&
+                (token() !== SyntaxKind.LetKeyword || !lookAhead(nextTokenIsOpenBracket)) &&
                 isStartOfExpression();
         }
 
@@ -3624,6 +3637,13 @@ namespace ts {
             return finishNode(node);
         }
 
+        function parseThrowExpression() {
+            const node = <ThrowExpression>createNode(SyntaxKind.ThrowExpression);
+            nextToken();
+            node.expression = parseSimpleUnaryExpression();
+            return finishNode(node);
+        }
+
         function parseTypeOfExpression() {
             const node = <TypeOfExpression>createNode(SyntaxKind.TypeOfExpression);
             nextToken();
@@ -3730,6 +3750,8 @@ namespace ts {
                     return parsePrefixUnaryExpression();
                 case SyntaxKind.DeleteKeyword:
                     return parseDeleteExpression();
+                case SyntaxKind.ThrowKeyword:
+                    return parseThrowExpression();
                 case SyntaxKind.TypeOfKeyword:
                     return parseTypeOfExpression();
                 case SyntaxKind.VoidKeyword:
@@ -3768,6 +3790,7 @@ namespace ts {
                 case SyntaxKind.TildeToken:
                 case SyntaxKind.ExclamationToken:
                 case SyntaxKind.DeleteKeyword:
+                case SyntaxKind.ThrowKeyword:
                 case SyntaxKind.TypeOfKeyword:
                 case SyntaxKind.VoidKeyword:
                 case SyntaxKind.AwaitKeyword:
@@ -5772,6 +5795,10 @@ namespace ts {
 
         function nextTokenIsOpenParen() {
             return nextToken() === SyntaxKind.OpenParenToken;
+        }
+
+        function nextTokenIsOpenBracket() {
+            return nextToken() === SyntaxKind.OpenBracketToken;
         }
 
         function nextTokenIsSlash() {

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -79,6 +79,8 @@ namespace ts {
                     return visitForOfStatement(node as ForOfStatement, /*outermostLabeledStatement*/ undefined);
                 case SyntaxKind.ForStatement:
                     return visitForStatement(node as ForStatement);
+                case SyntaxKind.ThrowExpression:
+                    return visitThrowExpression(node as ThrowExpression);
                 case SyntaxKind.VoidExpression:
                     return visitVoidExpression(node as VoidExpression);
                 case SyntaxKind.Constructor:
@@ -276,6 +278,10 @@ namespace ts {
                 visitNode(node.incrementor, visitor, isExpression),
                 visitNode(node.statement, visitor, isStatement)
             );
+        }
+
+        function visitThrowExpression(node: ThrowExpression) {
+            return createThrowHelper(context, visitNode(node.expression, visitor, isExpression), node);
         }
 
         function visitVoidExpression(node: VoidExpression) {
@@ -981,6 +987,24 @@ namespace ts {
         return setTextRange(
             createCall(
                 getHelperName("__asyncValues"),
+                /*typeArguments*/ undefined,
+                [expression]
+            ),
+            location
+        );
+    }
+
+    const throwHelper: EmitHelper = {
+        name: "typescript:throw",
+        scoped: false,
+        text: `var __throw = (this && this.__throw) || function (e) { throw e; };`
+    };
+
+    function createThrowHelper(context: TransformationContext, expression: Expression, location?: TextRange) {
+        context.requestEmitHelper(throwHelper);
+        return setTextRange(
+            createCall(
+                getHelperName("__throw"),
                 /*typeArguments*/ undefined,
                 [expression]
             ),

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -257,6 +257,7 @@ namespace ts {
         FunctionExpression,
         ArrowFunction,
         DeleteExpression,
+        ThrowExpression,
         TypeOfExpression,
         VoidExpression,
         AwaitExpression,
@@ -1152,6 +1153,11 @@ namespace ts {
 
     export interface DeleteExpression extends UnaryExpression {
         kind: SyntaxKind.DeleteExpression;
+        expression: UnaryExpression;
+    }
+
+    export interface ThrowExpression extends UnaryExpression {
+        kind: SyntaxKind.ThrowExpression;
         expression: UnaryExpression;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3658,6 +3658,7 @@ namespace ts {
         emitBOM?: boolean;
         emitDecoratorMetadata?: boolean;
         experimentalDecorators?: boolean;
+        experimentalThrowExpressions?: boolean;
         forceConsistentCasingInFileNames?: boolean;
         /*@internal*/help?: boolean;
         importHelpers?: boolean;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1227,6 +1227,7 @@ namespace ts {
             case SyntaxKind.ArrowFunction:
             case SyntaxKind.VoidExpression:
             case SyntaxKind.DeleteExpression:
+            case SyntaxKind.ThrowExpression:
             case SyntaxKind.TypeOfExpression:
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
@@ -2129,6 +2130,7 @@ namespace ts {
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.TypeOfExpression:
             case SyntaxKind.VoidExpression:
+            case SyntaxKind.ThrowExpression:
             case SyntaxKind.DeleteExpression:
             case SyntaxKind.AwaitExpression:
             case SyntaxKind.ConditionalExpression:
@@ -2216,6 +2218,7 @@ namespace ts {
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.TypeOfExpression:
             case SyntaxKind.VoidExpression:
+            case SyntaxKind.ThrowExpression:
             case SyntaxKind.DeleteExpression:
             case SyntaxKind.AwaitExpression:
                 return 15;
@@ -4294,6 +4297,10 @@ namespace ts {
         return node.kind === SyntaxKind.DeleteExpression;
     }
 
+    export function isThrowExpression(node: Node): node is ThrowExpression {
+        return node.kind === SyntaxKind.ThrowExpression;
+    }
+
     export function isTypeOfExpression(node: Node): node is TypeOfExpression {
         return node.kind === SyntaxKind.AwaitExpression;
     }
@@ -5112,6 +5119,7 @@ namespace ts {
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
             case SyntaxKind.DeleteExpression:
+            case SyntaxKind.ThrowExpression:
             case SyntaxKind.TypeOfExpression:
             case SyntaxKind.VoidExpression:
             case SyntaxKind.AwaitExpression:

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -495,6 +495,10 @@ namespace ts {
                 return updateDelete(<DeleteExpression>node,
                     visitNode((<DeleteExpression>node).expression, visitor, isExpression));
 
+            case SyntaxKind.ThrowExpression:
+                return updateThrowExpression(<ThrowExpression>node,
+                    visitNode((<ThrowExpression>node).expression, visitor, isExpression));
+
             case SyntaxKind.TypeOfExpression:
                 return updateTypeOf(<TypeOfExpression>node,
                     visitNode((<TypeOfExpression>node).expression, visitor, isExpression));
@@ -1104,13 +1108,14 @@ namespace ts {
 
             case SyntaxKind.ParenthesizedExpression:
             case SyntaxKind.DeleteExpression:
+            case SyntaxKind.ThrowExpression:
             case SyntaxKind.TypeOfExpression:
             case SyntaxKind.VoidExpression:
             case SyntaxKind.AwaitExpression:
             case SyntaxKind.YieldExpression:
             case SyntaxKind.SpreadElement:
             case SyntaxKind.NonNullExpression:
-                result = reduceNode((<ParenthesizedExpression | DeleteExpression | TypeOfExpression | VoidExpression | AwaitExpression | YieldExpression | SpreadElement | NonNullExpression>node).expression, cbNode, result);
+                result = reduceNode((<ParenthesizedExpression | DeleteExpression | ThrowExpression | TypeOfExpression | VoidExpression | AwaitExpression | YieldExpression | SpreadElement | NonNullExpression>node).expression, cbNode, result);
                 break;
 
             case SyntaxKind.PrefixUnaryExpression:

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -535,12 +535,13 @@ namespace ts {
             case SyntaxKind.TypeQuery:
                 return isCompletedNode((<TypeQueryNode>n).exprName, sourceFile);
 
+            case SyntaxKind.ThrowExpression:
             case SyntaxKind.TypeOfExpression:
             case SyntaxKind.DeleteExpression:
             case SyntaxKind.VoidExpression:
             case SyntaxKind.YieldExpression:
             case SyntaxKind.SpreadElement:
-                const unaryWordExpression = n as (TypeOfExpression | DeleteExpression | VoidExpression | YieldExpression | SpreadElement);
+                const unaryWordExpression = n as (ThrowExpression | TypeOfExpression | DeleteExpression | VoidExpression | YieldExpression | SpreadElement);
                 return isCompletedNode(unaryWordExpression.expression, sourceFile);
 
             case SyntaxKind.TaggedTemplateExpression:

--- a/tests/baselines/reference/throwExpressions.es2015.js
+++ b/tests/baselines/reference/throwExpressions.es2015.js
@@ -1,0 +1,16 @@
+//// [throwExpressions.es2015.ts]
+declare const condition: boolean;
+const a = condition ? 1 : throw new Error();
+const b = condition || throw new Error();
+function c(d = throw new TypeError()) { }
+
+const x = "x", y = "y", z = "z";
+const w = condition ? throw true ? x : y : z;
+
+//// [throwExpressions.es2015.js]
+var __throw = (this && this.__throw) || function (e) { throw e; };
+const a = condition ? 1 : __throw(new Error());
+const b = condition || __throw(new Error());
+function c(d = __throw(new TypeError())) { }
+const x = "x", y = "y", z = "z";
+const w = condition ? __throw(true) ? x : y : z;

--- a/tests/baselines/reference/throwExpressions.es2015.symbols
+++ b/tests/baselines/reference/throwExpressions.es2015.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/conformance/expressions/throwExpressions/throwExpressions.es2015.ts ===
+declare const condition: boolean;
+>condition : Symbol(condition, Decl(throwExpressions.es2015.ts, 0, 13))
+
+const a = condition ? 1 : throw new Error();
+>a : Symbol(a, Decl(throwExpressions.es2015.ts, 1, 5))
+>condition : Symbol(condition, Decl(throwExpressions.es2015.ts, 0, 13))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+const b = condition || throw new Error();
+>b : Symbol(b, Decl(throwExpressions.es2015.ts, 2, 5))
+>condition : Symbol(condition, Decl(throwExpressions.es2015.ts, 0, 13))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+function c(d = throw new TypeError()) { }
+>c : Symbol(c, Decl(throwExpressions.es2015.ts, 2, 41))
+>d : Symbol(d, Decl(throwExpressions.es2015.ts, 3, 11))
+>TypeError : Symbol(TypeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+const x = "x", y = "y", z = "z";
+>x : Symbol(x, Decl(throwExpressions.es2015.ts, 5, 5))
+>y : Symbol(y, Decl(throwExpressions.es2015.ts, 5, 14))
+>z : Symbol(z, Decl(throwExpressions.es2015.ts, 5, 23))
+
+const w = condition ? throw true ? x : y : z;
+>w : Symbol(w, Decl(throwExpressions.es2015.ts, 6, 5))
+>condition : Symbol(condition, Decl(throwExpressions.es2015.ts, 0, 13))
+>x : Symbol(x, Decl(throwExpressions.es2015.ts, 5, 5))
+>y : Symbol(y, Decl(throwExpressions.es2015.ts, 5, 14))
+>z : Symbol(z, Decl(throwExpressions.es2015.ts, 5, 23))
+

--- a/tests/baselines/reference/throwExpressions.es2015.types
+++ b/tests/baselines/reference/throwExpressions.es2015.types
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/expressions/throwExpressions/throwExpressions.es2015.ts ===
+declare const condition: boolean;
+>condition : boolean
+
+const a = condition ? 1 : throw new Error();
+>a : 1
+>condition ? 1 : throw new Error() : 1
+>condition : boolean
+>1 : 1
+>throw new Error() : never
+>new Error() : Error
+>Error : ErrorConstructor
+
+const b = condition || throw new Error();
+>b : true
+>condition || throw new Error() : true
+>condition : true
+>throw new Error() : never
+>new Error() : Error
+>Error : ErrorConstructor
+
+function c(d = throw new TypeError()) { }
+>c : (d?: never) => void
+>d : never
+>throw new TypeError() : never
+>new TypeError() : TypeError
+>TypeError : TypeErrorConstructor
+
+const x = "x", y = "y", z = "z";
+>x : "x"
+>"x" : "x"
+>y : "y"
+>"y" : "y"
+>z : "z"
+>"z" : "z"
+
+const w = condition ? throw true ? x : y : z;
+>w : "x" | "y" | "z"
+>condition ? throw true ? x : y : z : "x" | "y" | "z"
+>condition : true
+>throw true ? x : y : "x" | "y"
+>throw true : never
+>true : true
+>x : "x"
+>y : "y"
+>z : "z"
+

--- a/tests/baselines/reference/throwExpressions.es2015.types
+++ b/tests/baselines/reference/throwExpressions.es2015.types
@@ -14,7 +14,7 @@ const a = condition ? 1 : throw new Error();
 const b = condition || throw new Error();
 >b : true
 >condition || throw new Error() : true
->condition : true
+>condition : boolean
 >throw new Error() : never
 >new Error() : Error
 >Error : ErrorConstructor
@@ -37,7 +37,7 @@ const x = "x", y = "y", z = "z";
 const w = condition ? throw true ? x : y : z;
 >w : "x" | "y" | "z"
 >condition ? throw true ? x : y : z : "x" | "y" | "z"
->condition : true
+>condition : boolean
 >throw true ? x : y : "x" | "y"
 >throw true : never
 >true : true

--- a/tests/baselines/reference/throwExpressions.esnext.js
+++ b/tests/baselines/reference/throwExpressions.esnext.js
@@ -1,0 +1,15 @@
+//// [throwExpressions.esnext.ts]
+declare const condition: boolean;
+const a = condition ? 1 : throw new Error();
+const b = condition || throw new Error();
+function c(d = throw new TypeError()) { }
+
+const x = "x", y = "y", z = "z";
+const w = condition ? throw true ? x : y : z;
+
+//// [throwExpressions.esnext.js]
+const a = condition ? 1 : throw new Error();
+const b = condition || throw new Error();
+function c(d = throw new TypeError()) { }
+const x = "x", y = "y", z = "z";
+const w = condition ? throw true ? x : y : z;

--- a/tests/baselines/reference/throwExpressions.esnext.symbols
+++ b/tests/baselines/reference/throwExpressions.esnext.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/conformance/expressions/throwExpressions/throwExpressions.esnext.ts ===
+declare const condition: boolean;
+>condition : Symbol(condition, Decl(throwExpressions.esnext.ts, 0, 13))
+
+const a = condition ? 1 : throw new Error();
+>a : Symbol(a, Decl(throwExpressions.esnext.ts, 1, 5))
+>condition : Symbol(condition, Decl(throwExpressions.esnext.ts, 0, 13))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+const b = condition || throw new Error();
+>b : Symbol(b, Decl(throwExpressions.esnext.ts, 2, 5))
+>condition : Symbol(condition, Decl(throwExpressions.esnext.ts, 0, 13))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+function c(d = throw new TypeError()) { }
+>c : Symbol(c, Decl(throwExpressions.esnext.ts, 2, 41))
+>d : Symbol(d, Decl(throwExpressions.esnext.ts, 3, 11))
+>TypeError : Symbol(TypeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+const x = "x", y = "y", z = "z";
+>x : Symbol(x, Decl(throwExpressions.esnext.ts, 5, 5))
+>y : Symbol(y, Decl(throwExpressions.esnext.ts, 5, 14))
+>z : Symbol(z, Decl(throwExpressions.esnext.ts, 5, 23))
+
+const w = condition ? throw true ? x : y : z;
+>w : Symbol(w, Decl(throwExpressions.esnext.ts, 6, 5))
+>condition : Symbol(condition, Decl(throwExpressions.esnext.ts, 0, 13))
+>x : Symbol(x, Decl(throwExpressions.esnext.ts, 5, 5))
+>y : Symbol(y, Decl(throwExpressions.esnext.ts, 5, 14))
+>z : Symbol(z, Decl(throwExpressions.esnext.ts, 5, 23))
+

--- a/tests/baselines/reference/throwExpressions.esnext.types
+++ b/tests/baselines/reference/throwExpressions.esnext.types
@@ -14,7 +14,7 @@ const a = condition ? 1 : throw new Error();
 const b = condition || throw new Error();
 >b : true
 >condition || throw new Error() : true
->condition : true
+>condition : boolean
 >throw new Error() : never
 >new Error() : Error
 >Error : ErrorConstructor
@@ -37,7 +37,7 @@ const x = "x", y = "y", z = "z";
 const w = condition ? throw true ? x : y : z;
 >w : "x" | "y" | "z"
 >condition ? throw true ? x : y : z : "x" | "y" | "z"
->condition : true
+>condition : boolean
 >throw true ? x : y : "x" | "y"
 >throw true : never
 >true : true

--- a/tests/baselines/reference/throwExpressions.esnext.types
+++ b/tests/baselines/reference/throwExpressions.esnext.types
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/expressions/throwExpressions/throwExpressions.esnext.ts ===
+declare const condition: boolean;
+>condition : boolean
+
+const a = condition ? 1 : throw new Error();
+>a : 1
+>condition ? 1 : throw new Error() : 1
+>condition : boolean
+>1 : 1
+>throw new Error() : never
+>new Error() : Error
+>Error : ErrorConstructor
+
+const b = condition || throw new Error();
+>b : true
+>condition || throw new Error() : true
+>condition : true
+>throw new Error() : never
+>new Error() : Error
+>Error : ErrorConstructor
+
+function c(d = throw new TypeError()) { }
+>c : (d?: never) => void
+>d : never
+>throw new TypeError() : never
+>new TypeError() : TypeError
+>TypeError : TypeErrorConstructor
+
+const x = "x", y = "y", z = "z";
+>x : "x"
+>"x" : "x"
+>y : "y"
+>"y" : "y"
+>z : "z"
+>"z" : "z"
+
+const w = condition ? throw true ? x : y : z;
+>w : "x" | "y" | "z"
+>condition ? throw true ? x : y : z : "x" | "y" | "z"
+>condition : true
+>throw true ? x : y : "x" | "y"
+>throw true : never
+>true : true
+>x : "x"
+>y : "y"
+>z : "z"
+

--- a/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
@@ -50,5 +50,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    // "experimentalThrowExpressions": true,  /* Enables experimental support for ECMAScript Stage-2 'throw' expressions. */
   }
 }

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -50,5 +50,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    // "experimentalThrowExpressions": true,  /* Enables experimental support for ECMAScript Stage-2 'throw' expressions. */
   }
 }

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -50,5 +50,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    // "experimentalThrowExpressions": true,  /* Enables experimental support for ECMAScript Stage-2 'throw' expressions. */
   }
 }

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
@@ -50,6 +50,7 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    // "experimentalThrowExpressions": true,  /* Enables experimental support for ECMAScript Stage-2 'throw' expressions. */
   },
   "files": [
     "file0.st",

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -50,5 +50,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    // "experimentalThrowExpressions": true,  /* Enables experimental support for ECMAScript Stage-2 'throw' expressions. */
   }
 }

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -50,5 +50,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    // "experimentalThrowExpressions": true,  /* Enables experimental support for ECMAScript Stage-2 'throw' expressions. */
   }
 }

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -50,5 +50,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    // "experimentalThrowExpressions": true,  /* Enables experimental support for ECMAScript Stage-2 'throw' expressions. */
   }
 }

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -50,5 +50,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    // "experimentalThrowExpressions": true,  /* Enables experimental support for ECMAScript Stage-2 'throw' expressions. */
   }
 }

--- a/tests/cases/conformance/expressions/throwExpressions/throwExpressions.es2015.ts
+++ b/tests/cases/conformance/expressions/throwExpressions/throwExpressions.es2015.ts
@@ -1,0 +1,8 @@
+// @target: es2015
+declare const condition: boolean;
+const a = condition ? 1 : throw new Error();
+const b = condition || throw new Error();
+function c(d = throw new TypeError()) { }
+
+const x = "x", y = "y", z = "z";
+const w = condition ? throw true ? x : y : z;

--- a/tests/cases/conformance/expressions/throwExpressions/throwExpressions.es2015.ts
+++ b/tests/cases/conformance/expressions/throwExpressions/throwExpressions.es2015.ts
@@ -1,4 +1,5 @@
 // @target: es2015
+// @experimentalThrowExpressions: true
 declare const condition: boolean;
 const a = condition ? 1 : throw new Error();
 const b = condition || throw new Error();

--- a/tests/cases/conformance/expressions/throwExpressions/throwExpressions.esnext.ts
+++ b/tests/cases/conformance/expressions/throwExpressions/throwExpressions.esnext.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @experimentalThrowExpressions: true
 declare const condition: boolean;
 const a = condition ? 1 : throw new Error();
 const b = condition || throw new Error();

--- a/tests/cases/conformance/expressions/throwExpressions/throwExpressions.esnext.ts
+++ b/tests/cases/conformance/expressions/throwExpressions/throwExpressions.esnext.ts
@@ -1,0 +1,8 @@
+// @target: esnext
+declare const condition: boolean;
+const a = condition ? 1 : throw new Error();
+const b = condition || throw new Error();
+function c(d = throw new TypeError()) { }
+
+const x = "x", y = "y", z = "z";
+const w = condition ? throw true ? x : y : z;


### PR DESCRIPTION
This PR adds support for the stage-2 ECMAScript 'throw' operator: https://github.com/tc39/proposal-throw-expressions.

NOTE: This feature does not yet support reachability checks at the expression level (e.g. in `(throw x), y`, `y` should be considered unreachable). I can investigate this either as part of this PR or (preferably) in a follow-up PR. Our current reachability algorithm does not work well with expressions and will require some further investigation to make it more robust.

Fixes: #18535