### PR TITLE
Fill missing type arguments during error reporting

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15652,7 +15652,7 @@ namespace ts {
                 const constraint = getConstraintOfTypeParameter(typeParameters[i]);
                 if (!constraint) continue;
 
-                const errorInfo = reportErrors && headMessage && chainDiagnosticMessages(undefined, Diagnostics.Type_0_does_not_satisfy_the_constraint_1);
+                const errorInfo = reportErrors && headMessage && chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Type_0_does_not_satisfy_the_constraint_1);
                 const typeArgumentHeadMessage = headMessage || Diagnostics.Type_0_does_not_satisfy_the_constraint_1;
                 if (!mapper) {
                     mapper = createTypeMapper(typeParameters, typeArgumentTypes);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15649,6 +15649,7 @@ namespace ts {
             const typeArgumentTypes = fillMissingTypeArguments(map(typeArgumentNodes, getTypeFromTypeNode), typeParameters, getMinTypeArgumentCount(typeParameters), isJavascript);
             let mapper: TypeMapper;
             for (let i = 0; i < typeArgumentNodes.length; i++) {
+                Debug.assert(typeParameters[i] !== undefined, "Should not call checkTypeArguments with too many type arguments");
                 const constraint = getConstraintOfTypeParameter(typeParameters[i]);
                 if (!constraint) continue;
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16203,8 +16203,10 @@ namespace ts {
                 checkApplicableSignature(node, args, candidateForArgumentError, assignableRelation, /*excludeArgument*/ undefined, /*reportErrors*/ true);
             }
             else if (candidateForTypeArgumentError) {
+                const isJavascript = isInJavaScriptFile(candidateForTypeArgumentError.declaration);
                 const typeArguments = (<CallExpression>node).typeArguments;
-                checkTypeArguments(candidateForTypeArgumentError, typeArguments, map(typeArguments, getTypeFromTypeNode), /*reportErrors*/ true, fallbackError);
+                const typeArgumentTypes = fillMissingTypeArguments(map(typeArguments, getTypeFromTypeNode), candidateForTypeArgumentError.typeParameters, getMinTypeArgumentCount(candidateForTypeArgumentError.typeParameters), isJavascript);
+                checkTypeArguments(candidateForTypeArgumentError, typeArguments, typeArgumentTypes, /*reportErrors*/ true, fallbackError);
             }
             else if (typeArguments && every(signatures, sig => length(sig.typeParameters) !== typeArguments.length)) {
                 let min = Number.POSITIVE_INFINITY;

--- a/tests/baselines/reference/incorrectNumberOfTypeArgumentsDuringErrorReporting.errors.txt
+++ b/tests/baselines/reference/incorrectNumberOfTypeArgumentsDuringErrorReporting.errors.txt
@@ -1,0 +1,28 @@
+tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts(18,4): error TS2559: Type 'MyObjA' has no properties in common with type 'ObjA'.
+
+
+==== tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts (1 errors) ====
+    interface ObjA {
+      y?:string,
+    }
+    
+    interface ObjB {[key:string]:any}
+    
+    interface Opts<A, B> {a:A, b:B}
+    
+    const fn = <
+      A extends ObjA,
+      B extends ObjB = ObjB
+    >(opts:Opts<A, B>):string => 'Z'
+    
+    interface MyObjA {
+      x:string,
+    }
+    
+    fn<MyObjA>({
+       ~~~~~~
+!!! error TS2559: Type 'MyObjA' has no properties in common with type 'ObjA'.
+      a: {x: 'X', y: 'Y'},
+      b: {},
+    })
+    

--- a/tests/baselines/reference/incorrectNumberOfTypeArgumentsDuringErrorReporting.js
+++ b/tests/baselines/reference/incorrectNumberOfTypeArgumentsDuringErrorReporting.js
@@ -1,0 +1,30 @@
+//// [incorrectNumberOfTypeArgumentsDuringErrorReporting.ts]
+interface ObjA {
+  y?:string,
+}
+
+interface ObjB {[key:string]:any}
+
+interface Opts<A, B> {a:A, b:B}
+
+const fn = <
+  A extends ObjA,
+  B extends ObjB = ObjB
+>(opts:Opts<A, B>):string => 'Z'
+
+interface MyObjA {
+  x:string,
+}
+
+fn<MyObjA>({
+  a: {x: 'X', y: 'Y'},
+  b: {},
+})
+
+
+//// [incorrectNumberOfTypeArgumentsDuringErrorReporting.js]
+var fn = function (opts) { return 'Z'; };
+fn({
+    a: { x: 'X', y: 'Y' },
+    b: {}
+});

--- a/tests/baselines/reference/incorrectNumberOfTypeArgumentsDuringErrorReporting.symbols
+++ b/tests/baselines/reference/incorrectNumberOfTypeArgumentsDuringErrorReporting.symbols
@@ -1,0 +1,60 @@
+=== tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts ===
+interface ObjA {
+>ObjA : Symbol(ObjA, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 0, 0))
+
+  y?:string,
+>y : Symbol(ObjA.y, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 0, 16))
+}
+
+interface ObjB {[key:string]:any}
+>ObjB : Symbol(ObjB, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 2, 1))
+>key : Symbol(key, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 4, 17))
+
+interface Opts<A, B> {a:A, b:B}
+>Opts : Symbol(Opts, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 4, 33))
+>A : Symbol(A, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 6, 15))
+>B : Symbol(B, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 6, 17))
+>a : Symbol(Opts.a, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 6, 22))
+>A : Symbol(A, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 6, 15))
+>b : Symbol(Opts.b, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 6, 26))
+>B : Symbol(B, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 6, 17))
+
+const fn = <
+>fn : Symbol(fn, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 8, 5))
+
+  A extends ObjA,
+>A : Symbol(A, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 8, 12))
+>ObjA : Symbol(ObjA, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 0, 0))
+
+  B extends ObjB = ObjB
+>B : Symbol(B, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 9, 17))
+>ObjB : Symbol(ObjB, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 2, 1))
+>ObjB : Symbol(ObjB, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 2, 1))
+
+>(opts:Opts<A, B>):string => 'Z'
+>opts : Symbol(opts, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 11, 2))
+>Opts : Symbol(Opts, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 4, 33))
+>A : Symbol(A, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 8, 12))
+>B : Symbol(B, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 9, 17))
+
+interface MyObjA {
+>MyObjA : Symbol(MyObjA, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 11, 32))
+
+  x:string,
+>x : Symbol(MyObjA.x, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 13, 18))
+}
+
+fn<MyObjA>({
+>fn : Symbol(fn, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 8, 5))
+>MyObjA : Symbol(MyObjA, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 11, 32))
+
+  a: {x: 'X', y: 'Y'},
+>a : Symbol(a, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 17, 12))
+>x : Symbol(x, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 18, 6))
+>y : Symbol(y, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 18, 13))
+
+  b: {},
+>b : Symbol(b, Decl(incorrectNumberOfTypeArgumentsDuringErrorReporting.ts, 18, 22))
+
+})
+

--- a/tests/baselines/reference/incorrectNumberOfTypeArgumentsDuringErrorReporting.types
+++ b/tests/baselines/reference/incorrectNumberOfTypeArgumentsDuringErrorReporting.types
@@ -1,0 +1,68 @@
+=== tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts ===
+interface ObjA {
+>ObjA : ObjA
+
+  y?:string,
+>y : string
+}
+
+interface ObjB {[key:string]:any}
+>ObjB : ObjB
+>key : string
+
+interface Opts<A, B> {a:A, b:B}
+>Opts : Opts<A, B>
+>A : A
+>B : B
+>a : A
+>A : A
+>b : B
+>B : B
+
+const fn = <
+>fn : <A extends ObjA, B extends ObjB = ObjB>(opts: Opts<A, B>) => string
+><  A extends ObjA,  B extends ObjB = ObjB>(opts:Opts<A, B>):string => 'Z' : <A extends ObjA, B extends ObjB = ObjB>(opts: Opts<A, B>) => string
+
+  A extends ObjA,
+>A : A
+>ObjA : ObjA
+
+  B extends ObjB = ObjB
+>B : B
+>ObjB : ObjB
+>ObjB : ObjB
+
+>(opts:Opts<A, B>):string => 'Z'
+>opts : Opts<A, B>
+>Opts : Opts<A, B>
+>A : A
+>B : B
+>'Z' : "Z"
+
+interface MyObjA {
+>MyObjA : MyObjA
+
+  x:string,
+>x : string
+}
+
+fn<MyObjA>({
+>fn<MyObjA>({  a: {x: 'X', y: 'Y'},  b: {},}) : any
+>fn : <A extends ObjA, B extends ObjB = ObjB>(opts: Opts<A, B>) => string
+>MyObjA : MyObjA
+>{  a: {x: 'X', y: 'Y'},  b: {},} : { a: { x: string; y: string; }; b: {}; }
+
+  a: {x: 'X', y: 'Y'},
+>a : { x: string; y: string; }
+>{x: 'X', y: 'Y'} : { x: string; y: string; }
+>x : string
+>'X' : "X"
+>y : string
+>'Y' : "Y"
+
+  b: {},
+>b : {}
+>{} : {}
+
+})
+

--- a/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
+++ b/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
@@ -1,0 +1,21 @@
+interface ObjA {
+  y?:string,
+}
+
+interface ObjB {[key:string]:any}
+
+interface Opts<A, B> {a:A, b:B}
+
+const fn = <
+  A extends ObjA,
+  B extends ObjB = ObjB
+>(opts:Opts<A, B>):string => 'Z'
+
+interface MyObjA {
+  x:string,
+}
+
+fn<MyObjA>({
+  a: {x: 'X', y: 'Y'},
+  b: {},
+})


### PR DESCRIPTION
Previously, only the success path did this; it was missing in the error reporting path in resolveCall. This resulted in crashes for unsupplied type arguments when the supplied type arguments were incorrect.

Fixes #18938