### PR TITLE
attach parent in setOriginalNode

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2827,6 +2827,15 @@ namespace ts {
         if (original) {
             const emitNode = original.emitNode;
             if (emitNode) node.emitNode = mergeEmitNode(emitNode, node.emitNode);
+
+            if (!node.parent) {
+                while(!original.parent && original.original) {
+                    original = original.original;
+                }
+                if (original.parent) {
+                    node.parent = original.parent;
+                };
+            }
         }
         return node;
     }


### PR DESCRIPTION
When calling `setOriginalNode` attach the original node's parent to the node, if the node does not have a parent.

This should solve all `TypeError: Cannot read property 'kind' of undefined` errors when working with transformers and decorators.

See #17384
Also see angular/angular#20216

Query:
The implementation does not invalidate `node.parent` when `original` is undefined.
I'm not sure if this is a valid use case but based on the existing logic, `node.original` is invalidated even if `original` is undefined...

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
