### PR TITLE
Fix 'any' and 'keyof any' in mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5777,7 +5777,7 @@ namespace ts {
                 for (const propertySymbol of getPropertiesOfType(modifiersType)) {
                     addMemberForKeyType(getLiteralTypeFromPropertyName(propertySymbol), propertySymbol);
                 }
-                if (getIndexInfoOfType(modifiersType, IndexKind.String)) {
+                if (modifiersType.flags & TypeFlags.Any || getIndexInfoOfType(modifiersType, IndexKind.String)) {
                     addMemberForKeyType(stringType);
                 }
             }
@@ -8386,7 +8386,7 @@ namespace ts {
         }
 
         function isMappableType(type: Type) {
-            return type.flags & (TypeFlags.TypeParameter | TypeFlags.Object | TypeFlags.Intersection | TypeFlags.IndexedAccess);
+            return type.flags & (TypeFlags.Any | TypeFlags.TypeParameter | TypeFlags.Object | TypeFlags.Intersection | TypeFlags.IndexedAccess);
         }
 
         function instantiateAnonymousType(type: AnonymousType, mapper: TypeMapper): AnonymousType {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5821,7 +5821,7 @@ namespace ts {
                     prop.syntheticLiteralTypeOrigin = t as StringLiteralType;
                     members.set(propName, prop);
                 }
-                else if (t.flags & TypeFlags.String) {
+                else if (t.flags & (TypeFlags.Any | TypeFlags.String)) {
                     stringIndexInfo = createIndexInfo(propType, templateReadonly);
                 }
             }

--- a/tests/baselines/reference/mappedTypeWithAny.errors.txt
+++ b/tests/baselines/reference/mappedTypeWithAny.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/conformance/types/mapped/mappedTypeWithAny.ts(23,16): error TS2339: Property 'notAValue' does not exist on type 'Data'.
+
+
+==== tests/cases/conformance/types/mapped/mappedTypeWithAny.ts (1 errors) ====
+    type Item = { value: string };
+    type ItemMap<T> = { [P in keyof T]: Item };
+    
+    declare let x0: keyof any;
+    declare let x1: { [P in any]: Item };
+    declare let x2: { [P in string]: Item };
+    declare let x3: { [P in keyof any]: Item };
+    declare let x4: ItemMap<any>;
+    
+    // Repro from #19152
+    
+    type Data = {
+      value: string;
+    }
+    
+    type StrictDataMap<T> = {
+      [P in keyof T]: Data
+    }
+    
+    declare let z: StrictDataMap<any>;
+    for (let id in z) {
+      let data = z[id];
+      let x = data.notAValue;  // Error
+                   ~~~~~~~~~
+!!! error TS2339: Property 'notAValue' does not exist on type 'Data'.
+    }
+    

--- a/tests/baselines/reference/mappedTypeWithAny.js
+++ b/tests/baselines/reference/mappedTypeWithAny.js
@@ -1,0 +1,60 @@
+//// [mappedTypeWithAny.ts]
+type Item = { value: string };
+type ItemMap<T> = { [P in keyof T]: Item };
+
+declare let x0: keyof any;
+declare let x1: { [P in any]: Item };
+declare let x2: { [P in string]: Item };
+declare let x3: { [P in keyof any]: Item };
+declare let x4: ItemMap<any>;
+
+// Repro from #19152
+
+type Data = {
+  value: string;
+}
+
+type StrictDataMap<T> = {
+  [P in keyof T]: Data
+}
+
+declare let z: StrictDataMap<any>;
+for (let id in z) {
+  let data = z[id];
+  let x = data.notAValue;  // Error
+}
+
+
+//// [mappedTypeWithAny.js]
+"use strict";
+for (var id in z) {
+    var data = z[id];
+    var x = data.notAValue; // Error
+}
+
+
+//// [mappedTypeWithAny.d.ts]
+declare type Item = {
+    value: string;
+};
+declare type ItemMap<T> = {
+    [P in keyof T]: Item;
+};
+declare let x0: keyof any;
+declare let x1: {
+    [P in any]: Item;
+};
+declare let x2: {
+    [P in string]: Item;
+};
+declare let x3: {
+    [P in keyof any]: Item;
+};
+declare let x4: ItemMap<any>;
+declare type Data = {
+    value: string;
+};
+declare type StrictDataMap<T> = {
+    [P in keyof T]: Data;
+};
+declare let z: StrictDataMap<any>;

--- a/tests/baselines/reference/mappedTypeWithAny.symbols
+++ b/tests/baselines/reference/mappedTypeWithAny.symbols
@@ -1,0 +1,71 @@
+=== tests/cases/conformance/types/mapped/mappedTypeWithAny.ts ===
+type Item = { value: string };
+>Item : Symbol(Item, Decl(mappedTypeWithAny.ts, 0, 0))
+>value : Symbol(value, Decl(mappedTypeWithAny.ts, 0, 13))
+
+type ItemMap<T> = { [P in keyof T]: Item };
+>ItemMap : Symbol(ItemMap, Decl(mappedTypeWithAny.ts, 0, 30))
+>T : Symbol(T, Decl(mappedTypeWithAny.ts, 1, 13))
+>P : Symbol(P, Decl(mappedTypeWithAny.ts, 1, 21))
+>T : Symbol(T, Decl(mappedTypeWithAny.ts, 1, 13))
+>Item : Symbol(Item, Decl(mappedTypeWithAny.ts, 0, 0))
+
+declare let x0: keyof any;
+>x0 : Symbol(x0, Decl(mappedTypeWithAny.ts, 3, 11))
+
+declare let x1: { [P in any]: Item };
+>x1 : Symbol(x1, Decl(mappedTypeWithAny.ts, 4, 11))
+>P : Symbol(P, Decl(mappedTypeWithAny.ts, 4, 19))
+>Item : Symbol(Item, Decl(mappedTypeWithAny.ts, 0, 0))
+
+declare let x2: { [P in string]: Item };
+>x2 : Symbol(x2, Decl(mappedTypeWithAny.ts, 5, 11))
+>P : Symbol(P, Decl(mappedTypeWithAny.ts, 5, 19))
+>Item : Symbol(Item, Decl(mappedTypeWithAny.ts, 0, 0))
+
+declare let x3: { [P in keyof any]: Item };
+>x3 : Symbol(x3, Decl(mappedTypeWithAny.ts, 6, 11))
+>P : Symbol(P, Decl(mappedTypeWithAny.ts, 6, 19))
+>Item : Symbol(Item, Decl(mappedTypeWithAny.ts, 0, 0))
+
+declare let x4: ItemMap<any>;
+>x4 : Symbol(x4, Decl(mappedTypeWithAny.ts, 7, 11))
+>ItemMap : Symbol(ItemMap, Decl(mappedTypeWithAny.ts, 0, 30))
+
+// Repro from #19152
+
+type Data = {
+>Data : Symbol(Data, Decl(mappedTypeWithAny.ts, 7, 29))
+
+  value: string;
+>value : Symbol(value, Decl(mappedTypeWithAny.ts, 11, 13))
+}
+
+type StrictDataMap<T> = {
+>StrictDataMap : Symbol(StrictDataMap, Decl(mappedTypeWithAny.ts, 13, 1))
+>T : Symbol(T, Decl(mappedTypeWithAny.ts, 15, 19))
+
+  [P in keyof T]: Data
+>P : Symbol(P, Decl(mappedTypeWithAny.ts, 16, 3))
+>T : Symbol(T, Decl(mappedTypeWithAny.ts, 15, 19))
+>Data : Symbol(Data, Decl(mappedTypeWithAny.ts, 7, 29))
+}
+
+declare let z: StrictDataMap<any>;
+>z : Symbol(z, Decl(mappedTypeWithAny.ts, 19, 11))
+>StrictDataMap : Symbol(StrictDataMap, Decl(mappedTypeWithAny.ts, 13, 1))
+
+for (let id in z) {
+>id : Symbol(id, Decl(mappedTypeWithAny.ts, 20, 8))
+>z : Symbol(z, Decl(mappedTypeWithAny.ts, 19, 11))
+
+  let data = z[id];
+>data : Symbol(data, Decl(mappedTypeWithAny.ts, 21, 5))
+>z : Symbol(z, Decl(mappedTypeWithAny.ts, 19, 11))
+>id : Symbol(id, Decl(mappedTypeWithAny.ts, 20, 8))
+
+  let x = data.notAValue;  // Error
+>x : Symbol(x, Decl(mappedTypeWithAny.ts, 22, 5))
+>data : Symbol(data, Decl(mappedTypeWithAny.ts, 21, 5))
+}
+

--- a/tests/baselines/reference/mappedTypeWithAny.types
+++ b/tests/baselines/reference/mappedTypeWithAny.types
@@ -1,0 +1,74 @@
+=== tests/cases/conformance/types/mapped/mappedTypeWithAny.ts ===
+type Item = { value: string };
+>Item : Item
+>value : string
+
+type ItemMap<T> = { [P in keyof T]: Item };
+>ItemMap : ItemMap<T>
+>T : T
+>P : P
+>T : T
+>Item : Item
+
+declare let x0: keyof any;
+>x0 : string
+
+declare let x1: { [P in any]: Item };
+>x1 : { [x: string]: Item; }
+>P : P
+>Item : Item
+
+declare let x2: { [P in string]: Item };
+>x2 : { [x: string]: Item; }
+>P : P
+>Item : Item
+
+declare let x3: { [P in keyof any]: Item };
+>x3 : { [x: string]: Item; }
+>P : P
+>Item : Item
+
+declare let x4: ItemMap<any>;
+>x4 : ItemMap<any>
+>ItemMap : ItemMap<T>
+
+// Repro from #19152
+
+type Data = {
+>Data : Data
+
+  value: string;
+>value : string
+}
+
+type StrictDataMap<T> = {
+>StrictDataMap : StrictDataMap<T>
+>T : T
+
+  [P in keyof T]: Data
+>P : P
+>T : T
+>Data : Data
+}
+
+declare let z: StrictDataMap<any>;
+>z : StrictDataMap<any>
+>StrictDataMap : StrictDataMap<T>
+
+for (let id in z) {
+>id : string
+>z : StrictDataMap<any>
+
+  let data = z[id];
+>data : Data
+>z[id] : Data
+>z : StrictDataMap<any>
+>id : string
+
+  let x = data.notAValue;  // Error
+>x : any
+>data.notAValue : any
+>data : Data
+>notAValue : any
+}
+

--- a/tests/cases/conformance/types/mapped/mappedTypeWithAny.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeWithAny.ts
@@ -1,0 +1,27 @@
+// @strict: true
+// @declaration: true
+
+type Item = { value: string };
+type ItemMap<T> = { [P in keyof T]: Item };
+
+declare let x0: keyof any;
+declare let x1: { [P in any]: Item };
+declare let x2: { [P in string]: Item };
+declare let x3: { [P in keyof any]: Item };
+declare let x4: ItemMap<any>;
+
+// Repro from #19152
+
+type Data = {
+  value: string;
+}
+
+type StrictDataMap<T> = {
+  [P in keyof T]: Data
+}
+
+declare let z: StrictDataMap<any>;
+for (let id in z) {
+  let data = z[id];
+  let x = data.notAValue;  // Error
+}


### PR DESCRIPTION
This PR fixes some inconsistencies relating to `any` and `keyof any` as the constraint type in a mapped type.
 Specifically, the mapped types `{ [P in any]: T }` and `{ [P in keyof any]: T }` both now yield a type corresponding to `{ [x: string]: T }`.

Fixes #19152.