### PR TITLE
Fixes the issue with emit where in same file is emitted multiple times

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -238,7 +238,7 @@ namespace ts {
             const cachedDiagnostics = semanticDiagnosticsPerFile.get(path);
             // Report the semantic diagnostics from the cache if we already have those diagnostics present
             if (cachedDiagnostics) {
-                cachedDiagnostics;
+                return cachedDiagnostics;
             }
 
             // Diagnostics werent cached, get them from program, and cache the result

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -1,5 +1,6 @@
 /// <reference path="core.ts" />
 
+/* @internal */
 namespace ts {
     /**
      * Updates the existing missing file watches with the new set of missing files after new program is created
@@ -72,10 +73,7 @@ namespace ts {
             existingWatchedForWildcards.set(directory, createWildcardDirectoryWatcher(directory, flags));
         }
     }
-}
 
-/* @internal */
-namespace ts {
     export function addFileWatcher(host: System, file: string, cb: FileWatcherCallback): FileWatcher {
         return host.watchFile(file, cb);
     }

--- a/src/harness/unittests/builder.ts
+++ b/src/harness/unittests/builder.ts
@@ -46,28 +46,20 @@ namespace ts {
     function makeAssertChanges(getProgram: () => Program): (fileNames: ReadonlyArray<string>) => void  {
         const builder = createBuilder({
             getCanonicalFileName: identity,
-            getEmitOutput: getFileEmitOutput,
-            computeHash: identity,
-            shouldEmitFile: returnTrue,
+            computeHash: identity
         });
         return fileNames => {
             const program = getProgram();
             builder.updateProgram(program);
-            const changedFiles = builder.emitChangedFiles(program);
-            assert.deepEqual(changedFileNames(changedFiles), fileNames);
+            const outputFileNames: string[] = [];
+            builder.emitChangedFiles(program, fileName => outputFileNames.push(fileName));
+            assert.deepEqual(outputFileNames, fileNames);
         };
     }
 
     function updateProgramFile(program: ProgramWithSourceTexts, fileName: string, fileContent: string): ProgramWithSourceTexts {
         return updateProgram(program, program.getRootFileNames(), program.getCompilerOptions(), files => {
             updateProgramText(files, fileName, fileContent);
-        });
-    }
-
-    function changedFileNames(changedFiles: ReadonlyArray<EmitOutputDetailed>): string[] {
-        return changedFiles.map(f => {
-            assert.lengthOf(f.outputFiles, 1);
-            return f.outputFiles[0].name;
         });
     }
 }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -448,9 +448,13 @@ namespace ts.server {
                     computeHash: data =>
                         this.projectService.host.createHash(data),
                     shouldEmitFile: sourceFile =>
-                        !this.projectService.getScriptInfoForPath(sourceFile.path).isDynamicOrHasMixedContent()
+                        !this.shouldEmitFile(sourceFile)
                 });
             }
+        }
+
+        private shouldEmitFile(sourceFile: SourceFile) {
+            return !this.projectService.getScriptInfoForPath(sourceFile.path).isDynamicOrHasMixedContent();
         }
 
         getCompileOnSaveAffectedFileList(scriptInfo: ScriptInfo): string[] {
@@ -459,7 +463,8 @@ namespace ts.server {
             }
             this.updateGraph();
             this.ensureBuilder();
-            return this.builder.getFilesAffectedBy(this.program, scriptInfo.path);
+            return mapDefined(this.builder.getFilesAffectedBy(this.program, scriptInfo.path),
+                sourceFile => this.shouldEmitFile(sourceFile) ? sourceFile.fileName : undefined);
         }
 
         /**

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -443,18 +443,13 @@ namespace ts.server {
             if (!this.builder) {
                 this.builder = createBuilder({
                     getCanonicalFileName: this.projectService.toCanonicalFileName,
-                    getEmitOutput: (_program, sourceFile, emitOnlyDts, isDetailed) =>
-                        this.getFileEmitOutput(sourceFile, emitOnlyDts, isDetailed),
-                    computeHash: data =>
-                        this.projectService.host.createHash(data),
-                    shouldEmitFile: sourceFile =>
-                        !this.shouldEmitFile(sourceFile)
+                    computeHash: data => this.projectService.host.createHash(data)
                 });
             }
         }
 
-        private shouldEmitFile(sourceFile: SourceFile) {
-            return !this.projectService.getScriptInfoForPath(sourceFile.path).isDynamicOrHasMixedContent();
+        private shouldEmitFile(scriptInfo: ScriptInfo) {
+            return scriptInfo && !scriptInfo.isDynamicOrHasMixedContent();
         }
 
         getCompileOnSaveAffectedFileList(scriptInfo: ScriptInfo): string[] {
@@ -464,15 +459,17 @@ namespace ts.server {
             this.updateGraph();
             this.ensureBuilder();
             return mapDefined(this.builder.getFilesAffectedBy(this.program, scriptInfo.path),
-                sourceFile => this.shouldEmitFile(sourceFile) ? sourceFile.fileName : undefined);
+                sourceFile => this.shouldEmitFile(this.projectService.getScriptInfoForPath(sourceFile.path)) ? sourceFile.fileName : undefined);
         }
 
         /**
          * Returns true if emit was conducted
          */
         emitFile(scriptInfo: ScriptInfo, writeFile: (path: string, data: string, writeByteOrderMark?: boolean) => void): boolean {
-            this.ensureBuilder();
-            const { emitSkipped, outputFiles } = this.builder.emitFile(this.program, scriptInfo.path);
+            if (!this.languageServiceEnabled || !this.shouldEmitFile(scriptInfo)) {
+                return false;
+            }
+            const { emitSkipped, outputFiles } = this.getLanguageService(/*ensureSynchronized*/ false).getEmitOutput(scriptInfo.fileName);
             if (!emitSkipped) {
                 for (const outputFile of outputFiles) {
                     const outputFileAbsoluteFileName = getNormalizedAbsolutePath(outputFile.name, this.currentDirectory);
@@ -596,13 +593,6 @@ namespace ts.server {
                 }
                 return scriptInfo;
             });
-        }
-
-        private getFileEmitOutput(sourceFile: SourceFile, emitOnlyDtsFiles: boolean, isDetailed: boolean) {
-            if (!this.languageServiceEnabled) {
-                return undefined;
-            }
-            return this.getLanguageService(/*ensureSynchronized*/ false).getEmitOutput(sourceFile.fileName, emitOnlyDtsFiles, isDetailed);
         }
 
         getExcludedFiles(): ReadonlyArray<NormalizedPath> {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1511,12 +1511,12 @@ namespace ts {
             return ts.NavigateTo.getNavigateToItems(sourceFiles, program.getTypeChecker(), cancellationToken, searchValue, maxResultCount, excludeDtsFiles);
         }
 
-        function getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean, isDetailed?: boolean) {
+        function getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean) {
             synchronizeHostData();
 
             const sourceFile = getValidSourceFile(fileName);
             const customTransformers = host.getCustomTransformers && host.getCustomTransformers();
-            return getFileEmitOutput(program, sourceFile, emitOnlyDtsFiles, isDetailed, cancellationToken, customTransformers);
+            return getFileEmitOutput(program, sourceFile, emitOnlyDtsFiles, cancellationToken, customTransformers);
         }
 
         // Signature help

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -287,7 +287,6 @@ namespace ts {
         getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string): RefactorEditInfo | undefined;
 
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
-        getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean, isDetailed?: boolean): EmitOutput | EmitOutputDetailed;
 
         getProgram(): Program;
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3731,17 +3731,11 @@ declare namespace ts {
         outputFiles: OutputFile[];
         emitSkipped: boolean;
     }
-    interface EmitOutputDetailed extends EmitOutput {
-        diagnostics: Diagnostic[];
-        sourceMaps: SourceMapData[];
-        emittedSourceFiles: SourceFile[];
-    }
     interface OutputFile {
         name: string;
         writeByteOrderMark: boolean;
         text: string;
     }
-    function getFileEmitOutput(program: Program, sourceFile: SourceFile, emitOnlyDtsFiles: boolean, isDetailed: boolean, cancellationToken?: CancellationToken, customTransformers?: CustomTransformers): EmitOutput | EmitOutputDetailed;
 }
 declare namespace ts {
     function findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean, configName?: string): string;
@@ -3953,7 +3947,6 @@ declare namespace ts {
         getApplicableRefactors(fileName: string, positionOrRaneg: number | TextRange): ApplicableRefactorInfo[];
         getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string): RefactorEditInfo | undefined;
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
-        getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean, isDetailed?: boolean): EmitOutput | EmitOutputDetailed;
         getProgram(): Program;
         dispose(): void;
     }
@@ -7043,23 +7036,6 @@ declare namespace ts.server {
         isJavaScript(): boolean;
     }
 }
-declare namespace ts {
-    /**
-     * Updates the existing missing file watches with the new set of missing files after new program is created
-     */
-    function updateMissingFilePathsWatch(program: Program, missingFileWatches: Map<FileWatcher>, createMissingFileWatch: (missingFilePath: Path) => FileWatcher): void;
-    interface WildcardDirectoryWatcher {
-        watcher: FileWatcher;
-        flags: WatchDirectoryFlags;
-    }
-    /**
-     * Updates the existing wild card directory watches with the new set of wild card directories from the config file
-     * after new program is created because the config file was reloaded or program was created first time from the config file
-     * Note that there is no need to call this function when the program is updated with additional files without reloading config files,
-     * as wildcard directories wont change unless reloading config file
-     */
-    function updateWatchingWildcardDirectories(existingWatchedForWildcards: Map<WildcardDirectoryWatcher>, wildcardDirectories: Map<WatchDirectoryFlags>, watchDirectory: (directory: string, flags: WatchDirectoryFlags) => FileWatcher): void;
-}
 declare namespace ts.server {
     interface InstallPackageOptionsWithProjectRootPath extends InstallPackageOptions {
         projectRootPath: Path;
@@ -7204,6 +7180,7 @@ declare namespace ts.server {
         getAllProjectErrors(): ReadonlyArray<Diagnostic>;
         getLanguageService(ensureSynchronized?: boolean): LanguageService;
         private ensureBuilder();
+        private shouldEmitFile(scriptInfo);
         getCompileOnSaveAffectedFileList(scriptInfo: ScriptInfo): string[];
         /**
          * Returns true if emit was conducted
@@ -7222,7 +7199,6 @@ declare namespace ts.server {
         getRootFiles(): NormalizedPath[];
         getRootScriptInfos(): ScriptInfo[];
         getScriptInfos(): ScriptInfo[];
-        private getFileEmitOutput(sourceFile, emitOnlyDtsFiles, isDetailed);
         getExcludedFiles(): ReadonlyArray<NormalizedPath>;
         getFileNames(excludeFilesFromExternalLibraries?: boolean, excludeConfigFiles?: boolean): NormalizedPath[];
         hasConfigFile(configFilePath: NormalizedPath): boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3678,17 +3678,11 @@ declare namespace ts {
         outputFiles: OutputFile[];
         emitSkipped: boolean;
     }
-    interface EmitOutputDetailed extends EmitOutput {
-        diagnostics: Diagnostic[];
-        sourceMaps: SourceMapData[];
-        emittedSourceFiles: SourceFile[];
-    }
     interface OutputFile {
         name: string;
         writeByteOrderMark: boolean;
         text: string;
     }
-    function getFileEmitOutput(program: Program, sourceFile: SourceFile, emitOnlyDtsFiles: boolean, isDetailed: boolean, cancellationToken?: CancellationToken, customTransformers?: CustomTransformers): EmitOutput | EmitOutputDetailed;
 }
 declare namespace ts {
     function findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean, configName?: string): string;
@@ -3953,7 +3947,6 @@ declare namespace ts {
         getApplicableRefactors(fileName: string, positionOrRaneg: number | TextRange): ApplicableRefactorInfo[];
         getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string): RefactorEditInfo | undefined;
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
-        getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean, isDetailed?: boolean): EmitOutput | EmitOutputDetailed;
         getProgram(): Program;
         dispose(): void;
     }


### PR DESCRIPTION
Before this change, all the affected files list was emitted and the file write callback was used to ensure we mark duplicate source files that would result in computing same output file (eg with --out) The issue with this was that writeFileCallback doesn't list ```.d.ts``` files as computing to same output files, yet emit with that file as sourceFile emits the same --out file. This means whenever there are multiple d.ts files are present in affected file list, it would result in same file being emitted multiple times. 
The problem got worse since builder always created emit output in memory, which means till all the changed files are written to disk those huge strings and other data exists in memory. That means you can run out of memory pretty soon. (Resulting in #19253) 

This fix deals with this by:

- emitChangedFiles in the builder doesn't generate output in memory, instead it takes the writeFileCallback (just like program::emit method)
- Do not record deleted files in changedFileSet since they are anyways not going to result in any kind of emit
- With this, now if there there is even a single file in changedFilesSet, and emit is going to use single file to output, just emit it. since with any change in program file (whether it changes shape or not) same file is going to be emitted
-  Do not cache semantic diagnostics when --out or --outFile is specified since we would anyways need to remove the diagnostics for the files that result in this emit
- Also now store the files that have already computed if the shape was changed. This helps in not returning the file as updated shape multiple times. This is needed to ensure we don't compute same d.ts files again and again to see if signature is updated.
- For declaration file, use its version as the signature instead of text so that we don't need to compute hash for them.

Apart from this another TODO and to think in future to see if we can ensure that emitter always emits just declaration file without doing any additional diagnostics/no emit checks. This would help in figuring out dependencies correctly. Right now in all these cases (for some reason emit is skipped) shape is assumed to be Skipped.

Fixes #19253 
