### PR TITLE
Properly indent JSXText on format document

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -715,7 +715,7 @@ namespace ts.formatting {
                 processNode(child, childContextNode, childStartLine, undecoratedChildStartLine, childIndentation.indentation, childIndentation.delta);
 
                 if (child.kind === SyntaxKind.JsxText) {
-                    const range = { pos: child.getStart(), end: child.getEnd() };
+                    const range: TextRange = { pos: child.getStart(), end: child.getEnd() };
                     indentMultilineCommentOrJsxText(range, childIndentation.indentation, /*firstLineIsIndented*/ true, /*indentFinalLine*/ false);
                 }
 

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -714,6 +714,11 @@ namespace ts.formatting {
 
                 processNode(child, childContextNode, childStartLine, undecoratedChildStartLine, childIndentation.indentation, childIndentation.delta);
 
+                if (child.kind === SyntaxKind.JsxText) {
+                    const range = { pos: child.getStart(), end: child.getEnd() };
+                    indentMultilineCommentOrJsxText(range, childIndentation.indentation, /*firstLineIsIndented*/ true, /*indentFinalLine*/ false);
+                }
+
                 childContextNode = node;
 
                 if (isFirstListItem && parent.kind === SyntaxKind.ArrayLiteralExpression && inheritedIndentation === Constants.Unknown) {
@@ -833,7 +838,7 @@ namespace ts.formatting {
                             switch (triviaItem.kind) {
                                 case SyntaxKind.MultiLineCommentTrivia:
                                     if (triviaInRange) {
-                                        indentMultilineComment(triviaItem, commentIndentation, /*firstLineIsIndented*/ !indentNextTokenOrTrivia);
+                                        indentMultilineCommentOrJsxText(triviaItem, commentIndentation, /*firstLineIsIndented*/ !indentNextTokenOrTrivia);
                                     }
                                     indentNextTokenOrTrivia = false;
                                     break;
@@ -985,7 +990,7 @@ namespace ts.formatting {
             return indentationString !== sourceFile.text.substr(startLinePosition, indentationString.length);
         }
 
-        function indentMultilineComment(commentRange: TextRange, indentation: number, firstLineIsIndented: boolean) {
+        function indentMultilineCommentOrJsxText(commentRange: TextRange, indentation: number, firstLineIsIndented: boolean, indentFinalLine = true) {
             // split comment in lines
             let startLine = sourceFile.getLineAndCharacterOfPosition(commentRange.pos).line;
             const endLine = sourceFile.getLineAndCharacterOfPosition(commentRange.end).line;
@@ -1006,7 +1011,9 @@ namespace ts.formatting {
                     startPos = getStartPositionOfLine(line + 1, sourceFile);
                 }
 
-                parts.push({ pos: startPos, end: commentRange.end });
+                if (indentFinalLine) {
+                    parts.push({ pos: startPos, end: commentRange.end });
+                }
             }
 
             const startLinePos = getStartPositionOfLine(startLine, sourceFile);

--- a/tests/cases/fourslash/indentationInJsx3.ts
+++ b/tests/cases/fourslash/indentationInJsx3.ts
@@ -4,8 +4,8 @@
 ////function foo() {
 ////   return (
 ////        <div>
-/////*0*/hello
-/////*1*/goodbye
+////hello
+////goodbye
 ////        </div>
 ////    )
 ////}

--- a/tests/cases/fourslash/indentationInJsx3.ts
+++ b/tests/cases/fourslash/indentationInJsx3.ts
@@ -4,28 +4,20 @@
 ////function foo () {
 ////   return (
 ////        <div>
-////hello
-////goodbye
+/////*0*/hello
+/////*1*/goodbye
 ////        </div>
 ////    )
 ////}
 
-goTo.position(21);
-verify.textAtCaretIs("return");
-goTo.position(38);
-verify.textAtCaretIs("<div>");
-goTo.position(44);
-verify.textAtCaretIs("hello");
-goTo.position(50);
-verify.textAtCaretIs("goodbye");
+goTo.marker('0');
+verify.currentLineContentIs("hello");
+goTo.marker('1');
+verify.currentLineContentIs("goodbye");
 
 format.document();
 
-goTo.position(21);
-verify.textAtCaretIs("return");
-goTo.position(38);
-verify.textAtCaretIs("<div>");
-goTo.position(56);
-verify.textAtCaretIs("hello");
-goTo.position(74);
-verify.textAtCaretIs("goodbye");
+goTo.marker('0');
+verify.currentLineContentIs("            hello");
+goTo.marker('1');
+verify.currentLineContentIs("            goodbye");

--- a/tests/cases/fourslash/indentationInJsx3.ts
+++ b/tests/cases/fourslash/indentationInJsx3.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 //@Filename: file.tsx
-////function foo () {
+////function foo() {
 ////   return (
 ////        <div>
 /////*0*/hello
@@ -10,14 +10,26 @@
 ////    )
 ////}
 
-goTo.marker('0');
-verify.currentLineContentIs("hello");
-goTo.marker('1');
-verify.currentLineContentIs("goodbye");
+verify.currentFileContentIs(
+`function foo() {
+   return (
+        <div>
+hello
+goodbye
+        </div>
+    )
+}`
+);
 
 format.document();
 
-goTo.marker('0');
-verify.currentLineContentIs("            hello");
-goTo.marker('1');
-verify.currentLineContentIs("            goodbye");
+verify.currentFileContentIs(
+`function foo() {
+    return (
+        <div>
+            hello
+            goodbye
+        </div>
+    )
+}`
+);

--- a/tests/cases/fourslash/indentationInJsx3.ts
+++ b/tests/cases/fourslash/indentationInJsx3.ts
@@ -1,0 +1,31 @@
+/// <reference path='fourslash.ts' />
+
+//@Filename: file.tsx
+////function foo () {
+////   return (
+////        <div>
+////hello
+////goodbye
+////        </div>
+////    )
+////}
+
+goTo.position(21);
+verify.textAtCaretIs("return");
+goTo.position(38);
+verify.textAtCaretIs("<div>");
+goTo.position(44);
+verify.textAtCaretIs("hello");
+goTo.position(50);
+verify.textAtCaretIs("goodbye");
+
+format.document();
+
+goTo.position(21);
+verify.textAtCaretIs("return");
+goTo.position(38);
+verify.textAtCaretIs("<div>");
+goTo.position(56);
+verify.textAtCaretIs("hello");
+goTo.position(74);
+verify.textAtCaretIs("goodbye");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[X] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[X] Code is up-to-date with the `master` branch
[X] You've successfully run `jake runtests` locally
[X] You've signed the CLA
[X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Currently, only the first line of a contiguous block of text within a JSX element properly respects indentation when the document is formatted; all others are unaffected. This change inserts whitespace as needed so that all other lines indent properly as well.
