### PR TITLE
Disable error sourcemaps during session test

### DIFF
--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -398,6 +398,18 @@ namespace ts.server {
     });
 
     describe("exceptions", () => {
+
+        // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
+        let oldPrepare: Function;
+        before(() => {
+            oldPrepare = (Error as any).prepareStackTrace;
+            delete (Error as any).prepareStackTrace;
+        });
+
+        after(() => {
+            (Error as any).prepareStackTrace = oldPrepare;
+        });
+
         const command = "testhandler";
         class TestSession extends Session {
             lastSent: protocol.Message;

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -53,6 +53,17 @@ namespace ts.server {
             return new TestSession(opts);
         }
 
+        // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
+        let oldPrepare: Function;
+        before(() => {
+            oldPrepare = (Error as any).prepareStackTrace;
+            delete (Error as any).prepareStackTrace;
+        });
+
+        after(() => {
+            (Error as any).prepareStackTrace = oldPrepare;
+        });
+
         beforeEach(() => {
             session = createSession();
             session.send = (msg: protocol.Message) => {


### PR DESCRIPTION
The session API test takes 3.3s on my machine - most of this time is spent sourcemapping errors (intentionally generated) which are just swallowed by a null logger (I suspect `source-map` doesn't handle large files particularly elegantly - it spends a lot of time in a custom `quickSort`). This change disables sourcemaps on errors for the duration of the test, bring the test duration down from 3.3s to under 300ms (it no longer appears in the top 200, and I didn't bother digging for the exact time).