### PR TITLE
For @types installing quickfix, only activate for implicit-any module

### DIFF
--- a/src/services/codefixes/fixCannotFindModule.ts
+++ b/src/services/codefixes/fixCannotFindModule.ts
@@ -2,7 +2,6 @@
 namespace ts.codefix {
     registerCodeFix({
         errorCodes: [
-            Diagnostics.Cannot_find_module_0.code,
             Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type.code,
         ],
         getCodeActions: context => {

--- a/tests/cases/fourslash/codeFixCannotFindModule.ts
+++ b/tests/cases/fourslash/codeFixCannotFindModule.ts
@@ -1,10 +1,19 @@
 /// <reference path='fourslash.ts' />
 
-////import * as abs from "abs";
+// @moduleResolution: node
+// @noImplicitAny: true
+
+// @Filename: /node_modules/abs/index.js
+////not read
+
+// @Filename: /a.ts
+/////**/import * as abs from "abs";
 
 test.setTypesRegistry({
     "abs": undefined,
 });
+
+goTo.marker();
 
 verify.codeFixAvailable([{
     description: "Install '@types/abs'",

--- a/tests/cases/fourslash/codeFixCannotFindModule_notIfMissing.ts
+++ b/tests/cases/fourslash/codeFixCannotFindModule_notIfMissing.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////import * as abs from "abs";
+
+test.setTypesRegistry({
+    "abs": undefined,
+});
+
+// We only give the fix for an implicit-any module, not for a missing module.
+verify.not.codeFixAvailable();


### PR DESCRIPTION
Should fix the immediate issue in #19378. @mjbvz was getting an error since "lodash" wasn't resolving at all since he had classic module resolution set. Now we would not provide the codefix in that case (although we would still provide the refactoring).
