### PR TITLE
importFixes: Remove unnecessary undefined check

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -16,7 +16,7 @@ namespace ts.codefix {
         moduleSpecifier?: string;
     }
 
-    enum ModuleSpecifierComparison {
+    const enum ModuleSpecifierComparison {
         Better,
         Equal,
         Worse
@@ -26,10 +26,6 @@ namespace ts.codefix {
         private symbolIdToActionMap: ImportCodeAction[][] = [];
 
         addAction(symbolId: number, newAction: ImportCodeAction) {
-            if (!newAction) {
-                return;
-            }
-
             const actions = this.symbolIdToActionMap[symbolId];
             if (!actions) {
                 this.symbolIdToActionMap[symbolId] = [newAction];


### PR DESCRIPTION
It doesn't look like we ever send `undefined` into this function -- tested with `Debug.assert(!!newAction)`.