### PR TITLE
Enable 'no-invalid-template-strings' lint rule

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -363,8 +363,10 @@ namespace ts {
             case SyntaxKind.NoSubstitutionTemplateLiteral:
                 return "`" + escapeText(node.text, CharacterCodes.backtick) + "`";
             case SyntaxKind.TemplateHead:
+                // tslint:disable-next-line no-invalid-template-strings
                 return "`" + escapeText(node.text, CharacterCodes.backtick) + "${";
             case SyntaxKind.TemplateMiddle:
+                // tslint:disable-next-line no-invalid-template-strings
                 return "}" + escapeText(node.text, CharacterCodes.backtick) + "${";
             case SyntaxKind.TemplateTail:
                 return "}" + escapeText(node.text, CharacterCodes.backtick) + "`";

--- a/src/harness/unittests/printer.ts
+++ b/src/harness/unittests/printer.ts
@@ -55,6 +55,7 @@ namespace ts {
             printsCorrectly("removeComments", { removeComments: true }, printer => printer.printFile(sourceFile));
 
             // github #14948
+            // tslint:disable-next-line no-invalid-template-strings
             printsCorrectly("templateLiteral", {}, printer => printer.printFile(createSourceFile("source.ts", "let greeting = `Hi ${name}, how are you?`;", ScriptTarget.ES2017)));
 
             // github #18071

--- a/src/harness/unittests/services/colorization.ts
+++ b/src/harness/unittests/services/colorization.ts
@@ -1,5 +1,7 @@
 /// <reference path="..\..\harnessLanguageService.ts" />
 
+// tslint:disable no-invalid-template-strings (lots of tests use quoted code)
+
 interface ClassificationEntry {
     value: any;
     classification: ts.TokenClass;

--- a/tslint.json
+++ b/tslint.json
@@ -89,7 +89,6 @@
         "no-empty": false,
         "no-empty-interface": false,
         "no-eval": false,
-        "no-invalid-template-strings": false,
         "no-object-literal-type-assertion": false,
         "no-shadowed-variable": false,
         "no-submodule-imports": false,


### PR DESCRIPTION
Didn't actually find any mistakes, but I've made a few in the past...