### PR TITLE
Use UTF8 BOM in emit

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -125,6 +125,8 @@ namespace ts {
     };
 
     export let sys: System = (() => {
+        const utf8ByteOrderMark = "\u00EF\u00BB\u00BF";
+
         function getNodeSystem(): System {
             const _fs = require("fs");
             const _path = require("path");
@@ -348,7 +350,7 @@ namespace ts {
             function writeFile(fileName: string, data: string, writeByteOrderMark?: boolean): void {
                 // If a BOM is required, emit one
                 if (writeByteOrderMark) {
-                    data = "\u00EF\u00BB\u00BF" + data;
+                    data = utf8ByteOrderMark + data;
                 }
 
                 let fd: number;
@@ -549,7 +551,7 @@ namespace ts {
                 writeFile(path: string, data: string, writeByteOrderMark?: boolean) {
                     // If a BOM is required, emit one
                     if (writeByteOrderMark) {
-                        data = "\u00EF\u00BB\u00BF" + data;
+                        data = utf8ByteOrderMark + data;
                     }
 
                     ChakraHost.writeFile(path, data);

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -348,7 +348,7 @@ namespace ts {
             function writeFile(fileName: string, data: string, writeByteOrderMark?: boolean): void {
                 // If a BOM is required, emit one
                 if (writeByteOrderMark) {
-                    data = "\uFEFF" + data;
+                    data = "\u00EF\u00BB\u00BF" + data;
                 }
 
                 let fd: number;
@@ -549,7 +549,7 @@ namespace ts {
                 writeFile(path: string, data: string, writeByteOrderMark?: boolean) {
                     // If a BOM is required, emit one
                     if (writeByteOrderMark) {
-                        data = "\uFEFF" + data;
+                        data = "\u00EF\u00BB\u00BF" + data;
                     }
 
                     ChakraHost.writeFile(path, data);


### PR DESCRIPTION
I found this while working on the test harness. When we write a file and pass `true` for the `writeByteOrderMark` parameter, we incorrectly prefix the content with the UTF-16 Big Endian BOM (`0xFE 0xFF`) instead of the UTF-8 BOM (`0xEF 0xBB 0xBF`), despite the fact that we explicitly write the file as UTF-8.

We don't see an error in our tests because our test harness supplies its own `writeFile` function which emits the correct BOM for tests.