### PR TITLE
Update project on PackageInstalledResponse

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -540,7 +540,7 @@ namespace ts.server {
             }
         }
 
-        updateTypingsForProject(response: SetTypings | InvalidateCachedTypings): void {
+        updateTypingsForProject(response: SetTypings | InvalidateCachedTypings | PackageInstalledResponse): void {
             const project = this.findProject(response.projectName);
             if (!project) {
                 return;

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -249,7 +249,7 @@ namespace ts.server {
             return this.typingsCache.isKnownTypesPackageName(name);
         }
         installPackage(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult> {
-            return this.typingsCache.installPackage({ ...options, projectRootPath: this.toPath(this.currentDirectory) });
+            return this.typingsCache.installPackage({ ...options, projectName: this.projectName, projectRootPath: this.toPath(this.currentDirectory) });
         }
         private get typingsCache(): TypingsCache {
             return this.projectService.typingsCache;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -573,7 +573,7 @@ namespace ts.server {
         }
 
         private writeToEventSocket(body: any, eventName: string): void {
-            this.eventSocket.write(formatMessage(toEvent(body, eventName), this.logger, this.byteLength, this.host.newLine), "utf8");
+            this.eventSocket.write(formatMessage(toEvent(eventName, body), this.logger, this.byteLength, this.host.newLine), "utf8");
         }
 
         exit() {

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -4,8 +4,8 @@ namespace ts.server {
     // tslint:disable variable-name
     export const ActionSet: ActionSet = "action::set";
     export const ActionInvalidate: ActionInvalidate = "action::invalidate";
+    export const ActionPackageInstalled: ActionPackageInstalled = "action::packageInstalled";
     export const EventTypesRegistry: EventTypesRegistry = "event::typesRegistry";
-    export const EventPackageInstalled: EventPackageInstalled = "event::packageInstalled";
     export const EventBeginInstallTypes: EventBeginInstallTypes = "event::beginInstallTypes";
     export const EventEndInstallTypes: EventEndInstallTypes = "event::endInstallTypes";
     export const EventInitializationFailed: EventInitializationFailed = "event::initializationFailed";

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -53,7 +53,7 @@ declare namespace ts.server {
         readonly kind: "typesRegistry";
     }
 
-    export interface InstallPackageRequest {
+    export interface InstallPackageRequest extends TypingInstallerRequestWithProjectName {
         readonly kind: "installPackage";
         readonly fileName: Path;
         readonly packageName: string;
@@ -62,14 +62,14 @@ declare namespace ts.server {
 
     export type ActionSet = "action::set";
     export type ActionInvalidate = "action::invalidate";
+    export type ActionPackageInstalled = "action::packageInstalled";
     export type EventTypesRegistry = "event::typesRegistry";
-    export type EventPackageInstalled = "event::packageInstalled";
     export type EventBeginInstallTypes = "event::beginInstallTypes";
     export type EventEndInstallTypes = "event::endInstallTypes";
     export type EventInitializationFailed = "event::initializationFailed";
 
     export interface TypingInstallerResponse {
-        readonly kind: ActionSet | ActionInvalidate | EventTypesRegistry | EventPackageInstalled | EventBeginInstallTypes | EventEndInstallTypes | EventInitializationFailed;
+        readonly kind: ActionSet | ActionInvalidate | EventTypesRegistry | ActionPackageInstalled | EventBeginInstallTypes | EventEndInstallTypes | EventInitializationFailed;
     }
     /* @internal */
     export type TypingInstallerResponseUnion = SetTypings | InvalidateCachedTypings | TypesRegistryResponse | PackageInstalledResponse | InstallTypes | InitializationFailedResponse;
@@ -80,9 +80,8 @@ declare namespace ts.server {
         readonly typesRegistry: MapLike<void>;
     }
 
-    /* @internal */
-    export interface PackageInstalledResponse extends TypingInstallerResponse {
-        readonly kind: EventPackageInstalled;
+    export interface PackageInstalledResponse extends ProjectResponse {
+        readonly kind: ActionPackageInstalled;
         readonly success: boolean;
         readonly message: string;
     }

--- a/src/server/typingsCache.ts
+++ b/src/server/typingsCache.ts
@@ -1,14 +1,15 @@
 /// <reference path="project.ts"/>
 
 namespace ts.server {
-    export interface InstallPackageOptionsWithProjectRootPath extends InstallPackageOptions {
+    export interface InstallPackageOptionsWithProject extends InstallPackageOptions {
+        projectName: string;
         projectRootPath: Path;
     }
 
     // tslint:disable-next-line interface-name (for backwards-compatibility)
     export interface ITypingsInstaller {
         isKnownTypesPackageName(name: string): boolean;
-        installPackage(options: InstallPackageOptionsWithProjectRootPath): Promise<ApplyCodeActionCommandResult>;
+        installPackage(options: InstallPackageOptionsWithProject): Promise<ApplyCodeActionCommandResult>;
         enqueueInstallTypingsRequest(p: Project, typeAcquisition: TypeAcquisition, unresolvedImports: SortedReadonlyArray<string>): void;
         attach(projectService: ProjectService): void;
         onProjectClosed(p: Project): void;
@@ -91,7 +92,7 @@ namespace ts.server {
             return this.installer.isKnownTypesPackageName(name);
         }
 
-        installPackage(options: InstallPackageOptionsWithProjectRootPath): Promise<ApplyCodeActionCommandResult> {
+        installPackage(options: InstallPackageOptionsWithProject): Promise<ApplyCodeActionCommandResult> {
             return this.installer.installPackage(options);
         }
 

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -150,17 +150,17 @@ namespace ts.server.typingsInstaller {
                         break;
                     }
                     case "installPackage": {
-                        const { fileName, packageName, projectRootPath } = req;
+                        const { fileName, packageName, projectName, projectRootPath } = req;
                         const cwd = getDirectoryOfPackageJson(fileName, this.installTypingHost) || projectRootPath;
                         if (cwd) {
                             this.installWorker(-1, [packageName], cwd, success => {
                                 const message = success ? `Package ${packageName} installed.` : `There was an error installing ${packageName}.`;
-                                const response: PackageInstalledResponse = { kind: EventPackageInstalled, success, message };
+                                const response: PackageInstalledResponse = { kind: ActionPackageInstalled, projectName, success, message };
                                 this.sendResponse(response);
                             });
                         }
                         else {
-                            const response: PackageInstalledResponse = { kind: EventPackageInstalled, success: false, message: "Could not determine a project root path." };
+                            const response: PackageInstalledResponse = { kind: ActionPackageInstalled, projectName, success: false, message: "Could not determine a project root path." };
                             this.sendResponse(response);
                         }
                         break;


### PR DESCRIPTION
As with `SetTypings`, new typings have been installed so the project should be updated and the client should be notified (via event).
    
Changed PackageInstalledResponse from "event" to "action" for the sake of explicitness.
    
Fixes #20084.