### PR TITLE
Use minimal lib for project and watch tests

### DIFF
--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -1,10 +1,17 @@
 /// <reference path="harness.ts" />
 
 namespace ts.TestFSWithWatch {
-    const { content: libFileContent } = Harness.getDefaultLibraryFile(Harness.IO);
     export const libFile: FileOrFolder = {
         path: "/a/lib/lib.d.ts",
-        content: libFileContent
+        content: `/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> {}`
     };
 
     export const safeList = {


### PR DESCRIPTION
This replaces the contents of the `lib.d.ts` used by the project and watch tests to be the minimal usable without error while still having the members required for the tests to execute correctly.

This takes the project and watch tests out of the top 10 slowest tests and, in fact, does away with all units which took more than 10s on my machine (and there's only 1 which is >5s). Wall-clock, this strips off around another 10s from overall test time for me (while running in parallel).