### PR TITLE
Stop using expensive directoryExists in unit/rwc tests where it does not matter

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1196,6 +1196,9 @@ namespace Harness {
                 traceResults = [];
                 compilerHost.trace = text => traceResults.push(text);
             }
+            else {
+                compilerHost.directoryExists = () => true; // This only visibly affects resolution traces, so to save time we always return true where possible
+            }
             const program = ts.createProgram(programFileNames, options, compilerHost);
 
             const emitResult = program.emit();


### PR DESCRIPTION
The `harness` `directoryExists` implementation iterated over every file in the compilation to see if any started with the given path in order to return true. `directoryExists` is only used as a "shortcut" in module resolution to avoid doing `exists` calls on a bunch of files within a directory. In the test harness, unlike on disk, the directory exists check is crazy expensive for large tests (like RWC tests - this was ~20s of time on our largest test!), while the file stat is almost free.

With this change, the harness `directoryExists` implementation becomes `() => true` for all tests where the difference is not observable - the old implementation is now only used by tests which baseline module resolution traces.