### PR TITLE
Generate tsconfig.json for RWC projects that lack them.

### DIFF
--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -159,7 +159,7 @@ namespace Playback {
     }
 
     const canonicalizeForHarness = ts.createGetCanonicalFileName(/*caseSensitive*/ false); // This is done so tests work on windows _and_ linux
-    function sanitizeTestFilePath(name: string) {
+    export function sanitizeTestFilePath(name: string) {
         const path = ts.toPath(ts.normalizeSlashes(name.replace(/[\^<>:"|?*%]/g, "_")).replace(/\.\.\//g, "__dotdot/"), "", canonicalizeForHarness);
         if (ts.startsWith(path, "/")) {
             return path.substring(1);

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -268,7 +268,7 @@ namespace Playback {
             const files = [];
             for (const file of newLog.filesRead) {
                 if (file.result.contentsPath &&
-                    !/lib\.d\.ts$/.test(file.result.contentsPath) &&
+                    Harness.isDefaultLibraryFile(file.result.contentsPath) &&
                     /\.[tj]s$/.test(file.result.contentsPath)) {
                     files.push(file.result.contentsPath);
                 }

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -262,7 +262,7 @@ namespace Playback {
         };
 
         function generateTsconfig(newLog: IOLog): undefined | { compilerOptions: ts.CompilerOptions, files: string[] } {
-            if (newLog.filesRead.some(file => /tsconfig.json$/.test(file.path))) {
+            if (newLog.filesRead.some(file => /tsconfig.+json$/.test(file.path))) {
                 return;
             }
             const files = [];

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -159,7 +159,7 @@ namespace Playback {
     }
 
     const canonicalizeForHarness = ts.createGetCanonicalFileName(/*caseSensitive*/ false); // This is done so tests work on windows _and_ linux
-    export function sanitizeTestFilePath(name: string) {
+    function sanitizeTestFilePath(name: string) {
         const path = ts.toPath(ts.normalizeSlashes(name.replace(/[\^<>:"|?*%]/g, "_")).replace(/\.\.\//g, "__dotdot/"), "", canonicalizeForHarness);
         if (ts.startsWith(path, "/")) {
             return path.substring(1);
@@ -249,12 +249,32 @@ namespace Playback {
         wrapper.endRecord = () => {
             if (recordLog !== undefined) {
                 let i = 0;
-                const fn = () => recordLogFileNameBase + i;
-                while (underlying.fileExists(ts.combinePaths(fn(), "test.json"))) i++;
-                underlying.writeFile(ts.combinePaths(fn(), "test.json"), JSON.stringify(oldStyleLogIntoNewStyleLog(recordLog, (path, string) => underlying.writeFile(path, string), fn()), null, 4)); // tslint:disable-line:no-null-keyword
+                const getBase = () => recordLogFileNameBase + i;
+                while (underlying.fileExists(ts.combinePaths(getBase(), "test.json"))) i++;
+                const newLog = oldStyleLogIntoNewStyleLog(recordLog, (path, string) => underlying.writeFile(path, string), getBase());
+                underlying.writeFile(ts.combinePaths(getBase(), "test.json"), JSON.stringify(newLog, null, 4)); // tslint:disable-line:no-null-keyword
+                const syntheticTsconfig = generateTsconfig(newLog);
+                if (syntheticTsconfig) {
+                    underlying.writeFile(ts.combinePaths(getBase(), "tsconfig.json"), JSON.stringify(syntheticTsconfig, null, 4)); // tslint:disable-line:no-null-keyword
+                }
                 recordLog = undefined;
             }
         };
+
+        function generateTsconfig(newLog: IOLog): undefined | { compilerOptions: ts.CompilerOptions, files: string[] } {
+            if (newLog.filesRead.some(file => /tsconfig.json$/.test(file.path))) {
+                return;
+            }
+            const files = [];
+            for (const file of newLog.filesRead) {
+                if (file.result.contentsPath &&
+                    !/lib\.d\.ts$/.test(file.result.contentsPath) &&
+                    /\.[tj]s$/.test(file.result.contentsPath)) {
+                    files.push(file.result.contentsPath);
+                }
+            }
+            return { compilerOptions: ts.parseCommandLine(newLog.arguments).options, files };
+        }
 
         wrapper.fileExists = recordReplay(wrapper.fileExists, underlying)(
             path => callAndRecord(underlying.fileExists(path), recordLog.fileExists, { path }),

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -70,10 +70,11 @@ namespace RWC {
                     opts.options.noEmitOnError = false;
                 });
 
+                let tsconfigFile: IOLogFile;
                 runWithIOLog(ioLog, oldIO => {
                     let fileNames = opts.fileNames;
 
-                    const tsconfigFile = ts.forEach(ioLog.filesRead, f => isTsConfigFile(f) ? f : undefined);
+                    tsconfigFile = ts.forEach(ioLog.filesRead, f => isTsConfigFile(f) ? f : undefined);
                     if (tsconfigFile) {
                         const tsconfigFileContents = getHarnessCompilerInputUnit(tsconfigFile.path);
                         tsconfigFiles.push({ unitName: tsconfigFile.path, content: tsconfigFileContents.content });
@@ -154,6 +155,11 @@ namespace RWC {
                     compilerOptions = output.options;
                     compilerResult = output.result;
                 });
+
+                if (!tsconfigFile) {
+                    const files = inputFiles.map(f => Playback.sanitizeTestFilePath(f.unitName));
+                    Harness.IO.writeFile(`internal/cases/rwc/${baseName}/read/tsconfig.json`, JSON.stringify({ compilerOptions, files }));
+                }
 
                 function getHarnessCompilerInputUnit(fileName: string): Harness.Compiler.TestFile {
                     const unitName = ts.normalizeSlashes(Harness.IO.resolvePath(fileName));

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -70,11 +70,10 @@ namespace RWC {
                     opts.options.noEmitOnError = false;
                 });
 
-                let tsconfigFile: IOLogFile;
                 runWithIOLog(ioLog, oldIO => {
                     let fileNames = opts.fileNames;
 
-                    tsconfigFile = ts.forEach(ioLog.filesRead, f => isTsConfigFile(f) ? f : undefined);
+                    const tsconfigFile = ts.forEach(ioLog.filesRead, f => isTsConfigFile(f) ? f : undefined);
                     if (tsconfigFile) {
                         const tsconfigFileContents = getHarnessCompilerInputUnit(tsconfigFile.path);
                         tsconfigFiles.push({ unitName: tsconfigFile.path, content: tsconfigFileContents.content });
@@ -155,11 +154,6 @@ namespace RWC {
                     compilerOptions = output.options;
                     compilerResult = output.result;
                 });
-
-                if (!tsconfigFile) {
-                    const files = inputFiles.map(f => Playback.sanitizeTestFilePath(f.unitName));
-                    Harness.IO.writeFile(`internal/cases/rwc/${baseName}/read/tsconfig.json`, JSON.stringify({ compilerOptions, files }));
-                }
 
                 function getHarnessCompilerInputUnit(fileName: string): Harness.Compiler.TestFile {
                     const unitName = ts.normalizeSlashes(Harness.IO.resolvePath(fileName));


### PR DESCRIPTION
This should make all RWC projects browseable with an editor on Windows (except two, see below). On Linux it still works pretty well if you are willing to lowercase the imports of the file you're interested in.

Many RWC projects already have tsconfig.json files, but this change creates one for projects that don't -- *after* running their respective RWC test. That's because all the information is most easily available at that time, and you probably won't need it until a RWC test failure anyway.

Note that two RWC projects use relative paths in their list of stored files and don't work with this simple scheme. I'll look at that next, but if I can't figure it out in the next hour or two, I'd prefer to merge this since it's immediately useful for all the other projects.
