### PR TITLE
allow returning an array of jsx elements

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15208,7 +15208,7 @@ namespace ts {
             if (!deferredJsxStatelessElementType) {
                 const jsxElementType = getJsxGlobalElementType();
                 if (jsxElementType) {
-                    deferredJsxStatelessElementType = getUnionType([jsxElementType, nullType]);
+                    deferredJsxStatelessElementType = getUnionType([createArrayType(jsxElementType), jsxElementType, nullType]);
                 }
             }
             return deferredJsxStatelessElementType;

--- a/tests/baselines/reference/tsxSfcReturnArray.js
+++ b/tests/baselines/reference/tsxSfcReturnArray.js
@@ -1,0 +1,24 @@
+//// [file.tsx]
+import React = require('react');
+
+const Foo = (props: any) => [<span />, <span />];
+
+function Greet(x: { name?: string }) {
+	return [<span />, <span />];
+}
+
+const foo = <Foo />;
+const G = <Greet />;
+
+
+//// [file.jsx]
+define(["require", "exports", "react"], function (require, exports, React) {
+    "use strict";
+    exports.__esModule = true;
+    var Foo = function (props) { return [<span />, <span />]; };
+    function Greet(x) {
+        return [<span />, <span />];
+    }
+    var foo = <Foo />;
+    var G = <Greet />;
+});

--- a/tests/baselines/reference/tsxSfcReturnArray.symbols
+++ b/tests/baselines/reference/tsxSfcReturnArray.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/jsx/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+const Foo = (props: any) => [<span />, <span />];
+>Foo : Symbol(Foo, Decl(file.tsx, 2, 5))
+>props : Symbol(props, Decl(file.tsx, 2, 13))
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+
+function Greet(x: { name?: string }) {
+>Greet : Symbol(Greet, Decl(file.tsx, 2, 49))
+>x : Symbol(x, Decl(file.tsx, 4, 15))
+>name : Symbol(name, Decl(file.tsx, 4, 19))
+
+	return [<span />, <span />];
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2461, 51))
+}
+
+const foo = <Foo />;
+>foo : Symbol(foo, Decl(file.tsx, 8, 5))
+>Foo : Symbol(Foo, Decl(file.tsx, 2, 5))
+
+const G = <Greet />;
+>G : Symbol(G, Decl(file.tsx, 9, 5))
+>Greet : Symbol(Greet, Decl(file.tsx, 2, 49))
+

--- a/tests/baselines/reference/tsxSfcReturnArray.types
+++ b/tests/baselines/reference/tsxSfcReturnArray.types
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/jsx/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+const Foo = (props: any) => [<span />, <span />];
+>Foo : (props: any) => JSX.Element[]
+>(props: any) => [<span />, <span />] : (props: any) => JSX.Element[]
+>props : any
+>[<span />, <span />] : JSX.Element[]
+><span /> : JSX.Element
+>span : any
+><span /> : JSX.Element
+>span : any
+
+function Greet(x: { name?: string }) {
+>Greet : (x: { name?: string; }) => JSX.Element[]
+>x : { name?: string; }
+>name : string
+
+	return [<span />, <span />];
+>[<span />, <span />] : JSX.Element[]
+><span /> : JSX.Element
+>span : any
+><span /> : JSX.Element
+>span : any
+}
+
+const foo = <Foo />;
+>foo : JSX.Element
+><Foo /> : JSX.Element
+>Foo : (props: any) => JSX.Element[]
+
+const G = <Greet />;
+>G : JSX.Element
+><Greet /> : JSX.Element
+>Greet : (x: { name?: string; }) => JSX.Element[]
+

--- a/tests/cases/conformance/jsx/tsxSfcReturnArray.tsx
+++ b/tests/cases/conformance/jsx/tsxSfcReturnArray.tsx
@@ -1,0 +1,17 @@
+// @filename: file.tsx
+// @jsx: preserve
+// @module: amd
+// @noLib: true
+// @skipLibCheck: true
+// @libFiles: react.d.ts,lib.d.ts
+
+import React = require('react');
+
+const Foo = (props: any) => [<span />, <span />];
+
+function Greet(x: { name?: string }) {
+	return [<span />, <span />];
+}
+
+const foo = <Foo />;
+const G = <Greet />;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Hi everyone! First time contributor here 👋  At least in terms of the compiler.

It is currently not possible to return an array of JSX Elements inside of a stateless React component. The change can't be applied to the typings directly, because the constructor is affected. See here for an open issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20356 and this comment https://github.com/DefinitelyTyped/DefinitelyTyped/pull/19363#issuecomment-337161610.

I basically want to be able to change `(props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;` of the stateless component to
`(props: P & { children?: ReactNode }, context?: any): ReactElement<any>[] | ReactElement<any>| null;`.

I looked for older similar issues and found this one: https://github.com/Microsoft/TypeScript/pull/14152. (Surprise. This is actually a fix for an older issue I reported, because I couldn't return `null`. 😄  https://github.com/Microsoft/TypeScript/issues/11566) (Note that it's hard to initially find the correct code via GitHubs search, because the `checker.ts` is too big. It looks like GitHub doesn't allow searching in big files. I usually start by finding and reading the code on GitHub, before I clone the repo to get some initial impression if it is fixable for me.)

So here I am. This is an ongoing PR. If you have any feedback, I'd be happy. Is this even the right place to make the change?

I'll start looking into tests as the next step.