### PR TITLE
[release-2.6] Mark the files found during node_modules search correctly when reusing program structure completely

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1049,6 +1049,10 @@ namespace ts {
             // update fileName -> file mapping
             for (let i = 0; i < newSourceFiles.length; i++) {
                 filesByName.set(filePaths[i], newSourceFiles[i]);
+                // Set the file as found during node modules search if it was found that way in old progra,
+                if (oldProgram.isSourceFileFromExternalLibrary(oldProgram.getSourceFileByPath(filePaths[i]))) {
+                    sourceFilesFoundSearchingNodeModules.set(filePaths[i], true);
+                }
             }
 
             files = newSourceFiles;

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -1927,6 +1927,7 @@ declare module "fs" {
             expectedFiles[1].isExpectedToEmit = false;
             host.reloadFS(programFiles.concat(configFile));
             host.runQueuedTimeoutCallbacks();
+            checkProgramActualFiles(watch(), programFiles.map(f => f.path));
             checkOutputErrors(host, emptyArray);
             verifyExpectedFiles(expectedFiles);
 


### PR DESCRIPTION
Port to release-2.6 of #19435
Without this fix the source files reused from node_modules folder that weren't part of program output structure were used as normal files in new program resulting in incorrect errors and incorrect program output structure
Fixes #19327 
I also think this might be fix for #19280, #19290