### PR TITLE
Introduce getSynthesizedDeepClone

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -71,16 +71,6 @@ namespace ts {
         return clone;
     }
 
-    /**
-     * Creates a deep, memberwise clone of a node with no source map location.
-     */
-    /* @internal */
-    export function getSynthesizedDeepClone<T extends Node>(node: T | undefined): T | undefined {
-        return node
-            ? getSynthesizedClone(visitEachChild(node, child => getSynthesizedDeepClone(child), nullTransformationContext))
-            : undefined;
-    }
-
     // Literals
 
     export function createLiteral(value: string): StringLiteral;

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -47,10 +47,15 @@ namespace ts {
      * Creates a shallow, memberwise clone of a node with no source map location.
      */
     /* @internal */
-    export function getSynthesizedClone<T extends Node>(node: T | undefined): T {
+    export function getSynthesizedClone<T extends Node>(node: T | undefined): T | undefined {
         // We don't use "clone" from core.ts here, as we need to preserve the prototype chain of
         // the original node. We also need to exclude specific properties and only include own-
         // properties (to skip members already defined on the shared prototype).
+
+        if (node === undefined) {
+            return undefined;
+        }
+
         const clone = <T>createSynthesizedNode(node.kind);
         clone.flags |= node.flags;
         setOriginalNode(clone, node);

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -74,6 +74,7 @@ namespace ts {
     /**
      * Creates a deep, memberwise clone of a node with no source map location.
      */
+    /* @internal */
     export function getSynthesizedDeepClone<T extends Node>(node: T | undefined): T | undefined {
         return node
             ? getSynthesizedClone(visitEachChild(node, child => getSynthesizedDeepClone(child), nullTransformationContext))

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -71,6 +71,15 @@ namespace ts {
         return clone;
     }
 
+    /**
+     * Creates a deep, memberwise clone of a node with no source map location.
+     */
+    export function getSynthesizedDeepClone<T extends Node>(node: T | undefined): T | undefined {
+        return node
+            ? getSynthesizedClone(visitEachChild(node, child => getSynthesizedDeepClone(child), nullTransformationContext))
+            : undefined;
+    }
+
     // Literals
 
     export function createLiteral(value: string): StringLiteral;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1349,15 +1349,16 @@ namespace ts {
         const visited = visitEachChild(node, getSynthesizedDeepClone, nullTransformationContext);
         if (visited === node) {
             // This only happens for leaf nodes - internal nodes always see their children change.
-            return getSynthesizedClone(node);
+            const clone = getSynthesizedClone(node);
+            clone.pos = node.pos;
+            clone.end = node.end;
+            return clone;
         }
 
         // PERF: As an optimization, rather than calling getSynthesizedClone, we'll update
         // the new node created by visitEachChild with the extra changes getSynthesizedClone
         // would have made.
 
-        visited.pos = -1;
-        visited.end = -1;
         visited.parent = undefined;
 
         return visited;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1334,4 +1334,16 @@ namespace ts {
         }
         return position;
     }
+
+    /**
+     * Creates a deep, memberwise clone of a node with no source map location.
+     *
+     * WARNING: This is an expensive operation and is only intended to be used in refactorings
+     * and code fixes (because those are triggered by explicit user actions).
+     */
+    export function getSynthesizedDeepClone<T extends Node>(node: T | undefined): T | undefined {
+        return node
+            ? getSynthesizedClone(visitEachChild(node, child => getSynthesizedDeepClone(child), nullTransformationContext))
+            : undefined;
+    }
 }


### PR DESCRIPTION
During refactoring, it seems quite common to require that a node appear in more than one place in the rewritten tree.