### PR TITLE
Fix formatting of multiline variable declaration initializers

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -709,7 +709,20 @@ namespace ts.formatting {
                     return inheritedIndentation;
                 }
 
-                const effectiveParentStartLine = child.kind === SyntaxKind.Decorator ? childStartLine : undecoratedParentStartLine;
+                let effectiveParentStartLine = child.kind === SyntaxKind.Decorator ? childStartLine : undecoratedParentStartLine;
+
+                // variable declarations with multiline initializers
+                if (node.kind === SyntaxKind.VariableDeclaration) {
+                    const variableDeclaration = node as VariableDeclaration;
+                    if (variableDeclaration.initializer === child) {
+                        if (variableDeclaration.name.kind & (SyntaxKind.ObjectBindingPattern | SyntaxKind.ArrayBindingPattern)) {
+                            const pos = sourceFile.getLineAndCharacterOfPosition(variableDeclaration.name.pos);
+                            const end = sourceFile.getLineAndCharacterOfPosition(variableDeclaration.name.end);
+                            effectiveParentStartLine += end.line - pos.line;
+                        }
+                    }
+                }
+
                 const childIndentation = computeIndentation(child, childStartLine, childIndentationAmount, node, parentDynamicIndentation, effectiveParentStartLine);
 
                 processNode(child, childContextNode, childStartLine, undecoratedChildStartLine, childIndentation.indentation, childIndentation.delta);

--- a/tests/cases/fourslash/formattingInDestructuring5.ts
+++ b/tests/cases/fourslash/formattingInDestructuring5.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts'/>
+
+/////*1*/const { 
+/////*2*/    a,
+/////*3*/    b,
+/////*4*/} = parseInt(
+/////*5*/    '12'
+/////*6*/);
+
+format.document();
+
+goTo.marker("1");
+verify.currentLineContentIs("const {");
+goTo.marker("2");
+verify.currentLineContentIs("    a,");
+goTo.marker("3");
+verify.currentLineContentIs("    b,");
+goTo.marker("4");
+verify.currentLineContentIs("} = parseInt(");
+goTo.marker("5");
+verify.currentLineContentIs("    '12'");
+goTo.marker("6");
+verify.currentLineContentIs(");");

--- a/tests/cases/fourslash/formattingInDestructuring6.ts
+++ b/tests/cases/fourslash/formattingInDestructuring6.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts'/>
+
+/////*1*/const [
+/////*2*/    a,
+/////*3*/    b,
+/////*4*/] = [
+/////*5*/    1, 2
+/////*6*/];
+
+format.document();
+
+goTo.marker("1");
+verify.currentLineContentIs("const [");
+goTo.marker("2");
+verify.currentLineContentIs("    a,");
+goTo.marker("3");
+verify.currentLineContentIs("    b,");
+goTo.marker("4");
+verify.currentLineContentIs("] = [");
+goTo.marker("5");
+verify.currentLineContentIs("    1, 2");
+goTo.marker("6");
+verify.currentLineContentIs("];");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #19167

Sets the `effectiveParentStartLine` to the last line of a multiline variable declaration name, so that `effectiveParentStartLine === startLine` evaluates to `true`.

This fixes the case presented in the issue, and also for array destructuring. It does not handle the case of a type definition after the variable name:

```
const {
    a,
    b
}: {
    a: number,
    b: number
};
```

Or a type definition followed by an initializer:

```
const {
    a,
    b
}: {
    a: number,
    b: number
} = {
    a: 5,
    b: 4
};
```

Which will behave the same as prior to the fix. These can be fixed by offsetting `effectiveParentStartLine` to be the last line of the previous relevant `Node`, which I can do if the general idea is sound.

