### PR TITLE
Fixes for refactor "Annotate with type from JSDoc"

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7064,14 +7064,6 @@ namespace ts {
             }
         }
 
-        function isJSDocIndexSignature(node: TypeReferenceNode | ExpressionWithTypeArguments) {
-            return isTypeReferenceNode(node) &&
-                isIdentifier(node.typeName) &&
-                node.typeName.escapedText === "Object" &&
-                node.typeArguments && node.typeArguments.length === 2 &&
-                (node.typeArguments[0].kind === SyntaxKind.StringKeyword || node.typeArguments[0].kind === SyntaxKind.NumberKeyword);
-        }
-
         function getTypeFromJSDocNullableTypeNode(node: JSDocNullableType) {
             const type = getTypeFromTypeNode(node.type);
             return strictNullChecks ? getUnionType([type, nullType]) : type;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1360,6 +1360,14 @@ namespace ts {
         return node && !!(node.flags & NodeFlags.JSDoc);
     }
 
+    export function isJSDocIndexSignature(node: TypeReferenceNode | ExpressionWithTypeArguments) {
+        return isTypeReferenceNode(node) &&
+            isIdentifier(node.typeName) &&
+            node.typeName.escapedText === "Object" &&
+            node.typeArguments && node.typeArguments.length === 2 &&
+            (node.typeArguments[0].kind === SyntaxKind.StringKeyword || node.typeArguments[0].kind === SyntaxKind.NumberKeyword);
+    }
+
     /**
      * Returns true if the node is a CallExpression to the identifier 'require' with
      * exactly one argument (of the form 'require("name")').

--- a/src/services/refactors/annotateWithTypeFromJSDoc.ts
+++ b/src/services/refactors/annotateWithTypeFromJSDoc.ts
@@ -249,12 +249,4 @@ namespace ts.refactor.annotateWithTypeFromJSDoc {
         setEmitFlags(indexSignature, EmitFlags.SingleLine);
         return indexSignature;
     }
-
-    function isJSDocIndexSignature(node: TypeReferenceNode | ExpressionWithTypeArguments) {
-        return isTypeReferenceNode(node) &&
-            isIdentifier(node.typeName) &&
-            node.typeName.escapedText === "Object" &&
-            node.typeArguments && node.typeArguments.length === 2 &&
-            (node.typeArguments[0].kind === SyntaxKind.StringKeyword || node.typeArguments[0].kind === SyntaxKind.NumberKeyword);
-    }
 }

--- a/tests/baselines/reference/jsdocIndexSignature.errors.txt
+++ b/tests/baselines/reference/jsdocIndexSignature.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/conformance/jsdoc/indices.js(9,5): error TS2322: Type '1' is not assignable to type 'boolean'.
+
+
+==== tests/cases/conformance/jsdoc/indices.js (1 errors) ====
+    /** @type {Object.<string, number>} */
+    var o1;
+    /** @type {Object.<number, boolean>} */
+    var o2;
+    /** @type {Object.<boolean, string>} */
+    var o3;
+    /** @param {Object.<string, boolean>} o */
+    function f(o) {
+        o.foo = 1; // error
+        ~~~~~
+!!! error TS2322: Type '1' is not assignable to type 'boolean'.
+        o.bar = false; // ok
+    }
+    

--- a/tests/baselines/reference/jsdocIndexSignature.symbols
+++ b/tests/baselines/reference/jsdocIndexSignature.symbols
@@ -11,3 +11,15 @@ var o2;
 var o3;
 >o3 : Symbol(o3, Decl(indices.js, 5, 3))
 
+/** @param {Object.<string, boolean>} o */
+function f(o) {
+>f : Symbol(f, Decl(indices.js, 5, 7))
+>o : Symbol(o, Decl(indices.js, 7, 11))
+
+    o.foo = 1; // error
+>o : Symbol(o, Decl(indices.js, 7, 11))
+
+    o.bar = false; // ok
+>o : Symbol(o, Decl(indices.js, 7, 11))
+}
+

--- a/tests/baselines/reference/jsdocIndexSignature.types
+++ b/tests/baselines/reference/jsdocIndexSignature.types
@@ -11,3 +11,23 @@ var o2;
 var o3;
 >o3 : any
 
+/** @param {Object.<string, boolean>} o */
+function f(o) {
+>f : (o: { [x: string]: boolean; }) => void
+>o : { [x: string]: boolean; }
+
+    o.foo = 1; // error
+>o.foo = 1 : 1
+>o.foo : boolean
+>o : { [x: string]: boolean; }
+>foo : boolean
+>1 : 1
+
+    o.bar = false; // ok
+>o.bar = false : false
+>o.bar : boolean
+>o : { [x: string]: boolean; }
+>bar : boolean
+>false : false
+}
+

--- a/tests/cases/conformance/jsdoc/jsdocIndexSignature.ts
+++ b/tests/cases/conformance/jsdoc/jsdocIndexSignature.ts
@@ -8,3 +8,8 @@ var o1;
 var o2;
 /** @type {Object.<boolean, string>} */
 var o3;
+/** @param {Object.<string, boolean>} o */
+function f(o) {
+    o.foo = 1; // error
+    o.bar = false; // ok
+}

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc10.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc10.ts
@@ -12,4 +12,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
  * @param {?} x
  * @returns {number}
  */
-var f = (x: any): number => x`, 'Annotate with types from JSDoc', 'annotate');
+var f = (x: any): number => x`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc11.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc11.ts
@@ -12,4 +12,4 @@ verify.fileAfterApplyingRefactorAtMarker('2',
  * @param {?} x
  * @returns {number}
  */
-var f = (x: any): number => x`, 'Annotate with types from JSDoc', 'annotate');
+var f = (x: any): number => x`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc12.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc12.ts
@@ -15,4 +15,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
      */
     m(x): any[] {
     }
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc13.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc13.ts
@@ -8,4 +8,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
 `class C {
     /** @return {number} */
     get c(): number { return 12; }
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc14.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc14.ts
@@ -8,4 +8,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
 `/** @return {number} */
 function f(): number {
     return 12;
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc15.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc15.ts
@@ -27,4 +27,4 @@ verify.fileAfterApplyingRefactorAtMarker('9',
  * @param {promise<String>} zeta
  */
 function f(x: boolean, y: string, z: number, alpha: object, beta: Date, gamma: Promise<any>, delta: Array<any>, epsilon: Array<number>, zeta: Promise<string>) {
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc17.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc17.ts
@@ -14,5 +14,5 @@ verify.fileAfterApplyingRefactorAtMarker('1',
      */
     constructor(x: number) {
     }
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');
 

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc18.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc18.ts
@@ -8,4 +8,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
 `class C {
     /** @param {number} value */
     set c(value: number) { return 12; }
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc19.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc19.ts
@@ -16,4 +16,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
  * @param {T} b
  */
 function f<T>(a: number, b: T) {
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc20.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc20.ts
@@ -14,4 +14,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
  * @param {T} b
  */
 function f<T>(a: number, b: T) {
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc21.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc21.ts
@@ -1,0 +1,73 @@
+/// <reference path='fourslash.ts' />
+// @strict: true
+/////**
+//// * @return {number}
+//// */
+////function /*1*/f(x, y) {
+////}
+////
+/////**
+//// * @return {number}
+//// */
+////function /*2*/g(x, y): number {
+////    return 0;
+////}
+/////**
+//// * @param {number} x
+//// */
+////function /*3*/h(x: number, y): number {
+////    return 0;
+////}
+////
+/////**
+//// * @param {number} x
+//// * @param {string} y
+//// */
+////function /*4*/i(x: number, y: string) {
+////}
+/////**
+//// * @param {number} x
+//// * @return {boolean}
+//// */
+////function /*5*/j(x: number, y): boolean {
+////    return true;
+////}
+
+verify.not.applicableRefactorAvailableAtMarker('2');
+verify.not.applicableRefactorAvailableAtMarker('3');
+verify.not.applicableRefactorAvailableAtMarker('4');
+verify.not.applicableRefactorAvailableAtMarker('5');
+verify.applicableRefactorAvailableAtMarker('1');
+verify.fileAfterApplyingRefactorAtMarker('1',
+`/**
+ * @return {number}
+ */
+function f(x, y): number {
+}
+
+/**
+ * @return {number}
+ */
+function g(x, y): number {
+    return 0;
+}
+/**
+ * @param {number} x
+ */
+function h(x: number, y): number {
+    return 0;
+}
+
+/**
+ * @param {number} x
+ * @param {string} y
+ */
+function i(x: number, y: string) {
+}
+/**
+ * @param {number} x
+ * @return {boolean}
+ */
+function j(x: number, y): boolean {
+    return true;
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc22.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc22.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+// @strict: true
+////
+/////** @param {Object<string, boolean>} sb
+////  * @param {Object<number, string>} ns */
+////function /*1*/f(sb, ns) {
+////}
+verify.applicableRefactorAvailableAtMarker('1');
+verify.fileAfterApplyingRefactorAtMarker('1',
+`
+/** @param {Object<string, boolean>} sb
+  * @param {Object<number, string>} ns */
+function f(sb: { [s: string]: boolean; }, ns: { [n: number]: string; }) {
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc3.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc3.ts
@@ -24,5 +24,5 @@ function f(x: number, y: {
     a: string;
     b: Date;
 }, z: string, alpha, beta: any) {
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');
 

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc3.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc3.ts
@@ -20,9 +20,6 @@ verify.fileAfterApplyingRefactorAtMarker('1',
  * @param alpha - the other best parameter
  * @param {*} beta - I have no idea how this got here
  */
-function f(x: number, y: {
-    a: string;
-    b: Date;
-}, z: string, alpha, beta: any) {
+function f(x: number, y: { a: string; b: Date; }, z: string, alpha, beta: any) {
 }`, 'Annotate with type from JSDoc', 'annotate');
 

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc4.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc4.ts
@@ -23,7 +23,5 @@ verify.fileAfterApplyingRefactorAtMarker('5',
  * @param {number?} gamma
  * @param {number!} delta
  */
-function f(x: any, y: any, z: number | undefined, alpha: number[], beta: (this: {
-    a: string;
-}, arg1: string, arg2: number) => boolean, gamma: number | null, delta: number) {
+function f(x: any, y: any, z: number | undefined, alpha: number[], beta: (this: { a: string; }, arg1: string, arg2: number) => boolean, gamma: number | null, delta: number) {
 }`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc4.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc4.ts
@@ -26,4 +26,4 @@ verify.fileAfterApplyingRefactorAtMarker('5',
 function f(x: any, y: any, z: number | undefined, alpha: number[], beta: (this: {
     a: string;
 }, arg1: string, arg2: number) => boolean, gamma: number | null, delta: number) {
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc7.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc7.ts
@@ -14,4 +14,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
  * @returns {number}
  */
 function f(x: number): number {
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc8.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc8.ts
@@ -14,4 +14,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
  * @returns {number}
  */
 var f = function(x: number): number {
-}`, 'Annotate with types from JSDoc', 'annotate');
+}`, 'Annotate with type from JSDoc', 'annotate');

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc9.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc9.ts
@@ -12,4 +12,4 @@ verify.fileAfterApplyingRefactorAtMarker('1',
  * @param {?} x
  * @returns {number}
  */
-var f = (x: any): number => x`, 'Annotate with types from JSDoc', 'annotate');
+var f = (x: any): number => x`, 'Annotate with type from JSDoc', 'annotate');


### PR DESCRIPTION
1. Collapse both refactors down to one. The message only differed by one character, so the hassle wasn't worth it. This fixes the duplicate available refactors.
2. Transform JSDoc index signatures (`Object<string, T>`) to TS index signatures.
3. Only make the refactor available when it could add types. It's not available when there's a type already, or when there's no applicable JSDoc type.
4. Remove an erroneous error on JSDoc index signatures on `@param` tags saying that "Object is not generic".

Fixes #19266 
Fixes #19238 
Fixes #19258 