### PR TITLE
Remove unnecessary truthy check

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -492,7 +492,7 @@ namespace ts.refactor.extractSymbol {
             }
 
             // A function parameter's initializer is actually in the outer scope, not the function declaration
-            if (current && current.parent && current.parent.kind === SyntaxKind.Parameter) {
+            if (current.parent.kind === SyntaxKind.Parameter) {
                 // Skip all the way to the outer scope of the function that declared this parameter
                 current = findAncestor(current, parent => isFunctionLikeDeclaration(parent)).parent;
             }


### PR DESCRIPTION
This occurs after a `while (current)` check, with no assignments to `current` in between.
Also, we are assuming that `current.parent` is defined, or else `scopes` will be undefined. (#18862)