### PR TITLE
Add skip lib check to many tests

### DIFF
--- a/src/harness/parallel/worker.ts
+++ b/src/harness/parallel/worker.ts
@@ -12,6 +12,11 @@ namespace Harness.Parallel.Worker {
             testList.length = 0;
         }
         reportedUnitTests = true;
+        if (testList.length) {
+            // Execute unit tests
+            testList.forEach(({ name, callback, kind }) => executeCallback(name, callback, kind));
+            testList.length = 0;
+        }
         const start = +(new Date());
         runner.initializeTests();
         testList.forEach(({ name, callback, kind }) => executeCallback(name, callback, kind));

--- a/tests/cases/compiler/APISample_compile.ts
+++ b/tests/cases/compiler/APISample_compile.ts
@@ -1,4 +1,5 @@
 ﻿// @module: commonjs
+// @skipLibCheck: true
 // @includebuiltfile: typescript_standalone.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true

--- a/tests/cases/compiler/APISample_jsdoc.ts
+++ b/tests/cases/compiler/APISample_jsdoc.ts
@@ -1,4 +1,5 @@
 // @module: commonjs
+// @skipLibCheck: true
 // @includebuiltfile: typescript_standalone.d.ts
 // @strict:true
 

--- a/tests/cases/compiler/APISample_linter.ts
+++ b/tests/cases/compiler/APISample_linter.ts
@@ -1,4 +1,5 @@
 ﻿// @module: commonjs
+// @skipLibCheck: true
 // @includebuiltfile: typescript_standalone.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true

--- a/tests/cases/compiler/APISample_parseConfig.ts
+++ b/tests/cases/compiler/APISample_parseConfig.ts
@@ -1,4 +1,5 @@
 // @module: commonjs
+// @skipLibCheck: true
 // @includebuiltfile: typescript_standalone.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true

--- a/tests/cases/compiler/APISample_transform.ts
+++ b/tests/cases/compiler/APISample_transform.ts
@@ -1,4 +1,5 @@
 ﻿// @module: commonjs
+// @skipLibCheck: true
 // @includebuiltfile: typescript_standalone.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true

--- a/tests/cases/compiler/APISample_watcher.ts
+++ b/tests/cases/compiler/APISample_watcher.ts
@@ -1,4 +1,5 @@
 ﻿// @module: commonjs
+// @skipLibCheck: true
 // @includebuiltfile: typescript_standalone.d.ts
 // @noImplicitAny:true
 // @strictNullChecks:true

--- a/tests/cases/compiler/contextuallyTypeArgumentsKeyword.ts
+++ b/tests/cases/compiler/contextuallyTypeArgumentsKeyword.ts
@@ -1,6 +1,7 @@
 // @noEmit: true
 // @allowJs: true
 // @checkJs: true
+// @skipLibCheck: true
 // @lib: es2017, dom
 // @Filename: foo.js
 // Repro for #16585

--- a/tests/cases/compiler/correctOrderOfPromiseMethod.ts
+++ b/tests/cases/compiler/correctOrderOfPromiseMethod.ts
@@ -1,3 +1,4 @@
+// @skipLibCheck: true
 // @lib: dom, es7
 
 interface A {

--- a/tests/cases/compiler/metadataOfEventAlias.ts
+++ b/tests/cases/compiler/metadataOfEventAlias.ts
@@ -1,6 +1,7 @@
 // @experimentalDecorators: true
 // @emitDecoratorMetadata: true
 // @target: es5
+// @skipLibCheck: true
 // @includeBuiltFile: lib.d.ts
 
 // @filename: event.ts

--- a/tests/cases/compiler/modularizeLibrary_Dom.iterable.ts
+++ b/tests/cases/compiler/modularizeLibrary_Dom.iterable.ts
@@ -1,4 +1,5 @@
-﻿// @lib: es6,dom,dom.iterable
+﻿// @skipLibCheck: true
+// @lib: es6,dom,dom.iterable
 // @target: es6
 
 for (const element of document.getElementsByTagName("a")) {

--- a/tests/cases/compiler/symbolMergeValueAndImportedType.ts
+++ b/tests/cases/compiler/symbolMergeValueAndImportedType.ts
@@ -1,5 +1,6 @@
 // @target: es2015
 // @module: commonjs
+// @skipLibCheck: true
 // @lib: es2015,dom
 // @filename: main.ts
 import { X } from "./other";

--- a/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
+++ b/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
@@ -1,6 +1,7 @@
 // @filename: file.tsx
 // @jsx: preserve
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react');

--- a/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
+++ b/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
@@ -1,6 +1,7 @@
 // @filename: file.tsx
 // @jsx: preserve
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react');

--- a/tests/cases/conformance/jsx/checkJsxChildrenProperty5.tsx
+++ b/tests/cases/conformance/jsx/checkJsxChildrenProperty5.tsx
@@ -1,6 +1,7 @@
 // @filename: file.tsx
 // @jsx: preserve
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react');

--- a/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences1.tsx
+++ b/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences1.tsx
@@ -1,6 +1,7 @@
 // @target: es2017
 // @jsx: react
 // @moduleResolution: node
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 // @filename: declaration.d.ts

--- a/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences2.tsx
+++ b/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences2.tsx
@@ -1,6 +1,7 @@
 // @target: es2017
 // @jsx: react
 // @moduleResolution: node
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 // @filename: declaration.d.ts

--- a/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences3.tsx
+++ b/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences3.tsx
@@ -2,6 +2,7 @@
 // @jsx: react
 // @moduleResolution: node
 // @noImplicitAny: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 // @filename: declaration.d.ts

--- a/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences4.tsx
+++ b/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences4.tsx
@@ -1,6 +1,7 @@
 // @target: es2017
 // @jsx: react
 // @moduleResolution: node
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 // @filename: declaration.d.ts

--- a/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
+++ b/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
@@ -1,6 +1,7 @@
 // @filename: file.tsx
 // @jsx: preserve
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react');

--- a/tests/cases/conformance/jsx/tsxSfcReturnNull.tsx
+++ b/tests/cases/conformance/jsx/tsxSfcReturnNull.tsx
@@ -2,6 +2,7 @@
 // @jsx: preserve
 // @module: amd
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react');

--- a/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
@@ -1,6 +1,7 @@
 // @filename: file.tsx
 // @jsx: preserve
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react');

--- a/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
+++ b/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
@@ -2,6 +2,7 @@
 // @jsx: preserve
 // @module: amd
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react')

--- a/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
+++ b/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
@@ -2,6 +2,7 @@
 // @jsx: preserve
 // @module: amd
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react')

--- a/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
+++ b/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
@@ -2,6 +2,7 @@
 // @jsx: preserve
 // @module: amd
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react')

--- a/tests/cases/conformance/jsx/tsxStatelessFunctionComponents1.tsx
+++ b/tests/cases/conformance/jsx/tsxStatelessFunctionComponents1.tsx
@@ -1,6 +1,7 @@
 // @filename: file.tsx
 // @jsx: preserve
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 function EmptyPropSFC() {

--- a/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments2.tsx
+++ b/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments2.tsx
@@ -2,6 +2,7 @@
 // @jsx: preserve
 // @module: amd
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react')

--- a/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
+++ b/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
@@ -2,6 +2,7 @@
 // @jsx: preserve
 // @module: amd
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react')

--- a/tests/cases/conformance/jsx/tsxUnionTypeComponent1.tsx
+++ b/tests/cases/conformance/jsx/tsxUnionTypeComponent1.tsx
@@ -1,6 +1,7 @@
 // @filename: file.tsx
 // @jsx: react
 // @noLib: true
+// @skipLibCheck: true
 // @libFiles: react.d.ts,lib.d.ts
 
 import React = require('react');

--- a/tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/parser.asyncGenerators.objectLiteralMethods.esnext.ts
+++ b/tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/parser.asyncGenerators.objectLiteralMethods.esnext.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @skipLibCheck: true
 // @lib: esnext
 // @noEmit: true
 // @filename: methodIsOk.ts


### PR DESCRIPTION
And do not include unit test duration in profiler duration. I would say that "this should make the tests execute faster" - individually, the affected tests are faster - but unfortunately, this reveals that the critical path for test completion is now the unit test thread. To rectify this, unit tests must be load-balanced similarly to how the rest of our tests are, which is going to require some work.
