### PR TITLE
Remove unnecessary *OrUndefined calls

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -853,6 +853,11 @@ namespace ts {
         return elementAt(array, -1);
     }
 
+    export function last<T>(array: ReadonlyArray<T>): T {
+        Debug.assert(array.length !== 0);
+        return array[array.length - 1];
+    }
+
     /**
      * Returns the only element of an array if it contains only one element, `undefined` otherwise.
      */

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -846,6 +846,11 @@ namespace ts {
         return elementAt(array, 0);
     }
 
+    export function first<T>(array: ReadonlyArray<T>): T {
+        Debug.assert(array.length !== 0);
+        return array[0];
+    }
+
     /**
      * Returns the last element of an array if non-empty, `undefined` otherwise.
      */

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -469,7 +469,7 @@ namespace ts.refactor.extractSymbol {
      * depending on what's in the extracted body.
      */
     function collectEnclosingScopes(range: TargetRange): Scope[] | undefined {
-        let current: Node = isReadonlyArray(range.range) ? firstOrUndefined(range.range) : range.range;
+        let current: Node = isReadonlyArray(range.range) ? range.range[0] : range.range;
         if (range.facts & RangeFacts.UsesThis) {
             // if range uses this as keyword or as type inside the class then it can only be extracted to a method of the containing class
             const containingClass = getContainingClass(current);
@@ -728,7 +728,7 @@ namespace ts.refactor.extractSymbol {
         }
 
         const changeTracker = textChanges.ChangeTracker.fromContext(context);
-        const minInsertionPos = (isReadonlyArray(range.range) ? lastOrUndefined(range.range) : range.range).end;
+        const minInsertionPos = (isReadonlyArray(range.range) ? last(range.range) : range.range).end;
         const nodeToInsertBefore = getNodeToInsertFunctionBefore(minInsertionPos, scope);
         if (nodeToInsertBefore) {
             changeTracker.insertNodeBefore(context.file, nodeToInsertBefore, newFunction, { suffix: context.newLineCharacter + context.newLineCharacter });
@@ -1175,7 +1175,7 @@ namespace ts.refactor.extractSymbol {
 
         const expressionDiagnostic =
             isReadonlyArray(targetRange.range) && !(targetRange.range.length === 1 && isExpressionStatement(targetRange.range[0]))
-                ? ((start, end) => createFileDiagnostic(sourceFile, start, end - start, Messages.ExpressionExpected))(firstOrUndefined(targetRange.range).getStart(), lastOrUndefined(targetRange.range).end)
+                ? ((start, end) => createFileDiagnostic(sourceFile, start, end - start, Messages.ExpressionExpected))(targetRange.range[0].getStart(), last(targetRange.range).end)
                 : undefined;
 
         // initialize results

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -469,7 +469,7 @@ namespace ts.refactor.extractSymbol {
      * depending on what's in the extracted body.
      */
     function collectEnclosingScopes(range: TargetRange): Scope[] | undefined {
-        let current: Node = isReadonlyArray(range.range) ? range.range[0] : range.range;
+        let current: Node = isReadonlyArray(range.range) ? first(range.range) : range.range;
         if (range.facts & RangeFacts.UsesThis) {
             // if range uses this as keyword or as type inside the class then it can only be extracted to a method of the containing class
             const containingClass = getContainingClass(current);
@@ -812,7 +812,7 @@ namespace ts.refactor.extractSymbol {
         }
 
         const edits = changeTracker.getChanges();
-        const renameRange = isReadonlyArray(range.range) ? range.range[0] : range.range;
+        const renameRange = isReadonlyArray(range.range) ? first(range.range) : range.range;
 
         const renameFilename = renameRange.getSourceFile().fileName;
         const renameLocation = getRenameLocation(edits, renameFilename, functionNameText, /*isDeclaredBeforeUse*/ false);
@@ -1129,7 +1129,7 @@ namespace ts.refactor.extractSymbol {
      */
     function getEnclosingTextRange(targetRange: TargetRange, sourceFile: SourceFile): TextRange {
         return isReadonlyArray(targetRange.range)
-            ? { pos: targetRange.range[0].getStart(sourceFile), end: targetRange.range[targetRange.range.length - 1].getEnd() }
+            ? { pos: first(targetRange.range).getStart(sourceFile), end: last(targetRange.range).getEnd() }
             : targetRange.range;
     }
 
@@ -1175,7 +1175,7 @@ namespace ts.refactor.extractSymbol {
 
         const expressionDiagnostic =
             isReadonlyArray(targetRange.range) && !(targetRange.range.length === 1 && isExpressionStatement(targetRange.range[0]))
-                ? ((start, end) => createFileDiagnostic(sourceFile, start, end - start, Messages.ExpressionExpected))(targetRange.range[0].getStart(), last(targetRange.range).end)
+                ? ((start, end) => createFileDiagnostic(sourceFile, start, end - start, Messages.ExpressionExpected))(first(targetRange.range).getStart(), last(targetRange.range).end)
                 : undefined;
 
         // initialize results
@@ -1202,7 +1202,7 @@ namespace ts.refactor.extractSymbol {
         const target = isReadonlyArray(targetRange.range) ? createBlock(<Statement[]>targetRange.range) : targetRange.range;
         const containingLexicalScopeOfExtraction = isBlockScope(scopes[0], scopes[0].parent) ? scopes[0] : getEnclosingBlockScopeContainer(scopes[0]);
 
-        const unmodifiedNode = isReadonlyArray(targetRange.range) ? targetRange.range[0] : targetRange.range;
+        const unmodifiedNode = isReadonlyArray(targetRange.range) ? first(targetRange.range) : targetRange.range;
         const inGenericContext = isInGenericContext(unmodifiedNode);
 
         collectUsages(target);


### PR DESCRIPTION
The `range` array should be non-empty; we are treating accesses to `firstOrUndefined` and `lastOrUndefined` as certainly defined, so it makes sense to just use `range[0]` and `last(range)`.