### PR TITLE
Watch directories through polling when recursive options is not supported on the system

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -577,7 +577,7 @@ gulp.task(specMd, /*help*/ false, [word2mdJs], (done) => {
 gulp.task("generate-spec", "Generates a Markdown version of the Language Specification", [specMd]);
 
 gulp.task("clean", "Cleans the compiler output, declare files, and tests", [], () => {
-    return del([builtDirectory]);
+    return del([builtDirectory, processDiagnosticMessagesJs, generatedDiagnosticMessagesJSON, diagnosticInfoMapTs]);
 });
 
 gulp.task("useDebugMode", /*help*/ false, [], (done) => { useDebugMode = true; done(); });

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -716,6 +716,9 @@ task("default", ["local"]);
 desc("Cleans the compiler output, declare files, and tests");
 task("clean", function () {
     jake.rmRf(builtDirectory);
+    jake.rmRf(processDiagnosticMessagesJs);
+    jake.rmRf(generatedDiagnosticMessagesJSON);
+    jake.rmRf(diagnosticInfoMapTs);
 });
 
 // Generate Markdown spec

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2025,7 +2025,7 @@ namespace ts {
     export function getFileNamesFromConfigSpecs(spec: ConfigFileSpecs, basePath: string, options: CompilerOptions, host: ParseConfigHost, extraFileExtensions: ReadonlyArray<JsFileExtensionInfo> = []): ExpandResult {
         basePath = normalizePath(basePath);
 
-        const keyMapper = host.useCaseSensitiveFileNames ? caseSensitiveKeyMapper : caseInsensitiveKeyMapper;
+        const keyMapper = host.useCaseSensitiveFileNames ? identity : toLowerCase;
 
         // Literal file names (provided via the "files" array in tsconfig.json) are stored in a
         // file map with a possibly case insensitive key. We use this map later when when including
@@ -2230,24 +2230,6 @@ namespace ts {
             const lowerPriorityPath = keyMapper(changeExtension(file, lowerPriorityExtension));
             wildcardFiles.delete(lowerPriorityPath);
         }
-    }
-
-    /**
-     * Gets a case sensitive key.
-     *
-     * @param key The original key.
-     */
-    function caseSensitiveKeyMapper(key: string) {
-        return key;
-    }
-
-    /**
-     * Gets a case insensitive key.
-     *
-     * @param key The original key.
-     */
-    function caseInsensitiveKeyMapper(key: string) {
-        return key.toLowerCase();
     }
 
     /**

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -20,6 +20,12 @@ namespace ts {
 
 /* @internal */
 namespace ts {
+    export const emptyArray: never[] = [] as never[];
+
+    export function closeFileWatcher(watcher: FileWatcher) {
+        watcher.close();
+    }
+
     /** Create a MapLike with good performance. */
     function createDictionaryObject<T>(): MapLike<T> {
         const map = Object.create(/*prototype*/ null); // tslint:disable-line:no-null-keyword

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1398,6 +1398,9 @@ namespace ts {
     /** Returns its argument. */
     export function identity<T>(x: T) { return x; }
 
+    /** Returns the lower case string */
+    export function toLowerCase(x: string) { return x.toLowerCase(); }
+
     /** Throws an error because a function is not implemented. */
     export function notImplemented(): never {
         throw new Error("Not implemented");
@@ -2871,9 +2874,7 @@ namespace ts {
 
     export type GetCanonicalFileName = (fileName: string) => string;
     export function createGetCanonicalFileName(useCaseSensitiveFileNames: boolean): GetCanonicalFileName {
-        return useCaseSensitiveFileNames
-            ? ((fileName) => fileName)
-            : ((fileName) => fileName.toLowerCase());
+        return useCaseSensitiveFileNames ? identity : toLowerCase;
     }
 
     /**

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -832,6 +832,44 @@ namespace ts {
         return result;
     }
 
+    /**
+     * Enumreates on two sorted arrays newItems and oldItems by invoking
+     * - inserted on items that are present in newItems but not in oldItems
+     * - deleted on items that are present in oldItems but not in newIterms
+     * - unchanged if provided on items that are present in both newItems and oldItems
+     */
+    export function enumerateInsertsAndDeletes<T, U>(newItems: ReadonlyArray<T>, oldItems: ReadonlyArray<U>, comparer: (a: T, b: U) => Comparison, inserted: (newItem: T) => void, deleted: (oldItem: U) => void, unchanged?: (oldItem: U, newItem: T) => void) {
+        unchanged = unchanged || noop;
+        let newIndex = 0;
+        let oldIndex = 0;
+        const newLen = newItems.length;
+        const oldLen = oldItems.length;
+        while (newIndex < newLen && oldIndex < oldLen) {
+            const newItem = newItems[newIndex];
+            const oldItem = oldItems[oldIndex];
+            const compareResult = comparer(newItem, oldItem);
+            if (compareResult === Comparison.LessThan) {
+                inserted(newItem);
+                newIndex++;
+            }
+            else if (compareResult === Comparison.GreaterThan) {
+                deleted(oldItem);
+                oldIndex++;
+            }
+            else {
+                unchanged(oldItem, newItem);
+                newIndex++;
+                oldIndex++;
+            }
+        }
+        while (newIndex < newLen) {
+            inserted(newItems[newIndex++]);
+        }
+        while (oldIndex < oldLen) {
+            deleted(oldItems[oldIndex++]);
+        }
+    }
+
     export function sum<T extends Record<K, number>, K extends string>(array: ReadonlyArray<T>, prop: K): number {
         let result = 0;
         for (const v of array) {

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -217,7 +217,7 @@ namespace ts {
              * Create new childDirectoryWatcher and add it to the new ChildDirectoryWatcher list
              */
             function createAndAddChildDirectoryWatcher(childName: string) {
-                const childPath = getNormalizedAbsolutePath(parentDir, childName);
+                const childPath = ts.getNormalizedAbsolutePath(childName, parentDir);
                 const result = createDirectoryWatcher(childPath) as ChildDirectoryWatcher;
                 result.childName = childName;
                 addChildDirectoryWatcher(result);

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -145,7 +145,6 @@ namespace ts {
             }
 
             const useNonPollingWatchers = process.env.TSC_NONPOLLING_WATCHER;
-            const watchedFileSet = createWatchedFileSet();
 
             const nodeSystem: System = {
                 args: process.argv.slice(2),
@@ -156,17 +155,7 @@ namespace ts {
                 },
                 readFile,
                 writeFile,
-                watchFile: (fileName, callback, pollingInterval) => {
-                    if (useNonPollingWatchers) {
-                        const watchedFile = watchedFileSet.addFile(fileName, callback);
-                        return {
-                            close: () => watchedFileSet.removeFile(watchedFile)
-                        };
-                    }
-                    else {
-                        return fsWatchFile(fileName, callback, pollingInterval);
-                    }
-                },
+                watchFile: useNonPollingWatchers ? createNonPollingWatchFile() : fsWatchFile,
                 watchDirectory: (directoryName, callback, recursive) => {
                     // Node 4.0 `fs.watch` function supports the "recursive" option on both OSX and Windows
                     // (ref: https://github.com/nodejs/node/pull/2649 and https://github.com/Microsoft/TypeScript/issues/4643)
@@ -265,73 +254,53 @@ namespace ts {
                 });
             }
 
-            function createWatchedFileSet() {
-                const dirWatchers = createMap<DirectoryWatcher>();
+            function createNonPollingWatchFile() {
                 // One file can have multiple watchers
                 const fileWatcherCallbacks = createMultiMap<FileWatcherCallback>();
-                return { addFile, removeFile };
+                const dirWatchers = createMap<DirectoryWatcher>();
+                const toCanonicalName = createGetCanonicalFileName(useCaseSensitiveFileNames);
+                return nonPollingWatchFile;
 
-                function reduceDirWatcherRefCountForFile(fileName: string) {
-                    const dirName = getDirectoryPath(fileName);
-                    const watcher = dirWatchers.get(dirName);
-                    if (watcher) {
-                        watcher.referenceCount -= 1;
-                        if (watcher.referenceCount <= 0) {
-                            watcher.close();
-                            dirWatchers.delete(dirName);
-                        }
-                    }
-                }
-
-                function addDirWatcher(dirPath: string): void {
-                    let watcher = dirWatchers.get(dirPath);
-                    if (watcher) {
-                        watcher.referenceCount += 1;
-                        return;
-                    }
-                    watcher = fsWatchDirectory(
-                        dirPath || ".",
-                        (eventName: string, relativeFileName: string) => fileEventHandler(eventName, relativeFileName, dirPath)
-                    ) as DirectoryWatcher;
-                    watcher.referenceCount = 1;
-                    dirWatchers.set(dirPath, watcher);
-                    return;
-                }
-
-                function addFileWatcherCallback(filePath: string, callback: FileWatcherCallback): void {
+                function nonPollingWatchFile(fileName: string, callback: FileWatcherCallback): FileWatcher {
+                    const filePath = toCanonicalName(fileName);
                     fileWatcherCallbacks.add(filePath, callback);
+                    const dirPath = getDirectoryPath(filePath) || ".";
+                    const watcher = dirWatchers.get(dirPath) || createDirectoryWatcher(getDirectoryPath(fileName) || ".", dirPath);
+                    watcher.referenceCount++;
+                    return {
+                        close: () => {
+                            if (watcher.referenceCount === 1) {
+                                watcher.close();
+                                dirWatchers.delete(dirPath);
+                            }
+                            else {
+                                watcher.referenceCount--;
+                            }
+                            fileWatcherCallbacks.remove(filePath, callback);
+                        }
+                    };
                 }
 
-                function addFile(fileName: string, callback: FileWatcherCallback): WatchedFile {
-                    addFileWatcherCallback(fileName, callback);
-                    addDirWatcher(getDirectoryPath(fileName));
-
-                    return { fileName, callback };
-                }
-
-                function removeFile(watchedFile: WatchedFile) {
-                    removeFileWatcherCallback(watchedFile.fileName, watchedFile.callback);
-                    reduceDirWatcherRefCountForFile(watchedFile.fileName);
-                }
-
-                function removeFileWatcherCallback(filePath: string, callback: FileWatcherCallback) {
-                    fileWatcherCallbacks.remove(filePath, callback);
-                }
-
-                function fileEventHandler(eventName: string, relativeFileName: string | undefined, baseDirPath: string) {
-                    // When files are deleted from disk, the triggered "rename" event would have a relativefileName of "undefined"
-                    const fileName = !isString(relativeFileName)
-                        ? undefined
-                        : ts.getNormalizedAbsolutePath(relativeFileName, baseDirPath);
-                    // Some applications save a working file via rename operations
-                    if ((eventName === "change" || eventName === "rename")) {
-                        const callbacks = fileWatcherCallbacks.get(fileName);
-                        if (callbacks) {
-                            for (const fileCallback of callbacks) {
-                                fileCallback(fileName, FileWatcherEventKind.Changed);
+                function createDirectoryWatcher(dirName: string, dirPath: string) {
+                    const watcher = fsWatchDirectory(
+                        dirName,
+                        (_eventName: string, relativeFileName) => {
+                            // When files are deleted from disk, the triggered "rename" event would have a relativefileName of "undefined"
+                            const fileName = !isString(relativeFileName)
+                                ? undefined
+                                : ts.getNormalizedAbsolutePath(relativeFileName, dirName);
+                            // Some applications save a working file via rename operations
+                            const callbacks = fileWatcherCallbacks.get(toCanonicalName(fileName));
+                            if (callbacks) {
+                                for (const fileCallback of callbacks) {
+                                    fileCallback(fileName, FileWatcherEventKind.Changed);
+                                }
                             }
                         }
-                    }
+                    ) as DirectoryWatcher;
+                    watcher.referenceCount = 0;
+                    dirWatchers.set(dirPath, watcher);
+                    return watcher;
                 }
             }
 

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -290,12 +290,11 @@ namespace ts {
                         callback
                     );
                     dirWatcher.on("error", () => {
-                        if (!directoryExists(directoryName)) {
-                            // Deleting directory
-                            watcher = watchMissingDirectory();
-                            // Call the callback for current directory
-                            callback("rename", "");
-                        }
+                        // Watch the missing directory
+                        watcher.close();
+                        watcher = watchMissingDirectory();
+                        // Call the callback for current directory
+                        callback("rename", "");
                     });
                     return dirWatcher;
                 }

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -231,26 +231,28 @@ namespace ts {
 
             function fsWatchFile(fileName: string, callback: FileWatcherCallback, pollingInterval?: number): FileWatcher {
                 _fs.watchFile(fileName, { persistent: true, interval: pollingInterval || 250 }, fileChanged);
+                let eventKind: FileWatcherEventKind;
                 return {
                     close: () => _fs.unwatchFile(fileName, fileChanged)
                 };
 
                 function fileChanged(curr: any, prev: any) {
-                    const isCurrZero = +curr.mtime === 0;
-                    const isPrevZero = +prev.mtime === 0;
-                    const created = !isCurrZero && isPrevZero;
-                    const deleted = isCurrZero && !isPrevZero;
-
-                    const eventKind = created
-                        ? FileWatcherEventKind.Created
-                        : deleted
-                            ? FileWatcherEventKind.Deleted
-                            : FileWatcherEventKind.Changed;
-
-                    if (eventKind === FileWatcherEventKind.Changed && +curr.mtime <= +prev.mtime) {
+                    if (+curr.mtime === 0) {
+                        eventKind = FileWatcherEventKind.Deleted;
+                    }
+                    // previous event kind check is to ensure we send created event when file is restored or renamed twice (that is it disappears and reappears)
+                    // since in that case the prevTime returned is same as prev time of event when file was deleted as per node documentation
+                    else if (+prev.mtime === 0 || eventKind === FileWatcherEventKind.Deleted) {
+                        eventKind = FileWatcherEventKind.Created;
+                    }
+                    // If there is no change in modified time, ignore the event
+                    else if (+curr.mtime === +prev.mtime) {
                         return;
                     }
-
+                    else {
+                        // File changed
+                        eventKind = FileWatcherEventKind.Changed;
+                    }
                     callback(fileName, eventKind);
                 }
             }

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -125,11 +125,6 @@ namespace ts {
     };
 
     /*@internal*/
-    export function closeFileWatcher(watcher: FileWatcher) {
-        watcher.close();
-    }
-
-    /*@internal*/
     export interface PollingWatchDirectoryHost {
         watchFile: System["watchFile"];
         getAccessileSortedChildDirectories(path: string): ReadonlyArray<string>;

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -133,7 +133,137 @@ namespace ts {
             const _os = require("os");
             const _crypto = require("crypto");
 
+            const nodeVersion = getNodeMajorVersion();
+            const isNode4OrLater = nodeVersion >= 4;
+
+            const platform: string = _os.platform();
+            const useCaseSensitiveFileNames = isFileSystemCaseSensitive();
+
+            const enum FileSystemEntryKind {
+                File,
+                Directory
+            }
+
             const useNonPollingWatchers = process.env.TSC_NONPOLLING_WATCHER;
+            const watchedFileSet = createWatchedFileSet();
+
+            const nodeSystem: System = {
+                args: process.argv.slice(2),
+                newLine: _os.EOL,
+                useCaseSensitiveFileNames,
+                write(s: string): void {
+                    process.stdout.write(s);
+                },
+                readFile,
+                writeFile,
+                watchFile: (fileName, callback, pollingInterval) => {
+                    if (useNonPollingWatchers) {
+                        const watchedFile = watchedFileSet.addFile(fileName, callback);
+                        return {
+                            close: () => watchedFileSet.removeFile(watchedFile)
+                        };
+                    }
+                    else {
+                        return fsWatchFile(fileName, callback, pollingInterval);
+                    }
+                },
+                watchDirectory: (directoryName, callback, recursive) => {
+                    // Node 4.0 `fs.watch` function supports the "recursive" option on both OSX and Windows
+                    // (ref: https://github.com/nodejs/node/pull/2649 and https://github.com/Microsoft/TypeScript/issues/4643)
+                    return fsWatchDirectory(directoryName, (eventName, relativeFileName) => {
+                        // In watchDirectory we only care about adding and removing files (when event name is
+                        // "rename"); changes made within files are handled by corresponding fileWatchers (when
+                        // event name is "change")
+                        if (eventName === "rename") {
+                            // When deleting a file, the passed baseFileName is null
+                            callback(!relativeFileName ? relativeFileName : normalizePath(combinePaths(directoryName, relativeFileName)));
+                        }
+                    }, recursive);
+                },
+                resolvePath: path => _path.resolve(path),
+                fileExists,
+                directoryExists,
+                createDirectory(directoryName: string) {
+                    if (!nodeSystem.directoryExists(directoryName)) {
+                        _fs.mkdirSync(directoryName);
+                    }
+                },
+                getExecutingFilePath() {
+                    return __filename;
+                },
+                getCurrentDirectory() {
+                    return process.cwd();
+                },
+                getDirectories,
+                getEnvironmentVariable(name: string) {
+                    return process.env[name] || "";
+                },
+                readDirectory,
+                getModifiedTime(path) {
+                    try {
+                        return _fs.statSync(path).mtime;
+                    }
+                    catch (e) {
+                        return undefined;
+                    }
+                },
+                createHash(data) {
+                    const hash = _crypto.createHash("md5");
+                    hash.update(data);
+                    return hash.digest("hex");
+                },
+                getMemoryUsage() {
+                    if (global.gc) {
+                        global.gc();
+                    }
+                    return process.memoryUsage().heapUsed;
+                },
+                getFileSize(path) {
+                    try {
+                        const stat = _fs.statSync(path);
+                        if (stat.isFile()) {
+                            return stat.size;
+                        }
+                    }
+                    catch { /*ignore*/ }
+                    return 0;
+                },
+                exit(exitCode?: number): void {
+                    process.exit(exitCode);
+                },
+                realpath(path: string): string {
+                    return _fs.realpathSync(path);
+                },
+                debugMode: some(<string[]>process.execArgv, arg => /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(arg)),
+                tryEnableSourceMapsForHost() {
+                    try {
+                        require("source-map-support").install();
+                    }
+                    catch {
+                        // Could not enable source maps.
+                    }
+                },
+                setTimeout,
+                clearTimeout
+            };
+            return nodeSystem;
+
+            function isFileSystemCaseSensitive(): boolean {
+                // win32\win64 are case insensitive platforms
+                if (platform === "win32" || platform === "win64") {
+                    return false;
+                }
+                // If this file exists under a different case, we must be case-insensitve.
+                return !fileExists(swapCase(__filename));
+            }
+
+            /** Convert all lowercase chars to uppercase, and vice-versa */
+            function swapCase(s: string): string {
+                return s.replace(/\w/g, (ch) => {
+                    const up = ch.toUpperCase();
+                    return ch === up ? ch.toLowerCase() : up;
+                });
+            }
 
             function createWatchedFileSet() {
                 const dirWatchers = createMap<DirectoryWatcher>();
@@ -204,30 +334,6 @@ namespace ts {
                     }
                 }
             }
-            const watchedFileSet = createWatchedFileSet();
-
-            const nodeVersion = getNodeMajorVersion();
-            const isNode4OrLater = nodeVersion >= 4;
-
-            function isFileSystemCaseSensitive(): boolean {
-                // win32\win64 are case insensitive platforms
-                if (platform === "win32" || platform === "win64") {
-                    return false;
-                }
-                // If this file exists under a different case, we must be case-insensitve.
-                return !fileExists(swapCase(__filename));
-            }
-
-            /** Convert all lowercase chars to uppercase, and vice-versa */
-            function swapCase(s: string): string {
-                return s.replace(/\w/g, (ch) => {
-                    const up = ch.toUpperCase();
-                    return ch === up ? ch.toLowerCase() : up;
-                });
-            }
-
-            const platform: string = _os.platform();
-            const useCaseSensitiveFileNames = isFileSystemCaseSensitive();
 
             function fsWatchFile(fileName: string, callback: FileWatcherCallback, pollingInterval?: number): FileWatcher {
                 _fs.watchFile(fileName, { persistent: true, interval: pollingInterval || 250 }, fileChanged);
@@ -406,11 +512,6 @@ namespace ts {
                 return matchFiles(path, extensions, excludes, includes, useCaseSensitiveFileNames, process.cwd(), depth, getAccessibleFileSystemEntries);
             }
 
-            const enum FileSystemEntryKind {
-                File,
-                Directory
-            }
-
             function fileSystemEntryExists(path: string, entryKind: FileSystemEntryKind): boolean {
                 try {
                     const stat = _fs.statSync(path);
@@ -435,107 +536,6 @@ namespace ts {
             function getDirectories(path: string): string[] {
                 return filter<string>(_fs.readdirSync(path), dir => fileSystemEntryExists(combinePaths(path, dir), FileSystemEntryKind.Directory));
             }
-
-            const nodeSystem: System = {
-                args: process.argv.slice(2),
-                newLine: _os.EOL,
-                useCaseSensitiveFileNames,
-                write(s: string): void {
-                    process.stdout.write(s);
-                },
-                readFile,
-                writeFile,
-                watchFile: (fileName, callback, pollingInterval) => {
-                    if (useNonPollingWatchers) {
-                        const watchedFile = watchedFileSet.addFile(fileName, callback);
-                        return {
-                            close: () => watchedFileSet.removeFile(watchedFile)
-                        };
-                    }
-                    else {
-                        return fsWatchFile(fileName, callback, pollingInterval);
-                    }
-                },
-                watchDirectory: (directoryName, callback, recursive) => {
-                    // Node 4.0 `fs.watch` function supports the "recursive" option on both OSX and Windows
-                    // (ref: https://github.com/nodejs/node/pull/2649 and https://github.com/Microsoft/TypeScript/issues/4643)
-                    return fsWatchDirectory(directoryName, (eventName, relativeFileName) => {
-                        // In watchDirectory we only care about adding and removing files (when event name is
-                        // "rename"); changes made within files are handled by corresponding fileWatchers (when
-                        // event name is "change")
-                        if (eventName === "rename") {
-                            // When deleting a file, the passed baseFileName is null
-                            callback(!relativeFileName ? relativeFileName : normalizePath(combinePaths(directoryName, relativeFileName)));
-                        }
-                    }, recursive);
-                },
-                resolvePath: path => _path.resolve(path),
-                fileExists,
-                directoryExists,
-                createDirectory(directoryName: string) {
-                    if (!nodeSystem.directoryExists(directoryName)) {
-                        _fs.mkdirSync(directoryName);
-                    }
-                },
-                getExecutingFilePath() {
-                    return __filename;
-                },
-                getCurrentDirectory() {
-                    return process.cwd();
-                },
-                getDirectories,
-                getEnvironmentVariable(name: string) {
-                    return process.env[name] || "";
-                },
-                readDirectory,
-                getModifiedTime(path) {
-                    try {
-                        return _fs.statSync(path).mtime;
-                    }
-                    catch (e) {
-                        return undefined;
-                    }
-                },
-                createHash(data) {
-                    const hash = _crypto.createHash("md5");
-                    hash.update(data);
-                    return hash.digest("hex");
-                },
-                getMemoryUsage() {
-                    if (global.gc) {
-                        global.gc();
-                    }
-                    return process.memoryUsage().heapUsed;
-                },
-                getFileSize(path) {
-                    try {
-                        const stat = _fs.statSync(path);
-                        if (stat.isFile()) {
-                            return stat.size;
-                        }
-                    }
-                    catch { /*ignore*/ }
-                    return 0;
-                },
-                exit(exitCode?: number): void {
-                    process.exit(exitCode);
-                },
-                realpath(path: string): string {
-                    return _fs.realpathSync(path);
-                },
-                debugMode: some(<string[]>process.execArgv, arg => /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(arg)),
-                tryEnableSourceMapsForHost() {
-                    try {
-                        require("source-map-support").install();
-                    }
-                    catch {
-                        // Could not enable source maps.
-                    }
-                },
-                setTimeout,
-                clearTimeout
-            };
-            return nodeSystem;
         }
 
         function getChakraSystem(): System {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2,7 +2,6 @@
 
 /* @internal */
 namespace ts {
-    export const emptyArray: never[] = [] as never[];
     export const emptyMap: ReadonlyMap<never> = createMap<never>();
 
     export const externalHelpersModuleNameText = "tslib";

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -151,10 +151,6 @@ namespace ts {
         };
     }
 
-    export function closeFileWatcher(watcher: FileWatcher) {
-        watcher.close();
-    }
-
     export function closeFileWatcherOf<T extends { watcher: FileWatcher; }>(objWithWatcher: T) {
         objWithWatcher.watcher.close();
     }

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -10,7 +10,7 @@ namespace ts.projectSystem {
     export import TestServerHost = ts.TestFSWithWatch.TestServerHost;
     export type FileOrFolder = ts.TestFSWithWatch.FileOrFolder;
     export import createServerHost = ts.TestFSWithWatch.createServerHost;
-    export import checkFileNames = ts.TestFSWithWatch.checkFileNames;
+    export import checkArray = ts.TestFSWithWatch.checkArray;
     export import libFile = ts.TestFSWithWatch.libFile;
     export import checkWatchedFiles = ts.TestFSWithWatch.checkWatchedFiles;
     import checkWatchedDirectories = ts.TestFSWithWatch.checkWatchedDirectories;
@@ -330,11 +330,11 @@ namespace ts.projectSystem {
     }
 
     export function checkProjectActualFiles(project: server.Project, expectedFiles: string[]) {
-        checkFileNames(`${server.ProjectKind[project.projectKind]} project, actual files`, project.getFileNames(), expectedFiles);
+        checkArray(`${server.ProjectKind[project.projectKind]} project, actual files`, project.getFileNames(), expectedFiles);
     }
 
     function checkProjectRootFiles(project: server.Project, expectedFiles: string[]) {
-        checkFileNames(`${server.ProjectKind[project.projectKind]} project, rootFileNames`, project.getRootFiles(), expectedFiles);
+        checkArray(`${server.ProjectKind[project.projectKind]} project, rootFileNames`, project.getRootFiles(), expectedFiles);
     }
 
     function mapCombinedPathsInAncestor(dir: string, path2: string, mapAncestor: (ancestor: string) => boolean) {
@@ -367,7 +367,7 @@ namespace ts.projectSystem {
     }
 
     function checkOpenFiles(projectService: server.ProjectService, expectedFiles: FileOrFolder[]) {
-        checkFileNames("Open files", arrayFrom(projectService.openFiles.keys(), path => projectService.getScriptInfoForPath(path as Path).fileName), expectedFiles.map(file => file.path));
+        checkArray("Open files", arrayFrom(projectService.openFiles.keys(), path => projectService.getScriptInfoForPath(path as Path).fileName), expectedFiles.map(file => file.path));
     }
 
     /**
@@ -506,7 +506,7 @@ namespace ts.projectSystem {
 
             const project = projectService.inferredProjects[0];
 
-            checkFileNames("inferred project", project.getFileNames(), [appFile.path, libFile.path, moduleFile.path]);
+            checkArray("inferred project", project.getFileNames(), [appFile.path, libFile.path, moduleFile.path]);
             const configFileLocations = ["/a/b/c/", "/a/b/", "/a/", "/"];
             const configFiles = flatMap(configFileLocations, location => [location + "tsconfig.json", location + "jsconfig.json"]);
             checkWatchedFiles(host, configFiles.concat(libFile.path, moduleFile.path));
@@ -6468,6 +6468,64 @@ namespace ts.projectSystem {
 
         it("When files at some folder other than root", () => {
             verifyWatchedDirectories(/*useProjectAtRoot*/ false);
+        });
+    });
+
+    describe("WatchingDirectories with polling", () => {
+        it("when file is added to subfolder, completion list has new file", () => {
+            const projectFolder = "/a/username/project";
+            const projectSrcFolder = `${projectFolder}/src`;
+            const configFile: FileOrFolder = {
+                path: `${projectFolder}/tsconfig.json`,
+                content: "{}"
+            };
+            const index: FileOrFolder = {
+                path: `${projectSrcFolder}/index.ts`,
+                content: `import {} from "./"`
+            };
+            const file1: FileOrFolder = {
+                path: `${projectSrcFolder}/file1.ts`,
+                content: ""
+            };
+
+            const files = [index, file1, configFile, libFile];
+            const fileNames = files.map(file => file.path);
+            // All closed files(files other than index), project folder, project/src folder and project/node_modules/@types folder
+            const expectedWatchedFiles = fileNames.slice(1).concat(projectFolder, projectSrcFolder, `${projectFolder}/${nodeModulesAtTypes}`);
+            const expectedCompletions = ["file1"];
+            const completionPosition = index.content.lastIndexOf('"');
+            const host = createServerHost(files);
+            host.setWatchDirectoryWithPolling();
+            const projectService = createProjectService(host);
+            projectService.openClientFile(index.path);
+
+            const project = projectService.configuredProjects.get(configFile.path);
+            assert.isDefined(project);
+            verifyProjectAndCompletions();
+
+            // Add file2
+            const file2: FileOrFolder = {
+                path: `${projectSrcFolder}/file2.ts`,
+                content: ""
+            };
+            files.push(file2);
+            fileNames.push(file2.path);
+            expectedWatchedFiles.push(file2.path);
+            expectedCompletions.push("file2");
+            host.reloadFS(files);
+            host.runQueuedTimeoutCallbacks();
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
+            verifyProjectAndCompletions();
+
+            function verifyProjectAndCompletions() {
+                checkWatchedDirectories(host, emptyArray, /*recursive*/ false);
+                checkWatchedDirectories(host, emptyArray, /*recursive*/ true);
+                checkWatchedFiles(host, expectedWatchedFiles);
+                checkProjectActualFiles(project, fileNames);
+
+                const completions = project.getLanguageService().getCompletionsAtPosition(index.path, completionPosition, { includeExternalModuleExports: false });
+                checkArray("Completion Entries", completions.entries.map(e => e.name), expectedCompletions);
+            }
         });
     });
 }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -143,10 +143,10 @@ interface Array<T> {}`
         }
     }
 
-    export function checkFileNames(caption: string, actualFileNames: ReadonlyArray<string>, expectedFileNames: string[]) {
-        assert.equal(actualFileNames.length, expectedFileNames.length, `${caption}: incorrect actual number of files, expected:\r\n${expectedFileNames.join("\r\n")}\r\ngot: ${actualFileNames.join("\r\n")}`);
-        for (const f of expectedFileNames) {
-            assert.equal(true, contains(actualFileNames, f), `${caption}: expected to find ${f} in ${actualFileNames}`);
+    export function checkArray(caption: string, actual: ReadonlyArray<string>, expected: ReadonlyArray<string>) {
+        assert.equal(actual.length, expected.length, `${caption}: incorrect actual number of files, expected:\r\n${expected.join("\r\n")}\r\ngot: ${actual.join("\r\n")}`);
+        for (const f of expected) {
+            assert.equal(true, contains(actual, f), `${caption}: expected to find ${f} in ${actual}`);
         }
     }
 
@@ -588,7 +588,9 @@ interface Array<T> {}`
         getPollingWatchDirectoryHost() {
             return this.pollingWatchDirectoryHost || (this.pollingWatchDirectoryHost = {
                 watchFile: (fileName, cb) => this.watchFile(fileName, cb),
-                getAccessileSortedChildDirectories: path => this.getDirectories(path),
+                // Since we are watching missing directories as well with polling,
+                // check for directory exists before getting directories of the path
+                getAccessileSortedChildDirectories: path => this.directoryExists(path) ? this.getDirectories(path) : emptyArray,
                 filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
             });
         }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -588,9 +588,8 @@ interface Array<T> {}`
         getPollingWatchDirectoryHost() {
             return this.pollingWatchDirectoryHost || (this.pollingWatchDirectoryHost = {
                 watchFile: (fileName, cb) => this.watchFile(fileName, cb),
-                // Since we are watching missing directories as well with polling,
-                // check for directory exists before getting directories of the path
-                getAccessileSortedChildDirectories: path => this.directoryExists(path) ? this.getDirectories(path) : emptyArray,
+                directoryExists: path => this.directoryExists(path),
+                getAccessileSortedChildDirectories: path => this.getDirectories(path).sort(this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive),
                 filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
             });
         }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -257,13 +257,20 @@ interface Array<T> {}`
         readonly watchedFiles = createMultiMap<TestFileWatcher>();
         private readonly executingFilePath: string;
         private readonly currentDirectory: string;
+        watchDirectory: (directoryName: string, cb: DirectoryWatcherCallback, recursive: boolean) => FileWatcher;
+        pollingWatchDirectoryHost: PollingWatchDirectoryHost;
 
         constructor(public withSafeList: boolean, public useCaseSensitiveFileNames: boolean, executingFilePath: string, currentDirectory: string, fileOrFolderList: ReadonlyArray<FileOrFolder>, public readonly newLine = "\n", public readonly useWindowsStylePath?: boolean) {
+            this.watchDirectory = this.watchDirectoryWithCallbacks;
             this.getCanonicalFileName = createGetCanonicalFileName(useCaseSensitiveFileNames);
             this.toPath = s => toPath(s, currentDirectory, this.getCanonicalFileName);
             this.executingFilePath = this.getHostSpecificPath(executingFilePath);
             this.currentDirectory = this.getHostSpecificPath(currentDirectory);
             this.reloadFS(fileOrFolderList);
+        }
+
+        setWatchDirectoryWithPolling() {
+            this.watchDirectory = this.watchDirectoryWithPolling;
         }
 
         getNewLine() {
@@ -420,9 +427,7 @@ interface Array<T> {}`
             if (ignoreWatch) {
                 return;
             }
-            if (isFile(fileOrDirectory)) {
-                this.invokeFileWatcher(fileOrDirectory.fullPath, FileWatcherEventKind.Created);
-            }
+            this.invokeFileWatcher(fileOrDirectory.fullPath, FileWatcherEventKind.Created);
             this.invokeDirectoryWatcher(folder.fullPath, fileOrDirectory.fullPath);
         }
 
@@ -435,10 +440,8 @@ interface Array<T> {}`
             }
             this.fs.delete(fileOrDirectory.path);
 
-            if (isFile(fileOrDirectory)) {
-                this.invokeFileWatcher(fileOrDirectory.fullPath, FileWatcherEventKind.Deleted);
-            }
-            else {
+            this.invokeFileWatcher(fileOrDirectory.fullPath, FileWatcherEventKind.Deleted);
+            if (!isFile(fileOrDirectory)) {
                 Debug.assert(fileOrDirectory.entries.length === 0 || isRenaming);
                 const relativePath = this.getRelativePathToDirectory(fileOrDirectory.fullPath, fileOrDirectory.fullPath);
                 // Invoke directory and recursive directory watcher for the folder
@@ -472,6 +475,8 @@ interface Array<T> {}`
          */
         private invokeDirectoryWatcher(folderFullPath: string, fileName: string) {
             const relativePath = this.getRelativePathToDirectory(folderFullPath, fileName);
+            // Folder is changed when the directory watcher is invoked
+            invokeWatcherCallbacks(this.watchedFiles.get(this.toPath(folderFullPath)), ({ cb, fileName }) => cb(fileName, FileWatcherEventKind.Changed));
             invokeWatcherCallbacks(this.watchedDirectories.get(this.toPath(folderFullPath)), cb => this.directoryCallback(cb, relativePath));
             this.invokeRecursiveDirectoryWatcher(folderFullPath, fileName);
         }
@@ -567,7 +572,7 @@ interface Array<T> {}`
             });
         }
 
-        watchDirectory(directoryName: string, cb: DirectoryWatcherCallback, recursive: boolean): FileWatcher {
+        watchDirectoryWithCallbacks(directoryName: string, cb: DirectoryWatcherCallback, recursive: boolean): FileWatcher {
             const path = this.toFullPath(directoryName);
             const map = recursive ? this.watchedDirectoriesRecursive : this.watchedDirectories;
             const callback: TestDirectoryWatcher = {
@@ -578,6 +583,18 @@ interface Array<T> {}`
             return {
                 close: () => map.remove(path, callback)
             };
+        }
+
+        getPollingWatchDirectoryHost() {
+            return this.pollingWatchDirectoryHost || (this.pollingWatchDirectoryHost = {
+                watchFile: (fileName, cb) => this.watchFile(fileName, cb),
+                getAccessileSortedChildDirectories: path => this.getDirectories(path),
+                filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
+            });
+        }
+
+        watchDirectoryWithPolling(directoryName: string, cb: DirectoryWatcherCallback, recursive: boolean): FileWatcher {
+            return watchDirectoryWithPolling(directoryName, recursive, this.getPollingWatchDirectoryHost(), () => cb(directoryName));
         }
 
         createHash(s: string): string {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -856,6 +856,7 @@ namespace ts.server {
             const oldExternalFiles = this.externalFiles || emptyArray as SortedReadonlyArray<string>;
             this.externalFiles = this.getExternalFiles();
             enumerateInsertsAndDeletes(this.externalFiles, oldExternalFiles,
+                compareStringsCaseSensitive,
                 // Ensure a ScriptInfo is created for new external files. This is performed indirectly
                 // by the LSHost for files in the program when the program is retrieved above but
                 // the program doesn't contain external files so this must be done explicitly.
@@ -863,8 +864,7 @@ namespace ts.server {
                     const scriptInfo = this.projectService.getOrCreateScriptInfoNotOpenedByClient(inserted, this.currentDirectory, this.directoryStructureHost);
                     scriptInfo.attachToProject(this);
                 },
-                removed => this.detachScriptInfoFromProject(removed),
-                compareStringsCaseSensitive
+                removed => this.detachScriptInfoFromProject(removed)
             );
             const elapsed = timestamp() - start;
             this.writeLog(`Finishing updateGraphWorker: Project: ${this.getProjectName()} structureChanged: ${hasChanges} Elapsed: ${elapsed}ms`);

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -289,36 +289,6 @@ namespace ts.server {
         return index === 0 || value !== array[index - 1];
     }
 
-    export function enumerateInsertsAndDeletes<T>(newItems: SortedReadonlyArray<T>, oldItems: SortedReadonlyArray<T>, inserted: (newItem: T) => void, deleted: (oldItem: T) => void, comparer: Comparer<T>) {
-        let newIndex = 0;
-        let oldIndex = 0;
-        const newLen = newItems.length;
-        const oldLen = oldItems.length;
-        while (newIndex < newLen && oldIndex < oldLen) {
-            const newItem = newItems[newIndex];
-            const oldItem = oldItems[oldIndex];
-            const compareResult = comparer(newItem, oldItem);
-            if (compareResult === Comparison.LessThan) {
-                inserted(newItem);
-                newIndex++;
-            }
-            else if (compareResult === Comparison.GreaterThan) {
-                deleted(oldItem);
-                oldIndex++;
-            }
-            else {
-                newIndex++;
-                oldIndex++;
-            }
-        }
-        while (newIndex < newLen) {
-            inserted(newItems[newIndex++]);
-        }
-        while (oldIndex < oldLen) {
-            deleted(oldItems[oldIndex++]);
-        }
-    }
-
     /* @internal */
     export function indent(str: string): string {
         return "\n    " + str;


### PR DESCRIPTION
Issue: Currently if system doesn't support watching directories recursively, we aren't watching the sub folders of the watched directories. But we rely heavily on recursive directory watching, either for failed lookup locations of module resolutions, watching for node_modules/@types or to watch directories specified through tsconfig itself (eg when it doesn't have file list or uses recursive directory inclusion pattern) That means on systems that don't support directory watching, if the files are added/removed in the sub folders of the directory being watched, there is no indication of such and program would get out of sync.

Fix: Watch the directories and its sub folders through polling (like fs.watchFile) for the changes. Currently for any changes either in the directory that's watched recursively or its sub directories, the callback is invoked for the directory being watched recursively. It works especially because we don't end up spending time to find changes that might not be important to project/program.

We could poll the directories and subdirectories just once and keep refcount avoiding duplicate polling of children, but that can be done as next PR.

Fixes #19989, #20023
