### PR TITLE
Latest mocha uses titlePath instead of fullTitle

### DIFF
--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -312,6 +312,9 @@ namespace Harness.Parallel.Host {
         function makeMochaTest(test: ErrorInfo) {
             return {
                 fullTitle: () => {
+                    return test.name.join(" ");
+                },
+                titlePath: () => {
                     return test.name;
                 },
                 err: {

--- a/src/harness/parallel/shared.ts
+++ b/src/harness/parallel/shared.ts
@@ -6,8 +6,8 @@ namespace Harness.Parallel {
     export type ParallelCloseMessage = { type: "close" } | never;
     export type ParallelHostMessage = ParallelTestMessage | ParallelCloseMessage | ParallelBatchMessage;
 
-    export type ParallelErrorMessage = { type: "error", payload: { error: string, stack: string, name?: string } } | never;
-    export type ErrorInfo = ParallelErrorMessage["payload"] & { name: string };
+    export type ParallelErrorMessage = { type: "error", payload: { error: string, stack: string, name?: string[] } } | never;
+    export type ErrorInfo = ParallelErrorMessage["payload"] & { name: string[] };
     export type ParallelResultMessage = { type: "result", payload: { passing: number, errors: ErrorInfo[], duration: number, runner: TestRunnerKind, file: string } } | never;
     export type ParallelBatchProgressMessage = { type: "progress", payload: ParallelResultMessage["payload"] } | never;
     export type ParallelClientMessage = ParallelErrorMessage | ParallelResultMessage | ParallelBatchProgressMessage;

--- a/src/harness/parallel/worker.ts
+++ b/src/harness/parallel/worker.ts
@@ -57,14 +57,14 @@ namespace Harness.Parallel.Worker {
             callback.call(fakeContext);
         }
         catch (e) {
-            errors.push({ error: `Error executing suite: ${e.message}`, stack: e.stack, name: namestack.join(" ") });
+            errors.push({ error: `Error executing suite: ${e.message}`, stack: e.stack, name: [...namestack] });
             return cleanup();
         }
         try {
             beforeFunc && beforeFunc();
         }
         catch (e) {
-            errors.push({ error: `Error executing before function: ${e.message}`, stack: e.stack, name: namestack.join(" ") });
+            errors.push({ error: `Error executing before function: ${e.message}`, stack: e.stack, name: [...namestack] });
             return cleanup();
         }
         finally {
@@ -76,7 +76,7 @@ namespace Harness.Parallel.Worker {
             afterFunc && afterFunc();
         }
         catch (e) {
-            errors.push({ error: `Error executing after function: ${e.message}`, stack: e.stack, name: namestack.join(" ") });
+            errors.push({ error: `Error executing after function: ${e.message}`, stack: e.stack, name: [...namestack] });
         }
         finally {
             afterFunc = undefined;
@@ -107,13 +107,12 @@ namespace Harness.Parallel.Worker {
             slow() { return this; },
         };
         namestack.push(name);
-        name = namestack.join(" ");
         if (beforeEachFunc) {
             try {
                 beforeEachFunc();
             }
             catch (error) {
-                errors.push({ error: error.message, stack: error.stack, name });
+                errors.push({ error: error.message, stack: error.stack, name: [...namestack] });
                 namestack.pop();
                 return;
             }
@@ -124,7 +123,7 @@ namespace Harness.Parallel.Worker {
                 callback.call(fakeContext);
             }
             catch (error) {
-                errors.push({ error: error.message, stack: error.stack, name });
+                errors.push({ error: error.message, stack: error.stack, name: [...namestack] });
                 return;
             }
             finally {
@@ -141,7 +140,7 @@ namespace Harness.Parallel.Worker {
                         throw new Error(`done() callback called multiple times; ensure it is only called once.`);
                     }
                     if (err) {
-                        errors.push({ error: err.toString(), stack: "", name });
+                        errors.push({ error: err.toString(), stack: "", name: [...namestack] });
                     }
                     else {
                         passing++;
@@ -150,14 +149,14 @@ namespace Harness.Parallel.Worker {
                 });
             }
             catch (error) {
-                errors.push({ error: error.message, stack: error.stack, name });
+                errors.push({ error: error.message, stack: error.stack, name: [...namestack] });
                 return;
             }
             finally {
                 namestack.pop();
             }
             if (!completed) {
-                errors.push({ error: "Test completes asynchronously, which is unsupported by the parallel harness", stack: "", name });
+                errors.push({ error: "Test completes asynchronously, which is unsupported by the parallel harness", stack: "", name: [...namestack] });
             }
         }
     }
@@ -204,7 +203,7 @@ namespace Harness.Parallel.Worker {
             }
         });
         process.on("uncaughtException", error => {
-            const message: ParallelErrorMessage = { type: "error", payload: { error: error.message, stack: error.stack, name: namestack.join(" ") } };
+            const message: ParallelErrorMessage = { type: "error", payload: { error: error.message, stack: error.stack, name: [...namestack] } };
             try {
                 process.send(message);
             }


### PR DESCRIPTION
Ron happened to update his `node_modules` cache and saw an error at the end of his installation (and not the helpful kind) - the `latest` version of mocha [added a new function onto its test object, which it now uses to format error output](https://github.com/mochajs/mocha/pull/2814). This should provide that function, and thereby fix our parallel test failure output on latest mocha.