### PR TITLE
Apply 'interface-name' lint rule

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -1106,7 +1106,7 @@ gulp.task("lint", "Runs tslint on the compiler sources. Optional arguments are: 
     const fileMatcher = cmdLineOptions.files;
     const files = fileMatcher
         ? `src/**/${fileMatcher}`
-        : "Gulpfile.ts 'scripts/generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude src/lib/es5.d.ts --exclude 'src/lib/*.generated.d.ts'";
+        : "Gulpfile.ts 'scripts/generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude 'src/lib/*.d.ts'";
     const cmd = `node node_modules/tslint/bin/tslint ${files} --formatters-dir ./built/local/tslint/formatters --format autolinkableStylish`;
     console.log("Linting: " + cmd);
     child_process.execSync(cmd, { stdio: [0, 1, 2] });

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -1283,7 +1283,7 @@ task("lint", ["build-rules"], () => {
     const fileMatcher = process.env.f || process.env.file || process.env.files;
     const files = fileMatcher
         ? `src/**/${fileMatcher}`
-        : "Gulpfile.ts 'scripts/generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude src/lib/es5.d.ts --exclude 'src/lib/*.generated.d.ts'";
+        : "Gulpfile.ts 'scripts/generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude 'src/lib/*.d.ts'";
     const cmd = `node node_modules/tslint/bin/tslint ${files} --formatters-dir ./built/local/tslint/formatters --format autolinkableStylish`;
     console.log("Linting: " + cmd);
     jake.exec([cmd], { interactive: true }, () => {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -479,7 +479,7 @@ namespace Utils {
 }
 
 namespace Harness {
-    export interface IO {
+    export interface Io {
         newLine(): string;
         getCurrentDirectory(): string;
         useCaseSensitiveFileNames(): boolean;
@@ -502,7 +502,7 @@ namespace Harness {
         tryEnableSourceMapsForHost?(): void;
         getEnvironmentVariable?(name: string): string;
     }
-    export let IO: IO;
+    export let IO: Io;
 
     // harness always uses one kind of new line
     // But note that `parseTestData` in `fourslash.ts` uses "\n"
@@ -2145,7 +2145,7 @@ namespace Harness {
         return filePath.indexOf(Harness.libFolder) === 0;
     }
 
-    export function getDefaultLibraryFile(io: Harness.IO): Harness.Compiler.TestFile {
+    export function getDefaultLibraryFile(io: Harness.Io): Harness.Compiler.TestFile {
         const libFile = Harness.userSpecifiedRoot + Harness.libFolder + Harness.Compiler.defaultLibFileName;
         return { unitName: libFile, content: io.readFile(libFile) };
     }

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -544,9 +544,9 @@ namespace Harness.LanguageService {
         getClassifier(): ts.Classifier { return new ClassifierShimProxy(this.factory.createClassifierShim(this.host)); }
         getPreProcessedFileInfo(fileName: string, fileContents: string): ts.PreProcessedFileInfo {
             let shimResult: {
-                referencedFiles: ts.IFileReference[];
-                typeReferenceDirectives: ts.IFileReference[];
-                importedFiles: ts.IFileReference[];
+                referencedFiles: ts.ShimsFileReference[];
+                typeReferenceDirectives: ts.ShimsFileReference[];
+                importedFiles: ts.ShimsFileReference[];
                 isLibFile: boolean;
             };
 

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -14,19 +14,19 @@ interface FileInformation {
 interface FindFileResult {
 }
 
-interface IOLogFile {
+interface IoLogFile {
     path: string;
     codepage: number;
     result?: FileInformation;
 }
 
-interface IOLog {
+interface IoLog {
     timestamp: string;
     arguments: string[];
     executingPath: string;
     currentDirectory: string;
     useCustomLibraryFile?: boolean;
-    filesRead: IOLogFile[];
+    filesRead: IoLogFile[];
     filesWritten: {
         path: string;
         contents?: string;
@@ -80,16 +80,16 @@ interface IOLog {
 interface PlaybackControl {
     startReplayFromFile(logFileName: string): void;
     startReplayFromString(logContents: string): void;
-    startReplayFromData(log: IOLog): void;
+    startReplayFromData(log: IoLog): void;
     endReplay(): void;
     startRecord(logFileName: string): void;
     endRecord(): void;
 }
 
 namespace Playback {
-    let recordLog: IOLog = undefined;
-    let replayLog: IOLog = undefined;
-    let replayFilesRead: ts.Map<IOLogFile> | undefined = undefined;
+    let recordLog: IoLog = undefined;
+    let replayLog: IoLog = undefined;
+    let replayFilesRead: ts.Map<IoLogFile> | undefined = undefined;
     let recordLogFileNameBase = "";
 
     interface Memoized<T> {
@@ -110,11 +110,11 @@ namespace Playback {
         return run;
     }
 
-    export interface PlaybackIO extends Harness.IO, PlaybackControl { }
+    export interface PlaybackIO extends Harness.Io, PlaybackControl { }
 
     export interface PlaybackSystem extends ts.System, PlaybackControl { }
 
-    function createEmptyLog(): IOLog {
+    function createEmptyLog(): IoLog {
         return {
             timestamp: (new Date()).toString(),
             arguments: [],
@@ -134,7 +134,7 @@ namespace Playback {
         };
     }
 
-    export function newStyleLogIntoOldStyleLog(log: IOLog, host: ts.System | Harness.IO, baseName: string) {
+    export function newStyleLogIntoOldStyleLog(log: IoLog, host: ts.System | Harness.Io, baseName: string) {
         for (const file of log.filesAppended) {
             if (file.contentsPath) {
                 file.contents = host.readFile(ts.combinePaths(baseName, file.contentsPath));
@@ -167,7 +167,7 @@ namespace Playback {
         return path;
     }
 
-    export function oldStyleLogIntoNewStyleLog(log: IOLog, writeFile: typeof Harness.IO.writeFile, baseTestName: string) {
+    export function oldStyleLogIntoNewStyleLog(log: IoLog, writeFile: typeof Harness.IO.writeFile, baseTestName: string) {
         if (log.filesAppended) {
             for (const file of log.filesAppended) {
                 if (file.contents !== undefined) {
@@ -210,8 +210,8 @@ namespace Playback {
     }
 
     function initWrapper(wrapper: PlaybackSystem, underlying: ts.System): void;
-    function initWrapper(wrapper: PlaybackIO, underlying: Harness.IO): void;
-    function initWrapper(wrapper: PlaybackSystem | PlaybackIO, underlying: ts.System | Harness.IO): void {
+    function initWrapper(wrapper: PlaybackIO, underlying: Harness.Io): void;
+    function initWrapper(wrapper: PlaybackSystem | PlaybackIO, underlying: ts.System | Harness.Io): void {
         ts.forEach(Object.keys(underlying), prop => {
             (<any>wrapper)[prop] = (<any>underlying)[prop];
         });
@@ -261,7 +261,7 @@ namespace Playback {
             }
         };
 
-        function generateTsconfig(newLog: IOLog): undefined | { compilerOptions: ts.CompilerOptions, files: string[] } {
+        function generateTsconfig(newLog: IoLog): undefined | { compilerOptions: ts.CompilerOptions, files: string[] } {
             if (newLog.filesRead.some(file => /tsconfig.+json$/.test(file.path))) {
                 return;
             }
@@ -426,7 +426,7 @@ namespace Playback {
         // console.log("Swallowed write operation during replay: " + name);
     }
 
-    export function wrapIO(underlying: Harness.IO): PlaybackIO {
+    export function wrapIO(underlying: Harness.Io): PlaybackIO {
         const wrapper: PlaybackIO = <any>{};
         initWrapper(wrapper, underlying);
 

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -6,7 +6,7 @@
 /* tslint:disable:no-null-keyword */
 
 namespace RWC {
-    function runWithIOLog(ioLog: IOLog, fn: (oldIO: Harness.IO) => void) {
+    function runWithIOLog(ioLog: IoLog, fn: (oldIO: Harness.Io) => void) {
         const oldIO = Harness.IO;
 
         const wrappedIO = Playback.wrapIO(oldIO);
@@ -58,7 +58,7 @@ namespace RWC {
                 this.timeout(800000); // Allow long timeouts for RWC compilations
                 let opts: ts.ParsedCommandLine;
 
-                const ioLog: IOLog = Playback.newStyleLogIntoOldStyleLog(JSON.parse(Harness.IO.readFile(`internal/cases/rwc/${jsonPath}/test.json`)), Harness.IO, `internal/cases/rwc/${baseName}`);
+                const ioLog: IoLog = Playback.newStyleLogIntoOldStyleLog(JSON.parse(Harness.IO.readFile(`internal/cases/rwc/${jsonPath}/test.json`)), Harness.IO, `internal/cases/rwc/${baseName}`);
                 currentDirectory = ioLog.currentDirectory;
                 useCustomLibraryFile = ioLog.useCustomLibraryFile;
                 runWithIOLog(ioLog, () => {

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -10,7 +10,7 @@ namespace ts.server {
         charCount(): number;
         lineCount(): number;
         isLeaf(): this is LineLeaf;
-        walk(rangeStart: number, rangeLength: number, walkFns: ILineIndexWalker): void;
+        walk(rangeStart: number, rangeLength: number, walkFns: LineIndexWalker): void;
     }
 
     export interface AbsolutePositionAndLineText {
@@ -27,7 +27,7 @@ namespace ts.server {
         PostEnd
     }
 
-    interface ILineIndexWalker {
+    interface LineIndexWalker {
         goSubtree: boolean;
         done: boolean;
         leaf(relativeStart: number, relativeLength: number, lineCollection: LineLeaf): void;
@@ -37,7 +37,7 @@ namespace ts.server {
             parent: LineNode, nodeType: CharRangeSection): void;
     }
 
-    class EditWalker implements ILineIndexWalker {
+    class EditWalker implements LineIndexWalker {
         goSubtree = true;
         get done() { return false; }
 
@@ -429,7 +429,7 @@ namespace ts.server {
             }
         }
 
-        walk(rangeStart: number, rangeLength: number, walkFns: ILineIndexWalker) {
+        walk(rangeStart: number, rangeLength: number, walkFns: LineIndexWalker) {
             this.root.walk(rangeStart, rangeLength, walkFns);
         }
 
@@ -458,7 +458,7 @@ namespace ts.server {
             const walkFns = {
                 goSubtree: true,
                 done: false,
-                leaf(this: ILineIndexWalker, relativeStart: number, relativeLength: number, ll: LineLeaf) {
+                leaf(this: LineIndexWalker, relativeStart: number, relativeLength: number, ll: LineLeaf) {
                     if (!f(ll, relativeStart, relativeLength)) {
                         this.done = true;
                     }
@@ -580,7 +580,7 @@ namespace ts.server {
             }
         }
 
-        private execWalk(rangeStart: number, rangeLength: number, walkFns: ILineIndexWalker, childIndex: number, nodeType: CharRangeSection) {
+        private execWalk(rangeStart: number, rangeLength: number, walkFns: LineIndexWalker, childIndex: number, nodeType: CharRangeSection) {
             if (walkFns.pre) {
                 walkFns.pre(rangeStart, rangeLength, this.children[childIndex], this, nodeType);
             }
@@ -596,14 +596,14 @@ namespace ts.server {
             return walkFns.done;
         }
 
-        private skipChild(relativeStart: number, relativeLength: number, childIndex: number, walkFns: ILineIndexWalker, nodeType: CharRangeSection) {
+        private skipChild(relativeStart: number, relativeLength: number, childIndex: number, walkFns: LineIndexWalker, nodeType: CharRangeSection) {
             if (walkFns.pre && (!walkFns.done)) {
                 walkFns.pre(relativeStart, relativeLength, this.children[childIndex], this, nodeType);
                 walkFns.goSubtree = true;
             }
         }
 
-        walk(rangeStart: number, rangeLength: number, walkFns: ILineIndexWalker) {
+        walk(rangeStart: number, rangeLength: number, walkFns: LineIndexWalker) {
             // assume (rangeStart < this.totalChars) && (rangeLength <= this.totalChars)
             let childIndex = 0;
             let childCharCount = this.children[childIndex].charCount();
@@ -814,7 +814,7 @@ namespace ts.server {
             return true;
         }
 
-        walk(rangeStart: number, rangeLength: number, walkFns: ILineIndexWalker) {
+        walk(rangeStart: number, rangeLength: number, walkFns: LineIndexWalker) {
             walkFns.leaf(rangeStart, rangeLength, this);
         }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3,7 +3,7 @@
 /// <reference path="session.ts" />
 
 namespace ts.server {
-    interface IOSessionOptions {
+    interface IoSessionOptions {
         host: ServerHost;
         cancellationToken: ServerCancellationToken;
         canUseEvents: boolean;
@@ -529,7 +529,7 @@ namespace ts.server {
     }
 
     class IOSession extends Session {
-        constructor(options: IOSessionOptions) {
+        constructor(options: IoSessionOptions) {
             const { host, installerEventPort, globalTypingsCacheLocation, typingSafeListLocation, typesMapLocation, npmLocation, canUseEvents } = options;
             const typingsInstaller = disableAutomaticTypingAcquisition
                 ? undefined
@@ -933,7 +933,7 @@ namespace ts.server {
     const disableAutomaticTypingAcquisition = hasArgument("--disableAutomaticTypingAcquisition");
     const telemetryEnabled = hasArgument(Arguments.EnableTelemetry);
 
-    const options: IOSessionOptions = {
+    const options: IoSessionOptions = {
         host: sys,
         cancellationToken,
         installerEventPort: eventPort,

--- a/src/server/typingsCache.ts
+++ b/src/server/typingsCache.ts
@@ -5,6 +5,7 @@ namespace ts.server {
         projectRootPath: Path;
     }
 
+    // tslint:disable-next-line interface-name (for backwards-compatibility)
     export interface ITypingsInstaller {
         isKnownTypesPackageName(name: string): boolean;
         installPackage(options: InstallPackageOptionsWithProjectRootPath): Promise<ApplyCodeActionCommandResult>;

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -106,7 +106,7 @@ namespace ts {
     ///
     // Note: This is being using by the host (VS) and is marshaled back and forth.
     // When changing this make sure the changes are reflected in the managed side as well
-    export interface IFileReference {
+    export interface ShimsFileReference {
         path: string;
         position: number;
         length: number;
@@ -1104,11 +1104,11 @@ namespace ts {
             );
         }
 
-        private convertFileReferences(refs: FileReference[]): IFileReference[] {
+        private convertFileReferences(refs: FileReference[]): ShimsFileReference[] {
             if (!refs) {
                 return undefined;
             }
-            const result: IFileReference[] = [];
+            const result: ShimsFileReference[] = [];
             for (const ref of refs) {
                 result.push({
                     path: normalizeSlashes(ref.fileName),

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -86,6 +86,7 @@ namespace ts {
      * snapshot is observably immutable. i.e. the same calls with the same parameters will return
      * the same values.
      */
+    // tslint:disable-next-line interface-name
     export interface IScriptSnapshot {
         /** Gets a portion of the script snapshot specified by [start, end). */
         getText(start: number, end: number): string;

--- a/tslint.json
+++ b/tslint.json
@@ -13,6 +13,7 @@
         "indent": [true,
             "spaces"
         ],
+        "interface-name": [true, "never-prefix"],
         "interface-over-type-literal": true,
         "jsdoc-format": true,
         "linebreak-style": [true, "CRLF"],
@@ -112,7 +113,6 @@
         "no-consecutive-blank-lines": false,
 
         // Not doing
-        "interface-name": false,
         "max-classes-per-file": false,
         "member-ordering": false,
         "no-angle-bracket-type-assertion": false,


### PR DESCRIPTION
Our [coding guidelines](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines) say to never use an `I` prefix, but we don't seem to have been following that advice everywhere...