### PR TITLE
This fixes the issue with tsc --watch when module emit kind is none and directory watcher gets invoked instead of file

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2701,8 +2701,14 @@ namespace ts {
 
     export function assertTypeIsNever(_: never): void { }
 
+    export interface FileAndDirectoryExistence {
+        fileExists: boolean;
+        directoryExists: boolean;
+    }
+
     export interface CachedDirectoryStructureHost extends DirectoryStructureHost {
-        addOrDeleteFileOrDirectory(fileOrDirectory: string, fileOrDirectoryPath: Path): void;
+        /** Returns the queried result for the file exists and directory exists if at all it was done */
+        addOrDeleteFileOrDirectory(fileOrDirectory: string, fileOrDirectoryPath: Path): FileAndDirectoryExistence | undefined;
         addOrDeleteFile(fileName: string, filePath: Path, eventKind: FileWatcherEventKind): void;
         clearCache(): void;
     }
@@ -2872,8 +2878,13 @@ namespace ts {
                 if (parentResult) {
                     const baseName = getBaseNameOfFileName(fileOrDirectory);
                     if (parentResult) {
-                        updateFilesOfFileSystemEntry(parentResult, baseName, host.fileExists(fileOrDirectoryPath));
-                        updateFileSystemEntry(parentResult.directories, baseName, host.directoryExists(fileOrDirectoryPath));
+                        const fsQueryResult: FileAndDirectoryExistence = {
+                            fileExists: host.fileExists(fileOrDirectoryPath),
+                            directoryExists: host.directoryExists(fileOrDirectoryPath)
+                        };
+                        updateFilesOfFileSystemEntry(parentResult, baseName, fsQueryResult.fileExists);
+                        updateFileSystemEntry(parentResult.directories, baseName, fsQueryResult.directoryExists);
+                        return fsQueryResult;
                     }
                 }
             }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -250,7 +250,7 @@ namespace ts.TestFSWithWatch {
             return this.toPath(this.toNormalizedAbsolutePath(s));
         }
 
-        reloadFS(fileOrFolderList: ReadonlyArray<FileOrFolder>) {
+        reloadFS(fileOrFolderList: ReadonlyArray<FileOrFolder>, invokeDirectoryWatcherInsteadOfFileChanged?: boolean) {
             const mapNewLeaves = createMap<true>();
             const isNewFs = this.fs.size === 0;
             // always inject safelist file in the list of files
@@ -265,7 +265,12 @@ namespace ts.TestFSWithWatch {
                             // Update file
                             if (currentEntry.content !== fileOrDirectory.content) {
                                 currentEntry.content = fileOrDirectory.content;
-                                this.invokeFileWatcher(currentEntry.fullPath, FileWatcherEventKind.Changed);
+                                if (invokeDirectoryWatcherInsteadOfFileChanged) {
+                                    this.invokeDirectoryWatcher(getDirectoryPath(currentEntry.fullPath), currentEntry.fullPath);
+                                }
+                                else {
+                                    this.invokeFileWatcher(currentEntry.fullPath, FileWatcherEventKind.Changed);
+                                }
                             }
                         }
                         else {


### PR DESCRIPTION
This handles the case when directory watcher is invoked instead of file watcher for the changes in the file.
This only needs handling tsc --watch callback since from tsserver side we don't do anything specific with file changed or when file added to the directory.
Also this is only issue when module emit kind is none = builder will use non emit handler which means that it wont do any extra checks if file versions have not changed hence not facing this issue otherwise.
Fixes #19206
