### PR TITLE
Add readonly control property to HTMLLabelElement

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -5517,6 +5517,10 @@ interface HTMLLabelElement extends HTMLElement {
      */
     readonly form: HTMLFormElement | null;
     /**
+     * Retrieves a reference to the input representing the control with which the label is associated.
+     */
+    readonly control: HTMLInputElement | null;
+    /**
      * Sets or retrieves the object to which the given label object is assigned.
      */
     htmlFor: string;


### PR DESCRIPTION
Per the MDN documentation for Label elements: https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement

Currently that is not the case: https://github.com/Microsoft/TypeScript/issues/19477

Label elements have a read only control property which references the input element by which the label is associated.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes # added the control prop to the HTMLLabelElement type.
