### PR TITLE
Check children of JSXFragment

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14378,19 +14378,7 @@ namespace ts {
             const parent = openingLikeElement.parent.kind === SyntaxKind.JsxElement ? openingLikeElement.parent as JsxElement : undefined;
             // We have to check that openingElement of the parent is the one we are visiting as this may not be true for selfClosingElement
             if (parent && parent.openingElement === openingLikeElement && parent.children.length > 0) {
-                const childrenTypes: Type[] = [];
-                for (const child of (parent as JsxElement).children) {
-                    // In React, JSX text that contains only whitespaces will be ignored so we don't want to type-check that
-                    // because then type of children property will have constituent of string type.
-                    if (child.kind === SyntaxKind.JsxText) {
-                        if (!child.containsOnlyWhiteSpaces) {
-                            childrenTypes.push(stringType);
-                        }
-                    }
-                    else {
-                        childrenTypes.push(checkExpression(child, checkMode));
-                    }
-                }
+                const childrenTypes: Type[] = checkJsxChildren(parent as JsxElement, checkMode);
 
                 if (!hasSpreadAnyType && jsxChildrenPropertyName && jsxChildrenPropertyName !== "") {
                     // Error if there is a attribute named "children" explicitly specified and children element.
@@ -14428,6 +14416,23 @@ namespace ts {
                 result.objectFlags |= ObjectFlags.ObjectLiteral;
                 return result;
             }
+        }
+
+        function checkJsxChildren(node: JsxElement | JsxFragment, checkMode?: CheckMode) {
+            const childrenTypes: Type[] = [];
+            for (const child of node.children) {
+                // In React, JSX text that contains only whitespaces will be ignored so we don't want to type-check that
+                // because then type of children property will have constituent of string type.
+                if (child.kind === SyntaxKind.JsxText) {
+                    if (!child.containsOnlyWhiteSpaces) {
+                        childrenTypes.push(stringType);
+                    }
+                }
+                else {
+                    childrenTypes.push(checkExpression(child, checkMode));
+                }
+            }
+            return childrenTypes;
         }
 
         /**
@@ -14963,6 +14968,9 @@ namespace ts {
 
             if (isNodeOpeningLikeElement) {
                 checkJsxAttributesAssignableToTagNameAttributes(<JsxOpeningLikeElement>node);
+            }
+            else {
+                checkJsxChildren((node as JsxOpeningFragment).parent);
             }
         }
 

--- a/tests/baselines/reference/jsxFactoryAndFragment.errors.txt
+++ b/tests/baselines/reference/jsxFactoryAndFragment.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/compiler/jsxFactoryAndFragment.tsx(3,1): error TS17016: JSX fragment is not supported when using --jsxFactory
 tests/cases/compiler/jsxFactoryAndFragment.tsx(4,1): error TS17016: JSX fragment is not supported when using --jsxFactory
+tests/cases/compiler/jsxFactoryAndFragment.tsx(4,17): error TS17016: JSX fragment is not supported when using --jsxFactory
 
 
-==== tests/cases/compiler/jsxFactoryAndFragment.tsx (2 errors) ====
+==== tests/cases/compiler/jsxFactoryAndFragment.tsx (3 errors) ====
     declare var h: any;
     
     <></>;
@@ -10,4 +11,6 @@ tests/cases/compiler/jsxFactoryAndFragment.tsx(4,1): error TS17016: JSX fragment
 !!! error TS17016: JSX fragment is not supported when using --jsxFactory
     <><span>1</span><><span>2.1</span><span>2.2</span></></>;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17016: JSX fragment is not supported when using --jsxFactory
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS17016: JSX fragment is not supported when using --jsxFactory

--- a/tests/baselines/reference/tsxFragmentChildrenCheck.js
+++ b/tests/baselines/reference/tsxFragmentChildrenCheck.js
@@ -1,0 +1,68 @@
+//// [tests/cases/compiler/tsxFragmentChildrenCheck.ts] ////
+
+//// [my-component.tsx]
+declare var React: any;
+
+export function MyComponent(props: any) {
+    return <span>my component</span>;
+}
+
+//// [file1.tsx]
+import * as React from 'react'
+import { MyComponent } from './my-component'
+
+const MY_STRING: string = 'Ceci n\'est pas une string.'
+const MY_CLASSNAME: string = 'jeclass'
+
+class RenderString extends React.PureComponent<any, any> {
+  render() {
+    return (
+      <>
+        <MyComponent />
+        <span>{ MY_STRING }</span>
+        <span className={ MY_CLASSNAME } />
+      </>
+    )
+  }
+}
+
+export default RenderString
+
+//// [my-component.js]
+"use strict";
+exports.__esModule = true;
+function MyComponent(props) {
+    return React.createElement("span", null, "my component");
+}
+exports.MyComponent = MyComponent;
+//// [file1.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+var React = require("react");
+var my_component_1 = require("./my-component");
+var MY_STRING = 'Ceci n\'est pas une string.';
+var MY_CLASSNAME = 'jeclass';
+var RenderString = /** @class */ (function (_super) {
+    __extends(RenderString, _super);
+    function RenderString() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    RenderString.prototype.render = function () {
+        return (React.createElement(React.Fragment, null,
+            React.createElement(my_component_1.MyComponent, null),
+            React.createElement("span", null, MY_STRING),
+            React.createElement("span", { className: MY_CLASSNAME })));
+    };
+    return RenderString;
+}(React.PureComponent));
+exports["default"] = RenderString;

--- a/tests/baselines/reference/tsxFragmentChildrenCheck.symbols
+++ b/tests/baselines/reference/tsxFragmentChildrenCheck.symbols
@@ -1,0 +1,58 @@
+=== tests/cases/compiler/my-component.tsx ===
+declare var React: any;
+>React : Symbol(React, Decl(my-component.tsx, 0, 11))
+
+export function MyComponent(props: any) {
+>MyComponent : Symbol(MyComponent, Decl(my-component.tsx, 0, 23))
+>props : Symbol(props, Decl(my-component.tsx, 2, 28))
+
+    return <span>my component</span>;
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+}
+
+=== tests/cases/compiler/file1.tsx ===
+import * as React from 'react'
+>React : Symbol(React, Decl(file1.tsx, 0, 6))
+
+import { MyComponent } from './my-component'
+>MyComponent : Symbol(MyComponent, Decl(file1.tsx, 1, 8))
+
+const MY_STRING: string = 'Ceci n\'est pas une string.'
+>MY_STRING : Symbol(MY_STRING, Decl(file1.tsx, 3, 5))
+
+const MY_CLASSNAME: string = 'jeclass'
+>MY_CLASSNAME : Symbol(MY_CLASSNAME, Decl(file1.tsx, 4, 5))
+
+class RenderString extends React.PureComponent<any, any> {
+>RenderString : Symbol(RenderString, Decl(file1.tsx, 4, 38))
+>React.PureComponent : Symbol(React.PureComponent, Decl(react.d.ts, 180, 5))
+>React : Symbol(React, Decl(file1.tsx, 0, 6))
+>PureComponent : Symbol(React.PureComponent, Decl(react.d.ts, 180, 5))
+
+  render() {
+>render : Symbol(RenderString.render, Decl(file1.tsx, 6, 58))
+
+    return (
+      <>
+        <MyComponent />
+>MyComponent : Symbol(MyComponent, Decl(file1.tsx, 1, 8))
+
+        <span>{ MY_STRING }</span>
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+>MY_STRING : Symbol(MY_STRING, Decl(file1.tsx, 3, 5))
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+
+        <span className={ MY_CLASSNAME } />
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+>className : Symbol(className, Decl(file1.tsx, 12, 13))
+>MY_CLASSNAME : Symbol(MY_CLASSNAME, Decl(file1.tsx, 4, 5))
+
+      </>
+    )
+  }
+}
+
+export default RenderString
+>RenderString : Symbol(RenderString, Decl(file1.tsx, 4, 38))
+

--- a/tests/baselines/reference/tsxFragmentChildrenCheck.types
+++ b/tests/baselines/reference/tsxFragmentChildrenCheck.types
@@ -1,0 +1,68 @@
+=== tests/cases/compiler/my-component.tsx ===
+declare var React: any;
+>React : any
+
+export function MyComponent(props: any) {
+>MyComponent : (props: any) => JSX.Element
+>props : any
+
+    return <span>my component</span>;
+><span>my component</span> : JSX.Element
+>span : any
+>span : any
+}
+
+=== tests/cases/compiler/file1.tsx ===
+import * as React from 'react'
+>React : typeof React
+
+import { MyComponent } from './my-component'
+>MyComponent : (props: any) => JSX.Element
+
+const MY_STRING: string = 'Ceci n\'est pas une string.'
+>MY_STRING : string
+>'Ceci n\'est pas une string.' : "Ceci n'est pas une string."
+
+const MY_CLASSNAME: string = 'jeclass'
+>MY_CLASSNAME : string
+>'jeclass' : "jeclass"
+
+class RenderString extends React.PureComponent<any, any> {
+>RenderString : RenderString
+>React.PureComponent : React.PureComponent<any, any>
+>React : typeof React
+>PureComponent : typeof React.PureComponent
+
+  render() {
+>render : () => JSX.Element
+
+    return (
+>(      <>        <MyComponent />        <span>{ MY_STRING }</span>        <span className={ MY_CLASSNAME } />      </>    ) : JSX.Element
+
+      <>
+><>        <MyComponent />        <span>{ MY_STRING }</span>        <span className={ MY_CLASSNAME } />      </> : JSX.Element
+
+        <MyComponent />
+><MyComponent /> : JSX.Element
+>MyComponent : (props: any) => JSX.Element
+
+        <span>{ MY_STRING }</span>
+><span>{ MY_STRING }</span> : JSX.Element
+>span : any
+>MY_STRING : string
+>span : any
+
+        <span className={ MY_CLASSNAME } />
+><span className={ MY_CLASSNAME } /> : JSX.Element
+>span : any
+>className : string
+>MY_CLASSNAME : string
+
+      </>
+    )
+  }
+}
+
+export default RenderString
+>RenderString : RenderString
+

--- a/tests/cases/compiler/tsxFragmentChildrenCheck.ts
+++ b/tests/cases/compiler/tsxFragmentChildrenCheck.ts
@@ -1,0 +1,34 @@
+// @jsx: react
+// @noUnusedLocals: true
+// @noLib: true
+// @skipLibCheck: true
+// @libFiles: react.d.ts,lib.d.ts
+
+// @Filename: my-component.tsx
+declare var React: any;
+
+export function MyComponent(props: any) {
+    return <span>my component</span>;
+}
+
+// @Filename: file1.tsx
+
+import * as React from 'react'
+import { MyComponent } from './my-component'
+
+const MY_STRING: string = 'Ceci n\'est pas une string.'
+const MY_CLASSNAME: string = 'jeclass'
+
+class RenderString extends React.PureComponent<any, any> {
+  render() {
+    return (
+      <>
+        <MyComponent />
+        <span>{ MY_STRING }</span>
+        <span className={ MY_CLASSNAME } />
+      </>
+    )
+  }
+}
+
+export default RenderString


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #19939.

Previously, we were simply returning the Element type when we checked a JSXFragment. However, even though we still don't want to restrict the children of a JSXFragment, we do need to check the individual expressions and make sure they are ok.