### PR TITLE
Stop erroneous match of midfile sourceMappingUrl, fix runtests-browser

### DIFF
--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -619,7 +619,7 @@ namespace ts.projectSystem {
             assert.isTrue(host.fileExists(expectedOutFileName));
             const outFileContent = host.readFile(expectedOutFileName);
             verifyContentHasString(outFileContent, file1.content);
-            verifyContentHasString(outFileContent, `//# sourceMappingURL=${outFileName}.map`);
+            verifyContentHasString(outFileContent, `//# ${"sourceMappingURL"}=${outFileName}.map`); // Sometimes tools can sometimes see this line as a source mapping url comment, so we obfuscate it a little
 
             // Verify map file
             const expectedMapFileName = expectedOutFileName + ".map";


### PR DESCRIPTION
[As you can see](https://github.com/Microsoft/TypeScript/search?l=TypeScript&q=sourceMappingURL&type=&utf8=%E2%9C%93), this is not the first time we have had to contend with our build tools being a little loose with what they'll consider as a valid `sourceMappingURL` comment. Twas not a dependeny update that broke us, but the introduction of another such psuedo-comment.

Fixes #19075
