### PR TITLE
Fix supportedMethods property type

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -696,7 +696,7 @@ interface PaymentDetails {
 interface PaymentDetailsModifier {
     additionalDisplayItems?: PaymentItem[];
     data?: any;
-    supportedMethods: string[];
+    supportedMethods: string;
     total?: PaymentItem;
 }
 
@@ -708,7 +708,7 @@ interface PaymentItem {
 
 interface PaymentMethodData {
     data?: any;
-    supportedMethods: string[];
+    supportedMethods: string;
 }
 
 interface PaymentOptions {


### PR DESCRIPTION
According to https://www.w3.org/TR/payment-request/#paymentmethoddata-dictionary.

Fixes #19200.