### PR TITLE
Apply isLiteralContextualType recursively for unions and intersections.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18458,7 +18458,17 @@ namespace ts {
                     }
                     contextualType = constraint;
                 }
-                return maybeTypeOfKind(contextualType, (TypeFlags.Literal | TypeFlags.Index));
+                if (contextualType.flags & (TypeFlags.Literal | TypeFlags.Index)) {
+                    return true;
+                }
+                if (contextualType.flags & TypeFlags.UnionOrIntersection) {
+                    const types = (<UnionOrIntersectionType>contextualType).types;
+                    for (const t of types) {
+                        if (isLiteralContextualType(t)) {
+                            return true;
+                        }
+                    }
+                }
             }
             return false;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18446,7 +18446,7 @@ namespace ts {
                 isTypeAssertion(declaration.initializer) ? type : getWidenedLiteralType(type);
         }
 
-        function isLiteralContextualType(contextualType: Type) {
+        function isLiteralContextualType(contextualType: Type): boolean {
             if (contextualType) {
                 if (contextualType.flags & TypeFlags.TypeVariable) {
                     const constraint = getBaseConstraintOfType(contextualType) || emptyObjectType;
@@ -18458,17 +18458,9 @@ namespace ts {
                     }
                     contextualType = constraint;
                 }
-                if (contextualType.flags & (TypeFlags.Literal | TypeFlags.Index)) {
-                    return true;
-                }
-                if (contextualType.flags & TypeFlags.UnionOrIntersection) {
-                    const types = (<UnionOrIntersectionType>contextualType).types;
-                    for (const t of types) {
-                        if (isLiteralContextualType(t)) {
-                            return true;
-                        }
-                    }
-                }
+                return !!(contextualType.flags & (TypeFlags.Literal | TypeFlags.Index) ||
+                    contextualType.flags & TypeFlags.UnionOrIntersection
+                        && forEach((<UnionOrIntersectionType>contextualType).types, isLiteralContextualType));
             }
             return false;
         }

--- a/tests/baselines/reference/genericCallStringLiteralUnionNested.errors.txt
+++ b/tests/baselines/reference/genericCallStringLiteralUnionNested.errors.txt
@@ -1,0 +1,50 @@
+tests/cases/compiler/genericCallStringLiteralUnionNested.ts(23,7): error TS2322: Type 'string[]' is not assignable to type '"z"[]'.
+  Type 'string' is not assignable to type '"z"'.
+tests/cases/compiler/genericCallStringLiteralUnionNested.ts(24,7): error TS2322: Type 'number[]' is not assignable to type '1[]'.
+  Type 'number' is not assignable to type '1'.
+tests/cases/compiler/genericCallStringLiteralUnionNested.ts(27,7): error TS2322: Type 'string[]' is not assignable to type '"z"[]'.
+tests/cases/compiler/genericCallStringLiteralUnionNested.ts(28,7): error TS2322: Type 'number[]' is not assignable to type '3[]'.
+  Type 'number' is not assignable to type '3'.
+
+
+==== tests/cases/compiler/genericCallStringLiteralUnionNested.ts (4 errors) ====
+    declare function nestedUnionExtendsString<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+    const t1: {z: string} = nestedUnionExtendsString({ fields: "z" });
+    
+    declare function nestedUnionExtendsLiterals<A extends "z" | "y">(a: { fields: A | A[] }): A[];
+    const t2: "z"[] = nestedUnionExtendsLiterals({ fields: "z" });
+    
+    declare function nestedGenericIntersection<A extends B & C, B extends string, C extends string>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+    const t3: "z"[] = nestedGenericIntersection({ fields: "z" }, ["z", "y"], ["z", "y"]);
+    
+    declare function nestedUnionExtendsNumber<A extends number>(a: { fields: A | A[] }): A[];
+    const t4: 1[] = nestedUnionExtendsNumber({ fields: 1 });
+    
+    declare function nestedUnionExtendsLiteralsNumber<A extends 1 | 2>(a: { fields: A | A[] }): A[];
+    const t5: 2[] = nestedUnionExtendsLiteralsNumber({ fields: 2 });
+    
+    declare function nestedUnionIntersectionGenericNumber<A extends B & C, B extends number, C extends number>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+    const t6: 3[] = nestedUnionIntersectionGenericNumber({ fields: 3 }, [1, 3], [1, 3]);
+    
+    
+    // The following are expected to fail because they don't have an extend string or extend number generic constraint.
+    
+    declare function nestedUnionPlain<A>(a: { fields: A | A[] }): A[];
+    const expectedFail1: "z"[] = nestedUnionPlain({ fields: "z" });
+          ~~~~~~~~~~~~~
+!!! error TS2322: Type 'string[]' is not assignable to type '"z"[]'.
+!!! error TS2322:   Type 'string' is not assignable to type '"z"'.
+    const expectedFail2: 1[] = nestedUnionPlain({ fields: 1 });
+          ~~~~~~~~~~~~~
+!!! error TS2322: Type 'number[]' is not assignable to type '1[]'.
+!!! error TS2322:   Type 'number' is not assignable to type '1'.
+    
+    declare function nestedUnionIntersectionPlainGenerics<A extends B & C, B, C>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+    const expectedFail3: "z"[] = nestedUnionIntersectionPlainGenerics({ fields: "z" }, ["z", "y"], ["z", "y"]);
+          ~~~~~~~~~~~~~
+!!! error TS2322: Type 'string[]' is not assignable to type '"z"[]'.
+    const expectedFail4: 3[] = nestedUnionIntersectionPlainGenerics({ fields: 3 }, [1, 3], [1, 3]);
+          ~~~~~~~~~~~~~
+!!! error TS2322: Type 'number[]' is not assignable to type '3[]'.
+!!! error TS2322:   Type 'number' is not assignable to type '3'.
+    

--- a/tests/baselines/reference/genericCallStringLiteralUnionNested.js
+++ b/tests/baselines/reference/genericCallStringLiteralUnionNested.js
@@ -1,7 +1,42 @@
 //// [genericCallStringLiteralUnionNested.ts]
-declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>;
-const result: {z: string} = nestedUnion({ fields: "z" });
+declare function nestedUnionExtendsString<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+const t1: {z: string} = nestedUnionExtendsString({ fields: "z" });
+
+declare function nestedUnionExtendsLiterals<A extends "z" | "y">(a: { fields: A | A[] }): A[];
+const t2: "z"[] = nestedUnionExtendsLiterals({ fields: "z" });
+
+declare function nestedGenericIntersection<A extends B & C, B extends string, C extends string>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+const t3: "z"[] = nestedGenericIntersection({ fields: "z" }, ["z", "y"], ["z", "y"]);
+
+declare function nestedUnionExtendsNumber<A extends number>(a: { fields: A | A[] }): A[];
+const t4: 1[] = nestedUnionExtendsNumber({ fields: 1 });
+
+declare function nestedUnionExtendsLiteralsNumber<A extends 1 | 2>(a: { fields: A | A[] }): A[];
+const t5: 2[] = nestedUnionExtendsLiteralsNumber({ fields: 2 });
+
+declare function nestedUnionIntersectionGenericNumber<A extends B & C, B extends number, C extends number>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+const t6: 3[] = nestedUnionIntersectionGenericNumber({ fields: 3 }, [1, 3], [1, 3]);
+
+
+// The following are expected to fail because they don't have an extend string or extend number generic constraint.
+
+declare function nestedUnionPlain<A>(a: { fields: A | A[] }): A[];
+const expectedFail1: "z"[] = nestedUnionPlain({ fields: "z" });
+const expectedFail2: 1[] = nestedUnionPlain({ fields: 1 });
+
+declare function nestedUnionIntersectionPlainGenerics<A extends B & C, B, C>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+const expectedFail3: "z"[] = nestedUnionIntersectionPlainGenerics({ fields: "z" }, ["z", "y"], ["z", "y"]);
+const expectedFail4: 3[] = nestedUnionIntersectionPlainGenerics({ fields: 3 }, [1, 3], [1, 3]);
 
 
 //// [genericCallStringLiteralUnionNested.js]
-var result = nestedUnion({ fields: "z" });
+var t1 = nestedUnionExtendsString({ fields: "z" });
+var t2 = nestedUnionExtendsLiterals({ fields: "z" });
+var t3 = nestedGenericIntersection({ fields: "z" }, ["z", "y"], ["z", "y"]);
+var t4 = nestedUnionExtendsNumber({ fields: 1 });
+var t5 = nestedUnionExtendsLiteralsNumber({ fields: 2 });
+var t6 = nestedUnionIntersectionGenericNumber({ fields: 3 }, [1, 3], [1, 3]);
+var expectedFail1 = nestedUnionPlain({ fields: "z" });
+var expectedFail2 = nestedUnionPlain({ fields: 1 });
+var expectedFail3 = nestedUnionIntersectionPlainGenerics({ fields: "z" }, ["z", "y"], ["z", "y"]);
+var expectedFail4 = nestedUnionIntersectionPlainGenerics({ fields: 3 }, [1, 3], [1, 3]);

--- a/tests/baselines/reference/genericCallStringLiteralUnionNested.js
+++ b/tests/baselines/reference/genericCallStringLiteralUnionNested.js
@@ -1,0 +1,7 @@
+//// [genericCallStringLiteralUnionNested.ts]
+declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+const result: {z: string} = nestedUnion({ fields: "z" });
+
+
+//// [genericCallStringLiteralUnionNested.js]
+var result = nestedUnion({ fields: "z" });

--- a/tests/baselines/reference/genericCallStringLiteralUnionNested.symbols
+++ b/tests/baselines/reference/genericCallStringLiteralUnionNested.symbols
@@ -1,17 +1,152 @@
 === tests/cases/compiler/genericCallStringLiteralUnionNested.ts ===
-declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>;
->nestedUnion : Symbol(nestedUnion, Decl(genericCallStringLiteralUnionNested.ts, 0, 0))
->A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 29))
->a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 0, 47))
->fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 0, 51))
->A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 29))
->A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 29))
+declare function nestedUnionExtendsString<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+>nestedUnionExtendsString : Symbol(nestedUnionExtendsString, Decl(genericCallStringLiteralUnionNested.ts, 0, 0))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 42))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 0, 60))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 0, 64))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 42))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 42))
 >Record : Symbol(Record, Decl(lib.d.ts, --, --))
->A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 29))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 42))
 
-const result: {z: string} = nestedUnion({ fields: "z" });
->result : Symbol(result, Decl(genericCallStringLiteralUnionNested.ts, 1, 5))
->z : Symbol(z, Decl(genericCallStringLiteralUnionNested.ts, 1, 15))
->nestedUnion : Symbol(nestedUnion, Decl(genericCallStringLiteralUnionNested.ts, 0, 0))
->fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 1, 41))
+const t1: {z: string} = nestedUnionExtendsString({ fields: "z" });
+>t1 : Symbol(t1, Decl(genericCallStringLiteralUnionNested.ts, 1, 5))
+>z : Symbol(z, Decl(genericCallStringLiteralUnionNested.ts, 1, 11))
+>nestedUnionExtendsString : Symbol(nestedUnionExtendsString, Decl(genericCallStringLiteralUnionNested.ts, 0, 0))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 1, 50))
+
+declare function nestedUnionExtendsLiterals<A extends "z" | "y">(a: { fields: A | A[] }): A[];
+>nestedUnionExtendsLiterals : Symbol(nestedUnionExtendsLiterals, Decl(genericCallStringLiteralUnionNested.ts, 1, 66))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 3, 44))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 3, 65))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 3, 69))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 3, 44))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 3, 44))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 3, 44))
+
+const t2: "z"[] = nestedUnionExtendsLiterals({ fields: "z" });
+>t2 : Symbol(t2, Decl(genericCallStringLiteralUnionNested.ts, 4, 5))
+>nestedUnionExtendsLiterals : Symbol(nestedUnionExtendsLiterals, Decl(genericCallStringLiteralUnionNested.ts, 1, 66))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 4, 46))
+
+declare function nestedGenericIntersection<A extends B & C, B extends string, C extends string>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+>nestedGenericIntersection : Symbol(nestedGenericIntersection, Decl(genericCallStringLiteralUnionNested.ts, 4, 62))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 6, 43))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 6, 59))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 6, 77))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 6, 59))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 6, 77))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 6, 96))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 6, 100))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 6, 43))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 6, 43))
+>b : Symbol(b, Decl(genericCallStringLiteralUnionNested.ts, 6, 119))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 6, 59))
+>c : Symbol(c, Decl(genericCallStringLiteralUnionNested.ts, 6, 127))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 6, 77))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 6, 43))
+
+const t3: "z"[] = nestedGenericIntersection({ fields: "z" }, ["z", "y"], ["z", "y"]);
+>t3 : Symbol(t3, Decl(genericCallStringLiteralUnionNested.ts, 7, 5))
+>nestedGenericIntersection : Symbol(nestedGenericIntersection, Decl(genericCallStringLiteralUnionNested.ts, 4, 62))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 7, 45))
+
+declare function nestedUnionExtendsNumber<A extends number>(a: { fields: A | A[] }): A[];
+>nestedUnionExtendsNumber : Symbol(nestedUnionExtendsNumber, Decl(genericCallStringLiteralUnionNested.ts, 7, 85))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 9, 42))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 9, 60))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 9, 64))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 9, 42))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 9, 42))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 9, 42))
+
+const t4: 1[] = nestedUnionExtendsNumber({ fields: 1 });
+>t4 : Symbol(t4, Decl(genericCallStringLiteralUnionNested.ts, 10, 5))
+>nestedUnionExtendsNumber : Symbol(nestedUnionExtendsNumber, Decl(genericCallStringLiteralUnionNested.ts, 7, 85))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 10, 42))
+
+declare function nestedUnionExtendsLiteralsNumber<A extends 1 | 2>(a: { fields: A | A[] }): A[];
+>nestedUnionExtendsLiteralsNumber : Symbol(nestedUnionExtendsLiteralsNumber, Decl(genericCallStringLiteralUnionNested.ts, 10, 56))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 12, 50))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 12, 67))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 12, 71))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 12, 50))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 12, 50))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 12, 50))
+
+const t5: 2[] = nestedUnionExtendsLiteralsNumber({ fields: 2 });
+>t5 : Symbol(t5, Decl(genericCallStringLiteralUnionNested.ts, 13, 5))
+>nestedUnionExtendsLiteralsNumber : Symbol(nestedUnionExtendsLiteralsNumber, Decl(genericCallStringLiteralUnionNested.ts, 10, 56))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 13, 50))
+
+declare function nestedUnionIntersectionGenericNumber<A extends B & C, B extends number, C extends number>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+>nestedUnionIntersectionGenericNumber : Symbol(nestedUnionIntersectionGenericNumber, Decl(genericCallStringLiteralUnionNested.ts, 13, 64))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 15, 54))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 15, 70))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 15, 88))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 15, 70))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 15, 88))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 15, 107))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 15, 111))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 15, 54))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 15, 54))
+>b : Symbol(b, Decl(genericCallStringLiteralUnionNested.ts, 15, 130))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 15, 70))
+>c : Symbol(c, Decl(genericCallStringLiteralUnionNested.ts, 15, 138))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 15, 88))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 15, 54))
+
+const t6: 3[] = nestedUnionIntersectionGenericNumber({ fields: 3 }, [1, 3], [1, 3]);
+>t6 : Symbol(t6, Decl(genericCallStringLiteralUnionNested.ts, 16, 5))
+>nestedUnionIntersectionGenericNumber : Symbol(nestedUnionIntersectionGenericNumber, Decl(genericCallStringLiteralUnionNested.ts, 13, 64))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 16, 54))
+
+
+// The following are expected to fail because they don't have an extend string or extend number generic constraint.
+
+declare function nestedUnionPlain<A>(a: { fields: A | A[] }): A[];
+>nestedUnionPlain : Symbol(nestedUnionPlain, Decl(genericCallStringLiteralUnionNested.ts, 16, 84))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 21, 34))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 21, 37))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 21, 41))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 21, 34))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 21, 34))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 21, 34))
+
+const expectedFail1: "z"[] = nestedUnionPlain({ fields: "z" });
+>expectedFail1 : Symbol(expectedFail1, Decl(genericCallStringLiteralUnionNested.ts, 22, 5))
+>nestedUnionPlain : Symbol(nestedUnionPlain, Decl(genericCallStringLiteralUnionNested.ts, 16, 84))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 22, 47))
+
+const expectedFail2: 1[] = nestedUnionPlain({ fields: 1 });
+>expectedFail2 : Symbol(expectedFail2, Decl(genericCallStringLiteralUnionNested.ts, 23, 5))
+>nestedUnionPlain : Symbol(nestedUnionPlain, Decl(genericCallStringLiteralUnionNested.ts, 16, 84))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 23, 45))
+
+declare function nestedUnionIntersectionPlainGenerics<A extends B & C, B, C>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+>nestedUnionIntersectionPlainGenerics : Symbol(nestedUnionIntersectionPlainGenerics, Decl(genericCallStringLiteralUnionNested.ts, 23, 59))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 25, 54))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 25, 70))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 25, 73))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 25, 70))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 25, 73))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 25, 77))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 25, 81))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 25, 54))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 25, 54))
+>b : Symbol(b, Decl(genericCallStringLiteralUnionNested.ts, 25, 100))
+>B : Symbol(B, Decl(genericCallStringLiteralUnionNested.ts, 25, 70))
+>c : Symbol(c, Decl(genericCallStringLiteralUnionNested.ts, 25, 108))
+>C : Symbol(C, Decl(genericCallStringLiteralUnionNested.ts, 25, 73))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 25, 54))
+
+const expectedFail3: "z"[] = nestedUnionIntersectionPlainGenerics({ fields: "z" }, ["z", "y"], ["z", "y"]);
+>expectedFail3 : Symbol(expectedFail3, Decl(genericCallStringLiteralUnionNested.ts, 26, 5))
+>nestedUnionIntersectionPlainGenerics : Symbol(nestedUnionIntersectionPlainGenerics, Decl(genericCallStringLiteralUnionNested.ts, 23, 59))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 26, 67))
+
+const expectedFail4: 3[] = nestedUnionIntersectionPlainGenerics({ fields: 3 }, [1, 3], [1, 3]);
+>expectedFail4 : Symbol(expectedFail4, Decl(genericCallStringLiteralUnionNested.ts, 27, 5))
+>nestedUnionIntersectionPlainGenerics : Symbol(nestedUnionIntersectionPlainGenerics, Decl(genericCallStringLiteralUnionNested.ts, 23, 59))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 27, 65))
 

--- a/tests/baselines/reference/genericCallStringLiteralUnionNested.symbols
+++ b/tests/baselines/reference/genericCallStringLiteralUnionNested.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/genericCallStringLiteralUnionNested.ts ===
+declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+>nestedUnion : Symbol(nestedUnion, Decl(genericCallStringLiteralUnionNested.ts, 0, 0))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 29))
+>a : Symbol(a, Decl(genericCallStringLiteralUnionNested.ts, 0, 47))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 0, 51))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 29))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 29))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>A : Symbol(A, Decl(genericCallStringLiteralUnionNested.ts, 0, 29))
+
+const result: {z: string} = nestedUnion({ fields: "z" });
+>result : Symbol(result, Decl(genericCallStringLiteralUnionNested.ts, 1, 5))
+>z : Symbol(z, Decl(genericCallStringLiteralUnionNested.ts, 1, 15))
+>nestedUnion : Symbol(nestedUnion, Decl(genericCallStringLiteralUnionNested.ts, 0, 0))
+>fields : Symbol(fields, Decl(genericCallStringLiteralUnionNested.ts, 1, 41))
+

--- a/tests/baselines/reference/genericCallStringLiteralUnionNested.types
+++ b/tests/baselines/reference/genericCallStringLiteralUnionNested.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/genericCallStringLiteralUnionNested.ts ===
+declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+>nestedUnion : <A extends string>(a: { fields: A | A[]; }) => Record<A, string>
+>A : A
+>a : { fields: A | A[]; }
+>fields : A | A[]
+>A : A
+>A : A
+>Record : Record<K, T>
+>A : A
+
+const result: {z: string} = nestedUnion({ fields: "z" });
+>result : { z: string; }
+>z : string
+>nestedUnion({ fields: "z" }) : Record<"z", string>
+>nestedUnion : <A extends string>(a: { fields: A | A[]; }) => Record<A, string>
+>{ fields: "z" } : { fields: "z"; }
+>fields : string
+>"z" : "z"
+

--- a/tests/baselines/reference/genericCallStringLiteralUnionNested.types
+++ b/tests/baselines/reference/genericCallStringLiteralUnionNested.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/genericCallStringLiteralUnionNested.ts ===
-declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>;
->nestedUnion : <A extends string>(a: { fields: A | A[]; }) => Record<A, string>
+declare function nestedUnionExtendsString<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+>nestedUnionExtendsString : <A extends string>(a: { fields: A | A[]; }) => Record<A, string>
 >A : A
 >a : { fields: A | A[]; }
 >fields : A | A[]
@@ -9,12 +9,198 @@ declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A
 >Record : Record<K, T>
 >A : A
 
-const result: {z: string} = nestedUnion({ fields: "z" });
->result : { z: string; }
+const t1: {z: string} = nestedUnionExtendsString({ fields: "z" });
+>t1 : { z: string; }
 >z : string
->nestedUnion({ fields: "z" }) : Record<"z", string>
->nestedUnion : <A extends string>(a: { fields: A | A[]; }) => Record<A, string>
+>nestedUnionExtendsString({ fields: "z" }) : Record<"z", string>
+>nestedUnionExtendsString : <A extends string>(a: { fields: A | A[]; }) => Record<A, string>
 >{ fields: "z" } : { fields: "z"; }
 >fields : string
 >"z" : "z"
+
+declare function nestedUnionExtendsLiterals<A extends "z" | "y">(a: { fields: A | A[] }): A[];
+>nestedUnionExtendsLiterals : <A extends "z" | "y">(a: { fields: A | A[]; }) => A[]
+>A : A
+>a : { fields: A | A[]; }
+>fields : A | A[]
+>A : A
+>A : A
+>A : A
+
+const t2: "z"[] = nestedUnionExtendsLiterals({ fields: "z" });
+>t2 : "z"[]
+>nestedUnionExtendsLiterals({ fields: "z" }) : "z"[]
+>nestedUnionExtendsLiterals : <A extends "z" | "y">(a: { fields: A | A[]; }) => A[]
+>{ fields: "z" } : { fields: "z"; }
+>fields : string
+>"z" : "z"
+
+declare function nestedGenericIntersection<A extends B & C, B extends string, C extends string>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+>nestedGenericIntersection : <A extends B & C, B extends string, C extends string>(a: { fields: A | A[]; }, b: B[], c: C[]) => A[]
+>A : A
+>B : B
+>C : C
+>B : B
+>C : C
+>a : { fields: A | A[]; }
+>fields : A | A[]
+>A : A
+>A : A
+>b : B[]
+>B : B
+>c : C[]
+>C : C
+>A : A
+
+const t3: "z"[] = nestedGenericIntersection({ fields: "z" }, ["z", "y"], ["z", "y"]);
+>t3 : "z"[]
+>nestedGenericIntersection({ fields: "z" }, ["z", "y"], ["z", "y"]) : "z"[]
+>nestedGenericIntersection : <A extends B & C, B extends string, C extends string>(a: { fields: A | A[]; }, b: B[], c: C[]) => A[]
+>{ fields: "z" } : { fields: "z"; }
+>fields : string
+>"z" : "z"
+>["z", "y"] : ("z" | "y")[]
+>"z" : "z"
+>"y" : "y"
+>["z", "y"] : ("z" | "y")[]
+>"z" : "z"
+>"y" : "y"
+
+declare function nestedUnionExtendsNumber<A extends number>(a: { fields: A | A[] }): A[];
+>nestedUnionExtendsNumber : <A extends number>(a: { fields: A | A[]; }) => A[]
+>A : A
+>a : { fields: A | A[]; }
+>fields : A | A[]
+>A : A
+>A : A
+>A : A
+
+const t4: 1[] = nestedUnionExtendsNumber({ fields: 1 });
+>t4 : 1[]
+>nestedUnionExtendsNumber({ fields: 1 }) : 1[]
+>nestedUnionExtendsNumber : <A extends number>(a: { fields: A | A[]; }) => A[]
+>{ fields: 1 } : { fields: 1; }
+>fields : number
+>1 : 1
+
+declare function nestedUnionExtendsLiteralsNumber<A extends 1 | 2>(a: { fields: A | A[] }): A[];
+>nestedUnionExtendsLiteralsNumber : <A extends 1 | 2>(a: { fields: A | A[]; }) => A[]
+>A : A
+>a : { fields: A | A[]; }
+>fields : A | A[]
+>A : A
+>A : A
+>A : A
+
+const t5: 2[] = nestedUnionExtendsLiteralsNumber({ fields: 2 });
+>t5 : 2[]
+>nestedUnionExtendsLiteralsNumber({ fields: 2 }) : 2[]
+>nestedUnionExtendsLiteralsNumber : <A extends 1 | 2>(a: { fields: A | A[]; }) => A[]
+>{ fields: 2 } : { fields: 2; }
+>fields : number
+>2 : 2
+
+declare function nestedUnionIntersectionGenericNumber<A extends B & C, B extends number, C extends number>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+>nestedUnionIntersectionGenericNumber : <A extends B & C, B extends number, C extends number>(a: { fields: A | A[]; }, b: B[], c: C[]) => A[]
+>A : A
+>B : B
+>C : C
+>B : B
+>C : C
+>a : { fields: A | A[]; }
+>fields : A | A[]
+>A : A
+>A : A
+>b : B[]
+>B : B
+>c : C[]
+>C : C
+>A : A
+
+const t6: 3[] = nestedUnionIntersectionGenericNumber({ fields: 3 }, [1, 3], [1, 3]);
+>t6 : 3[]
+>nestedUnionIntersectionGenericNumber({ fields: 3 }, [1, 3], [1, 3]) : 3[]
+>nestedUnionIntersectionGenericNumber : <A extends B & C, B extends number, C extends number>(a: { fields: A | A[]; }, b: B[], c: C[]) => A[]
+>{ fields: 3 } : { fields: 3; }
+>fields : number
+>3 : 3
+>[1, 3] : (1 | 3)[]
+>1 : 1
+>3 : 3
+>[1, 3] : (1 | 3)[]
+>1 : 1
+>3 : 3
+
+
+// The following are expected to fail because they don't have an extend string or extend number generic constraint.
+
+declare function nestedUnionPlain<A>(a: { fields: A | A[] }): A[];
+>nestedUnionPlain : <A>(a: { fields: A | A[]; }) => A[]
+>A : A
+>a : { fields: A | A[]; }
+>fields : A | A[]
+>A : A
+>A : A
+>A : A
+
+const expectedFail1: "z"[] = nestedUnionPlain({ fields: "z" });
+>expectedFail1 : "z"[]
+>nestedUnionPlain({ fields: "z" }) : string[]
+>nestedUnionPlain : <A>(a: { fields: A | A[]; }) => A[]
+>{ fields: "z" } : { fields: string; }
+>fields : string
+>"z" : "z"
+
+const expectedFail2: 1[] = nestedUnionPlain({ fields: 1 });
+>expectedFail2 : 1[]
+>nestedUnionPlain({ fields: 1 }) : number[]
+>nestedUnionPlain : <A>(a: { fields: A | A[]; }) => A[]
+>{ fields: 1 } : { fields: number; }
+>fields : number
+>1 : 1
+
+declare function nestedUnionIntersectionPlainGenerics<A extends B & C, B, C>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+>nestedUnionIntersectionPlainGenerics : <A extends B & C, B, C>(a: { fields: A | A[]; }, b: B[], c: C[]) => A[]
+>A : A
+>B : B
+>C : C
+>B : B
+>C : C
+>a : { fields: A | A[]; }
+>fields : A | A[]
+>A : A
+>A : A
+>b : B[]
+>B : B
+>c : C[]
+>C : C
+>A : A
+
+const expectedFail3: "z"[] = nestedUnionIntersectionPlainGenerics({ fields: "z" }, ["z", "y"], ["z", "y"]);
+>expectedFail3 : "z"[]
+>nestedUnionIntersectionPlainGenerics({ fields: "z" }, ["z", "y"], ["z", "y"]) : string[]
+>nestedUnionIntersectionPlainGenerics : <A extends B & C, B, C>(a: { fields: A | A[]; }, b: B[], c: C[]) => A[]
+>{ fields: "z" } : { fields: string; }
+>fields : string
+>"z" : "z"
+>["z", "y"] : string[]
+>"z" : "z"
+>"y" : "y"
+>["z", "y"] : string[]
+>"z" : "z"
+>"y" : "y"
+
+const expectedFail4: 3[] = nestedUnionIntersectionPlainGenerics({ fields: 3 }, [1, 3], [1, 3]);
+>expectedFail4 : 3[]
+>nestedUnionIntersectionPlainGenerics({ fields: 3 }, [1, 3], [1, 3]) : number[]
+>nestedUnionIntersectionPlainGenerics : <A extends B & C, B, C>(a: { fields: A | A[]; }, b: B[], c: C[]) => A[]
+>{ fields: 3 } : { fields: number; }
+>fields : number
+>3 : 3
+>[1, 3] : number[]
+>1 : 1
+>3 : 3
+>[1, 3] : number[]
+>1 : 1
+>3 : 3
 

--- a/tests/cases/compiler/genericCallStringLiteralUnionNested.ts
+++ b/tests/cases/compiler/genericCallStringLiteralUnionNested.ts
@@ -1,0 +1,2 @@
+declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+const result: {z: string} = nestedUnion({ fields: "z" });

--- a/tests/cases/compiler/genericCallStringLiteralUnionNested.ts
+++ b/tests/cases/compiler/genericCallStringLiteralUnionNested.ts
@@ -1,2 +1,28 @@
-declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>;
-const result: {z: string} = nestedUnion({ fields: "z" });
+declare function nestedUnionExtendsString<A extends string>(a: { fields: A | A[] }): Record<A, string>;
+const t1: {z: string} = nestedUnionExtendsString({ fields: "z" });
+
+declare function nestedUnionExtendsLiterals<A extends "z" | "y">(a: { fields: A | A[] }): A[];
+const t2: "z"[] = nestedUnionExtendsLiterals({ fields: "z" });
+
+declare function nestedGenericIntersection<A extends B & C, B extends string, C extends string>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+const t3: "z"[] = nestedGenericIntersection({ fields: "z" }, ["z", "y"], ["z", "y"]);
+
+declare function nestedUnionExtendsNumber<A extends number>(a: { fields: A | A[] }): A[];
+const t4: 1[] = nestedUnionExtendsNumber({ fields: 1 });
+
+declare function nestedUnionExtendsLiteralsNumber<A extends 1 | 2>(a: { fields: A | A[] }): A[];
+const t5: 2[] = nestedUnionExtendsLiteralsNumber({ fields: 2 });
+
+declare function nestedUnionIntersectionGenericNumber<A extends B & C, B extends number, C extends number>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+const t6: 3[] = nestedUnionIntersectionGenericNumber({ fields: 3 }, [1, 3], [1, 3]);
+
+
+// The following are expected to fail because they don't have an extend string or extend number generic constraint.
+
+declare function nestedUnionPlain<A>(a: { fields: A | A[] }): A[];
+const expectedFail1: "z"[] = nestedUnionPlain({ fields: "z" });
+const expectedFail2: 1[] = nestedUnionPlain({ fields: 1 });
+
+declare function nestedUnionIntersectionPlainGenerics<A extends B & C, B, C>(a: { fields: A | A[] }, b: B[], c: C[]): A[];
+const expectedFail3: "z"[] = nestedUnionIntersectionPlainGenerics({ fields: "z" }, ["z", "y"], ["z", "y"]);
+const expectedFail4: 3[] = nestedUnionIntersectionPlainGenerics({ fields: 3 }, [1, 3], [1, 3]);


### PR DESCRIPTION
Fixes #19632. The issue was isLiteralContextualType was only checking
for type parameters that extended a literal base type at the top level.
It was already recursively checking the constituents of unions and
intersections but it did so using maybeTypeOfKind which only compared
type flags matching literal or index.

Also adds a test case that failed before this change and succeeds now.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

I realize this wasn't an issue marked as "help wanted" so I understand the PR might not be accepted. I was just curious why the issue I was having was happening and figured it'd be a good way to learn more about how Typescript worked internally, and once I figured out why it was happening it looked easy to fix so I figured I'd try.