### PR TITLE
Remove duplicate type

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -171,9 +171,9 @@ const librarySourceMap = [
     // JavaScript + all host library
     { target: "lib.d.ts", sources: ["header.d.ts", "es5.d.ts"].concat(hostsLibrarySources) },
     { target: "lib.es6.d.ts", sources: ["header.d.ts", "es5.d.ts"].concat(es2015LibrarySources, hostsLibrarySources, "dom.iterable.d.ts") },
-    { target: "lib.es2016.full.d.ts", sources: ["header.d.ts", "es2016.d.ts"].concat(es2015LibrarySources, hostsLibrarySources, "dom.iterable.d.ts") },
-    { target: "lib.es2017.full.d.ts", sources: ["header.d.ts", "es2017.d.ts"].concat(es2015LibrarySources, hostsLibrarySources, "dom.iterable.d.ts") },
-    { target: "lib.esnext.full.d.ts", sources: ["header.d.ts", "esnext.d.ts"].concat(es2015LibrarySources, hostsLibrarySources, "dom.iterable.d.ts") },
+    { target: "lib.es2016.full.d.ts", sources: ["header.d.ts", "es2016.d.ts"].concat(hostsLibrarySources, "dom.iterable.d.ts") },
+    { target: "lib.es2017.full.d.ts", sources: ["header.d.ts", "es2017.d.ts"].concat(hostsLibrarySources, "dom.iterable.d.ts") },
+    { target: "lib.esnext.full.d.ts", sources: ["header.d.ts", "esnext.d.ts"].concat(hostsLibrarySources, "dom.iterable.d.ts") },
 ].concat(es2015LibrarySourceMap, es2016LibrarySourceMap, es2017LibrarySourceMap, esnextLibrarySourceMap);
 
 const libraryTargets = librarySourceMap.map(function(f) {

--- a/lib/lib.esnext.full.d.ts
+++ b/lib/lib.esnext.full.d.ts
@@ -21,9 +21,6 @@ and limitations under the License.
 /// <reference path="lib.es2017.d.ts" />
 /// <reference path="lib.esnext.asynciterable.d.ts" />
 
-
-declare type PropertyKey = string | number | symbol;
-
 interface Array<T> {
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined

--- a/lib/lib.esnext.full.d.ts
+++ b/lib/lib.esnext.full.d.ts
@@ -21,6 +21,9 @@ and limitations under the License.
 /// <reference path="lib.es2017.d.ts" />
 /// <reference path="lib.esnext.asynciterable.d.ts" />
 
+
+declare type PropertyKey = string | number | symbol;
+
 interface Array<T> {
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined


### PR DESCRIPTION
Fixes #19575

`esnext.full` references `es2017` references `es2016` references `es2015` references `es2015.core` which already defined this type.