### PR TITLE
Error when LHS of instanceof is Union of Primitives #18519

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17588,13 +17588,9 @@ namespace ts {
         }
 
         function allTypesAssignableToKind(source: Type, kind: TypeFlags, strict?: boolean): boolean {
-            if (source.flags & TypeFlags.Union) {
-                const unionTypes = (source as UnionType).types;
-
-                return every(unionTypes, subType => allTypesAssignableToKind(subType, kind, strict));
-            }
-
-            return isTypeAssignableToKind(source, kind, strict);
+            return source.flags & TypeFlags.Union ?
+                every((source as UnionType).types, subType => allTypesAssignableToKind(subType, kind, strict)) :
+                isTypeAssignableToKind(source, kind, strict);
         }
 
         function isConstEnumObjectType(type: Type): boolean {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17604,7 +17604,9 @@ namespace ts {
             // and the right operand to be of type Any, a subtype of the 'Function' interface type, or have a call or construct signature.
             // The result is always of the Boolean primitive type.
             // NOTE: do not raise error if leftType is unknown as related error was already reported
-            if (!isTypeAny(leftType) && isTypeAssignableToKind(leftType, TypeFlags.Primitive)) {
+            if (!isTypeAny(leftType) &&
+                (isTypeAssignableToKind(leftType, TypeFlags.Primitive) ||
+                 isTypeUnionOfPrimitives(leftType))) {
                 error(left, Diagnostics.The_left_hand_side_of_an_instanceof_expression_must_be_of_type_any_an_object_type_or_a_type_parameter);
             }
             // NOTE: do not raise error if right is unknown as related error was already reported
@@ -17615,6 +17617,16 @@ namespace ts {
                 error(right, Diagnostics.The_right_hand_side_of_an_instanceof_expression_must_be_of_type_any_or_of_a_type_assignable_to_the_Function_interface_type);
             }
             return booleanType;
+        }
+
+        function isTypeUnionOfPrimitives(source: Type) {
+            if (!(source.flags & TypeFlags.Union)) {
+                return false;
+            }
+
+            const unionTypes = (source as UnionType).types;
+
+            return every(unionTypes, subType => isTypeAssignableToKind(subType, TypeFlags.Primitive));
         }
 
         function checkInExpression(left: Expression, right: Expression, leftType: Type, rightType: Type): Type {

--- a/tests/baselines/reference/instanceofWithPrimitiveUnion.errors.txt
+++ b/tests/baselines/reference/instanceofWithPrimitiveUnion.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/instanceofWithPrimitiveUnion.ts(2,9): error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
+
+
+==== tests/cases/compiler/instanceofWithPrimitiveUnion.ts (1 errors) ====
+    function foo(x: number | string) {
+        if (x instanceof Object) {
+            ~
+!!! error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
+            x;
+        }
+    }
+    

--- a/tests/baselines/reference/instanceofWithPrimitiveUnion.errors.txt
+++ b/tests/baselines/reference/instanceofWithPrimitiveUnion.errors.txt
@@ -1,8 +1,17 @@
 tests/cases/compiler/instanceofWithPrimitiveUnion.ts(2,9): error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
+tests/cases/compiler/instanceofWithPrimitiveUnion.ts(8,9): error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/compiler/instanceofWithPrimitiveUnion.ts (1 errors) ====
-    function foo(x: number | string) {
+==== tests/cases/compiler/instanceofWithPrimitiveUnion.ts (2 errors) ====
+    function test1(x: number | string) {
+        if (x instanceof Object) {
+            ~
+!!! error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
+            x;
+        }
+    }
+    
+    function test2(x: (number | string) | number) {
         if (x instanceof Object) {
             ~
 !!! error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/instanceofWithPrimitiveUnion.js
+++ b/tests/baselines/reference/instanceofWithPrimitiveUnion.js
@@ -1,5 +1,11 @@
 //// [instanceofWithPrimitiveUnion.ts]
-function foo(x: number | string) {
+function test1(x: number | string) {
+    if (x instanceof Object) {
+        x;
+    }
+}
+
+function test2(x: (number | string) | number) {
     if (x instanceof Object) {
         x;
     }
@@ -7,7 +13,12 @@ function foo(x: number | string) {
 
 
 //// [instanceofWithPrimitiveUnion.js]
-function foo(x) {
+function test1(x) {
+    if (x instanceof Object) {
+        x;
+    }
+}
+function test2(x) {
     if (x instanceof Object) {
         x;
     }

--- a/tests/baselines/reference/instanceofWithPrimitiveUnion.js
+++ b/tests/baselines/reference/instanceofWithPrimitiveUnion.js
@@ -1,0 +1,14 @@
+//// [instanceofWithPrimitiveUnion.ts]
+function foo(x: number | string) {
+    if (x instanceof Object) {
+        x;
+    }
+}
+
+
+//// [instanceofWithPrimitiveUnion.js]
+function foo(x) {
+    if (x instanceof Object) {
+        x;
+    }
+}

--- a/tests/baselines/reference/instanceofWithPrimitiveUnion.symbols
+++ b/tests/baselines/reference/instanceofWithPrimitiveUnion.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/instanceofWithPrimitiveUnion.ts ===
+function foo(x: number | string) {
+>foo : Symbol(foo, Decl(instanceofWithPrimitiveUnion.ts, 0, 0))
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 13))
+
+    if (x instanceof Object) {
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 13))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+        x;
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 13))
+    }
+}
+

--- a/tests/baselines/reference/instanceofWithPrimitiveUnion.symbols
+++ b/tests/baselines/reference/instanceofWithPrimitiveUnion.symbols
@@ -1,14 +1,27 @@
 === tests/cases/compiler/instanceofWithPrimitiveUnion.ts ===
-function foo(x: number | string) {
->foo : Symbol(foo, Decl(instanceofWithPrimitiveUnion.ts, 0, 0))
->x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 13))
+function test1(x: number | string) {
+>test1 : Symbol(test1, Decl(instanceofWithPrimitiveUnion.ts, 0, 0))
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 15))
 
     if (x instanceof Object) {
->x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 13))
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 15))
 >Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
         x;
->x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 13))
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 0, 15))
+    }
+}
+
+function test2(x: (number | string) | number) {
+>test2 : Symbol(test2, Decl(instanceofWithPrimitiveUnion.ts, 4, 1))
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 6, 15))
+
+    if (x instanceof Object) {
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 6, 15))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+        x;
+>x : Symbol(x, Decl(instanceofWithPrimitiveUnion.ts, 6, 15))
     }
 }
 

--- a/tests/baselines/reference/instanceofWithPrimitiveUnion.types
+++ b/tests/baselines/reference/instanceofWithPrimitiveUnion.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/instanceofWithPrimitiveUnion.ts ===
+function foo(x: number | string) {
+>foo : (x: string | number) => void
+>x : string | number
+
+    if (x instanceof Object) {
+>x instanceof Object : boolean
+>x : string | number
+>Object : ObjectConstructor
+
+        x;
+>x : string | number
+    }
+}
+

--- a/tests/baselines/reference/instanceofWithPrimitiveUnion.types
+++ b/tests/baselines/reference/instanceofWithPrimitiveUnion.types
@@ -1,6 +1,20 @@
 === tests/cases/compiler/instanceofWithPrimitiveUnion.ts ===
-function foo(x: number | string) {
->foo : (x: string | number) => void
+function test1(x: number | string) {
+>test1 : (x: string | number) => void
+>x : string | number
+
+    if (x instanceof Object) {
+>x instanceof Object : boolean
+>x : string | number
+>Object : ObjectConstructor
+
+        x;
+>x : string | number
+    }
+}
+
+function test2(x: (number | string) | number) {
+>test2 : (x: string | number) => void
 >x : string | number
 
     if (x instanceof Object) {

--- a/tests/cases/compiler/instanceofWithPrimitiveUnion.ts
+++ b/tests/cases/compiler/instanceofWithPrimitiveUnion.ts
@@ -1,0 +1,5 @@
+function foo(x: number | string) {
+    if (x instanceof Object) {
+        x;
+    }
+}

--- a/tests/cases/compiler/instanceofWithPrimitiveUnion.ts
+++ b/tests/cases/compiler/instanceofWithPrimitiveUnion.ts
@@ -1,4 +1,10 @@
-function foo(x: number | string) {
+function test1(x: number | string) {
+    if (x instanceof Object) {
+        x;
+    }
+}
+
+function test2(x: (number | string) | number) {
     if (x instanceof Object) {
         x;
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #18519

Added additional check for if the left-hand operand of an `instanceof` is a union of primitives and raise an error in that case as well.
