### PR TITLE
Fix acquiring format options for getEditsForRefactor

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -4256,23 +4256,18 @@ namespace ts.projectSystem {
             const session = createSession(host);
             openFilesForSession([file], session);
 
-            const command0: server.protocol.ConfigureRequest = {
-                type: "request",
+            const response0 = session.executeCommandSeq<server.protocol.ConfigureRequest>({
                 command: server.protocol.CommandTypes.Configure,
-                seq: 0,
                 arguments: {
                     formatOptions: {
                         indentSize: 2,
                     },
                 },
-            };
-            const response0 = session.executeCommand(command0).response;
+            }).response;
             assert.deepEqual(response0, /*expected*/ undefined);
 
-            const command: server.protocol.GetEditsForRefactorRequest = {
-                type: "request",
+            const response1 = session.executeCommandSeq<server.protocol.GetEditsForRefactorRequest>({
                 command: server.protocol.CommandTypes.GetEditsForRefactor,
-                seq: 1,
                 arguments: {
                     refactor: "Extract Symbol",
                     action: "function_scope_1",
@@ -4282,9 +4277,8 @@ namespace ts.projectSystem {
                     endLine: 2,
                     endOffset: 4,
                 },
-            };
-            const response = session.executeCommand(command).response;
-            assert.deepEqual(response, {
+            }).response;
+            assert.deepEqual(response1, {
                 edits: [
                     {
                         fileName: "/a.ts",

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -4247,7 +4247,7 @@ namespace ts.projectSystem {
     });
 
     describe("refactors", () => {
-        it("abcdefg", () => {
+        it("use formatting options", () => {
             const file = {
                 path: "/a.ts",
                 content: "function f() {\n  1;\n}",

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -573,7 +573,7 @@ namespace ts.server {
 
         getEditsForRefactor(
             fileName: string,
-            formatOptions: FormatCodeSettings,
+            _formatOptions: FormatCodeSettings,
             positionOrRange: number | TextRange,
             refactorName: string,
             actionName: string): RefactorEditInfo {
@@ -581,7 +581,6 @@ namespace ts.server {
             const args = this.createFileLocationOrRangeRequestArgs(positionOrRange, fileName) as protocol.GetEditsForRefactorRequestArgs;
             args.refactor = refactorName;
             args.action = actionName;
-            args.formatOptions = formatOptions;
 
             const request = this.processRequest<protocol.GetEditsForRefactorRequest>(CommandNames.GetEditsForRefactor, args);
             const response = this.processResponse<protocol.GetEditsForRefactorResponse>(request);

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -494,7 +494,6 @@ namespace ts.server.protocol {
         refactor: string;
         /* The 'name' property from the refactoring action */
         action: string;
-        formatOptions?: FormatCodeSettings,
     };
 
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1488,7 +1488,7 @@ namespace ts.server {
 
             const result = project.getLanguageService().getEditsForRefactor(
                 file,
-                args.formatOptions ? convertFormatOptions(args.formatOptions) : this.projectService.getFormatCodeOptions(),
+                this.projectService.getFormatCodeOptions(file),
                 position || textRange,
                 args.refactor,
                 args.action

--- a/tests/cases/fourslash/server/convertFunctionToEs6Class-server.ts
+++ b/tests/cases/fourslash/server/convertFunctionToEs6Class-server.ts
@@ -14,13 +14,14 @@
 verify.applicableRefactorAvailableAtMarker('1');
 // NOTE: '// Comment' should be included, but due to incorrect handling of trivia,
 // it's omitted right now.
+// TODO: GH#18445
 verify.fileAfterApplyingRefactorAtMarker('1',
-`class fn {
-    constructor() {
-        this.baz = 10;
-    }
-    bar() {
-        console.log('hello world');
-    }
-}
+`class fn {\r
+    constructor() {\r
+        this.baz = 10;\r
+    }\r
+    bar() {\r
+        console.log('hello world');\r
+    }\r
+}\r
 `, 'Convert to ES2015 class', 'convert');


### PR DESCRIPTION
Fixes #18328.
Thanks @sheetalkamat for the help spotting this fix.
Also removed `formatOptions` from `GetEditsForRefactorRequestArgs` since that should be sent only once, not once per refactor. (This was added only recently so should be fine to remove before anyone uses it.)