### PR TITLE
When emitting all files, emit the changed file first

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -129,6 +129,7 @@ var harnessSources = harnessCoreSources.concat([
     "textStorage.ts",
     "moduleResolution.ts",
     "tsconfigParsing.ts",
+    "builder.ts",
     "commandLineParsing.ts",
     "configurationExtension.ts",
     "convertCompilerOptionsFromJson.ts",

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -308,7 +308,7 @@ namespace ts {
             getCurrentDirectory()
         );
         // There is no extra check needed since we can just rely on the program to decide emit
-        const builder = createBuilder(getCanonicalFileName, getFileEmitOutput, computeHash, _sourceFile => true);
+        const builder = createBuilder({ getCanonicalFileName, getEmitOutput: getFileEmitOutput, computeHash, shouldEmitFile: () => true });
 
         synchronizeProgram();
 

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -116,6 +116,7 @@
         "./unittests/reuseProgramStructure.ts",
         "./unittests/moduleResolution.ts",
         "./unittests/tsconfigParsing.ts",
+        "./unittests/builder.ts",
         "./unittests/commandLineParsing.ts",
         "./unittests/configurationExtension.ts",
         "./unittests/convertCompilerOptionsFromJson.ts",

--- a/src/harness/unittests/builder.ts
+++ b/src/harness/unittests/builder.ts
@@ -1,0 +1,73 @@
+/// <reference path="reuseProgramStructure.ts" />
+
+namespace ts {
+    describe("builder", () => {
+        it("emits dependent files", () => {
+            const files: NamedSourceText[] = [
+                { name: "/a.ts", text: SourceText.New("", 'import { b } from "./b";', "") },
+                { name: "/b.ts", text: SourceText.New("", ' import { c } from "./c";', "export const b = c;") },
+                { name: "/c.ts", text: SourceText.New("", "", "export const c = 0;") },
+            ];
+
+            let program = newProgram(files, ["/a.ts"], {});
+            const assertChanges = makeAssertChanges(() => program);
+
+            assertChanges(["/c.js", "/b.js", "/a.js"]);
+
+            program = updateProgramFile(program, "/a.ts", "//comment");
+            assertChanges(["/a.js"]);
+
+            program = updateProgramFile(program, "/b.ts", "export const b = c + 1;");
+            assertChanges(["/b.js", "/a.js"]);
+
+            program = updateProgramFile(program, "/c.ts", "export const c = 1;");
+            assertChanges(["/c.js", "/b.js"]);
+        });
+
+        it("if emitting all files, emits the changed file first", () => {
+            const files: NamedSourceText[] = [
+                { name: "/a.ts", text: SourceText.New("", "", "namespace A { export const x = 0; }") },
+                { name: "/b.ts", text: SourceText.New("", "", "namespace B { export const x = 0; }") },
+            ];
+
+            let program = newProgram(files, ["/a.ts", "/b.ts"], {});
+            const assertChanges = makeAssertChanges(() => program);
+
+            assertChanges(["/a.js", "/b.js"]);
+
+            program = updateProgramFile(program, "/a.ts", "namespace A { export const x = 1; }");
+            assertChanges(["/a.js", "/b.js"]);
+
+            program = updateProgramFile(program, "/b.ts", "namespace B { export const x = 1; }");
+            assertChanges(["/b.js", "/a.js"]);
+        });
+    });
+
+    function makeAssertChanges(getProgram: () => Program): (fileNames: ReadonlyArray<string>) => void  {
+        const builder = createBuilder({
+            getCanonicalFileName: identity,
+            getEmitOutput: getFileEmitOutput,
+            computeHash: identity,
+            shouldEmitFile: returnTrue,
+        });
+        return fileNames => {
+            const program = getProgram();
+            builder.updateProgram(program);
+            const changedFiles = builder.emitChangedFiles(program);
+            assert.deepEqual(changedFileNames(changedFiles), fileNames);
+        };
+    }
+
+    function updateProgramFile(program: ProgramWithSourceTexts, fileName: string, fileContent: string): ProgramWithSourceTexts {
+        return updateProgram(program, program.getRootFileNames(), program.getCompilerOptions(), files => {
+            updateProgramText(files, fileName, fileContent);
+        });
+    }
+
+    function changedFileNames(changedFiles: ReadonlyArray<EmitOutputDetailed>): string[] {
+        return changedFiles.map(f => {
+            assert.lengthOf(f.outputFiles, 1);
+            return f.outputFiles[0].name;
+        });
+    }
+}

--- a/src/harness/unittests/reuseProgramStructure.ts
+++ b/src/harness/unittests/reuseProgramStructure.ts
@@ -15,12 +15,12 @@ namespace ts {
         sourceText?: SourceText;
     }
 
-    interface NamedSourceText {
+    export interface NamedSourceText {
         name: string;
         text: SourceText;
     }
 
-    interface ProgramWithSourceTexts extends Program {
+    export interface ProgramWithSourceTexts extends Program {
         sourceTexts?: ReadonlyArray<NamedSourceText>;
         host: TestCompilerHost;
     }
@@ -29,7 +29,7 @@ namespace ts {
         getTrace(): string[];
     }
 
-    class SourceText implements IScriptSnapshot {
+    export class SourceText implements IScriptSnapshot {
         private fullText: string;
 
         constructor(private references: string,
@@ -103,10 +103,11 @@ namespace ts {
     function createSourceFileWithText(fileName: string, sourceText: SourceText, target: ScriptTarget) {
         const file = <SourceFileWithText>createSourceFile(fileName, sourceText.getFullText(), target);
         file.sourceText = sourceText;
+        file.version = "" + sourceText.getVersion();
         return file;
     }
 
-    function createTestCompilerHost(texts: ReadonlyArray<NamedSourceText>, target: ScriptTarget, oldProgram?: ProgramWithSourceTexts): TestCompilerHost {
+    export function createTestCompilerHost(texts: ReadonlyArray<NamedSourceText>, target: ScriptTarget, oldProgram?: ProgramWithSourceTexts): TestCompilerHost {
         const files = arrayToMap(texts, t => t.name, t => {
             if (oldProgram) {
                 let oldFile = <SourceFileWithText>oldProgram.getSourceFile(t.name);
@@ -154,7 +155,7 @@ namespace ts {
         };
     }
 
-    function newProgram(texts: NamedSourceText[], rootNames: string[], options: CompilerOptions): ProgramWithSourceTexts {
+    export function newProgram(texts: NamedSourceText[], rootNames: string[], options: CompilerOptions): ProgramWithSourceTexts {
         const host = createTestCompilerHost(texts, options.target);
         const program = <ProgramWithSourceTexts>createProgram(rootNames, options, host);
         program.sourceTexts = texts;
@@ -162,7 +163,7 @@ namespace ts {
         return program;
     }
 
-    function updateProgram(oldProgram: ProgramWithSourceTexts, rootNames: ReadonlyArray<string>, options: CompilerOptions, updater: (files: NamedSourceText[]) => void, newTexts?: NamedSourceText[]) {
+    export function updateProgram(oldProgram: ProgramWithSourceTexts, rootNames: ReadonlyArray<string>, options: CompilerOptions, updater: (files: NamedSourceText[]) => void, newTexts?: NamedSourceText[]) {
         if (!newTexts) {
             newTexts = (<ProgramWithSourceTexts>oldProgram).sourceTexts.slice(0);
         }
@@ -174,7 +175,7 @@ namespace ts {
         return program;
     }
 
-    function updateProgramText(files: ReadonlyArray<NamedSourceText>, fileName: string, newProgramText: string) {
+    export function updateProgramText(files: ReadonlyArray<NamedSourceText>, fileName: string, newProgramText: string) {
         const file = find(files, f => f.name === fileName)!;
         file.text = file.text.updateProgram(newProgramText);
     }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -417,12 +417,15 @@ namespace ts.server {
 
         private ensureBuilder() {
             if (!this.builder) {
-                this.builder = createBuilder(
-                    this.projectService.toCanonicalFileName,
-                    (_program, sourceFile, emitOnlyDts, isDetailed) => this.getFileEmitOutput(sourceFile, emitOnlyDts, isDetailed),
-                    data => this.projectService.host.createHash(data),
-                    sourceFile => !this.projectService.getScriptInfoForPath(sourceFile.path).isDynamicOrHasMixedContent()
-                );
+                this.builder = createBuilder({
+                    getCanonicalFileName: this.projectService.toCanonicalFileName,
+                    getEmitOutput: (_program, sourceFile, emitOnlyDts, isDetailed) =>
+                        this.getFileEmitOutput(sourceFile, emitOnlyDts, isDetailed),
+                    computeHash: data =>
+                        this.projectService.host.createHash(data),
+                    shouldEmitFile: sourceFile =>
+                        !this.projectService.getScriptInfoForPath(sourceFile.path).isDynamicOrHasMixedContent()
+                });
             }
         }
 


### PR DESCRIPTION
Fixes #16888
Currently, when a global file is updated, we will emit all files in include order. This changes it so that we first emit the changed file, then emit all other files in include order.
Also adds infrastructure for testing the builder.
The builder API is still in flux, so these tests will have to be updated once an API is decided on.
