### PR TITLE
Fine tune logging so that only triggers in watch are logged in normal mode vs verbose

### DIFF
--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -249,10 +249,10 @@ namespace ts {
         let hasChangedAutomaticTypeDirectiveNames = false;                  // True if the automatic type directives have changed
 
         const loggingEnabled = compilerOptions.diagnostics || compilerOptions.extendedDiagnostics;
-        const writeLog: (s: string) => void = loggingEnabled ? s => system.write(s) : noop;
-        const watchFile = loggingEnabled ? ts.addFileWatcherWithLogging : ts.addFileWatcher;
-        const watchFilePath = loggingEnabled ? ts.addFilePathWatcherWithLogging : ts.addFilePathWatcher;
-        const watchDirectoryWorker = loggingEnabled ? ts.addDirectoryWatcherWithLogging : ts.addDirectoryWatcher;
+        const writeLog: (s: string) => void = loggingEnabled ? s => { system.write(s); system.write(system.newLine); } : noop;
+        const watchFile = compilerOptions.extendedDiagnostics ? ts.addFileWatcherWithLogging : loggingEnabled ? ts.addFileWatcherWithOnlyTriggerLogging : ts.addFileWatcher;
+        const watchFilePath = compilerOptions.extendedDiagnostics ? ts.addFilePathWatcherWithLogging : ts.addFilePathWatcher;
+        const watchDirectoryWorker = compilerOptions.extendedDiagnostics ? ts.addDirectoryWatcherWithLogging : ts.addDirectoryWatcher;
 
         watchingHost = watchingHost || createWatchingSystemHost(compilerOptions.pretty);
         const { system, parseConfigFile, reportDiagnostic, reportWatchDiagnostic, beforeCompile, afterCompile } = watchingHost;

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -431,6 +431,11 @@ namespace ts.server {
                 this.watchFilePath = (host, file, cb, path, watchType, project) => ts.addFilePathWatcherWithLogging(host, file, cb, path, this.createWatcherLog(watchType, project));
                 this.watchDirectory = (host, dir, cb, flags, watchType, project) => ts.addDirectoryWatcherWithLogging(host, dir, cb, flags, this.createWatcherLog(watchType, project));
             }
+            else if (this.logger.loggingEnabled()) {
+                this.watchFile = (host, file, cb, watchType, project) => ts.addFileWatcherWithOnlyTriggerLogging(host, file, cb, this.createWatcherLog(watchType, project));
+                this.watchFilePath = (host, file, cb, path, watchType, project) => ts.addFilePathWatcherWithOnlyTriggerLogging(host, file, cb, path, this.createWatcherLog(watchType, project));
+                this.watchDirectory = (host, dir, cb, flags, watchType, project) => ts.addDirectoryWatcherWithOnlyTriggerLogging(host, dir, cb, flags, this.createWatcherLog(watchType, project));
+            }
             else {
                 this.watchFile = ts.addFileWatcher;
                 this.watchFilePath = ts.addFilePathWatcher;


### PR DESCRIPTION
Found that there was too much logging still enabled in tsc --w by default when --diagnostics was supported. This change would report only triggers in the watch in --diagnostics mode