### PR TITLE
Fix TokenOrIdentifierObject.getText() crash

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -276,7 +276,10 @@ namespace ts {
         }
 
         public getText(sourceFile?: SourceFile): string {
-            return (sourceFile || this.getSourceFile()).text.substring(this.getStart(), this.getEnd());
+            if (!sourceFile) {
+                sourceFile = this.getSourceFile();
+            }
+            return sourceFile.text.substring(this.getStart(sourceFile), this.getEnd());
         }
 
         public getChildCount(): number {


### PR DESCRIPTION
`TokenOrIdentifierObject.getText()` needs to pass `sourceFile` as an argument to `getStart()`.

Fixes #19670
