### PR TITLE
Adds original names to the source maps.

### DIFF
--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -75,7 +75,8 @@ namespace ts {
         emittedColumn: 1,
         sourceLine: 1,
         sourceColumn: 1,
-        sourceIndex: 0
+        sourceIndex: 0,
+        nameIndex: undefined
     };
 
     export function createSourceMapWriter(host: EmitHost, writer: EmitTextWriter): SourceMapWriter {
@@ -95,6 +96,7 @@ namespace ts {
 
         // Source map data
         let sourceMapData: SourceMapData;
+        let sourceMapNamesIndex: Map<number>;
         let disabled: boolean = !(compilerOptions.sourceMap || compilerOptions.inlineSourceMap);
 
         return {
@@ -156,6 +158,8 @@ namespace ts {
                 sourceMapSourcesContent: compilerOptions.inlineSources ? [] : undefined,
                 sourceMapDecodedMappings: []
             };
+
+            sourceMapNamesIndex = ts.createMap<number>();
 
             // Normalize source root and make sure it has trailing "/" so that it can be used to combine paths with the
             // relative paths of the sources list in the sourcemap
@@ -243,8 +247,7 @@ namespace ts {
             sourceMapData.sourceMapMappings += base64VLQFormatEncode(lastRecordedSourceMapSpan.sourceColumn - lastEncodedSourceMapSpan.sourceColumn);
 
             // 5. Relative namePosition 0 based
-            if (lastRecordedSourceMapSpan.nameIndex >= 0) {
-                Debug.assert(false, "We do not support name index right now, Make sure to update updateLastEncodedAndRecordedSpans when we start using this");
+            if (lastRecordedSourceMapSpan.nameIndex != undefined) {
                 sourceMapData.sourceMapMappings += base64VLQFormatEncode(lastRecordedSourceMapSpan.nameIndex - lastEncodedNameIndex);
                 lastEncodedNameIndex = lastRecordedSourceMapSpan.nameIndex;
             }
@@ -261,7 +264,7 @@ namespace ts {
          *
          * @param pos The position.
          */
-        function emitPos(pos: number) {
+        function emitPos(pos: number, nameIndex?: number) {
             if (disabled || positionIsSynthesized(pos)) {
                 return;
             }
@@ -283,6 +286,7 @@ namespace ts {
             if (!lastRecordedSourceMapSpan ||
                 lastRecordedSourceMapSpan.emittedLine !== emittedLine ||
                 lastRecordedSourceMapSpan.emittedColumn !== emittedColumn ||
+                lastRecordedSourceMapSpan.nameIndex != undefined ||
                 (lastRecordedSourceMapSpan.sourceIndex === sourceMapSourceIndex &&
                     (lastRecordedSourceMapSpan.sourceLine > sourceLinePos.line ||
                         (lastRecordedSourceMapSpan.sourceLine === sourceLinePos.line && lastRecordedSourceMapSpan.sourceColumn > sourceLinePos.character)))) {
@@ -296,7 +300,8 @@ namespace ts {
                     emittedColumn,
                     sourceLine: sourceLinePos.line,
                     sourceColumn: sourceLinePos.character,
-                    sourceIndex: sourceMapSourceIndex
+                    sourceIndex: sourceMapSourceIndex,
+                    nameIndex,
                 };
             }
             else {
@@ -304,6 +309,7 @@ namespace ts {
                 lastRecordedSourceMapSpan.sourceLine = sourceLinePos.line;
                 lastRecordedSourceMapSpan.sourceColumn = sourceLinePos.character;
                 lastRecordedSourceMapSpan.sourceIndex = sourceMapSourceIndex;
+                lastRecordedSourceMapSpan.nameIndex = nameIndex;
             }
 
             if (extendedDiagnostics) {
@@ -333,12 +339,26 @@ namespace ts {
                 const oldSource = currentSource;
                 if (source === oldSource) source = undefined;
 
+                let nameIndex;
+                if (isIdentifier(node)) {
+                    const originalName = getTextOfNodeFromSourceText(currentSourceText, node);
+                    if (originalName) {
+                        if (sourceMapNamesIndex.has(originalName)) {
+                            nameIndex = sourceMapNamesIndex.get(originalName);
+                        } else {
+                            nameIndex = sourceMapData.sourceMapNames.length;
+                            sourceMapData.sourceMapNames.push(originalName);
+                            sourceMapNamesIndex.set(originalName, nameIndex);
+                        }
+                    }
+                }
+
                 if (source) setSourceFile(source);
 
                 if (node.kind !== SyntaxKind.NotEmittedStatement
                     && (emitFlags & EmitFlags.NoLeadingSourceMap) === 0
                     && pos >= 0) {
-                    emitPos(skipSourceTrivia(pos));
+                    emitPos(skipSourceTrivia(pos), nameIndex);
                 }
 
                 if (source) setSourceFile(oldSource);


### PR DESCRIPTION
Related Issues:
- #9627
- https://github.com/Microsoft/TypeScript/blob/027528e9b8da9f81421a98f0dd458dccfc8b922b/src/compiler/sourcemap.ts#L247

Source maps tests will fail since names contains data (e.g. tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap1_ES5.ts)

TODO:
- [x] CLA ?
- [ ] Update add tests? Re-inspect failing tests?
