### PR TITLE
Handle multiline jsx strings correctly, emit escapes in jsx attributes correctly

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -932,7 +932,7 @@ namespace ts {
             return value;
         }
 
-        function scanString(allowEscapes = true): string {
+        function scanString(jsxAttributeString = false): string {
             const quote = text.charCodeAt(pos);
             pos++;
             let result = "";
@@ -950,13 +950,13 @@ namespace ts {
                     pos++;
                     break;
                 }
-                if (ch === CharacterCodes.backslash && allowEscapes) {
+                if (ch === CharacterCodes.backslash && !jsxAttributeString) {
                     result += text.substring(start, pos);
                     result += scanEscapeSequence();
                     start = pos;
                     continue;
                 }
-                if (isLineBreak(ch)) {
+                if (isLineBreak(ch) && !jsxAttributeString) {
                     result += text.substring(start, pos);
                     tokenFlags |= TokenFlags.Unterminated;
                     error(Diagnostics.Unterminated_string_literal);
@@ -1811,7 +1811,7 @@ namespace ts {
             switch (text.charCodeAt(pos)) {
                 case CharacterCodes.doubleQuote:
                 case CharacterCodes.singleQuote:
-                    tokenValue = scanString(/*allowEscapes*/ false);
+                    tokenValue = scanString(/*jsxAttributeString*/ true);
                     return token = SyntaxKind.StringLiteral;
                 default:
                     // If this scans anything other than `{`, it's a parse error.

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
@@ -1,76 +1,92 @@
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(3,1): error TS1128: Declaration or statement expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(3,3): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(3,4): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(4,3): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(5,1): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(5,2): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(5,3): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(5,6): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(5,7): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(6,1): error TS2695: Left side of comma operator is unused and has no side effects.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(6,6): error TS1005: '{' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(6,6): error TS2304: Cannot find name 'd'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(6,9): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(6,10): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(7,1): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(8,4): error TS17002: Expected corresponding JSX closing tag for 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(9,13): error TS1002: Unterminated string literal.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(10,1): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(10,6): error TS17002: Expected corresponding JSX closing tag for 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(10,10): error TS2657: JSX expressions must have one parent element.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,3): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,5): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,11): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,12): error TS2304: Cannot find name 'b'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,16): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,2): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,5): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,10): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,13): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,14): error TS2304: Cannot find name 'c'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,16): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(13,2): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(13,8): error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,1): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,2): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,5): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,7): error TS1128: Declaration or statement expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,8): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,10): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,2): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,4): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,7): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,9): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,3): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,4): error TS2304: Cannot find name 'foo'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,9): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,11): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,13): error TS2304: Cannot find name 'foo'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,18): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(17,3): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(17,11): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(17,13): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(17,22): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(18,2): error TS17008: JSX element 'a' has no corresponding closing tag.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(19,2): error TS17008: JSX element 'a' has no corresponding closing tag.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(22,10): error TS1005: '}' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(23,20): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(24,15): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(25,7): error TS1005: '...' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(25,7): error TS2304: Cannot find name 'props'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(27,17): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(28,10): error TS2304: Cannot find name 'props'.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(28,28): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(32,2): error TS17008: JSX element 'a' has no corresponding closing tag.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(32,6): error TS1005: '{' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,2): error TS17008: JSX element 'a' has no corresponding closing tag.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,6): error TS1005: '{' expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,7): error TS1109: Expression expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,4): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005: '</' expected.
+tests/cases/conformance/jsx/1.tsx(3,1): error TS1128: Declaration or statement expected.
+tests/cases/conformance/jsx/1.tsx(3,3): error TS1109: Expression expected.
+tests/cases/conformance/jsx/1.tsx(3,4): error TS1109: Expression expected.
+tests/cases/conformance/jsx/10.tsx(1,2): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/10.tsx(1,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/10.tsx(1,10): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/10.tsx(1,13): error TS1005: '>' expected.
+tests/cases/conformance/jsx/10.tsx(1,14): error TS2304: Cannot find name 'c'.
+tests/cases/conformance/jsx/10.tsx(1,16): error TS1109: Expression expected.
+tests/cases/conformance/jsx/11.tsx(1,2): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/11.tsx(1,8): error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
+tests/cases/conformance/jsx/12.tsx(1,1): error TS1109: Expression expected.
+tests/cases/conformance/jsx/12.tsx(1,2): error TS1109: Expression expected.
+tests/cases/conformance/jsx/12.tsx(1,5): error TS1109: Expression expected.
+tests/cases/conformance/jsx/12.tsx(1,7): error TS1128: Declaration or statement expected.
+tests/cases/conformance/jsx/12.tsx(1,8): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/12.tsx(1,10): error TS1109: Expression expected.
+tests/cases/conformance/jsx/13.tsx(1,2): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/13.tsx(1,4): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/13.tsx(1,7): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/13.tsx(1,9): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/14.tsx(1,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/14.tsx(1,4): error TS2304: Cannot find name 'foo'.
+tests/cases/conformance/jsx/14.tsx(1,9): error TS1109: Expression expected.
+tests/cases/conformance/jsx/14.tsx(1,11): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/14.tsx(1,13): error TS2304: Cannot find name 'foo'.
+tests/cases/conformance/jsx/14.tsx(1,18): error TS1109: Expression expected.
+tests/cases/conformance/jsx/15.tsx(1,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/15.tsx(1,11): error TS1109: Expression expected.
+tests/cases/conformance/jsx/15.tsx(1,13): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/15.tsx(1,22): error TS1109: Expression expected.
+tests/cases/conformance/jsx/16.tsx(1,2): error TS17008: JSX element 'a' has no corresponding closing tag.
+tests/cases/conformance/jsx/16.tsx(1,10): error TS1005: '</' expected.
+tests/cases/conformance/jsx/17.tsx(1,2): error TS17008: JSX element 'a' has no corresponding closing tag.
+tests/cases/conformance/jsx/17.tsx(1,10): error TS1005: '</' expected.
+tests/cases/conformance/jsx/18.tsx(1,9): error TS2695: Left side of comma operator is unused and has no side effects.
+tests/cases/conformance/jsx/18.tsx(1,37): error TS2657: JSX expressions must have one parent element.
+tests/cases/conformance/jsx/19.tsx(1,9): error TS2695: Left side of comma operator is unused and has no side effects.
+tests/cases/conformance/jsx/19.tsx(1,64): error TS2657: JSX expressions must have one parent element.
+tests/cases/conformance/jsx/2.tsx(1,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/20.tsx(1,10): error TS1005: '}' expected.
+tests/cases/conformance/jsx/21.tsx(1,20): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/22.tsx(1,15): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/22.tsx(1,21): error TS1109: Expression expected.
+tests/cases/conformance/jsx/23.tsx(1,7): error TS1005: '...' expected.
+tests/cases/conformance/jsx/23.tsx(1,7): error TS2304: Cannot find name 'props'.
+tests/cases/conformance/jsx/24.tsx(1,17): error TS1005: '>' expected.
+tests/cases/conformance/jsx/24.tsx(1,18): error TS1128: Declaration or statement expected.
+tests/cases/conformance/jsx/24.tsx(1,21): error TS2304: Cannot find name 'props'.
+tests/cases/conformance/jsx/24.tsx(1,27): error TS1109: Expression expected.
+tests/cases/conformance/jsx/24.tsx(1,28): error TS1109: Expression expected.
+tests/cases/conformance/jsx/25.tsx(1,10): error TS2304: Cannot find name 'props'.
+tests/cases/conformance/jsx/25.tsx(1,28): error TS1005: '>' expected.
+tests/cases/conformance/jsx/25.tsx(1,29): error TS1128: Declaration or statement expected.
+tests/cases/conformance/jsx/25.tsx(1,32): error TS2304: Cannot find name 'props'.
+tests/cases/conformance/jsx/25.tsx(1,38): error TS1109: Expression expected.
+tests/cases/conformance/jsx/25.tsx(1,39): error TS1109: Expression expected.
+tests/cases/conformance/jsx/28.tsx(1,2): error TS17008: JSX element 'a' has no corresponding closing tag.
+tests/cases/conformance/jsx/28.tsx(1,6): error TS1005: '{' expected.
+tests/cases/conformance/jsx/28.tsx(2,1): error TS1005: '</' expected.
+tests/cases/conformance/jsx/29.tsx(1,2): error TS17008: JSX element 'a' has no corresponding closing tag.
+tests/cases/conformance/jsx/29.tsx(1,6): error TS1005: '{' expected.
+tests/cases/conformance/jsx/29.tsx(1,7): error TS1109: Expression expected.
+tests/cases/conformance/jsx/29.tsx(2,1): error TS1005: '</' expected.
+tests/cases/conformance/jsx/3.tsx(1,1): error TS1109: Expression expected.
+tests/cases/conformance/jsx/3.tsx(1,2): error TS1109: Expression expected.
+tests/cases/conformance/jsx/3.tsx(1,3): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/3.tsx(1,6): error TS1109: Expression expected.
+tests/cases/conformance/jsx/3.tsx(1,7): error TS1109: Expression expected.
+tests/cases/conformance/jsx/31.tsx(1,4): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/4.tsx(1,6): error TS1005: '{' expected.
+tests/cases/conformance/jsx/4.tsx(1,6): error TS2304: Cannot find name 'd'.
+tests/cases/conformance/jsx/4.tsx(1,9): error TS1109: Expression expected.
+tests/cases/conformance/jsx/4.tsx(1,10): error TS1109: Expression expected.
+tests/cases/conformance/jsx/4.tsx(1,11): error TS1005: '/' expected.
+tests/cases/conformance/jsx/5.tsx(1,2): error TS17008: JSX element 'a' has no corresponding closing tag.
+tests/cases/conformance/jsx/5.tsx(1,5): error TS1005: '</' expected.
+tests/cases/conformance/jsx/6.tsx(1,4): error TS17002: Expected corresponding JSX closing tag for 'a'.
+tests/cases/conformance/jsx/7.tsx(1,13): error TS1002: Unterminated string literal.
+tests/cases/conformance/jsx/8.tsx(1,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/8.tsx(1,6): error TS17002: Expected corresponding JSX closing tag for 'a'.
+tests/cases/conformance/jsx/9.tsx(1,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/9.tsx(1,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/9.tsx(1,11): error TS1005: '>' expected.
+tests/cases/conformance/jsx/9.tsx(1,12): error TS2304: Cannot find name 'b'.
+tests/cases/conformance/jsx/9.tsx(1,16): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx (70 errors) ====
+==== tests/cases/conformance/jsx/1.tsx (3 errors) ====
     declare var React: any;
     
     </>;
@@ -80,9 +96,11 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS1109: Expression expected.
        ~
 !!! error TS1109: Expression expected.
+==== tests/cases/conformance/jsx/2.tsx (1 errors) ====
     <a: />;
       ~
 !!! error TS1003: Identifier expected.
+==== tests/cases/conformance/jsx/3.tsx (5 errors) ====
     <:a />;
     ~
 !!! error TS1109: Expression expected.
@@ -94,9 +112,8 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS1109: Expression expected.
           ~
 !!! error TS1109: Expression expected.
+==== tests/cases/conformance/jsx/4.tsx (5 errors) ====
     <a b=d />;
-    ~~~~~~~~~~
-!!! error TS2695: Left side of comma operator is unused and has no side effects.
          ~
 !!! error TS1005: '{' expected.
          ~
@@ -105,22 +122,29 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS1109: Expression expected.
              ~
 !!! error TS1109: Expression expected.
+              
+!!! error TS1005: '/' expected.
+==== tests/cases/conformance/jsx/5.tsx (2 errors) ====
     <a>;
-    ~
-!!! error TS1003: Identifier expected.
+     ~
+!!! error TS17008: JSX element 'a' has no corresponding closing tag.
+        
+!!! error TS1005: '</' expected.
+==== tests/cases/conformance/jsx/6.tsx (1 errors) ====
     <a></b>;
        ~~~~
 !!! error TS17002: Expected corresponding JSX closing tag for 'a'.
+==== tests/cases/conformance/jsx/7.tsx (1 errors) ====
     <a foo="bar;
                 
 !!! error TS1002: Unterminated string literal.
+==== tests/cases/conformance/jsx/8.tsx (2 errors) ====
     <a:b></b>;
-    ~
+      ~
 !!! error TS1003: Identifier expected.
          ~~~~
 !!! error TS17002: Expected corresponding JSX closing tag for 'a'.
-             ~
-!!! error TS2657: JSX expressions must have one parent element.
+==== tests/cases/conformance/jsx/9.tsx (5 errors) ====
     <a:b.c></a:b.c>;
       ~
 !!! error TS1003: Identifier expected.
@@ -132,6 +156,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS2304: Cannot find name 'b'.
                    ~
 !!! error TS1109: Expression expected.
+==== tests/cases/conformance/jsx/10.tsx (6 errors) ====
     <a.b:c></a.b:c>;
      ~
 !!! error TS2304: Cannot find name 'a'.
@@ -145,11 +170,13 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS2304: Cannot find name 'c'.
                    ~
 !!! error TS1109: Expression expected.
+==== tests/cases/conformance/jsx/11.tsx (2 errors) ====
     <a.b.c></a>;
      ~
 !!! error TS2304: Cannot find name 'a'.
            ~~~~
 !!! error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
+==== tests/cases/conformance/jsx/12.tsx (6 errors) ====
     <.a></.a>;
     ~
 !!! error TS1109: Expression expected.
@@ -163,6 +190,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS2304: Cannot find name 'a'.
              ~
 !!! error TS1109: Expression expected.
+==== tests/cases/conformance/jsx/13.tsx (4 errors) ====
     <a.></a.>;
      ~
 !!! error TS2304: Cannot find name 'a'.
@@ -172,6 +200,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS2304: Cannot find name 'a'.
             ~
 !!! error TS1003: Identifier expected.
+==== tests/cases/conformance/jsx/14.tsx (6 errors) ====
     <a[foo]></a[foo]>;
       ~
 !!! error TS1003: Identifier expected.
@@ -185,6 +214,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS2304: Cannot find name 'foo'.
                      ~
 !!! error TS1109: Expression expected.
+==== tests/cases/conformance/jsx/15.tsx (4 errors) ====
     <a['foo']></a['foo']>;
       ~
 !!! error TS1003: Identifier expected.
@@ -194,45 +224,96 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS2304: Cannot find name 'a'.
                          ~
 !!! error TS1109: Expression expected.
+==== tests/cases/conformance/jsx/16.tsx (2 errors) ====
     <a><a />;
      ~
 !!! error TS17008: JSX element 'a' has no corresponding closing tag.
+             
+!!! error TS1005: '</' expected.
+==== tests/cases/conformance/jsx/17.tsx (2 errors) ====
     <a b={}>;
      ~
 !!! error TS17008: JSX element 'a' has no corresponding closing tag.
+             
+!!! error TS1005: '</' expected.
+==== tests/cases/conformance/jsx/18.tsx (2 errors) ====
     var x = <div>one</div><div>two</div>;;
+            ~~~~~~~~~~~~~~
+!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                                        ~
+!!! error TS2657: JSX expressions must have one parent element.
+==== tests/cases/conformance/jsx/19.tsx (2 errors) ====
     var x = <div>one</div> /* intervening comment */ <div>two</div>;;
+            ~~~~~~~~~~~~~~
+!!! error TS2695: Left side of comma operator is unused and has no side effects.
+                                                                   ~
+!!! error TS2657: JSX expressions must have one parent element.
+==== tests/cases/conformance/jsx/20.tsx (1 errors) ====
     <a>{"str";}</a>;
              ~
 !!! error TS1005: '}' expected.
+==== tests/cases/conformance/jsx/21.tsx (1 errors) ====
     <span className="a", id="b" />;
                        ~
 !!! error TS1003: Identifier expected.
+==== tests/cases/conformance/jsx/22.tsx (2 errors) ====
     <div className"app">;
                   ~~~~~
 !!! error TS1003: Identifier expected.
+                        ~
+!!! error TS1109: Expression expected.
+==== tests/cases/conformance/jsx/23.tsx (2 errors) ====
     <div {props} />;
           ~~~~~
 !!! error TS1005: '...' expected.
           ~~~~~
 !!! error TS2304: Cannot find name 'props'.
     
+==== tests/cases/conformance/jsx/24.tsx (5 errors) ====
     <div>stuff</div {...props}>;
                     ~
 !!! error TS1005: '>' expected.
+                     ~~~
+!!! error TS1128: Declaration or statement expected.
+                        ~~~~~
+!!! error TS2304: Cannot find name 'props'.
+                              ~
+!!! error TS1109: Expression expected.
+                               ~
+!!! error TS1109: Expression expected.
+    
+==== tests/cases/conformance/jsx/25.tsx (6 errors) ====
     <div {...props}>stuff</div {...props}>;
              ~~~~~
 !!! error TS2304: Cannot find name 'props'.
                                ~
 !!! error TS1005: '>' expected.
+                                ~~~
+!!! error TS1128: Declaration or statement expected.
+                                   ~~~~~
+!!! error TS2304: Cannot find name 'props'.
+                                         ~
+!!! error TS1109: Expression expected.
+                                          ~
+!!! error TS1109: Expression expected.
     
+    
+==== tests/cases/conformance/jsx/26.tsx (0 errors) ====
     <a>></a>;
+    
+==== tests/cases/conformance/jsx/27.tsx (0 errors) ====
     <a> ></a>;
+    
+==== tests/cases/conformance/jsx/28.tsx (3 errors) ====
     <a b=}>;
      ~
 !!! error TS17008: JSX element 'a' has no corresponding closing tag.
          ~
 !!! error TS1005: '{' expected.
+    
+    
+!!! error TS1005: '</' expected.
+==== tests/cases/conformance/jsx/29.tsx (4 errors) ====
     <a b=<}>;
      ~
 !!! error TS17008: JSX element 'a' has no corresponding closing tag.
@@ -240,9 +321,13 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS1005:
 !!! error TS1005: '{' expected.
           ~
 !!! error TS1109: Expression expected.
+    
+    
+!!! error TS1005: '</' expected.
+==== tests/cases/conformance/jsx/30.tsx (0 errors) ====
     <a>}</a>;
+    
+==== tests/cases/conformance/jsx/31.tsx (1 errors) ====
     <a .../*hai*/asdf/>;
        ~~~
 !!! error TS1003: Identifier expected.
-                        
-!!! error TS1005: '</' expected.

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.js
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.js
@@ -1,79 +1,159 @@
-//// [jsxInvalidEsprimaTestSuite.tsx]
+//// [tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx] ////
+
+//// [1.tsx]
 declare var React: any;
 
 </>;
+//// [2.tsx]
 <a: />;
+//// [3.tsx]
 <:a />;
+//// [4.tsx]
 <a b=d />;
+//// [5.tsx]
 <a>;
+//// [6.tsx]
 <a></b>;
+//// [7.tsx]
 <a foo="bar;
+//// [8.tsx]
 <a:b></b>;
+//// [9.tsx]
 <a:b.c></a:b.c>;
+//// [10.tsx]
 <a.b:c></a.b:c>;
+//// [11.tsx]
 <a.b.c></a>;
+//// [12.tsx]
 <.a></.a>;
+//// [13.tsx]
 <a.></a.>;
+//// [14.tsx]
 <a[foo]></a[foo]>;
+//// [15.tsx]
 <a['foo']></a['foo']>;
+//// [16.tsx]
 <a><a />;
+//// [17.tsx]
 <a b={}>;
+//// [18.tsx]
 var x = <div>one</div><div>two</div>;;
+//// [19.tsx]
 var x = <div>one</div> /* intervening comment */ <div>two</div>;;
+//// [20.tsx]
 <a>{"str";}</a>;
+//// [21.tsx]
 <span className="a", id="b" />;
+//// [22.tsx]
 <div className"app">;
+//// [23.tsx]
 <div {props} />;
 
+//// [24.tsx]
 <div>stuff</div {...props}>;
+
+//// [25.tsx]
 <div {...props}>stuff</div {...props}>;
 
+
+//// [26.tsx]
 <a>></a>;
+
+//// [27.tsx]
 <a> ></a>;
+
+//// [28.tsx]
 <a b=}>;
+
+//// [29.tsx]
 <a b=<}>;
+
+//// [30.tsx]
 <a>}</a>;
+
+//// [31.tsx]
 <a .../*hai*/asdf/>;
 
-//// [jsxInvalidEsprimaTestSuite.jsx]
+//// [1.jsx]
  > ;
+//// [2.jsx]
 <a />;
-    < ;
+//// [3.jsx]
+ < ;
 a /  > ;
-<a b={d /  > }/>
-    ,
-        <a>;
+//// [4.jsx]
+<a b={d /  > }/>;
+//// [5.jsx]
+<a>;</>;
+//// [6.jsx]
 <a></b>;
-<a foo="bar;/>a:b></b>;
+//// [7.jsx]
+<a foo="bar;/>;
+//// [8.jsx]
+<a b></b>;
+//// [9.jsx]
 <a b c></a>;
 b.c > ;
+//// [10.jsx]
 <a.b c></a.b>;
 c > ;
+//// [11.jsx]
 <a.b.c></a>;
-    < .a > ;
+//// [12.jsx]
+ < .a > ;
 a > ;
+//// [13.jsx]
 <a.></a.>;
+//// [14.jsx]
 <a />;
 [foo] > ;
 a[foo] > ;
+//// [15.jsx]
 <a />;
 ['foo'] > ;
 a['foo'] > ;
-<a><a />;
-<a b=>;
-var x = <div>one</div><div>two</div>;;
-var x = <div>one</div> /* intervening comment */ /* intervening comment */ <div>two</div>;;
+//// [16.jsx]
+<a><a />;</>;
+//// [17.jsx]
+<a b=>;</>;
+//// [18.jsx]
+var x = <div>one</div>, <div>two</div>;
+;
+//// [19.jsx]
+var x = <div>one</div> /* intervening comment */, /* intervening comment */ <div>two</div>;
+;
+//// [20.jsx]
 <a>{"str"}}</a>;
-<span className="a"/> id="b" />;
-<div className/>>;
+//// [21.jsx]
+<span className="a" id="b"/>;
+//// [22.jsx]
+<div className/>;
+"app" > ;
+//// [23.jsx]
 <div {...props}/>;
-
-<div>stuff</div>...props}>;
-<div {...props}>stuff</div>...props}>;
-
+//// [24.jsx]
+<div>stuff</div>;
+{
+    props;
+}
+ > ;
+//// [25.jsx]
+<div {...props}>stuff</div>;
+{
+    props;
+}
+ > ;
+//// [26.jsx]
 <a>></a>;
+//// [27.jsx]
 <a> ></a>;
+//// [28.jsx]
 <a b=>;
+</>;
+//// [29.jsx]
 <a b={ < }>;
+</>;
+//// [30.jsx]
 <a>}</a>;
-<a /> /*hai*//*hai*/asdf/>;</></></></>;
+//// [31.jsx]
+<a asdf/>;

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.symbols
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.symbols
@@ -1,113 +1,150 @@
-=== tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx ===
+=== tests/cases/conformance/jsx/1.tsx ===
 declare var React: any;
->React : Symbol(React, Decl(jsxInvalidEsprimaTestSuite.tsx, 0, 11))
+>React : Symbol(React, Decl(1.tsx, 0, 11))
 
 </>;
+=== tests/cases/conformance/jsx/2.tsx ===
 <a: />;
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/3.tsx ===
 <:a />;
+No type information for this code.=== tests/cases/conformance/jsx/4.tsx ===
 <a b=d />;
 >a : Symbol(unknown)
->b : Symbol(b, Decl(jsxInvalidEsprimaTestSuite.tsx, 5, 2))
+>b : Symbol(b, Decl(4.tsx, 0, 2))
 
+=== tests/cases/conformance/jsx/5.tsx ===
 <a>;
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/6.tsx ===
 <a></b>;
 >a : Symbol(unknown)
 >b : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/7.tsx ===
 <a foo="bar;
 >a : Symbol(unknown)
->foo : Symbol(foo, Decl(jsxInvalidEsprimaTestSuite.tsx, 8, 2))
+>foo : Symbol(foo, Decl(7.tsx, 0, 2))
 
+=== tests/cases/conformance/jsx/8.tsx ===
 <a:b></b>;
+>a : Symbol(unknown)
+>b : Symbol(b, Decl(8.tsx, 0, 3))
 >b : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/9.tsx ===
 <a:b.c></a:b.c>;
 >a : Symbol(unknown)
->b : Symbol(b, Decl(jsxInvalidEsprimaTestSuite.tsx, 10, 3))
->c : Symbol(c, Decl(jsxInvalidEsprimaTestSuite.tsx, 10, 5))
+>b : Symbol(b, Decl(9.tsx, 0, 3))
+>c : Symbol(c, Decl(9.tsx, 0, 5))
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/10.tsx ===
 <a.b:c></a.b:c>;
->c : Symbol(c, Decl(jsxInvalidEsprimaTestSuite.tsx, 11, 5))
+>c : Symbol(c, Decl(10.tsx, 0, 5))
 
+=== tests/cases/conformance/jsx/11.tsx ===
 <a.b.c></a>;
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/12.tsx ===
 <.a></.a>;
+No type information for this code.=== tests/cases/conformance/jsx/13.tsx ===
 <a.></a.>;
+No type information for this code.=== tests/cases/conformance/jsx/14.tsx ===
 <a[foo]></a[foo]>;
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/15.tsx ===
 <a['foo']></a['foo']>;
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/16.tsx ===
 <a><a />;
 >a : Symbol(unknown)
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/17.tsx ===
 <a b={}>;
 >a : Symbol(unknown)
->b : Symbol(b, Decl(jsxInvalidEsprimaTestSuite.tsx, 18, 2))
+>b : Symbol(b, Decl(17.tsx, 0, 2))
 
+=== tests/cases/conformance/jsx/18.tsx ===
 var x = <div>one</div><div>two</div>;;
+>x : Symbol(x, Decl(18.tsx, 0, 3), Decl(19.tsx, 0, 3))
 >div : Symbol(unknown)
 >div : Symbol(unknown)
 >div : Symbol(unknown)
 >div : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/19.tsx ===
 var x = <div>one</div> /* intervening comment */ <div>two</div>;;
+>x : Symbol(x, Decl(18.tsx, 0, 3), Decl(19.tsx, 0, 3))
 >div : Symbol(unknown)
 >div : Symbol(unknown)
 >div : Symbol(unknown)
 >div : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/20.tsx ===
 <a>{"str";}</a>;
 >a : Symbol(unknown)
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/21.tsx ===
 <span className="a", id="b" />;
 >span : Symbol(unknown)
->className : Symbol(className, Decl(jsxInvalidEsprimaTestSuite.tsx, 22, 5))
+>className : Symbol(className, Decl(21.tsx, 0, 5))
+>id : Symbol(id, Decl(21.tsx, 0, 20))
 
+=== tests/cases/conformance/jsx/22.tsx ===
 <div className"app">;
 >div : Symbol(unknown)
->className : Symbol(className, Decl(jsxInvalidEsprimaTestSuite.tsx, 23, 4))
+>className : Symbol(className, Decl(22.tsx, 0, 4))
 
+=== tests/cases/conformance/jsx/23.tsx ===
 <div {props} />;
 >div : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/24.tsx ===
 <div>stuff</div {...props}>;
 >div : Symbol(unknown)
 >div : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/25.tsx ===
 <div {...props}>stuff</div {...props}>;
 >div : Symbol(unknown)
 >div : Symbol(unknown)
 
+
+=== tests/cases/conformance/jsx/26.tsx ===
 <a>></a>;
 >a : Symbol(unknown)
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/27.tsx ===
 <a> ></a>;
 >a : Symbol(unknown)
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/28.tsx ===
 <a b=}>;
 >a : Symbol(unknown)
->b : Symbol(b, Decl(jsxInvalidEsprimaTestSuite.tsx, 31, 2))
+>b : Symbol(b, Decl(28.tsx, 0, 2))
 
+=== tests/cases/conformance/jsx/29.tsx ===
 <a b=<}>;
 >a : Symbol(unknown)
->b : Symbol(b, Decl(jsxInvalidEsprimaTestSuite.tsx, 32, 2))
+>b : Symbol(b, Decl(29.tsx, 0, 2))
 
+=== tests/cases/conformance/jsx/30.tsx ===
 <a>}</a>;
 >a : Symbol(unknown)
 >a : Symbol(unknown)
 
+=== tests/cases/conformance/jsx/31.tsx ===
 <a .../*hai*/asdf/>;
 >a : Symbol(unknown)
+>asdf : Symbol(asdf, Decl(31.tsx, 0, 6))
 

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.types
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.types
@@ -1,4 +1,4 @@
-=== tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx ===
+=== tests/cases/conformance/jsx/1.tsx ===
 declare var React: any;
 >React : any
 
@@ -7,10 +7,12 @@ declare var React: any;
 > : any
 > : any
 
+=== tests/cases/conformance/jsx/2.tsx ===
 <a: />;
 ><a: /> : any
 >a : any
 
+=== tests/cases/conformance/jsx/3.tsx ===
 <:a />;
 >< : boolean
 > : any
@@ -21,8 +23,8 @@ declare var React: any;
 > : any
 > : any
 
+=== tests/cases/conformance/jsx/4.tsx ===
 <a b=d />;
-><a b=d />;<a>;<a></b>;<a foo="bar;<a:b></b> : any
 ><a b=d />; : any
 >a : any
 >b : boolean
@@ -32,23 +34,32 @@ declare var React: any;
 > : any
 > : any
 
+=== tests/cases/conformance/jsx/5.tsx ===
 <a>;
-><a>;<a></b>;<a foo="bar;<a:b></b> : any
+><a>; : any
 >a : any
+> : any
 
+=== tests/cases/conformance/jsx/6.tsx ===
 <a></b>;
 ><a></b> : any
 >a : any
 >b : any
 
+=== tests/cases/conformance/jsx/7.tsx ===
 <a foo="bar;
-><a foo="bar;< : any
+><a foo="bar; : any
 >a : any
 >foo : string
 
+=== tests/cases/conformance/jsx/8.tsx ===
 <a:b></b>;
+><a:b></b> : any
+>a : any
+>b : true
 >b : any
 
+=== tests/cases/conformance/jsx/9.tsx ===
 <a:b.c></a:b.c>;
 ><a:b.c></a : any
 >a : any
@@ -61,6 +72,7 @@ declare var React: any;
 >c : any
 > : any
 
+=== tests/cases/conformance/jsx/10.tsx ===
 <a.b:c></a.b:c>;
 ><a.b:c></a.b : any
 >a.b : any
@@ -74,6 +86,7 @@ declare var React: any;
 >c : any
 > : any
 
+=== tests/cases/conformance/jsx/11.tsx ===
 <a.b.c></a>;
 ><a.b.c></a> : any
 >a.b.c : any
@@ -83,6 +96,7 @@ declare var React: any;
 >c : any
 >a : any
 
+=== tests/cases/conformance/jsx/12.tsx ===
 <.a></.a>;
 ><.a> : boolean
 ><.a : boolean
@@ -95,6 +109,7 @@ declare var React: any;
 >a : any
 > : any
 
+=== tests/cases/conformance/jsx/13.tsx ===
 <a.></a.>;
 ><a.></a.> : any
 >a. : any
@@ -104,6 +119,7 @@ declare var React: any;
 >a : any
 > : any
 
+=== tests/cases/conformance/jsx/14.tsx ===
 <a[foo]></a[foo]>;
 ><a : any
 >a : any
@@ -117,6 +133,7 @@ declare var React: any;
 >foo : any
 > : any
 
+=== tests/cases/conformance/jsx/15.tsx ===
 <a['foo']></a['foo']>;
 ><a : any
 >a : any
@@ -130,18 +147,25 @@ declare var React: any;
 >'foo' : "foo"
 > : any
 
+=== tests/cases/conformance/jsx/16.tsx ===
 <a><a />;
-><a><a />;<a b={}>;var x = <div>one</div><div>two</div>;;var x = <div>one</div> /* intervening comment */ <div>two</div>;;<a>{"str";}</a>;<span className="a", id="b" />;<div className"app">;<div {props} />;<div>stuff</div {...props}>;<div {...props}>stuff</div {...props}>;<a>></a>;<a> ></a>;<a b=}>;<a b=<}>;<a>}</a>;<a .../*hai*/asdf/>; : any
+><a><a />; : any
 >a : any
 ><a /> : any
 >a : any
+> : any
 
+=== tests/cases/conformance/jsx/17.tsx ===
 <a b={}>;
-><a b={}>;var x = <div>one</div><div>two</div>;;var x = <div>one</div> /* intervening comment */ <div>two</div>;;<a>{"str";}</a>;<span className="a", id="b" />;<div className"app">;<div {props} />;<div>stuff</div {...props}>;<div {...props}>stuff</div {...props}>;<a>></a>;<a> ></a>;<a b=}>;<a b=<}>;<a>}</a>;<a .../*hai*/asdf/>; : any
+><a b={}>; : any
 >a : any
 >b : any
+> : any
 
+=== tests/cases/conformance/jsx/18.tsx ===
 var x = <div>one</div><div>two</div>;;
+>x : any
+><div>one</div><div>two</div> : any
 ><div>one</div> : any
 >div : any
 >div : any
@@ -149,7 +173,10 @@ var x = <div>one</div><div>two</div>;;
 >div : any
 >div : any
 
+=== tests/cases/conformance/jsx/19.tsx ===
 var x = <div>one</div> /* intervening comment */ <div>two</div>;;
+>x : any
+><div>one</div> /* intervening comment */ <div>two</div> : any
 ><div>one</div> : any
 >div : any
 >div : any
@@ -157,71 +184,97 @@ var x = <div>one</div> /* intervening comment */ <div>two</div>;;
 >div : any
 >div : any
 
+=== tests/cases/conformance/jsx/20.tsx ===
 <a>{"str";}</a>;
 ><a>{"str";}</a> : any
 >a : any
 >"str" : "str"
 >a : any
 
+=== tests/cases/conformance/jsx/21.tsx ===
 <span className="a", id="b" />;
-><span className="a", : any
+><span className="a", id="b" /> : any
 >span : any
 >className : string
+>id : string
 
+=== tests/cases/conformance/jsx/22.tsx ===
 <div className"app">;
-><div className"app" : any
+><div className : any
 >div : any
 >className : true
+>"app"> : boolean
+>"app" : "app"
+> : any
 
+=== tests/cases/conformance/jsx/23.tsx ===
 <div {props} />;
 ><div {props} /> : any
 >div : any
 >props : any
 
+=== tests/cases/conformance/jsx/24.tsx ===
 <div>stuff</div {...props}>;
-><div>stuff</div { : any
+><div>stuff</div : any
 >div : any
 >div : any
+>props : any
+>> : boolean
+> : any
+> : any
 
+=== tests/cases/conformance/jsx/25.tsx ===
 <div {...props}>stuff</div {...props}>;
-><div {...props}>stuff</div { : any
+><div {...props}>stuff</div : any
 >div : any
 >props : any
 >div : any
+>props : any
+>> : boolean
+> : any
+> : any
 
+
+=== tests/cases/conformance/jsx/26.tsx ===
 <a>></a>;
 ><a>></a> : any
 >a : any
 >a : any
 
+=== tests/cases/conformance/jsx/27.tsx ===
 <a> ></a>;
 ><a> ></a> : any
 >a : any
 >a : any
 
+=== tests/cases/conformance/jsx/28.tsx ===
 <a b=}>;
-><a b=}>;<a b=<}>;<a>}</a>;<a .../*hai*/asdf/>; : any
+><a b=}>; : any
 >a : any
 >b : any
 
+> : any
+
+=== tests/cases/conformance/jsx/29.tsx ===
 <a b=<}>;
-><a b=<}>;<a>}</a>;<a .../*hai*/asdf/>; : any
+><a b=<}>; : any
 >a : any
 >b : boolean
 >< : boolean
 > : any
 > : any
 
+> : any
+
+=== tests/cases/conformance/jsx/30.tsx ===
 <a>}</a>;
 ><a>}</a> : any
 >a : any
 >a : any
 
+=== tests/cases/conformance/jsx/31.tsx ===
 <a .../*hai*/asdf/>;
-><a ... : any
+><a .../*hai*/asdf/> : any
 >a : any
-> : any
-> : any
-> : any
-> : any
+>asdf : true
 

--- a/tests/baselines/reference/jsxMultilineAttributeStringValues.js
+++ b/tests/baselines/reference/jsxMultilineAttributeStringValues.js
@@ -1,0 +1,16 @@
+//// [jsxMultilineAttributeStringValues.tsx]
+const a = <input value="
+  foo: 23
+"></input>;
+const b = <input value='
+foo: 23
+'></input>;
+
+
+//// [jsxMultilineAttributeStringValues.jsx]
+var a = <input value="
+  foo: 23
+"></input>;
+var b = <input value='
+foo: 23
+'></input>;

--- a/tests/baselines/reference/jsxMultilineAttributeStringValues.symbols
+++ b/tests/baselines/reference/jsxMultilineAttributeStringValues.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/jsxMultilineAttributeStringValues.tsx ===
+const a = <input value="
+>a : Symbol(a, Decl(jsxMultilineAttributeStringValues.tsx, 0, 5))
+>input : Symbol(unknown)
+>value : Symbol(value, Decl(jsxMultilineAttributeStringValues.tsx, 0, 16))
+
+  foo: 23
+"></input>;
+>input : Symbol(unknown)
+
+const b = <input value='
+>b : Symbol(b, Decl(jsxMultilineAttributeStringValues.tsx, 3, 5))
+>input : Symbol(unknown)
+>value : Symbol(value, Decl(jsxMultilineAttributeStringValues.tsx, 3, 16))
+
+foo: 23
+'></input>;
+>input : Symbol(unknown)
+

--- a/tests/baselines/reference/jsxMultilineAttributeStringValues.types
+++ b/tests/baselines/reference/jsxMultilineAttributeStringValues.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/jsxMultilineAttributeStringValues.tsx ===
+const a = <input value="
+>a : any
+><input value="  foo: 23"></input> : any
+>input : any
+>value : string
+
+  foo: 23
+"></input>;
+>input : any
+
+const b = <input value='
+>b : any
+><input value='foo: 23'></input> : any
+>input : any
+>value : string
+
+foo: 23
+'></input>;
+>input : any
+

--- a/tests/baselines/reference/jsxMultilineAttributeValuesReact.js
+++ b/tests/baselines/reference/jsxMultilineAttributeValuesReact.js
@@ -1,0 +1,17 @@
+//// [jsxMultilineAttributeValuesReact.tsx]
+declare var React: any;
+const a = <input value="
+foo: 23
+"></input>;
+const b = <input value='
+foo: 23
+'></input>;
+const c = <input value='
+foo: 23\n
+'></input>;
+
+
+//// [jsxMultilineAttributeValuesReact.js]
+var a = React.createElement("input", { value: "\nfoo: 23\n" });
+var b = React.createElement("input", { value: '\nfoo: 23\n' });
+var c = React.createElement("input", { value: '\nfoo: 23\\n\n' });

--- a/tests/baselines/reference/jsxMultilineAttributeValuesReact.symbols
+++ b/tests/baselines/reference/jsxMultilineAttributeValuesReact.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/jsxMultilineAttributeValuesReact.tsx ===
+declare var React: any;
+>React : Symbol(React, Decl(jsxMultilineAttributeValuesReact.tsx, 0, 11))
+
+const a = <input value="
+>a : Symbol(a, Decl(jsxMultilineAttributeValuesReact.tsx, 1, 5))
+>input : Symbol(unknown)
+>value : Symbol(value, Decl(jsxMultilineAttributeValuesReact.tsx, 1, 16))
+
+foo: 23
+"></input>;
+>input : Symbol(unknown)
+
+const b = <input value='
+>b : Symbol(b, Decl(jsxMultilineAttributeValuesReact.tsx, 4, 5))
+>input : Symbol(unknown)
+>value : Symbol(value, Decl(jsxMultilineAttributeValuesReact.tsx, 4, 16))
+
+foo: 23
+'></input>;
+>input : Symbol(unknown)
+
+const c = <input value='
+>c : Symbol(c, Decl(jsxMultilineAttributeValuesReact.tsx, 7, 5))
+>input : Symbol(unknown)
+>value : Symbol(value, Decl(jsxMultilineAttributeValuesReact.tsx, 7, 16))
+
+foo: 23\n
+'></input>;
+>input : Symbol(unknown)
+

--- a/tests/baselines/reference/jsxMultilineAttributeValuesReact.types
+++ b/tests/baselines/reference/jsxMultilineAttributeValuesReact.types
@@ -1,0 +1,34 @@
+=== tests/cases/compiler/jsxMultilineAttributeValuesReact.tsx ===
+declare var React: any;
+>React : any
+
+const a = <input value="
+>a : any
+><input value="foo: 23"></input> : any
+>input : any
+>value : string
+
+foo: 23
+"></input>;
+>input : any
+
+const b = <input value='
+>b : any
+><input value='foo: 23'></input> : any
+>input : any
+>value : string
+
+foo: 23
+'></input>;
+>input : any
+
+const c = <input value='
+>c : any
+><input value='foo: 23\n'></input> : any
+>input : any
+>value : string
+
+foo: 23\n
+'></input>;
+>input : any
+

--- a/tests/cases/compiler/jsxMultilineAttributeStringValues.tsx
+++ b/tests/cases/compiler/jsxMultilineAttributeStringValues.tsx
@@ -1,0 +1,7 @@
+// @jsx: preserve
+const a = <input value="
+  foo: 23
+"></input>;
+const b = <input value='
+foo: 23
+'></input>;

--- a/tests/cases/compiler/jsxMultilineAttributeValuesReact.tsx
+++ b/tests/cases/compiler/jsxMultilineAttributeValuesReact.tsx
@@ -1,0 +1,11 @@
+// @jsx: react
+declare var React: any;
+const a = <input value="
+foo: 23
+"></input>;
+const b = <input value='
+foo: 23
+'></input>;
+const c = <input value='
+foo: 23\n
+'></input>;

--- a/tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx
+++ b/tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx
@@ -1,36 +1,74 @@
 // @jsx: preserve
+// @filename: 1.tsx
 declare var React: any;
 
 </>;
+// @filename: 2.tsx
 <a: />;
+// @filename: 3.tsx
 <:a />;
+// @filename: 4.tsx
 <a b=d />;
+// @filename: 5.tsx
 <a>;
+// @filename: 6.tsx
 <a></b>;
+// @filename: 7.tsx
 <a foo="bar;
+// @filename: 8.tsx
 <a:b></b>;
+// @filename: 9.tsx
 <a:b.c></a:b.c>;
+// @filename: 10.tsx
 <a.b:c></a.b:c>;
+// @filename: 11.tsx
 <a.b.c></a>;
+// @filename: 12.tsx
 <.a></.a>;
+// @filename: 13.tsx
 <a.></a.>;
+// @filename: 14.tsx
 <a[foo]></a[foo]>;
+// @filename: 15.tsx
 <a['foo']></a['foo']>;
+// @filename: 16.tsx
 <a><a />;
+// @filename: 17.tsx
 <a b={}>;
+// @filename: 18.tsx
 var x = <div>one</div><div>two</div>;;
+// @filename: 19.tsx
 var x = <div>one</div> /* intervening comment */ <div>two</div>;;
+// @filename: 20.tsx
 <a>{"str";}</a>;
+// @filename: 21.tsx
 <span className="a", id="b" />;
+// @filename: 22.tsx
 <div className"app">;
+// @filename: 23.tsx
 <div {props} />;
 
+// @filename: 24.tsx
 <div>stuff</div {...props}>;
+
+// @filename: 25.tsx
 <div {...props}>stuff</div {...props}>;
 
+
+// @filename: 26.tsx
 <a>></a>;
+
+// @filename: 27.tsx
 <a> ></a>;
+
+// @filename: 28.tsx
 <a b=}>;
+
+// @filename: 29.tsx
 <a b=<}>;
+
+// @filename: 30.tsx
 <a>}</a>;
+
+// @filename: 31.tsx
 <a .../*hai*/asdf/>;


### PR DESCRIPTION
Fixes #13328

I also changed `jsxInvalidEsprimaTestSuite.tsx` to actually start a new parser context for each invalid line, since this change caused a change in the error cascade in that file that I'd rather avoid. Unfortunately, that exposed another bug: we parse `<a>}</a>;` and `<a>></a>;` as _valid_ jsx, when they should be _invalid_ (`}` and `>` are both explicitly not part of the JsxText character set in the spec).