### PR TITLE
Enable 'callable-types' tslint rule

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -69,9 +69,8 @@ namespace ts {
 
     export const maxNumberOfFilesToIterateForInvalidation = 256;
 
-    interface GetResolutionWithResolvedFileName<T extends ResolutionWithFailedLookupLocations = ResolutionWithFailedLookupLocations, R extends ResolutionWithResolvedFileName = ResolutionWithResolvedFileName> {
-        (resolution: T): R;
-    }
+    type GetResolutionWithResolvedFileName<T extends ResolutionWithFailedLookupLocations = ResolutionWithFailedLookupLocations, R extends ResolutionWithResolvedFileName = ResolutionWithResolvedFileName> =
+        (resolution: T) => R;
 
     export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootDirForResolution: string): ResolutionCache {
         let filesWithChangedSetOfUnresolvedImports: Path[] | undefined;

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2,9 +2,7 @@
 /// <reference path="diagnosticInformationMap.generated.ts"/>
 
 namespace ts {
-    export interface ErrorCallback {
-        (message: DiagnosticMessage, length: number): void;
-    }
+    export type ErrorCallback = (message: DiagnosticMessage, length: number) => void;
 
     /* @internal */
     export function tokenIsIdentifierOrKeyword(token: SyntaxKind): boolean {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2471,9 +2471,13 @@ namespace ts {
         readFile(path: string): string | undefined;
     }
 
-    export interface WriteFileCallback {
-        (fileName: string, data: string, writeByteOrderMark: boolean, onError: ((message: string) => void) | undefined, sourceFiles: ReadonlyArray<SourceFile>): void;
-    }
+    export type WriteFileCallback = (
+        fileName: string,
+        data: string,
+        writeByteOrderMark: boolean,
+        onError: ((message: string) => void) | undefined,
+        sourceFiles: ReadonlyArray<SourceFile>,
+    ) => void;
 
     export class OperationCanceledException { }
 
@@ -3582,9 +3586,7 @@ namespace ts {
     }
 
     /* @internal */
-    export interface TypeMapper {
-        (t: TypeParameter): Type;
-    }
+    export type TypeMapper = (t: TypeParameter) => Type;
 
     export const enum InferencePriority {
         Contravariant     = 1 << 0,  // Inference from contravariant position
@@ -4192,9 +4194,7 @@ namespace ts {
     }
 
     /* @internal */
-    export interface HasInvalidatedResolution {
-        (sourceFile: Path): boolean;
-    }
+    export type HasInvalidatedResolution = (sourceFile: Path) => boolean;
 
     export interface CompilerHost extends ModuleResolutionHost {
         getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void, shouldCreateNewSourceFile?: boolean): SourceFile | undefined;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -784,9 +784,15 @@ namespace Harness {
         ? IO.newLine() + `//# sourceURL=${IO.resolvePath(tcServicesFileName)}`
         : "");
 
-    export interface SourceMapEmitterCallback {
-        (emittedFile: string, emittedLine: number, emittedColumn: number, sourceFile: string, sourceLine: number, sourceColumn: number, sourceName: string): void;
-    }
+    export type SourceMapEmitterCallback = (
+        emittedFile: string,
+        emittedLine: number,
+        emittedColumn: number,
+        sourceFile: string,
+        sourceLine: number,
+        sourceColumn: number,
+        sourceName: string,
+    ) => void;
 
     // Settings
     export let userSpecifiedRoot = "";

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -78,9 +78,7 @@ namespace ts.server {
 
     export type ProjectServiceEvent = ProjectsUpdatedInBackgroundEvent | ConfigFileDiagEvent | ProjectLanguageServiceStateEvent | ProjectInfoTelemetryEvent;
 
-    export interface ProjectServiceEventHandler {
-        (event: ProjectServiceEvent): void;
-    }
+    export type ProjectServiceEventHandler = (event: ProjectServiceEvent) => void;
 
     export interface SafeList {
         [name: string]: { match: RegExp, exclude?: (string | number)[][], types?: string[] };

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -98,9 +98,7 @@ namespace ts.server {
         getExternalFiles?(proj: Project): string[];
     }
 
-    export interface PluginModuleFactory {
-        (mod: { typescript: typeof ts }): PluginModule;
-    }
+    export type PluginModuleFactory = (mod: { typescript: typeof ts }) => PluginModule;
 
     /**
      * The project root can be script info - if root is present,

--- a/src/services/formatting/ruleOperationContext.ts
+++ b/src/services/formatting/ruleOperationContext.ts
@@ -4,9 +4,9 @@
 namespace ts.formatting {
 
     export class RuleOperationContext {
-        private readonly customContextChecks: { (context: FormattingContext): boolean; }[];
+        private readonly customContextChecks: ((context: FormattingContext) => boolean)[];
 
-        constructor(...funcs: { (context: FormattingContext): boolean; }[]) {
+        constructor(...funcs: ((context: FormattingContext) => boolean)[]) {
             this.customContextChecks = funcs;
         }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1623,9 +1623,7 @@ declare namespace ts {
         fileExists(path: string): boolean;
         readFile(path: string): string | undefined;
     }
-    interface WriteFileCallback {
-        (fileName: string, data: string, writeByteOrderMark: boolean, onError: ((message: string) => void) | undefined, sourceFiles: ReadonlyArray<SourceFile>): void;
-    }
+    type WriteFileCallback = (fileName: string, data: string, writeByteOrderMark: boolean, onError: ((message: string) => void) | undefined, sourceFiles: ReadonlyArray<SourceFile>) => void;
     class OperationCanceledException {
     }
     interface CancellationToken {
@@ -3095,9 +3093,7 @@ declare namespace ts {
     function isGetAccessor(node: Node): node is GetAccessorDeclaration;
 }
 declare namespace ts {
-    interface ErrorCallback {
-        (message: DiagnosticMessage, length: number): void;
-    }
+    type ErrorCallback = (message: DiagnosticMessage, length: number) => void;
     interface Scanner {
         getStartPos(): number;
         getToken(): SyntaxKind;
@@ -7144,11 +7140,9 @@ declare namespace ts.server {
         create(createInfo: PluginCreateInfo): LanguageService;
         getExternalFiles?(proj: Project): string[];
     }
-    interface PluginModuleFactory {
-        (mod: {
-            typescript: typeof ts;
-        }): PluginModule;
-    }
+    type PluginModuleFactory = (mod: {
+        typescript: typeof ts;
+    }) => PluginModule;
     /**
      * The project root can be script info - if root is present,
      * or it could be just normalized path if root wasnt present on the host(only for non inferred project)
@@ -7418,9 +7412,7 @@ declare namespace ts.server {
         readonly dts: number;
     }
     type ProjectServiceEvent = ProjectsUpdatedInBackgroundEvent | ConfigFileDiagEvent | ProjectLanguageServiceStateEvent | ProjectInfoTelemetryEvent;
-    interface ProjectServiceEventHandler {
-        (event: ProjectServiceEvent): void;
-    }
+    type ProjectServiceEventHandler = (event: ProjectServiceEvent) => void;
     interface SafeList {
         [name: string]: {
             match: RegExp;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1623,9 +1623,7 @@ declare namespace ts {
         fileExists(path: string): boolean;
         readFile(path: string): string | undefined;
     }
-    interface WriteFileCallback {
-        (fileName: string, data: string, writeByteOrderMark: boolean, onError: ((message: string) => void) | undefined, sourceFiles: ReadonlyArray<SourceFile>): void;
-    }
+    type WriteFileCallback = (fileName: string, data: string, writeByteOrderMark: boolean, onError: ((message: string) => void) | undefined, sourceFiles: ReadonlyArray<SourceFile>) => void;
     class OperationCanceledException {
     }
     interface CancellationToken {
@@ -2758,9 +2756,7 @@ declare namespace ts {
     let sys: System;
 }
 declare namespace ts {
-    interface ErrorCallback {
-        (message: DiagnosticMessage, length: number): void;
-    }
+    type ErrorCallback = (message: DiagnosticMessage, length: number) => void;
     interface Scanner {
         getStartPos(): number;
         getToken(): SyntaxKind;

--- a/tslint.json
+++ b/tslint.json
@@ -76,7 +76,6 @@
         "arrow-return-shorthand": false,
         "ban-comma-operator": false,
         "ban-types": false,
-        "callable-types": false,
         "forin": false,
         "member-access": false, // [true, "no-public"]
         "no-conditional-assignment": false,


### PR DESCRIPTION
This was pretty easy to fix. 99% of the time we've been using function literal types instead of interfaces.