### PR TITLE
In getContextuallyTypedParameterType, skip a `this` parameter when counting parameter index

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13182,7 +13182,7 @@ namespace ts {
         }
 
         // Return contextual type of parameter or undefined if no contextual type is available
-        function getContextuallyTypedParameterType(parameter: ParameterDeclaration): Type {
+        function getContextuallyTypedParameterType(parameter: ParameterDeclaration): Type | undefined {
             const func = parameter.parent;
             if (isContextSensitiveFunctionOrObjectLiteralMethod(func)) {
                 const iife = getImmediatelyInvokedFunctionExpression(func);
@@ -13208,7 +13208,12 @@ namespace ts {
                 if (contextualSignature) {
                     const funcHasRestParameters = hasRestParameter(func);
                     const len = func.parameters.length - (funcHasRestParameters ? 1 : 0);
-                    const indexOfParameter = indexOf(func.parameters, parameter);
+                    let indexOfParameter = indexOf(func.parameters, parameter);
+                    if (getThisParameter(func) !== undefined && !contextualSignature.thisParameter) {
+                        Debug.assert(indexOfParameter !== 0); // Otherwise we should not have called `getContextuallyTypedParameterType`.
+                        indexOfParameter -= 1;
+                    }
+
                     if (indexOfParameter < len) {
                         return getTypeAtPosition(contextualSignature, indexOfParameter);
                     }

--- a/tests/cases/fourslash/quickInfoParameter_skipThisParameter.ts
+++ b/tests/cases/fourslash/quickInfoParameter_skipThisParameter.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts'/>
+
+////function f(cb: (x: number) => void) {}
+////f(function(this: any, /**/x) {});
+
+verify.quickInfoAt("", "(parameter) x: number");


### PR DESCRIPTION
Fixes #19022