### PR TITLE
Support contextual type for property assignments in JS that are not declarations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13096,13 +13096,25 @@ namespace ts {
             const binaryExpression = <BinaryExpression>node.parent;
             const operator = binaryExpression.operatorToken.kind;
             if (isAssignmentOperator(operator)) {
-                // Don't do this for special property assignments to avoid circularity
-                if (getSpecialPropertyAssignmentKind(binaryExpression) !== SpecialPropertyAssignmentKind.None) {
-                    return undefined;
-                }
-
-                // In an assignment expression, the right operand is contextually typed by the type of the left operand.
                 if (node === binaryExpression.right) {
+                    // Don't do this for special property assignments to avoid circularity
+                    switch (getSpecialPropertyAssignmentKind(binaryExpression)) {
+                        case SpecialPropertyAssignmentKind.None:
+                            break;
+                        case SpecialPropertyAssignmentKind.Property:
+                            // If `binaryExpression.left` was assigned a symbol, then this is a new declaration; otherwise it is an assignment to an existing declaration.
+                            // See `bindStaticPropertyAssignment` in `binder.ts`.
+                            if (!binaryExpression.left.symbol) {
+                                break;
+                            }
+                            // falls through
+                        case SpecialPropertyAssignmentKind.ExportsProperty:
+                        case SpecialPropertyAssignmentKind.ModuleExports:
+                        case SpecialPropertyAssignmentKind.PrototypeProperty:
+                        case SpecialPropertyAssignmentKind.ThisProperty:
+                            return undefined;
+                    }
+                    // In an assignment expression, the right operand is contextually typed by the type of the left operand.
                     return getTypeOfExpression(binaryExpression.left);
                 }
             }

--- a/tests/cases/fourslash/codeFixUndeclaredAcrossFiles1.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredAcrossFiles1.ts
@@ -23,7 +23,7 @@ verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
 verify.getAndApplyCodeFix(/*errorCode*/undefined, 0);
 
 verify.rangeIs(`
-    y: { [x: string]: any; };
+    y: {};
     m1(): any {
         throw new Error("Method not implemented.");
     }

--- a/tests/cases/fourslash/completionsJsPropertyAssignment.ts
+++ b/tests/cases/fourslash/completionsJsPropertyAssignment.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: /a.js
+/////** @type {{ p: "x" | "y" }} */
+////const x = { p: "x"  };
+////x.p = "/**/";
+
+verify.completionsAt("", ["x", "y"]);


### PR DESCRIPTION
Fixes  #18817
`getSpecialPropertyAssignmentKind !== SpecialPropertyAssignmentKind.None` is not sufficient to know that something is a special property assignment. It returns `true` for any property assignment, and then the binder does more work to determine whether it should actually be treated specially.