### PR TITLE
Remove escaped names of well known symbols from string completions

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -385,12 +385,6 @@ namespace ts {
         return (identifier.length >= 2 && identifier.charCodeAt(0) === CharacterCodes._ && identifier.charCodeAt(1) === CharacterCodes._ ? "_" + identifier : identifier) as __String;
     }
 
-    export function isEscapedNameOfWellKnownSymbol(escapedName: __String) {
-        return (escapedName as string).charCodeAt(0) === CharacterCodes._ &&
-            (escapedName as string).charCodeAt(1) === CharacterCodes._ &&
-            (escapedName as string).charCodeAt(2) === CharacterCodes.at;
-    }
-
     /**
      * @deprecated Use `id.escapedText` to get the escaped text of an Identifier.
      * @param identifier The identifier to escape

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -385,6 +385,12 @@ namespace ts {
         return (identifier.length >= 2 && identifier.charCodeAt(0) === CharacterCodes._ && identifier.charCodeAt(1) === CharacterCodes._ ? "_" + identifier : identifier) as __String;
     }
 
+    export function isEscapedNameOfWellKnownSymbol(escapedName: __String) {
+        return (escapedName as string).charCodeAt(0) === CharacterCodes._ &&
+            (escapedName as string).charCodeAt(1) === CharacterCodes._ &&
+            (escapedName as string).charCodeAt(2) === CharacterCodes.at;
+    }
+
     /**
      * @deprecated Use `id.escapedText` to get the escaped text of an Identifier.
      * @param identifier The identifier to escape

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -167,15 +167,17 @@ namespace ts.Completions {
         const uniqueNames = createMap<true>();
         if (symbols) {
             for (const symbol of symbols) {
-                const entry = createCompletionEntry(symbol, location, performCharacterChecks, typeChecker, target, allowStringLiteral);
-                if (entry) {
-                    const id = entry.name;
-                    if (!uniqueNames.has(id)) {
-                        if (symbolToOriginInfoMap && symbolToOriginInfoMap[getUniqueSymbolId(symbol, typeChecker)]) {
-                            entry.hasAction = true;
+                if (!isEscapedNameOfWellKnownSymbol(symbol.escapedName)) {
+                    const entry = createCompletionEntry(symbol, location, performCharacterChecks, typeChecker, target, allowStringLiteral);
+                    if (entry) {
+                        const id = entry.name;
+                        if (!uniqueNames.has(id)) {
+                            if (symbolToOriginInfoMap && symbolToOriginInfoMap[getUniqueSymbolId(symbol, typeChecker)]) {
+                                entry.hasAction = true;
+                            }
+                            entries.push(entry);
+                            uniqueNames.set(id, true);
                         }
-                        entries.push(entry);
-                        uniqueNames.set(id, true);
                     }
                 }
             }

--- a/tests/cases/fourslash/completionForStringLiteral13.ts
+++ b/tests/cases/fourslash/completionForStringLiteral13.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts'/>
+
+////interface SymbolConstructor {
+////    readonly species: symbol;
+////}
+////var Symbol: SymbolConstructor;
+////interface PromiseConstructor {
+////  [Symbol.species]: PromiseConstructor;
+////}
+////var Promise: PromiseConstructor;
+////Promise["/*1*/"];
+
+goTo.marker('1');
+verify.not.completionListContains("__@species");


### PR DESCRIPTION
When reporting completions for string literals we were incorrectly including the internal escaped names of ES symbols, such as `__@iterator` or `__@species`.

Fixes #19349
