### PR TITLE
Cut off inference for recursive mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11127,7 +11127,7 @@ namespace ts {
          * property is computed by inferring from the source property type to X for the type
          * variable T[P] (i.e. we treat the type T[P] as the type variable we're inferring for).
          */
-        function inferTypeForHomomorphicMappedType(source: Type, target: MappedType, mappedTypeStack: [Type, Symbol][]): Type {
+        function inferTypeForHomomorphicMappedType(source: Type, target: MappedType, mappedTypeStack: string[]): Type {
             const properties = getPropertiesOfType(source);
             let indexInfo = getIndexInfoOfType(source, IndexKind.String);
             if (properties.length === 0 && !indexInfo) {
@@ -11178,7 +11178,7 @@ namespace ts {
             return undefined;
         }
 
-        function inferTypes(inferences: InferenceInfo[], originalSource: Type, originalTarget: Type, priority: InferencePriority = 0, mappedTypeStack?: [Type, Symbol][]) {
+        function inferTypes(inferences: InferenceInfo[], originalSource: Type, originalTarget: Type, priority: InferencePriority = 0, mappedTypeStack?: string[]) {
             let symbolStack: Symbol[];
             let visited: Map<boolean>;
             inferFromTypes(originalSource, originalTarget);
@@ -11395,10 +11395,11 @@ namespace ts {
                         // such that direct inferences to T get priority over inferences to Partial<T>, for example.
                         const inference = getInferenceInfoForType((<IndexType>constraintType).type);
                         if (inference && !inference.isFixed) {
-                            if (contains(mappedTypeStack, [source, target.symbol], ([s1, t1], [s2, t2]) => s1 === s2 && t1 === t2)) {
+                            const key = (source.symbol ? getSymbolId(source.symbol) : "no symbol") + "," + getSymbolId(target.symbol);
+                            if (contains(mappedTypeStack, key)) {
                                 return;
                             }
-                            (mappedTypeStack || (mappedTypeStack = [])).push([source, target.symbol]);
+                            (mappedTypeStack || (mappedTypeStack = [])).push(key);
                             const inferredType = inferTypeForHomomorphicMappedType(source, <MappedType>target, mappedTypeStack);
                             mappedTypeStack.pop();
                             if (inferredType) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11395,7 +11395,7 @@ namespace ts {
                         // such that direct inferences to T get priority over inferences to Partial<T>, for example.
                         const inference = getInferenceInfoForType((<IndexType>constraintType).type);
                         if (inference && !inference.isFixed) {
-                            const key = (source.symbol ? getSymbolId(source.symbol) : "no symbol") + "," + getSymbolId(target.symbol);
+                            const key = (source.symbol ? getSymbolId(source.symbol) + "," : "") + getSymbolId(target.symbol);
                             if (contains(mappedTypeStack, key)) {
                                 return;
                             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11395,7 +11395,7 @@ namespace ts {
                         // such that direct inferences to T get priority over inferences to Partial<T>, for example.
                         const inference = getInferenceInfoForType((<IndexType>constraintType).type);
                         if (inference && !inference.isFixed) {
-                            if (contains(mappedTypeStack, [source, target.symbol], ([s1,t1],[s2,t2]) => s1 === s2 && t1 === t2)) {
+                            if (contains(mappedTypeStack, [source, target.symbol], ([s1, t1], [s2, t2]) => s1 === s2 && t1 === t2)) {
                                 return;
                             }
                             (mappedTypeStack || (mappedTypeStack = [])).push([source, target.symbol]);

--- a/tests/baselines/reference/mappedTypeRecursiveInference.js
+++ b/tests/baselines/reference/mappedTypeRecursiveInference.js
@@ -1,0 +1,10 @@
+//// [mappedTypeRecursiveInference.ts]
+interface A { a: A }
+declare let a: A;
+type Deep<T> = { [K in keyof T]: Deep<T[K]> }
+declare function foo<T>(deep: Deep<T>): T;
+const out = foo(a);
+
+
+//// [mappedTypeRecursiveInference.js]
+var out = foo(a);

--- a/tests/baselines/reference/mappedTypeRecursiveInference.symbols
+++ b/tests/baselines/reference/mappedTypeRecursiveInference.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/mappedTypeRecursiveInference.ts ===
+interface A { a: A }
+>A : Symbol(A, Decl(mappedTypeRecursiveInference.ts, 0, 0))
+>a : Symbol(A.a, Decl(mappedTypeRecursiveInference.ts, 0, 13))
+>A : Symbol(A, Decl(mappedTypeRecursiveInference.ts, 0, 0))
+
+declare let a: A;
+>a : Symbol(a, Decl(mappedTypeRecursiveInference.ts, 1, 11))
+>A : Symbol(A, Decl(mappedTypeRecursiveInference.ts, 0, 0))
+
+type Deep<T> = { [K in keyof T]: Deep<T[K]> }
+>Deep : Symbol(Deep, Decl(mappedTypeRecursiveInference.ts, 1, 17))
+>T : Symbol(T, Decl(mappedTypeRecursiveInference.ts, 2, 10))
+>K : Symbol(K, Decl(mappedTypeRecursiveInference.ts, 2, 18))
+>T : Symbol(T, Decl(mappedTypeRecursiveInference.ts, 2, 10))
+>Deep : Symbol(Deep, Decl(mappedTypeRecursiveInference.ts, 1, 17))
+>T : Symbol(T, Decl(mappedTypeRecursiveInference.ts, 2, 10))
+>K : Symbol(K, Decl(mappedTypeRecursiveInference.ts, 2, 18))
+
+declare function foo<T>(deep: Deep<T>): T;
+>foo : Symbol(foo, Decl(mappedTypeRecursiveInference.ts, 2, 45))
+>T : Symbol(T, Decl(mappedTypeRecursiveInference.ts, 3, 21))
+>deep : Symbol(deep, Decl(mappedTypeRecursiveInference.ts, 3, 24))
+>Deep : Symbol(Deep, Decl(mappedTypeRecursiveInference.ts, 1, 17))
+>T : Symbol(T, Decl(mappedTypeRecursiveInference.ts, 3, 21))
+>T : Symbol(T, Decl(mappedTypeRecursiveInference.ts, 3, 21))
+
+const out = foo(a);
+>out : Symbol(out, Decl(mappedTypeRecursiveInference.ts, 4, 5))
+>foo : Symbol(foo, Decl(mappedTypeRecursiveInference.ts, 2, 45))
+>a : Symbol(a, Decl(mappedTypeRecursiveInference.ts, 1, 11))
+

--- a/tests/baselines/reference/mappedTypeRecursiveInference.types
+++ b/tests/baselines/reference/mappedTypeRecursiveInference.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/mappedTypeRecursiveInference.ts ===
+interface A { a: A }
+>A : A
+>a : A
+>A : A
+
+declare let a: A;
+>a : A
+>A : A
+
+type Deep<T> = { [K in keyof T]: Deep<T[K]> }
+>Deep : Deep<T>
+>T : T
+>K : K
+>T : T
+>Deep : Deep<T>
+>T : T
+>K : K
+
+declare function foo<T>(deep: Deep<T>): T;
+>foo : <T>(deep: Deep<T>) => T
+>T : T
+>deep : Deep<T>
+>Deep : Deep<T>
+>T : T
+>T : T
+
+const out = foo(a);
+>out : { a: {}; }
+>foo(a) : { a: {}; }
+>foo : <T>(deep: Deep<T>) => T
+>a : A
+

--- a/tests/cases/compiler/mappedTypeRecursiveInference.ts
+++ b/tests/cases/compiler/mappedTypeRecursiveInference.ts
@@ -1,0 +1,5 @@
+interface A { a: A }
+declare let a: A;
+type Deep<T> = { [K in keyof T]: Deep<T[K]> }
+declare function foo<T>(deep: Deep<T>): T;
+const out = foo(a);


### PR DESCRIPTION
Fixes #19951 


Previously, when inferring to a self-referential (or otherwise recursive) homomorphic mapped type from a source type that also has recursive references, type inference would enter infinite recursion.

Now there is a more complex stack for mapped type inference. It mirrors the existing `symbolStack` but (1) includes the source type and (2) is passed through `inferTypeForHomomorphicMappedType`, which is actually called outside of `inferTypes`, and so restarts the `symbolStack` cache every time.

Note that it might be possible to avoid restarting inference inside `inferTypeForHomomorphicMappedType` and share the two caches by using a cache key. I only experimented briefly with this so far.