### PR TITLE
Overwrite and simplify assert.isFalse

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -32,6 +32,9 @@
 // this will work in the browser via browserify
 var _chai: typeof chai = require("chai");
 var assert: typeof _chai.assert = _chai.assert;
+// chai's builtin `assert.isFalse` is featureful but slow - we don't use those features,
+// so we'll just overwrite it as an alterative to migrating a bunch of code off of chai
+assert.isFalse = (expr, msg) => { if (expr as any as boolean !== false) throw new Error(msg); };
 declare var __dirname: string; // Node-specific
 var global: NodeJS.Global = <any>Function("return this").call(undefined);
 


### PR DESCRIPTION
Chai's builtin `assert.isFalse` is very featureful - it lets you build an assertion chain and then evaluate it. We do not use the functionality. By replacing `assert.isFalse` with a simple function call which can throw, we _significantly_ reduce the runtime of assertion-heavy tests, like `assertInvariants`. As a extreme example, this brings the runtime of the incremental parsing test suite, `Incremental`, down from 1s to 0.4s, _or_ brings running tests with `light=false` down from 1m56s to 1m15s.