### PR TITLE
Remove trailing whitespace from unit tests

### DIFF
--- a/src/harness/unittests/textChanges.ts
+++ b/src/harness/unittests/textChanges.ts
@@ -122,9 +122,9 @@ namespace ts {
 
         {
             const text = `
-namespace M 
+namespace M
 {
-    namespace M2 
+    namespace M2
     {
         function foo() {
             // comment 1
@@ -572,7 +572,7 @@ const x = 1;`;
         }
         {
             const text = `
-const x = 1, 
+const x = 1,
     y = 2;`;
             runSingleFileTest("insertNodeInListAfter6", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), createVariableDeclaration("z", /*type*/ undefined, createLiteral(1)));
@@ -583,7 +583,7 @@ const x = 1,
         }
         {
             const text = `
-const /*x*/ x = 1, 
+const /*x*/ x = 1,
     /*y*/ y = 2;`;
             runSingleFileTest("insertNodeInListAfter8", /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
                 changeTracker.insertNodeInListAfter(sourceFile, findChild("x", sourceFile), createVariableDeclaration("z", /*type*/ undefined, createLiteral(1)));

--- a/tests/baselines/reference/textChanges/extractMethodLike.js
+++ b/tests/baselines/reference/textChanges/extractMethodLike.js
@@ -1,8 +1,8 @@
 ===ORIGINAL===
 
-namespace M 
+namespace M
 {
-    namespace M2 
+    namespace M2
     {
         function foo() {
             // comment 1
@@ -22,7 +22,7 @@ namespace M
 }
 ===MODIFIED===
 
-namespace M 
+namespace M
 {
     function bar(): any
     {
@@ -37,7 +37,7 @@ namespace M
         const y = 2; // comment 3
         return 1;
     }
-    namespace M2 
+    namespace M2
     {
         function foo() {
             // comment 1

--- a/tests/baselines/reference/textChanges/insertNodeInListAfter6.js
+++ b/tests/baselines/reference/textChanges/insertNodeInListAfter6.js
@@ -1,9 +1,9 @@
 ===ORIGINAL===
 
-const x = 1, 
+const x = 1,
     y = 2;
 ===MODIFIED===
 
-const x = 1, 
-    z = 1, 
+const x = 1,
+    z = 1,
     y = 2;

--- a/tests/baselines/reference/textChanges/insertNodeInListAfter7.js
+++ b/tests/baselines/reference/textChanges/insertNodeInListAfter7.js
@@ -1,9 +1,9 @@
 ===ORIGINAL===
 
-const x = 1, 
+const x = 1,
     y = 2;
 ===MODIFIED===
 
-const x = 1, 
+const x = 1,
     y = 2,
     z = 1;

--- a/tests/baselines/reference/textChanges/insertNodeInListAfter8.js
+++ b/tests/baselines/reference/textChanges/insertNodeInListAfter8.js
@@ -1,9 +1,9 @@
 ===ORIGINAL===
 
-const /*x*/ x = 1, 
+const /*x*/ x = 1,
     /*y*/ y = 2;
 ===MODIFIED===
 
-const /*x*/ x = 1, 
-    z = 1, 
+const /*x*/ x = 1,
+    z = 1,
     /*y*/ y = 2;

--- a/tests/baselines/reference/textChanges/insertNodeInListAfter9.js
+++ b/tests/baselines/reference/textChanges/insertNodeInListAfter9.js
@@ -1,9 +1,9 @@
 ===ORIGINAL===
 
-const /*x*/ x = 1, 
+const /*x*/ x = 1,
     /*y*/ y = 2;
 ===MODIFIED===
 
-const /*x*/ x = 1, 
+const /*x*/ x = 1,
     /*y*/ y = 2,
     z = 1;


### PR DESCRIPTION
Don't think these spaces are essential to the tests. I end up removing them every time I save while in this file.