### PR TITLE
Fix RWC's handling of "lib" from tsconfig

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -2146,8 +2146,8 @@ namespace Harness {
         return filePath.indexOf(Harness.libFolder) === 0;
     }
 
-    export function getDefaultLibraryFile(libPath: string, io: Harness.Io): Harness.Compiler.TestFile {
-        const libFile = Harness.userSpecifiedRoot + Harness.libFolder + libPath.slice(io.directoryName(libPath).length + 1);
+    export function getDefaultLibraryFile(filePath: string, io: Harness.Io): Harness.Compiler.TestFile {
+        const libFile = Harness.userSpecifiedRoot + Harness.libFolder + ts.getBaseFileName(ts.normalizeSlashes(filePath));
         return { unitName: libFile, content: io.readFile(libFile) };
     }
 

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -2146,8 +2146,8 @@ namespace Harness {
         return filePath.indexOf(Harness.libFolder) === 0;
     }
 
-    export function getDefaultLibraryFile(io: Harness.Io): Harness.Compiler.TestFile {
-        const libFile = Harness.userSpecifiedRoot + Harness.libFolder + Harness.Compiler.defaultLibFileName;
+    export function getDefaultLibraryFile(libPath: string, io: Harness.Io): Harness.Compiler.TestFile {
+        const libFile = Harness.userSpecifiedRoot + Harness.libFolder + libPath.slice(io.directoryName(libPath).length + 1);
         return { unitName: libFile, content: io.readFile(libFile) };
     }
 

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -138,6 +138,7 @@ namespace RWC {
                     }
 
                     // do not use lib since we already read it in above
+                    opts.options.lib = undefined;
                     opts.options.noLib = true;
 
                     // Emit the results

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -131,7 +131,7 @@ namespace RWC {
                                 }
                                 else {
                                     // set the flag to put default library to the beginning of the list
-                                    inputFiles.unshift(Harness.getDefaultLibraryFile(oldIO));
+                                    inputFiles.unshift(Harness.getDefaultLibraryFile(fileRead.path, oldIO));
                                 }
                             }
                         }


### PR DESCRIPTION
Previously, it would add "built/local/lib.d.ts" multiple times for each lib.*.ts entry in `"lib"` in the tsconfig of a RWC project. Now it correctly adds the entries from `"lib"`, then disables lib so that it doesn't conflict with noLib.

This improves a *lot* of baselines. I'll update them in an internal PR.