### PR TITLE
Don't error on missing `Symbol` in `getApparentType`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6082,7 +6082,7 @@ namespace ts {
                 t.flags & TypeFlags.StringLike ? globalStringType :
                 t.flags & TypeFlags.NumberLike ? globalNumberType :
                 t.flags & TypeFlags.BooleanLike ? globalBooleanType :
-                t.flags & TypeFlags.ESSymbol ? getGlobalESSymbolType(/*reportErrors*/ languageVersion >= ScriptTarget.ES2015) :
+                t.flags & TypeFlags.ESSymbol ? getGlobalESSymbolType() :
                 t.flags & TypeFlags.NonPrimitive ? emptyObjectType :
                 t;
         }
@@ -7119,8 +7119,8 @@ namespace ts {
             return deferredGlobalESSymbolConstructorSymbol || (deferredGlobalESSymbolConstructorSymbol = getGlobalValueSymbol("Symbol" as __String, reportErrors));
         }
 
-        function getGlobalESSymbolType(reportErrors: boolean) {
-            return deferredGlobalESSymbolType || (deferredGlobalESSymbolType = getGlobalType("Symbol" as __String, /*arity*/ 0, reportErrors)) || emptyObjectType;
+        function getGlobalESSymbolType() {
+            return deferredGlobalESSymbolType || (deferredGlobalESSymbolType = getGlobalType("Symbol" as __String, /*arity*/ 0, /*reportErrors*/ false)) || emptyObjectType;
         }
 
         function getGlobalPromiseType(reportErrors: boolean) {
@@ -8898,7 +8898,7 @@ namespace ts {
                 if ((globalStringType === source && stringType === target) ||
                     (globalNumberType === source && numberType === target) ||
                     (globalBooleanType === source && booleanType === target) ||
-                    (getGlobalESSymbolType(/*reportErrors*/ false) === source && esSymbolType === target)) {
+                    (getGlobalESSymbolType() === source && esSymbolType === target)) {
                     reportError(Diagnostics._0_is_a_primitive_but_1_is_a_wrapper_object_Prefer_using_0_when_possible, targetType, sourceType);
                 }
             }

--- a/tests/baselines/reference/getGlobalESSymbolType.js
+++ b/tests/baselines/reference/getGlobalESSymbolType.js
@@ -1,0 +1,13 @@
+//// [getGlobalESSymbolType.ts]
+interface A {
+    m(x: string): void;
+}
+
+declare class B {
+    m(x: string | symbol): void;
+}
+
+declare class C extends B implements A {}
+
+
+//// [getGlobalESSymbolType.js]

--- a/tests/baselines/reference/getGlobalESSymbolType.symbols
+++ b/tests/baselines/reference/getGlobalESSymbolType.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/getGlobalESSymbolType.ts ===
+interface A {
+>A : Symbol(A, Decl(getGlobalESSymbolType.ts, 0, 0))
+
+    m(x: string): void;
+>m : Symbol(A.m, Decl(getGlobalESSymbolType.ts, 0, 13))
+>x : Symbol(x, Decl(getGlobalESSymbolType.ts, 1, 6))
+}
+
+declare class B {
+>B : Symbol(B, Decl(getGlobalESSymbolType.ts, 2, 1))
+
+    m(x: string | symbol): void;
+>m : Symbol(B.m, Decl(getGlobalESSymbolType.ts, 4, 17))
+>x : Symbol(x, Decl(getGlobalESSymbolType.ts, 5, 6))
+}
+
+declare class C extends B implements A {}
+>C : Symbol(C, Decl(getGlobalESSymbolType.ts, 6, 1))
+>B : Symbol(B, Decl(getGlobalESSymbolType.ts, 2, 1))
+>A : Symbol(A, Decl(getGlobalESSymbolType.ts, 0, 0))
+

--- a/tests/baselines/reference/getGlobalESSymbolType.types
+++ b/tests/baselines/reference/getGlobalESSymbolType.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/getGlobalESSymbolType.ts ===
+interface A {
+>A : A
+
+    m(x: string): void;
+>m : (x: string) => void
+>x : string
+}
+
+declare class B {
+>B : B
+
+    m(x: string | symbol): void;
+>m : (x: string | symbol) => void
+>x : string | symbol
+}
+
+declare class C extends B implements A {}
+>C : C
+>B : B
+>A : A
+

--- a/tests/cases/compiler/getGlobalESSymbolType.ts
+++ b/tests/cases/compiler/getGlobalESSymbolType.ts
@@ -1,0 +1,12 @@
+// @lib: es5
+// @target: es6
+
+interface A {
+    m(x: string): void;
+}
+
+declare class B {
+    m(x: string | symbol): void;
+}
+
+declare class C extends B implements A {}


### PR DESCRIPTION
Fixes #18893

This is basically @begincalendar's suggestion.