### PR TITLE
Fix build break

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -451,7 +451,7 @@ namespace ts {
         /* @internal */
         PossiblyContainsDynamicImport = 1 << 19,
         JSDoc =              1 << 20, // If node was parsed inside jsdoc
-        InWithStatement =    1 << 21, // If any ancestor of node was the `statement` of a WithStatement (not the `expression`)
+        /* @internal */ InWithStatement =    1 << 21, // If any ancestor of node was the `statement` of a WithStatement (not the `expression`)
 
         BlockScoped = Let | Const,
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -408,7 +408,7 @@ declare namespace ts {
         BlockScoped = 3,
         ReachabilityCheckFlags = 384,
         ReachabilityAndEmitFlags = 1408,
-        ContextFlags = 96256,
+        ContextFlags = 2193408,
         TypeExcludesFlags = 20480,
     }
     enum ModifierFlags {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -408,7 +408,7 @@ declare namespace ts {
         BlockScoped = 3,
         ReachabilityCheckFlags = 384,
         ReachabilityAndEmitFlags = 1408,
-        ContextFlags = 96256,
+        ContextFlags = 2193408,
         TypeExcludesFlags = 20480,
     }
     enum ModifierFlags {


### PR DESCRIPTION
159a0a21973cd882fb04d01335aaf7a12bc7ad45 merged and broke the build by exposing an API change - I don't think we wanted the new node flag public, so I marked it internal and captured an update of the API baselines.
