### PR TITLE
Stop error checking script blocks

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2593,6 +2593,16 @@ namespace ts {
         return find<Extension>(supportedTypescriptExtensionsForExtractExtension, e => fileExtensionIs(path, e)) || find(supportedJavascriptExtensions, e => fileExtensionIs(path, e));
     }
 
+    // Retrieves any string from the final "." onwards from a base file name.
+    // Unlike extensionFromPath, which throws an exception on unrecognized extensions.
+    export function getAnyExtensionFromPath(path: string): string | undefined {
+        const baseFileName = getBaseFileName(path);
+        const extensionIndex = baseFileName.lastIndexOf(".");
+        if (extensionIndex >= 0) {
+            return baseFileName.substring(extensionIndex);
+        }
+    }
+
     export function isCheckJsEnabledForFile(sourceFile: SourceFile, compilerOptions: CompilerOptions) {
         return sourceFile.checkJsDirective ? sourceFile.checkJsDirective.enabled : compilerOptions.checkJs;
     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1146,8 +1146,10 @@ namespace ts {
                 const typeChecker = getDiagnosticsProducingTypeChecker();
 
                 Debug.assert(!!sourceFile.bindDiagnostics);
-                // For JavaScript files, we don't want to report semantic errors unless explicitly requested.
-                const includeBindAndCheckDiagnostics = !isSourceFileJavaScript(sourceFile) || isCheckJsEnabledForFile(sourceFile, options);
+
+                // By default, only type-check .ts, .tsx, and 'External' files (external files are added by plugins)
+                const includeBindAndCheckDiagnostics = sourceFile.scriptKind === ScriptKind.TS || sourceFile.scriptKind === ScriptKind.TSX ||
+                    sourceFile.scriptKind === ScriptKind.External || isCheckJsEnabledForFile(sourceFile, options);
                 const bindDiagnostics = includeBindAndCheckDiagnostics ? sourceFile.bindDiagnostics : emptyArray;
                 const checkDiagnostics = includeBindAndCheckDiagnostics ? typeChecker.getDiagnostics(sourceFile, cancellationToken) : emptyArray;
                 const fileProcessingDiagnosticsInFile = fileProcessingDiagnostics.getDiagnostics(sourceFile.fileName);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3499,6 +3499,7 @@ namespace ts {
     export interface JsFileExtensionInfo {
         extension: string;
         isMixedContent: boolean;
+        scriptKind?: ScriptKind;
     }
 
     export interface DiagnosticMessage {


### PR DESCRIPTION
Set the script kind as provided by the editor for the extra file extensions in the 'configure' command.

Without this, the ScriptKind was being left undefined, and later `ensureScriptKind` was defaulting it to TypeScript - which means it was getting type checked by default.

CC @mhegazy @amcasey 