### PR TITLE
Fix bug: Report errors on `extends` expression in JS even if an `@augments` tag is present

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4917,6 +4917,8 @@ namespace ts {
          */
         function getBaseConstructorTypeOfClass(type: InterfaceType): Type {
             if (!type.resolvedBaseConstructorType) {
+                const decl = <ClassLikeDeclaration>type.symbol.valueDeclaration;
+                const extended = getClassExtendsHeritageClauseElement(decl);
                 const baseTypeNode = getBaseTypeNodeOfClass(type);
                 if (!baseTypeNode) {
                     return type.resolvedBaseConstructorType = undefinedType;
@@ -4925,6 +4927,10 @@ namespace ts {
                     return unknownType;
                 }
                 const baseConstructorType = checkExpression(baseTypeNode.expression);
+                if (extended && baseTypeNode !== extended) {
+                    Debug.assert(!extended.typeArguments); // Because this is in a JS file, and baseTypeNode is in an @extends tag
+                    checkExpression(extended.expression);
+                }
                 if (baseConstructorType.flags & (TypeFlags.Object | TypeFlags.Intersection)) {
                     // Resolving the members of a class requires us to resolve the base class of that class.
                     // We force resolution here such that we catch circularities now.

--- a/tests/baselines/reference/jsdocAugments_errorInExtendsExpression.errors.txt
+++ b/tests/baselines/reference/jsdocAugments_errorInExtendsExpression.errors.txt
@@ -1,0 +1,10 @@
+/a.js(3,17): error TS2304: Cannot find name 'err'.
+
+
+==== /a.js (1 errors) ====
+    class A {}
+    /** @augments A */
+    class B extends err() {}
+                    ~~~
+!!! error TS2304: Cannot find name 'err'.
+    

--- a/tests/baselines/reference/jsdocAugments_errorInExtendsExpression.symbols
+++ b/tests/baselines/reference/jsdocAugments_errorInExtendsExpression.symbols
@@ -1,0 +1,8 @@
+=== /a.js ===
+class A {}
+>A : Symbol(A, Decl(a.js, 0, 0))
+
+/** @augments A */
+class B extends err() {}
+>B : Symbol(B, Decl(a.js, 0, 10))
+

--- a/tests/baselines/reference/jsdocAugments_errorInExtendsExpression.types
+++ b/tests/baselines/reference/jsdocAugments_errorInExtendsExpression.types
@@ -1,0 +1,10 @@
+=== /a.js ===
+class A {}
+>A : A
+
+/** @augments A */
+class B extends err() {}
+>B : B
+>err() : A
+>err : any
+

--- a/tests/cases/compiler/jsdocAugments_errorInExtendsExpression.ts
+++ b/tests/cases/compiler/jsdocAugments_errorInExtendsExpression.ts
@@ -1,0 +1,8 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /a.js
+class A {}
+/** @augments A */
+class B extends err() {}


### PR DESCRIPTION
Sequel to #18775
Turns out `getBaseConstructorTypeOfClass` was the *only* place we checked the `extends` expression, so that PR turned off checking if an `@augments` tag was present.
It would seem neater to have a `checkExpression(baseTypeNode)` call in `checkClassLikeDeclaration`, but that would mean we check it twice in the usual case.