### PR TITLE
Unswap arguments

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -232,7 +232,7 @@ namespace ts.projectSystem {
             return this.executeCommand(<T>request);
         }
 
-        public event<T>(body: T, eventName: string) {
+        public event<T extends object>(body: T, eventName: string) {
             this.events.push(server.toEvent(eventName, body));
             super.event(body, eventName);
         }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -502,7 +502,7 @@ namespace ts.server {
         constructor(options: IoSessionOptions) {
             const { host, eventPort, globalTypingsCacheLocation, typingSafeListLocation, typesMapLocation, npmLocation, canUseEvents } = options;
 
-            const event: Event | undefined = (body: {}, eventName: string) => {
+            const event: Event | undefined = (body: object, eventName: string) => {
                 if (this.constructed) {
                     this.event(body, eventName);
                 }
@@ -551,7 +551,7 @@ namespace ts.server {
             this.constructed = true;
         }
 
-        event<T>(body: T, eventName: string): void {
+        event<T extends object>(body: T, eventName: string): void {
             Debug.assert(this.constructed, "Should only call `IOSession.prototype.event` on an initialized IOSession");
 
             if (this.canUseEvents && this.eventPort) {
@@ -572,7 +572,7 @@ namespace ts.server {
             }
         }
 
-        private writeToEventSocket(body: {}, eventName: string): void {
+        private writeToEventSocket(body: object, eventName: string): void {
             this.eventSocket.write(formatMessage(toEvent(eventName, body), this.logger, this.byteLength, this.host.newLine), "utf8");
         }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -573,7 +573,7 @@ namespace ts.server {
         }
 
         private writeToEventSocket(body: any, eventName: string): void {
-            this.eventSocket.write(formatMessage(toEvent(body, eventName), this.logger, this.byteLength, this.host.newLine), "utf8");
+            this.eventSocket.write(formatMessage(toEvent(eventName, body), this.logger, this.byteLength, this.host.newLine), "utf8");
         }
 
         exit() {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -572,7 +572,7 @@ namespace ts.server {
             }
         }
 
-        private writeToEventSocket(body: any, eventName: string): void {
+        private writeToEventSocket(body: {}, eventName: string): void {
             this.eventSocket.write(formatMessage(toEvent(eventName, body), this.logger, this.byteLength, this.host.newLine), "utf8");
         }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -239,14 +239,14 @@ namespace ts.server {
         }
     }
 
-    export type Event = <T>(body: T, eventName: string) => void;
+    export type Event = <T extends object>(body: T, eventName: string) => void;
 
     export interface EventSender {
         event: Event;
     }
 
     /** @internal */
-    export function toEvent(eventName: string, body: {}): protocol.Event {
+    export function toEvent(eventName: string, body: object): protocol.Event {
         return {
             seq: 0,
             type: "event",
@@ -409,7 +409,7 @@ namespace ts.server {
             this.host.write(formatMessage(msg, this.logger, this.byteLength, this.host.newLine));
         }
 
-        public event<T>(body: T, eventName: string): void {
+        public event<T extends object>(body: T, eventName: string): void {
             this.send(toEvent(eventName, body));
         }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6930,7 +6930,7 @@ declare namespace ts.server {
     type CommandNames = protocol.CommandTypes;
     const CommandNames: any;
     function formatMessage<T extends protocol.Message>(msg: T, logger: server.Logger, byteLength: (s: string, encoding: string) => number, newLine: string): string;
-    type Event = <T>(body: T, eventName: string) => void;
+    type Event = <T extends object>(body: T, eventName: string) => void;
     interface EventSender {
         event: Event;
     }
@@ -6973,7 +6973,7 @@ declare namespace ts.server {
         private projectsUpdatedInBackgroundEvent(openFiles);
         logError(err: Error, cmd: string): void;
         send(msg: protocol.Message): void;
-        event<T>(body: T, eventName: string): void;
+        event<T extends object>(body: T, eventName: string): void;
         /** @deprecated */
         output(info: any, cmdName: string, reqSeq?: number, errorMsg?: string): void;
         private doOutput(info, cmdName, reqSeq, success, message?);


### PR DESCRIPTION
VS is ignoring all events because the event name is currently in the `body` field.  As a result, projects are not refreshed when typings are installed.