### PR TITLE
Binding element with parent type any is of type any

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4151,13 +4151,13 @@ namespace ts {
             if (parentType === unknownType) {
                 return unknownType;
             }
-            // If no type was specified or inferred for parent, or if the specified or inferred type is any,
-            // infer from the initializer of the binding element if one is present. Otherwise, go with the
-            // undefined or any type of the parent.
-            if (!parentType || isTypeAny(parentType)) {
-                if (declaration.initializer) {
-                    return checkDeclarationInitializer(declaration);
-                }
+            // If no type was specified or inferred for parent,
+            // infer from the initializer of the binding element if one is present.
+            // Otherwise, go with the undefined type of the parent.
+            if (!parentType) {
+                return declaration.initializer ? checkDeclarationInitializer(declaration) : parentType;
+            }
+            if (isTypeAny(parentType)) {
                 return parentType;
             }
 
@@ -4182,9 +4182,6 @@ namespace ts {
                     if (isComputedNonLiteralName(name)) {
                         // computed properties with non-literal names are treated as 'any'
                         return anyType;
-                    }
-                    if (declaration.initializer) {
-                        getContextualType(declaration.initializer);
                     }
 
                     // Use type of the specified property, or otherwise, for a numeric name, the type of the numeric index signature,

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.types
@@ -28,9 +28,9 @@ var [a0, a1]: any = undefined;
 >undefined : undefined
 
 var [a2 = false, a3 = 1]: any = undefined;
->a2 : boolean
+>a2 : any
 >false : false
->a3 : number
+>a3 : any
 >1 : 1
 >undefined : undefined
 

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.types
@@ -28,9 +28,9 @@ var [a0, a1]: any = undefined;
 >undefined : undefined
 
 var [a2 = false, a3 = 1]: any = undefined;
->a2 : boolean
+>a2 : any
 >false : false
->a3 : number
+>a3 : any
 >1 : 1
 >undefined : undefined
 

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES6.types
@@ -28,9 +28,9 @@ var [a0, a1]: any = undefined;
 >undefined : undefined
 
 var [a2 = false, a3 = 1]: any = undefined;
->a2 : boolean
+>a2 : any
 >false : false
->a3 : number
+>a3 : any
 >1 : 1
 >undefined : undefined
 

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
@@ -39,7 +39,7 @@ var {1: b3} = { 1: "string" };
 >"string" : "string"
 
 var {b4 = 1}: any = { b4: 100000 };
->b4 : number
+>b4 : any
 >1 : 1
 >{ b4: 100000 } : { b4: number; }
 >b4 : number

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
@@ -39,7 +39,7 @@ var {1: b3} = { 1: "string" };
 >"string" : "string"
 
 var {b4 = 1}: any = { b4: 100000 };
->b4 : number
+>b4 : any
 >1 : 1
 >{ b4: 100000 } : { b4: number; }
 >b4 : number

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment4.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment4.types
@@ -1,20 +1,20 @@
 === tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment4.ts ===
 const {
     a = 1,
->a : 1
+>a : any
 >1 : 1
 
     b = 2,
->b : 2
+>b : any
 >2 : 2
 
     c = b, // ok
->c : 2
->b : 2
+>c : any
+>b : any
 
     d = a, // ok
->d : 1
->a : 1
+>d : any
+>a : any
 
     e = f, // error
 >e : any

--- a/tests/baselines/reference/objectRestParameter.types
+++ b/tests/baselines/reference/objectRestParameter.types
@@ -77,7 +77,7 @@ class C {
 }
 function foobar({ bar={}, ...opts }: any = {}) {
 >foobar : ({ bar, ...opts }?: any) => void
->bar : {}
+>bar : any
 >{} : {}
 >opts : any
 >{} : {}

--- a/tests/baselines/reference/objectRestParameterES5.types
+++ b/tests/baselines/reference/objectRestParameterES5.types
@@ -77,7 +77,7 @@ class C {
 }
 function foobar({ bar={}, ...opts }: any = {}) {
 >foobar : ({ bar, ...opts }?: any) => void
->bar : {}
+>bar : any
 >{} : {}
 >opts : any
 >{} : {}


### PR DESCRIPTION
Previously if the binding element had an initializer, then that type would be used. But this is incorrect:

```ts
function f(x: any) {
  let { d = 1 } = x;
  // d should have type any not number.
  // f can be called with anything:
}
f({ d: 0 });
f({ d: 'hi' });
f({});
```

Fixes #12620

Also get rid of a useless call to `getContextualType`. I added it a year and a half ago and it just makes no sense.