### PR TITLE
Report JSDoc errors as semantic errors in checkJS mode

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1273,15 +1273,16 @@ namespace ts {
 
                 Debug.assert(!!sourceFile.bindDiagnostics);
 
+                const isCheckJs = isCheckJsEnabledForFile(sourceFile, options);
                 // By default, only type-check .ts, .tsx, and 'External' files (external files are added by plugins)
                 const includeBindAndCheckDiagnostics = sourceFile.scriptKind === ScriptKind.TS || sourceFile.scriptKind === ScriptKind.TSX ||
-                    sourceFile.scriptKind === ScriptKind.External || isCheckJsEnabledForFile(sourceFile, options);
+                    sourceFile.scriptKind === ScriptKind.External || isCheckJs;
                 const bindDiagnostics = includeBindAndCheckDiagnostics ? sourceFile.bindDiagnostics : emptyArray;
                 const checkDiagnostics = includeBindAndCheckDiagnostics ? typeChecker.getDiagnostics(sourceFile, cancellationToken) : emptyArray;
                 const fileProcessingDiagnosticsInFile = fileProcessingDiagnostics.getDiagnostics(sourceFile.fileName);
                 const programDiagnosticsInFile = programDiagnostics.getDiagnostics(sourceFile.fileName);
                 let diagnostics = bindDiagnostics.concat(checkDiagnostics, fileProcessingDiagnosticsInFile, programDiagnosticsInFile);
-                if (isCheckJsEnabledForFile(sourceFile, options)) {
+                if (isCheckJs) {
                     diagnostics = concatenate(diagnostics, sourceFile.jsDocDiagnostics);
                 }
                 return filter(diagnostics, shouldReportDiagnostic);

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1227,9 +1227,6 @@ namespace ts {
             if (isSourceFileJavaScript(sourceFile)) {
                 if (!sourceFile.additionalSyntacticDiagnostics) {
                     sourceFile.additionalSyntacticDiagnostics = getJavaScriptSyntacticDiagnosticsForFile(sourceFile);
-                    if (isCheckJsEnabledForFile(sourceFile, options)) {
-                        sourceFile.additionalSyntacticDiagnostics = concatenate(sourceFile.additionalSyntacticDiagnostics, sourceFile.jsDocDiagnostics);
-                    }
                 }
                 return concatenate(sourceFile.additionalSyntacticDiagnostics, sourceFile.parseDiagnostics);
             }
@@ -1283,8 +1280,10 @@ namespace ts {
                 const checkDiagnostics = includeBindAndCheckDiagnostics ? typeChecker.getDiagnostics(sourceFile, cancellationToken) : emptyArray;
                 const fileProcessingDiagnosticsInFile = fileProcessingDiagnostics.getDiagnostics(sourceFile.fileName);
                 const programDiagnosticsInFile = programDiagnostics.getDiagnostics(sourceFile.fileName);
-
-                const diagnostics = bindDiagnostics.concat(checkDiagnostics, fileProcessingDiagnosticsInFile, programDiagnosticsInFile);
+                let diagnostics = bindDiagnostics.concat(checkDiagnostics, fileProcessingDiagnosticsInFile, programDiagnosticsInFile);
+                if (isCheckJsEnabledForFile(sourceFile, options)) {
+                    diagnostics = concatenate(diagnostics, sourceFile.jsDocDiagnostics);
+                }
                 return filter(diagnostics, shouldReportDiagnostic);
             });
         }

--- a/tests/baselines/reference/syntaxErrors.errors.txt
+++ b/tests/baselines/reference/syntaxErrors.errors.txt
@@ -12,8 +12,10 @@ tests/cases/conformance/jsdoc/badTypeArguments.js(2,22): error TS1009: Trailing 
     /** @param {C.<number,>} y */
                          ~
 !!! error TS1009: Trailing comma not allowed.
-    function f(x, y) {
+    // @ts-ignore
+    /** @param {C.<number,>} skipped */
+    function f(x, y, skipped) {
         return x.t + y.t;
     }
-    var x = f({ t: 1000 }, { t: 3000 });
+    var x = f({ t: 1000 }, { t: 3000 }, { t: 5000 });
     

--- a/tests/baselines/reference/syntaxErrors.symbols
+++ b/tests/baselines/reference/syntaxErrors.symbols
@@ -8,22 +8,26 @@ declare class C<T> { t: T }
 === tests/cases/conformance/jsdoc/badTypeArguments.js ===
 /** @param {C.<>} x */
 /** @param {C.<number,>} y */
-function f(x, y) {
+// @ts-ignore
+/** @param {C.<number,>} skipped */
+function f(x, y, skipped) {
 >f : Symbol(f, Decl(badTypeArguments.js, 0, 0))
->x : Symbol(x, Decl(badTypeArguments.js, 2, 11))
->y : Symbol(y, Decl(badTypeArguments.js, 2, 13))
+>x : Symbol(x, Decl(badTypeArguments.js, 4, 11))
+>y : Symbol(y, Decl(badTypeArguments.js, 4, 13))
+>skipped : Symbol(skipped, Decl(badTypeArguments.js, 4, 16))
 
     return x.t + y.t;
 >x.t : Symbol(C.t, Decl(dummyType.d.ts, 0, 20))
->x : Symbol(x, Decl(badTypeArguments.js, 2, 11))
+>x : Symbol(x, Decl(badTypeArguments.js, 4, 11))
 >t : Symbol(C.t, Decl(dummyType.d.ts, 0, 20))
 >y.t : Symbol(C.t, Decl(dummyType.d.ts, 0, 20))
->y : Symbol(y, Decl(badTypeArguments.js, 2, 13))
+>y : Symbol(y, Decl(badTypeArguments.js, 4, 13))
 >t : Symbol(C.t, Decl(dummyType.d.ts, 0, 20))
 }
-var x = f({ t: 1000 }, { t: 3000 });
->x : Symbol(x, Decl(badTypeArguments.js, 5, 3))
+var x = f({ t: 1000 }, { t: 3000 }, { t: 5000 });
+>x : Symbol(x, Decl(badTypeArguments.js, 7, 3))
 >f : Symbol(f, Decl(badTypeArguments.js, 0, 0))
->t : Symbol(t, Decl(badTypeArguments.js, 5, 11))
->t : Symbol(t, Decl(badTypeArguments.js, 5, 24))
+>t : Symbol(t, Decl(badTypeArguments.js, 7, 11))
+>t : Symbol(t, Decl(badTypeArguments.js, 7, 24))
+>t : Symbol(t, Decl(badTypeArguments.js, 7, 37))
 

--- a/tests/baselines/reference/syntaxErrors.types
+++ b/tests/baselines/reference/syntaxErrors.types
@@ -8,10 +8,13 @@ declare class C<T> { t: T }
 === tests/cases/conformance/jsdoc/badTypeArguments.js ===
 /** @param {C.<>} x */
 /** @param {C.<number,>} y */
-function f(x, y) {
->f : (x: C<any>, y: C<number>) => any
+// @ts-ignore
+/** @param {C.<number,>} skipped */
+function f(x, y, skipped) {
+>f : (x: C<any>, y: C<number>, skipped: C<number>) => any
 >x : C<any>
 >y : C<number>
+>skipped : C<number>
 
     return x.t + y.t;
 >x.t + y.t : any
@@ -22,14 +25,17 @@ function f(x, y) {
 >y : C<number>
 >t : number
 }
-var x = f({ t: 1000 }, { t: 3000 });
+var x = f({ t: 1000 }, { t: 3000 }, { t: 5000 });
 >x : any
->f({ t: 1000 }, { t: 3000 }) : any
->f : (x: C<any>, y: C<number>) => any
+>f({ t: 1000 }, { t: 3000 }, { t: 5000 }) : any
+>f : (x: C<any>, y: C<number>, skipped: C<number>) => any
 >{ t: 1000 } : { t: number; }
 >t : number
 >1000 : 1000
 >{ t: 3000 } : { t: number; }
 >t : number
 >3000 : 3000
+>{ t: 5000 } : { t: number; }
+>t : number
+>5000 : 5000
 

--- a/tests/cases/conformance/jsdoc/syntaxErrors.ts
+++ b/tests/cases/conformance/jsdoc/syntaxErrors.ts
@@ -8,7 +8,9 @@ declare class C<T> { t: T }
 // @Filename: badTypeArguments.js
 /** @param {C.<>} x */
 /** @param {C.<number,>} y */
-function f(x, y) {
+// @ts-ignore
+/** @param {C.<number,>} skipped */
+function f(x, y, skipped) {
     return x.t + y.t;
 }
-var x = f({ t: 1000 }, { t: 3000 });
+var x = f({ t: 1000 }, { t: 3000 }, { t: 5000 });


### PR DESCRIPTION
Fixes #19999 

This allows reporting of semantic errors as well. Semantic errors are likely to outnumber syntactic errors, so it's valuable not to block semantic errors on a few syntactic errors.