### PR TITLE
Memoize test rule provider

### DIFF
--- a/src/harness/unittests/extractTestHelpers.ts
+++ b/src/harness/unittests/extractTestHelpers.ts
@@ -67,7 +67,8 @@ namespace ts {
     }
 
     export const newLineCharacter = "\n";
-    export function getRuleProvider(action?: (opts: FormatCodeSettings) => void) {
+    export const getRuleProvider = memoize(getRuleProviderInternal);
+    function getRuleProviderInternal() {
         const options = {
             indentSize: 4,
             tabSize: 4,
@@ -89,9 +90,6 @@ namespace ts {
             placeOpenBraceOnNewLineForFunctions: false,
             placeOpenBraceOnNewLineForControlBlocks: false,
         };
-        if (action) {
-            action(options);
-        }
         const rulesProvider = new formatting.RulesProvider();
         rulesProvider.ensureUpToDate(options);
         return rulesProvider;


### PR DESCRIPTION
Formatting rule provider construction had become the _majority_ of the time spent on the extract symbol/function tests, and as it turns out it is completely reusable (the optional action param to modify the options was never used). This memoizes it, which removes ~3s from the runtime of each of extract symbols and extract function, bringing each's runtime down to 2s and 3s, respectively.
