### PR TITLE
Do not rely on parent pointers in the binder

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -143,6 +143,15 @@ namespace ts {
         let subtreeTransformFlags: TransformFlags = TransformFlags.None;
         let skipTransformFlagAggregation: boolean;
 
+        /**
+         * Inside the binder, we may create a diagnostic for an as-yet unbound node (with potentially no parent pointers, implying no accessible source file)
+         * If so, the node _must_ be in the current file (as that's the only way anything could have traversed to it to yield it as the error node)
+         * This version of `createDiagnosticForNode` uses the binder's context to account for this, and always yields correct diagnostics even in these situations.
+         */
+        function createDiagnosticForNode(node: Node, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number): Diagnostic {
+            return createDiagnosticForNodeInSourceFile(getSourceFileOfNode(node) || file, node, message, arg0, arg1, arg2);
+        }
+
         function bindSourceFile(f: SourceFile, opts: CompilerOptions) {
             file = f;
             options = opts;


### PR DESCRIPTION
Our internal CI had failing unit tests because it ran under the `light` flag. Under this flag we do not set parent pointers in the parser, meaning they get set in the binder. The issue with this is that we recently started issuing diagnostics on nodes which had not yet been reached in the binder's walk. As they had no parent pointers, the container source file was not available, thus: errors. With this change, we account for this by overriding `createDiagnosticForNode` within the binder to, if a source file is not reachable from a node, use the file currently being bound (as any node passed must have been reached from the current file if it is not already bound).
