### PR TITLE
Improve Extract* unit test coverage and correctness

### DIFF
--- a/tests/baselines/reference/extractConstant/extractConstant_BlockScopes_NoDependencies.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_BlockScopes_NoDependencies.js
@@ -1,0 +1,14 @@
+// ==ORIGINAL==
+for (let i = 0; i < 10; i++) {
+    for (let j = 0; j < 10; j++) {
+        let x = 1;
+    }
+}
+// ==SCOPE::Extract to constant in global scope==
+const newLocal = 1;
+
+for (let i = 0; i < 10; i++) {
+    for (let j = 0; j < 10; j++) {
+        let x = /*RENAME*/newLocal;
+    }
+}

--- a/tests/baselines/reference/extractConstant/extractConstant_Class.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Class.js
@@ -1,0 +1,10 @@
+// ==ORIGINAL==
+class C {
+    x = 1;
+}
+// ==SCOPE::Extract to constant in global scope==
+const newLocal = 1;
+
+class C {
+    x = /*RENAME*/newLocal;
+}

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition.js
@@ -1,0 +1,34 @@
+// ==ORIGINAL==
+class C {
+    a = 1;
+    b = 2;
+    M1() { }
+    M2() { }
+    M3() {
+        let x = 1;
+    }
+}
+// ==SCOPE::Extract to constant in method 'M3==
+class C {
+    a = 1;
+    b = 2;
+    M1() { }
+    M2() { }
+    M3() {
+        const newLocal = 1;
+
+        let x = /*RENAME*/newLocal;
+    }
+}
+// ==SCOPE::Extract to constant in global scope==
+const newLocal = 1;
+
+class C {
+    a = 1;
+    b = 2;
+    M1() { }
+    M2() { }
+    M3() {
+        let x = /*RENAME*/newLocal;
+    }
+}

--- a/tests/baselines/reference/extractConstant/extractConstant_ExpressionStatement.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ExpressionStatement.js
@@ -1,0 +1,4 @@
+// ==ORIGINAL==
+"hello";
+// ==SCOPE::Extract to constant in global scope==
+const /*RENAME*/newLocal = "hello";

--- a/tests/baselines/reference/extractConstant/extractConstant_ExpressionStatementExpression.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ExpressionStatementExpression.js
@@ -1,0 +1,4 @@
+// ==ORIGINAL==
+"hello";
+// ==SCOPE::Extract to constant in global scope==
+const /*RENAME*/newLocal = "hello";

--- a/tests/baselines/reference/extractConstant/extractConstant_Function.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Function.js
@@ -1,0 +1,16 @@
+// ==ORIGINAL==
+function F() {
+    let x = 1;
+}
+// ==SCOPE::Extract to constant in function 'F'==
+function F() {
+    const newLocal = 1;
+
+    let x = /*RENAME*/newLocal;
+}
+// ==SCOPE::Extract to constant in global scope==
+const newLocal = 1;
+
+function F() {
+    let x = /*RENAME*/newLocal;
+}

--- a/tests/baselines/reference/extractConstant/extractConstant_Method.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Method.js
@@ -1,0 +1,22 @@
+// ==ORIGINAL==
+class C {
+    M() {
+        let x = 1;
+    }
+}
+// ==SCOPE::Extract to constant in method 'M==
+class C {
+    M() {
+        const newLocal = 1;
+
+        let x = /*RENAME*/newLocal;
+    }
+}
+// ==SCOPE::Extract to constant in global scope==
+const newLocal = 1;
+
+class C {
+    M() {
+        let x = /*RENAME*/newLocal;
+    }
+}

--- a/tests/baselines/reference/extractConstant/extractConstant_Parameters.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Parameters.js
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+function F() {
+    let w = 1;
+    let x = w + 1;
+}
+// ==SCOPE::Extract to constant in function 'F'==
+function F() {
+    let w = 1;
+    const newLocal = w + 1;
+
+    let x = /*RENAME*/newLocal;
+}

--- a/tests/baselines/reference/extractConstant/extractConstant_TopLevel.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_TopLevel.js
@@ -1,0 +1,6 @@
+// ==ORIGINAL==
+let x = 1;
+// ==SCOPE::Extract to constant in global scope==
+const newLocal = 1;
+
+let x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractFunction/extractFunction20.js
+++ b/tests/baselines/reference/extractFunction/extractFunction20.js
@@ -1,0 +1,28 @@
+// ==ORIGINAL==
+const _ = class {
+    a() {
+        let a1 = { x: 1 };
+        return a1.x + 10;
+    }
+}
+// ==SCOPE::Extract to method in anonymous class expression==
+const _ = class {
+    a() {
+        return this./*RENAME*/newMethod();
+    }
+
+    newMethod() {
+        let a1 = { x: 1 };
+        return a1.x + 10;
+    }
+}
+// ==SCOPE::Extract to function in global scope==
+const _ = class {
+    a() {
+        return /*RENAME*/newFunction();
+    }
+}
+function newFunction() {
+    let a1 = { x: 1 };
+    return a1.x + 10;
+}

--- a/tests/baselines/reference/extractFunction/extractFunction21.js
+++ b/tests/baselines/reference/extractFunction/extractFunction21.js
@@ -1,0 +1,26 @@
+// ==ORIGINAL==
+function foo() {
+    let x = 10;
+    x++;
+    return;
+}
+// ==SCOPE::Extract to inner function in function 'foo'==
+function foo() {
+    let x = 10;
+    return /*RENAME*/newFunction();
+
+    function newFunction() {
+        x++;
+        return;
+    }
+}
+// ==SCOPE::Extract to function in global scope==
+function foo() {
+    let x = 10;
+    x = /*RENAME*/newFunction(x);
+    return;
+}
+function newFunction(x) {
+    x++;
+    return x;
+}

--- a/tests/baselines/reference/extractFunction/extractFunction22.js
+++ b/tests/baselines/reference/extractFunction/extractFunction22.js
@@ -1,0 +1,31 @@
+// ==ORIGINAL==
+function test() {
+    try {
+    }
+    finally {
+        return 1;
+    }
+}
+// ==SCOPE::Extract to inner function in function 'test'==
+function test() {
+    try {
+    }
+    finally {
+        return /*RENAME*/newFunction();
+    }
+
+    function newFunction() {
+        return 1;
+    }
+}
+// ==SCOPE::Extract to function in global scope==
+function test() {
+    try {
+    }
+    finally {
+        return /*RENAME*/newFunction();
+    }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractFunction/extractFunction24.js
+++ b/tests/baselines/reference/extractFunction/extractFunction24.js
@@ -1,0 +1,43 @@
+// ==ORIGINAL==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return 1;
+    }
+    function M3() { }
+}
+// ==SCOPE::Extract to inner function in function 'M2'==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return /*RENAME*/newFunction();
+
+        function newFunction() {
+            return 1;
+        }
+    }
+    function M3() { }
+}
+// ==SCOPE::Extract to inner function in function 'Outer'==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return /*RENAME*/newFunction();
+    }
+    function newFunction() {
+        return 1;
+    }
+
+    function M3() { }
+}
+// ==SCOPE::Extract to function in global scope==
+function Outer() {
+    function M1() { }
+    function M2() {
+        return /*RENAME*/newFunction();
+    }
+    function M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractFunction/extractFunction25.js
+++ b/tests/baselines/reference/extractFunction/extractFunction25.js
@@ -1,0 +1,26 @@
+// ==ORIGINAL==
+function M1() { }
+function M2() {
+    return 1;
+}
+function M3() { }
+// ==SCOPE::Extract to inner function in function 'M2'==
+function M1() { }
+function M2() {
+    return /*RENAME*/newFunction();
+
+    function newFunction() {
+        return 1;
+    }
+}
+function M3() { }
+// ==SCOPE::Extract to function in global scope==
+function M1() { }
+function M2() {
+    return /*RENAME*/newFunction();
+}
+function newFunction() {
+    return 1;
+}
+
+function M3() { }

--- a/tests/baselines/reference/extractFunction/extractFunction26.js
+++ b/tests/baselines/reference/extractFunction/extractFunction26.js
@@ -1,0 +1,31 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    M3() { }
+}
+// ==SCOPE::Extract to method in class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this./*RENAME*/newMethod();
+    }
+    newMethod() {
+        return 1;
+    }
+
+    M3() { }
+}
+// ==SCOPE::Extract to function in global scope==
+class C {
+    M1() { }
+    M2() {
+        return /*RENAME*/newFunction();
+    }
+    M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractFunction/extractFunction27.js
+++ b/tests/baselines/reference/extractFunction/extractFunction27.js
@@ -1,0 +1,34 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    constructor() { }
+    M3() { }
+}
+// ==SCOPE::Extract to method in class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this./*RENAME*/newMethod();
+    }
+    constructor() { }
+    newMethod() {
+        return 1;
+    }
+
+    M3() { }
+}
+// ==SCOPE::Extract to function in global scope==
+class C {
+    M1() { }
+    M2() {
+        return /*RENAME*/newFunction();
+    }
+    constructor() { }
+    M3() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractFunction/extractFunction28.js
+++ b/tests/baselines/reference/extractFunction/extractFunction28.js
@@ -1,0 +1,34 @@
+// ==ORIGINAL==
+class C {
+    M1() { }
+    M2() {
+        return 1;
+    }
+    M3() { }
+    constructor() { }
+}
+// ==SCOPE::Extract to method in class 'C'==
+class C {
+    M1() { }
+    M2() {
+        return this./*RENAME*/newMethod();
+    }
+    newMethod() {
+        return 1;
+    }
+
+    M3() { }
+    constructor() { }
+}
+// ==SCOPE::Extract to function in global scope==
+class C {
+    M1() { }
+    M2() {
+        return /*RENAME*/newFunction();
+    }
+    M3() { }
+    constructor() { }
+}
+function newFunction() {
+    return 1;
+}

--- a/tests/baselines/reference/extractFunction/extractFunction33.js
+++ b/tests/baselines/reference/extractFunction/extractFunction33.js
@@ -1,0 +1,19 @@
+// ==ORIGINAL==
+function F() {
+    function G() { }
+}
+// ==SCOPE::Extract to inner function in function 'F'==
+function F() {
+    /*RENAME*/newFunction();
+
+    function newFunction() {
+        function G() { }
+    }
+}
+// ==SCOPE::Extract to function in global scope==
+function F() {
+    /*RENAME*/newFunction();
+}
+function newFunction() {
+    function G() { }
+}


### PR DESCRIPTION
1) For any input that is valid JS, also generate a JS baseline.
2) Validate that all baselines are syntactically valid.

Supersedes https://github.com/Microsoft/TypeScript/pull/18627.