### PR TITLE
Log top 5 largest files when TS language service is disabling.

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1402,6 +1402,7 @@ namespace ts.server {
             }
 
             if (totalNonTsFileSize > availableSpace) {
+                this.logger.info(`Non TS file size exceeded limit (${maxProgramSizeForNonTsFiles}). Largest files: ${top5LargestFiles.map(file => `${file.name}:${file.size}`).join(", ")}`);
                 return true;
             }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1382,28 +1382,31 @@ namespace ts.server {
                 totalNonTsFileSize += this.host.getFileSize(fileName);
 
                 if (totalNonTsFileSize > maxProgramSizeForNonTsFiles) {
-                    this.logger.info(getExceedLimitMessage(this.host, totalNonTsFileSize));
+                    this.logger.info(getExceedLimitMessage({ propertyReader, hasTypeScriptFileExtension, host: this.host }, totalNonTsFileSize));
                     // Keep the size as zero since it's disabled
                     return true;
                 }
             }
 
             if (totalNonTsFileSize > availableSpace) {
-                this.logger.info(getExceedLimitMessage(this.host, totalNonTsFileSize));
+                this.logger.info(getExceedLimitMessage({ propertyReader, hasTypeScriptFileExtension, host: this.host }, totalNonTsFileSize));
                 return true;
             }
 
             this.projectToSizeMap.set(name, totalNonTsFileSize);
             return false;
 
-            function getExceedLimitMessage(host: ServerHost, totalNonTsFileSize: number) {
-                const files = fileNames.map(f => propertyReader.getFileName(f))
+            function getExceedLimitMessage(context: { propertyReader: FilePropertyReader<any>, hasTypeScriptFileExtension: (filename: string) => boolean, host: ServerHost }, totalNonTsFileSize: number) {
+                const files = getTop5LargestFiles(context);
+
+                return `Non TS file size exceeded limit (${totalNonTsFileSize}). Largest files: ${files.map(file => `${file.name}:${file.size}`).join(", ")}`;
+            }
+            function getTop5LargestFiles({ propertyReader, hasTypeScriptFileExtension, host }: { propertyReader: FilePropertyReader<any>, hasTypeScriptFileExtension: (filename: string) => boolean, host: ServerHost }) {
+                return fileNames.map(f => propertyReader.getFileName(f))
                     .filter(name => hasTypeScriptFileExtension(name))
                     .map(name => ({ name, size: host.getFileSize(name) }))
                     .sort((a, b) => b.size - a.size)
                     .slice(0, 5);
-
-                return `Non TS file size exceeded limit (${totalNonTsFileSize}). Largest files: ${files.map(file => `${file.name}:${file.size}`).join(", ")}`;
             }
         }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1385,19 +1385,23 @@ namespace ts.server {
                 files.push({ name: fileName, size: fileSize });
                 totalNonTsFileSize += fileSize;
                 if (totalNonTsFileSize > maxProgramSizeForNonTsFiles) {
-                    this.logger.info(`Non TS file size exceeded limit (${maxProgramSizeForNonTsFiles}). Largest files: ${getTop5LargestFiles(files).map(file => `${file.name}:${file.size}`).join(", ")}`);
+                    logExceedLimit(this.logger, maxProgramSizeForNonTsFiles, files);
                     // Keep the size as zero since it's disabled
                     return true;
                 }
             }
 
             if (totalNonTsFileSize > availableSpace) {
-                this.logger.info(`Non TS file size exceeded limit (${maxProgramSizeForNonTsFiles}). Largest files: ${getTop5LargestFiles(files).map(file => `${file.name}:${file.size}`).join(", ")}`);
+                logExceedLimit(this.logger, maxProgramSizeForNonTsFiles, files);
                 return true;
             }
 
             this.projectToSizeMap.set(name, totalNonTsFileSize);
             return false;
+
+            function logExceedLimit(logger: Logger, maxProgramSizeForNonTsFiles: number, files: { name: string, size: number }[]) {
+                logger.info(`Non TS file size exceeded limit (${maxProgramSizeForNonTsFiles}). Largest files: ${getTop5LargestFiles(files).map(file => `${file.name}:${file.size}`).join(", ")}`);
+            }
 
             function getTop5LargestFiles(files: { name: string, size: number }[]) {
                 return files.sort((a, b) => b.size - a.size).slice(0, 5);

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1382,28 +1382,28 @@ namespace ts.server {
                 totalNonTsFileSize += this.host.getFileSize(fileName);
 
                 if (totalNonTsFileSize > maxProgramSizeForNonTsFiles) {
-                    logExceedLimit.call(this, totalNonTsFileSize);
+                    this.logger.info(getExceedLimitMessage(this.host, totalNonTsFileSize));
                     // Keep the size as zero since it's disabled
                     return true;
                 }
             }
 
             if (totalNonTsFileSize > availableSpace) {
-                logExceedLimit.call(this, totalNonTsFileSize);
+                this.logger.info(getExceedLimitMessage(this.host, totalNonTsFileSize));
                 return true;
             }
 
             this.projectToSizeMap.set(name, totalNonTsFileSize);
             return false;
 
-            function logExceedLimit(this: ProjectService, totalNonTsFileSize: number) {
+            function getExceedLimitMessage(host: ServerHost, totalNonTsFileSize: number) {
                 const files = fileNames.map(f => propertyReader.getFileName(f))
                     .filter(name => hasTypeScriptFileExtension(name))
-                    .map(name => ({ name, size: this.host.getFileSize(name) }))
+                    .map(name => ({ name, size: host.getFileSize(name) }))
                     .sort((a, b) => b.size - a.size)
                     .slice(0, 5);
 
-                this.logger.info(`Non TS file size exceeded limit (${totalNonTsFileSize}). Largest files: ${files.map(file => `${file.name}:${file.size}`).join(", ")}`);
+                return `Non TS file size exceeded limit (${totalNonTsFileSize}). Largest files: ${files.map(file => `${file.name}:${file.size}`).join(", ")}`;
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This PR mitigates an issue on vscode: https://github.com/Microsoft/vscode/issues/35549

It will now log the top 5 largest files loaded.
Suggestion on how to format the message is welcome.

There is no test added 😞  because I can't find a way to test this private method, and also stubbing the logger to validate the output.
