### PR TITLE
Moved minified file exclusion

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -156,9 +156,8 @@ namespace ts.server {
             "exclude": [["^", 1, "/.*"]],                     // Exclude that whole folder if the file indicated above is found in it
             "types": ["office"]                               // @types package to fetch instead
         },
-        "Minified files": {
-            // e.g. /whatever/blah.min.js
-            "match": /^(.+\.min\.js)$/i,
+        "References": {
+            "match": /^(.*\/_references\.js)$/i,
             "exclude": [["^", 1, "$"]]
         }
     };

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1881,7 +1881,13 @@ namespace ts.server {
                         }
                     }
                     if (!exclude) {
-                        filesToKeep.push(proj.rootFiles[i]);
+                        // Exclude any minified files that get this far
+                        if (/^.+[\.-]min\.js$/.test(normalizedNames[i])) {
+                            excludedFiles.push(normalizedNames[i]);
+                        }
+                        else {
+                            filesToKeep.push(proj.rootFiles[i]);
+                        }
                     }
                 }
             }

--- a/src/server/typesMap.json
+++ b/src/server/typesMap.json
@@ -10,7 +10,7 @@
             "types": ["winjs"]
         },
         "Kendo": {
-            "match": "^(.*\\/kendo)\\/kendo\\.all\\.min\\.js$",
+            "match": "^(.*\\/kendo(-ui)?)\\/kendo\\.all(\\.min)?\\.js$",
             "exclude": [["^", 1, "/.*"]],
             "types": ["kendo-ui"]
         },
@@ -19,8 +19,8 @@
             "exclude": [["^", 1, "/.*"]],
             "types": ["office"]
         },
-        "Minified files": {
-            "match": "^(.+\\.min\\.js)$",
+        "References": {
+            "match": "^(.*\\/_references\\.js)$",
             "exclude": [["^", 1, "$"]]
         }
     },


### PR DESCRIPTION
CC @RyanCavanaugh 

This excludes minified files only after all other safelist processing. It also excludes the _references.js file with may already exist in old projects and continue to suck in all JavaScript.

Also included the improved Kendo detection from @armanio123 