### PR TITLE
Bidirectional comparable relation for primitive types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8907,7 +8907,9 @@ namespace ts {
             if (target.flags & TypeFlags.StringOrNumberLiteral && target.flags & TypeFlags.FreshLiteral) {
                 target = (<LiteralType>target).regularType;
             }
-            if (source === target || relation !== identityRelation && isSimpleTypeRelatedTo(source, target, relation)) {
+            if (source === target ||
+                relation === comparableRelation && !(target.flags & TypeFlags.Never) && isSimpleTypeRelatedTo(target, source, relation) ||
+                relation !== identityRelation && isSimpleTypeRelatedTo(source, target, relation)) {
                 return true;
             }
             if (source.flags & TypeFlags.Object && target.flags & TypeFlags.Object) {
@@ -9050,7 +9052,8 @@ namespace ts {
                     return isIdenticalTo(source, target);
                 }
 
-                if (isSimpleTypeRelatedTo(source, target, relation, reportErrors ? reportError : undefined)) return Ternary.True;
+                if (relation === comparableRelation && !(target.flags & TypeFlags.Never) && isSimpleTypeRelatedTo(target, source, relation) ||
+                    isSimpleTypeRelatedTo(source, target, relation, reportErrors ? reportError : undefined)) return Ternary.True;
 
                 if (isObjectLiteralType(source) && source.flags & TypeFlags.FreshLiteral) {
                     if (hasExcessProperties(<FreshObjectLiteralType>source, target, reportErrors)) {

--- a/tests/baselines/reference/independentPropertyVariance.js
+++ b/tests/baselines/reference/independentPropertyVariance.js
@@ -1,5 +1,5 @@
 //// [independentPropertyVariance.ts]
-// Verify that properties can vary idependently in comparable relationship
+// Verify that properties can vary independently in comparable relationship
 
 declare const x: { a: 1, b: string };
 declare const y: { a: number, b: 'a' };
@@ -9,5 +9,5 @@ x === y;
 
 //// [independentPropertyVariance.js]
 "use strict";
-// Verify that properties can vary idependently in comparable relationship
+// Verify that properties can vary independently in comparable relationship
 x === y;

--- a/tests/baselines/reference/independentPropertyVariance.js
+++ b/tests/baselines/reference/independentPropertyVariance.js
@@ -1,0 +1,13 @@
+//// [independentPropertyVariance.ts]
+// Verify that properties can vary idependently in comparable relationship
+
+declare const x: { a: 1, b: string };
+declare const y: { a: number, b: 'a' };
+
+x === y;
+
+
+//// [independentPropertyVariance.js]
+"use strict";
+// Verify that properties can vary idependently in comparable relationship
+x === y;

--- a/tests/baselines/reference/independentPropertyVariance.symbols
+++ b/tests/baselines/reference/independentPropertyVariance.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts ===
+// Verify that properties can vary idependently in comparable relationship
+
+declare const x: { a: 1, b: string };
+>x : Symbol(x, Decl(independentPropertyVariance.ts, 2, 13))
+>a : Symbol(a, Decl(independentPropertyVariance.ts, 2, 18))
+>b : Symbol(b, Decl(independentPropertyVariance.ts, 2, 24))
+
+declare const y: { a: number, b: 'a' };
+>y : Symbol(y, Decl(independentPropertyVariance.ts, 3, 13))
+>a : Symbol(a, Decl(independentPropertyVariance.ts, 3, 18))
+>b : Symbol(b, Decl(independentPropertyVariance.ts, 3, 29))
+
+x === y;
+>x : Symbol(x, Decl(independentPropertyVariance.ts, 2, 13))
+>y : Symbol(y, Decl(independentPropertyVariance.ts, 3, 13))
+

--- a/tests/baselines/reference/independentPropertyVariance.symbols
+++ b/tests/baselines/reference/independentPropertyVariance.symbols
@@ -1,5 +1,5 @@
 === tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts ===
-// Verify that properties can vary idependently in comparable relationship
+// Verify that properties can vary independently in comparable relationship
 
 declare const x: { a: 1, b: string };
 >x : Symbol(x, Decl(independentPropertyVariance.ts, 2, 13))

--- a/tests/baselines/reference/independentPropertyVariance.types
+++ b/tests/baselines/reference/independentPropertyVariance.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts ===
+// Verify that properties can vary idependently in comparable relationship
+
+declare const x: { a: 1, b: string };
+>x : { a: 1; b: string; }
+>a : 1
+>b : string
+
+declare const y: { a: number, b: 'a' };
+>y : { a: number; b: "a"; }
+>a : number
+>b : "a"
+
+x === y;
+>x === y : boolean
+>x : { a: 1; b: string; }
+>y : { a: number; b: "a"; }
+

--- a/tests/baselines/reference/independentPropertyVariance.types
+++ b/tests/baselines/reference/independentPropertyVariance.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts ===
-// Verify that properties can vary idependently in comparable relationship
+// Verify that properties can vary independently in comparable relationship
 
 declare const x: { a: 1, b: string };
 >x : { a: 1; b: string; }

--- a/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
+++ b/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
@@ -1,6 +1,6 @@
 // @strict: true
 
-// Verify that properties can vary idependently in comparable relationship
+// Verify that properties can vary independently in comparable relationship
 
 declare const x: { a: 1, b: string };
 declare const y: { a: number, b: 'a' };

--- a/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
+++ b/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
@@ -1,0 +1,8 @@
+// @strict: true
+
+// Verify that properties can vary idependently in comparable relationship
+
+declare const x: { a: 1, b: string };
+declare const y: { a: number, b: 'a' };
+
+x === y;


### PR DESCRIPTION
This PR makes the comparable relation bidirectional for primitive types. For example, the following previously was an error but is now permitted:

```ts
declare const x: { a: 1, b: string };
declare const y: { a: number, b: 'a' };

x === y;  // Now ok, previously was error
```