### PR TITLE
Reduce cache overhead

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -373,23 +373,23 @@ namespace ts {
         const maximumSuggestionCount = 10;
         const mergedSymbols: Symbol[] = [];
         const symbolLinks: SymbolLinks[] = [];
-        const nodeLinks: {[K in keyof NodeLinks]: Map<NodeLinks[K]>} = {
-            containsArgumentsReference: createMap(),
-            enumMemberValue: createMap(),
-            flags: createMap(),
-            hasReportedStatementInAmbientContext: createMap(),
-            hasSuperCall: createMap(),
-            isVisible: createMap(),
-            jsxFlags: createMap(),
-            maybeTypePredicate: createMap(),
-            resolvedIndexInfo: createMap(),
-            resolvedJsxElementAllAttributesType: createMap(),
-            resolvedJsxElementAttributesType: createMap(),
-            resolvedSignature: createMap(),
-            resolvedSymbol: createMap(),
-            resolvedType: createMap(),
-            superCall: createMap(),
-            switchTypes: createMap(),
+        const nodeLinks: {[K in keyof NodeLinks]: NodeLinks[K][]} = {
+            containsArgumentsReference: [],
+            enumMemberValue: [],
+            flags: [],
+            hasReportedStatementInAmbientContext: [],
+            hasSuperCall: [],
+            isVisible: [],
+            jsxFlags: [],
+            maybeTypePredicate: [],
+            resolvedIndexInfo: [],
+            resolvedJsxElementAllAttributesType: [],
+            resolvedJsxElementAttributesType: [],
+            resolvedSignature: [],
+            resolvedSymbol: [],
+            resolvedType: [],
+            superCall: [],
+            switchTypes: [],
         };
         const flowLoopCaches: Map<Type>[] = [];
         const flowLoopNodes: FlowNode[] = [];
@@ -752,11 +752,11 @@ namespace ts {
         }
 
         function getNodeLink<K extends keyof NodeLinks>(node: Node, prop: K): NodeLinks[K] {
-            return nodeLinks[prop].get("" + getNodeId(node));
+            return nodeLinks[prop][getNodeId(node)];
         }
 
         function setNodeLink<K extends keyof NodeLinks>(node: Node, prop: K, value: NodeLinks[K]): NodeLinks[K] {
-            (nodeLinks[prop].set as (key: string, value: NodeLinks[K]) => void)("" + getNodeId(node), value);
+            nodeLinks[prop][getNodeId(node)] = value;
             return value;
         }
 


### PR DESCRIPTION
In [this comment](https://github.com/Microsoft/TypeScript/pull/19047#discussion_r144432518), I supposed that if we were concerned about the overhead of `NodeLinks`, we could reduce or remove it by inverting the shape of our cache structure. This is that.

This comparison was captured over 10 iterations on my machine (with a scanner exception for `node` and forced high power mode, as is usual for a windows machine):

Metric | master | reduce-cache-overhead | Delta | Best | Worst
-- | -- | -- | -- | -- | --
Compiler - Unions - node (v8.3.0, x64)
Memory used | 203,010k (±  0.04%) | 195,375k (±  0.04%) | -7,636k (-  3.76%) | 195,145k | 195,530k
Parse Time | 0.76s (±  3.91%) | 0.73s (±  1.76%) | -0.02s (-  3.03%) | 0.72s | 0.78s
Bind Time | 0.66s (±  2.88%) | 0.65s (±  0.72%) | -0.01s (-  2.11%) | 0.64s | 0.66s
Check Time | 10.19s (±  2.70%) | 9.84s (±  1.81%) | -0.35s (-  3.45%) | 9.72s | 10.54s
Emit Time | 0.00s (±  0.00%) | 0.00s (±  0.00%) | 0.00s (    NaN%) | 0.00s | 0.00s
Total Time | 11.61s (±  2.55%) | 11.22s (±  1.56%) | -0.39s (-  3.36%) | 11.08s | 11.91s
Monaco - node (v8.3.0, x64)
Memory used | 331,677k (±  0.01%) | 320,180k (±  0.02%) | -11,497k (-  3.47%) | 320,012k | 320,301k
Parse Time | 1.75s (±  1.32%) | 1.73s (±  1.49%) | -0.02s (-  1.03%) | 1.70s | 1.83s
Bind Time | 0.70s (±  1.72%) | 0.69s (±  1.22%) | -0.01s (-  0.86%) | 0.68s | 0.71s
Check Time | 3.69s (±  0.98%) | 3.67s (±  1.16%) | -0.02s (-  0.54%) | 3.60s | 3.79s
Emit Time | 2.39s (±  1.20%) | 2.38s (±  1.72%) | -0.02s (-  0.75%) | 2.31s | 2.53s
Total Time | 8.53s (±  0.73%) | 8.47s (±  0.68%) | -0.06s (-  0.73%) | 8.37s | 8.63s
TFS - node (v8.3.0, x64)
Memory used | 288,481k (±  0.02%) | 274,252k (±  0.02%) | -14,229k (-  4.93%) | 274,172k | 274,334k
Parse Time | 1.26s (±  1.99%) | 1.24s (±  1.23%) | -0.02s (-  1.19%) | 1.23s | 1.30s
Bind Time | 0.71s (±  2.84%) | 0.70s (±  0.68%) | -0.01s (-  1.54%) | 0.69s | 0.71s
Check Time | 3.25s (±  1.83%) | 3.18s (±  0.96%) | -0.07s (-  2.18%) | 3.13s | 3.27s
Emit Time | 2.23s (±  2.55%) | 2.11s (±  0.86%) | -0.11s (-  4.99%) | 2.07s | 2.15s
Total Time | 7.46s (±  1.86%) | 7.25s (±  0.64%) | -0.21s (-  2.79%) | 7.15s | 7.37s

There is _consistently_ lower memory usage (since just add entries to spare arrays rather than allocate objects), and possible check time savings, too (since we no longer use a polymorphic `NodeLinks` object).

I'll try applying the same technique to `SymbolLinks` and see what the improvement there is.