### PR TITLE
Omit late bound privates from declaration emit if their name is inaccessable

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -1237,14 +1237,23 @@ namespace ts {
             enclosingDeclaration = prevEnclosingDeclaration;
         }
 
-        function emitPropertyDeclaration(node: Declaration) {
-            if (hasDynamicName(node) && !resolver.isLateBound(node)) {
+        function hasNoncollidingLateBoundPropertyName(node: VariableDeclaration | PropertyDeclaration | PropertySignature | ParameterDeclaration) {
+            if (!hasModifier(node, ModifierFlags.Private)) {
+                return false;
+            }
+            const entityName = (node as NamedDeclaration as LateBoundDeclaration).name.expression;
+            const visibilityResult = resolver.isEntityNameVisible(entityName, enclosingDeclaration);
+            return visibilityResult.accessibility !== SymbolAccessibility.Accessible;
+        }
+
+        function emitPropertyDeclaration(node: ParameterDeclaration | PropertyDeclaration) {
+            if (hasDynamicName(node) && (!resolver.isLateBound(node) || hasNoncollidingLateBoundPropertyName(node))) {
                 return;
             }
 
             emitJsDocComments(node);
             emitClassMemberDeclarationFlags(getModifierFlags(node));
-            emitVariableDeclaration(<VariableDeclaration>node);
+            emitVariableDeclaration(node);
             write(";");
             writeLine();
         }

--- a/tests/baselines/reference/privateSymbolNoDeclarationEmit.js
+++ b/tests/baselines/reference/privateSymbolNoDeclarationEmit.js
@@ -1,0 +1,23 @@
+//// [privateSymbolNoDeclarationEmit.ts]
+const _data = Symbol('data');
+
+export class User {
+    private [_data] : any;
+};
+
+//// [privateSymbolNoDeclarationEmit.js]
+"use strict";
+exports.__esModule = true;
+var _data = Symbol('data');
+var User = /** @class */ (function () {
+    function User() {
+    }
+    return User;
+}());
+exports.User = User;
+;
+
+
+//// [privateSymbolNoDeclarationEmit.d.ts]
+export declare class User {
+}

--- a/tests/baselines/reference/privateSymbolNoDeclarationEmit.symbols
+++ b/tests/baselines/reference/privateSymbolNoDeclarationEmit.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/privateSymbolNoDeclarationEmit.ts ===
+const _data = Symbol('data');
+>_data : Symbol(_data, Decl(privateSymbolNoDeclarationEmit.ts, 0, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+
+export class User {
+>User : Symbol(User, Decl(privateSymbolNoDeclarationEmit.ts, 0, 29))
+
+    private [_data] : any;
+>_data : Symbol(_data, Decl(privateSymbolNoDeclarationEmit.ts, 0, 5))
+
+};

--- a/tests/baselines/reference/privateSymbolNoDeclarationEmit.types
+++ b/tests/baselines/reference/privateSymbolNoDeclarationEmit.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/privateSymbolNoDeclarationEmit.ts ===
+const _data = Symbol('data');
+>_data : unique symbol
+>Symbol('data') : unique symbol
+>Symbol : SymbolConstructor
+>'data' : "data"
+
+export class User {
+>User : User
+
+    private [_data] : any;
+>_data : unique symbol
+
+};

--- a/tests/cases/compiler/privateSymbolNoDeclarationEmit.ts
+++ b/tests/cases/compiler/privateSymbolNoDeclarationEmit.ts
@@ -1,0 +1,7 @@
+// @lib: es6
+// @declaration: true
+const _data = Symbol('data');
+
+export class User {
+    private [_data] : any;
+};


### PR DESCRIPTION
This _may_ only be considered always safe enough to do if the private is a `unique symbol`; then again this is likely fine for all late bound names (as implemented) as prior to adding late bound name support we would have elided them anyway.

Fixes #20080
