### PR TITLE
Fix generated name scope when emitting async functions

### DIFF
--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -463,7 +463,7 @@ namespace ts {
         );
 
         // Mark this node as originally an async function
-        (generatorFunc.emitNode || (generatorFunc.emitNode = {})).flags |= EmitFlags.AsyncFunctionBody;
+        (generatorFunc.emitNode || (generatorFunc.emitNode = {})).flags |= EmitFlags.AsyncFunctionBody | EmitFlags.ReuseTempVariableScope;
 
         return createCall(
             getHelperName("__awaiter"),

--- a/tests/baselines/reference/asyncFunctionTempVariableScoping.js
+++ b/tests/baselines/reference/asyncFunctionTempVariableScoping.js
@@ -1,0 +1,64 @@
+//// [asyncFunctionTempVariableScoping.ts]
+// https://github.com/Microsoft/TypeScript/issues/19187
+
+async ({ foo, bar, ...rest }) => bar(await foo);
+
+//// [asyncFunctionTempVariableScoping.js]
+// https://github.com/Microsoft/TypeScript/issues/19187
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+            t[p[i]] = s[p[i]];
+    return t;
+};
+var _this = this;
+(function (_a) { return __awaiter(_this, void 0, void 0, function () {
+    var foo = _a.foo, bar = _a.bar, rest = __rest(_a, ["foo", "bar"]);
+    var _b;
+    return __generator(this, function (_c) {
+        switch (_c.label) {
+            case 0:
+                _b = bar;
+                return [4 /*yield*/, foo];
+            case 1: return [2 /*return*/, _b.apply(void 0, [_c.sent()])];
+        }
+    });
+}); });

--- a/tests/baselines/reference/asyncFunctionTempVariableScoping.symbols
+++ b/tests/baselines/reference/asyncFunctionTempVariableScoping.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/asyncFunctionTempVariableScoping.ts ===
+// https://github.com/Microsoft/TypeScript/issues/19187
+
+async ({ foo, bar, ...rest }) => bar(await foo);
+>foo : Symbol(foo, Decl(asyncFunctionTempVariableScoping.ts, 2, 8))
+>bar : Symbol(bar, Decl(asyncFunctionTempVariableScoping.ts, 2, 13))
+>rest : Symbol(rest, Decl(asyncFunctionTempVariableScoping.ts, 2, 18))
+>bar : Symbol(bar, Decl(asyncFunctionTempVariableScoping.ts, 2, 13))
+>foo : Symbol(foo, Decl(asyncFunctionTempVariableScoping.ts, 2, 8))
+

--- a/tests/baselines/reference/asyncFunctionTempVariableScoping.types
+++ b/tests/baselines/reference/asyncFunctionTempVariableScoping.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/asyncFunctionTempVariableScoping.ts ===
+// https://github.com/Microsoft/TypeScript/issues/19187
+
+async ({ foo, bar, ...rest }) => bar(await foo);
+>async ({ foo, bar, ...rest }) => bar(await foo) : ({ foo, bar, ...rest }: { [x: string]: any; foo: any; bar: any; }) => Promise<any>
+>foo : any
+>bar : any
+>rest : { [x: string]: any; }
+>bar(await foo) : any
+>bar : any
+>await foo : any
+>foo : any
+

--- a/tests/cases/compiler/asyncFunctionTempVariableScoping.ts
+++ b/tests/cases/compiler/asyncFunctionTempVariableScoping.ts
@@ -1,0 +1,5 @@
+// @target: es5
+// @lib: es2015
+// https://github.com/Microsoft/TypeScript/issues/19187
+
+async ({ foo, bar, ...rest }) => bar(await foo);


### PR DESCRIPTION
Normally in the emitter we push a new "name generation scope" whenever we emit the signature and body of a function (or method), and pop it when we finish emitting the function. In certain situations, we can prevent pushing and popping the scope so that we can have functions that close over the previous scope. Currently we do this for down-level generators, but were not doing this for down-level async functions. The issue was due to the fact that we synthesize a unique parameter name (`_a`) in the outermost function of the async function, but pushed a new scope inside of the function we pass to `__awaiter`. This results in us shadowing `_a` with a new temporary variable.

The fix is to have the function we pass to `__awaiter` also have the flag set to prevent pushing and popping the scope.

Fixes #19187
