### PR TITLE
Always preserve const enums in the Jakefile

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -285,7 +285,6 @@ var builtLocalCompiler = path.join(builtLocalDirectory, compilerFilename);
     * @param {boolean} opts.generateDeclarations: true to compile using --declaration
     * @param {string}  opts.outDir: value for '--outDir' command line option
     * @param {boolean} opts.keepComments: false to compile using --removeComments
-    * @param {boolean} opts.preserveConstEnums: true if compiler should keep const enums in code
     * @param {boolean} opts.noResolve: true if compiler should not include non-rooted files in compilation
     * @param {boolean} opts.stripInternal: true if compiler should remove declarations marked as @internal
     * @param {boolean} opts.inlineSourceMap: true if compiler should inline sourceMap
@@ -315,9 +314,7 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, opts
             options += " --declaration";
         }
 
-        if (opts.preserveConstEnums || useDebugMode) {
-            options += " --preserveConstEnums";
-        }
+        options += " --preserveConstEnums";
 
         if (opts.outDir) {
             options += " --outDir " + opts.outDir;
@@ -589,7 +586,6 @@ compileFile(servicesFile, servicesSources, [builtLocalDirectory, copyright].conc
             /*opts*/ {
         noOutFile: false,
         generateDeclarations: true,
-        preserveConstEnums: true,
         keepComments: true,
         noResolve: false,
         stripInternal: true
@@ -628,7 +624,7 @@ var watchGuardFile = path.join(builtLocalDirectory, "watchGuard.js");
 compileFile(watchGuardFile, watchGuardSources, [builtLocalDirectory].concat(watchGuardSources), /*prefixes*/ [copyright], /*useBuiltCompiler*/ true, { types: ["node"], outDir: builtLocalDirectory, noOutFile: false, lib: "es6" });
 
 var serverFile = path.join(builtLocalDirectory, "tsserver.js");
-compileFile(serverFile, serverSources, [builtLocalDirectory, copyright, cancellationTokenFile, typingsInstallerFile, watchGuardFile].concat(serverSources).concat(servicesSources), /*prefixes*/ [copyright], /*useBuiltCompiler*/ true, { types: ["node"], preserveConstEnums: true, lib: "es6" });
+compileFile(serverFile, serverSources, [builtLocalDirectory, copyright, cancellationTokenFile, typingsInstallerFile, watchGuardFile].concat(serverSources).concat(servicesSources), /*prefixes*/ [copyright], /*useBuiltCompiler*/ true, { types: ["node"], lib: "es6" });
 var tsserverLibraryFile = path.join(builtLocalDirectory, "tsserverlibrary.js");
 var tsserverLibraryDefinitionFile = path.join(builtLocalDirectory, "tsserverlibrary.d.ts");
 file(typesMapOutputPath, function() {
@@ -647,7 +643,7 @@ compileFile(
     [builtLocalDirectory, copyright, builtLocalCompiler].concat(languageServiceLibrarySources).concat(libraryTargets),
     /*prefixes*/[copyright],
     /*useBuiltCompiler*/ true,
-    { noOutFile: false, generateDeclarations: true, stripInternal: true, preserveConstEnums: true, keepComments: true },
+    { noOutFile: false, generateDeclarations: true, stripInternal: true, keepComments: true },
     /*callback*/ function () {
         prependFile(copyright, tsserverLibraryDefinitionFile);
 
@@ -765,7 +761,7 @@ compileFile(
     /*prereqs*/[builtLocalDirectory, tscFile, tsserverLibraryFile].concat(libraryTargets).concat(servicesSources).concat(harnessSources),
     /*prefixes*/[],
     /*useBuiltCompiler:*/ true,
-    /*opts*/ { types: ["node", "mocha", "chai"], lib: "es6" });
+    /*opts*/ { types: ["node", "mocha", "chai"], lib: "es6", keepComments: true });
 
 var internalTests = "internal/";
 


### PR DESCRIPTION
It's part of our base tsconfig, but was optional in the Jakefile. The discrepancy actually causes `jake release runtests` to fail (as we require preserved const enums to run correctly), as `preserveConstEnums` was only locked to `true` for debug builds.

TBQH, I'd like to remove the `useDebugMode` flag entirely (meaning every build is the same as a `release` build), but that necessitates fixing up soucemaps after concatenating the copyright.