### PR TITLE
Fix four tsc-instrumented bugs

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -570,10 +570,9 @@ namespace ts {
                 realpath
             };
         }
-
         function recursiveCreateDirectory(directoryPath: string, sys: System) {
             const basePath = getDirectoryPath(directoryPath);
-            const shouldCreateParent = directoryPath !== basePath && !sys.directoryExists(basePath);
+            const shouldCreateParent = basePath !== "" && directoryPath !== basePath && !sys.directoryExists(basePath);
             if (shouldCreateParent) {
                 recursiveCreateDirectory(basePath, sys);
             }

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -570,6 +570,7 @@ namespace ts {
                 realpath
             };
         }
+
         function recursiveCreateDirectory(directoryPath: string, sys: System) {
             const basePath = getDirectoryPath(directoryPath);
             const shouldCreateParent = basePath !== "" && directoryPath !== basePath && !sys.directoryExists(basePath);


### PR DESCRIPTION
1. Make recursiveCreateDirectory correctly handle relative paths.
2. Remove dependency on Harness
3. Correctly increment iocapture0, iocapture1, ... iocaptureN.
4. Stop double-nesting baseline files.