### PR TITLE
compileOnSaveAffectedFileList shouldn't return any files for noEmit projects

### DIFF
--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -304,6 +304,24 @@ namespace ts.projectSystem {
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, []);
             });
 
+            it("should return empty array if noEmit is set", () => {
+                configFile = {
+                    path: "/a/b/tsconfig.json",
+                    content: `{
+                        "compileOnSave": true,
+                        "compilerOptions": {
+                            "noEmit": true
+                        }
+                    }`
+                };
+
+                const host = createServerHost([moduleFile1, file1Consumer1, file1Consumer2, configFile, libFile]);
+                const typingsInstaller = createTestTypingsInstaller(host);
+                const session = createSession(host, typingsInstaller);
+                openFilesForSession([moduleFile1], session);
+                sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, []);
+            });
+
             it("should save when compileOnSave is enabled in base tsconfig.json", () => {
                 configFile = {
                     path: "/a/b/tsconfig.json",

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1245,7 +1245,7 @@ namespace ts.server {
             // if specified a project, we only return affected file list in this project
             const projectsToSearch = args.projectFileName ? [this.projectService.findProject(args.projectFileName)] : info.containingProjects;
             for (const project of projectsToSearch) {
-                if (project.compileOnSaveEnabled && project.languageServiceEnabled) {
+                if (project.compileOnSaveEnabled && project.languageServiceEnabled && !project.getCompilationSettings().noEmit) {
                     result.push({
                         projectFileName: project.getProjectName(),
                         fileNames: project.getCompileOnSaveAffectedFileList(info),


### PR DESCRIPTION
compileOnSaveAffectedFileList can be expensive, and there is no point in gathering up a list of files to be emitted only to throw it away later.