### PR TITLE
Enable "space-within-parens" lint rule

### DIFF
--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -378,7 +378,7 @@ namespace ts {
             const catchVariable = getGeneratedNameForNode(errorRecord);
             const returnMethod = createTempVariable(/*recordTempVariable*/ undefined);
             const callValues = createAsyncValuesHelper(context, expression, /*location*/ node.expression);
-            const callNext = createCall(createPropertyAccess(iterator, "next" ), /*typeArguments*/ undefined, []);
+            const callNext = createCall(createPropertyAccess(iterator, "next"), /*typeArguments*/ undefined, []);
             const getDone = createPropertyAccess(result, "done");
             const getValue = createPropertyAccess(result, "value");
             const callReturn = createFunctionCall(returnMethod, iterator, []);

--- a/src/harness/unittests/cachingInServerLSHost.ts
+++ b/src/harness/unittests/cachingInServerLSHost.ts
@@ -64,7 +64,7 @@ namespace ts {
         const rootScriptInfo = projectService.getOrCreateScriptInfo(rootFile, /* openedByClient */ true, /*containingProject*/ undefined);
 
         const project = projectService.createInferredProjectWithRootFileIfNecessary(rootScriptInfo);
-        project.setCompilerOptions({ module: ts.ModuleKind.AMD, noLib: true } );
+        project.setCompilerOptions({ module: ts.ModuleKind.AMD, noLib: true });
         return {
             project,
             rootScriptInfo

--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -162,7 +162,7 @@ interface Math {
      *     If any argument is NaN, the result is NaN.
      *     If all arguments are either +0 or −0, the result is +0.
      */
-    hypot(...values: number[] ): number;
+    hypot(...values: number[]): number;
 
     /**
      * Returns the integral part of the a numeric expression, x, removing any fractional digits.

--- a/tslint.json
+++ b/tslint.json
@@ -41,6 +41,7 @@
             "avoid-escape"
         ],
         "semicolon": [true, "always", "ignore-bound-class-methods"],
+        "space-within-parens": true,
         "triple-equals": true,
         "type-operator-spacing": true,
         "typedef-whitespace": [


### PR DESCRIPTION
We almost never include a space within parentheses -- we should standardize on that.