### PR TITLE
Silence NPM warnings when installing typings

### DIFF
--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -248,7 +248,7 @@ namespace ts.server.typingsInstaller {
                     this.log.writeLine(`Npm config file: '${npmConfigPath}' is missing, creating new one...`);
                 }
                 this.ensureDirectoryExists(directory, this.installTypingHost);
-                this.installTypingHost.writeFile(npmConfigPath, '{ "description": "", "repository": "", "license": "" }');
+                this.installTypingHost.writeFile(npmConfigPath, '{ "private": true }');
             }
         }
 


### PR DESCRIPTION
Even with PR https://github.com/Microsoft/TypeScript/pull/19663, NPM still outputs warnings about mandatory fields in `package.json` when installing typings because these fields must be set to something else than an empty string.

Fixes https://github.com/Microsoft/TypeScript/issues/19660.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/typescript/19749)
<!-- Reviewable:end -->
