### PR TITLE
Swallow the directory watcher exceptions and ignore them

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14012,7 +14012,7 @@ namespace ts {
          */
         function isUnhyphenatedJsxName(name: string | __String) {
             // - is the only character supported in JSX attribute names that isn't valid in JavaScript identifiers
-            return (name as string).indexOf("-") < 0;
+            return !stringContains(name as string, "-");
         }
 
         /**

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1663,7 +1663,7 @@ namespace ts {
     }
 
     export function isUrl(path: string) {
-        return path && !isRootedDiskPath(path) && path.indexOf("://") !== -1;
+        return path && !isRootedDiskPath(path) && stringContains(path, "://");
     }
 
     export function pathIsRelative(path: string): boolean {
@@ -1932,8 +1932,12 @@ namespace ts {
         return expectedPos >= 0 && str.indexOf(suffix, expectedPos) === expectedPos;
     }
 
+    export function stringContains(str: string, substring: string): boolean {
+        return str.indexOf(substring) !== -1;
+    }
+
     export function hasExtension(fileName: string): boolean {
-        return getBaseFileName(fileName).indexOf(".") >= 0;
+        return stringContains(getBaseFileName(fileName), ".");
     }
 
     export function fileExtensionIs(path: string, extension: string): boolean {

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -172,7 +172,7 @@ namespace ts {
 
         function hasInternalAnnotation(range: CommentRange) {
             const comment = currentText.substring(range.pos, range.end);
-            return comment.indexOf("@internal") >= 0;
+            return stringContains(comment, "@internal");
         }
 
         function stripInternal(node: Node) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1226,7 +1226,7 @@ namespace ts {
                 // check if numeric literal is a decimal literal that was originally written with a dot
                 const text = getLiteralTextOfNode(<LiteralExpression>expression);
                 return !expression.numericLiteralFlags
-                    && text.indexOf(tokenToString(SyntaxKind.DotToken)) < 0;
+                    && !stringContains(text, tokenToString(SyntaxKind.DotToken));
             }
             else if (isPropertyAccessExpression(expression) || isElementAccessExpression(expression)) {
                 // check if constant enum value is integer

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1061,7 +1061,7 @@ namespace ts {
     export function getPackageNameFromAtTypesDirectory(mangledName: string): string {
         const withoutAtTypePrefix = removePrefix(mangledName, "@types/");
         if (withoutAtTypePrefix !== mangledName) {
-            return withoutAtTypePrefix.indexOf(mangledScopedPackageSeparator) !== -1 ?
+            return stringContains(withoutAtTypePrefix, mangledScopedPackageSeparator) ?
                 "@" + withoutAtTypePrefix.replace(mangledScopedPackageSeparator, ts.directorySeparator) :
                 withoutAtTypePrefix;
         }

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -324,7 +324,7 @@ namespace ts {
             let dirPath = getDirectoryPath(failedLookupLocationPath);
 
             // If directory path contains node module, get the most parent node_modules directory for watching
-            while (dirPath.indexOf("/node_modules/") !== -1) {
+            while (stringContains(dirPath, "/node_modules/")) {
                 dir = getDirectoryPath(dir);
                 dirPath = getDirectoryPath(dirPath);
             }
@@ -333,7 +333,6 @@ namespace ts {
             if (isNodeModulesDirectory(dirPath)) {
                 return { dir, dirPath };
             }
-
 
             // Use some ancestor of the root directory
             if (rootPath !== undefined) {

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -323,19 +323,17 @@ namespace ts {
             let dir = getDirectoryPath(getNormalizedAbsolutePath(failedLookupLocation, getCurrentDirectory()));
             let dirPath = getDirectoryPath(failedLookupLocationPath);
 
+            // If directory path contains node module, get the most parent node_modules directory for watching
+            while (dirPath.indexOf("/node_modules/") !== -1) {
+                dir = getDirectoryPath(dir);
+                dirPath = getDirectoryPath(dirPath);
+            }
+
             // If the directory is node_modules use it to watch
             if (isNodeModulesDirectory(dirPath)) {
                 return { dir, dirPath };
             }
 
-            // If directory path contains node module, get the node_modules directory for watching
-            if (dirPath.indexOf("/node_modules/") !== -1) {
-                while (!isNodeModulesDirectory(dirPath)) {
-                    dir = getDirectoryPath(dir);
-                    dirPath = getDirectoryPath(dirPath);
-                }
-                return { dir, dirPath };
-            }
 
             // Use some ancestor of the root directory
             if (rootPath !== undefined) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1205,7 +1205,7 @@ namespace ts.server {
             projectRootPath?: NormalizedPath) {
             let searchPath = asNormalizedPath(getDirectoryPath(info.fileName));
 
-            while (!projectRootPath || searchPath.indexOf(projectRootPath) >= 0) {
+            while (!projectRootPath || stringContains(searchPath, projectRootPath)) {
                 const canonicalSearchPath = normalizedPathToPath(searchPath, this.currentDirectory, this.toCanonicalFileName);
                 const tsconfigFileName = asNormalizedPath(combinePaths(searchPath, "tsconfig.json"));
                 let result = action(tsconfigFileName, combinePaths(canonicalSearchPath, "tsconfig.json"));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -753,10 +753,21 @@ namespace ts.server {
     const sys = <ServerHost>ts.sys;
     // use watchGuard process on Windows when node version is 4 or later
     const useWatchGuard = process.platform === "win32" && getNodeMajorVersion() >= 4;
+    const originalWatchDirectory = sys.watchDirectory;
+    const noopWatcher: FileWatcher = { close: noop };
+    function watchDirectorySwallowingException(path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher {
+        try {
+            return originalWatchDirectory.call(sys, path, callback, recursive);
+        }
+        catch (e) {
+            logger.info(`Exception when creating directory watcher: ${e.message}`);
+            return noopWatcher;
+        }
+    }
+
     if (useWatchGuard) {
         const currentDrive = extractWatchDirectoryCacheKey(sys.resolvePath(sys.getCurrentDirectory()), /*currentDriveKey*/ undefined);
         const statusCache = createMap<boolean>();
-        const originalWatchDirectory = sys.watchDirectory;
         sys.watchDirectory = function (path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher {
             const cacheKey = extractWatchDirectoryCacheKey(path, currentDrive);
             let status = cacheKey && statusCache.get(cacheKey);
@@ -790,13 +801,16 @@ namespace ts.server {
             }
             if (status) {
                 // this drive is safe to use - call real 'watchDirectory'
-                return originalWatchDirectory.call(sys, path, callback, recursive);
+                return watchDirectorySwallowingException(path, callback, recursive);
             }
             else {
                 // this drive is unsafe - return no-op watcher
-                return { close() { } };
+                return noopWatcher;
             }
         };
+    }
+    else {
+        sys.watchDirectory = watchDirectorySwallowingException;
     }
 
     // Override sys.write because fs.writeSync is not reliable on Node 4

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1608,7 +1608,7 @@ namespace ts.server {
             }
 
             // No need to analyze lib.d.ts
-            const fileNamesInProject = fileNames.filter(value => value.indexOf("lib.d.ts") < 0);
+            const fileNamesInProject = fileNames.filter(value => !stringContains(value, "lib.d.ts"));
             if (fileNamesInProject.length === 0) {
                 return;
             }

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -88,7 +88,7 @@ namespace ts.server.typingsInstaller {
             this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0]);
 
             // If the NPM path contains spaces and isn't wrapped in quotes, do so.
-            if (this.npmPath.indexOf(" ") !== -1 && this.npmPath[0] !== `"`) {
+            if (stringContains(this.npmPath, " ") && this.npmPath[0] !== `"`) {
                 this.npmPath = `"${this.npmPath}"`;
             }
             if (this.log.isEnabled()) {

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -195,7 +195,7 @@ namespace ts.Completions.PathCompletions {
                 const normalizedPrefixDirectory = getDirectoryPath(normalizedPrefix);
                 const normalizedPrefixBase = getBaseFileName(normalizedPrefix);
 
-                const fragmentHasPath = fragment.indexOf(directorySeparator) !== -1;
+                const fragmentHasPath = stringContains(fragment, directorySeparator);
 
                 // Try and expand the prefix to include any path from the fragment so that we can limit the readDirectory call
                 const expandedPrefixDirectory = fragmentHasPath ? combinePaths(normalizedPrefixDirectory, normalizedPrefixBase + getDirectoryPath(fragment)) : normalizedPrefixDirectory;
@@ -235,7 +235,7 @@ namespace ts.Completions.PathCompletions {
 
     function enumeratePotentialNonRelativeModules(fragment: string, scriptPath: string, options: CompilerOptions, typeChecker: TypeChecker, host: LanguageServiceHost): string[] {
         // Check If this is a nested module
-        const isNestedModule = fragment.indexOf(directorySeparator) !== -1;
+        const isNestedModule = stringContains(fragment, directorySeparator);
         const moduleNameFragment = isNestedModule ? fragment.substr(0, fragment.lastIndexOf(directorySeparator)) : undefined;
 
         // Get modules that the type checker picked up

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -660,7 +660,7 @@ namespace ts.refactor.extractSymbol {
 
     function getUniqueName(baseName: string, fileText: string): string {
         let nameText = baseName;
-        for (let i = 1; fileText.indexOf(nameText) !== -1; i++) {
+        for (let i = 1; stringContains(fileText, nameText); i++) {
             nameText = `${baseName}_${i}`;
         }
         return nameText;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1952,7 +1952,7 @@ namespace ts {
             function isNodeModulesFile(path: string): boolean {
                 const node_modulesFolderName = "/node_modules/";
 
-                return path.indexOf(node_modulesFolderName) !== -1;
+                return stringContains(path, node_modulesFolderName);
             }
         }
 


### PR DESCRIPTION
- Always use parent most node_modules directory to watch, that should reduce the directory watchers
- Swallow directory watcher exceptions - the better approach is to either do polling directory watch or some sort of host handled directory watches, but this should fix the experience for now
Fixes #18996