### PR TITLE
Detect re-exports from "export *" in completions

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1703,8 +1703,8 @@ Actual: ${stringify(fullActual)}`);
             Harness.IO.log(stringify(sigHelp));
         }
 
-        public printCompletionListMembers() {
-            const completions = this.getCompletionListAtCaret();
+        public printCompletionListMembers(options: ts.GetCompletionsAtPositionOptions | undefined) {
+            const completions = this.getCompletionListAtCaret(options);
             this.printMembersOrCompletions(completions);
         }
 
@@ -3073,44 +3073,44 @@ Actual: ${stringify(fullActual)}`);
             hasAction: boolean | undefined,
             options: FourSlashInterface.VerifyCompletionListContainsOptions | undefined,
         ) {
-            for (const item of items) {
-                if (item.name === entryId.name && item.source === entryId.source) {
-                    if (documentation !== undefined || text !== undefined || entryId.source !== undefined) {
-                        const details = this.getCompletionEntryDetails(item.name, item.source);
+            const matchingItems = items.filter(item => item.name === entryId.name && item.source === entryId.source);
+            if (matchingItems.length === 0) {
+                const itemsString = items.map(item => stringify({ name: item.name, source: item.source, kind: item.kind })).join(",\n");
+                this.raiseError(`Expected "${stringify({ entryId, text, documentation, kind })}" to be in list [${itemsString}]`);
+            }
+            else if (matchingItems.length > 1 && !(options && options.allowDuplicate)) {
+                this.raiseError(`Found duplicate completion items for ${stringify(entryId)}`);
+            }
+            const item = matchingItems[0];
 
-                        if (documentation !== undefined) {
-                            assert.equal(ts.displayPartsToString(details.documentation), documentation, this.assertionMessageAtLastKnownMarker("completion item documentation for " + entryId));
-                        }
-                        if (text !== undefined) {
-                            assert.equal(ts.displayPartsToString(details.displayParts), text, this.assertionMessageAtLastKnownMarker("completion item detail text for " + entryId));
-                        }
+            if (documentation !== undefined || text !== undefined || entryId.source !== undefined) {
+                const details = this.getCompletionEntryDetails(item.name, item.source);
 
-                        if (entryId.source === undefined) {
-                            assert.equal(options && options.sourceDisplay, undefined);
-                        }
-                        else {
-                            assert.deepEqual(details.source, [ts.textPart(options!.sourceDisplay)]);
-                        }
-                    }
+                if (documentation !== undefined) {
+                    assert.equal(ts.displayPartsToString(details.documentation), documentation, this.assertionMessageAtLastKnownMarker("completion item documentation for " + entryId));
+                }
+                if (text !== undefined) {
+                    assert.equal(ts.displayPartsToString(details.displayParts), text, this.assertionMessageAtLastKnownMarker("completion item detail text for " + entryId));
+                }
 
-                    if (kind !== undefined) {
-                        assert.equal(item.kind, kind, this.assertionMessageAtLastKnownMarker("completion item kind for " + entryId));
-                    }
-
-                    if (spanIndex !== undefined) {
-                        const span = this.getTextSpanForRangeAtIndex(spanIndex);
-                        assert.isTrue(TestState.textSpansEqual(span, item.replacementSpan), this.assertionMessageAtLastKnownMarker(stringify(span) + " does not equal " + stringify(item.replacementSpan) + " replacement span for " + entryId));
-                    }
-
-                    assert.equal(item.hasAction, hasAction);
-
-                    return;
+                if (entryId.source === undefined) {
+                    assert.equal(options && options.sourceDisplay, undefined);
+                }
+                else {
+                    assert.deepEqual(details.source, [ts.textPart(options!.sourceDisplay)]);
                 }
             }
 
-            const itemsString = items.map(item => stringify({ name: item.name, source: item.source, kind: item.kind })).join(",\n");
+            if (kind !== undefined) {
+                assert.equal(item.kind, kind, this.assertionMessageAtLastKnownMarker("completion item kind for " + entryId));
+            }
 
-            this.raiseError(`Expected "${stringify({ entryId, text, documentation, kind })}" to be in list [${itemsString}]`);
+            if (spanIndex !== undefined) {
+                const span = this.getTextSpanForRangeAtIndex(spanIndex);
+                assert.isTrue(TestState.textSpansEqual(span, item.replacementSpan), this.assertionMessageAtLastKnownMarker(stringify(span) + " does not equal " + stringify(item.replacementSpan) + " replacement span for " + entryId));
+            }
+
+            assert.equal(item.hasAction, hasAction);
         }
 
         private findFile(indexOrName: string | number) {
@@ -4355,8 +4355,8 @@ namespace FourSlashInterface {
             this.state.printCurrentSignatureHelp();
         }
 
-        public printCompletionListMembers() {
-            this.state.printCompletionListMembers();
+        public printCompletionListMembers(options: ts.GetCompletionsAtPositionOptions | undefined) {
+            this.state.printCompletionListMembers(options);
         }
 
         public printAvailableCodeFixes() {
@@ -4555,6 +4555,7 @@ namespace FourSlashInterface {
 
     export interface VerifyCompletionListContainsOptions extends ts.GetCompletionsAtPositionOptions {
         sourceDisplay: string;
+        allowDuplicate: boolean; // TODO: GH#20042
     }
 
     export interface NewContentOptions {

--- a/tests/cases/fourslash/completionForStringLiteralNonrelativeImport8.ts
+++ b/tests/cases/fourslash/completionForStringLiteralNonrelativeImport8.ts
@@ -51,5 +51,5 @@ for (const kind of kinds) {
     verify.completionListContains("1test");
 
     goTo.marker(kind + "2");
-    verify.completionListContains("2test");
+    verify.completionListContains("2test", undefined, undefined, undefined, undefined, undefined, { allowDuplicate: true }); // TODO: GH#20042
 }

--- a/tests/cases/fourslash/completionInJSDocFunctionNew.ts
+++ b/tests/cases/fourslash/completionInJSDocFunctionNew.ts
@@ -7,4 +7,4 @@
 
 goTo.marker();
 verify.completionListCount(118);
-verify.completionListContains('new');
+verify.completionListContains('new', undefined, undefined, undefined, undefined, undefined, { allowDuplicate: true }); // TODO: GH#20042

--- a/tests/cases/fourslash/completionInJSDocFunctionThis.ts
+++ b/tests/cases/fourslash/completionInJSDocFunctionThis.ts
@@ -6,5 +6,4 @@
 
 goTo.marker();
 verify.completionListCount(119);
-verify.completionListContains('this');
-
+verify.completionListContains('this', undefined, undefined, undefined, undefined, undefined, { allowDuplicate: true }); // TODO: GH#20042

--- a/tests/cases/fourslash/completionListPrimitives.ts
+++ b/tests/cases/fourslash/completionListPrimitives.ts
@@ -8,5 +8,5 @@ verify.completionListContains("boolean");
 verify.completionListContains("null");
 verify.completionListContains("number");
 verify.completionListContains("string");
-verify.completionListContains("undefined");
+verify.completionListContains("undefined", undefined, undefined, undefined, undefined, undefined, { allowDuplicate: true }); // TODO: GH#20042
 verify.completionListContains("void");

--- a/tests/cases/fourslash/completionsImport_default_didNotExistBefore.ts
+++ b/tests/cases/fourslash/completionsImport_default_didNotExistBefore.ts
@@ -1,5 +1,7 @@
 /// <reference path="fourslash.ts" />
 
+// @noLib: true
+
 // @Filename: /a.ts
 ////export default function foo() {}
 

--- a/tests/cases/fourslash/completionsImport_ofAlias.ts
+++ b/tests/cases/fourslash/completionsImport_ofAlias.ts
@@ -11,14 +11,19 @@
 // Should not show up in completions
 ////export { foo } from "./a";
 
+// @Filename: /a_reexport_2.ts
+////export * from "./a";
+
 // @Filename: /b.ts
 ////fo/**/
 
 goTo.marker("");
 const options = { includeExternalModuleExports: true, sourceDisplay: "./a" };
 // TODO: https://github.com/Microsoft/TypeScript/issues/14003
+//TODO: verify that there's only one!
 verify.completionListContains({ name: "foo", source: "/a" }, "import foo", "", "alias", /*spanIndex*/ undefined, /*hasAction*/ true, options);
 verify.not.completionListContains({ name: "foo", source: "/a_reexport" }, undefined, undefined, undefined, undefined, undefined, options);
+verify.not.completionListContains({ name: "foo", source: "/a_reexport_2" }, undefined, undefined, undefined, undefined, undefined, options);
 
 verify.applyCodeActionFromCompletion("", {
     name: "foo",

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -148,7 +148,7 @@ declare namespace FourSlashInterface {
             kind?: string,
             spanIndex?: number,
             hasAction?: boolean,
-            options?: { includeExternalModuleExports: boolean, sourceDisplay: string },
+            options?: { includeExternalModuleExports?: boolean, sourceDisplay?: string, allowDuplicate?: boolean },
         ): void;
         completionListItemsCountIsGreaterThan(count: number): void;
         completionListIsEmpty(): void;
@@ -358,7 +358,7 @@ declare namespace FourSlashInterface {
         printCurrentFileStateWithoutCaret(): void;
         printCurrentQuickInfo(): void;
         printCurrentSignatureHelp(): void;
-        printCompletionListMembers(): void;
+        printCompletionListMembers(options?: { includeExternalModuleExports: boolean }): void;
         printAvailableCodeFixes(): void;
         printBreakpointLocation(pos: number): void;
         printBreakpointAtCurrentLocation(): void;

--- a/tests/cases/fourslash/getJavaScriptCompletions2.ts
+++ b/tests/cases/fourslash/getJavaScriptCompletions2.ts
@@ -7,4 +7,4 @@
 ////v./**/
 
 goTo.marker();
-verify.completionListContains("valueOf", /*displayText:*/ undefined, /*documentation*/ undefined, "method");
+verify.completionListContains("valueOf", /*displayText:*/ undefined, /*documentation*/ undefined, "method", undefined, undefined, { allowDuplicate: true }); // TODO: GH#20042

--- a/tests/cases/fourslash/javaScriptClass1.ts
+++ b/tests/cases/fourslash/javaScriptClass1.ts
@@ -28,4 +28,4 @@ verify.completionListContains("substr", /*displayText*/ undefined, /*documentati
 edit.backspace('bar.'.length);
 
 edit.insert('union.');
-verify.completionListContains("toString", /*displayText*/ undefined, /*documentation*/ undefined, "method");
+verify.completionListContains("toString", /*displayText*/ undefined, /*documentation*/ undefined, "method", undefined, undefined, { allowDuplicate: true });


### PR DESCRIPTION
Fixes #19889 and #19922
Testing for duplicates also uncovered #20042
