### PR TITLE
Enable ban-types lint rule

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -1106,7 +1106,7 @@ gulp.task("lint", "Runs tslint on the compiler sources. Optional arguments are: 
     const fileMatcher = cmdLineOptions.files;
     const files = fileMatcher
         ? `src/**/${fileMatcher}`
-        : "Gulpfile.ts 'scripts/generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude src/lib/es5.d.ts --exclude 'src/lib/*.generated.d.ts'";
+        : "Gulpfile.ts 'scripts/generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude 'src/lib/*.d.ts'";
     const cmd = `node node_modules/tslint/bin/tslint ${files} --formatters-dir ./built/local/tslint/formatters --format autolinkableStylish`;
     console.log("Linting: " + cmd);
     child_process.execSync(cmd, { stdio: [0, 1, 2] });

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -1282,7 +1282,7 @@ task("lint", ["build-rules"], () => {
     const fileMatcher = process.env.f || process.env.file || process.env.files;
     const files = fileMatcher
         ? `src/**/${fileMatcher}`
-        : "Gulpfile.ts 'scripts/generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude src/lib/es5.d.ts --exclude 'src/lib/*.generated.d.ts'";
+        : "Gulpfile.ts 'scripts/generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude 'src/lib/*.d.ts'";
     const cmd = `node node_modules/tslint/bin/tslint ${files} --formatters-dir ./built/local/tslint/formatters --format autolinkableStylish`;
     console.log("Linting: " + cmd);
     jake.exec([cmd], { interactive: true }, () => {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2490,7 +2490,7 @@ namespace ts {
             return currentAssertionLevel >= level;
         }
 
-        export function assert(expression: boolean, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: Function): void {
+        export function assert(expression: boolean, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: FunctionForStackTrace): void {
             if (!expression) {
                 if (verboseDebugInfo) {
                     message += "\r\nVerbose Debug Information: " + (typeof verboseDebugInfo === "string" ? verboseDebugInfo : verboseDebugInfo());
@@ -2524,7 +2524,9 @@ namespace ts {
             }
         }
 
-        export function fail(message?: string, stackCrawlMark?: Function): never {
+        type FunctionForStackTrace = (...args: never[]) => {} | null | undefined | void;
+
+        export function fail(message?: string, stackCrawlMark?: FunctionForStackTrace): never {
             debugger;
             const e = new Error(message ? `Debug Failure. ${message}` : "Debug Failure.");
             if ((<any>Error).captureStackTrace) {
@@ -2533,11 +2535,11 @@ namespace ts {
             throw e;
         }
 
-        export function assertNever(member: never, message?: string, stackCrawlMark?: Function): never {
+        export function assertNever(member: never, message?: string, stackCrawlMark?: FunctionForStackTrace): never {
             return fail(message || `Illegal value: ${member}`, stackCrawlMark || assertNever);
         }
 
-        export function getFunctionName(func: Function) {
+        export function getFunctionName(func: FunctionForStackTrace) {
             if (typeof func !== "function") {
                 return "";
             }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2482,6 +2482,12 @@ namespace ts {
         VeryAggressive = 3,
     }
 
+    /**
+     * Safer version of `Function` which should not be called.
+     * Every function should be assignable to this, but this should not be assignable to every function.
+     */
+    export type AnyFunction = (...args: never[]) => {} | null | undefined | void;
+
     export namespace Debug {
         export let currentAssertionLevel = AssertionLevel.None;
         export let isDebugging = false;
@@ -2490,7 +2496,7 @@ namespace ts {
             return currentAssertionLevel >= level;
         }
 
-        export function assert(expression: boolean, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: FunctionForStackTrace): void {
+        export function assert(expression: boolean, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: AnyFunction): void {
             if (!expression) {
                 if (verboseDebugInfo) {
                     message += "\r\nVerbose Debug Information: " + (typeof verboseDebugInfo === "string" ? verboseDebugInfo : verboseDebugInfo());
@@ -2524,9 +2530,7 @@ namespace ts {
             }
         }
 
-        type FunctionForStackTrace = (...args: never[]) => {} | null | undefined | void;
-
-        export function fail(message?: string, stackCrawlMark?: FunctionForStackTrace): never {
+        export function fail(message?: string, stackCrawlMark?: AnyFunction): never {
             debugger;
             const e = new Error(message ? `Debug Failure. ${message}` : "Debug Failure.");
             if ((<any>Error).captureStackTrace) {
@@ -2535,11 +2539,11 @@ namespace ts {
             throw e;
         }
 
-        export function assertNever(member: never, message?: string, stackCrawlMark?: FunctionForStackTrace): never {
+        export function assertNever(member: never, message?: string, stackCrawlMark?: AnyFunction): never {
             return fail(message || `Illegal value: ${member}`, stackCrawlMark || assertNever);
         }
 
-        export function getFunctionName(func: FunctionForStackTrace) {
+        export function getFunctionName(func: AnyFunction) {
             if (typeof func !== "function") {
                 return "";
             }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2486,7 +2486,7 @@ namespace ts {
      * Safer version of `Function` which should not be called.
      * Every function should be assignable to this, but this should not be assignable to every function.
      */
-    export type AnyFunction = (...args: never[]) => {} | null | undefined | void;
+    export type AnyFunction = (...args: never[]) => void;
 
     export namespace Debug {
         export let currentAssertionLevel = AssertionLevel.None;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -135,6 +135,7 @@ namespace Utils {
         return content;
     }
 
+    // tslint:disable-next-line ban-types
     export function memoize<T extends Function>(f: T, memoKey: (...anything: any[]) => string): T {
         const cache = ts.createMap<any>();
 

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -135,8 +135,7 @@ namespace Utils {
         return content;
     }
 
-    // tslint:disable-next-line ban-types
-    export function memoize<T extends Function>(f: T, memoKey: (...anything: any[]) => string): T {
+    export function memoize<T extends ts.AnyFunction>(f: T, memoKey: (...anything: any[]) => string): T {
         const cache = ts.createMap<any>();
 
         return <any>(function(this: any, ...args: any[]) {

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -364,8 +364,7 @@ namespace Playback {
         };
     }
 
-    // tslint:disable-next-line ban-types
-    function recordReplay<T extends Function>(original: T, underlying: any) {
+    function recordReplay<T extends ts.AnyFunction>(original: T, underlying: any) {
         function createWrapper(record: T, replay: T): T {
             return <any>(function () {
                 if (replayLog !== undefined) {

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -364,6 +364,7 @@ namespace Playback {
         };
     }
 
+    // tslint:disable-next-line ban-types
     function recordReplay<T extends Function>(original: T, underlying: any) {
         function createWrapper(record: T, replay: T): T {
             return <any>(function () {

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -54,7 +54,7 @@ namespace ts.server {
         }
 
         // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
-        let oldPrepare: {};
+        let oldPrepare: AnyFunction;
         before(() => {
             oldPrepare = (Error as any).prepareStackTrace;
             delete (Error as any).prepareStackTrace;
@@ -400,7 +400,7 @@ namespace ts.server {
     describe("exceptions", () => {
 
         // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
-        let oldPrepare: {};
+        let oldPrepare: AnyFunction;
         before(() => {
             oldPrepare = (Error as any).prepareStackTrace;
             delete (Error as any).prepareStackTrace;

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -54,7 +54,7 @@ namespace ts.server {
         }
 
         // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
-        let oldPrepare: Function;
+        let oldPrepare: {};
         before(() => {
             oldPrepare = (Error as any).prepareStackTrace;
             delete (Error as any).prepareStackTrace;
@@ -400,7 +400,7 @@ namespace ts.server {
     describe("exceptions", () => {
 
         // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
-        let oldPrepare: Function;
+        let oldPrepare: {};
         before(() => {
             oldPrepare = (Error as any).prepareStackTrace;
             delete (Error as any).prepareStackTrace;

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -4455,7 +4455,7 @@ namespace ts.projectSystem {
 
     describe("cancellationToken", () => {
         // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
-        let oldPrepare: {};
+        let oldPrepare: ts.AnyFunction;
         before(() => {
             oldPrepare = (Error as any).prepareStackTrace;
             delete (Error as any).prepareStackTrace;

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -4455,7 +4455,7 @@ namespace ts.projectSystem {
 
     describe("cancellationToken", () => {
         // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
-        let oldPrepare: Function;
+        let oldPrepare: {};
         before(() => {
             oldPrepare = (Error as any).prepareStackTrace;
             delete (Error as any).prepareStackTrace;

--- a/tslint.json
+++ b/tslint.json
@@ -2,6 +2,15 @@
     "rulesDirectory": "built/local/tslint/rules",
     "rules": {
         "array-type": [true, "array"],
+        "ban-types": {
+            "options": [
+                ["Object", "Avoid using the `Object` type. Did you mean `object`?"],
+                ["Function", "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."],
+                ["Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?"],
+                ["Number", "Avoid using the `Number` type. Did you mean `number`?"],
+                ["String", "Avoid using the `String` type. Did you mean `string`?"]
+            ]
+        },
         "boolean-trivia": true,
         "class-name": true,
         "comment-format": [true,

--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,7 @@
         "ban-types": {
             "options": [
                 ["Object", "Avoid using the `Object` type. Did you mean `object`?"],
-                ["Function", "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."],
+                ["Function", "Avoid using the `Function` type. Prefer a specific function type, like `() => void`, or use `ts.AnyFunction`."],
                 ["Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?"],
                 ["Number", "Avoid using the `Number` type. Did you mean `number`?"],
                 ["String", "Avoid using the `String` type. Did you mean `string`?"]


### PR DESCRIPTION
`Function`is unsafe as any function is assignable to it and it can be called with arbitrary arguments.
There are a few places where we just need something to be a `Function` for the purpose of having a stack trace but we don't ever actually call it.

Disabled running this rule on `Symbol` since we use that to mean something else.