### PR TITLE
Fix enum typed object members declaration emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3536,15 +3536,27 @@ namespace ts {
                     if (links.target && links.target.escapedName === InternalSymbolName.Computed) {
                         const name = ((prop.declarations[0] as NamedDeclaration).name as ComputedPropertyName).expression;
                         const t = getTypeOfNode(name);
-                        const sym = getSymbolAtLocation(name);
-                        const access = isSymbolAccessible(sym, enclosingDeclaration, SymbolFlags.Value, /*shouldComputeAliases*/ false);
                         writePunctuation(writer, SyntaxKind.OpenBracketToken);
-                        if (access.accessibility !== SymbolAccessibility.Accessible && !(t.flags & TypeFlags.Union) && isLiteralType(t)) {
+                        if (!(t.flags & TypeFlags.Union) && isLiteralType(t)) {
                             writer.writeStringLiteral(literalTypeToString(t as LiteralType));
                         }
                         else {
-                            // By passing in `enclosingDeclaration`, we should write the name in appropriately qualified way
-                            buildSymbolDisplay(sym, writer, enclosingDeclaration);
+                            writer.writeSymbol("key", prop);
+                            writePunctuation(writer, SyntaxKind.ColonToken);
+                            writeSpace(writer);
+                            let base = getBaseTypeOfLiteralType(t);
+                            if (base !== stringType && base !== numberType) {
+                                if (isTypeAssignableToKind(base, TypeFlags.String)) {
+                                    base = stringType;
+                                }
+                                else if (isTypeAssignableToKind(base, TypeFlags.Number)) {
+                                    base = numberType;
+                                }
+                                else {
+                                    base = anyType;
+                                }
+                            }
+                            writeType(base, globalFlags);
                         }
                         writePunctuation(writer, SyntaxKind.CloseBracketToken);
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3532,7 +3532,25 @@ namespace ts {
                         writeKeyword(writer, SyntaxKind.ReadonlyKeyword);
                         writeSpace(writer);
                     }
-                    buildSymbolDisplay(prop, writer);
+                    const links = getSymbolLinks(prop);
+                    if (links.target && links.target.escapedName === InternalSymbolName.Computed) {
+                        const name = ((prop.declarations[0] as NamedDeclaration).name as ComputedPropertyName).expression;
+                        const t = getTypeOfNode(name);
+                        const sym = getSymbolAtLocation(name);
+                        const access = isSymbolAccessible(sym, enclosingDeclaration, SymbolFlags.Value, /*shouldComputeAliases*/ false);
+                        writePunctuation(writer, SyntaxKind.OpenBracketToken);
+                        if (access.accessibility !== SymbolAccessibility.Accessible && !(t.flags & TypeFlags.Union) && isLiteralType(t)) {
+                            writer.writeStringLiteral(literalTypeToString(t as LiteralType));
+                        }
+                        else {
+                            // By passing in `enclosingDeclaration`, we should write the name in appropriately qualified way
+                            buildSymbolDisplay(sym, writer, enclosingDeclaration);
+                        }
+                        writePunctuation(writer, SyntaxKind.CloseBracketToken);
+                    }
+                    else {
+                        buildSymbolDisplay(prop, writer);
+                    }
                     if (prop.flags & SymbolFlags.Optional) {
                         writePunctuation(writer, SyntaxKind.QuestionToken);
                     }

--- a/tests/baselines/reference/declarationEmitPrivateInComputedName.js
+++ b/tests/baselines/reference/declarationEmitPrivateInComputedName.js
@@ -1,0 +1,105 @@
+//// [declarationEmitPrivateInComputedName.ts]
+enum MyEnum {
+    member = 0
+}
+
+export const someVar1 = {
+    [MyEnum.member]: ""
+};
+
+enum MyStringEnum {
+    str = "str"
+}
+
+export const someVar2 = {
+    [MyStringEnum.str]: ""
+};
+
+export enum MyExportEnum {
+    member = 0
+}
+
+export const someVar3 = {
+    [MyExportEnum.member]: ""
+};
+
+export enum MyExportStringEnum {
+    str = "str"
+}
+
+export const someVar4 = {
+    [MyExportStringEnum.str]: ""
+};
+
+enum MyComputedEnum {
+    member = Math.random()
+}
+
+export const someVar5 = {
+    [MyComputedEnum.member]: ""
+};
+
+
+//// [declarationEmitPrivateInComputedName.js]
+"use strict";
+exports.__esModule = true;
+var MyEnum;
+(function (MyEnum) {
+    MyEnum[MyEnum["member"] = 0] = "member";
+})(MyEnum || (MyEnum = {}));
+exports.someVar1 = (_a = {},
+    _a[MyEnum.member] = "",
+    _a);
+var MyStringEnum;
+(function (MyStringEnum) {
+    MyStringEnum["str"] = "str";
+})(MyStringEnum || (MyStringEnum = {}));
+exports.someVar2 = (_b = {},
+    _b[MyStringEnum.str] = "",
+    _b);
+var MyExportEnum;
+(function (MyExportEnum) {
+    MyExportEnum[MyExportEnum["member"] = 0] = "member";
+})(MyExportEnum = exports.MyExportEnum || (exports.MyExportEnum = {}));
+exports.someVar3 = (_c = {},
+    _c[MyExportEnum.member] = "",
+    _c);
+var MyExportStringEnum;
+(function (MyExportStringEnum) {
+    MyExportStringEnum["str"] = "str";
+})(MyExportStringEnum = exports.MyExportStringEnum || (exports.MyExportStringEnum = {}));
+exports.someVar4 = (_d = {},
+    _d[MyExportStringEnum.str] = "",
+    _d);
+var MyComputedEnum;
+(function (MyComputedEnum) {
+    MyComputedEnum[MyComputedEnum["member"] = Math.random()] = "member";
+})(MyComputedEnum || (MyComputedEnum = {}));
+exports.someVar5 = (_e = {},
+    _e[MyComputedEnum.member] = "",
+    _e);
+var _a, _b, _c, _d, _e;
+
+
+//// [declarationEmitPrivateInComputedName.d.ts]
+export declare const someVar1: {
+    [0]: string;
+};
+export declare const someVar2: {
+    ["str"]: string;
+};
+export declare enum MyExportEnum {
+    member = 0,
+}
+export declare const someVar3: {
+    [0]: string;
+};
+export declare enum MyExportStringEnum {
+    str = "str",
+}
+export declare const someVar4: {
+    ["str"]: string;
+};
+export declare const someVar5: {
+    [x: number]: string;
+};

--- a/tests/baselines/reference/declarationEmitPrivateInComputedName.symbols
+++ b/tests/baselines/reference/declarationEmitPrivateInComputedName.symbols
@@ -1,0 +1,89 @@
+=== tests/cases/compiler/declarationEmitPrivateInComputedName.ts ===
+enum MyEnum {
+>MyEnum : Symbol(MyEnum, Decl(declarationEmitPrivateInComputedName.ts, 0, 0))
+
+    member = 0
+>member : Symbol(MyEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 0, 13))
+}
+
+export const someVar1 = {
+>someVar1 : Symbol(someVar1, Decl(declarationEmitPrivateInComputedName.ts, 4, 12))
+
+    [MyEnum.member]: ""
+>MyEnum.member : Symbol(MyEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 0, 13))
+>MyEnum : Symbol(MyEnum, Decl(declarationEmitPrivateInComputedName.ts, 0, 0))
+>member : Symbol(MyEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 0, 13))
+
+};
+
+enum MyStringEnum {
+>MyStringEnum : Symbol(MyStringEnum, Decl(declarationEmitPrivateInComputedName.ts, 6, 2))
+
+    str = "str"
+>str : Symbol(MyStringEnum.str, Decl(declarationEmitPrivateInComputedName.ts, 8, 19))
+}
+
+export const someVar2 = {
+>someVar2 : Symbol(someVar2, Decl(declarationEmitPrivateInComputedName.ts, 12, 12))
+
+    [MyStringEnum.str]: ""
+>MyStringEnum.str : Symbol(MyStringEnum.str, Decl(declarationEmitPrivateInComputedName.ts, 8, 19))
+>MyStringEnum : Symbol(MyStringEnum, Decl(declarationEmitPrivateInComputedName.ts, 6, 2))
+>str : Symbol(MyStringEnum.str, Decl(declarationEmitPrivateInComputedName.ts, 8, 19))
+
+};
+
+export enum MyExportEnum {
+>MyExportEnum : Symbol(MyExportEnum, Decl(declarationEmitPrivateInComputedName.ts, 14, 2))
+
+    member = 0
+>member : Symbol(MyExportEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 16, 26))
+}
+
+export const someVar3 = {
+>someVar3 : Symbol(someVar3, Decl(declarationEmitPrivateInComputedName.ts, 20, 12))
+
+    [MyExportEnum.member]: ""
+>MyExportEnum.member : Symbol(MyExportEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 16, 26))
+>MyExportEnum : Symbol(MyExportEnum, Decl(declarationEmitPrivateInComputedName.ts, 14, 2))
+>member : Symbol(MyExportEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 16, 26))
+
+};
+
+export enum MyExportStringEnum {
+>MyExportStringEnum : Symbol(MyExportStringEnum, Decl(declarationEmitPrivateInComputedName.ts, 22, 2))
+
+    str = "str"
+>str : Symbol(MyExportStringEnum.str, Decl(declarationEmitPrivateInComputedName.ts, 24, 32))
+}
+
+export const someVar4 = {
+>someVar4 : Symbol(someVar4, Decl(declarationEmitPrivateInComputedName.ts, 28, 12))
+
+    [MyExportStringEnum.str]: ""
+>MyExportStringEnum.str : Symbol(MyExportStringEnum.str, Decl(declarationEmitPrivateInComputedName.ts, 24, 32))
+>MyExportStringEnum : Symbol(MyExportStringEnum, Decl(declarationEmitPrivateInComputedName.ts, 22, 2))
+>str : Symbol(MyExportStringEnum.str, Decl(declarationEmitPrivateInComputedName.ts, 24, 32))
+
+};
+
+enum MyComputedEnum {
+>MyComputedEnum : Symbol(MyComputedEnum, Decl(declarationEmitPrivateInComputedName.ts, 30, 2))
+
+    member = Math.random()
+>member : Symbol(MyComputedEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 32, 21))
+>Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+}
+
+export const someVar5 = {
+>someVar5 : Symbol(someVar5, Decl(declarationEmitPrivateInComputedName.ts, 36, 12))
+
+    [MyComputedEnum.member]: ""
+>MyComputedEnum.member : Symbol(MyComputedEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 32, 21))
+>MyComputedEnum : Symbol(MyComputedEnum, Decl(declarationEmitPrivateInComputedName.ts, 30, 2))
+>member : Symbol(MyComputedEnum.member, Decl(declarationEmitPrivateInComputedName.ts, 32, 21))
+
+};
+

--- a/tests/baselines/reference/declarationEmitPrivateInComputedName.types
+++ b/tests/baselines/reference/declarationEmitPrivateInComputedName.types
@@ -1,0 +1,104 @@
+=== tests/cases/compiler/declarationEmitPrivateInComputedName.ts ===
+enum MyEnum {
+>MyEnum : MyEnum
+
+    member = 0
+>member : MyEnum
+>0 : 0
+}
+
+export const someVar1 = {
+>someVar1 : { [MyEnum.member]: string; }
+>{    [MyEnum.member]: ""} : { [MyEnum.member]: string; }
+
+    [MyEnum.member]: ""
+>MyEnum.member : MyEnum
+>MyEnum : typeof MyEnum
+>member : MyEnum
+>"" : ""
+
+};
+
+enum MyStringEnum {
+>MyStringEnum : MyStringEnum
+
+    str = "str"
+>str : MyStringEnum
+>"str" : "str"
+}
+
+export const someVar2 = {
+>someVar2 : { [MyStringEnum.str]: string; }
+>{    [MyStringEnum.str]: ""} : { [MyStringEnum.str]: string; }
+
+    [MyStringEnum.str]: ""
+>MyStringEnum.str : MyStringEnum
+>MyStringEnum : typeof MyStringEnum
+>str : MyStringEnum
+>"" : ""
+
+};
+
+export enum MyExportEnum {
+>MyExportEnum : MyExportEnum
+
+    member = 0
+>member : MyExportEnum
+>0 : 0
+}
+
+export const someVar3 = {
+>someVar3 : { [MyExportEnum.member]: string; }
+>{    [MyExportEnum.member]: ""} : { [MyExportEnum.member]: string; }
+
+    [MyExportEnum.member]: ""
+>MyExportEnum.member : MyExportEnum
+>MyExportEnum : typeof MyExportEnum
+>member : MyExportEnum
+>"" : ""
+
+};
+
+export enum MyExportStringEnum {
+>MyExportStringEnum : MyExportStringEnum
+
+    str = "str"
+>str : MyExportStringEnum
+>"str" : "str"
+}
+
+export const someVar4 = {
+>someVar4 : { [MyExportStringEnum.str]: string; }
+>{    [MyExportStringEnum.str]: ""} : { [MyExportStringEnum.str]: string; }
+
+    [MyExportStringEnum.str]: ""
+>MyExportStringEnum.str : MyExportStringEnum
+>MyExportStringEnum : typeof MyExportStringEnum
+>str : MyExportStringEnum
+>"" : ""
+
+};
+
+enum MyComputedEnum {
+>MyComputedEnum : MyComputedEnum
+
+    member = Math.random()
+>member : MyComputedEnum
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+}
+
+export const someVar5 = {
+>someVar5 : { [x: number]: string; }
+>{    [MyComputedEnum.member]: ""} : { [x: number]: string; }
+
+    [MyComputedEnum.member]: ""
+>MyComputedEnum.member : MyComputedEnum
+>MyComputedEnum : typeof MyComputedEnum
+>member : MyComputedEnum
+>"" : ""
+
+};
+

--- a/tests/cases/compiler/declarationEmitPrivateInComputedName.ts
+++ b/tests/cases/compiler/declarationEmitPrivateInComputedName.ts
@@ -1,0 +1,40 @@
+// @declaration: true
+enum MyEnum {
+    member = 0
+}
+
+export const someVar1 = {
+    [MyEnum.member]: ""
+};
+
+enum MyStringEnum {
+    str = "str"
+}
+
+export const someVar2 = {
+    [MyStringEnum.str]: ""
+};
+
+export enum MyExportEnum {
+    member = 0
+}
+
+export const someVar3 = {
+    [MyExportEnum.member]: ""
+};
+
+export enum MyExportStringEnum {
+    str = "str"
+}
+
+export const someVar4 = {
+    [MyExportStringEnum.str]: ""
+};
+
+enum MyComputedEnum {
+    member = Math.random()
+}
+
+export const someVar5 = {
+    [MyComputedEnum.member]: ""
+};


### PR DESCRIPTION
Fixes #19704, however I feel like this emit is a bit subpar compared to what we can emit once #15473 is merged; so it's probably worth just waiting for that. TBQH, I'd also like to see #18860 merged so I can deal with less merge conflicts and needed reimplementations with respect to the symbol display builder itself.
