### PR TITLE
Add dt baseline folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ tests/cases/user/*/**/*.d.ts
 !tests/cases/user/zone.js/
 !tests/cases/user/bignumber.js/
 !tests/cases/user/discord.js/
+tests/baselines/reference/dt


### PR DESCRIPTION
This way I can keep using `git add .` when I have `dt` baselines saved locally.
