### PR TITLE
In typings installer, provide mandatory 'package.json' fields

### DIFF
--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -248,7 +248,7 @@ namespace ts.server.typingsInstaller {
                     this.log.writeLine(`Npm config file: '${npmConfigPath}' is missing, creating new one...`);
                 }
                 this.ensureDirectoryExists(directory, this.installTypingHost);
-                this.installTypingHost.writeFile(npmConfigPath, "{}");
+                this.installTypingHost.writeFile(npmConfigPath, '{ "description": "", "repository": "", "license": "" }');
             }
         }
 


### PR DESCRIPTION
May fix #19660 -- NPM expects every `package.json` to contain certain fields.
