### PR TITLE
Fixup line and offset of rename location of refactor

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -351,7 +351,7 @@ namespace ts {
     /**
      * We assume the first line starts at position 0 and 'position' is non-negative.
      */
-    export function computeLineAndCharacterOfPosition(lineStarts: ReadonlyArray<number>, position: number) {
+    export function computeLineAndCharacterOfPosition(lineStarts: ReadonlyArray<number>, position: number): LineAndCharacter {
         let lineNumber = binarySearch(lineStarts, position);
         if (lineNumber < 0) {
             // If the actual position was not found,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3810,9 +3810,10 @@ namespace ts {
     }
 
     export interface LineAndCharacter {
+        /** 0-based. */
         line: number;
         /*
-         * This value denotes the character position in line and is different from the 'column' because of tab characters.
+         * 0-based. This value denotes the character position in line and is different from the 'column' because of tab characters.
          */
         character: number;
     }

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -680,7 +680,8 @@ namespace ts.server {
                     },
                 ],
             };
-            fixupLineAndOffset({ line: 2, offset: 11 }, text, newLocation, fileName, [edits]);
+            const res = fixupLineAndOffset({ line: 2, offset: 11 }, text, newLocation, fileName, [edits]);
+            assert.deepEqual(res, { line: 4, offset: 11 });
         });
     });
 }

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -661,4 +661,26 @@ namespace ts.server {
             session.consumeQueue();
         });
     });
+
+    describe("helpers", () => {
+        it(fixupLineAndOffset.name, () => {
+            const text = `// blank line\nconst x = 0;`;
+            const newLocation = text.indexOf("0");
+            const fileName = "/a.ts";
+            const edits: ts.FileTextChanges = {
+                fileName,
+                textChanges: [
+                    {
+                        span: { start: 0, length: 0 },
+                        newText: "const newLocal = 0;\n\n",
+                    },
+                    {
+                        span: { start: newLocation, length: 1 },
+                        newText: "newLocal",
+                    },
+                ],
+            };
+            fixupLineAndOffset({ line: 2, offset: 11 }, text, newLocation, fileName, [edits]);
+        });
+    });
 }

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -663,9 +663,9 @@ namespace ts.server {
     });
 
     describe("helpers", () => {
-        it(fixupLineAndOffset.name, () => {
+        it(getLocationInNewDocument.name, () => {
             const text = `// blank line\nconst x = 0;`;
-            const newLocation = text.indexOf("0");
+            const renameLocationInOldText = text.indexOf("0");
             const fileName = "/a.ts";
             const edits: ts.FileTextChanges = {
                 fileName,
@@ -675,12 +675,13 @@ namespace ts.server {
                         newText: "const newLocal = 0;\n\n",
                     },
                     {
-                        span: { start: newLocation, length: 1 },
+                        span: { start: renameLocationInOldText, length: 1 },
                         newText: "newLocal",
                     },
                 ],
             };
-            const res = fixupLineAndOffset({ line: 2, offset: 11 }, text, newLocation, fileName, [edits]);
+            const renameLocationInNewText = renameLocationInOldText + edits.textChanges[0].newText.length;
+            const res = getLocationInNewDocument(text, fileName, renameLocationInNewText, [edits]);
             assert.deepEqual(res, { line: 4, offset: 11 });
         });
     });

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -2049,8 +2049,17 @@ namespace ts.server {
     function countNewlines(s: string): number {
         let count = 0;
         for (let i = 0; i < s.length; i++) {
-            if (s.charCodeAt(i) === CharacterCodes.lineFeed) {
-                count++;
+            switch (s.charCodeAt(i)) {
+                case CharacterCodes.carriageReturn:
+                    count++;
+                    i++;
+                    // Skip a "\n" after a "\r" because "\r\n" is only one newline. But "\r\r" is two.
+                    if (s.charCodeAt(i) === CharacterCodes.carriageReturn) {
+                        count++;
+                    }
+                    break;
+                case CharacterCodes.lineFeed:
+                    count++;
             }
         }
         return count;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -2090,7 +2090,7 @@ namespace ts.server {
                     count++;
                     i++;
                     // Skip a "\n" after a "\r" because "\r\n" is only one newline. But "\r\r" is two.
-                    if (s.charCodeAt(i) === CharacterCodes.carriageReturn) {
+                    if (i < s.length && s.charCodeAt(i) === CharacterCodes.carriageReturn) {
                         count++;
                     }
                     break;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2306,6 +2306,7 @@ declare namespace ts {
         LineFeed = 1,
     }
     interface LineAndCharacter {
+        /** 0-based. */
         line: number;
         character: number;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2306,6 +2306,7 @@ declare namespace ts {
         LineFeed = 1,
     }
     interface LineAndCharacter {
+        /** 0-based. */
         line: number;
         character: number;
     }


### PR DESCRIPTION
Fixes #19116
Tested by pointing vscode to the output of `gulp local`.