### PR TITLE
compareValues only works for string/string or number/number

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -738,7 +738,7 @@ namespace ts {
      * are not present in `arrayA` but are present in `arrayB`. Assumes both arrays are sorted
      * based on the provided comparer.
      */
-    export function relativeComplement<T>(arrayA: T[] | undefined, arrayB: T[] | undefined, comparer: Comparer<T> = compareValues, offsetA = 0, offsetB = 0): T[] | undefined {
+    export function relativeComplement<T>(arrayA: T[] | undefined, arrayB: T[] | undefined, comparer: Comparer<T>, offsetA = 0, offsetB = 0): T[] | undefined {
         if (!arrayB || !arrayA || arrayB.length === 0 || arrayA.length === 0) return arrayB;
         const result: T[] = [];
         outer: for (; offsetB < arrayB.length; offsetB++) {
@@ -839,7 +839,7 @@ namespace ts {
     /**
      * Stable sort of an array. Elements equal to each other maintain their relative position in the array.
      */
-    export function stableSort<T>(array: ReadonlyArray<T>, comparer: Comparer<T> = compareValues) {
+    export function stableSort<T>(array: ReadonlyArray<T>, comparer: Comparer<T>) {
         return array
             .map((_, i) => i) // create array of indices
             .sort((x, y) => comparer(array[x], array[y]) || compareValues(x, y)) // sort indices by value then position
@@ -1489,7 +1489,12 @@ namespace ts {
         return headChain;
     }
 
-    export function compareValues<T>(a: T, b: T): Comparison {
+    /**
+     * Compare two values for their order relative to each other.
+     */
+    export function compareValues(a: number, b: number): Comparison;
+    export function compareValues(a: string, b: string): Comparison;
+    export function compareValues(a: number | string, b: number | string): Comparison {
         if (a === b) return Comparison.EqualTo;
         if (a === undefined) return Comparison.LessThan;
         if (b === undefined) return Comparison.GreaterThan;

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -306,7 +306,7 @@ namespace ts {
 
         // Sort our options by their names, (e.g. "--noImplicitAny" comes before "--watch")
         const optsList = showAllOptions ?
-            optionDeclarations.slice().sort((a, b) => compareValues<string>(a.name.toLowerCase(), b.name.toLowerCase())) :
+            optionDeclarations.slice().sort((a, b) => compareValues(a.name.toLowerCase(), b.name.toLowerCase())) :
             filter(optionDeclarations.slice(), v => v.showInSimplifiedHelpView);
 
         // We want our descriptions to align at the same column in our output,

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -860,7 +860,8 @@ namespace ts.server {
                     const scriptInfo = this.projectService.getOrCreateScriptInfoNotOpenedByClient(inserted, this.directoryStructureHost);
                     scriptInfo.attachToProject(this);
                 },
-                removed => this.detachScriptInfoFromProject(removed)
+                removed => this.detachScriptInfoFromProject(removed),
+                compareValues,
             );
             const elapsed = timestamp() - start;
             this.writeLog(`Finishing updateGraphWorker: Project: ${this.getProjectName()} structureChanged: ${hasChanges} Elapsed: ${elapsed}ms`);

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -288,8 +288,7 @@ namespace ts.server {
         return index === 0 || value !== array[index - 1];
     }
 
-    export function enumerateInsertsAndDeletes<T>(newItems: SortedReadonlyArray<T>, oldItems: SortedReadonlyArray<T>, inserted: (newItem: T) => void, deleted: (oldItem: T) => void, compare?: Comparer<T>) {
-        compare = compare || compareValues;
+    export function enumerateInsertsAndDeletes<T>(newItems: SortedReadonlyArray<T>, oldItems: SortedReadonlyArray<T>, inserted: (newItem: T) => void, deleted: (oldItem: T) => void, compare: Comparer<T>) {
         let newIndex = 0;
         let oldIndex = 0;
         const newLen = newItems.length;


### PR DESCRIPTION
We wouldn't want to be calling this function on an arbitrary `T`.
Noticed this during review of #19452.