### PR TITLE
fix super call from class that has no basetype but with same symbol (#19068)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13043,12 +13043,14 @@ namespace ts {
 
             // at this point the only legal case for parent is ClassLikeDeclaration
             const classLikeDeclaration = <ClassLikeDeclaration>container.parent;
+            if (!getClassExtendsHeritageClauseElement(classLikeDeclaration)) {
+                error(node, Diagnostics.super_can_only_be_referenced_in_a_derived_class);
+                return unknownType;
+            }
+
             const classType = <InterfaceType>getDeclaredTypeOfSymbol(getSymbolOfNode(classLikeDeclaration));
             const baseClassType = classType && getBaseTypes(classType)[0];
             if (!baseClassType) {
-                if (!getClassExtendsHeritageClauseElement(classLikeDeclaration)) {
-                    error(node, Diagnostics.super_can_only_be_referenced_in_a_derived_class);
-                }
                 return unknownType;
             }
 

--- a/tests/baselines/reference/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.errors.txt
+++ b/tests/baselines/reference/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts(5,9): error TS2335: 'super' can only be referenced in a derived class.
+
+
+==== tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts (1 errors) ====
+    interface Foo extends Array<number> {}
+    
+    class Foo {
+        constructor() {
+            super(); // error
+            ~~~~~
+!!! error TS2335: 'super' can only be referenced in a derived class.
+        }
+    }
+    

--- a/tests/baselines/reference/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.js
+++ b/tests/baselines/reference/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.js
@@ -1,0 +1,17 @@
+//// [superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts]
+interface Foo extends Array<number> {}
+
+class Foo {
+    constructor() {
+        super(); // error
+    }
+}
+
+
+//// [superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.js]
+var Foo = /** @class */ (function () {
+    function Foo() {
+        _this = _super.call(this) || this; // error
+    }
+    return Foo;
+}());

--- a/tests/baselines/reference/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.symbols
+++ b/tests/baselines/reference/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts ===
+interface Foo extends Array<number> {}
+>Foo : Symbol(Foo, Decl(superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts, 0, 0), Decl(superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts, 0, 38))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+class Foo {
+>Foo : Symbol(Foo, Decl(superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts, 0, 0), Decl(superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts, 0, 38))
+
+    constructor() {
+        super(); // error
+    }
+}
+

--- a/tests/baselines/reference/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.types
+++ b/tests/baselines/reference/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.types
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts ===
+interface Foo extends Array<number> {}
+>Foo : Foo
+>Array : T[]
+
+class Foo {
+>Foo : Foo
+
+    constructor() {
+        super(); // error
+>super() : void
+>super : any
+    }
+}
+

--- a/tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts
+++ b/tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts
@@ -1,0 +1,7 @@
+interface Foo extends Array<number> {}
+
+class Foo {
+    constructor() {
+        super(); // error
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #19068 
