### PR TITLE
Make all runner describe blocks contain their lowercase runner name

### DIFF
--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -48,7 +48,7 @@ class CompilerBaselineRunner extends RunnerBase {
     }
 
     public checkTestCodeOutput(fileName: string) {
-        describe("compiler tests for " + fileName, () => {
+        describe(`${this.testSuiteName} tests for ${fileName}`, () => {
             // Mocha holds onto the closure environment of the describe callback even after the test is done.
             // Everything declared here should be cleared out in the "after" callback.
             let justName: string;

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -443,7 +443,7 @@ class ProjectRunner extends RunnerBase {
 
         const name = "Compiling project for " + testCase.scenario + ": testcase " + testCaseFileName;
 
-        describe("Projects tests", () => {
+        describe("projects tests", () => {
             describe(name, () => {
                 function verifyCompilerResults(moduleKind: ts.ModuleKind) {
                     let compilerResult: BatchCompileProjectTestCaseResult;

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -26,7 +26,7 @@ namespace RWC {
     }
 
     export function runRWCTest(jsonPath: string) {
-        describe("Testing a RWC project: " + jsonPath, () => {
+        describe("Testing a rwc project: " + jsonPath, () => {
             let inputFiles: Harness.Compiler.TestFile[] = [];
             let otherFiles: Harness.Compiler.TestFile[] = [];
             let tsconfigFiles: Harness.Compiler.TestFile[] = [];
@@ -266,6 +266,7 @@ class RWCRunner extends RunnerBase {
     public initializeTests(): void {
         // Read in and evaluate the test list
         const testList = this.tests && this.tests.length ? this.tests : this.enumerateTestFiles();
+
         for (let i = 0; i < testList.length; i++) {
             this.runTest(testList[i]);
         }


### PR DESCRIPTION
Mocha's `-g` parameter has become case-sensitive (or rather, it should have been case sensitive for awhile, but the update with the change was only published ~2.5 weeks ago) - this is why rwc tests had stopped running on internal CI - we launch with `jake runtests tests=rwc`, which tells our harness to load the `rwc` runner _and_ passes the string `"rwc"` into mocha to filter with. I'll probably separate the grep vs the runner selection into differing `jake` arguments in the near future, as I would like the ability to run a single `rwc` test in the future, but for now this gets RWC CI running again.