### PR TITLE
Make sure autoArrayType is unique, even if no lib is available

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25138,7 +25138,7 @@ namespace ts {
 
             autoArrayType = createArrayType(autoType);
             if (autoArrayType === emptyObjectType) {
-                // autoArrayType is used as a marker, so even if global Array type is not defined, it needs ot be a unique type
+                // autoArrayType is used as a marker, so even if global Array type is not defined, it needs to be a unique type
                 autoArrayType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
             }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25135,7 +25135,12 @@ namespace ts {
             globalBooleanType = getGlobalType("Boolean" as __String, /*arity*/ 0, /*reportErrors*/ true);
             globalRegExpType = getGlobalType("RegExp" as __String, /*arity*/ 0, /*reportErrors*/ true);
             anyArrayType = createArrayType(anyType);
+
             autoArrayType = createArrayType(autoType);
+            if (autoArrayType === emptyObjectType) {
+                // autoArrayType is used as a marker, so even if global Array type is not defined, it needs ot be a unique type
+                autoArrayType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
+            }
 
             globalReadonlyArrayType = <GenericType>getGlobalTypeOrUndefined("ReadonlyArray" as __String, /*arity*/ 1);
             anyReadonlyArrayType = globalReadonlyArrayType ? createTypeFromGenericGlobalType(globalReadonlyArrayType, [anyType]) : anyArrayType;

--- a/tests/baselines/reference/noCrashOnNoLib.errors.txt
+++ b/tests/baselines/reference/noCrashOnNoLib.errors.txt
@@ -1,0 +1,25 @@
+error TS2318: Cannot find global type 'Array'.
+error TS2318: Cannot find global type 'Boolean'.
+error TS2318: Cannot find global type 'Function'.
+error TS2318: Cannot find global type 'IArguments'.
+error TS2318: Cannot find global type 'Number'.
+error TS2318: Cannot find global type 'Object'.
+error TS2318: Cannot find global type 'RegExp'.
+error TS2318: Cannot find global type 'String'.
+
+
+!!! error TS2318: Cannot find global type 'Array'.
+!!! error TS2318: Cannot find global type 'Boolean'.
+!!! error TS2318: Cannot find global type 'Function'.
+!!! error TS2318: Cannot find global type 'IArguments'.
+!!! error TS2318: Cannot find global type 'Number'.
+!!! error TS2318: Cannot find global type 'Object'.
+!!! error TS2318: Cannot find global type 'RegExp'.
+!!! error TS2318: Cannot find global type 'String'.
+==== tests/cases/compiler/noCrashOnNoLib.ts (0 errors) ====
+    export function f() {
+        let e: {}[];
+        while (true) {
+          e = [...(e || [])];
+        }
+    }

--- a/tests/baselines/reference/noCrashOnNoLib.js
+++ b/tests/baselines/reference/noCrashOnNoLib.js
@@ -1,0 +1,18 @@
+//// [noCrashOnNoLib.ts]
+export function f() {
+    let e: {}[];
+    while (true) {
+      e = [...(e || [])];
+    }
+}
+
+//// [noCrashOnNoLib.js]
+"use strict";
+exports.__esModule = true;
+function f() {
+    var e;
+    while (true) {
+        e = (e || []).slice();
+    }
+}
+exports.f = f;

--- a/tests/baselines/reference/noCrashOnNoLib.symbols
+++ b/tests/baselines/reference/noCrashOnNoLib.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/noCrashOnNoLib.ts ===
+export function f() {
+>f : Symbol(f, Decl(noCrashOnNoLib.ts, 0, 0))
+
+    let e: {}[];
+>e : Symbol(e, Decl(noCrashOnNoLib.ts, 1, 7))
+
+    while (true) {
+      e = [...(e || [])];
+>e : Symbol(e, Decl(noCrashOnNoLib.ts, 1, 7))
+>e : Symbol(e, Decl(noCrashOnNoLib.ts, 1, 7))
+    }
+}

--- a/tests/baselines/reference/noCrashOnNoLib.types
+++ b/tests/baselines/reference/noCrashOnNoLib.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/noCrashOnNoLib.ts ===
+export function f() {
+>f : () => void
+
+    let e: {}[];
+>e : {}
+
+    while (true) {
+>true : true
+
+      e = [...(e || [])];
+>e = [...(e || [])] : {}
+>e : {}
+>[...(e || [])] : {}
+>...(e || []) : any
+>(e || []) : {}
+>e || [] : {}
+>e : {}
+>[] : {}
+    }
+}

--- a/tests/cases/compiler/noCrashOnNoLib.ts
+++ b/tests/cases/compiler/noCrashOnNoLib.ts
@@ -1,0 +1,8 @@
+// @noLib: true
+
+export function f() {
+    let e: {}[];
+    while (true) {
+      e = [...(e || [])];
+    }
+}


### PR DESCRIPTION
make sure that the type we use for `autoArrayType` is unique even if no global `Array` type was provided

Fixes #20333
