### PR TITLE
Fix crash when extending non-EntityNameExpression

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1272,8 +1272,10 @@ namespace ts {
                 case SyntaxKind.PropertyAccessExpression:
                     return node.parent ? getEntityNameForExtendingInterface(node.parent) : undefined;
                 case SyntaxKind.ExpressionWithTypeArguments:
-                    Debug.assert(isEntityNameExpression((<ExpressionWithTypeArguments>node).expression));
-                    return <EntityNameExpression>(<ExpressionWithTypeArguments>node).expression;
+                    if (isEntityNameExpression((<ExpressionWithTypeArguments>node).expression)) {
+                        return <EntityNameExpression>(<ExpressionWithTypeArguments>node).expression;
+                    }
+                    // falls through
                 default:
                     return undefined;
             }

--- a/tests/baselines/reference/classExtendsInterface_not.errors.txt
+++ b/tests/baselines/reference/classExtendsInterface_not.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/classExtendsInterface_not.ts(1,20): error TS2339: Property 'bogus' does not exist on type '""'.
+
+
+==== tests/cases/compiler/classExtendsInterface_not.ts (1 errors) ====
+    class C extends "".bogus {}
+                       ~~~~~
+!!! error TS2339: Property 'bogus' does not exist on type '""'.
+    

--- a/tests/baselines/reference/classExtendsInterface_not.js
+++ b/tests/baselines/reference/classExtendsInterface_not.js
@@ -1,0 +1,22 @@
+//// [classExtendsInterface_not.ts]
+class C extends "".bogus {}
+
+
+//// [classExtendsInterface_not.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}("".bogus));

--- a/tests/baselines/reference/classExtendsInterface_not.symbols
+++ b/tests/baselines/reference/classExtendsInterface_not.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/classExtendsInterface_not.ts ===
+class C extends "".bogus {}
+>C : Symbol(C, Decl(classExtendsInterface_not.ts, 0, 0))
+

--- a/tests/baselines/reference/classExtendsInterface_not.types
+++ b/tests/baselines/reference/classExtendsInterface_not.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/classExtendsInterface_not.ts ===
+class C extends "".bogus {}
+>C : C
+>"".bogus : any
+>"" : ""
+>bogus : any
+

--- a/tests/cases/compiler/classExtendsInterface_not.ts
+++ b/tests/cases/compiler/classExtendsInterface_not.ts
@@ -1,0 +1,1 @@
+class C extends "".bogus {}


### PR DESCRIPTION
This assertion wasn't valid, because it's possible to extend an arbitrary expression.