### PR TITLE
Add 'scripthost' to 'lib' for the 'generate-spec' target.

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -731,7 +731,10 @@ compileFile(word2mdJs,
     [word2mdTs],
     [word2mdTs],
     [],
-            /*useBuiltCompiler*/ false);
+    /*useBuiltCompiler*/ false,
+    {
+        lib: "scripthost,es5"
+    });
 
 // The generated spec.md; built for the 'generate-spec' task
 file(specMd, [word2mdJs, specWord], function () {


### PR DESCRIPTION
Cherry-picks the first commit from #17215.

Fixes #19924.