### PR TITLE
Support quick info at `function` and `=>` locations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23638,6 +23638,8 @@ namespace ts {
                     return objectType && getPropertyOfType(objectType, escapeLeadingUnderscores((node as StringLiteral | NumericLiteral).text));
 
                 case SyntaxKind.DefaultKeyword:
+                case SyntaxKind.FunctionKeyword:
+                case SyntaxKind.EqualsGreaterThanToken:
                     return getSymbolOfNode(node.parent);
 
                 default:

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -489,8 +489,10 @@ namespace ts.SymbolDisplay {
             addNewLineIfDisplayPartsExist();
             if (symbolKind) {
                 pushTypePart(symbolKind);
-                displayParts.push(spacePart());
-                addFullSymbolName(symbol);
+                if (!some(symbol.declarations, d => isArrowFunction(d) || (isFunctionExpression(d) || isClassExpression(d)) && !d.name)) {
+                    displayParts.push(spacePart());
+                    addFullSymbolName(symbol);
+                }
             }
         }
 

--- a/tests/cases/fourslash/quickInfoFunctionKeyword.ts
+++ b/tests/cases/fourslash/quickInfoFunctionKeyword.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts'/>
+
+////[1].forEach(fu/*1*/nction() {});
+////[1].map(x =/*2*/> x + 1);
+
+verify.quickInfoAt("1", "(local function)(): void");
+verify.quickInfoAt("2", "function(x: number): number");

--- a/tests/cases/fourslash/quickInfoInvalidLocations.ts
+++ b/tests/cases/fourslash/quickInfoInvalidLocations.ts
@@ -1,35 +1,35 @@
 /// <reference path='fourslash.ts' />
 
 
-////inter/*invlaid1*/face IFoo {
+////inter/*invalid1*/face IFoo {
 ////    new(): IFoo;
 ////    [indexer: string]: number;
 ////    method(value: number): string;
 ////    property: string;
-/////*invlaid2*/}
+/////*invalid2*/}
 ////
-////cl/*invlaid3*/ass bar imple/*invlaid4*/ments IFoo {
-////    constructor(   /*invlaid5*/  ) {
+////cl/*invalid3*/ass bar imple/*invalid4*/ments IFoo {
+////    constructor(   /*invalid5*/  ) {
 ////
 ////    }
 ////
-////    pu/*invlaid6*/blic method(value: string): string {
-////        retu/*invlaid7*/rn null;
+////    pu/*invalid6*/blic method(value: string): string {
+////        retu/*invalid7*/rn null;
 ////    }
 ////
-////    public property: string  /*invlaid8*/= "string";
+////    public property: string  /*invalid8*/= "string";
 ////
-////    public ge/*invlaid9*/t value() {
+////    public ge/*invalid9*/t value() {
 ////        return 0;
 ////    }
 ////}
 ////
 ////
-////mod/*invlaid10*/ule m1 {
-////    va/*invlaid11*/r varibale = 0;
+////mod/*invalid10*/ule m1 {
+////    va/*invalid11*/r varibale = 0;
 ////
-////    func/*invlaid12*/tion foo(arg1: number) {
-////        ret/*invlaid13*/urn string;
+////    function foo(arg1: number) {
+////        ret/*invalid13*/urn string;
 ////    }
 ////
 ////    class foo {
@@ -40,7 +40,7 @@
 ////        value1: "string",
 ////        value2: {
 ////            value21: number
-////        /*invlaid14*/}
+////        /*invalid14*/}
 ////    };
 ////}
 


### PR DESCRIPTION
Fixes  #2736

I think this would be better-looking if we stopped writing `(local function)` and just used `function`, although that was apparently intentional at some point and would change a lot of baselines.
