### PR TITLE
Maintain Export Modifier when Refactoring to ES6 Class #18435

### DIFF
--- a/src/services/refactors/convertFunctionToEs6Class.ts
+++ b/src/services/refactors/convertFunctionToEs6Class.ts
@@ -243,7 +243,8 @@ namespace ts.refactor.convertFunctionToES6Class {
                 memberElements.unshift(createConstructor(/*decorators*/ undefined, /*modifiers*/ undefined, initializer.parameters, initializer.body));
             }
 
-            const cls = createClassDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, node.name,
+            const modifiers = getExportModifierFromSource(precedingNode);
+            const cls = createClassDeclaration(/*decorators*/ undefined, modifiers, node.name,
                 /*typeParameters*/ undefined, /*heritageClauses*/ undefined, memberElements);
             // Don't call copyComments here because we'll already leave them in place
             return cls;
@@ -255,10 +256,15 @@ namespace ts.refactor.convertFunctionToES6Class {
                 memberElements.unshift(createConstructor(/*decorators*/ undefined, /*modifiers*/ undefined, node.parameters, node.body));
             }
 
-            const cls = createClassDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, node.name,
+            const modifiers = getExportModifierFromSource(node);
+            const cls = createClassDeclaration(/*decorators*/ undefined, modifiers, node.name,
                 /*typeParameters*/ undefined, /*heritageClauses*/ undefined, memberElements);
             // Don't call copyComments here because we'll already leave them in place
             return cls;
+        }
+
+        function getExportModifierFromSource(source: Node) {
+            return filter(source.modifiers, modifier => modifier.kind === SyntaxKind.ExportKeyword);
         }
     }
 }

--- a/tests/cases/fourslash/convertFunctionToEs6Class_exportModifier1.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class_exportModifier1.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: test123.js
+////export function /**/MyClass() {
+////}
+////MyClass.prototype.foo = function() {
+////}
+
+verify.applicableRefactorAvailableAtMarker("");
+verify.fileAfterApplyingRefactorAtMarker("",
+`export class MyClass {
+    constructor() {
+    }
+    foo() {
+    }
+}
+`,
+'Convert to ES2015 class', 'convert');

--- a/tests/cases/fourslash/convertFunctionToEs6Class_exportModifier2.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class_exportModifier2.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: test123.js
+////export const /**/foo = function() {
+////};
+////foo.prototype.instanceMethod = function() {
+////};
+
+verify.applicableRefactorAvailableAtMarker("");
+verify.fileAfterApplyingRefactorAtMarker("",
+`export class foo {
+    constructor() {
+    }
+    instanceMethod() {
+    }
+}
+`,
+'Convert to ES2015 class', 'convert');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #18435

Check modifiers when doing the conversion refactor and ensure the `export` modifier is included in the resulting class.
