### PR TITLE
The global "JSON" object should always exist

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -43,20 +43,12 @@ namespace ts {
         return s;
     }
 
-    function isJSONSupported() {
-        return typeof JSON === "object" && typeof JSON.parse === "function";
-    }
-
     export function executeCommandLine(args: string[]): void {
         const commandLine = parseCommandLine(args);
 
         // Configuration file name (if any)
         let configFileName: string;
         if (commandLine.options.locale) {
-            if (!isJSONSupported()) {
-                reportDiagnostic(createCompilerDiagnostic(Diagnostics.The_current_host_does_not_support_the_0_option, "--locale"));
-                return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
-            }
             validateLocaleAndSetLanguage(commandLine.options.locale, sys, commandLine.errors);
         }
 
@@ -84,10 +76,6 @@ namespace ts {
         }
 
         if (commandLine.options.project) {
-            if (!isJSONSupported()) {
-                reportDiagnostic(createCompilerDiagnostic(Diagnostics.The_current_host_does_not_support_the_0_option, "--project"));
-                return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
-            }
             if (commandLine.fileNames.length !== 0) {
                 reportDiagnostic(createCompilerDiagnostic(Diagnostics.Option_project_cannot_be_mixed_with_source_files_on_a_command_line));
                 return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
@@ -109,7 +97,7 @@ namespace ts {
                 }
             }
         }
-        else if (commandLine.fileNames.length === 0 && isJSONSupported()) {
+        else if (commandLine.fileNames.length === 0) {
             const searchPath = normalizePath(sys.getCurrentDirectory());
             configFileName = findConfigFile(searchPath, sys.fileExists);
         }


### PR DESCRIPTION
According to [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) this should be present as of Internet Explorer 8, and is used unguarded in a lot of places already.