### PR TITLE
In `forEachExternalModule`, skip node_modules beginning with `_`.

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2540,6 +2540,11 @@ Actual: ${stringify(fullActual)}`);
             const scriptInfo = this.languageServiceAdapterHost.getScriptInfo(codeFixes[0].changes[0].fileName);
             const originalContent = scriptInfo.content;
             for (const codeFix of codeFixes) {
+                if (!/^(Import|Change|Add)/.test(codeFix.description)) {
+                    // Ignore other fixes
+                    continue;
+                }
+
                 this.applyEdits(codeFix.changes[0].fileName, codeFix.changes[0].textChanges, /*isFormattingEdit*/ false);
                 let text = this.rangeText(ranges[0]);
                 // TODO:GH#18445 (remove this line to see errors in many `importNameCodeFix` tests)
@@ -2549,6 +2554,9 @@ Actual: ${stringify(fullActual)}`);
             }
             const sortedExpectedArray = expectedTextArray.sort();
             const sortedActualArray = actualTextArray.sort();
+            if (sortedExpectedArray.length !== sortedActualArray.length) {
+                this.raiseError(`Expected ${sortedExpectedArray.length} import fixes, got ${sortedActualArray.length}`);
+            }
             ts.zipWith(sortedExpectedArray, sortedActualArray, (expected, actual, index) => {
                 if (expected !== actual) {
                     this.raiseError(`Import fix at index ${index} doesn't match.\n${showTextDiff(expected, actual)}`);

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -727,7 +727,8 @@ namespace ts.codefix {
             cb(ambient);
         }
         for (const sourceFile of allSourceFiles) {
-            if (isExternalOrCommonJsModule(sourceFile)) {
+            // Exclude accidental inclusion of underscored node_module. https://github.com/Microsoft/TypeScript/issues/19893
+            if (isExternalOrCommonJsModule(sourceFile) && !stringContains(sourceFile.fileName, "node_modules/_") && !stringContains(sourceFile.fileName, "node_modules\_")) {
                 cb(sourceFile.symbol);
             }
         }

--- a/tests/cases/fourslash/importNameCodeFix_nodeModulesUnderscore.ts
+++ b/tests/cases/fourslash/importNameCodeFix_nodeModulesUnderscore.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+// @maxNodeModuleJsDepth: 2
+// @moduleResolution: node
+
+// @Filename: /node_modules/_foo/index.js
+////exports.render = 0;
+
+// @Filename: /node_modules/foo/index.js
+////exports.render = 0;
+
+// @Filename: /a.js
+////[|render/**/;|]
+
+goTo.file("/a.js");
+
+// No import fix for `_foo`
+verify.importFixAtPosition([
+`import { render } from "foo";
+
+render;`,
+]);


### PR DESCRIPTION
Fixes #19893
This is probably not the right solution -- why are we including everything in `node_modules` even when they were never imported before?