### PR TITLE
Fix recursive reference in type parameter default

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2224,6 +2224,10 @@
         "category": "Error",
         "code": 2715
     },
+    "Type parameter '{0}' has a circular default.": {
+        "category": "Error",
+        "code": 2716
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/genericDefaults.js
+++ b/tests/baselines/reference/genericDefaults.js
@@ -489,6 +489,9 @@ const t03c02 = (<t03<number, number>>x).a;
 const t03c03 = (<t03<1, 1>>x).a;
 const t03c04 = (<t03<number, 1>>x).a;
 
+// https://github.com/Microsoft/TypeScript/issues/16221
+interface SelfReference<T = SelfReference<string>> {}
+
 //// [genericDefaults.js]
 // no inference
 f00();
@@ -1024,3 +1027,5 @@ declare const t03c01: [1, 1];
 declare const t03c02: [number, number];
 declare const t03c03: [1, 1];
 declare const t03c04: [number, 1];
+interface SelfReference<T = SelfReference<string>> {
+}

--- a/tests/baselines/reference/genericDefaults.symbols
+++ b/tests/baselines/reference/genericDefaults.symbols
@@ -2291,3 +2291,9 @@ const t03c04 = (<t03<number, 1>>x).a;
 >x : Symbol(x, Decl(genericDefaults.ts, 13, 13))
 >a : Symbol(a, Decl(genericDefaults.ts, 483, 47))
 
+// https://github.com/Microsoft/TypeScript/issues/16221
+interface SelfReference<T = SelfReference<string>> {}
+>SelfReference : Symbol(SelfReference, Decl(genericDefaults.ts, 488, 37))
+>T : Symbol(T, Decl(genericDefaults.ts, 491, 24))
+>SelfReference : Symbol(SelfReference, Decl(genericDefaults.ts, 488, 37))
+

--- a/tests/baselines/reference/genericDefaults.types
+++ b/tests/baselines/reference/genericDefaults.types
@@ -2643,3 +2643,9 @@ const t03c04 = (<t03<number, 1>>x).a;
 >x : any
 >a : [number, 1]
 
+// https://github.com/Microsoft/TypeScript/issues/16221
+interface SelfReference<T = SelfReference<string>> {}
+>SelfReference : SelfReference<T>
+>T : T
+>SelfReference : SelfReference<T>
+

--- a/tests/baselines/reference/genericDefaultsErrors.errors.txt
+++ b/tests/baselines/reference/genericDefaultsErrors.errors.txt
@@ -21,7 +21,7 @@ tests/cases/compiler/genericDefaultsErrors.ts(33,15): error TS2707: Generic type
 tests/cases/compiler/genericDefaultsErrors.ts(36,15): error TS2707: Generic type 'i09<T, U, V>' requires between 2 and 3 type arguments.
 tests/cases/compiler/genericDefaultsErrors.ts(38,20): error TS2304: Cannot find name 'T'.
 tests/cases/compiler/genericDefaultsErrors.ts(38,20): error TS4033: Property 'x' of exported interface has or is using private name 'T'.
-tests/cases/compiler/genericDefaultsErrors.ts(42,29): error TS2715: Type parameter 'T' has a circular default.
+tests/cases/compiler/genericDefaultsErrors.ts(42,29): error TS2716: Type parameter 'T' has a circular default.
 
 
 ==== tests/cases/compiler/genericDefaultsErrors.ts (22 errors) ====
@@ -112,4 +112,4 @@ tests/cases/compiler/genericDefaultsErrors.ts(42,29): error TS2715: Type paramet
     // https://github.com/Microsoft/TypeScript/issues/16221
     interface SelfReference<T = SelfReference> {}
                                 ~~~~~~~~~~~~~
-!!! error TS2715: Type parameter 'T' has a circular default.
+!!! error TS2716: Type parameter 'T' has a circular default.

--- a/tests/baselines/reference/genericDefaultsErrors.errors.txt
+++ b/tests/baselines/reference/genericDefaultsErrors.errors.txt
@@ -21,9 +21,10 @@ tests/cases/compiler/genericDefaultsErrors.ts(33,15): error TS2707: Generic type
 tests/cases/compiler/genericDefaultsErrors.ts(36,15): error TS2707: Generic type 'i09<T, U, V>' requires between 2 and 3 type arguments.
 tests/cases/compiler/genericDefaultsErrors.ts(38,20): error TS2304: Cannot find name 'T'.
 tests/cases/compiler/genericDefaultsErrors.ts(38,20): error TS4033: Property 'x' of exported interface has or is using private name 'T'.
+tests/cases/compiler/genericDefaultsErrors.ts(42,29): error TS2715: Type parameter 'T' has a circular default.
 
 
-==== tests/cases/compiler/genericDefaultsErrors.ts (21 errors) ====
+==== tests/cases/compiler/genericDefaultsErrors.ts (22 errors) ====
     declare const x: any;
     
     declare function f03<T extends string = number>(): void; // error
@@ -107,3 +108,8 @@ tests/cases/compiler/genericDefaultsErrors.ts(38,20): error TS4033: Property 'x'
                        ~
 !!! error TS4033: Property 'x' of exported interface has or is using private name 'T'.
     interface i10<T = number> {}
+    
+    // https://github.com/Microsoft/TypeScript/issues/16221
+    interface SelfReference<T = SelfReference> {}
+                                ~~~~~~~~~~~~~
+!!! error TS2715: Type parameter 'T' has a circular default.

--- a/tests/baselines/reference/genericDefaultsErrors.js
+++ b/tests/baselines/reference/genericDefaultsErrors.js
@@ -39,6 +39,9 @@ type i09t04 = i09<1, 2, 3, 4>; // error
 interface i10 { x: T; } // error
 interface i10<T = number> {}
 
+// https://github.com/Microsoft/TypeScript/issues/16221
+interface SelfReference<T = SelfReference> {}
+
 //// [genericDefaultsErrors.js]
 f11(); // ok
 f11(); // error

--- a/tests/baselines/reference/genericDefaultsErrors.symbols
+++ b/tests/baselines/reference/genericDefaultsErrors.symbols
@@ -136,3 +136,9 @@ interface i10<T = number> {}
 >i10 : Symbol(i10, Decl(genericDefaultsErrors.ts, 35, 30), Decl(genericDefaultsErrors.ts, 37, 23))
 >T : Symbol(T, Decl(genericDefaultsErrors.ts, 38, 14))
 
+// https://github.com/Microsoft/TypeScript/issues/16221
+interface SelfReference<T = SelfReference> {}
+>SelfReference : Symbol(SelfReference, Decl(genericDefaultsErrors.ts, 38, 28))
+>T : Symbol(T, Decl(genericDefaultsErrors.ts, 41, 24))
+>SelfReference : Symbol(SelfReference, Decl(genericDefaultsErrors.ts, 38, 28))
+

--- a/tests/baselines/reference/genericDefaultsErrors.types
+++ b/tests/baselines/reference/genericDefaultsErrors.types
@@ -145,3 +145,9 @@ interface i10<T = number> {}
 >i10 : i10<T>
 >T : T
 
+// https://github.com/Microsoft/TypeScript/issues/16221
+interface SelfReference<T = SelfReference> {}
+>SelfReference : SelfReference<T>
+>T : T
+>SelfReference : SelfReference<T>
+

--- a/tests/cases/compiler/genericDefaults.ts
+++ b/tests/cases/compiler/genericDefaults.ts
@@ -488,3 +488,6 @@ const t03c01 = (<t03<1>>x).a;
 const t03c02 = (<t03<number, number>>x).a;
 const t03c03 = (<t03<1, 1>>x).a;
 const t03c04 = (<t03<number, 1>>x).a;
+
+// https://github.com/Microsoft/TypeScript/issues/16221
+interface SelfReference<T = SelfReference<string>> {}

--- a/tests/cases/compiler/genericDefaultsErrors.ts
+++ b/tests/cases/compiler/genericDefaultsErrors.ts
@@ -39,3 +39,6 @@ type i09t04 = i09<1, 2, 3, 4>; // error
 
 interface i10 { x: T; } // error
 interface i10<T = number> {}
+
+// https://github.com/Microsoft/TypeScript/issues/16221
+interface SelfReference<T = SelfReference> {}


### PR DESCRIPTION
This change allows `class SelfReference<T = SelfReference<string>> {}` but reports an error for `class SelfReference<T = SelfReference> {}`. Previously this would result in a stack overflow.

Fixes #16221