### PR TITLE
Support arbitrary prototype property assignments in navigation bar

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -269,6 +269,24 @@ namespace ts.NavigationBar {
                 addLeafNode(node);
                 break;
 
+            case SyntaxKind.BinaryExpression: {
+                const special = getSpecialPropertyAssignmentKind(node as BinaryExpression);
+                switch (special) {
+                    case SpecialPropertyAssignmentKind.ExportsProperty:
+                    case SpecialPropertyAssignmentKind.ModuleExports:
+                    case SpecialPropertyAssignmentKind.PrototypeProperty:
+                        addNodeWithRecursiveChild(node, (node as BinaryExpression).right);
+                        break;
+                    case SpecialPropertyAssignmentKind.ThisProperty:
+                    case SpecialPropertyAssignmentKind.Property:
+                    case SpecialPropertyAssignmentKind.None:
+                        break;
+                    default:
+                        Debug.assertNever(special);
+                }
+            }
+            // falls through
+
             default:
                 if (hasJSDocNodes(node)) {
                     forEach(node.jsDoc, jsDoc => {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -364,7 +364,7 @@ namespace ts {
                         const rightKind = getNodeKind(right);
                         return rightKind === ScriptElementKind.unknown ? ScriptElementKind.constElement : rightKind;
                     case SpecialPropertyAssignmentKind.PrototypeProperty:
-                        return ScriptElementKind.memberFunctionElement; // instance method
+                        return isFunctionExpression(right) ? ScriptElementKind.memberFunctionElement : ScriptElementKind.memberVariableElement;
                     case SpecialPropertyAssignmentKind.ThisProperty:
                         return ScriptElementKind.memberVariableElement; // property
                     case SpecialPropertyAssignmentKind.Property:

--- a/tests/cases/fourslash/navigationBarFunctionPrototype.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype.ts
@@ -1,0 +1,42 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: foo.js
+////function f() {}
+////f.prototype.x = 0;
+
+verify.navigationTree({
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+        {
+            "text": "f",
+            "kind": "function"
+        },
+        {
+            "text": "x",
+            "kind": "property"
+        }
+    ]
+});
+
+verify.navigationBar([
+    {
+        "text": "<global>",
+        "kind": "script",
+        "childItems": [
+            {
+                "text": "f",
+                "kind": "function"
+            },
+            {
+                "text": "x",
+                "kind": "property"
+            }
+        ]
+    },
+    {
+        "text": "f",
+        "kind": "function",
+        "indent": 1
+    }
+]);


### PR DESCRIPTION
Fixes #19921 
The only reason it happened to work for `C.prototype.f = function() {}` before was that we added an entry for any `function` expression that had a name. This would make it work for values too, and would also work for `exports.x = 0;`.