### PR TITLE
Handle failure to properly resolve type reference directives

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25004,7 +25004,6 @@ namespace ts {
                         return;
                     }
                     const file = host.getSourceFile(resolvedDirective.resolvedFileName);
-                    Debug.assert(!!file, `Resolved filename ${resolvedDirective.resolvedFileName} did not map to existing source file. Consider enabling --preserveSymlinks if appropriate`); // tslint:disable-line
                     fileToDirective.set(file.path, key);
                 });
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25000,10 +25000,11 @@ namespace ts {
                 // populate reverse mapping: file path -> type reference directive that was resolved to this file
                 fileToDirective = createMap<string>();
                 resolvedTypeReferenceDirectives.forEach((resolvedDirective, key) => {
-                    if (!resolvedDirective) {
+                    if (!resolvedDirective || !resolvedDirective.resolvedFileName) {
                         return;
                     }
                     const file = host.getSourceFile(resolvedDirective.resolvedFileName);
+                    Debug.assert(!!file, `Resolved filename ${resolvedDirective.resolvedFileName} did not map to existing source file. Consider enabling --preserveSymlinks if appropriate`); // tslint:disable-line
                     fileToDirective.set(file.path, key);
                 });
             }

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -782,7 +782,7 @@ namespace ts {
         if (traceEnabled) {
             trace(host, Diagnostics.Resolving_real_path_for_0_result_1, path, real);
         }
-        Debug.assert(host.fileExists(real), `${path} linked to non-existing file ${real}`); // tslint:disable-line
+        Debug.assert(host.fileExists(real), `${path} linked to nonexistent file ${real}`); // tslint:disable-line
         return real;
     }
 

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -782,6 +782,7 @@ namespace ts {
         if (traceEnabled) {
             trace(host, Diagnostics.Resolving_real_path_for_0_result_1, path, real);
         }
+        Debug.assert(host.fileExists(real), `${path} linked to non-existing file ${real}`); // tslint:disable-line
         return real;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2736,7 +2736,7 @@ namespace ts {
         getCompilerOptions(): CompilerOptions;
 
         getSourceFiles(): ReadonlyArray<SourceFile>;
-        getSourceFile(fileName: string): SourceFile;
+        getSourceFile(fileName: string): SourceFile | undefined;
         getResolvedTypeReferenceDirectives(): ReadonlyMap<ResolvedTypeReferenceDirective>;
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Adding small null check.

Customer reported an issue whereby `file` was undefined or null in a CI scenario but not in a local build. 
The solution for the customer was to set `preserveSymlinks: true`, but this was not clear from the error message.
This change intends to make the error clearer. Suggestions regarding whether this is the proper way to report this error are welcome.