### PR TITLE
Convert legacy safe list keys to lowercase on construction

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -1561,7 +1561,11 @@ namespace ts.projectSystem {
                 path: "/a/b/foo.js",
                 content: ""
             };
-            const host = createServerHost([file1, file2, customTypesMap]);
+            const file3 = {
+                path: "/a/b/Bacon.js",
+                content: "let y = 5"
+            };
+            const host = createServerHost([file1, file2, file3, customTypesMap]);
             const projectService = createProjectService(host);
             try {
                 projectService.openExternalProject({ projectFileName: "project", options: {}, rootFiles: toExternalFiles([file1.path, file2.path]), typeAcquisition: { enable: true } });

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -528,7 +528,9 @@ namespace ts.server {
                 // raw is now fixed and ready
                 this.safelist = raw.typesMap;
                 for (const key in raw.simpleMap) {
-                    this.legacySafelist[key] = raw.simpleMap[key].toLowerCase();
+                    if (raw.simpleMap.hasOwnProperty(key)) {
+                        this.legacySafelist[key] = raw.simpleMap[key].toLowerCase();
+                    }
                 }
             }
             catch (e) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -527,7 +527,9 @@ namespace ts.server {
                 }
                 // raw is now fixed and ready
                 this.safelist = raw.typesMap;
-                this.legacySafelist = raw.simpleMap;
+                for (const key in raw.simpleMap) {
+                    this.legacySafelist[key] = raw.simpleMap[key].toLowerCase();
+                }
             }
             catch (e) {
                 this.logger.info(`Error loading types map: ${e}`);


### PR DESCRIPTION
...because we convert them to lowercase before checking membership.  As a result, safe list entries containing uppercase letters (e.g. "Bacon") never match.