### PR TITLE
Overwrite output js file from inferred project

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2200,17 +2200,17 @@ namespace ts {
                 const emitHost = getEmitHost();
                 const emitFilesSeen = createMap<true>();
                 forEachEmittedFile(emitHost, (emitFileNames) => {
-                    verifyEmitFilePath(emitFileNames.jsFilePath, emitFilesSeen);
-                    verifyEmitFilePath(emitFileNames.declarationFilePath, emitFilesSeen);
+                    verifyEmitFilePath(emitFileNames.jsFilePath, emitFilesSeen, /*isJsFile*/ true);
+                    verifyEmitFilePath(emitFileNames.declarationFilePath, emitFilesSeen, /*isJsFile*/ false);
                 });
             }
 
             // Verify that all the emit files are unique and don't overwrite input files
-            function verifyEmitFilePath(emitFileName: string, emitFilesSeen: Map<true>) {
+            function verifyEmitFilePath(emitFileName: string, emitFilesSeen: Map<true>, isJsFile: boolean) {
                 if (emitFileName) {
                     const emitFilePath = toPath(emitFileName);
                     // Report error if the output overwrites input file
-                    if (filesByName.has(emitFilePath)) {
+                    if (filesByName.has(emitFilePath) && !(isJsFile && options.isInferredProject)) {
                         let chain: DiagnosticMessageChain;
                         if (!options.configFilePath) {
                             // The program is from either an inferred project or an external project

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3679,6 +3679,7 @@ namespace ts {
         /*@internal*/init?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;
+        isInferredProject?: boolean;
         isolatedModules?: boolean;
         jsx?: JsxEmit;
         lib?: string[];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3679,7 +3679,7 @@ namespace ts {
         /*@internal*/init?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;
-        isInferredProject?: boolean;
+        /*@internal*/isInferredProject?: boolean;
         isolatedModules?: boolean;
         jsx?: JsxEmit;
         lib?: string[];

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2556,7 +2556,7 @@ namespace ts {
     export interface EmitFileNames {
         jsFilePath: string;
         sourceMapFilePath: string;
-        declarationFilePath: string;
+        declarationFilePath?: string;
     }
 
     /**

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -592,11 +592,11 @@ namespace ts.projectSystem {
         it("should emit js files in inferred projects when they could be input files", () => {
             const f1 = {
                 path: "/a/b/f1.ts",
-                content: "var test = \"\";"
+                content: "var test = 0;"
             };
             const f1js = {
                 path: "/a/b/f1.js",
-                content: "var test = \"\";"
+                content: "var test = 0;"
             };
             const host = createServerHost([f1, f1js, libFile]);
             const session = createSession(host, { useSingleInferredProject: true, useInferredProjectPerProjectRoot: true });
@@ -614,7 +614,7 @@ namespace ts.projectSystem {
                 seq: 2,
                 arguments: { projectFileName: projectName }
             }).response;
-            assert.isTrue(diags.length === 0);
+            assert.lengthOf(diags, 0);
 
             const emitRequest = makeSessionRequest<server.protocol.CompileOnSaveEmitFileRequestArgs>(CommandNames.CompileOnSaveEmitFile, { file: f1.path });
             const emitResponse = session.executeCommand(emitRequest).response;

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -156,7 +156,8 @@ namespace ts.server {
                         jsx: JsxEmit.React,
                         newLine: NewLineKind.LineFeed,
                         moduleResolution: ModuleResolutionKind.NodeJs,
-                        allowNonTsExtensions: true // injected by tsserver
+                        allowNonTsExtensions: true, // injected by tsserver
+                        isInferredProject: true // injected by tsserver
                     });
             });
         });

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -576,6 +576,8 @@ namespace ts.server {
             // previously we did not expose a way for user to change these settings and this option was enabled by default
             compilerOptions.allowNonTsExtensions = true;
 
+            compilerOptions.isInferredProject = true;
+
             if (projectRootPath) {
                 this.compilerOptionsForInferredProjectsPerProjectRoot.set(projectRootPath, compilerOptions);
             }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -576,6 +576,7 @@ namespace ts.server {
             // previously we did not expose a way for user to change these settings and this option was enabled by default
             compilerOptions.allowNonTsExtensions = true;
 
+            // set flag in options to mark it as for compiling an inferred project
             compilerOptions.isInferredProject = true;
 
             if (projectRootPath) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Currently, if a ts file that does not belong to a configured project is open in the editor alongside the js file to which it compiles, compilation of that file will fail. This change allows such files to be to be overwritten.
