### PR TITLE
Don't offer to prepend an underscore to the name of an unused private property

### DIFF
--- a/tests/cases/fourslash/unusedParameterInConstructor1AddUnderscore.ts
+++ b/tests/cases/fourslash/unusedParameterInConstructor1AddUnderscore.ts
@@ -1,12 +1,12 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 //// class C1 {
-////    [|constructor(private p1: string, public p2: boolean, public p3: any, p5) |] { p5; }
+////    [|constructor(p1: string, public p2: boolean, public p3: any, p5) |] { p5; }
 //// }
 
 verify.codeFix({
     description: "Prefix 'p1' with an underscore.",
     index: 1,
-    newRangeContent: "constructor(private _p1: string, public p2: boolean, public p3: any, p5)",
+    newRangeContent: "constructor(_p1: string, public p2: boolean, public p3: any, p5)",
 });


### PR DESCRIPTION
Underscores only help with unused parameters.