### PR TITLE
Track recursive callback-covariance calls to compareSignaturesRelated

### DIFF
--- a/tests/baselines/reference/mutuallyRecursiveCallbacks.errors.txt
+++ b/tests/baselines/reference/mutuallyRecursiveCallbacks.errors.txt
@@ -1,0 +1,35 @@
+tests/cases/compiler/mutuallyRecursiveCallbacks.ts(6,1): error TS2322: Type '<T>(bar: Bar<T>) => void' is not assignable to type 'Bar<{}>'.
+  Types of parameters 'bar' and 'foo' are incompatible.
+    Types of parameters 'bar' and 'foo' are incompatible.
+      Types of parameters 'bar' and 'foo' are incompatible.
+        Type 'Foo<{}>' is not assignable to type 'Bar<{}>'.
+          Types of parameters 'bar' and 'foo' are incompatible.
+            Types of parameters 'bar' and 'foo' are incompatible.
+              Types of parameters 'bar' and 'foo' are incompatible.
+                Type 'Foo<{}>' is not assignable to type 'Bar<{}>'.
+                  Types of parameters 'bar' and 'foo' are incompatible.
+                    Types of parameters 'bar' and 'foo' are incompatible.
+                      Type 'void' is not assignable to type 'Foo<{}>'.
+
+
+==== tests/cases/compiler/mutuallyRecursiveCallbacks.ts (1 errors) ====
+    // #18277
+    interface Foo<T> { (bar: Bar<T>): void };
+    type Bar<T> = (foo: Foo<T>) => Foo<T>;
+    declare function foo<T>(bar: Bar<T>): void;
+    declare var bar: Bar<{}>;
+    bar = foo;
+    ~~~
+!!! error TS2322: Type '<T>(bar: Bar<T>) => void' is not assignable to type 'Bar<{}>'.
+!!! error TS2322:   Types of parameters 'bar' and 'foo' are incompatible.
+!!! error TS2322:     Types of parameters 'bar' and 'foo' are incompatible.
+!!! error TS2322:       Types of parameters 'bar' and 'foo' are incompatible.
+!!! error TS2322:         Type 'Foo<{}>' is not assignable to type 'Bar<{}>'.
+!!! error TS2322:           Types of parameters 'bar' and 'foo' are incompatible.
+!!! error TS2322:             Types of parameters 'bar' and 'foo' are incompatible.
+!!! error TS2322:               Types of parameters 'bar' and 'foo' are incompatible.
+!!! error TS2322:                 Type 'Foo<{}>' is not assignable to type 'Bar<{}>'.
+!!! error TS2322:                   Types of parameters 'bar' and 'foo' are incompatible.
+!!! error TS2322:                     Types of parameters 'bar' and 'foo' are incompatible.
+!!! error TS2322:                       Type 'void' is not assignable to type 'Foo<{}>'.
+    

--- a/tests/baselines/reference/mutuallyRecursiveCallbacks.js
+++ b/tests/baselines/reference/mutuallyRecursiveCallbacks.js
@@ -1,0 +1,12 @@
+//// [mutuallyRecursiveCallbacks.ts]
+// #18277
+interface Foo<T> { (bar: Bar<T>): void };
+type Bar<T> = (foo: Foo<T>) => Foo<T>;
+declare function foo<T>(bar: Bar<T>): void;
+declare var bar: Bar<{}>;
+bar = foo;
+
+
+//// [mutuallyRecursiveCallbacks.js]
+;
+bar = foo;

--- a/tests/baselines/reference/mutuallyRecursiveCallbacks.symbols
+++ b/tests/baselines/reference/mutuallyRecursiveCallbacks.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/mutuallyRecursiveCallbacks.ts ===
+// #18277
+interface Foo<T> { (bar: Bar<T>): void };
+>Foo : Symbol(Foo, Decl(mutuallyRecursiveCallbacks.ts, 0, 0))
+>T : Symbol(T, Decl(mutuallyRecursiveCallbacks.ts, 1, 14))
+>bar : Symbol(bar, Decl(mutuallyRecursiveCallbacks.ts, 1, 20))
+>Bar : Symbol(Bar, Decl(mutuallyRecursiveCallbacks.ts, 1, 41))
+>T : Symbol(T, Decl(mutuallyRecursiveCallbacks.ts, 1, 14))
+
+type Bar<T> = (foo: Foo<T>) => Foo<T>;
+>Bar : Symbol(Bar, Decl(mutuallyRecursiveCallbacks.ts, 1, 41))
+>T : Symbol(T, Decl(mutuallyRecursiveCallbacks.ts, 2, 9))
+>foo : Symbol(foo, Decl(mutuallyRecursiveCallbacks.ts, 2, 15))
+>Foo : Symbol(Foo, Decl(mutuallyRecursiveCallbacks.ts, 0, 0))
+>T : Symbol(T, Decl(mutuallyRecursiveCallbacks.ts, 2, 9))
+>Foo : Symbol(Foo, Decl(mutuallyRecursiveCallbacks.ts, 0, 0))
+>T : Symbol(T, Decl(mutuallyRecursiveCallbacks.ts, 2, 9))
+
+declare function foo<T>(bar: Bar<T>): void;
+>foo : Symbol(foo, Decl(mutuallyRecursiveCallbacks.ts, 2, 38))
+>T : Symbol(T, Decl(mutuallyRecursiveCallbacks.ts, 3, 21))
+>bar : Symbol(bar, Decl(mutuallyRecursiveCallbacks.ts, 3, 24))
+>Bar : Symbol(Bar, Decl(mutuallyRecursiveCallbacks.ts, 1, 41))
+>T : Symbol(T, Decl(mutuallyRecursiveCallbacks.ts, 3, 21))
+
+declare var bar: Bar<{}>;
+>bar : Symbol(bar, Decl(mutuallyRecursiveCallbacks.ts, 4, 11))
+>Bar : Symbol(Bar, Decl(mutuallyRecursiveCallbacks.ts, 1, 41))
+
+bar = foo;
+>bar : Symbol(bar, Decl(mutuallyRecursiveCallbacks.ts, 4, 11))
+>foo : Symbol(foo, Decl(mutuallyRecursiveCallbacks.ts, 2, 38))
+

--- a/tests/baselines/reference/mutuallyRecursiveCallbacks.types
+++ b/tests/baselines/reference/mutuallyRecursiveCallbacks.types
@@ -1,0 +1,34 @@
+=== tests/cases/compiler/mutuallyRecursiveCallbacks.ts ===
+// #18277
+interface Foo<T> { (bar: Bar<T>): void };
+>Foo : Foo<T>
+>T : T
+>bar : Bar<T>
+>Bar : Bar<T>
+>T : T
+
+type Bar<T> = (foo: Foo<T>) => Foo<T>;
+>Bar : Bar<T>
+>T : T
+>foo : Foo<T>
+>Foo : Foo<T>
+>T : T
+>Foo : Foo<T>
+>T : T
+
+declare function foo<T>(bar: Bar<T>): void;
+>foo : <T>(bar: Bar<T>) => void
+>T : T
+>bar : Bar<T>
+>Bar : Bar<T>
+>T : T
+
+declare var bar: Bar<{}>;
+>bar : Bar<{}>
+>Bar : Bar<T>
+
+bar = foo;
+>bar = foo : <T>(bar: Bar<T>) => void
+>bar : Bar<{}>
+>foo : <T>(bar: Bar<T>) => void
+

--- a/tests/cases/compiler/mutuallyRecursiveCallbacks.ts
+++ b/tests/cases/compiler/mutuallyRecursiveCallbacks.ts
@@ -1,0 +1,6 @@
+// #18277
+interface Foo<T> { (bar: Bar<T>): void };
+type Bar<T> = (foo: Foo<T>) => Foo<T>;
+declare function foo<T>(bar: Bar<T>): void;
+declare var bar: Bar<{}>;
+bar = foo;


### PR DESCRIPTION
Previously, `compareSignaturesRelated` would try to relate (parameters of) callback parameters covariantly without checking whether the two signatures were already being checked. This led to an infinite recursion when checking recursive types with callbacks:

```ts
interface Foo<T> { (bar: Bar<T>): void }
type Bar<T> = (foo: Foo<T>) => Foo<T>
declare function foo<T>(bar: Bar<T>): void
declare var bar: Bar<{}>
bar = foo
```

The fix is to track which callbacks are already being compared. The mechanism is per-call to compareSignaturesRelated, so it only stops recursions on the callback-covariance code path. However, the maybe cache check in recursiveTypeRelatedTo will catch infinite recursions on the usual code path through isRelatedTo.

Fixes #18277