### PR TITLE
Fix crash on non-dts-require

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17164,7 +17164,7 @@ namespace ts {
             if (targetDeclarationKind !== SyntaxKind.Unknown) {
                 const decl = getDeclarationOfKind(resolvedRequire, targetDeclarationKind);
                 // function/variable declaration should be ambient
-                return !!(decl.flags & NodeFlags.Ambient);
+                return !!decl && !!(decl.flags & NodeFlags.Ambient);
             }
             return false;
         }

--- a/tests/baselines/reference/noCrashOnParameterNamedRequire.js
+++ b/tests/baselines/reference/noCrashOnParameterNamedRequire.js
@@ -1,0 +1,11 @@
+//// [index.js]
+(function(require, module, exports){
+    const mod = require("./mod");
+    mod.foo;
+})(null, null, null);
+
+//// [index.js]
+(function (require, module, exports) {
+    var mod = require("./mod");
+    mod.foo;
+})(null, null, null);

--- a/tests/baselines/reference/noCrashOnParameterNamedRequire.symbols
+++ b/tests/baselines/reference/noCrashOnParameterNamedRequire.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/index.js ===
+(function(require, module, exports){
+>require : Symbol(require, Decl(index.js, 0, 10))
+>module : Symbol(module, Decl(index.js, 0, 18))
+>exports : Symbol(exports, Decl(index.js, 0, 26))
+
+    const mod = require("./mod");
+>mod : Symbol(mod, Decl(index.js, 1, 9))
+>require : Symbol(require, Decl(index.js, 0, 10))
+
+    mod.foo;
+>mod : Symbol(mod, Decl(index.js, 1, 9))
+
+})(null, null, null);

--- a/tests/baselines/reference/noCrashOnParameterNamedRequire.types
+++ b/tests/baselines/reference/noCrashOnParameterNamedRequire.types
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/index.js ===
+(function(require, module, exports){
+>(function(require, module, exports){    const mod = require("./mod");    mod.foo;})(null, null, null) : void
+>(function(require, module, exports){    const mod = require("./mod");    mod.foo;}) : (require: any, module: any, exports: any) => void
+>function(require, module, exports){    const mod = require("./mod");    mod.foo;} : (require: any, module: any, exports: any) => void
+>require : any
+>module : any
+>exports : any
+
+    const mod = require("./mod");
+>mod : any
+>require("./mod") : any
+>require : any
+>"./mod" : "./mod"
+
+    mod.foo;
+>mod.foo : any
+>mod : any
+>foo : any
+
+})(null, null, null);
+>null : null
+>null : null
+>null : null
+

--- a/tests/cases/compiler/noCrashOnParameterNamedRequire.ts
+++ b/tests/cases/compiler/noCrashOnParameterNamedRequire.ts
@@ -1,0 +1,8 @@
+// @allowJs: true
+// @checkJs: true
+// @outDir: ./built
+// @filename: index.js
+(function(require, module, exports){
+    const mod = require("./mod");
+    mod.foo;
+})(null, null, null);


### PR DESCRIPTION
We were crashing when a JS file contained a `require` whose reference looked like it may be a commonjs require, but did not refer to the global `require` symbol. Likely introduced by cc2a2a79b5b342a11e8e034f2f917c2c357db3d4, so it hasn't been broken long. Found while trying to add a `checkJs` user test.
