### PR TITLE
Fix https://github.com/Microsoft/TypeScript/issues/19270: ensure output name is a valid locale name

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -180,6 +180,11 @@ const libraryTargets = librarySourceMap.map(function(f) {
     return path.join(builtLocalDirectory, f.target);
 });
 
+const generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages.generated.json.lcg");
+var localizationTargets = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"].map(function (f) {
+    return path.join(builtLocalDirectory, f, "diagnosticMessages.generated.json");
+}).concat(generatedLCGFile);
+
 for (const i in libraryTargets) {
     const entry = librarySourceMap[i];
     const target = libraryTargets[i];
@@ -398,7 +403,6 @@ gulp.task(generateLocalizedDiagnosticMessagesJs, /*help*/ false, [], () => {
 });
 
 // Localize diagnostics
-const generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages.generated.json.lcg");
 gulp.task(generatedLCGFile, [generateLocalizedDiagnosticMessagesJs, diagnosticInfoMapTs], (done) => {
     if (fs.existsSync(builtLocalDirectory) && needsUpdate(generatedDiagnosticMessagesJSON, generatedLCGFile)) {
         exec(host, [generateLocalizedDiagnosticMessagesJs, lclDirectory, builtLocalDirectory, generatedDiagnosticMessagesJSON], done, done);
@@ -576,8 +580,7 @@ gulp.task("dontUseDebugMode", /*help*/ false, [], (done) => { useDebugMode = fal
 gulp.task("VerifyLKG", /*help*/ false, [], () => {
     const expectedFiles = [builtLocalCompiler, servicesFile, serverFile, nodePackageFile, nodeDefinitionsFile, standaloneDefinitionsFile, tsserverLibraryFile, tsserverLibraryDefinitionFile, typingsInstallerJs, cancellationTokenJs].concat(libraryTargets);
     const missingFiles = expectedFiles.
-        concat(fs.readdirSync(lclDirectory).map(function (d) { return path.join(builtLocalDirectory, d, "diagnosticMessages.generated.json"); })).
-        concat(generatedLCGFile).
+        concat(localizationTargets).
         filter(f => !fs.existsSync(f));
     if (missingFiles.length > 0) {
         throw new Error("Cannot replace the LKG unless all built targets are present in directory " + builtLocalDirectory +

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -180,7 +180,19 @@ const libraryTargets = librarySourceMap.map(function(f) {
     return path.join(builtLocalDirectory, f.target);
 });
 
+/**
+ * .lcg file is what localization team uses to know what messages to localize.
+ * The file is always generated in 'enu\diagnosticMessages.generated.json.lcg'
+ */
 const generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages.generated.json.lcg");
+
+/**
+ * The localization target produces the two following transformation:
+ *    1. 'src\loc\lcl\<locale>\diagnosticMessages.generated.json.lcl' => 'built\local\<locale>\diagnosticMessages.generated.json'
+ *       convert localized resources into a .json file the compiler can understand
+ *    2. 'src\compiler\diagnosticMessages.generated.json' => 'built\local\ENU\diagnosticMessages.generated.json.lcg'
+ *       generate the lcg file (source of messages to localize) from the diagnosticMessages.generated.json
+ */
 const localizationTargets = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"].map(function (f) {
     return path.join(builtLocalDirectory, f, "diagnosticMessages.generated.json");
 }).concat(generatedLCGFile);

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -181,7 +181,7 @@ const libraryTargets = librarySourceMap.map(function(f) {
 });
 
 const generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages.generated.json.lcg");
-var localizationTargets = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"].map(function (f) {
+const localizationTargets = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"].map(function (f) {
     return path.join(builtLocalDirectory, f, "diagnosticMessages.generated.json");
 }).concat(generatedLCGFile);
 

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -187,7 +187,7 @@ const libraryTargets = librarySourceMap.map(function(f) {
 const generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages.generated.json.lcg");
 
 /**
- * The localization target produces the two following transformation:
+ * The localization target produces the two following transformations:
  *    1. 'src\loc\lcl\<locale>\diagnosticMessages.generated.json.lcl' => 'built\local\<locale>\diagnosticMessages.generated.json'
  *       convert localized resources into a .json file the compiler can understand
  *    2. 'src\compiler\diagnosticMessages.generated.json' => 'built\local\ENU\diagnosticMessages.generated.json.lcg'

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -239,6 +239,19 @@ var libraryTargets = librarySourceMap.map(function (f) {
     return path.join(builtLocalDirectory, f.target);
 });
 
+/**
+ * .lcg file is what localization team uses to know what messages to localize.
+ * The file is always generated in 'enu\diagnosticMessages.generated.json.lcg'
+ */
+var generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages.generated.json.lcg");
+
+/**
+ * The localization target produces the two following transformation:
+ *    1. 'src\loc\lcl\<locale>\diagnosticMessages.generated.json.lcl' => 'built\local\<locale>\diagnosticMessages.generated.json'
+ *       convert localized resources into a .json file the compiler can understand
+ *    2. 'src\compiler\diagnosticMessages.generated.json' => 'built\local\ENU\diagnosticMessages.generated.json.lcg'
+ *       generate the lcg file (source of messages to localize) from the diagnosticMessages.generated.json
+ */
 var localizationTargets = ["cs", "de", "enu", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"].map(function (f) {
     return path.join(builtLocalDirectory, f);
 });
@@ -448,7 +461,6 @@ compileFile(generateLocalizedDiagnosticMessagesJs,
     /*useBuiltCompiler*/ false, { noOutFile: true, types: ["node", "xml2js"] });
 
 // Localize diagnostics
-var generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages.generated.json.lcg");
 file(generatedLCGFile, [generateLocalizedDiagnosticMessagesJs, diagnosticInfoMapTs, generatedDiagnosticMessagesJSON], function () {
     var cmd = host + " " + generateLocalizedDiagnosticMessagesJs + " " + lclDirectory + " " + builtLocalDirectory + " " + generatedDiagnosticMessagesJSON;
     console.log(cmd);

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -246,7 +246,7 @@ var libraryTargets = librarySourceMap.map(function (f) {
 var generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages.generated.json.lcg");
 
 /**
- * The localization target produces the two following transformation:
+ * The localization target produces the two following transformations:
  *    1. 'src\loc\lcl\<locale>\diagnosticMessages.generated.json.lcl' => 'built\local\<locale>\diagnosticMessages.generated.json'
  *       convert localized resources into a .json file the compiler can understand
  *    2. 'src\compiler\diagnosticMessages.generated.json' => 'built\local\ENU\diagnosticMessages.generated.json.lcg'

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -239,6 +239,10 @@ var libraryTargets = librarySourceMap.map(function (f) {
     return path.join(builtLocalDirectory, f.target);
 });
 
+var localizationTargets = ["cs", "de", "enu", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"].map(function (f) {
+    return path.join(builtLocalDirectory, f);
+});
+
 // Prepends the contents of prefixFile to destinationFile
 function prependFile(prefixFile, destinationFile) {
     if (!fs.existsSync(prefixFile)) {
@@ -736,8 +740,7 @@ desc("Makes a new LKG out of the built js files");
 task("LKG", ["clean", "release", "local"].concat(libraryTargets), function () {
     var expectedFiles = [tscFile, servicesFile, serverFile, nodePackageFile, nodeDefinitionsFile, standaloneDefinitionsFile, tsserverLibraryFile, tsserverLibraryDefinitionFile, cancellationTokenFile, typingsInstallerFile, buildProtocolDts, watchGuardFile].
         concat(libraryTargets).
-        concat(fs.readdirSync(lclDirectory).map(function (d) { return path.join(builtLocalDirectory, d) })).
-        concat(path.dirname(generatedLCGFile));
+        concat(localizationTargets);
     var missingFiles = expectedFiles.filter(function (f) {
         return !fs.existsSync(f);
     });

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -252,9 +252,9 @@ var generatedLCGFile = path.join(builtLocalDirectory, "enu", "diagnosticMessages
  *    2. 'src\compiler\diagnosticMessages.generated.json' => 'built\local\ENU\diagnosticMessages.generated.json.lcg'
  *       generate the lcg file (source of messages to localize) from the diagnosticMessages.generated.json
  */
-var localizationTargets = ["cs", "de", "enu", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"].map(function (f) {
+var localizationTargets = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"].map(function (f) {
     return path.join(builtLocalDirectory, f);
-});
+}).concat(path.dirname(generatedLCGFile));
 
 // Prepends the contents of prefixFile to destinationFile
 function prependFile(prefixFile, destinationFile) {

--- a/scripts/generateLocalizedDiagnosticMessages.ts
+++ b/scripts/generateLocalizedDiagnosticMessages.ts
@@ -27,14 +27,52 @@ function main(): void {
 
     function visitDirectory(name: string) {
         const inputFilePath = path.join(inputPath, name, "diagnosticMessages", "diagnosticMessages.generated.json.lcl");
-        const outputFilePath = path.join(outputPath, name, "diagnosticMessages.generated.json");
+
         fs.readFile(inputFilePath, (err, data) => {
             handleError(err);
             xml2js.parseString(data.toString(), (err, result) => {
                 handleError(err);
-                writeFile(outputFilePath, xmlObjectToString(result));
+                if (!result || !result.LCX || !result.LCX.$ || !result.LCX.$.TgtCul) {
+                    console.error("Unexpected XML file structure. Expected to find result.LCX.$.TgtCul.");
+                    process.exit(1);
+                }
+                const outputDirectoryName = getPreferedLocaleName(result.LCX.$.TgtCul);
+                if (!outputDirectoryName) {
+                    console.error(`Invalid output locale name for '${result.LCX.$.TgtCul}'.`);
+                    process.exit(1);
+                }
+                writeFile(path.join(outputPath, outputDirectoryName, "diagnosticMessages.generated.json"), xmlObjectToString(result));
             });
         });
+    }
+
+    /**
+     * A locale name is based on the language tagging conventions of RFC 4646 (Windows Vista
+     * and later), and is represented by LOCALE_SNAME.
+     * Generally, the pattern <language>-<REGION> is used. Here, language is a lowercase ISO 639
+     * language code. The codes from ISO 639-1 are used when available. Otherwise, codes from
+     * ISO 639-2/T are used. REGION specifies an uppercase ISO 3166-1 country/region identifier.
+     * For example, the locale name for English (United States) is "en-US" and the locale name
+     * for Divehi (Maldives) is "dv-MV".
+     *
+     * If the locale is a neutral locale (no region), the LOCALE_SNAME value follows the
+     * pattern <language>. If it is a neutral locale for which the script is significant, the
+     * pattern is <language>-<Script>.
+     *
+     * More at https://msdn.microsoft.com/en-us/library/windows/desktop/dd373814(v=vs.85).aspx
+     *
+     * Most of the languages we support are neutral locales, so we want to use the language name.
+     * There are three exceptions, zh-CN, zh-TW and pt-BR.
+     */
+    function getPreferedLocaleName(localeName: string) {
+        switch (localeName) {
+            case "zh-CN":
+            case "zh-TW":
+            case "pt-BR":
+                return localeName;
+            default:
+                return localeName.split("-")[0];
+        }
     }
 
     function handleError(err: null | object) {


### PR DESCRIPTION
Follow up on https://github.com/Microsoft/TypeScript/pull/18702.

In the original iteration, I have wrongly produced the output in a folder with the same name as the input. the input folder names are [3-letter abbreviations](https://msdn.microsoft.com/en-us/library/aa246450(v=vs.60).aspx) used by VS, but the output should be valid [locale names](https://msdn.microsoft.com/en-us/library/windows/desktop/dd373814(v=vs.85).aspx).

Fixes https://github.com/Microsoft/TypeScript/issues/19270