### PR TITLE
Modified Kendo regex to include -ui folders and files without min

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -1518,6 +1518,10 @@ namespace ts.projectSystem {
                 path: "/q/lib/kendo/kendo.ui.min.js",
                 content: "unspecified"
             };
+            const kendoFile3 = {
+                path: "/q/lib/kendo-ui/kendo.all.js",
+                content: "unspecified"
+            };
             const officeFile1 = {
                 path: "/scripts/Office/1/excel-15.debug.js",
                 content: "unspecified"
@@ -1526,7 +1530,7 @@ namespace ts.projectSystem {
                 path: "/scripts/Office/1/powerpoint.js",
                 content: "unspecified"
             };
-            const files = [file1, minFile, kendoFile1, kendoFile2, officeFile1, officeFile2];
+            const files = [file1, minFile, kendoFile1, kendoFile2, kendoFile3, officeFile1, officeFile2];
             const host = createServerHost(files);
             const projectService = createProjectService(host);
             try {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -145,7 +145,7 @@ namespace ts.server {
         },
         "Kendo": {
             // e.g. /Kendo3/wwwroot/lib/kendo/kendo.all.min.js
-            match: /^(.*\/kendo)\/kendo\.all\.min\.js$/i,
+            match: /^(.*\/kendo(-ui)?)\/kendo\.all(\.min)?\.js$/i,
             exclude: [["^", 1, "/.*"]],
             types: ["kendo-ui"]
         },

--- a/src/server/typesMap.json
+++ b/src/server/typesMap.json
@@ -10,7 +10,7 @@
             "types": ["winjs"]
         },
         "Kendo": {
-            "match": "^(.*\\/kendo(-ui)?\\/kendo\\.all(\\.min)?\\.js$",
+            "match": "^(.*\\/kendo(-ui)?)\\/kendo\\.all(\\.min)?\\.js$",
             "exclude": [["^", 1, "/.*"]],
             "types": ["kendo-ui"]
         },

--- a/src/server/typesMap.json
+++ b/src/server/typesMap.json
@@ -10,7 +10,7 @@
             "types": ["winjs"]
         },
         "Kendo": {
-            "match": "^(.*\\/kendo)\\/kendo\\.all\\.min\\.js$",
+            "match": "^(.*\\/kendo(-ui)?\\/kendo\\.all(\\.min)?\\.js$",
             "exclude": [["^", 1, "/.*"]],
             "types": ["kendo-ui"]
         },


### PR DESCRIPTION
Added more cases for excluding Kendo libraries. Scenarios like below are going to be excluded.

kendo/kendo.all.min.js
kendo/kendo.all.js
kendo-ui/kendo.all.min.js
kendo-ui/kendo.all.js

As a drawback, Kendo source code files inside those two folders are going to be excluded.