### PR TITLE
Exclude global types from devtools user test

### DIFF
--- a/tests/cases/user/chrome-devtools-frontend/tsconfig.json
+++ b/tests/cases/user/chrome-devtools-frontend/tsconfig.json
@@ -3,7 +3,8 @@
         "outDir": "./built",
         "allowJs": true,
         "checkJs": true,
-        "lib": ["dom", "es2017"]
+        "lib": ["dom", "es2017"],
+        "types": []
     },
     "include": [
         "./node_modules/chrome-devtools-frontend/front_end/**/*.js"


### PR DESCRIPTION
Because it contained a handful of conflicting declarations which happened to trigger an error from #19356, which has a machine-specific path in the message.

Could we revert #19356 and instead implement #10489 in the near future? At least internally I don't think we've ever been happy with seeing those paths in any baselines; especially when they appear in a library file.