### PR TITLE
Fix undefined error using `getEffectiveTypeRoots`

### DIFF
--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -212,6 +212,11 @@ namespace Harness.LanguageService {
             return script ? script.version.toString() : undefined;
         }
 
+        directoryExists(dirName: string): boolean {
+            const fileEntry = this.virtualFileSystem.traversePath(dirName);
+            return fileEntry && fileEntry.isDirectory();
+        }
+
         fileExists(fileName: string): boolean {
             const script = this.getScriptSnapshot(fileName);
             return script !== undefined;

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -367,7 +367,8 @@ namespace ts.codefix {
         getCanonicalFileName: (file: string) => string,
         moduleFileName: string,
     ): string | undefined {
-        return firstDefined(getEffectiveTypeRoots(options, host), unNormalizedTypeRoot => {
+        const roots = getEffectiveTypeRoots(options, host);
+        return roots && firstDefined(roots, unNormalizedTypeRoot => {
             const typeRoot = toPath(unNormalizedTypeRoot, /*basePath*/ undefined, getCanonicalFileName);
             if (startsWith(moduleFileName, typeRoot)) {
                 return removeExtensionAndIndexPostFix(moduleFileName.substring(typeRoot.length + 1));


### PR DESCRIPTION
Fixes #19286

Needed to get the test harness to implement `directoryExists` to expose the error, otherwise `getDefaultTypeRoots` would return a hardcoded value. Normally it will be `undefined` if you don't have `node_modules` installed.