### PR TITLE
spelling correction: Used toLowerCase() to ensure lowercase suggestions

### DIFF
--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -31,7 +31,7 @@ namespace ts.codefix {
                     fileName: sourceFile.fileName,
                     textChanges: [{
                         span: { start: node.getStart(), length: node.getWidth() },
-                        newText: suggestion
+                        newText: suggestion.toLowerCase()
                     }],
                 }],
             }];


### PR DESCRIPTION
Should fix https://github.com/Microsoft/TypeScript/issues/17219

I have used toLowerCase() function to ensure the suggestion returned is in lowercase only.
This is my first PR to TypeScript. Please let me know if I am missing something.
I would be glad to do any changes suggested.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
