### PR TITLE
Error when accessing abstract property in constructor #9230

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14844,10 +14844,9 @@ namespace ts {
             // Referencing Abstract Properties within Constructors is not allowed
             if ((flags & ModifierFlags.Abstract) && symbolHasNonMethodDeclaration(prop)) {
                 const declaringClassDeclaration = <ClassLikeDeclaration>getClassLikeDeclarationOfSymbol(getParentOfSymbol(prop));
-                const declaringClassConstructor = declaringClassDeclaration && findConstructorDeclaration(declaringClassDeclaration);
 
-                if (declaringClassConstructor && isNodeWithinFunction(node, declaringClassConstructor)) {
-                    error(errorNode, Diagnostics.Abstract_property_0_in_class_1_cannot_be_accessed_in_constructor, symbolToString(prop), typeToString(getDeclaringClass(prop)));
+                if (declaringClassDeclaration && isNodeWithinConstructor(node, declaringClassDeclaration)) {
+                    error(errorNode, Diagnostics.Abstract_property_0_in_class_1_cannot_be_accessed_in_the_constructor, symbolToString(prop), typeToString(getDeclaringClass(prop)));
                     return false;
                 }
             }
@@ -23153,8 +23152,16 @@ namespace ts {
             return result;
         }
 
-        function isNodeWithinFunction(node: Node, functionDeclaration: FunctionLike) {
-            return getContainingFunction(node) === functionDeclaration;
+        function isNodeWithinConstructor(node: Node, classDeclaration: ClassLikeDeclaration) {
+            return findAncestor(node, element => {
+                if (isConstructorDeclaration(element) && nodeIsPresent(element.body)) {
+                    return true;
+                } else if (element === classDeclaration || isFunctionLikeDeclaration(element)) {
+                    return "quit";
+                }
+
+                return false;
+            });
         }
 
         function isNodeWithinClass(node: Node, classDeclaration: ClassLikeDeclaration) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23156,7 +23156,8 @@ namespace ts {
             return findAncestor(node, element => {
                 if (isConstructorDeclaration(element) && nodeIsPresent(element.body)) {
                     return true;
-                } else if (element === classDeclaration || isFunctionLikeDeclaration(element)) {
+                }
+                else if (element === classDeclaration || isFunctionLikeDeclaration(element)) {
                     return "quit";
                 }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2220,6 +2220,10 @@
         "category": "Error",
         "code": 2714
     },
+    "Abstract property '{0}' in class '{1}' cannot be accessed in constructor.": {
+        "category": "Error",
+        "code": 2715
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2220,7 +2220,7 @@
         "category": "Error",
         "code": 2714
     },
-    "Abstract property '{0}' in class '{1}' cannot be accessed in constructor.": {
+    "Abstract property '{0}' in class '{1}' cannot be accessed in the constructor.": {
         "category": "Error",
         "code": 2715
     },

--- a/tests/baselines/reference/abstractPropertyInConstructor.errors.txt
+++ b/tests/baselines/reference/abstractPropertyInConstructor.errors.txt
@@ -1,20 +1,32 @@
-tests/cases/compiler/abstractPropertyInConstructor.ts(4,24): error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in constructor.
-tests/cases/compiler/abstractPropertyInConstructor.ts(5,14): error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in constructor.
+tests/cases/compiler/abstractPropertyInConstructor.ts(4,24): error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in the constructor.
+tests/cases/compiler/abstractPropertyInConstructor.ts(7,18): error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in the constructor.
+tests/cases/compiler/abstractPropertyInConstructor.ts(9,14): error TS2715: Abstract property 'cb' in class 'AbstractClass' cannot be accessed in the constructor.
 
 
-==== tests/cases/compiler/abstractPropertyInConstructor.ts (2 errors) ====
+==== tests/cases/compiler/abstractPropertyInConstructor.ts (3 errors) ====
     abstract class AbstractClass {
         constructor(str: string) {
             this.method(parseInt(str));
             let val = this.prop.toLowerCase();
                            ~~~~
-!!! error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in constructor.
-            this.prop = "Hello World";
-                 ~~~~
-!!! error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in constructor.
+!!! error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in the constructor.
+    
+            if (!str) {
+                this.prop = "Hello World";
+                     ~~~~
+!!! error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in the constructor.
+            }
+            this.cb(str);
+                 ~~
+!!! error TS2715: Abstract property 'cb' in class 'AbstractClass' cannot be accessed in the constructor.
+    
+            const innerFunction = () => {
+                return this.prop;
+            }
         }
     
         abstract prop: string;
+        abstract cb: (s: string) => void;
     
         abstract method(num: number): void;
     

--- a/tests/baselines/reference/abstractPropertyInConstructor.errors.txt
+++ b/tests/baselines/reference/abstractPropertyInConstructor.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/compiler/abstractPropertyInConstructor.ts(4,24): error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in constructor.
+tests/cases/compiler/abstractPropertyInConstructor.ts(5,14): error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in constructor.
+
+
+==== tests/cases/compiler/abstractPropertyInConstructor.ts (2 errors) ====
+    abstract class AbstractClass {
+        constructor(str: string) {
+            this.method(parseInt(str));
+            let val = this.prop.toLowerCase();
+                           ~~~~
+!!! error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in constructor.
+            this.prop = "Hello World";
+                 ~~~~
+!!! error TS2715: Abstract property 'prop' in class 'AbstractClass' cannot be accessed in constructor.
+        }
+    
+        abstract prop: string;
+    
+        abstract method(num: number): void;
+    
+        method2() {
+            this.prop = this.prop + "!";
+        }
+    }
+    

--- a/tests/baselines/reference/abstractPropertyInConstructor.js
+++ b/tests/baselines/reference/abstractPropertyInConstructor.js
@@ -1,0 +1,30 @@
+//// [abstractPropertyInConstructor.ts]
+abstract class AbstractClass {
+    constructor(str: string) {
+        this.method(parseInt(str));
+        let val = this.prop.toLowerCase();
+        this.prop = "Hello World";
+    }
+
+    abstract prop: string;
+
+    abstract method(num: number): void;
+
+    method2() {
+        this.prop = this.prop + "!";
+    }
+}
+
+
+//// [abstractPropertyInConstructor.js]
+var AbstractClass = /** @class */ (function () {
+    function AbstractClass(str) {
+        this.method(parseInt(str));
+        var val = this.prop.toLowerCase();
+        this.prop = "Hello World";
+    }
+    AbstractClass.prototype.method2 = function () {
+        this.prop = this.prop + "!";
+    };
+    return AbstractClass;
+}());

--- a/tests/baselines/reference/abstractPropertyInConstructor.js
+++ b/tests/baselines/reference/abstractPropertyInConstructor.js
@@ -3,10 +3,19 @@ abstract class AbstractClass {
     constructor(str: string) {
         this.method(parseInt(str));
         let val = this.prop.toLowerCase();
-        this.prop = "Hello World";
+
+        if (!str) {
+            this.prop = "Hello World";
+        }
+        this.cb(str);
+
+        const innerFunction = () => {
+            return this.prop;
+        }
     }
 
     abstract prop: string;
+    abstract cb: (s: string) => void;
 
     abstract method(num: number): void;
 
@@ -19,9 +28,16 @@ abstract class AbstractClass {
 //// [abstractPropertyInConstructor.js]
 var AbstractClass = /** @class */ (function () {
     function AbstractClass(str) {
+        var _this = this;
         this.method(parseInt(str));
         var val = this.prop.toLowerCase();
-        this.prop = "Hello World";
+        if (!str) {
+            this.prop = "Hello World";
+        }
+        this.cb(str);
+        var innerFunction = function () {
+            return _this.prop;
+        };
     }
     AbstractClass.prototype.method2 = function () {
         this.prop = this.prop + "!";

--- a/tests/baselines/reference/abstractPropertyInConstructor.symbols
+++ b/tests/baselines/reference/abstractPropertyInConstructor.symbols
@@ -1,0 +1,48 @@
+=== tests/cases/compiler/abstractPropertyInConstructor.ts ===
+abstract class AbstractClass {
+>AbstractClass : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
+
+    constructor(str: string) {
+>str : Symbol(str, Decl(abstractPropertyInConstructor.ts, 1, 16))
+
+        this.method(parseInt(str));
+>this.method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 7, 26))
+>this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
+>method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 7, 26))
+>parseInt : Symbol(parseInt, Decl(lib.d.ts, --, --))
+>str : Symbol(str, Decl(abstractPropertyInConstructor.ts, 1, 16))
+
+        let val = this.prop.toLowerCase();
+>val : Symbol(val, Decl(abstractPropertyInConstructor.ts, 3, 11))
+>this.prop.toLowerCase : Symbol(String.toLowerCase, Decl(lib.d.ts, --, --))
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.d.ts, --, --))
+
+        this.prop = "Hello World";
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+    }
+
+    abstract prop: string;
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+
+    abstract method(num: number): void;
+>method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 7, 26))
+>num : Symbol(num, Decl(abstractPropertyInConstructor.ts, 9, 20))
+
+    method2() {
+>method2 : Symbol(AbstractClass.method2, Decl(abstractPropertyInConstructor.ts, 9, 39))
+
+        this.prop = this.prop + "!";
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+    }
+}
+

--- a/tests/baselines/reference/abstractPropertyInConstructor.symbols
+++ b/tests/baselines/reference/abstractPropertyInConstructor.symbols
@@ -6,43 +6,65 @@ abstract class AbstractClass {
 >str : Symbol(str, Decl(abstractPropertyInConstructor.ts, 1, 16))
 
         this.method(parseInt(str));
->this.method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 7, 26))
+>this.method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 16, 37))
 >this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
->method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 7, 26))
+>method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 16, 37))
 >parseInt : Symbol(parseInt, Decl(lib.d.ts, --, --))
 >str : Symbol(str, Decl(abstractPropertyInConstructor.ts, 1, 16))
 
         let val = this.prop.toLowerCase();
 >val : Symbol(val, Decl(abstractPropertyInConstructor.ts, 3, 11))
 >this.prop.toLowerCase : Symbol(String.toLowerCase, Decl(lib.d.ts, --, --))
->this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
 >this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
->prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
 >toLowerCase : Symbol(String.toLowerCase, Decl(lib.d.ts, --, --))
 
-        this.prop = "Hello World";
->this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+        if (!str) {
+>str : Symbol(str, Decl(abstractPropertyInConstructor.ts, 1, 16))
+
+            this.prop = "Hello World";
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
 >this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
->prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
+        }
+        this.cb(str);
+>this.cb : Symbol(AbstractClass.cb, Decl(abstractPropertyInConstructor.ts, 15, 26))
+>this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
+>cb : Symbol(AbstractClass.cb, Decl(abstractPropertyInConstructor.ts, 15, 26))
+>str : Symbol(str, Decl(abstractPropertyInConstructor.ts, 1, 16))
+
+        const innerFunction = () => {
+>innerFunction : Symbol(innerFunction, Decl(abstractPropertyInConstructor.ts, 10, 13))
+
+            return this.prop;
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
+>this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
+        }
     }
 
     abstract prop: string;
->prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
+
+    abstract cb: (s: string) => void;
+>cb : Symbol(AbstractClass.cb, Decl(abstractPropertyInConstructor.ts, 15, 26))
+>s : Symbol(s, Decl(abstractPropertyInConstructor.ts, 16, 18))
 
     abstract method(num: number): void;
->method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 7, 26))
->num : Symbol(num, Decl(abstractPropertyInConstructor.ts, 9, 20))
+>method : Symbol(AbstractClass.method, Decl(abstractPropertyInConstructor.ts, 16, 37))
+>num : Symbol(num, Decl(abstractPropertyInConstructor.ts, 18, 20))
 
     method2() {
->method2 : Symbol(AbstractClass.method2, Decl(abstractPropertyInConstructor.ts, 9, 39))
+>method2 : Symbol(AbstractClass.method2, Decl(abstractPropertyInConstructor.ts, 18, 39))
 
         this.prop = this.prop + "!";
->this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
 >this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
->prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
->this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
+>this.prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
 >this : Symbol(AbstractClass, Decl(abstractPropertyInConstructor.ts, 0, 0))
->prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 5, 5))
+>prop : Symbol(AbstractClass.prop, Decl(abstractPropertyInConstructor.ts, 13, 5))
     }
 }
 

--- a/tests/baselines/reference/abstractPropertyInConstructor.types
+++ b/tests/baselines/reference/abstractPropertyInConstructor.types
@@ -23,16 +23,41 @@ abstract class AbstractClass {
 >prop : string
 >toLowerCase : () => string
 
-        this.prop = "Hello World";
+        if (!str) {
+>!str : boolean
+>str : string
+
+            this.prop = "Hello World";
 >this.prop = "Hello World" : "Hello World"
 >this.prop : string
 >this : this
 >prop : string
 >"Hello World" : "Hello World"
+        }
+        this.cb(str);
+>this.cb(str) : void
+>this.cb : (s: string) => void
+>this : this
+>cb : (s: string) => void
+>str : string
+
+        const innerFunction = () => {
+>innerFunction : () => string
+>() => {            return this.prop;        } : () => string
+
+            return this.prop;
+>this.prop : string
+>this : this
+>prop : string
+        }
     }
 
     abstract prop: string;
 >prop : string
+
+    abstract cb: (s: string) => void;
+>cb : (s: string) => void
+>s : string
 
     abstract method(num: number): void;
 >method : (num: number) => void

--- a/tests/baselines/reference/abstractPropertyInConstructor.types
+++ b/tests/baselines/reference/abstractPropertyInConstructor.types
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/abstractPropertyInConstructor.ts ===
+abstract class AbstractClass {
+>AbstractClass : AbstractClass
+
+    constructor(str: string) {
+>str : string
+
+        this.method(parseInt(str));
+>this.method(parseInt(str)) : void
+>this.method : (num: number) => void
+>this : this
+>method : (num: number) => void
+>parseInt(str) : number
+>parseInt : (s: string, radix?: number) => number
+>str : string
+
+        let val = this.prop.toLowerCase();
+>val : string
+>this.prop.toLowerCase() : string
+>this.prop.toLowerCase : () => string
+>this.prop : string
+>this : this
+>prop : string
+>toLowerCase : () => string
+
+        this.prop = "Hello World";
+>this.prop = "Hello World" : "Hello World"
+>this.prop : string
+>this : this
+>prop : string
+>"Hello World" : "Hello World"
+    }
+
+    abstract prop: string;
+>prop : string
+
+    abstract method(num: number): void;
+>method : (num: number) => void
+>num : number
+
+    method2() {
+>method2 : () => void
+
+        this.prop = this.prop + "!";
+>this.prop = this.prop + "!" : string
+>this.prop : string
+>this : this
+>prop : string
+>this.prop + "!" : string
+>this.prop : string
+>this : this
+>prop : string
+>"!" : "!"
+    }
+}
+

--- a/tests/cases/compiler/abstractPropertyInConstructor.ts
+++ b/tests/cases/compiler/abstractPropertyInConstructor.ts
@@ -1,0 +1,15 @@
+abstract class AbstractClass {
+    constructor(str: string) {
+        this.method(parseInt(str));
+        let val = this.prop.toLowerCase();
+        this.prop = "Hello World";
+    }
+
+    abstract prop: string;
+
+    abstract method(num: number): void;
+
+    method2() {
+        this.prop = this.prop + "!";
+    }
+}

--- a/tests/cases/compiler/abstractPropertyInConstructor.ts
+++ b/tests/cases/compiler/abstractPropertyInConstructor.ts
@@ -2,10 +2,19 @@ abstract class AbstractClass {
     constructor(str: string) {
         this.method(parseInt(str));
         let val = this.prop.toLowerCase();
-        this.prop = "Hello World";
+
+        if (!str) {
+            this.prop = "Hello World";
+        }
+        this.cb(str);
+
+        const innerFunction = () => {
+            return this.prop;
+        }
     }
 
     abstract prop: string;
+    abstract cb: (s: string) => void;
 
     abstract method(num: number): void;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #9230

Add an error when accessing an abstract property within the constructor of the abstract class.

This is the first `Effort: Moderate` issue that I have tackled and the first time I have dealt with adding a new diagnostic message, so please let me know if there is something that I overlooked.
