### PR TITLE
Support completion details for special JsDoc completions

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -108,6 +108,8 @@ namespace ts.JsDoc {
         }));
     }
 
+    export const getJSDocTagNameCompletionDetails = getJSDocTagCompletionDetails;
+
     export function getJSDocTagCompletions(): CompletionEntry[] {
         return jsDocTagCompletionEntries || (jsDocTagCompletionEntries = ts.map(jsDocTagNames, tagName => {
             return {
@@ -117,6 +119,18 @@ namespace ts.JsDoc {
                 sortText: "0"
             };
         }));
+    }
+
+    export function getJSDocTagCompletionDetails(name: string): CompletionEntryDetails {
+        return {
+            name,
+            kind: ScriptElementKind.unknown, // TODO: should have its own kind?
+            kindModifiers: "",
+            displayParts: [textPart(name)],
+            documentation: emptyArray,
+            tags: emptyArray,
+            codeActions: undefined,
+        };
     }
 
     export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): CompletionEntry[] {
@@ -139,6 +153,18 @@ namespace ts.JsDoc {
 
             return { name, kind: ScriptElementKind.parameterElement, kindModifiers: "", sortText: "0" };
         });
+    }
+
+    export function getJSDocParameterNameCompletionDetails(name: string): CompletionEntryDetails {
+        return {
+            name,
+            kind: ScriptElementKind.parameterElement,
+            kindModifiers: "",
+            displayParts: [textPart(name)],
+            documentation: emptyArray,
+            tags: emptyArray,
+            codeActions: undefined,
+        };
     }
 
     /**

--- a/tests/cases/fourslash/completionsJsdocTag.ts
+++ b/tests/cases/fourslash/completionsJsdocTag.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////**
+//// * @typedef {object} T
+//// * /**/
+//// */
+
+goTo.marker();
+verify.completionListContains("@property", "@property", "", "keyword");


### PR DESCRIPTION
Fixes #19442 

Also, our public API specifies `getCompletionEntryDetails` as never returning `undefined`, but this seems unavoidable if we receive a name we didn't provide an entry for. Maybe we should `Debug.fail` in that case instead of returning `undefined`?