### PR TITLE
Fix crash when running tsc with -diagnostics

### DIFF
--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -10,7 +10,8 @@ namespace ts {
 namespace ts.performance {
     declare const onProfilerEvent: { (markName: string): void; profiler: boolean; };
 
-    const profilerEvent: (markName: string) => void = typeof onProfilerEvent === "function" && onProfilerEvent.profiler === true ? onProfilerEvent : noop;
+    // NOTE: cannot use ts.noop as core.ts loads after this
+    const profilerEvent: (markName: string) => void = typeof onProfilerEvent === "function" && onProfilerEvent.profiler === true ? onProfilerEvent : () => { /*empty*/ };
 
     let enabled = false;
     let profilerStart = 0;


### PR DESCRIPTION
This fixes a crash when running tsc with `-diagnostics` since `ts.noop` is not yet available.