### PR TITLE
Stop collecting type baselines for RWC tests

### DIFF
--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -39,8 +39,6 @@ namespace RWC {
             const baseName = ts.getBaseFileName(jsonPath);
             let currentDirectory: string;
             let useCustomLibraryFile: boolean;
-            let skipTypeBaselines = false;
-            const typeSizeLimit = 10000000;
             after(() => {
                 // Mocha holds onto the closure environment of the describe callback even after the test is done.
                 // Therefore we have to clean out large objects after the test is done.
@@ -54,7 +52,6 @@ namespace RWC {
                 // or to use lib.d.ts inside the json object. If the flag is true, use the lib.d.ts inside json file
                 // otherwise use the lib.d.ts from built/local
                 useCustomLibraryFile = undefined;
-                skipTypeBaselines = false;
             });
 
             it("can compile", function(this: Mocha.ITestCallbackContext) {
@@ -64,7 +61,6 @@ namespace RWC {
                 const ioLog: IOLog = Playback.newStyleLogIntoOldStyleLog(JSON.parse(Harness.IO.readFile(`internal/cases/rwc/${jsonPath}/test.json`)), Harness.IO, `internal/cases/rwc/${baseName}`);
                 currentDirectory = ioLog.currentDirectory;
                 useCustomLibraryFile = ioLog.useCustomLibraryFile;
-                skipTypeBaselines = ioLog.filesRead.reduce((acc, elem) => (elem && elem.result && elem.result.contents) ? acc + elem.result.contents.length : acc, 0) > typeSizeLimit;
                 runWithIOLog(ioLog, () => {
                     opts = ts.parseCommandLine(ioLog.arguments, fileName => Harness.IO.readFile(fileName));
                     assert.equal(opts.errors.length, 0);
@@ -199,14 +195,6 @@ namespace RWC {
                 }, baselineOpts, [".map"]);
             });
 
-            /*it("has correct source map record", () => {
-                if (compilerOptions.sourceMap) {
-                    Harness.Baseline.runBaseline(baseName + ".sourcemap.txt", () => {
-                        return compilerResult.getSourceMapRecord();
-                    }, baselineOpts);
-                }
-            });*/
-
             it("has the expected errors", () => {
                 Harness.Baseline.runMultifileBaseline(baseName, ".errors.txt", () => {
                     if (compilerResult.errors.length === 0) {
@@ -217,14 +205,6 @@ namespace RWC {
                     const errors = compilerResult.errors.filter(e => !e.file || !Harness.isDefaultLibraryFile(e.file.fileName));
                     return Harness.Compiler.iterateErrorBaseline(baselineFiles, errors);
                 }, baselineOpts);
-            });
-
-            it("has the expected types", () => {
-                // We don't need to pass the extension here because "doTypeAndSymbolBaseline" will append appropriate extension of ".types" or ".symbols"
-                Harness.Compiler.doTypeAndSymbolBaseline(baseName, compilerResult.program, inputFiles
-                    .concat(otherFiles)
-                    .filter(file => !!compilerResult.program.getSourceFile(file.unitName))
-                    .filter(e => !Harness.isDefaultLibraryFile(e.unitName)), baselineOpts, /*multifile*/ true, skipTypeBaselines, /*skipSymbolbaselines*/ true);
             });
 
             // Ideally, a generated declaration file will have no errors. But we allow generated


### PR DESCRIPTION
They are crazy slow, as it turns out - 66% of the overall test time is due to the increased GC pressure the additional generated nodes/cached types cause. While I like the value they provide, they're likely not worth it. Will look into making type baselines more optional for normal tests shortly. There is a paired internal PR with this PR.