### PR TITLE
Update PR template to use `help wanted` instead of `Accepting PRs`

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,7 +3,7 @@ Thank you for submitting a pull request!
 
 Here's a checklist you might find useful.
 [ ] There is an associated issue that is labelled
-  'Bug' or 'Accepting PRs' or is in the Community milestone
+  'Bug' or 'help wanted' or is in the Community milestone
 [ ] Code is up-to-date with the `master` branch
 [ ] You've successfully run `jake runtests` locally
 [ ] You've signed the CLA


### PR DESCRIPTION
Github now supports a standardized label for contributions under `"help wanted"`. I have renamed our `"Accepting PRs"` to be `"help wanted"`.  This is a change to the template to reflect that.