### PR TITLE
Disable sourcemaps during cancellationToken test

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -4454,6 +4454,17 @@ namespace ts.projectSystem {
     });
 
     describe("cancellationToken", () => {
+        // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
+        let oldPrepare: Function;
+        before(() => {
+            oldPrepare = (Error as any).prepareStackTrace;
+            delete (Error as any).prepareStackTrace;
+        });
+
+        after(() => {
+            (Error as any).prepareStackTrace = oldPrepare;
+        });
+
         it("is attached to request", () => {
             const f1 = {
                 path: "/a/b/app.ts",


### PR DESCRIPTION
Similarly to #19504, the `cancellationToken` suite intentionally throws many exceptions (in this case to test cancellation) - source map support on these exceptions is incredibly costly, so this disables sourcemap support on error messages for the duration of the test. This takes the suite runtime from 3s down to <300ms on my machine.
