### PR TITLE
Apply TS2713 to classes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1338,7 +1338,7 @@ namespace ts {
 
         function checkAndReportErrorForUsingTypeAsNamespace(errorLocation: Node, name: __String, meaning: SymbolFlags): boolean {
             if (meaning === SymbolFlags.Namespace) {
-                const symbol = resolveSymbol(resolveName(errorLocation, name, SymbolFlags.Type & ~SymbolFlags.Value, /*nameNotFoundMessage*/undefined, /*nameArg*/ undefined, /*isUse*/ false));
+                const symbol = resolveSymbol(resolveName(errorLocation, name, SymbolFlags.Class | SymbolFlags.Interface | SymbolFlags.TypeAlias, /*nameNotFoundMessage*/undefined, /*nameArg*/ undefined, /*isUse*/ false));
                 const parent = errorLocation.parent;
                 if (symbol) {
                     if (isQualifiedName(parent)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1338,7 +1338,7 @@ namespace ts {
 
         function checkAndReportErrorForUsingTypeAsNamespace(errorLocation: Node, name: __String, meaning: SymbolFlags): boolean {
             if (meaning === SymbolFlags.Namespace) {
-                const symbol = resolveSymbol(resolveName(errorLocation, name, SymbolFlags.Class | SymbolFlags.Interface | SymbolFlags.TypeAlias, /*nameNotFoundMessage*/undefined, /*nameArg*/ undefined, /*isUse*/ false));
+                const symbol = resolveSymbol(resolveName(errorLocation, name, SymbolFlags.Type & ~SymbolFlags.Namespace, /*nameNotFoundMessage*/undefined, /*nameArg*/ undefined, /*isUse*/ false));
                 const parent = errorLocation.parent;
                 if (symbol) {
                     if (isQualifiedName(parent)) {

--- a/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision7.errors.txt
+++ b/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision7.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/service.ts(7,9): error TS2503: Cannot find namespace 'db'.
-tests/cases/compiler/service.ts(9,21): error TS2503: Cannot find namespace 'db'.
+tests/cases/compiler/service.ts(7,9): error TS2702: 'db' only refers to a type, but is being used as a namespace here.
+tests/cases/compiler/service.ts(9,21): error TS2702: 'db' only refers to a type, but is being used as a namespace here.
 
 
 ==== tests/cases/compiler/db.ts (0 errors) ====
@@ -17,11 +17,11 @@ tests/cases/compiler/service.ts(9,21): error TS2503: Cannot find namespace 'db'.
     class MyClass {
         db: db.db; //error
             ~~
-!!! error TS2503: Cannot find namespace 'db'.
+!!! error TS2702: 'db' only refers to a type, but is being used as a namespace here.
     
         constructor(db: db.db) { // error
                         ~~
-!!! error TS2503: Cannot find namespace 'db'.
+!!! error TS2702: 'db' only refers to a type, but is being used as a namespace here.
             this.db = db;
             this.db.doSomething();
         }

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType01.errors.txt
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType01.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/errorForUsingPropertyOfTypeAsType01.ts(6,12): error TS2713: Cannot access 'Foo.bar' because 'Foo' is a type, but not a namespace. Did you mean to retrieve the type of the property 'bar' in 'Foo' with 'Foo["bar"]'?
 tests/cases/compiler/errorForUsingPropertyOfTypeAsType01.ts(7,18): error TS2694: Namespace 'Test1' has no exported member 'Foo'.
-tests/cases/compiler/errorForUsingPropertyOfTypeAsType01.ts(15,12): error TS2503: Cannot find namespace 'Foo'.
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType01.ts(15,12): error TS2713: Cannot access 'Foo.bar' because 'Foo' is a type, but not a namespace. Did you mean to retrieve the type of the property 'bar' in 'Foo' with 'Foo["bar"]'?
 tests/cases/compiler/errorForUsingPropertyOfTypeAsType01.ts(16,18): error TS2694: Namespace 'Test2' has no exported member 'Foo'.
 tests/cases/compiler/errorForUsingPropertyOfTypeAsType01.ts(24,12): error TS2713: Cannot access 'Foo.bar' because 'Foo' is a type, but not a namespace. Did you mean to retrieve the type of the property 'bar' in 'Foo' with 'Foo["bar"]'?
 tests/cases/compiler/errorForUsingPropertyOfTypeAsType01.ts(25,18): error TS2694: Namespace 'Test3' has no exported member 'Foo'.
@@ -32,8 +32,8 @@ tests/cases/compiler/errorForUsingPropertyOfTypeAsType01.ts(44,24): error TS1003
         }
     
         var x: Foo.bar = "";
-               ~~~
-!!! error TS2503: Cannot find namespace 'Foo'.
+               ~~~~~~~
+!!! error TS2713: Cannot access 'Foo.bar' because 'Foo' is a type, but not a namespace. Did you mean to retrieve the type of the property 'bar' in 'Foo' with 'Foo["bar"]'?
         var y: Test2.Foo.bar = "";
                      ~~~
 !!! error TS2694: Namespace 'Test2' has no exported member 'Foo'.

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType02.errors.txt
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType02.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts(3,16): error TS2713: Cannot access 'T.abc' because 'T' is a type, but not a namespace. Did you mean to retrieve the type of the property 'abc' in 'T' with 'T["abc"]'?
+
+
+==== tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts (1 errors) ====
+    namespace Test1 {
+        function foo<T extends { abc: number }>(x: T) {
+            let a: T.abc = x.abc;
+                   ~~~~~
+!!! error TS2713: Cannot access 'T.abc' because 'T' is a type, but not a namespace. Did you mean to retrieve the type of the property 'abc' in 'T' with 'T["abc"]'?
+        }
+    }

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType02.js
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType02.js
@@ -1,0 +1,14 @@
+//// [errorForUsingPropertyOfTypeAsType02.ts]
+namespace Test1 {
+    function foo<T extends { abc: number }>(x: T) {
+        let a: T.abc = x.abc;
+    }
+}
+
+//// [errorForUsingPropertyOfTypeAsType02.js]
+var Test1;
+(function (Test1) {
+    function foo(x) {
+        var a = x.abc;
+    }
+})(Test1 || (Test1 = {}));

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType02.symbols
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType02.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts ===
+namespace Test1 {
+>Test1 : Symbol(Test1, Decl(errorForUsingPropertyOfTypeAsType02.ts, 0, 0))
+
+    function foo<T extends { abc: number }>(x: T) {
+>foo : Symbol(foo, Decl(errorForUsingPropertyOfTypeAsType02.ts, 0, 17))
+>T : Symbol(T, Decl(errorForUsingPropertyOfTypeAsType02.ts, 1, 17))
+>abc : Symbol(abc, Decl(errorForUsingPropertyOfTypeAsType02.ts, 1, 28))
+>x : Symbol(x, Decl(errorForUsingPropertyOfTypeAsType02.ts, 1, 44))
+>T : Symbol(T, Decl(errorForUsingPropertyOfTypeAsType02.ts, 1, 17))
+
+        let a: T.abc = x.abc;
+>a : Symbol(a, Decl(errorForUsingPropertyOfTypeAsType02.ts, 2, 11))
+>x.abc : Symbol(abc, Decl(errorForUsingPropertyOfTypeAsType02.ts, 1, 28))
+>x : Symbol(x, Decl(errorForUsingPropertyOfTypeAsType02.ts, 1, 44))
+>abc : Symbol(abc, Decl(errorForUsingPropertyOfTypeAsType02.ts, 1, 28))
+    }
+}

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType02.types
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType02.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts ===
+namespace Test1 {
+>Test1 : typeof Test1
+
+    function foo<T extends { abc: number }>(x: T) {
+>foo : <T extends { abc: number; }>(x: T) => void
+>T : T
+>abc : number
+>x : T
+>T : T
+
+        let a: T.abc = x.abc;
+>a : any
+>T : any
+>abc : No type information available!
+>x.abc : number
+>x : T
+>abc : number
+    }
+}

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType03.errors.txt
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType03.errors.txt
@@ -1,0 +1,50 @@
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts(11,19): error TS2694: Namespace 'Color' has no exported member 'Red'.
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts(13,19): error TS2339: Property 'Red' does not exist on type 'Color'.
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts(19,13): error TS2503: Cannot find namespace 'T1'.
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts(20,13): error TS2503: Cannot find namespace 'T1'.
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts(21,16): error TS2339: Property 'Red' does not exist on type 'Color'.
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts(23,13): error TS2503: Cannot find namespace 'T2'.
+tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts(24,13): error TS2503: Cannot find namespace 'T2'.
+
+
+==== tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts (7 errors) ====
+    namespace Test1 {
+        enum Color {
+            Red,
+            Green,
+            Blue
+        }
+    
+        type C1 = Color;
+        type C2 = typeof Color;
+    
+        let a1: Color.Red.toString;
+                      ~~~
+!!! error TS2694: Namespace 'Color' has no exported member 'Red'.
+        let a2: Color.Red["toString"];
+        let a3: Color["Red"]["toString"];
+                      ~~~~~
+!!! error TS2339: Property 'Red' does not exist on type 'Color'.
+    
+        //let b1: (typeof Color).Red.toString;
+        //let b2: (typeof Color).Red["toString"];
+        let b3: (typeof Color)["Red"]["toString"];
+    
+        let c1: T1.Red.toString;
+                ~~
+!!! error TS2503: Cannot find namespace 'T1'.
+        let c2: T1.Red["toString"];
+                ~~
+!!! error TS2503: Cannot find namespace 'T1'.
+        let c3: C1["Red"]["toString"];
+                   ~~~~~
+!!! error TS2339: Property 'Red' does not exist on type 'Color'.
+    
+        let d1: T2.Red.toString;
+                ~~
+!!! error TS2503: Cannot find namespace 'T2'.
+        let d2: T2.Red["toString"];
+                ~~
+!!! error TS2503: Cannot find namespace 'T2'.
+        let d3: C2["Red"]["toString"];
+    }

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType03.js
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType03.js
@@ -1,0 +1,50 @@
+//// [errorForUsingPropertyOfTypeAsType03.ts]
+namespace Test1 {
+    enum Color {
+        Red,
+        Green,
+        Blue
+    }
+
+    type C1 = Color;
+    type C2 = typeof Color;
+
+    let a1: Color.Red.toString;
+    let a2: Color.Red["toString"];
+    let a3: Color["Red"]["toString"];
+
+    //let b1: (typeof Color).Red.toString;
+    //let b2: (typeof Color).Red["toString"];
+    let b3: (typeof Color)["Red"]["toString"];
+
+    let c1: T1.Red.toString;
+    let c2: T1.Red["toString"];
+    let c3: C1["Red"]["toString"];
+
+    let d1: T2.Red.toString;
+    let d2: T2.Red["toString"];
+    let d3: C2["Red"]["toString"];
+}
+
+//// [errorForUsingPropertyOfTypeAsType03.js]
+var Test1;
+(function (Test1) {
+    var Color;
+    (function (Color) {
+        Color[Color["Red"] = 0] = "Red";
+        Color[Color["Green"] = 1] = "Green";
+        Color[Color["Blue"] = 2] = "Blue";
+    })(Color || (Color = {}));
+    var a1;
+    var a2;
+    var a3;
+    //let b1: (typeof Color).Red.toString;
+    //let b2: (typeof Color).Red["toString"];
+    var b3;
+    var c1;
+    var c2;
+    var c3;
+    var d1;
+    var d2;
+    var d3;
+})(Test1 || (Test1 = {}));

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType03.symbols
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType03.symbols
@@ -1,0 +1,64 @@
+=== tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts ===
+namespace Test1 {
+>Test1 : Symbol(Test1, Decl(errorForUsingPropertyOfTypeAsType03.ts, 0, 0))
+
+    enum Color {
+>Color : Symbol(Color, Decl(errorForUsingPropertyOfTypeAsType03.ts, 0, 17))
+
+        Red,
+>Red : Symbol(Color.Red, Decl(errorForUsingPropertyOfTypeAsType03.ts, 1, 16))
+
+        Green,
+>Green : Symbol(Color.Green, Decl(errorForUsingPropertyOfTypeAsType03.ts, 2, 12))
+
+        Blue
+>Blue : Symbol(Color.Blue, Decl(errorForUsingPropertyOfTypeAsType03.ts, 3, 14))
+    }
+
+    type C1 = Color;
+>C1 : Symbol(C1, Decl(errorForUsingPropertyOfTypeAsType03.ts, 5, 5))
+>Color : Symbol(Color, Decl(errorForUsingPropertyOfTypeAsType03.ts, 0, 17))
+
+    type C2 = typeof Color;
+>C2 : Symbol(C2, Decl(errorForUsingPropertyOfTypeAsType03.ts, 7, 20))
+>Color : Symbol(Color, Decl(errorForUsingPropertyOfTypeAsType03.ts, 0, 17))
+
+    let a1: Color.Red.toString;
+>a1 : Symbol(a1, Decl(errorForUsingPropertyOfTypeAsType03.ts, 10, 7))
+>Color : Symbol(Color, Decl(errorForUsingPropertyOfTypeAsType03.ts, 0, 17))
+
+    let a2: Color.Red["toString"];
+>a2 : Symbol(a2, Decl(errorForUsingPropertyOfTypeAsType03.ts, 11, 7))
+>Color : Symbol(Color, Decl(errorForUsingPropertyOfTypeAsType03.ts, 0, 17))
+>Red : Symbol(Color.Red, Decl(errorForUsingPropertyOfTypeAsType03.ts, 1, 16))
+
+    let a3: Color["Red"]["toString"];
+>a3 : Symbol(a3, Decl(errorForUsingPropertyOfTypeAsType03.ts, 12, 7))
+>Color : Symbol(Color, Decl(errorForUsingPropertyOfTypeAsType03.ts, 0, 17))
+
+    //let b1: (typeof Color).Red.toString;
+    //let b2: (typeof Color).Red["toString"];
+    let b3: (typeof Color)["Red"]["toString"];
+>b3 : Symbol(b3, Decl(errorForUsingPropertyOfTypeAsType03.ts, 16, 7))
+>Color : Symbol(Color, Decl(errorForUsingPropertyOfTypeAsType03.ts, 0, 17))
+
+    let c1: T1.Red.toString;
+>c1 : Symbol(c1, Decl(errorForUsingPropertyOfTypeAsType03.ts, 18, 7))
+
+    let c2: T1.Red["toString"];
+>c2 : Symbol(c2, Decl(errorForUsingPropertyOfTypeAsType03.ts, 19, 7))
+
+    let c3: C1["Red"]["toString"];
+>c3 : Symbol(c3, Decl(errorForUsingPropertyOfTypeAsType03.ts, 20, 7))
+>C1 : Symbol(C1, Decl(errorForUsingPropertyOfTypeAsType03.ts, 5, 5))
+
+    let d1: T2.Red.toString;
+>d1 : Symbol(d1, Decl(errorForUsingPropertyOfTypeAsType03.ts, 22, 7))
+
+    let d2: T2.Red["toString"];
+>d2 : Symbol(d2, Decl(errorForUsingPropertyOfTypeAsType03.ts, 23, 7))
+
+    let d3: C2["Red"]["toString"];
+>d3 : Symbol(d3, Decl(errorForUsingPropertyOfTypeAsType03.ts, 24, 7))
+>C2 : Symbol(C2, Decl(errorForUsingPropertyOfTypeAsType03.ts, 7, 20))
+}

--- a/tests/baselines/reference/errorForUsingPropertyOfTypeAsType03.types
+++ b/tests/baselines/reference/errorForUsingPropertyOfTypeAsType03.types
@@ -1,0 +1,76 @@
+=== tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts ===
+namespace Test1 {
+>Test1 : typeof Test1
+
+    enum Color {
+>Color : Color
+
+        Red,
+>Red : Color.Red
+
+        Green,
+>Green : Color.Green
+
+        Blue
+>Blue : Color.Blue
+    }
+
+    type C1 = Color;
+>C1 : Color
+>Color : Color
+
+    type C2 = typeof Color;
+>C2 : typeof Color
+>Color : typeof Color
+
+    let a1: Color.Red.toString;
+>a1 : any
+>Color : any
+>Red : any
+>toString : No type information available!
+
+    let a2: Color.Red["toString"];
+>a2 : (radix?: number) => string
+>Color : any
+>Red : Color.Red
+
+    let a3: Color["Red"]["toString"];
+>a3 : any
+>Color : Color
+
+    //let b1: (typeof Color).Red.toString;
+    //let b2: (typeof Color).Red["toString"];
+    let b3: (typeof Color)["Red"]["toString"];
+>b3 : (radix?: number) => string
+>Color : typeof Color
+
+    let c1: T1.Red.toString;
+>c1 : any
+>T1 : any
+>Red : any
+>toString : No type information available!
+
+    let c2: T1.Red["toString"];
+>c2 : any
+>T1 : any
+>Red : No type information available!
+
+    let c3: C1["Red"]["toString"];
+>c3 : any
+>C1 : Color
+
+    let d1: T2.Red.toString;
+>d1 : any
+>T2 : any
+>Red : any
+>toString : No type information available!
+
+    let d2: T2.Red["toString"];
+>d2 : any
+>T2 : any
+>Red : No type information available!
+
+    let d3: C2["Red"]["toString"];
+>d3 : (radix?: number) => string
+>C2 : typeof Color
+}

--- a/tests/baselines/reference/invalidImportAliasIdentifiers.errors.txt
+++ b/tests/baselines/reference/invalidImportAliasIdentifiers.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts(5,12): error TS2503: Cannot find namespace 'V'.
-tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts(11,12): error TS2503: Cannot find namespace 'C'.
+tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts(11,12): error TS2702: 'C' only refers to a type, but is being used as a namespace here.
 tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts(23,12): error TS2702: 'I' only refers to a type, but is being used as a namespace here.
 
 
@@ -18,7 +18,7 @@ tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIde
     
     import c = C;
                ~
-!!! error TS2503: Cannot find namespace 'C'.
+!!! error TS2702: 'C' only refers to a type, but is being used as a namespace here.
     
     enum E {
         Red, Blue

--- a/tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts
+++ b/tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts
@@ -1,0 +1,5 @@
+namespace Test1 {
+    function foo<T extends { abc: number }>(x: T) {
+        let a: T.abc = x.abc;
+    }
+}

--- a/tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts
+++ b/tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts
@@ -1,0 +1,26 @@
+namespace Test1 {
+    enum Color {
+        Red,
+        Green,
+        Blue
+    }
+
+    type C1 = Color;
+    type C2 = typeof Color;
+
+    let a1: Color.Red.toString;
+    let a2: Color.Red["toString"];
+    let a3: Color["Red"]["toString"];
+
+    //let b1: (typeof Color).Red.toString;
+    //let b2: (typeof Color).Red["toString"];
+    let b3: (typeof Color)["Red"]["toString"];
+
+    let c1: T1.Red.toString;
+    let c2: T1.Red["toString"];
+    let c3: C1["Red"]["toString"];
+
+    let d1: T2.Red.toString;
+    let d2: T2.Red["toString"];
+    let d3: C2["Red"]["toString"];
+}


### PR DESCRIPTION
Formerly, they were excluded as values, but the error is just as
relevant for classes.

Note that it is not applied to enums since switching to an indexed
access expression will not help for an enum.