### PR TITLE
If there is an `export default x;` alias declaration, disallow other default exports

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2205,15 +2205,14 @@ namespace ts {
                 bindAnonymousDeclaration(node, SymbolFlags.Alias, getDeclarationName(node));
             }
             else {
-                // An export default clause with an expression exports a value
-                // We want to exclude both class and function here,  this is necessary to issue an error when there are both
-                // default export-assignment and default export function and class declaration.
-                const flags = node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(<ExportAssignment>node)
+                const flags = node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(node)
                     // An export default clause with an EntityNameExpression exports all meanings of that identifier
                     ? SymbolFlags.Alias
                     // An export default clause with any other expression exports a value
                     : SymbolFlags.Property;
-                declareSymbol(container.symbol.exports, container.symbol, node, flags, SymbolFlags.Property | SymbolFlags.AliasExcludes | SymbolFlags.Class | SymbolFlags.Function);
+                // If there is an `export default x;` alias declaration, can't `export default` anything else.
+                // (In contrast, you can still have `export default function f() {}` and `export default interface I {}`.)
+                declareSymbol(container.symbol.exports, container.symbol, node, flags, SymbolFlags.All);
             }
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3021,6 +3021,10 @@ namespace ts {
         Optional                = 1 << 24,  // Optional property
         Transient               = 1 << 25,  // Transient symbol (created during type check)
 
+        /* @internal */
+        All = FunctionScopedVariable | BlockScopedVariable | Property | EnumMember | Function | Class | Interface | ConstEnum | RegularEnum | ValueModule | NamespaceModule | TypeLiteral
+            | ObjectLiteral | Method | Constructor | GetAccessor | SetAccessor | Signature | TypeParameter | TypeAlias | ExportValue | Alias | Prototype | ExportStar | Optional | Transient,
+
         Enum = RegularEnum | ConstEnum,
         Variable = FunctionScopedVariable | BlockScopedVariable,
         Value = Variable | Property | EnumMember | Function | Class | Enum | ValueModule | Method | GetAccessor | SetAccessor,

--- a/tests/baselines/reference/exportDefaultAlias_excludesEverything.errors.txt
+++ b/tests/baselines/reference/exportDefaultAlias_excludesEverything.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/exportDefaultAlias_excludesEverything.ts(1,26): error TS2528: A module cannot have multiple default exports.
+tests/cases/compiler/exportDefaultAlias_excludesEverything.ts(3,16): error TS2528: A module cannot have multiple default exports.
+
+
+==== tests/cases/compiler/exportDefaultAlias_excludesEverything.ts (2 errors) ====
+    export default interface A {}
+                             ~
+!!! error TS2528: A module cannot have multiple default exports.
+    interface B {}
+    export default B;
+                   ~
+!!! error TS2528: A module cannot have multiple default exports.
+    

--- a/tests/baselines/reference/exportDefaultAlias_excludesEverything.js
+++ b/tests/baselines/reference/exportDefaultAlias_excludesEverything.js
@@ -1,0 +1,9 @@
+//// [exportDefaultAlias_excludesEverything.ts]
+export default interface A {}
+interface B {}
+export default B;
+
+
+//// [exportDefaultAlias_excludesEverything.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/exportDefaultAlias_excludesEverything.symbols
+++ b/tests/baselines/reference/exportDefaultAlias_excludesEverything.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/exportDefaultAlias_excludesEverything.ts ===
+export default interface A {}
+>A : Symbol(A, Decl(exportDefaultAlias_excludesEverything.ts, 0, 0))
+
+interface B {}
+>B : Symbol(B, Decl(exportDefaultAlias_excludesEverything.ts, 0, 29))
+
+export default B;
+>B : Symbol(B, Decl(exportDefaultAlias_excludesEverything.ts, 0, 29))
+

--- a/tests/baselines/reference/exportDefaultAlias_excludesEverything.types
+++ b/tests/baselines/reference/exportDefaultAlias_excludesEverything.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/exportDefaultAlias_excludesEverything.ts ===
+export default interface A {}
+>A : A
+
+interface B {}
+>B : B
+
+export default B;
+>B : B
+

--- a/tests/cases/compiler/exportDefaultAlias_excludesEverything.ts
+++ b/tests/cases/compiler/exportDefaultAlias_excludesEverything.ts
@@ -1,0 +1,3 @@
+export default interface A {}
+interface B {}
+export default B;


### PR DESCRIPTION
Fixes #19850