### PR TITLE
Narrow property access of undeclared properties from string index signatures

### DIFF
--- a/tests/baselines/reference/controlFlowStringIndex.js
+++ b/tests/baselines/reference/controlFlowStringIndex.js
@@ -1,8 +1,13 @@
 //// [controlFlowStringIndex.ts]
-type A = { [index: string]: number | null };
+type A = {
+    other: number | null;
+    [index: string]: number | null
+};
 declare const value: A;
 if (value.foo !== null) {
     value.foo.toExponential()
+    value.other // should still be number | null
+    value.bar // should still be number | null
 }
 
 
@@ -10,4 +15,6 @@ if (value.foo !== null) {
 "use strict";
 if (value.foo !== null) {
     value.foo.toExponential();
+    value.other; // should still be number | null
+    value.bar; // should still be number | null
 }

--- a/tests/baselines/reference/controlFlowStringIndex.js
+++ b/tests/baselines/reference/controlFlowStringIndex.js
@@ -1,0 +1,13 @@
+//// [controlFlowStringIndex.ts]
+type A = { [index: string]: number | null };
+declare const value: A;
+if (value.foo !== null) {
+    value.foo.toExponential()
+}
+
+
+//// [controlFlowStringIndex.js]
+"use strict";
+if (value.foo !== null) {
+    value.foo.toExponential();
+}

--- a/tests/baselines/reference/controlFlowStringIndex.symbols
+++ b/tests/baselines/reference/controlFlowStringIndex.symbols
@@ -1,18 +1,32 @@
 === tests/cases/conformance/controlFlow/controlFlowStringIndex.ts ===
-type A = { [index: string]: number | null };
+type A = {
 >A : Symbol(A, Decl(controlFlowStringIndex.ts, 0, 0))
->index : Symbol(index, Decl(controlFlowStringIndex.ts, 0, 12))
 
+    other: number | null;
+>other : Symbol(other, Decl(controlFlowStringIndex.ts, 0, 10))
+
+    [index: string]: number | null
+>index : Symbol(index, Decl(controlFlowStringIndex.ts, 2, 5))
+
+};
 declare const value: A;
->value : Symbol(value, Decl(controlFlowStringIndex.ts, 1, 13))
+>value : Symbol(value, Decl(controlFlowStringIndex.ts, 4, 13))
 >A : Symbol(A, Decl(controlFlowStringIndex.ts, 0, 0))
 
 if (value.foo !== null) {
->value : Symbol(value, Decl(controlFlowStringIndex.ts, 1, 13))
+>value : Symbol(value, Decl(controlFlowStringIndex.ts, 4, 13))
 
     value.foo.toExponential()
 >value.foo.toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
->value : Symbol(value, Decl(controlFlowStringIndex.ts, 1, 13))
+>value : Symbol(value, Decl(controlFlowStringIndex.ts, 4, 13))
 >toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+
+    value.other // should still be number | null
+>value.other : Symbol(other, Decl(controlFlowStringIndex.ts, 0, 10))
+>value : Symbol(value, Decl(controlFlowStringIndex.ts, 4, 13))
+>other : Symbol(other, Decl(controlFlowStringIndex.ts, 0, 10))
+
+    value.bar // should still be number | null
+>value : Symbol(value, Decl(controlFlowStringIndex.ts, 4, 13))
 }
 

--- a/tests/baselines/reference/controlFlowStringIndex.symbols
+++ b/tests/baselines/reference/controlFlowStringIndex.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/controlFlow/controlFlowStringIndex.ts ===
+type A = { [index: string]: number | null };
+>A : Symbol(A, Decl(controlFlowStringIndex.ts, 0, 0))
+>index : Symbol(index, Decl(controlFlowStringIndex.ts, 0, 12))
+
+declare const value: A;
+>value : Symbol(value, Decl(controlFlowStringIndex.ts, 1, 13))
+>A : Symbol(A, Decl(controlFlowStringIndex.ts, 0, 0))
+
+if (value.foo !== null) {
+>value : Symbol(value, Decl(controlFlowStringIndex.ts, 1, 13))
+
+    value.foo.toExponential()
+>value.foo.toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+>value : Symbol(value, Decl(controlFlowStringIndex.ts, 1, 13))
+>toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/controlFlowStringIndex.types
+++ b/tests/baselines/reference/controlFlowStringIndex.types
@@ -1,9 +1,16 @@
 === tests/cases/conformance/controlFlow/controlFlowStringIndex.ts ===
-type A = { [index: string]: number | null };
+type A = {
 >A : A
+
+    other: number | null;
+>other : number | null
+>null : null
+
+    [index: string]: number | null
 >index : string
 >null : null
 
+};
 declare const value: A;
 >value : A
 >A : A
@@ -22,5 +29,15 @@ if (value.foo !== null) {
 >value : A
 >foo : number
 >toExponential : (fractionDigits?: number | undefined) => string
+
+    value.other // should still be number | null
+>value.other : number | null
+>value : A
+>other : number | null
+
+    value.bar // should still be number | null
+>value.bar : number | null
+>value : A
+>bar : number | null
 }
 

--- a/tests/baselines/reference/controlFlowStringIndex.types
+++ b/tests/baselines/reference/controlFlowStringIndex.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/controlFlow/controlFlowStringIndex.ts ===
+type A = { [index: string]: number | null };
+>A : A
+>index : string
+>null : null
+
+declare const value: A;
+>value : A
+>A : A
+
+if (value.foo !== null) {
+>value.foo !== null : boolean
+>value.foo : number | null
+>value : A
+>foo : number | null
+>null : null
+
+    value.foo.toExponential()
+>value.foo.toExponential() : string
+>value.foo.toExponential : (fractionDigits?: number | undefined) => string
+>value.foo : number
+>value : A
+>foo : number
+>toExponential : (fractionDigits?: number | undefined) => string
+}
+

--- a/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
@@ -1,6 +1,11 @@
 // @strict: true
-type A = { [index: string]: number | null };
+type A = {
+    other: number | null;
+    [index: string]: number | null
+};
 declare const value: A;
 if (value.foo !== null) {
     value.foo.toExponential()
+    value.other // should still be number | null
+    value.bar // should still be number | null
 }

--- a/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
@@ -1,0 +1,6 @@
+// @strict: true
+type A = { [index: string]: number | null };
+declare const value: A;
+if (value.foo !== null) {
+    value.foo.toExponential()
+}


### PR DESCRIPTION
Previously these accesses did not use control flow to narrow property accesses of undefined properties that are resolved from a string index signature. Now the use control flow to narrow these just like normal properties.

Fixes #17567