### PR TITLE
Ensure that we continue recursing into TS transforms

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -225,7 +225,7 @@ namespace ts {
             if (parsed !== node) {
                 // If the node has been transformed by a `before` transformer, perform no ellision on it
                 // As the type information we would attempt to lookup to perform ellision is potentially unavailable for the synthesized nodes
-                return node;
+                return visitorWorker(node);
             }
             switch (node.kind) {
                 case SyntaxKind.ImportDeclaration:

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -225,7 +225,14 @@ namespace ts {
             if (parsed !== node) {
                 // If the node has been transformed by a `before` transformer, perform no ellision on it
                 // As the type information we would attempt to lookup to perform ellision is potentially unavailable for the synthesized nodes
-                return visitorWorker(node);
+                // We do not reuse `visitorWorker`, as the ellidable statement syntax kinds are technically unrecognized by the switch-case in `visitTypeScript`,
+                // and will trigger debug failures when debug verbosity is turned up
+                if (node.transformFlags & TransformFlags.ContainsTypeScript) {
+                    // This node contains TypeScript, so we should visit its children.
+                    return visitEachChild(node, visitor, context);
+                }
+                // Otherwise, we can just return the node
+                return node;
             }
             switch (node.kind) {
                 case SyntaxKind.ImportDeclaration:

--- a/src/harness/unittests/transform.ts
+++ b/src/harness/unittests/transform.ts
@@ -20,6 +20,15 @@ namespace ts {
             };
             return (file: ts.SourceFile) => file;
         }
+        function replaceNumberWith2(context: ts.TransformationContext) {
+            function visitor(node: Node): Node {
+                if (isNumericLiteral(node)) {
+                    return createNumericLiteral("2");
+                }
+                return visitEachChild(node, visitor, context);
+            }
+            return (file: ts.SourceFile) => visitNode(file, visitor);
+        }
 
         function replaceIdentifiersNamedOldNameWithNewName(context: ts.TransformationContext) {
             const previousOnSubstituteNode = context.onSubstituteNode;
@@ -93,6 +102,20 @@ namespace ts {
             `, {
                     transformers: {
                         before: [forceNamespaceRewrite],
+                    },
+                    compilerOptions: {
+                        target: ts.ScriptTarget.ESNext,
+                        newLine: NewLineKind.CarriageReturnLineFeed,
+                    }
+                }).outputText;
+        });
+
+        testBaseline("transformTypesInExportDefault", () => {
+            return ts.transpileModule(`
+            export default (foo: string) => { return 1; }
+            `, {
+                    transformers: {
+                        before: [replaceNumberWith2],
                     },
                     compilerOptions: {
                         target: ts.ScriptTarget.ESNext,

--- a/tests/baselines/reference/transformApi/transformsCorrectly.transformTypesInExportDefault.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.transformTypesInExportDefault.js
@@ -1,0 +1,1 @@
+export default (foo) => { return 2; };


### PR DESCRIPTION
Ensures that we continue recursing into TS transforms when avoiding export elliding for transformed nodes. This fixes #19649 .
