### PR TITLE
Don't try to run unit tests with rwc tests in the parallel runner

### DIFF
--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -137,7 +137,7 @@ namespace Harness.Parallel.Host {
         let closedWorkers = 0;
         for (let i = 0; i < workerCount; i++) {
             // TODO: Just send the config over the IPC channel or in the command line arguments
-            const config: TestConfig = { light: Harness.lightMode, listenForWork: true, runUnitTests: runners.length !== 1 };
+            const config: TestConfig = { light: Harness.lightMode, listenForWork: true, runUnitTests };
             const configPath = ts.combinePaths(taskConfigsFolder, `task-config${i}.json`);
             Harness.IO.writeFile(configPath, JSON.stringify(config));
             const child = fork(__filename, [`--config="${configPath}"`]);

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -82,7 +82,7 @@ let testConfigContent =
 
 let taskConfigsFolder: string;
 let workerCount: number;
-let runUnitTests = true;
+let runUnitTests: boolean | undefined;
 let noColors = false;
 
 interface TestConfig {
@@ -108,9 +108,7 @@ function handleTestConfig() {
         if (testConfig.light) {
             Harness.lightMode = true;
         }
-        if (testConfig.runUnitTests !== undefined) {
-            runUnitTests = testConfig.runUnitTests;
-        }
+        runUnitTests = testConfig.runUnitTests;
         if (testConfig.workerCount) {
             workerCount = +testConfig.workerCount;
         }
@@ -198,6 +196,9 @@ function handleTestConfig() {
         runners.push(new FourSlashRunner(FourSlashTestType.ShimsWithPreprocess));
         runners.push(new FourSlashRunner(FourSlashTestType.Server));
         // runners.push(new GeneratedFourslashRunner());
+    }
+    if (runUnitTests === undefined) {
+        runUnitTests = runners.length !== 1; // Don't run unit tests when running only one runner if unit tests were not explicitly asked for
     }
 }
 


### PR DESCRIPTION
The parallel runner was discovering unit tests alongside rwc tests after the new change to run unittests over multiple threads. This stops that.