### PR TITLE
Use lowercased names for generated locale directories

### DIFF
--- a/scripts/generateLocalizedDiagnosticMessages.ts
+++ b/scripts/generateLocalizedDiagnosticMessages.ts
@@ -65,10 +65,11 @@ function main(): void {
      * There are three exceptions, zh-CN, zh-TW and pt-BR.
      */
     function getPreferedLocaleName(localeName: string) {
+        localeName = localeName.toLowerCase();
         switch (localeName) {
-            case "zh-CN":
-            case "zh-TW":
-            case "pt-BR":
+            case "zh-cn":
+            case "zh-tw":
+            case "pt-br":
                 return localeName;
             default:
                 return localeName.split("-")[0];


### PR DESCRIPTION
Fixes #19568
`validateLocaleAndSetLanguage` explicitly lowercases locale before searching for it, so we should always generate lowercased locale directories.
