### PR TITLE
Do not include lib in extract symbol tests unless required

### DIFF
--- a/src/harness/unittests/extractFunctions.ts
+++ b/src/harness/unittests/extractFunctions.ts
@@ -195,12 +195,12 @@ namespace ts {
     function G<U extends T[]>(t2: U) {
         [#|t2.toString();|]
     }
-}`);
+}`, /*includeLib*/ true);
         // Confirm that the contextual type of an extracted expression counts as a use.
         testExtractFunction("extractFunction16",
             `function F<T>() {
     const array: T[] = [#|[]|];
-}`);
+}`, /*includeLib*/ true);
         // Class type parameter
         testExtractFunction("extractFunction17",
             `class C<T1, T2> {
@@ -219,7 +219,7 @@ namespace ts {
         testExtractFunction("extractFunction19",
             `function F<T, U extends T[], V extends U[]>(v: V) {
     [#|v.toString()|];
-}`);
+}`, /*includeLib*/ true);
 
         testExtractFunction("extractFunction20",
         `const _ = class {
@@ -542,7 +542,7 @@ var q = /*b*/ //c
     /*m*/; /*n*/ //o`);
     });
 
-    function testExtractFunction(caption: string, text: string) {
-        testExtractSymbol(caption, text, "extractFunction", Diagnostics.Extract_function);
+    function testExtractFunction(caption: string, text: string, includeLib?: boolean) {
+        testExtractSymbol(caption, text, "extractFunction", Diagnostics.Extract_function, includeLib);
     }
 }

--- a/src/harness/unittests/extractTestHelpers.ts
+++ b/src/harness/unittests/extractTestHelpers.ts
@@ -106,7 +106,7 @@ namespace ts {
         getCurrentDirectory: notImplemented,
     };
 
-    export function testExtractSymbol(caption: string, text: string, baselineFolder: string, description: DiagnosticMessage) {
+    export function testExtractSymbol(caption: string, text: string, baselineFolder: string, description: DiagnosticMessage, includeLib?: boolean) {
         const t = extractTest(text);
         const selectionRange = t.ranges.get("selection");
         if (!selectionRange) {
@@ -118,7 +118,7 @@ namespace ts {
 
         function runBaseline(extension: Extension) {
             const path = "/a" + extension;
-            const program = makeProgram({ path, content: t.source });
+            const program = makeProgram({ path, content: t.source }, includeLib);
 
             if (hasSyntacticDiagnostics(program)) {
                 // Don't bother generating JS baselines for inputs that aren't valid JS.
@@ -154,15 +154,15 @@ namespace ts {
                     const newTextWithRename = newText.slice(0, renameLocation) + "/*RENAME*/" + newText.slice(renameLocation);
                     data.push(newTextWithRename);
 
-                    const diagProgram = makeProgram({ path, content: newText });
+                    const diagProgram = makeProgram({ path, content: newText }, includeLib);
                     assert.isFalse(hasSyntacticDiagnostics(diagProgram));
                 }
                 return data.join(newLineCharacter);
             });
         }
 
-        function makeProgram(f: {path: string, content: string }) {
-            const host = projectSystem.createServerHost([f, projectSystem.libFile]);
+        function makeProgram(f: {path: string, content: string }, includeLib?: boolean) {
+            const host = projectSystem.createServerHost(includeLib ? [f, projectSystem.libFile] : [f]); // libFile is expensive to parse repeatedly - only test when required
             const projectService = projectSystem.createProjectService(host);
             projectService.openClientFile(f.path);
             const program = projectService.inferredProjects[0].getLanguageService().getProgram();


### PR DESCRIPTION
This cuts the runtime of the extract symbol tests by approximately an order of magnitude (40s + 60s to 4.5s + 6.7s), since only 3 tests depended on the presence of the lib.
