### PR TITLE
Always send a response to installTypings even if all types are cached

### DIFF
--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -300,8 +300,9 @@ namespace ts.server.typingsInstaller {
             const filteredTypings = this.filterTypings(typingsToInstall);
             if (filteredTypings.length === 0) {
                 if (this.log.isEnabled()) {
-                    this.log.writeLine(`All typings are known to be missing or invalid - no need to go any further`);
+                    this.log.writeLine(`All typings are known to be missing or invalid - no need to install more typings`);
                 }
+                this.sendResponse(this.createSetTypings(req, currentlyCachedTypings));
                 return;
             }
 


### PR DESCRIPTION
`installTypings` needs to *always* send exactly 1 response