### PR TITLE
Ensure Async Modifier is maintained through ES6 Class Conversion

### DIFF
--- a/src/services/refactors/convertFunctionToEs6Class.ts
+++ b/src/services/refactors/convertFunctionToEs6Class.ts
@@ -172,7 +172,8 @@ namespace ts.refactor.convertFunctionToES6Class {
                 switch (assignmentBinaryExpression.right.kind) {
                     case SyntaxKind.FunctionExpression: {
                         const functionExpression = assignmentBinaryExpression.right as FunctionExpression;
-                        const method = createMethod(/*decorators*/ undefined, modifiers, /*asteriskToken*/ undefined, memberDeclaration.name, /*questionToken*/ undefined,
+                        const fullModifiers = concatenate(modifiers, getModifierKindFromSource(functionExpression, SyntaxKind.AsyncKeyword));
+                        const method = createMethod(/*decorators*/ undefined, fullModifiers, /*asteriskToken*/ undefined, memberDeclaration.name, /*questionToken*/ undefined,
                             /*typeParameters*/ undefined, functionExpression.parameters, /*type*/ undefined, functionExpression.body);
                         copyComments(assignmentBinaryExpression, method);
                         return method;
@@ -192,7 +193,8 @@ namespace ts.refactor.convertFunctionToES6Class {
                             const expression = arrowFunctionBody as Expression;
                             bodyBlock = createBlock([createReturn(expression)]);
                         }
-                        const method = createMethod(/*decorators*/ undefined, modifiers, /*asteriskToken*/ undefined, memberDeclaration.name, /*questionToken*/ undefined,
+                        const fullModifiers = concatenate(modifiers, getModifierKindFromSource(arrowFunction, SyntaxKind.AsyncKeyword));
+                        const method = createMethod(/*decorators*/ undefined, fullModifiers, /*asteriskToken*/ undefined, memberDeclaration.name, /*questionToken*/ undefined,
                             /*typeParameters*/ undefined, arrowFunction.parameters, /*type*/ undefined, bodyBlock);
                         copyComments(assignmentBinaryExpression, method);
                         return method;
@@ -243,7 +245,7 @@ namespace ts.refactor.convertFunctionToES6Class {
                 memberElements.unshift(createConstructor(/*decorators*/ undefined, /*modifiers*/ undefined, initializer.parameters, initializer.body));
             }
 
-            const modifiers = getExportModifierFromSource(precedingNode);
+            const modifiers = getModifierKindFromSource(precedingNode, SyntaxKind.ExportKeyword);
             const cls = createClassDeclaration(/*decorators*/ undefined, modifiers, node.name,
                 /*typeParameters*/ undefined, /*heritageClauses*/ undefined, memberElements);
             // Don't call copyComments here because we'll already leave them in place
@@ -256,15 +258,15 @@ namespace ts.refactor.convertFunctionToES6Class {
                 memberElements.unshift(createConstructor(/*decorators*/ undefined, /*modifiers*/ undefined, node.parameters, node.body));
             }
 
-            const modifiers = getExportModifierFromSource(node);
+            const modifiers = getModifierKindFromSource(node, SyntaxKind.ExportKeyword);
             const cls = createClassDeclaration(/*decorators*/ undefined, modifiers, node.name,
                 /*typeParameters*/ undefined, /*heritageClauses*/ undefined, memberElements);
             // Don't call copyComments here because we'll already leave them in place
             return cls;
         }
 
-        function getExportModifierFromSource(source: Node) {
-            return filter(source.modifiers, modifier => modifier.kind === SyntaxKind.ExportKeyword);
+        function getModifierKindFromSource(source: Node, kind: SyntaxKind) {
+            return filter(source.modifiers, modifier => modifier.kind === kind);
         }
     }
 }

--- a/tests/cases/fourslash/convertFunctionToEs6Class_asyncMethods.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class_asyncMethods.ts
@@ -1,0 +1,27 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: test123.js
+////export function /**/MyClass() {
+////}
+////MyClass.prototype.foo = async function() {
+////    await 2;
+////}
+////MyClass.bar = async function() {
+////    await 3;
+////}
+
+verify.applicableRefactorAvailableAtMarker("");
+verify.fileAfterApplyingRefactorAtMarker("",
+`export class MyClass {
+    constructor() {
+    }
+    async foo() {
+        await 2;
+    }
+    static async bar() {
+        await 3;
+    }
+}
+`,
+'Convert to ES2015 class', 'convert');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes related issue raised by @mhegazy in #19070 : Updates 'Convert to ES2015 Class' refactor to correctly maintain `async` modifier in methods / static methods.
