### PR TITLE
Enable `noFallthroughCasesInSwitch`

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -355,7 +355,7 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, opts
         else {
             options += " --lib es5"
         }
-        options += " --noUnusedLocals --noUnusedParameters";
+        options += " --noUnusedLocals --noUnusedParameters --noFallthroughCasesInSwitch";
 
         var cmd = host + " " + compilerPath + " " + options + " ";
         cmd = cmd + sources.join(" ");

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1401,11 +1401,11 @@ namespace ts {
                 case SyntaxKind.SourceFile:
                     return ContainerFlags.IsContainer | ContainerFlags.IsControlFlowContainer | ContainerFlags.HasLocals;
 
+                // @ts-ignore falls through
                 case SyntaxKind.MethodDeclaration:
                     if (isObjectLiteralOrClassExpressionMethod(node)) {
                         return ContainerFlags.IsContainer | ContainerFlags.IsControlFlowContainer | ContainerFlags.HasLocals | ContainerFlags.IsFunctionLike | ContainerFlags.IsObjectLiteralOrClassExpressionMethod;
                     }
-                // falls through
                 case SyntaxKind.Constructor:
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.MethodSignature:
@@ -1700,12 +1700,12 @@ namespace ts {
                 case SyntaxKind.ModuleDeclaration:
                     declareModuleMember(node, symbolFlags, symbolExcludes);
                     break;
+                // @ts-ignore falls through
                 case SyntaxKind.SourceFile:
                     if (isExternalModule(<SourceFile>container)) {
                         declareModuleMember(node, symbolFlags, symbolExcludes);
                         break;
                     }
-                // falls through
                 default:
                     if (!blockScopeContainer.locals) {
                         blockScopeContainer.locals = createSymbolTable();
@@ -1980,6 +1980,7 @@ namespace ts {
         function bindWorker(node: Node) {
             switch (node.kind) {
                 /* Strict mode checks */
+                // @ts-ignore falls through
                 case SyntaxKind.Identifier:
                     // for typedef type names with namespaces, bind the new jsdoc type symbol here
                     // because it requires all containing namespaces to be in effect, namely the
@@ -1992,7 +1993,6 @@ namespace ts {
                         bindBlockScopedDeclaration(<Declaration>parentNode, SymbolFlags.TypeAlias, SymbolFlags.TypeAliasExcludes);
                         break;
                     }
-                // falls through
                 case SyntaxKind.ThisKeyword:
                     if (currentFlow && (isExpression(node) || parent.kind === SyntaxKind.ShorthandPropertyAssignment)) {
                         node.flowNode = currentFlow;
@@ -2140,19 +2140,19 @@ namespace ts {
                 case SyntaxKind.SourceFile:
                     updateStrictModeStatementList((<SourceFile>node).statements);
                     return bindSourceFileIfExternalModule();
+                // @ts-ignore falls through
                 case SyntaxKind.Block:
                     if (!isFunctionLike(node.parent)) {
                         return;
                     }
-                // falls through
                 case SyntaxKind.ModuleBlock:
                     return updateStrictModeStatementList((<Block | ModuleBlock>node).statements);
 
+                // @ts-ignore falls through
                 case SyntaxKind.JSDocParameterTag:
                     if (node.parent.kind !== SyntaxKind.JSDocTypeLiteral) {
                         break;
                     }
-                    // falls through
                 case SyntaxKind.JSDocPropertyTag:
                     const propTag = node as JSDocPropertyLikeTag;
                     const flags = propTag.isBracketed || propTag.typeExpression && propTag.typeExpression.type.kind === SyntaxKind.JSDocOptionalType ?

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -959,10 +959,10 @@ namespace ts {
                     }
                 }
                 switch (location.kind) {
+                    // @ts-ignore falls through
                     case SyntaxKind.SourceFile:
                         if (!isExternalOrCommonJsModule(<SourceFile>location)) break;
                         isInExternalModule = true;
-                        // falls through
                     case SyntaxKind.ModuleDeclaration:
                         const moduleExports = getSymbolOfNode(location).exports;
                         if (location.kind === SyntaxKind.SourceFile || isAmbientModule(location)) {
@@ -1288,11 +1288,11 @@ namespace ts {
                 case SyntaxKind.Identifier:
                 case SyntaxKind.PropertyAccessExpression:
                     return node.parent ? getEntityNameForExtendingInterface(node.parent) : undefined;
+                // @ts-ignore falls through
                 case SyntaxKind.ExpressionWithTypeArguments:
                     if (isEntityNameExpression((<ExpressionWithTypeArguments>node).expression)) {
                         return <EntityNameExpression>(<ExpressionWithTypeArguments>node).expression;
                     }
-                    // falls through
                 default:
                     return undefined;
             }
@@ -2075,11 +2075,11 @@ namespace ts {
                     }
                 }
                 switch (location.kind) {
+                    // @ts-ignore falls through
                     case SyntaxKind.SourceFile:
                         if (!isExternalOrCommonJsModule(<SourceFile>location)) {
                             break;
                         }
-                        // falls through
                     case SyntaxKind.ModuleDeclaration:
                         if (result = callback(getSymbolOfNode(location).exports)) {
                             return result;
@@ -3899,13 +3899,13 @@ namespace ts {
                 switch (node.kind) {
                     case SyntaxKind.BindingElement:
                         return isDeclarationVisible(<Declaration>node.parent.parent);
+                    // @ts-ignore falls through
                     case SyntaxKind.VariableDeclaration:
                         if (isBindingPattern((node as VariableDeclaration).name) &&
                             !((node as VariableDeclaration).name as BindingPattern).elements.length) {
                             // If the binding pattern is empty, this variable declaration is not visible
                             return false;
                         }
-                        // falls through
                     case SyntaxKind.ModuleDeclaration:
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.InterfaceDeclaration:
@@ -3931,13 +3931,13 @@ namespace ts {
                     case SyntaxKind.GetAccessor:
                     case SyntaxKind.SetAccessor:
                     case SyntaxKind.MethodDeclaration:
+                    // @ts-ignore falls through
                     case SyntaxKind.MethodSignature:
                         if (hasModifier(node, ModifierFlags.Private | ModifierFlags.Protected)) {
                             // Private/protected properties/methods are not visible
                             return false;
                         }
                         // Public properties/methods are visible if its parents are visible, so:
-                        // falls through
 
                     case SyntaxKind.Constructor:
                     case SyntaxKind.ConstructSignature:
@@ -13319,13 +13319,13 @@ namespace ts {
                     switch (getSpecialPropertyAssignmentKind(binaryExpression)) {
                         case SpecialPropertyAssignmentKind.None:
                             break;
+                        // @ts-ignore falls through
                         case SpecialPropertyAssignmentKind.Property:
                             // If `binaryExpression.left` was assigned a symbol, then this is a new declaration; otherwise it is an assignment to an existing declaration.
                             // See `bindStaticPropertyAssignment` in `binder.ts`.
                             if (!binaryExpression.left.symbol) {
                                 break;
                             }
-                            // falls through
                         case SpecialPropertyAssignmentKind.ExportsProperty:
                         case SpecialPropertyAssignmentKind.ModuleExports:
                         case SpecialPropertyAssignmentKind.PrototypeProperty:
@@ -18430,11 +18430,11 @@ namespace ts {
                     return checkPropertyAccessExpression(<PropertyAccessExpression>node);
                 case SyntaxKind.ElementAccessExpression:
                     return checkIndexedAccess(<ElementAccessExpression>node);
+                // @ts-ignore falls through
                 case SyntaxKind.CallExpression:
                     if ((<CallExpression>node).expression.kind === SyntaxKind.ImportKeyword) {
                         return checkImportCallExpression(<ImportCall>node);
                     }
-                    /* falls through */
                 case SyntaxKind.NewExpression:
                     return checkCallExpression(<CallExpression>node);
                 case SyntaxKind.TaggedTemplateExpression:
@@ -22383,6 +22383,7 @@ namespace ts {
                     grammarErrorOnFirstToken(node, Diagnostics.Imports_are_not_permitted_in_module_augmentations_Consider_moving_them_to_the_enclosing_external_module);
                     break;
                 case SyntaxKind.BindingElement:
+                // @ts-ignore falls through
                 case SyntaxKind.VariableDeclaration:
                     const name = (<VariableDeclaration | BindingElement>node).name;
                     if (isBindingPattern(name)) {
@@ -22392,7 +22393,6 @@ namespace ts {
                         }
                         break;
                     }
-                    // falls through
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.EnumDeclaration:
                 case SyntaxKind.FunctionDeclaration:
@@ -22795,9 +22795,9 @@ namespace ts {
                     return checkJSDocTypedefTag(node as JSDocTypedefTag);
                 case SyntaxKind.JSDocParameterTag:
                     return checkJSDocParameterTag(node as JSDocParameterTag);
+                // @ts-ignore falls through
                 case SyntaxKind.JSDocFunctionType:
                     checkSignatureDeclaration(node as JSDocFunctionType);
-                    // falls through
                 case SyntaxKind.JSDocVariadicType:
                 case SyntaxKind.JSDocNonNullableType:
                 case SyntaxKind.JSDocNullableType:
@@ -23077,12 +23077,12 @@ namespace ts {
                         case SyntaxKind.EnumDeclaration:
                             copySymbols(getSymbolOfNode(location).exports, meaning & SymbolFlags.EnumMember);
                             break;
+                        // @ts-ignore falls through
                         case SyntaxKind.ClassExpression:
                             const className = (<ClassExpression>location).name;
                             if (className) {
                                 copySymbol(location.symbol, meaning);
                             }
-                        // falls through
                         // this fall-through is necessary because we would like to handle
                         // type parameter inside class expression similar to how we handle it in classDeclaration and interface Declaration
                         case SyntaxKind.ClassDeclaration:
@@ -23387,6 +23387,7 @@ namespace ts {
                 case SyntaxKind.QualifiedName:
                     return getSymbolOfEntityNameOrPropertyAccessExpression(<EntityName | PropertyAccessExpression>node);
 
+                // @ts-ignore falls through
                 case SyntaxKind.ThisKeyword:
                     const container = getThisContainer(node, /*includeArrowFunctions*/ false);
                     if (isFunctionLike(container)) {
@@ -23398,7 +23399,6 @@ namespace ts {
                     if (isInExpressionContext(node)) {
                         return checkExpression(node as Expression).symbol;
                     }
-                    // falls through
 
                 case SyntaxKind.ThisType:
                     return getTypeFromThisTypeNode(node as ThisExpression | ThisTypeNode).symbol;
@@ -23414,6 +23414,7 @@ namespace ts {
                     }
                     return undefined;
 
+                // @ts-ignore falls through
                 case SyntaxKind.StringLiteral:
                     // 1). import x = require("./mo/*gotToDefinitionHere*/d")
                     // 2). External module name in an import declaration
@@ -23423,7 +23424,6 @@ namespace ts {
                         ((isInJavaScriptFile(node) && isRequireCall(node.parent, /*checkArgumentIsStringLiteral*/ false)) || isImportCall(node.parent))) {
                         return resolveExternalModuleName(node, <LiteralExpression>node);
                     }
-                    // falls through
 
                 case SyntaxKind.NumericLiteral:
                     // index access

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -4027,11 +4027,11 @@ namespace ts {
                     node = (<ConditionalExpression>node).condition;
                     continue;
 
+                // @ts-ignore falls through
                 case SyntaxKind.CallExpression:
                     if (stopAtCallExpressions) {
                         return node;
                     }
-                    // falls through
                 case SyntaxKind.ElementAccessExpression:
                 case SyntaxKind.PropertyAccessExpression:
                     node = (<CallExpression | PropertyAccessExpression | ElementAccessExpression>node).expression;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3738,11 +3738,11 @@ namespace ts {
                     //  UnaryExpression (modified):
                     //      < type > UnaryExpression
                     return parseTypeAssertion();
+                // @ts-ignore falls through
                 case SyntaxKind.AwaitKeyword:
                     if (isAwaitExpression()) {
                         return parseAwaitExpression();
                     }
-                    // falls through
                 default:
                     return parseUpdateExpression();
             }
@@ -3771,13 +3771,13 @@ namespace ts {
                 case SyntaxKind.VoidKeyword:
                 case SyntaxKind.AwaitKeyword:
                     return false;
+                // @ts-ignore falls through
                 case SyntaxKind.LessThanToken:
                     // If we are not in JSX context, we are parsing TypeAssertion which is an UnaryExpression
                     if (sourceFile.languageVariant !== LanguageVariant.JSX) {
                         return false;
                     }
                     // We are in JSX context and the token is part of JSXElement.
-                    // falls through
                 default:
                     return true;
             }
@@ -6450,6 +6450,7 @@ namespace ts {
                                     indent += whitespace.length;
                                 }
                                 break;
+                            // @ts-ignore falls through
                             case SyntaxKind.AsteriskToken:
                                 if (state === JSDocState.BeginningOfLine) {
                                     // leading asterisks start recording on the *next* (non-whitespace) token
@@ -6458,7 +6459,6 @@ namespace ts {
                                     break;
                                 }
                                 // record the * as a comment
-                                // falls through
                             default:
                                 state = JSDocState.SavingComments; // leading identifiers start recording as well
                                 pushComment(scanner.getTokenText());

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1329,12 +1329,12 @@ namespace ts {
 
                     switch (parent.kind) {
                         case SyntaxKind.Parameter:
+                        // @ts-ignore falls through
                         case SyntaxKind.PropertyDeclaration:
                             if ((<ParameterDeclaration | PropertyDeclaration>parent).questionToken === node) {
                                 diagnostics.push(createDiagnosticForNode(node, Diagnostics._0_can_only_be_used_in_a_ts_file, "?"));
                                 return;
                             }
-                        // falls through
                         case SyntaxKind.MethodDeclaration:
                         case SyntaxKind.MethodSignature:
                         case SyntaxKind.Constructor:
@@ -1410,13 +1410,13 @@ namespace ts {
                         case SyntaxKind.SetAccessor:
                         case SyntaxKind.FunctionExpression:
                         case SyntaxKind.FunctionDeclaration:
+                        // @ts-ignore falls through
                         case SyntaxKind.ArrowFunction:
                             // Check type parameters
                             if (nodes === (<ClassDeclaration | FunctionLikeDeclaration>parent).typeParameters) {
                                 diagnostics.push(createDiagnosticForNodeArray(nodes, Diagnostics.type_parameter_declarations_can_only_be_used_in_a_ts_file));
                                 return;
                             }
-                        // falls through
                         case SyntaxKind.VariableStatement:
                             // Check modifiers
                             if (nodes === (<ClassDeclaration | FunctionLikeDeclaration | VariableStatement>parent).modifiers) {
@@ -1460,12 +1460,11 @@ namespace ts {
                 function checkModifiers(modifiers: NodeArray<Modifier>, isConstValid: boolean) {
                     for (const modifier of modifiers) {
                         switch (modifier.kind) {
+                            // @ts-ignore falls through
                             case SyntaxKind.ConstKeyword:
                                 if (isConstValid) {
                                     continue;
                                 }
-                            // to report error,
-                            // falls through
                             case SyntaxKind.PublicKeyword:
                             case SyntaxKind.PrivateKeyword:
                             case SyntaxKind.ProtectedKeyword:

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -304,11 +304,11 @@ namespace ts {
            const ch = text.charCodeAt(pos);
            pos++;
            switch (ch) {
+                // @ts-ignore falls through
                 case CharacterCodes.carriageReturn:
                     if (text.charCodeAt(pos) === CharacterCodes.lineFeed) {
                         pos++;
                     }
-                    // falls through
                 case CharacterCodes.lineFeed:
                     result.push(lineStart);
                     lineStart = pos;
@@ -459,11 +459,11 @@ namespace ts {
           while (true) {
               const ch = text.charCodeAt(pos);
               switch (ch) {
+                  // @ts-ignore falls through
                   case CharacterCodes.carriageReturn:
                       if (text.charCodeAt(pos + 1) === CharacterCodes.lineFeed) {
                           pos++;
                       }
-                      // falls through
                   case CharacterCodes.lineFeed:
                       pos++;
                       if (stopAfterLineBreak) {
@@ -632,11 +632,11 @@ namespace ts {
         scan: while (pos >= 0 && pos < text.length) {
             const ch = text.charCodeAt(pos);
             switch (ch) {
+                // @ts-ignore falls through
                 case CharacterCodes.carriageReturn:
                     if (text.charCodeAt(pos + 1) === CharacterCodes.lineFeed) {
                         pos++;
                     }
-                    // falls through
                 case CharacterCodes.lineFeed:
                     pos++;
                     if (trailing) {
@@ -1081,11 +1081,11 @@ namespace ts {
 
                 // when encountering a LineContinuation (i.e. a backslash and a line terminator sequence),
                 // the line terminator is interpreted to be "the empty code unit sequence".
+                // @ts-ignore falls through
                 case CharacterCodes.carriageReturn:
                     if (pos < end && text.charCodeAt(pos) === CharacterCodes.lineFeed) {
                         pos++;
                     }
-                    // falls through
                 case CharacterCodes.lineFeed:
                 case CharacterCodes.lineSeparator:
                 case CharacterCodes.paragraphSeparator:
@@ -1429,6 +1429,7 @@ namespace ts {
                         pos++;
                         return token = SyntaxKind.SlashToken;
 
+                    // @ts-ignore falls through
                     case CharacterCodes._0:
                         if (pos + 2 < end && (text.charCodeAt(pos + 1) === CharacterCodes.X || text.charCodeAt(pos + 1) === CharacterCodes.x)) {
                             pos += 2;
@@ -1472,7 +1473,6 @@ namespace ts {
                         // This fall-through is a deviation from the EcmaScript grammar. The grammar says that a leading zero
                         // can only be followed by an octal digit, a dot, or the end of the number literal. However, we are being
                         // permissive and allowing decimal digits of the form 08* and 09* (which many browsers also do).
-                        // falls through
                     case CharacterCodes._1:
                     case CharacterCodes._2:
                     case CharacterCodes._3:

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -471,13 +471,13 @@ namespace ts {
                 for (const entry of group.externalImports) {
                     const importVariableName = getLocalNameForExternalImport(entry, currentSourceFile);
                     switch (entry.kind) {
+                        // @ts-ignore falls through
                         case SyntaxKind.ImportDeclaration:
                             if (!(<ImportDeclaration>entry).importClause) {
                                 // 'import "..."' case
                                 // module is imported only for side-effects, no emit required
                                 break;
                             }
-                            // falls through
 
                         case SyntaxKind.ImportEqualsDeclaration:
                             Debug.assert(importVariableName !== undefined);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -735,6 +735,7 @@ namespace ts {
 
             // Identifiers and qualified names may be type nodes, depending on their context. Climb
             // above them to find the lowest container
+            // @ts-ignore falls through
             case SyntaxKind.Identifier:
                 // If the identifier is the RHS of a qualified name, then it's a type iff its parent is.
                 if (node.parent.kind === SyntaxKind.QualifiedName && (<QualifiedName>node.parent).right === node) {
@@ -746,7 +747,6 @@ namespace ts {
                 // At this point, node is either a qualified name or an identifier
                 Debug.assert(node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.QualifiedName || node.kind === SyntaxKind.PropertyAccessExpression,
                     "'node' was expected to be a qualified name, identifier or property access in 'isPartOfTypeNode'.");
-                // falls through
             case SyntaxKind.QualifiedName:
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ThisKeyword:
@@ -1017,11 +1017,11 @@ namespace ts {
                         node = node.parent;
                     }
                     break;
+                // @ts-ignore falls through
                 case SyntaxKind.ArrowFunction:
                     if (!includeArrowFunctions) {
                         continue;
                     }
-                    // falls through
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.FunctionExpression:
                 case SyntaxKind.ModuleDeclaration:
@@ -1076,11 +1076,11 @@ namespace ts {
                     break;
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.FunctionExpression:
+                // @ts-ignore falls through
                 case SyntaxKind.ArrowFunction:
                     if (!stopOnFunctions) {
                         continue;
                     }
-                    // falls through
                 case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.PropertySignature:
                 case SyntaxKind.MethodDeclaration:
@@ -1260,11 +1260,11 @@ namespace ts {
                     node = node.parent;
                 }
                 return node.parent.kind === SyntaxKind.TypeQuery || isJSXTagName(node);
+            // @ts-ignore falls through
             case SyntaxKind.Identifier:
                 if (node.parent.kind === SyntaxKind.TypeQuery || isJSXTagName(node)) {
                     return true;
                 }
-                // falls through
             case SyntaxKind.NumericLiteral:
             case SyntaxKind.StringLiteral:
             case SyntaxKind.ThisKeyword:
@@ -1890,11 +1890,11 @@ namespace ts {
         switch (node.kind) {
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:
+            // @ts-ignore falls through
             case SyntaxKind.MethodDeclaration:
                 if (node.asteriskToken) {
                     flags |= FunctionFlags.Generator;
                 }
-                // falls through
             case SyntaxKind.ArrowFunction:
                 if (hasModifier(node, ModifierFlags.Async)) {
                     flags |= FunctionFlags.Async;

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -1362,9 +1362,9 @@ namespace ts {
                 break;
 
             // Clauses
+            // @ts-ignore falls through
             case SyntaxKind.CaseClause:
                 result = reduceNode((<CaseClause>node).expression, cbNode, result);
-                // falls through
 
             case SyntaxKind.DefaultClause:
                 result = reduceNodes((<CaseClause | DefaultClause>node).statements, cbNodes, result);

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -93,11 +93,11 @@ namespace ts.BreakpointResolver {
                     case SyntaxKind.ArrowFunction:
                         return spanInFunctionDeclaration(<FunctionLikeDeclaration>node);
 
+                    // @ts-ignore falls through
                     case SyntaxKind.Block:
                         if (isFunctionBlock(node)) {
                             return spanInFunctionBlock(<Block>node);
                         }
-                        // falls through
                     case SyntaxKind.ModuleBlock:
                         return spanInBlock(<Block>node);
 
@@ -181,12 +181,12 @@ namespace ts.BreakpointResolver {
                         // import statement without including semicolon
                         return textSpan(node, (<ExportDeclaration>node).moduleSpecifier);
 
+                    // @ts-ignore falls through
                     case SyntaxKind.ModuleDeclaration:
                         // span on complete module if it is instantiated
                         if (getModuleInstanceState(node) !== ModuleInstanceState.Instantiated) {
                             return undefined;
                         }
-                        // falls through
 
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.EnumDeclaration:
@@ -470,11 +470,11 @@ namespace ts.BreakpointResolver {
 
             function spanInBlock(block: Block): TextSpan {
                 switch (block.parent.kind) {
+                    // @ts-ignore falls through
                     case SyntaxKind.ModuleDeclaration:
                         if (getModuleInstanceState(block.parent) !== ModuleInstanceState.Instantiated) {
                             return undefined;
                         }
-                        // falls through
 
                     // Set on parent if on same line otherwise on first statement
                     case SyntaxKind.WhileStatement:
@@ -579,24 +579,24 @@ namespace ts.BreakpointResolver {
 
             function spanInCloseBraceToken(node: Node): TextSpan {
                 switch (node.parent.kind) {
+                    // @ts-ignore falls through
                     case SyntaxKind.ModuleBlock:
                         // If this is not an instantiated module block, no bp span
                         if (getModuleInstanceState(node.parent.parent) !== ModuleInstanceState.Instantiated) {
                             return undefined;
                         }
-                        // falls through
 
                     case SyntaxKind.EnumDeclaration:
                     case SyntaxKind.ClassDeclaration:
                         // Span on close brace token
                         return textSpan(node);
 
+                    // @ts-ignore falls through
                     case SyntaxKind.Block:
                         if (isFunctionBlock(node.parent)) {
                             // Span on close brace token
                             return textSpan(node);
                         }
-                        // falls through
 
                     case SyntaxKind.CatchClause:
                         return spanInNode(lastOrUndefined((<Block>node.parent).statements));

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -157,10 +157,10 @@ namespace ts {
                     text = "`\n" + text;
                     offset = 2;
                     break;
+                // @ts-ignore falls through
                 case EndOfLineState.InTemplateMiddleOrTail:
                     text = "}\n" + text;
                     offset = 2;
-                    // falls through
                 case EndOfLineState.InTemplateSubstitutionPosition:
                     templateStack.push(SyntaxKind.TemplateHead);
                     break;

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -46,6 +46,7 @@ namespace ts.codefix {
                 }
 
                 switch (this.compareModuleSpecifiers(existingAction.moduleSpecifier, newAction.moduleSpecifier)) {
+                    // @ts-ignore falls through
                     case ModuleSpecifierComparison.Better:
                         // the new one is not worth considering if it is a new import.
                         // However if it is instead a insertion into existing import, the user might want to use
@@ -53,7 +54,6 @@ namespace ts.codefix {
                         if (newAction.kind === "NewImport") {
                             return;
                         }
-                        // falls through
                     case ModuleSpecifierComparison.Equal:
                         // the current one is safe. But it is still possible that the new one is worse
                         // than another existing one. For example, you may have new imports from "./foo/bar"

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -517,12 +517,12 @@ namespace ts.Completions {
                         }
                         break;
 
+                    // @ts-ignore falls through
                     case SyntaxKind.BinaryExpression:
                         if (!((parent as BinaryExpression).left.flags & NodeFlags.ThisNodeHasError)) {
                             // It has a left-hand side, so we're not in an opening JSX tag.
                             break;
                         }
-                    // falls through
 
                     case SyntaxKind.JsxSelfClosingElement:
                     case SyntaxKind.JsxElement:
@@ -1372,11 +1372,11 @@ namespace ts.Completions {
                         containingNodeKind === SyntaxKind.NamespaceImport;
 
                 case SyntaxKind.GetKeyword:
+                // @ts-ignore falls through
                 case SyntaxKind.SetKeyword:
                     if (isFromClassElementDeclaration(contextToken)) {
                         return false;
                     }
-                // falls through
                 case SyntaxKind.ClassKeyword:
                 case SyntaxKind.EnumKeyword:
                 case SyntaxKind.InterfaceKeyword:

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -238,11 +238,11 @@ namespace ts.DocumentHighlights {
     function getBreakOrContinueOwner(statement: BreakOrContinueStatement): Node {
         for (let node = statement.parent; node; node = node.parent) {
             switch (node.kind) {
+                // @ts-ignore falls through
                 case SyntaxKind.SwitchStatement:
                     if (statement.kind === SyntaxKind.ContinueStatement) {
                         continue;
                     }
-                    // falls through
                 case SyntaxKind.ForStatement:
                 case SyntaxKind.ForInStatement:
                 case SyntaxKind.ForOfStatement:

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1262,11 +1262,11 @@ namespace ts.FindAllReferences.Core {
 
         switch (searchSpaceNode.kind) {
             case SyntaxKind.MethodDeclaration:
+            // @ts-ignore falls through
             case SyntaxKind.MethodSignature:
                 if (isObjectLiteralMethod(searchSpaceNode)) {
                     break;
                 }
-                // falls through
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.PropertySignature:
             case SyntaxKind.Constructor:
@@ -1275,11 +1275,11 @@ namespace ts.FindAllReferences.Core {
                 staticFlag &= getModifierFlags(searchSpaceNode);
                 searchSpaceNode = searchSpaceNode.parent; // re-assign to be the owning class
                 break;
+            // @ts-ignore falls through
             case SyntaxKind.SourceFile:
                 if (isExternalModule(<SourceFile>searchSpaceNode)) {
                     return undefined;
                 }
-                // falls through
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:
                 break;

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -512,11 +512,11 @@ namespace ts.formatting {
                 case SyntaxKind.EnumDeclaration: return SyntaxKind.EnumDeclaration;
                 case SyntaxKind.GetAccessor: return SyntaxKind.GetKeyword;
                 case SyntaxKind.SetAccessor: return SyntaxKind.SetKeyword;
+                // @ts-ignore falls through
                 case SyntaxKind.MethodDeclaration:
                     if ((<MethodDeclaration>node).asteriskToken) {
                         return SyntaxKind.AsteriskToken;
                     }
-                    // falls through
                 case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.Parameter:
                     return getNameOfDeclaration(<Declaration>node).kind;

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -137,6 +137,7 @@ namespace ts.OutliningElementsCollector {
             }
 
             switch (n.kind) {
+                // @ts-ignore falls through
                 case SyntaxKind.Block:
                     if (!isFunctionBlock(n)) {
                         const parent = n.parent;
@@ -188,7 +189,6 @@ namespace ts.OutliningElementsCollector {
                         });
                         break;
                     }
-                    // falls through
 
                 case SyntaxKind.ModuleBlock: {
                     const openBrace = findChildOfKind(n, SyntaxKind.OpenBraceToken, sourceFile);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -667,13 +667,14 @@ namespace ts {
                         forEachChild(node, visit);
                         break;
 
+                    // @ts-ignore falls through
                     case SyntaxKind.Parameter:
                         // Only consider parameter properties
                         if (!hasModifier(node, ModifierFlags.ParameterPropertyModifier)) {
                             break;
                         }
-                    // falls through
                     case SyntaxKind.VariableDeclaration:
+                    // @ts-ignore falls through
                     case SyntaxKind.BindingElement: {
                         const decl = <VariableDeclaration>node;
                         if (isBindingPattern(decl.name)) {
@@ -684,7 +685,6 @@ namespace ts {
                             visit(decl.initializer);
                         }
                     }
-                    // falls through
                     case SyntaxKind.EnumMember:
                     case SyntaxKind.PropertyDeclaration:
                     case SyntaxKind.PropertySignature:
@@ -722,11 +722,11 @@ namespace ts {
                         }
                         break;
 
+                    // @ts-ignore falls through
                     case SyntaxKind.BinaryExpression:
                         if (getSpecialPropertyAssignmentKind(node as BinaryExpression) !== SpecialPropertyAssignmentKind.None) {
                            addDeclaration(node as BinaryExpression);
                         }
-                        // falls through
 
                     default:
                         forEachChild(node, visit);
@@ -2103,11 +2103,11 @@ namespace ts {
     export function getContainingObjectLiteralElement(node: Node): ObjectLiteralElement {
         switch (node.kind) {
             case SyntaxKind.StringLiteral:
+            // @ts-ignore falls through
             case SyntaxKind.NumericLiteral:
                 if (node.parent.kind === SyntaxKind.ComputedPropertyName) {
                     return isObjectLiteralElement(node.parent.parent) ? node.parent.parent : undefined;
                 }
-            // falls through
             case SyntaxKind.Identifier:
                 return isObjectLiteralElement(node.parent) &&
                     (node.parent.parent.kind === SyntaxKind.ObjectLiteralExpression || node.parent.parent.kind === SyntaxKind.JsxAttributes) &&

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -451,11 +451,11 @@ namespace ts {
                 return nodeEndsWith(n, SyntaxKind.CloseBraceToken, sourceFile);
             case SyntaxKind.CatchClause:
                 return isCompletedNode((<CatchClause>n).block, sourceFile);
+            // @ts-ignore falls through
             case SyntaxKind.NewExpression:
                 if (!(<NewExpression>n).arguments) {
                     return true;
                 }
-            // falls through
             case SyntaxKind.CallExpression:
             case SyntaxKind.ParenthesizedExpression:
             case SyntaxKind.ParenthesizedType:

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -4,6 +4,7 @@
         "noEmitOnError": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noFallthroughCasesInSwitch": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "alwaysStrict": true,

--- a/tslint.json
+++ b/tslint.json
@@ -25,7 +25,6 @@
         "no-inferrable-types": true,
         "no-internal-module": true,
         "no-null-keyword": true,
-        "no-switch-case-fall-through": true,
         "no-trailing-whitespace": [true, "ignore-template-strings"],
         "no-type-assertion-whitespace": true,
         "no-var-keyword": true,


### PR DESCRIPTION
Since we have `// @ts-ignore` comments now, we don't need to use the lint rule for this any more.