### PR TITLE
Use `light` test flag by default

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -64,7 +64,7 @@ const cmdLineOptions = minimist(process.argv.slice(2), {
         browser: process.env.browser || process.env.b || "IE",
         timeout: process.env.timeout || 40000,
         tests: process.env.test || process.env.tests || process.env.t,
-        light: process.env.light || false,
+        light: process.env.light === undefined ? true : (process.env.light !== "false"),
         reporter: process.env.reporter || process.env.r,
         lint: process.env.lint || true,
         files: process.env.f || process.env.file || process.env.files || "",

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -64,7 +64,7 @@ const cmdLineOptions = minimist(process.argv.slice(2), {
         browser: process.env.browser || process.env.b || "IE",
         timeout: process.env.timeout || 40000,
         tests: process.env.test || process.env.tests || process.env.t,
-        light: process.env.light === undefined ? true : (process.env.light !== "false"),
+        light: process.env.light === undefined || process.env.light !== "false",
         reporter: process.env.reporter || process.env.r,
         lint: process.env.lint || true,
         files: process.env.f || process.env.file || process.env.files || "",

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -871,7 +871,7 @@ function runConsoleTests(defaultReporter, runInParallel) {
     var inspect = process.env.inspect || process.env["inspect-brk"] || process.env.i;
     var testTimeout = process.env.timeout || defaultTestTimeout;
     var tests = process.env.test || process.env.tests || process.env.t;
-    var light = process.env.light === undefined ? true : (process.env.light !== "false");
+    var light = process.env.light === undefined || process.env.light !== "false";
     var stackTraceLimit = process.env.stackTraceLimit;
     var testConfigFile = 'test.config';
     if (fs.existsSync(testConfigFile)) {

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -871,7 +871,7 @@ function runConsoleTests(defaultReporter, runInParallel) {
     var inspect = process.env.inspect || process.env["inspect-brk"] || process.env.i;
     var testTimeout = process.env.timeout || defaultTestTimeout;
     var tests = process.env.test || process.env.tests || process.env.t;
-    var light = process.env.light || false;
+    var light = process.env.light === undefined ? true : (process.env.light !== "false");
     var stackTraceLimit = process.env.stackTraceLimit;
     var testConfigFile = 'test.config';
     if (fs.existsSync(testConfigFile)) {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     },
     "scripts": {
         "pretest": "jake tests",
-        "test": "jake runtests-parallel",
+        "test": "jake runtests-parallel light=false",
         "build": "npm run build:compiler && npm run build:tests",
         "build:compiler": "jake local",
         "build:tests": "jake tests",


### PR DESCRIPTION
CI will still have the flag off, so we should still get the additional checks there; but this significantly reduces test runtime when running locally - `assertInvariants` dominates the runtime of many tests; especially those which include lib files, such as many jsx tests. Overall, this is ~25% savings in wall-clock time when running tests locally. This is likely fine since the invariant assertion rarely catches any bugs anymore, and it'll still be running on CI to catch things before they get merged.
