### PR TITLE
 fix #19220: polish arity error message 

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16274,25 +16274,33 @@ namespace ts {
             else if (args) {
                 const hasSpreadArgument = getSpreadArgumentIndex(args) > -1;
                 const argCount = args.length - (hasSpreadArgument ? 1 : 0);
-                if (hasSpreadArgument) {
-                    const hasRestParameter = some(signatures, sig => sig.hasRestParameter);
-                    const error = hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_a_minimum_of_1 : Diagnostics.Expected_0_arguments_but_got_1;
-                    const paramCount = reduceLeft(signatures, (min, sig) => Math.min(min, sig.minArgumentCount), Number.POSITIVE_INFINITY);
-                    diagnostics.add(createDiagnosticForNode(node, error, paramCount, argCount));
+                // polish error message for overloaded call without spread argument
+                if (!hasSpreadArgument && signatures.length > 1) {
+                    // compute arity bound to guess most matching overload
+                    let upper = Number.POSITIVE_INFINITY;
+                    let lower = Number.NEGATIVE_INFINITY;
+                    for (const sig of signatures) {
+                        const minParam = sig.minArgumentCount;
+                        const maxParam = sig.parameters.length;
+                        upper = minParam > argCount ? Math.min(upper, minParam) : upper;
+                        lower = maxParam < argCount ? Math.max(lower, maxParam) : lower;
+                    }
+                    const needMultipleCount = upper !== Number.POSITIVE_INFINITY && lower !== Number.NEGATIVE_INFINITY && upper !== lower;
+                    const paramCount = upper !== Number.POSITIVE_INFINITY ? upper : lower;
+                    diagnostics.add(needMultipleCount ?
+                        createDiagnosticForNode(node, Diagnostics.No_overload_expects_0_arguments_The_most_matching_overloads_expect_either_1_or_2_arguments, argCount, lower, upper) :
+                        createDiagnosticForNode(node, Diagnostics.Expected_0_arguments_but_got_1, paramCount, argCount));
                 } else {
                     let min = Number.POSITIVE_INFINITY;
                     let max = Number.NEGATIVE_INFINITY;
                     for (const sig of signatures) {
-                        const minParam = sig.minArgumentCount;
-                        const maxParam = sig.parameters.length;
-                        min = minParam > argCount ? Math.min(min, minParam) : min;
-                        max = maxParam < argCount ? Math.max(max, maxParam) : max;
+                        min = Math.min(min, sig.minArgumentCount);
+                        max = Math.max(max, sig.parameters.length);
                     }
-                    const needMultipleCount = min !== Number.POSITIVE_INFINITY && max !== Number.NEGATIVE_INFINITY && min !== max;
-                    const paramCount = min !== Number.POSITIVE_INFINITY ? min : max;
-                    diagnostics.add(needMultipleCount ?
-                        createDiagnosticForNode(node, Diagnostics.No_overload_expects_0_arguments_The_most_matching_overloads_expect_either_1_or_2_arguments, argCount, max, min) :
-                        createDiagnosticForNode(node, Diagnostics.Expected_0_arguments_but_got_1, paramCount, argCount));
+                    const hasRestParameter = some(signatures, sig => sig.hasRestParameter);
+                    const error = hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_a_minimum_of_1 : Diagnostics.Expected_0_arguments_but_got_1;
+                    const paramCount = (hasRestParameter || min >= max) ? min : min + "-" + max;
+                    diagnostics.add(createDiagnosticForNode(node, error, paramCount, argCount));
                 }
             }
             else if (fallbackError) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16285,11 +16285,10 @@ namespace ts {
                         upper = minParam > argCount ? Math.min(upper, minParam) : upper;
                         lower = maxParam < argCount ? Math.max(lower, maxParam) : lower;
                     }
-                    const needMultipleCount = upper !== Number.POSITIVE_INFINITY && lower !== Number.NEGATIVE_INFINITY && upper !== lower;
-                    const paramCount = upper !== Number.POSITIVE_INFINITY ? upper : lower;
-                    diagnostics.add(needMultipleCount ?
-                        createDiagnosticForNode(node, Diagnostics.No_overload_expects_0_arguments_The_most_matching_overloads_expect_either_1_or_2_arguments, argCount, lower, upper) :
-                        createDiagnosticForNode(node, Diagnostics.Expected_0_arguments_but_got_1, paramCount, argCount));
+                    const paramText = upper !== Number.POSITIVE_INFINITY && lower !== Number.NEGATIVE_INFINITY && upper !== lower ? `either ${lower} or ${upper}` :
+                        upper !== Number.POSITIVE_INFINITY ? upper : lower;
+                    diagnostics.add(
+                        createDiagnosticForNode(node, Diagnostics.No_overload_expects_0_arguments_The_most_matching_overloads_expect_1_arguments, argCount, paramText));
                 } else {
                     let min = Number.POSITIVE_INFINITY;
                     let max = Number.NEGATIVE_INFINITY;
@@ -16298,7 +16297,10 @@ namespace ts {
                         max = Math.max(max, sig.parameters.length);
                     }
                     const hasRestParameter = some(signatures, sig => sig.hasRestParameter);
-                    const error = hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_a_minimum_of_1 : Diagnostics.Expected_0_arguments_but_got_1;
+                    const error = hasRestParameter && hasSpreadArgument ? Diagnostics.Expected_at_least_0_arguments_but_got_a_minimum_of_1 :
+                        hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1 :
+                        hasSpreadArgument ? Diagnostics.Expected_0_arguments_but_got_a_minimum_of_1 :
+                        Diagnostics.Expected_0_arguments_but_got_1;
                     const paramCount = (hasRestParameter || min >= max) ? min : min + "-" + max;
                     diagnostics.add(createDiagnosticForNode(node, error, paramCount, argCount));
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16289,7 +16289,8 @@ namespace ts {
                         upper !== Number.POSITIVE_INFINITY ? upper : lower;
                     diagnostics.add(
                         createDiagnosticForNode(node, Diagnostics.No_overload_expects_0_arguments_The_most_matching_overloads_expect_1_arguments, argCount, paramText));
-                } else {
+                }
+                else {
                     let min = Number.POSITIVE_INFINITY;
                     let max = Number.NEGATIVE_INFINITY;
                     for (const sig of signatures) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2232,7 +2232,7 @@
         "category": "Error",
         "code": 2716
     },
-    "No overload expects {0} arguments. The most matching overloads expect either {1} or {2} arguments.": {
+    "No overload expects {0} arguments. The most matching overloads expect {1} arguments.": {
         "category": "Error",
         "code": 2717
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2228,6 +2228,14 @@
         "category": "Error",
         "code": 2716
     },
+    "Type parameter '{0}' has a circular default.": {
+        "category": "Error",
+        "code": 2716
+    },
+    "No overload expects {0} arguments. The most matching overloads expect either {1} or {2} arguments.": {
+        "category": "Error",
+        "code": 2717
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/blockScopedSameNameFunctionDeclarationES5.errors.txt
+++ b/tests/baselines/reference/blockScopedSameNameFunctionDeclarationES5.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(3,18): error TS2393: Duplicate function implementation.
-tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(5,9): error TS2554: Expected 0 arguments, but got 1.
+tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(5,9): error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
 tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(8,18): error TS2393: Duplicate function implementation.
-tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(10,9): error TS2554: Expected 0 arguments, but got 1.
-tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(12,5): error TS2554: Expected 0 arguments, but got 1.
+tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(10,9): error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
+tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(12,5): error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
 tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(16,1): error TS2554: Expected 1 arguments, but got 0.
 
 
@@ -15,7 +15,7 @@ tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(16,1): error T
             foo(); 
             foo(10); // not ok
             ~~~~~~~
-!!! error TS2554: Expected 0 arguments, but got 1.
+!!! error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
         }
         else {
             function foo() { } // duplicate function
@@ -24,11 +24,11 @@ tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts(16,1): error T
             foo(); 
             foo(10); // not ok
             ~~~~~~~
-!!! error TS2554: Expected 0 arguments, but got 1.
+!!! error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
         }
         foo(10); // not ok
         ~~~~~~~
-!!! error TS2554: Expected 0 arguments, but got 1.
+!!! error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
         foo(); 
     }
     foo(10);

--- a/tests/baselines/reference/blockScopedSameNameFunctionDeclarationES6.errors.txt
+++ b/tests/baselines/reference/blockScopedSameNameFunctionDeclarationES6.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(3,18): error TS2393: Duplicate function implementation.
-tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(5,9): error TS2554: Expected 0 arguments, but got 1.
+tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(5,9): error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
 tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(8,18): error TS2393: Duplicate function implementation.
-tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(10,9): error TS2554: Expected 0 arguments, but got 1.
-tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(12,5): error TS2554: Expected 0 arguments, but got 1.
+tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(10,9): error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
+tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(12,5): error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
 tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(16,1): error TS2554: Expected 1 arguments, but got 0.
 
 
@@ -15,7 +15,7 @@ tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(16,1): error T
             foo();
             foo(10); // not ok
             ~~~~~~~
-!!! error TS2554: Expected 0 arguments, but got 1.
+!!! error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
         }
         else {
             function foo() { } // duplicate
@@ -24,11 +24,11 @@ tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts(16,1): error T
             foo();
             foo(10);// not ok
             ~~~~~~~
-!!! error TS2554: Expected 0 arguments, but got 1.
+!!! error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
         }
         foo(10); // not ok
         ~~~~~~~
-!!! error TS2554: Expected 0 arguments, but got 1.
+!!! error TS2717: No overload expects 1 arguments. The most matching overloads expect 0 arguments.
         foo(); 
     }
     foo(10);

--- a/tests/baselines/reference/classWithConstructors.errors.txt
+++ b/tests/baselines/reference/classWithConstructors.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(6,13): error TS2554: Expected 1 arguments, but got 0.
-tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(15,14): error TS2554: Expected 1 arguments, but got 0.
-tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(21,13): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(15,14): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
+tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(21,13): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(31,13): error TS2554: Expected 1 arguments, but got 0.
-tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(40,14): error TS2554: Expected 1-2 arguments, but got 0.
-tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(46,13): error TS2554: Expected 1-2 arguments, but got 0.
+tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(40,14): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
+tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts(46,13): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 
 
 ==== tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts (6 errors) ====
@@ -25,7 +25,7 @@ tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstr
     
         var c3 = new C2(); // error
                  ~~~~~~~~
-!!! error TS2554: Expected 1 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
         var c4 = new C2(''); // ok
         var c5 = new C2(1); // ok
     
@@ -33,7 +33,7 @@ tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstr
     
         var d = new D(); // error
                 ~~~~~~~
-!!! error TS2554: Expected 1 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
         var d2 = new D(1); // ok
         var d3 = new D(''); // ok
     }
@@ -56,7 +56,7 @@ tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstr
     
         var c3 = new C2(); // error
                  ~~~~~~~~
-!!! error TS2554: Expected 1-2 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
         var c4 = new C2(''); // ok
         var c5 = new C2(1, 2); // ok
     
@@ -64,7 +64,7 @@ tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstr
     
         var d = new D(); // error
                 ~~~~~~~
-!!! error TS2554: Expected 1-2 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
         var d2 = new D(1); // ok
         var d3 = new D(''); // ok
     }

--- a/tests/baselines/reference/derivedClassWithoutExplicitConstructor2.errors.txt
+++ b/tests/baselines/reference/derivedClassWithoutExplicitConstructor2.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts(13,9): error TS2554: Expected 1-3 arguments, but got 0.
-tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts(30,9): error TS2554: Expected 1-3 arguments, but got 0.
+tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts(13,9): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
+tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts(30,9): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 
 
 ==== tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts (2 errors) ====
@@ -17,7 +17,7 @@ tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/de
     
     var r = new Derived(); // error
             ~~~~~~~~~~~~~
-!!! error TS2554: Expected 1-3 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
     var r2 = new Derived(1); 
     var r3 = new Derived(1, 2);
     var r4 = new Derived(1, 2, 3);
@@ -36,7 +36,7 @@ tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/de
     
     var d = new D(); // error
             ~~~~~~~
-!!! error TS2554: Expected 1-3 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
     var d2 = new D(new Date()); // ok
     var d3 = new D(new Date(), new Date());
     var d4 = new D(new Date(), new Date(), new Date());

--- a/tests/baselines/reference/functionOverloads29.errors.txt
+++ b/tests/baselines/reference/functionOverloads29.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/functionOverloads29.ts(4,9): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/compiler/functionOverloads29.ts(4,9): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 
 
 ==== tests/cases/compiler/functionOverloads29.ts (1 errors) ====
@@ -7,5 +7,5 @@ tests/cases/compiler/functionOverloads29.ts(4,9): error TS2554: Expected 1 argum
     function foo(bar:any):any{ return bar }
     var x = foo();
             ~~~~~
-!!! error TS2554: Expected 1 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
     

--- a/tests/baselines/reference/functionOverloads34.errors.txt
+++ b/tests/baselines/reference/functionOverloads34.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/functionOverloads34.ts(4,9): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/compiler/functionOverloads34.ts(4,9): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 
 
 ==== tests/cases/compiler/functionOverloads34.ts (1 errors) ====
@@ -7,5 +7,5 @@ tests/cases/compiler/functionOverloads34.ts(4,9): error TS2554: Expected 1 argum
     function foo(bar:{a:any;}):any{ return bar }
     var x = foo();
             ~~~~~
-!!! error TS2554: Expected 1 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
     

--- a/tests/baselines/reference/functionOverloads37.errors.txt
+++ b/tests/baselines/reference/functionOverloads37.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/functionOverloads37.ts(4,9): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/compiler/functionOverloads37.ts(4,9): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 
 
 ==== tests/cases/compiler/functionOverloads37.ts (1 errors) ====
@@ -7,5 +7,5 @@ tests/cases/compiler/functionOverloads37.ts(4,9): error TS2554: Expected 1 argum
     function foo(bar:{a:any;}[]):any{ return bar }
     var x = foo();
             ~~~~~
-!!! error TS2554: Expected 1 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
     

--- a/tests/baselines/reference/overload1.errors.txt
+++ b/tests/baselines/reference/overload1.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/overload1.ts(27,5): error TS2322: Type 'C' is not assignable to type 'string'.
 tests/cases/compiler/overload1.ts(29,1): error TS2322: Type 'number' is not assignable to type 'string'.
-tests/cases/compiler/overload1.ts(31,3): error TS2554: Expected 1-2 arguments, but got 3.
-tests/cases/compiler/overload1.ts(32,3): error TS2554: Expected 1-2 arguments, but got 0.
+tests/cases/compiler/overload1.ts(31,3): error TS2717: No overload expects 3 arguments. The most matching overloads expect 2 arguments.
+tests/cases/compiler/overload1.ts(32,3): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 tests/cases/compiler/overload1.ts(33,1): error TS2322: Type 'C' is not assignable to type 'string'.
 tests/cases/compiler/overload1.ts(34,9): error TS2345: Argument of type '2' is not assignable to parameter of type 'string'.
 
@@ -43,10 +43,10 @@ tests/cases/compiler/overload1.ts(34,9): error TS2345: Argument of type '2' is n
     var z:string=x.g(x.g(3,3)); // good
     z=x.g(2,2,2); // no match
       ~~~~~~~~~~
-!!! error TS2554: Expected 1-2 arguments, but got 3.
+!!! error TS2717: No overload expects 3 arguments. The most matching overloads expect 2 arguments.
     z=x.g(); // no match
       ~~~~~
-!!! error TS2554: Expected 1-2 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
     z=x.g(new O.B()); // ambiguous (up and down conversion)
     ~
 !!! error TS2322: Type 'C' is not assignable to type 'string'.

--- a/tests/baselines/reference/overload3.errors.txt
+++ b/tests/baselines/reference/overload3.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/overload3.ts(4,1): error TS2717: No overload expects 2 arguments. The most matching overloads expect either 1 or 3 arguments.
+
+
+==== tests/cases/compiler/overload3.ts (1 errors) ====
+    declare function foo(x: number): void;
+    declare function foo(x: number, y: number, z: number): void;
+    
+    foo(1, 2);
+    ~~~~~~~~~
+!!! error TS2717: No overload expects 2 arguments. The most matching overloads expect either 1 or 3 arguments.
+    

--- a/tests/baselines/reference/overload3.js
+++ b/tests/baselines/reference/overload3.js
@@ -1,0 +1,9 @@
+//// [overload3.ts]
+declare function foo(x: number): void;
+declare function foo(x: number, y: number, z: number): void;
+
+foo(1, 2);
+
+
+//// [overload3.js]
+foo(1, 2);

--- a/tests/baselines/reference/overload3.symbols
+++ b/tests/baselines/reference/overload3.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/overload3.ts ===
+declare function foo(x: number): void;
+>foo : Symbol(foo, Decl(overload3.ts, 0, 0), Decl(overload3.ts, 0, 38))
+>x : Symbol(x, Decl(overload3.ts, 0, 21))
+
+declare function foo(x: number, y: number, z: number): void;
+>foo : Symbol(foo, Decl(overload3.ts, 0, 0), Decl(overload3.ts, 0, 38))
+>x : Symbol(x, Decl(overload3.ts, 1, 21))
+>y : Symbol(y, Decl(overload3.ts, 1, 31))
+>z : Symbol(z, Decl(overload3.ts, 1, 42))
+
+foo(1, 2);
+>foo : Symbol(foo, Decl(overload3.ts, 0, 0), Decl(overload3.ts, 0, 38))
+

--- a/tests/baselines/reference/overload3.types
+++ b/tests/baselines/reference/overload3.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/overload3.ts ===
+declare function foo(x: number): void;
+>foo : { (x: number): void; (x: number, y: number, z: number): void; }
+>x : number
+
+declare function foo(x: number, y: number, z: number): void;
+>foo : { (x: number): void; (x: number, y: number, z: number): void; }
+>x : number
+>y : number
+>z : number
+
+foo(1, 2);
+>foo(1, 2) : any
+>foo : { (x: number): void; (x: number, y: number, z: number): void; }
+>1 : 1
+>2 : 2
+

--- a/tests/baselines/reference/recursiveFunctionTypes.errors.txt
+++ b/tests/baselines/reference/recursiveFunctionTypes.errors.txt
@@ -8,9 +8,9 @@ tests/cases/compiler/recursiveFunctionTypes.ts(17,5): error TS2322: Type '() => 
 tests/cases/compiler/recursiveFunctionTypes.ts(22,5): error TS2345: Argument of type '3' is not assignable to parameter of type '(t: typeof g) => void'.
 tests/cases/compiler/recursiveFunctionTypes.ts(25,1): error TS2322: Type '3' is not assignable to type '() => any'.
 tests/cases/compiler/recursiveFunctionTypes.ts(30,10): error TS2394: Overload signature is not compatible with function implementation.
-tests/cases/compiler/recursiveFunctionTypes.ts(33,1): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/recursiveFunctionTypes.ts(33,1): error TS2717: No overload expects 2 arguments. The most matching overloads expect 1 arguments.
 tests/cases/compiler/recursiveFunctionTypes.ts(34,4): error TS2345: Argument of type '""' is not assignable to parameter of type '{ (): typeof f6; (a: typeof f6): () => number; }'.
-tests/cases/compiler/recursiveFunctionTypes.ts(42,1): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/recursiveFunctionTypes.ts(42,1): error TS2717: No overload expects 2 arguments. The most matching overloads expect 1 arguments.
 tests/cases/compiler/recursiveFunctionTypes.ts(43,4): error TS2345: Argument of type '""' is not assignable to parameter of type '{ (): typeof f7; (a: typeof f7): () => number; (a: number): number; (a?: typeof f7): typeof f7; }'.
 
 
@@ -68,7 +68,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(43,4): error TS2345: Argument of 
     
     f6("", 3); // error (arity mismatch)
     ~~~~~~~~~
-!!! error TS2554: Expected 0-1 arguments, but got 2.
+!!! error TS2717: No overload expects 2 arguments. The most matching overloads expect 1 arguments.
     f6(""); // ok (function takes an any param)
        ~~
 !!! error TS2345: Argument of type '""' is not assignable to parameter of type '{ (): typeof f6; (a: typeof f6): () => number; }'.
@@ -81,7 +81,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(43,4): error TS2345: Argument of 
     
     f7("", 3); // error (arity mismatch)
     ~~~~~~~~~
-!!! error TS2554: Expected 0-1 arguments, but got 2.
+!!! error TS2717: No overload expects 2 arguments. The most matching overloads expect 1 arguments.
     f7(""); // ok (function takes an any param)
        ~~
 !!! error TS2345: Argument of type '""' is not assignable to parameter of type '{ (): typeof f7; (a: typeof f7): () => number; (a: number): number; (a?: typeof f7): typeof f7; }'.

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1.errors.txt
@@ -4,9 +4,9 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(11,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(12,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(13,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(14,9): error TS2554: Expected 1-3 arguments, but got 4.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(14,9): error TS2717: No overload expects 4 arguments. The most matching overloads expect 3 arguments.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(19,20): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(21,9): error TS2554: Expected 1-3 arguments, but got 4.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(21,9): error TS2717: No overload expects 4 arguments. The most matching overloads expect 3 arguments.
 
 
 ==== tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts (8 errors) ====
@@ -36,7 +36,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
     var f = foo([], 1, 2, 3);    // any (with error)
             ~~~~~~~~~~~~~~~~
-!!! error TS2554: Expected 1-3 arguments, but got 4.
+!!! error TS2717: No overload expects 4 arguments. The most matching overloads expect 3 arguments.
     
     var u = foo ``;              // number
     var v = foo `${1}`;          // string
@@ -47,5 +47,5 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     var y = foo `${1}${"2"}`;    // {}
     var z = foo `${1}${2}${3}`;  // any (with error)
             ~~~~~~~~~~~~~~~~~~
-!!! error TS2554: Expected 1-3 arguments, but got 4.
+!!! error TS2717: No overload expects 4 arguments. The most matching overloads expect 3 arguments.
     

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1_ES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1_ES6.errors.txt
@@ -4,9 +4,9 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(11,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(12,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(13,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(14,9): error TS2554: Expected 1-3 arguments, but got 4.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(14,9): error TS2717: No overload expects 4 arguments. The most matching overloads expect 3 arguments.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(19,20): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(21,9): error TS2554: Expected 1-3 arguments, but got 4.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(21,9): error TS2717: No overload expects 4 arguments. The most matching overloads expect 3 arguments.
 
 
 ==== tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts (8 errors) ====
@@ -36,7 +36,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
     var f = foo([], 1, 2, 3);    // any (with error)
             ~~~~~~~~~~~~~~~~
-!!! error TS2554: Expected 1-3 arguments, but got 4.
+!!! error TS2717: No overload expects 4 arguments. The most matching overloads expect 3 arguments.
     
     var u = foo ``;              // number
     var v = foo `${1}`;          // string
@@ -47,5 +47,5 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     var y = foo `${1}${"2"}`;    // {}
     var z = foo `${1}${2}${3}`;  // any (with error)
             ~~~~~~~~~~~~~~~~~~
-!!! error TS2554: Expected 1-3 arguments, but got 4.
+!!! error TS2717: No overload expects 4 arguments. The most matching overloads expect 3 arguments.
     

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(9,9): error TS2345: Argument of type '{}' is not assignable to parameter of type 'number'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(18,4): error TS2339: Property 'foo' does not exist on type 'Date'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(44,1): error TS2554: Expected 2-4 arguments, but got 1.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(44,1): error TS2717: No overload expects 1 arguments. The most matching overloads expect 2 arguments.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(62,9): error TS2345: Argument of type 'true' is not assignable to parameter of type 'number'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(63,18): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(69,18): error TS2339: Property 'toFixed' does not exist on type 'string'.
@@ -56,7 +56,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     // Generic overloads with differing arity tagging with argument count that doesn't match any overload
     fn3 ``; // Error
     ~~~~~~
-!!! error TS2554: Expected 2-4 arguments, but got 1.
+!!! error TS2717: No overload expects 1 arguments. The most matching overloads expect 2 arguments.
     
     // Generic overloads with constraints
     function fn4<T extends string, U extends number>(strs: TemplateStringsArray, n: T, m: U);

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(9,9): error TS2345: Argument of type '{}' is not assignable to parameter of type 'number'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(18,4): error TS2339: Property 'foo' does not exist on type 'Date'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(44,1): error TS2554: Expected 2-4 arguments, but got 1.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(44,1): error TS2717: No overload expects 1 arguments. The most matching overloads expect 2 arguments.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(62,9): error TS2345: Argument of type 'true' is not assignable to parameter of type 'number'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(63,18): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(69,18): error TS2551: Property 'toFixed' does not exist on type 'string'. Did you mean 'fixed'?
@@ -56,7 +56,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     // Generic overloads with differing arity tagging with argument count that doesn't match any overload
     fn3 ``; // Error
     ~~~~~~
-!!! error TS2554: Expected 2-4 arguments, but got 1.
+!!! error TS2717: No overload expects 1 arguments. The most matching overloads expect 2 arguments.
     
     // Generic overloads with constraints
     function fn4<T extends string, U extends number>(strs: TemplateStringsArray, n: T, m: U);

--- a/tests/baselines/reference/unionTypeCallSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeCallSignatures.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(9,43): error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'number'.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(10,29): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(15,29): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
-tests/cases/conformance/types/union/unionTypeCallSignatures.ts(16,1): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/types/union/unionTypeCallSignatures.ts(16,1): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(19,1): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((a: number) => number) | ((a: string) => Date)' has no compatible call signatures.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(20,1): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((a: number) => number) | ((a: string) => Date)' has no compatible call signatures.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(21,1): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((a: number) => number) | ((a: string) => Date)' has no compatible call signatures.
@@ -55,7 +55,7 @@ tests/cases/conformance/types/union/unionTypeCallSignatures.ts(73,12): error TS2
 !!! error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
     unionOfDifferentReturnType1(); // error missing parameter
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2554: Expected 1 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
     
     var unionOfDifferentParameterTypes: { (a: number): number; } | { (a: string): Date; };
     unionOfDifferentParameterTypes(10);// error - no call signatures

--- a/tests/baselines/reference/unionTypeConstructSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeConstructSignatures.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(9,47): error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'number'.
 tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(10,33): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
 tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(15,33): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
-tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(16,1): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(16,1): error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
 tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(19,1): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(20,1): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(21,1): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
@@ -54,7 +54,7 @@ tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(70,12): erro
 !!! error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
     new unionOfDifferentReturnType1(); // error missing parameter
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2554: Expected 1 arguments, but got 0.
+!!! error TS2717: No overload expects 0 arguments. The most matching overloads expect 1 arguments.
     
     var unionOfDifferentParameterTypes: { new (a: number): number; } | { new (a: string): Date; };
     new unionOfDifferentParameterTypes(10);// error - no call signatures

--- a/tests/cases/compiler/overload3.ts
+++ b/tests/cases/compiler/overload3.ts
@@ -1,0 +1,4 @@
+declare function foo(x: number): void;
+declare function foo(x: number, y: number, z: number): void;
+
+foo(1, 2);


### PR DESCRIPTION
Fix #19220 .

Only overloaded call without spread arguments has new error message. I also change the wording so the message seems more concise than that proposed in #19220. It's up to @DanielRosenwasser.

For single non-overloaded call, the original error message is better than the new one because it provides the range of acceptable argument number.

I cannot find a proper description for spread argument call. The message `No overload accepts {0} arguments` requires accurate argument number which isn't available in spread argument. So current error message is better IMHO.

Finally, range of argument number in overload function call isn't provided. Showing that range is too complex to preserve a sensible error message.

Thanks for your review in advance!