### PR TITLE
Add localizable diagnostic for "Install '{0}'"

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3793,5 +3793,9 @@
     "Infer parameter types from usage.": {
         "category": "Message",
         "code": 95012
+    },
+    "Install '{0}'": {
+        "category": "Message",
+        "code": 95013
     }
 }

--- a/src/services/codefixes/fixCannotFindModule.ts
+++ b/src/services/codefixes/fixCannotFindModule.ts
@@ -26,7 +26,7 @@ namespace ts.codefix {
 
         const typesPackageName = getTypesPackageName(packageName);
         return {
-            description: `Install '${typesPackageName}'`,
+            description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Install_0), [typesPackageName]),
             changes: [],
             commands: [{ type: "install package", packageName: typesPackageName }],
         };


### PR DESCRIPTION
Fixes #19626
