### PR TITLE
Drop node 4, add node 8 for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 
 node_js:
   - 'stable'
+  - '8'
   - '6'
-  - '4'
 
 sudo: false
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -5,7 +5,7 @@ import jobs.generation.Utilities;
 def project = GithubProject
 def branch = GithubBranchName
 
-def nodeVersions = ['stable', '6', '4']
+def nodeVersions = ['stable', '8', '6']
 
 nodeVersions.each { nodeVer ->
 


### PR DESCRIPTION
[Node 8.9.0](https://medium.com/@nodejs/news-node-js-8-moves-into-long-term-support-and-node-js-9-becomes-the-new-current-release-line-74cf754a10a0) is the new LTS version, and with it node 4 falls out of LTS and into maintenance. Given our test space is limited, it is prudent to just test on the stable and active LTS versions. 😉 
