### PR TITLE
Correct project root path passed to Typings Installer

### DIFF
--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -43,7 +43,7 @@ namespace ts.server {
                 return <Path>"";
             case ProjectKind.External:
                 const projectName = normalizeSlashes(project.getProjectName());
-                return project.projectService.host.fileExists(projectName) ? <Path>getDirectoryPath(projectName) : <Path>projectName;
+                return <Path>getDirectoryPath(projectName);
         }
     }
 


### PR DESCRIPTION
`createInstallTypingsRequest` has its own logic for extracting the
project root path from the project name and it disagrees with the
versions in the project flavors.  In particular, it only drops the last
component of the name if it exists.  For folder projects and JS-only
contexts, this will not be the case, but the last entry should still be
dropped.

TL;DR: stop creating filewatchers for
"c:/foo/foo.csproj*jscontent/node_modules"