### PR TITLE
Workaround for nonnull operator on indexed accesses

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11378,6 +11378,18 @@ namespace ts {
         }
 
         function getTypeWithFacts(type: Type, include: TypeFacts) {
+            if (type.flags & TypeFlags.IndexedAccess) {
+                // TODO (weswig): This is a substitute for a lazy negated type to remove the types indicated by the TypeFacts from the (potential) union the IndexedAccess refers to
+                //  - instead of defering the resolution of the access, we apply the facts to the base constraint of the access instead; so this works under most circumstances,
+                //    like when the index refers to an optional member and you want to access that member, but unfortunately if that member's type is supposed to vary with the base,
+                //    then the eager evaluation of this removes that relationship
+                const innerType = getBaseConstraintOfType(type) || emptyObjectType;
+                const result = filterType(innerType, t => (getTypeFacts(t) & include) !== 0);
+                if (result !== innerType) {
+                    return result;
+                }
+                return type;
+            }
             return filterType(type, t => (getTypeFacts(t) & include) !== 0);
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11380,12 +11380,10 @@ namespace ts {
         function getTypeWithFacts(type: Type, include: TypeFacts) {
             if (type.flags & TypeFlags.IndexedAccess) {
                 // TODO (weswig): This is a substitute for a lazy negated type to remove the types indicated by the TypeFacts from the (potential) union the IndexedAccess refers to
-                //  - instead of defering the resolution of the access, we apply the facts to the base constraint of the access instead; so this works under most circumstances,
-                //    like when the index refers to an optional member and you want to access that member, but unfortunately if that member's type is supposed to vary with the base,
-                //    then the eager evaluation of this removes that relationship
-                const innerType = getBaseConstraintOfType(type) || emptyObjectType;
-                const result = filterType(innerType, t => (getTypeFacts(t) & include) !== 0);
-                if (result !== innerType) {
+                //  - See discussion in https://github.com/Microsoft/TypeScript/pull/19275 for details, and test `strictNullNotNullIndexTypeShouldWork` for current behavior
+                const baseConstraint = getBaseConstraintOfType(type) || emptyObjectType;
+                const result = filterType(baseConstraint, t => (getTypeFacts(t) & include) !== 0);
+                if (result !== baseConstraint) {
                     return result;
                 }
                 return type;

--- a/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.js
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.js
@@ -14,13 +14,21 @@ class Test<T extends A> {
 interface Foo {
     foo?: number;
 }
-  
+
 class FooClass<P extends Foo = Foo> {
     properties: Readonly<P>;
 
     foo(): number {
         const { foo = 42 } = this.properties;
         return foo;
+    }
+}
+
+class Test2<T extends A> {
+    attrs: Readonly<T>;
+
+    m() {
+        return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
     }
 }
 
@@ -41,4 +49,12 @@ var FooClass = /** @class */ (function () {
         return foo;
     };
     return FooClass;
+}());
+var Test2 = /** @class */ (function () {
+    function Test2() {
+    }
+    Test2.prototype.m = function () {
+        return this.attrs.params; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+    };
+    return Test2;
 }());

--- a/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.js
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.js
@@ -1,0 +1,44 @@
+//// [strictNullNotNullIndexTypeShouldWork.ts]
+interface A {
+    params?: { name: string; };
+}
+
+class Test<T extends A> {
+    attrs: Readonly<T>;
+
+    m() {
+        this.attrs.params!.name;
+    }
+}
+
+interface Foo {
+    foo?: number;
+}
+  
+class FooClass<P extends Foo = Foo> {
+    properties: Readonly<P>;
+
+    foo(): number {
+        const { foo = 42 } = this.properties;
+        return foo;
+    }
+}
+
+//// [strictNullNotNullIndexTypeShouldWork.js]
+var Test = /** @class */ (function () {
+    function Test() {
+    }
+    Test.prototype.m = function () {
+        this.attrs.params.name;
+    };
+    return Test;
+}());
+var FooClass = /** @class */ (function () {
+    function FooClass() {
+    }
+    FooClass.prototype.foo = function () {
+        var _a = this.properties.foo, foo = _a === void 0 ? 42 : _a;
+        return foo;
+    };
+    return FooClass;
+}());

--- a/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.symbols
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.symbols
@@ -37,7 +37,7 @@ interface Foo {
     foo?: number;
 >foo : Symbol(Foo.foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 12, 15))
 }
-  
+
 class FooClass<P extends Foo = Foo> {
 >FooClass : Symbol(FooClass, Decl(strictNullNotNullIndexTypeShouldWork.ts, 14, 1))
 >P : Symbol(P, Decl(strictNullNotNullIndexTypeShouldWork.ts, 16, 15))
@@ -60,5 +60,27 @@ class FooClass<P extends Foo = Foo> {
 
         return foo;
 >foo : Symbol(foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 20, 15))
+    }
+}
+
+class Test2<T extends A> {
+>Test2 : Symbol(Test2, Decl(strictNullNotNullIndexTypeShouldWork.ts, 23, 1))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeShouldWork.ts, 25, 12))
+>A : Symbol(A, Decl(strictNullNotNullIndexTypeShouldWork.ts, 0, 0))
+
+    attrs: Readonly<T>;
+>attrs : Symbol(Test2.attrs, Decl(strictNullNotNullIndexTypeShouldWork.ts, 25, 26))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeShouldWork.ts, 25, 12))
+
+    m() {
+>m : Symbol(Test2.m, Decl(strictNullNotNullIndexTypeShouldWork.ts, 26, 23))
+
+        return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+>this.attrs.params : Symbol(params, Decl(strictNullNotNullIndexTypeShouldWork.ts, 0, 13))
+>this.attrs : Symbol(Test2.attrs, Decl(strictNullNotNullIndexTypeShouldWork.ts, 25, 26))
+>this : Symbol(Test2, Decl(strictNullNotNullIndexTypeShouldWork.ts, 23, 1))
+>attrs : Symbol(Test2.attrs, Decl(strictNullNotNullIndexTypeShouldWork.ts, 25, 26))
+>params : Symbol(params, Decl(strictNullNotNullIndexTypeShouldWork.ts, 0, 13))
     }
 }

--- a/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.symbols
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.symbols
@@ -1,0 +1,64 @@
+=== tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts ===
+interface A {
+>A : Symbol(A, Decl(strictNullNotNullIndexTypeShouldWork.ts, 0, 0))
+
+    params?: { name: string; };
+>params : Symbol(A.params, Decl(strictNullNotNullIndexTypeShouldWork.ts, 0, 13))
+>name : Symbol(name, Decl(strictNullNotNullIndexTypeShouldWork.ts, 1, 14))
+}
+
+class Test<T extends A> {
+>Test : Symbol(Test, Decl(strictNullNotNullIndexTypeShouldWork.ts, 2, 1))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeShouldWork.ts, 4, 11))
+>A : Symbol(A, Decl(strictNullNotNullIndexTypeShouldWork.ts, 0, 0))
+
+    attrs: Readonly<T>;
+>attrs : Symbol(Test.attrs, Decl(strictNullNotNullIndexTypeShouldWork.ts, 4, 25))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeShouldWork.ts, 4, 11))
+
+    m() {
+>m : Symbol(Test.m, Decl(strictNullNotNullIndexTypeShouldWork.ts, 5, 23))
+
+        this.attrs.params!.name;
+>this.attrs.params!.name : Symbol(name, Decl(strictNullNotNullIndexTypeShouldWork.ts, 1, 14))
+>this.attrs.params : Symbol(params, Decl(strictNullNotNullIndexTypeShouldWork.ts, 0, 13))
+>this.attrs : Symbol(Test.attrs, Decl(strictNullNotNullIndexTypeShouldWork.ts, 4, 25))
+>this : Symbol(Test, Decl(strictNullNotNullIndexTypeShouldWork.ts, 2, 1))
+>attrs : Symbol(Test.attrs, Decl(strictNullNotNullIndexTypeShouldWork.ts, 4, 25))
+>params : Symbol(params, Decl(strictNullNotNullIndexTypeShouldWork.ts, 0, 13))
+>name : Symbol(name, Decl(strictNullNotNullIndexTypeShouldWork.ts, 1, 14))
+    }
+}
+
+interface Foo {
+>Foo : Symbol(Foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 10, 1))
+
+    foo?: number;
+>foo : Symbol(Foo.foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 12, 15))
+}
+  
+class FooClass<P extends Foo = Foo> {
+>FooClass : Symbol(FooClass, Decl(strictNullNotNullIndexTypeShouldWork.ts, 14, 1))
+>P : Symbol(P, Decl(strictNullNotNullIndexTypeShouldWork.ts, 16, 15))
+>Foo : Symbol(Foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 10, 1))
+>Foo : Symbol(Foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 10, 1))
+
+    properties: Readonly<P>;
+>properties : Symbol(FooClass.properties, Decl(strictNullNotNullIndexTypeShouldWork.ts, 16, 37))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>P : Symbol(P, Decl(strictNullNotNullIndexTypeShouldWork.ts, 16, 15))
+
+    foo(): number {
+>foo : Symbol(FooClass.foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 17, 28))
+
+        const { foo = 42 } = this.properties;
+>foo : Symbol(foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 20, 15))
+>this.properties : Symbol(FooClass.properties, Decl(strictNullNotNullIndexTypeShouldWork.ts, 16, 37))
+>this : Symbol(FooClass, Decl(strictNullNotNullIndexTypeShouldWork.ts, 14, 1))
+>properties : Symbol(FooClass.properties, Decl(strictNullNotNullIndexTypeShouldWork.ts, 16, 37))
+
+        return foo;
+>foo : Symbol(foo, Decl(strictNullNotNullIndexTypeShouldWork.ts, 20, 15))
+    }
+}

--- a/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.types
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.types
@@ -1,0 +1,66 @@
+=== tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts ===
+interface A {
+>A : A
+
+    params?: { name: string; };
+>params : { name: string; } | undefined
+>name : string
+}
+
+class Test<T extends A> {
+>Test : Test<T>
+>T : T
+>A : A
+
+    attrs: Readonly<T>;
+>attrs : Readonly<T>
+>Readonly : Readonly<T>
+>T : T
+
+    m() {
+>m : () => void
+
+        this.attrs.params!.name;
+>this.attrs.params!.name : string
+>this.attrs.params! : { name: string; }
+>this.attrs.params : T["params"]
+>this.attrs : Readonly<T>
+>this : this
+>attrs : Readonly<T>
+>params : T["params"]
+>name : string
+    }
+}
+
+interface Foo {
+>Foo : Foo
+
+    foo?: number;
+>foo : number | undefined
+}
+  
+class FooClass<P extends Foo = Foo> {
+>FooClass : FooClass<P>
+>P : P
+>Foo : Foo
+>Foo : Foo
+
+    properties: Readonly<P>;
+>properties : Readonly<P>
+>Readonly : Readonly<T>
+>P : P
+
+    foo(): number {
+>foo : () => number
+
+        const { foo = 42 } = this.properties;
+>foo : number
+>42 : 42
+>this.properties : Readonly<P>
+>this : this
+>properties : Readonly<P>
+
+        return foo;
+>foo : number
+    }
+}

--- a/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.types
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.types
@@ -38,7 +38,7 @@ interface Foo {
     foo?: number;
 >foo : number | undefined
 }
-  
+
 class FooClass<P extends Foo = Foo> {
 >FooClass : FooClass<P>
 >P : P
@@ -62,5 +62,28 @@ class FooClass<P extends Foo = Foo> {
 
         return foo;
 >foo : number
+    }
+}
+
+class Test2<T extends A> {
+>Test2 : Test2<T>
+>T : T
+>A : A
+
+    attrs: Readonly<T>;
+>attrs : Readonly<T>
+>Readonly : Readonly<T>
+>T : T
+
+    m() {
+>m : () => { name: string; }
+
+        return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+>this.attrs.params! : { name: string; }
+>this.attrs.params : T["params"]
+>this.attrs : Readonly<T>
+>this : this
+>attrs : Readonly<T>
+>params : T["params"]
     }
 }

--- a/tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts
+++ b/tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts
@@ -1,0 +1,25 @@
+// @strictNullChecks: true
+interface A {
+    params?: { name: string; };
+}
+
+class Test<T extends A> {
+    attrs: Readonly<T>;
+
+    m() {
+        this.attrs.params!.name;
+    }
+}
+
+interface Foo {
+    foo?: number;
+}
+  
+class FooClass<P extends Foo = Foo> {
+    properties: Readonly<P>;
+
+    foo(): number {
+        const { foo = 42 } = this.properties;
+        return foo;
+    }
+}

--- a/tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts
+++ b/tests/cases/compiler/strictNullNotNullIndexTypeShouldWork.ts
@@ -14,12 +14,20 @@ class Test<T extends A> {
 interface Foo {
     foo?: number;
 }
-  
+
 class FooClass<P extends Foo = Foo> {
     properties: Readonly<P>;
 
     foo(): number {
         const { foo = 42 } = this.properties;
         return foo;
+    }
+}
+
+class Test2<T extends A> {
+    attrs: Readonly<T>;
+
+    m() {
+        return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
     }
 }


### PR DESCRIPTION
We now force the substitution of an indexed access with its base constraint when getting a type with facts, allowing the resulting type to be filtered. The correct approach would be to apply a lazy subtraction type to the indexed access type, and defer the evaluation until required; however @rbuckton is already working on something which can subsume that purpose.

Fixes #17005
