### PR TITLE
fix getParameterSymbolFromJSDoc

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1606,8 +1606,19 @@ namespace ts {
             return undefined;
         }
         const name = node.name.escapedText;
-        const func = getJSDocHost(node);
-        if (!isFunctionLike(func)) {
+        const decl = getJSDocHost(node);
+        let func: FunctionLike;
+        if (isExpressionStatement(decl) && isBinaryExpression(decl.expression) && isFunctionLike(decl.expression.right)) {
+            func = decl.expression.right;
+        }
+        else if (isVariableStatement(decl) && decl.declarationList.declarations.length === 1 && isVariableDeclaration(decl.declarationList.declarations[0])
+                 && isFunctionLike(decl.declarationList.declarations[0].initializer)) {
+            func = decl.declarationList.declarations[0].initializer as FunctionLike;
+        }
+        else if (isFunctionLike(decl)) {
+            func = decl;
+        }
+        else {
             return undefined;
         }
         const parameter = find(func.parameters, p =>

--- a/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.js
+++ b/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.js
@@ -1,0 +1,26 @@
+//// [0.js]
+// @ts-check
+/**
+ * @param {number=} n
+ * @param {string} [s]
+ */
+var x = function foo(n, s) {}
+var y;
+/**
+ * @param {boolean!} b
+ */
+y = function bar(b) {}
+
+
+//// [0.js]
+// @ts-check
+/**
+ * @param {number=} n
+ * @param {string} [s]
+ */
+var x = function foo(n, s) { };
+var y;
+/**
+ * @param {boolean!} b
+ */
+y = function bar(b) { };

--- a/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.js
+++ b/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.js
@@ -11,6 +11,11 @@ var y;
  */
 y = function bar(b) {}
 
+/**
+ * @param {string} s
+ */
+var one = function (s) { }, two = function (untyped) { };
+
 
 //// [0.js]
 // @ts-check
@@ -24,3 +29,7 @@ var y;
  * @param {boolean!} b
  */
 y = function bar(b) { };
+/**
+ * @param {string} s
+ */
+var one = function (s) { }, two = function (untyped) { };

--- a/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.symbols
+++ b/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.symbols
@@ -21,3 +21,12 @@ y = function bar(b) {}
 >bar : Symbol(bar, Decl(0.js, 10, 3))
 >b : Symbol(b, Decl(0.js, 10, 17))
 
+/**
+ * @param {string} s
+ */
+var one = function (s) { }, two = function (untyped) { };
+>one : Symbol(one, Decl(0.js, 15, 3))
+>s : Symbol(s, Decl(0.js, 15, 20))
+>two : Symbol(two, Decl(0.js, 15, 27))
+>untyped : Symbol(untyped, Decl(0.js, 15, 44))
+

--- a/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.symbols
+++ b/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/jsdoc/0.js ===
+// @ts-check
+/**
+ * @param {number=} n
+ * @param {string} [s]
+ */
+var x = function foo(n, s) {}
+>x : Symbol(x, Decl(0.js, 5, 3))
+>foo : Symbol(foo, Decl(0.js, 5, 7))
+>n : Symbol(n, Decl(0.js, 5, 21))
+>s : Symbol(s, Decl(0.js, 5, 23))
+
+var y;
+>y : Symbol(y, Decl(0.js, 6, 3))
+
+/**
+ * @param {boolean!} b
+ */
+y = function bar(b) {}
+>y : Symbol(y, Decl(0.js, 6, 3))
+>bar : Symbol(bar, Decl(0.js, 10, 3))
+>b : Symbol(b, Decl(0.js, 10, 17))
+

--- a/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.types
+++ b/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.types
@@ -24,3 +24,14 @@ y = function bar(b) {}
 >bar : (b: boolean) => void
 >b : boolean
 
+/**
+ * @param {string} s
+ */
+var one = function (s) { }, two = function (untyped) { };
+>one : (s: string) => void
+>function (s) { } : (s: string) => void
+>s : string
+>two : (untyped: any) => void
+>function (untyped) { } : (untyped: any) => void
+>untyped : any
+

--- a/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.types
+++ b/tests/baselines/reference/checkJsdocParamOnVariableDeclaredFunctionExpression.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/jsdoc/0.js ===
+// @ts-check
+/**
+ * @param {number=} n
+ * @param {string} [s]
+ */
+var x = function foo(n, s) {}
+>x : (n?: number, s?: string) => void
+>function foo(n, s) {} : (n?: number, s?: string) => void
+>foo : (n?: number, s?: string) => void
+>n : number
+>s : string
+
+var y;
+>y : any
+
+/**
+ * @param {boolean!} b
+ */
+y = function bar(b) {}
+>y = function bar(b) {} : (b: boolean) => void
+>y : any
+>function bar(b) {} : (b: boolean) => void
+>bar : (b: boolean) => void
+>b : boolean
+

--- a/tests/cases/conformance/jsdoc/checkJsdocParamOnVariableDeclaredFunctionExpression.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocParamOnVariableDeclaredFunctionExpression.ts
@@ -1,0 +1,15 @@
+// @allowJS: true
+// @suppressOutputPathCheck: true
+
+// @filename: 0.js
+// @ts-check
+/**
+ * @param {number=} n
+ * @param {string} [s]
+ */
+var x = function foo(n, s) {}
+var y;
+/**
+ * @param {boolean!} b
+ */
+y = function bar(b) {}

--- a/tests/cases/conformance/jsdoc/checkJsdocParamOnVariableDeclaredFunctionExpression.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocParamOnVariableDeclaredFunctionExpression.ts
@@ -13,3 +13,8 @@ var y;
  * @param {boolean!} b
  */
 y = function bar(b) {}
+
+/**
+ * @param {string} s
+ */
+var one = function (s) { }, two = function (untyped) { };


### PR DESCRIPTION
`getParameterSymbolFromJSDoc` didn't correctly track back to the source of a `@param` tag in a lot of cases, because it didn't match the lookup code in `getJSDocCommentsAndTags`. Now both functions share the same utility functions.

Note that the utility functions return `Node | undefined`, and the top-down uses from `getParameterSymbolFromJSDoc` take advantage of the return value, while the bottom-up uses from `getJSDocCommentsAndTags` just use the truthiness. I can annotate it as such, but didn't in the initial pass.

Fixes #19268
