### PR TITLE
In tsserver, indent logged JSON

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -350,14 +350,14 @@ namespace ts.server {
             const request = createInstallTypingsRequest(project, typeAcquisition, unresolvedImports);
             if (this.logger.hasLevel(LogLevel.verbose)) {
                 if (this.logger.hasLevel(LogLevel.verbose)) {
-                    this.logger.info(`Scheduling throttled operation: ${JSON.stringify(request)}`);
+                    this.logger.info(`Scheduling throttled operation:${stringifyIndented(request)}`);
                 }
             }
 
             const operationId = project.getProjectName();
             const operation = () => {
                 if (this.logger.hasLevel(LogLevel.verbose)) {
-                    this.logger.info(`Sending request: ${JSON.stringify(request)}`);
+                    this.logger.info(`Sending request:${stringifyIndented(request)}`);
                 }
                 this.installer.send(request);
             };
@@ -377,7 +377,7 @@ namespace ts.server {
 
         private handleMessage(response: SetTypings | InvalidateCachedTypings | BeginInstallTypes | EndInstallTypes | InitializationFailedResponse) {
             if (this.logger.hasLevel(LogLevel.verbose)) {
-                this.logger.info(`Received response: ${JSON.stringify(response)}`);
+                this.logger.info(`Received response:${stringifyIndented(response)}`);
             }
 
             switch (response.kind) {
@@ -767,7 +767,7 @@ namespace ts.server {
                 try {
                     const args = [combinePaths(__dirname, "watchGuard.js"), path];
                     if (logger.hasLevel(LogLevel.verbose)) {
-                        logger.info(`Starting ${process.execPath} with args ${JSON.stringify(args)}`);
+                        logger.info(`Starting ${process.execPath} with args:${stringifyIndented(args)}`);
                     }
                     childProcess.execFileSync(process.execPath, args, { stdio: "ignore", env: { "ELECTRON_RUN_AS_NODE": "1" } });
                     status = true;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -131,7 +131,7 @@ namespace ts.server {
 
         const json = JSON.stringify(msg);
         if (verboseLogging) {
-            logger.info(msg.type + ": " + json);
+            logger.info(msg.type + ":\n" + indent(json));
         }
 
         const len = byteLength(json, "utf8");
@@ -383,9 +383,9 @@ namespace ts.server {
         public logError(err: Error, cmd: string) {
             let msg = "Exception on executing command " + cmd;
             if (err.message) {
-                msg += ":\n" + err.message;
+                msg += ":\n" + indent(err.message);
                 if ((<StackTraceError>err).stack) {
-                    msg += "\n" + (<StackTraceError>err).stack;
+                    msg += "\n" + indent((<StackTraceError>err).stack);
                 }
             }
             this.logger.msg(msg, Msg.Err);
@@ -1957,7 +1957,7 @@ namespace ts.server {
                 return this.executeWithRequestId(request.seq, () => handler(request));
             }
             else {
-                this.logger.msg(`Unrecognized JSON command: ${JSON.stringify(request)}`, Msg.Err);
+                this.logger.msg(`Unrecognized JSON command:${stringifyIndented(request)}`, Msg.Err);
                 this.output(undefined, CommandNames.Unknown, request.seq, `Unrecognized JSON command: ${request.command}`);
                 return { responseRequired: false };
             }
@@ -1969,7 +1969,7 @@ namespace ts.server {
             if (this.logger.hasLevel(LogLevel.requestTime)) {
                 start = this.hrtime();
                 if (this.logger.hasLevel(LogLevel.verbose)) {
-                    this.logger.info(`request: ${message}`);
+                    this.logger.info(`request:${indent(message)}`);
                 }
             }
 

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -141,7 +141,7 @@ namespace ts.server.typingsInstaller {
 
         protected sendResponse(response: SetTypings | InvalidateCachedTypings | BeginInstallTypes | EndInstallTypes | InitializationFailedResponse) {
             if (this.log.isEnabled()) {
-                this.log.writeLine(`Sending response: ${JSON.stringify(response)}`);
+                this.log.writeLine(`Sending response:\n    ${JSON.stringify(response)}`);
             }
             process.send(response);
             if (this.log.isEnabled()) {

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -318,4 +318,15 @@ namespace ts.server {
             deleted(oldItems[oldIndex++]);
         }
     }
+
+    /* @internal */
+    export function indent(string: string): string {
+        return "\n    " + string;
+    }
+
+    /** Put stringified JSON on the next line, indented. */
+    /* @internal */
+    export function stringifyIndented(json: {}): string {
+        return "\n    " + JSON.stringify(json);
+    }
 }


### PR DESCRIPTION
Old:
```
Info 9    [14:7:29.315] request: {"seq":2,"type":"request","command":"open","arguments":{"file":"/home/andy/sample/ts/src/a.ts","fileContent":"const x = 0;\n","scriptKindName":"TS","projectRootPath":"/home/andy/sample/ts"}}
```

New:
```
Info 9    [14:6:59.951] request:
    {"seq":2,"type":"request","command":"open","arguments":{"file":"/home/andy/sample/ts/src/a.ts","fileContent":"const x = 0;\n","scriptKindName":"TS","projectRootPath":"/home/andy/sample/ts"}}
```

This is useful for large JSON strings: most text editors will allow you to collapse large indented sections.