### PR TITLE
Fix declaration emit for imported export alias specifiers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2161,7 +2161,6 @@ namespace ts {
                 return forEachEntry(symbols, symbolFromSymbolTable => {
                     if (symbolFromSymbolTable.flags & SymbolFlags.Alias
                         && symbolFromSymbolTable.escapedName !== "export="
-                        && !getDeclarationOfKind(symbolFromSymbolTable, SyntaxKind.ExportSpecifier)
                         && !(isUMDExportSymbol(symbolFromSymbolTable) && enclosingDeclaration && isExternalModule(getSourceFileOfNode(enclosingDeclaration)))
                         // If `!useOnlyExternalAliasing`, we can use any type of alias to get the name
                         && (!useOnlyExternalAliasing || some(symbolFromSymbolTable.declarations, isExternalModuleImportEqualsDeclaration))) {

--- a/tests/baselines/reference/declarationEmitOfTypeofAliasedExport.js
+++ b/tests/baselines/reference/declarationEmitOfTypeofAliasedExport.js
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/declarationEmitOfTypeofAliasedExport.ts] ////
+
+//// [a.ts]
+class C {}
+export { C as D }
+
+//// [b.ts]
+import * as a from "./a";
+export default a.D;
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+var C = /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());
+exports.D = C;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+var a = require("./a");
+exports["default"] = a.D;
+
+
+//// [a.d.ts]
+declare class C {
+}
+export { C as D };
+//// [b.d.ts]
+import * as a from "./a";
+declare const _default: typeof a.D;
+export default _default;

--- a/tests/baselines/reference/declarationEmitOfTypeofAliasedExport.symbols
+++ b/tests/baselines/reference/declarationEmitOfTypeofAliasedExport.symbols
@@ -1,0 +1,17 @@
+=== /a.ts ===
+class C {}
+>C : Symbol(C, Decl(a.ts, 0, 0))
+
+export { C as D }
+>C : Symbol(D, Decl(a.ts, 1, 8))
+>D : Symbol(D, Decl(a.ts, 1, 8))
+
+=== /b.ts ===
+import * as a from "./a";
+>a : Symbol(a, Decl(b.ts, 0, 6))
+
+export default a.D;
+>a.D : Symbol(a.D, Decl(a.ts, 1, 8))
+>a : Symbol(a, Decl(b.ts, 0, 6))
+>D : Symbol(a.D, Decl(a.ts, 1, 8))
+

--- a/tests/baselines/reference/declarationEmitOfTypeofAliasedExport.types
+++ b/tests/baselines/reference/declarationEmitOfTypeofAliasedExport.types
@@ -1,0 +1,17 @@
+=== /a.ts ===
+class C {}
+>C : C
+
+export { C as D }
+>C : typeof C
+>D : typeof C
+
+=== /b.ts ===
+import * as a from "./a";
+>a : typeof a
+
+export default a.D;
+>a.D : typeof a.D
+>a : typeof a
+>D : typeof a.D
+

--- a/tests/baselines/reference/es6ExportClauseWithoutModuleSpecifier.types
+++ b/tests/baselines/reference/es6ExportClauseWithoutModuleSpecifier.types
@@ -30,8 +30,8 @@ export { c as c2 } from "server";
 
 export { i, m as instantiatedModule } from "server";
 >i : any
->m : typeof m
->instantiatedModule : typeof m
+>m : typeof instantiatedModule
+>instantiatedModule : typeof instantiatedModule
 
 export { uninstantiated } from "server";
 >uninstantiated : any

--- a/tests/baselines/reference/es6ExportClauseWithoutModuleSpecifierInEs5.types
+++ b/tests/baselines/reference/es6ExportClauseWithoutModuleSpecifierInEs5.types
@@ -30,8 +30,8 @@ export { c as c2 } from "./server";
 
 export { i, m as instantiatedModule } from "./server";
 >i : any
->m : typeof m
->instantiatedModule : typeof m
+>m : typeof instantiatedModule
+>instantiatedModule : typeof instantiatedModule
 
 export { uninstantiated } from "./server";
 >uninstantiated : any

--- a/tests/baselines/reference/exportSpecifierForAGlobal.errors.txt
+++ b/tests/baselines/reference/exportSpecifierForAGlobal.errors.txt
@@ -1,14 +1,17 @@
 tests/cases/compiler/b.ts(1,9): error TS2661: Cannot export 'X'. Only local declarations can be exported from a module.
+tests/cases/compiler/b.ts(2,17): error TS4060: Return type of exported function has or is using private name 'X'.
 
 
 ==== tests/cases/compiler/a.d.ts (0 errors) ====
     declare class X { }
     
-==== tests/cases/compiler/b.ts (1 errors) ====
+==== tests/cases/compiler/b.ts (2 errors) ====
     export {X};
             ~
 !!! error TS2661: Cannot export 'X'. Only local declarations can be exported from a module.
     export function f() {
+                    ~
+!!! error TS4060: Return type of exported function has or is using private name 'X'.
         var x: X;
         return x;
     } 

--- a/tests/baselines/reference/exportSpecifierForAGlobal.js
+++ b/tests/baselines/reference/exportSpecifierForAGlobal.js
@@ -19,8 +19,3 @@ function f() {
     return x;
 }
 exports.f = f;
-
-
-//// [b.d.ts]
-export { X };
-export declare function f(): X;

--- a/tests/baselines/reference/exportsAndImports3-amd.symbols
+++ b/tests/baselines/reference/exportsAndImports3-amd.symbols
@@ -15,17 +15,17 @@ export enum E {
 >E : Symbol(E, Decl(t1.ts, 5, 1))
 
     A, B, C
->A : Symbol(E.A, Decl(t1.ts, 6, 15))
->B : Symbol(E.B, Decl(t1.ts, 7, 6))
->C : Symbol(E.C, Decl(t1.ts, 7, 9))
+>A : Symbol(E1.A, Decl(t1.ts, 6, 15))
+>B : Symbol(E1.B, Decl(t1.ts, 7, 6))
+>C : Symbol(E1.C, Decl(t1.ts, 7, 9))
 }
 export const enum D {
 >D : Symbol(D, Decl(t1.ts, 8, 1))
 
     A, B, C
->A : Symbol(D.A, Decl(t1.ts, 9, 21))
->B : Symbol(D.B, Decl(t1.ts, 10, 6))
->C : Symbol(D.C, Decl(t1.ts, 10, 9))
+>A : Symbol(D1.A, Decl(t1.ts, 9, 21))
+>B : Symbol(D1.B, Decl(t1.ts, 10, 6))
+>C : Symbol(D1.C, Decl(t1.ts, 10, 9))
 }
 export module M {
 >M : Symbol(M, Decl(t1.ts, 11, 1))

--- a/tests/baselines/reference/exportsAndImports3-es6.symbols
+++ b/tests/baselines/reference/exportsAndImports3-es6.symbols
@@ -15,17 +15,17 @@ export enum E {
 >E : Symbol(E, Decl(t1.ts, 5, 1))
 
     A, B, C
->A : Symbol(E.A, Decl(t1.ts, 6, 15))
->B : Symbol(E.B, Decl(t1.ts, 7, 6))
->C : Symbol(E.C, Decl(t1.ts, 7, 9))
+>A : Symbol(E1.A, Decl(t1.ts, 6, 15))
+>B : Symbol(E1.B, Decl(t1.ts, 7, 6))
+>C : Symbol(E1.C, Decl(t1.ts, 7, 9))
 }
 export const enum D {
 >D : Symbol(D, Decl(t1.ts, 8, 1))
 
     A, B, C
->A : Symbol(D.A, Decl(t1.ts, 9, 21))
->B : Symbol(D.B, Decl(t1.ts, 10, 6))
->C : Symbol(D.C, Decl(t1.ts, 10, 9))
+>A : Symbol(D1.A, Decl(t1.ts, 9, 21))
+>B : Symbol(D1.B, Decl(t1.ts, 10, 6))
+>C : Symbol(D1.C, Decl(t1.ts, 10, 9))
 }
 export module M {
 >M : Symbol(M, Decl(t1.ts, 11, 1))

--- a/tests/baselines/reference/exportsAndImports3.symbols
+++ b/tests/baselines/reference/exportsAndImports3.symbols
@@ -15,17 +15,17 @@ export enum E {
 >E : Symbol(E, Decl(t1.ts, 5, 1))
 
     A, B, C
->A : Symbol(E.A, Decl(t1.ts, 6, 15))
->B : Symbol(E.B, Decl(t1.ts, 7, 6))
->C : Symbol(E.C, Decl(t1.ts, 7, 9))
+>A : Symbol(E1.A, Decl(t1.ts, 6, 15))
+>B : Symbol(E1.B, Decl(t1.ts, 7, 6))
+>C : Symbol(E1.C, Decl(t1.ts, 7, 9))
 }
 export const enum D {
 >D : Symbol(D, Decl(t1.ts, 8, 1))
 
     A, B, C
->A : Symbol(D.A, Decl(t1.ts, 9, 21))
->B : Symbol(D.B, Decl(t1.ts, 10, 6))
->C : Symbol(D.C, Decl(t1.ts, 10, 9))
+>A : Symbol(D1.A, Decl(t1.ts, 9, 21))
+>B : Symbol(D1.B, Decl(t1.ts, 10, 6))
+>C : Symbol(D1.C, Decl(t1.ts, 10, 9))
 }
 export module M {
 >M : Symbol(M, Decl(t1.ts, 11, 1))

--- a/tests/baselines/reference/reexportWrittenCorrectlyInDeclaration.js
+++ b/tests/baselines/reference/reexportWrittenCorrectlyInDeclaration.js
@@ -1,0 +1,72 @@
+//// [tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts] ////
+
+//// [ThingA.ts]
+// https://github.com/Microsoft/TypeScript/issues/8612
+export class ThingA { } 
+
+//// [ThingB.ts]
+export class ThingB { }
+
+//// [Things.ts]
+export {ThingA} from "./ThingA";
+export {ThingB} from "./ThingB";
+
+//// [Test.ts]
+import * as things from "./Things";
+
+export class Test {
+    public method = (input: things.ThingA)  => { };
+}
+
+//// [ThingA.js]
+"use strict";
+exports.__esModule = true;
+// https://github.com/Microsoft/TypeScript/issues/8612
+var ThingA = /** @class */ (function () {
+    function ThingA() {
+    }
+    return ThingA;
+}());
+exports.ThingA = ThingA;
+//// [ThingB.js]
+"use strict";
+exports.__esModule = true;
+var ThingB = /** @class */ (function () {
+    function ThingB() {
+    }
+    return ThingB;
+}());
+exports.ThingB = ThingB;
+//// [Things.js]
+"use strict";
+exports.__esModule = true;
+var ThingA_1 = require("./ThingA");
+exports.ThingA = ThingA_1.ThingA;
+var ThingB_1 = require("./ThingB");
+exports.ThingB = ThingB_1.ThingB;
+//// [Test.js]
+"use strict";
+exports.__esModule = true;
+var Test = /** @class */ (function () {
+    function Test() {
+        this.method = function (input) { };
+    }
+    return Test;
+}());
+exports.Test = Test;
+
+
+//// [ThingA.d.ts]
+export declare class ThingA {
+}
+//// [ThingB.d.ts]
+export declare class ThingB {
+}
+//// [Things.d.ts]
+export { ThingA } from "./ThingA";
+export { ThingB } from "./ThingB";
+//// [Test.d.ts]
+import * as things from "./Things";
+export declare class Test {
+    method: (input: things.ThingA) => void;
+}

--- a/tests/baselines/reference/reexportWrittenCorrectlyInDeclaration.symbols
+++ b/tests/baselines/reference/reexportWrittenCorrectlyInDeclaration.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/ThingA.ts ===
+// https://github.com/Microsoft/TypeScript/issues/8612
+export class ThingA { } 
+>ThingA : Symbol(ThingA, Decl(ThingA.ts, 0, 0))
+
+=== tests/cases/compiler/ThingB.ts ===
+export class ThingB { }
+>ThingB : Symbol(ThingB, Decl(ThingB.ts, 0, 0))
+
+=== tests/cases/compiler/Things.ts ===
+export {ThingA} from "./ThingA";
+>ThingA : Symbol(ThingA, Decl(Things.ts, 0, 8))
+
+export {ThingB} from "./ThingB";
+>ThingB : Symbol(ThingB, Decl(Things.ts, 1, 8))
+
+=== tests/cases/compiler/Test.ts ===
+import * as things from "./Things";
+>things : Symbol(things, Decl(Test.ts, 0, 6))
+
+export class Test {
+>Test : Symbol(Test, Decl(Test.ts, 0, 35))
+
+    public method = (input: things.ThingA)  => { };
+>method : Symbol(Test.method, Decl(Test.ts, 2, 19))
+>input : Symbol(input, Decl(Test.ts, 3, 21))
+>things : Symbol(things, Decl(Test.ts, 0, 6))
+>ThingA : Symbol(things.ThingA, Decl(Things.ts, 0, 8))
+}

--- a/tests/baselines/reference/reexportWrittenCorrectlyInDeclaration.types
+++ b/tests/baselines/reference/reexportWrittenCorrectlyInDeclaration.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/ThingA.ts ===
+// https://github.com/Microsoft/TypeScript/issues/8612
+export class ThingA { } 
+>ThingA : ThingA
+
+=== tests/cases/compiler/ThingB.ts ===
+export class ThingB { }
+>ThingB : ThingB
+
+=== tests/cases/compiler/Things.ts ===
+export {ThingA} from "./ThingA";
+>ThingA : typeof ThingA
+
+export {ThingB} from "./ThingB";
+>ThingB : typeof ThingB
+
+=== tests/cases/compiler/Test.ts ===
+import * as things from "./Things";
+>things : typeof things
+
+export class Test {
+>Test : Test
+
+    public method = (input: things.ThingA)  => { };
+>method : (input: things.ThingA) => void
+>(input: things.ThingA)  => { } : (input: things.ThingA) => void
+>input : things.ThingA
+>things : any
+>ThingA : things.ThingA
+}

--- a/tests/baselines/reference/systemModule15.types
+++ b/tests/baselines/reference/systemModule15.types
@@ -23,9 +23,9 @@ use(moduleB.moduleC);
 use(moduleB.moduleCStar);
 >use(moduleB.moduleCStar) : void
 >use : (v: any) => void
->moduleB.moduleCStar : typeof "tests/cases/compiler/file3"
+>moduleB.moduleCStar : typeof moduleB.moduleCStar
 >moduleB : typeof moduleB
->moduleCStar : typeof "tests/cases/compiler/file3"
+>moduleCStar : typeof moduleB.moduleCStar
 
 === tests/cases/compiler/file2.ts ===
 import * as moduleCStar from "./file3"

--- a/tests/cases/compiler/declarationEmitOfTypeofAliasedExport.ts
+++ b/tests/cases/compiler/declarationEmitOfTypeofAliasedExport.ts
@@ -1,0 +1,8 @@
+// @declaration: true
+// @filename: /a.ts
+class C {}
+export { C as D }
+
+// @filename: /b.ts
+import * as a from "./a";
+export default a.D;

--- a/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
+++ b/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
@@ -1,0 +1,18 @@
+// https://github.com/Microsoft/TypeScript/issues/8612
+// @declaration: true
+// @filename: ThingA.ts
+export class ThingA { } 
+
+// @filename: ThingB.ts
+export class ThingB { }
+
+// @filename: Things.ts
+export {ThingA} from "./ThingA";
+export {ThingB} from "./ThingB";
+
+// @filename: Test.ts
+import * as things from "./Things";
+
+export class Test {
+    public method = (input: things.ThingA)  => { };
+}


### PR DESCRIPTION
Fixes #19825
Fixes #8612
Fixes #5938

This was actually broken waaaaaay back in TS 1.6 by #3641; the real underlying issue which prompted that change has since been fixed by other changes, so all this line did was break things. 😄 