### PR TITLE
Remove extra blank line in logs

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -131,7 +131,7 @@ namespace ts.server {
 
         const json = JSON.stringify(msg);
         if (verboseLogging) {
-            logger.info(msg.type + ":\n" + indent(json));
+            logger.info(`${msg.type}:${indent(json)}`);
         }
 
         const len = byteLength(json, "utf8");


### PR DESCRIPTION
Sequel to #19080
`indent` adds a newline, so this was leaving an extra blank line in the logs.