### PR TITLE
Handle cases when npm install doesnt get triggered with actual failed lookup location but instead the trigger is some folder in the node_modules

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -320,6 +320,10 @@ namespace ts {
             return endsWith(dirPath, "/node_modules");
         }
 
+        function isNodeModulesAtTypesDirectory(dirPath: Path) {
+            return endsWith(dirPath, "/node_modules/@types");
+        }
+
         function isDirectoryAtleastAtLevelFromFSRoot(dirPath: Path, minLevels: number) {
             for (let searchIndex = getRootLength(dirPath); minLevels > 0; minLevels--) {
                 searchIndex = dirPath.indexOf(directorySeparator, searchIndex) + 1;
@@ -560,11 +564,21 @@ namespace ts {
             else {
                 // Some file or directory in the watching directory is created
                 // Return early if it does not have any of the watching extension or not the custom failed lookup path
-                if (!isPathWithDefaultFailedLookupExtension(fileOrDirectoryPath) && !customFailedLookupPaths.has(fileOrDirectoryPath)) {
-                    return false;
+                const dirOfFileOrDirectory = getDirectoryPath(fileOrDirectoryPath);
+                if (isNodeModulesAtTypesDirectory(dirOfFileOrDirectory) || isNodeModulesDirectory(dirOfFileOrDirectory)) {
+                    // Invalidate any resolution from this directory
+                    isChangedFailedLookupLocation = location => {
+                        const locationPath = resolutionHost.toPath(location);
+                        return locationPath === fileOrDirectoryPath || startsWith(resolutionHost.toPath(location), fileOrDirectoryPath);
+                    };
                 }
-                // Resolution need to be invalidated if failed lookup location is same as the file or directory getting created
-                isChangedFailedLookupLocation = location => resolutionHost.toPath(location) === fileOrDirectoryPath;
+                else {
+                    if (!isPathWithDefaultFailedLookupExtension(fileOrDirectoryPath) && !customFailedLookupPaths.has(fileOrDirectoryPath)) {
+                        return false;
+                    }
+                    // Resolution need to be invalidated if failed lookup location is same as the file or directory getting created
+                    isChangedFailedLookupLocation = location => resolutionHost.toPath(location) === fileOrDirectoryPath;
+                }
             }
             const hasChangedFailedLookupLocation = (resolution: ResolutionWithFailedLookupLocations) => some(resolution.failedLookupLocations, isChangedFailedLookupLocation);
             const invalidatedFilesCount = filesWithInvalidatedResolutions && filesWithInvalidatedResolutions.size;

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -1988,7 +1988,7 @@ declare module "fs" {
 
             checkProgramActualFiles(watch(), mapDefined(files, f => f === configFile ? undefined : f.path));
             file1.content = "var zz30 = 100;";
-            host.reloadFS(files, /*invokeDirectoryWatcherInsteadOfFileChanged*/ true);
+            host.reloadFS(files, { invokeDirectoryWatcherInsteadOfFileChanged: true });
             host.runQueuedTimeoutCallbacks();
 
             checkProgramActualFiles(watch(), mapDefined(files, f => f === configFile ? undefined : f.path));


### PR DESCRIPTION
Fixes #19597