### PR TITLE
Import fix add import require support

### DIFF
--- a/tests/cases/fourslash/importNameCodeFixNewImportAllowSyntheticDefaultImports2.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportAllowSyntheticDefaultImports2.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 // @AllowSyntheticDefaultImports: false
+// @Module: system
 
 // @Filename: a/f1.ts
 //// [|export var x = 0;

--- a/tests/cases/fourslash/importNameCodeFixNewImportAllowSyntheticDefaultImports3.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportAllowSyntheticDefaultImports3.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+// @AllowSyntheticDefaultImports: false
+// @Module: commonjs
+
+// @Filename: a/f1.ts
+//// [|export var x = 0;
+//// bar/*0*/();|]
+
+// @Filename: a/foo.d.ts
+//// declare function bar(): number;
+//// export = bar;
+//// export as namespace bar;
+
+verify.importFixAtPosition([
+`import bar = require("./foo");
+
+export var x = 0;
+bar();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportAllowSyntheticDefaultImports4.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportAllowSyntheticDefaultImports4.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+// @AllowSyntheticDefaultImports: false
+// @Module: amd
+
+// @Filename: a/f1.ts
+//// [|export var x = 0;
+//// bar/*0*/();|]
+
+// @Filename: a/foo.d.ts
+//// declare function bar(): number;
+//// export = bar;
+//// export as namespace bar;
+
+verify.importFixAtPosition([
+`import bar = require("./foo");
+
+export var x = 0;
+bar();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportAllowSyntheticDefaultImports5.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportAllowSyntheticDefaultImports5.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+// @AllowSyntheticDefaultImports: false
+// @Module: umd
+
+// @Filename: a/f1.ts
+//// [|export var x = 0;
+//// bar/*0*/();|]
+
+// @Filename: a/foo.d.ts
+//// declare function bar(): number;
+//// export = bar;
+//// export as namespace bar;
+
+verify.importFixAtPosition([
+`import bar = require("./foo");
+
+export var x = 0;
+bar();`
+]);

--- a/tests/cases/fourslash/importNameCodeFixUMDGlobal0.ts
+++ b/tests/cases/fourslash/importNameCodeFixUMDGlobal0.ts
@@ -1,5 +1,8 @@
 /// <reference path="fourslash.ts" />
 
+// @AllowSyntheticDefaultImports: false
+// @Module: es2015
+
 // @Filename: a/f1.ts
 //// [|export function test() { };
 //// bar1/*0*/.bar;|]

--- a/tests/cases/fourslash/importNameCodeFixUMDGlobal1.ts
+++ b/tests/cases/fourslash/importNameCodeFixUMDGlobal1.ts
@@ -1,5 +1,8 @@
 /// <reference path="fourslash.ts" />
 
+// @AllowSyntheticDefaultImports: false
+// @Module: esnext
+
 // @Filename: a/f1.ts
 //// [|import { bar } from "./foo";
 ////

--- a/tests/cases/fourslash/importNameCodeFixUMDGlobalReact0.ts
+++ b/tests/cases/fourslash/importNameCodeFixUMDGlobalReact0.ts
@@ -1,6 +1,8 @@
 /// <reference path="fourslash.ts" />
 
 // @jsx: react
+// @allowSyntheticDefaultImports: false
+// @module: es2015
 
 // @Filename: /node_modules/@types/react/index.d.ts
 ////export = React;

--- a/tests/cases/fourslash/importNameCodeFixUMDGlobalReact1.ts
+++ b/tests/cases/fourslash/importNameCodeFixUMDGlobalReact1.ts
@@ -1,6 +1,8 @@
 /// <reference path="fourslash.ts" />
 
 // @jsx: react
+// @allowSyntheticDefaultImports: false
+// @module: es2015
 
 // @Filename: /node_modules/@types/react/index.d.ts
 ////export = React;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

In this follow-up to #19572 code fixes that import a UMD module now prefer the import..require syntax when `--module` is `commonjs`, `amd`, or `umd` and synthetic defaults are not available.