### PR TITLE
Fewer intermediate object literal and array literal types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10680,7 +10680,7 @@ namespace ts {
         }
 
         function getWidenedLiteralLikeTypeForContextualType(type: Type, contextualType: Type) {
-            if (!isLiteralLikeContextualType(contextualType)) {
+            if (!isLiteralOfContextualType(type, contextualType)) {
                 type = getWidenedUniqueESSymbolType(getWidenedLiteralType(type));
             }
             return type;
@@ -18901,19 +18901,33 @@ namespace ts {
                 isTypeAssertion(declaration.initializer) ? type : getWidenedLiteralType(type);
         }
 
-        function isLiteralLikeContextualType(contextualType: Type) {
+        function isLiteralOfContextualType(candidateType: Type, contextualType: Type): boolean {
             if (contextualType) {
-                if (contextualType.flags & TypeFlags.TypeVariable) {
-                    const constraint = getBaseConstraintOfType(contextualType) || emptyObjectType;
-                    // If the type parameter is constrained to the base primitive type we're checking for,
-                    // consider this a literal context. For example, given a type parameter 'T extends string',
-                    // this causes us to infer string literal types for T.
-                    if (constraint.flags & (TypeFlags.String | TypeFlags.Number | TypeFlags.Boolean | TypeFlags.Enum | TypeFlags.ESSymbol)) {
-                        return true;
-                    }
-                    contextualType = constraint;
+                if (contextualType.flags & TypeFlags.Union && !(contextualType.flags & TypeFlags.Boolean)) {
+                    // If the contextual type is a union containing both of the 'true' and 'false' types we
+                    // don't consider it a literal context for boolean literals.
+                    const types = (<UnionType>contextualType).types;
+                    return some(types, t =>
+                        !(t.flags & TypeFlags.BooleanLiteral && containsType(types, trueType) && containsType(types, falseType)) &&
+                        isLiteralOfContextualType(candidateType, t));
                 }
-                return maybeTypeOfKind(contextualType, (TypeFlags.Literal | TypeFlags.Index | TypeFlags.UniqueESSymbol));
+                if (contextualType.flags & TypeFlags.TypeVariable) {
+                    // If the contextual type is a type variable constrained to a primitive type, consider
+                    // this a literal context for literals of that primitive type. For example, given a
+                    // type parameter 'T extends string', infer string literal types for T.
+                    const constraint = getBaseConstraintOfType(contextualType) || emptyObjectType;
+                    return constraint.flags & TypeFlags.String && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
+                        constraint.flags & TypeFlags.Number && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral) ||
+                        constraint.flags & TypeFlags.Boolean && maybeTypeOfKind(candidateType, TypeFlags.BooleanLiteral) ||
+                        constraint.flags & TypeFlags.ESSymbol && maybeTypeOfKind(candidateType, TypeFlags.UniqueESSymbol) ||
+                        isLiteralOfContextualType(candidateType, constraint);
+                }
+                // If the contextual type is a literal of a particular primitive type, we consider this a
+                // literal context for all literals of that primitive type.
+                return contextualType.flags & (TypeFlags.StringLiteral | TypeFlags.Index) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
+                    contextualType.flags & TypeFlags.NumberLiteral && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral) ||
+                    contextualType.flags & TypeFlags.BooleanLiteral && maybeTypeOfKind(candidateType, TypeFlags.BooleanLiteral) ||
+                    contextualType.flags & TypeFlags.UniqueESSymbol && maybeTypeOfKind(candidateType, TypeFlags.UniqueESSymbol);
             }
             return false;
         }

--- a/tests/baselines/reference/argumentExpressionContextualTyping.types
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.types
@@ -51,13 +51,13 @@ var o1: { x: [string, number], y: { c: boolean, d: string, e: number } } = { x: 
 >c : boolean
 >d : string
 >e : number
->{ x: ["string", 1], y: { c: true, d: "world", e: 3 } } : { x: [string, number]; y: { c: true; d: string; e: number; }; }
+>{ x: ["string", 1], y: { c: true, d: "world", e: 3 } } : { x: [string, number]; y: { c: boolean; d: string; e: number; }; }
 >x : [string, number]
 >["string", 1] : [string, number]
 >"string" : "string"
 >1 : 1
->y : { c: true; d: string; e: number; }
->{ c: true, d: "world", e: 3 } : { c: true; d: string; e: number; }
+>y : { c: boolean; d: string; e: number; }
+>{ c: true, d: "world", e: 3 } : { c: boolean; d: string; e: number; }
 >c : boolean
 >true : true
 >d : string
@@ -96,7 +96,7 @@ var array = ["string", 1, true];
 
 var tuple: [string, number, boolean] = ["string", 1, true];
 >tuple : [string, number, boolean]
->["string", 1, true] : [string, number, true]
+>["string", 1, true] : [string, number, boolean]
 >"string" : "string"
 >1 : 1
 >true : true
@@ -109,7 +109,7 @@ baz(tuple);
 baz(["string", 1, true]);
 >baz(["string", 1, true]) : void
 >baz : (x: [string, number, boolean]) => void
->["string", 1, true] : [string, number, true]
+>["string", 1, true] : [string, number, boolean]
 >"string" : "string"
 >1 : 1
 >true : true

--- a/tests/baselines/reference/arrayBestCommonTypes.types
+++ b/tests/baselines/reference/arrayBestCommonTypes.types
@@ -255,14 +255,14 @@ module EmptyTypes {
 >x : boolean
 >y : base
 >base : base
->[{ x: true, y: new derived() }, { x: false, y: new base() }] : ({ x: true; y: derived; } | { x: false; y: base; })[]
->{ x: true, y: new derived() } : { x: true; y: derived; }
+>[{ x: true, y: new derived() }, { x: false, y: new base() }] : { x: boolean; y: derived; }[]
+>{ x: true, y: new derived() } : { x: boolean; y: derived; }
 >x : boolean
 >true : true
 >y : derived
 >new derived() : derived
 >derived : typeof derived
->{ x: false, y: new base() } : { x: false; y: base; }
+>{ x: false, y: new base() } : { x: boolean; y: base; }
 >x : boolean
 >false : false
 >y : base
@@ -658,14 +658,14 @@ module NonEmptyTypes {
 >x : boolean
 >y : base
 >base : base
->[{ x: true, y: new derived() }, { x: false, y: new base() }] : ({ x: true; y: derived; } | { x: false; y: base; })[]
->{ x: true, y: new derived() } : { x: true; y: derived; }
+>[{ x: true, y: new derived() }, { x: false, y: new base() }] : { x: boolean; y: base; }[]
+>{ x: true, y: new derived() } : { x: boolean; y: derived; }
 >x : boolean
 >true : true
 >y : derived
 >new derived() : derived
 >derived : typeof derived
->{ x: false, y: new base() } : { x: false; y: base; }
+>{ x: false, y: new base() } : { x: boolean; y: base; }
 >x : boolean
 >false : false
 >y : base

--- a/tests/baselines/reference/arrayLiterals3.errors.txt
+++ b/tests/baselines/reference/arrayLiterals3.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(10,5): error TS2322: Type 'undefined[]' is not assignable to type '[any, any, any]'.
   Property '0' is missing in type 'undefined[]'.
-tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(11,5): error TS2322: Type '["string", number, boolean]' is not assignable to type '[boolean, string, number]'.
-  Type '"string"' is not assignable to type 'boolean'.
+tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(11,5): error TS2322: Type '[string, number, boolean]' is not assignable to type '[boolean, string, number]'.
+  Type 'string' is not assignable to type 'boolean'.
 tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(17,5): error TS2322: Type '[number, number, string, boolean]' is not assignable to type '[number, number]'.
   Types of property 'length' are incompatible.
     Type '4' is not assignable to type '2'.
@@ -34,8 +34,8 @@ tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(34,5): error
 !!! error TS2322:   Property '0' is missing in type 'undefined[]'.
     var a1: [boolean, string, number] = ["string", 1, true];  // Error
         ~~
-!!! error TS2322: Type '["string", number, boolean]' is not assignable to type '[boolean, string, number]'.
-!!! error TS2322:   Type '"string"' is not assignable to type 'boolean'.
+!!! error TS2322: Type '[string, number, boolean]' is not assignable to type '[boolean, string, number]'.
+!!! error TS2322:   Type 'string' is not assignable to type 'boolean'.
     
     // The resulting type an array literal expression is determined as follows:
     //     - If the array literal contains no spread elements and is an array assignment pattern in a destructuring assignment (section 4.17.1),

--- a/tests/baselines/reference/arrayLiterals3.types
+++ b/tests/baselines/reference/arrayLiterals3.types
@@ -14,7 +14,7 @@ var a0: [any, any, any] = [];                             // Error
 
 var a1: [boolean, string, number] = ["string", 1, true];  // Error
 >a1 : [boolean, string, number]
->["string", 1, true] : ["string", number, boolean]
+>["string", 1, true] : [string, number, boolean]
 >"string" : "string"
 >1 : 1
 >true : true

--- a/tests/baselines/reference/assignToFn.types
+++ b/tests/baselines/reference/assignToFn.types
@@ -13,9 +13,9 @@ module M {
     var x:I={ f:function(n) { return true; } };
 >x : I
 >I : I
->{ f:function(n) { return true; } } : { f: (n: number) => true; }
->f : (n: number) => true
->function(n) { return true; } : (n: number) => true
+>{ f:function(n) { return true; } } : { f: (n: number) => boolean; }
+>f : (n: number) => boolean
+>function(n) { return true; } : (n: number) => boolean
 >n : number
 >true : true
 

--- a/tests/baselines/reference/assignmentTypeNarrowing.types
+++ b/tests/baselines/reference/assignmentTypeNarrowing.types
@@ -12,14 +12,14 @@ x; // string
 >x : string
 
 [x] = [true];
->[x] = [true] : [true]
+>[x] = [true] : [boolean]
 >[x] : [string | number | boolean | RegExp]
 >x : string | number | boolean | RegExp
->[true] : [true]
+>[true] : [boolean]
 >true : true
 
 x; // boolean
->x : true
+>x : boolean
 
 [x = ""] = [1];
 >[x = ""] = [1] : [number]
@@ -34,24 +34,24 @@ x; // string | number
 >x : string | number
 
 ({x} = {x: true});
->({x} = {x: true}) : { x: true; }
->{x} = {x: true} : { x: true; }
+>({x} = {x: true}) : { x: boolean; }
+>{x} = {x: true} : { x: boolean; }
 >{x} : { x: string | number | boolean | RegExp; }
 >x : string | number | boolean | RegExp
->{x: true} : { x: true; }
+>{x: true} : { x: boolean; }
 >x : boolean
 >true : true
 
 x; // boolean
->x : true
+>x : boolean
 
 ({y: x} = {y: 1});
->({y: x} = {y: 1}) : { y: 1; }
->{y: x} = {y: 1} : { y: 1; }
+>({y: x} = {y: 1}) : { y: number; }
+>{y: x} = {y: 1} : { y: number; }
 >{y: x} : { y: string | number | boolean | RegExp; }
 >y : string | number | boolean | RegExp
 >x : string | number | boolean | RegExp
->{y: 1} : { y: 1; }
+>{y: 1} : { y: number; }
 >y : number
 >1 : 1
 
@@ -59,16 +59,16 @@ x; // number
 >x : number
 
 ({x = ""} = {x: true});
->({x = ""} = {x: true}) : { x?: true; }
->{x = ""} = {x: true} : { x?: true; }
+>({x = ""} = {x: true}) : { x?: boolean; }
+>{x = ""} = {x: true} : { x?: boolean; }
 >{x = ""} : { x?: string | number | boolean | RegExp; }
 >x : string | number | boolean | RegExp
->{x: true} : { x?: true; }
+>{x: true} : { x?: boolean; }
 >x : boolean
 >true : true
 
 x; // string | boolean
->x : string | true
+>x : string | boolean
 
 ({y: x = /a/} = {y: 1});
 >({y: x = /a/} = {y: 1}) : { y?: number; }

--- a/tests/baselines/reference/asyncFunctionReturnType.types
+++ b/tests/baselines/reference/asyncFunctionReturnType.types
@@ -15,7 +15,7 @@ async function fAsyncExplicit(): Promise<[number, boolean]> {
 
     // This is contextually typed as a tuple.
     return [1, true];
->[1, true] : [number, true]
+>[1, true] : [number, boolean]
 >1 : 1
 >true : true
 }

--- a/tests/baselines/reference/computedPropertyNamesContextualType10_ES5.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesContextualType10_ES5.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES5.ts(5,5): error TS2322: Type '{ [x: number]: "" | 0; }' is not assignable to type 'I'.
+tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES5.ts(5,5): error TS2322: Type '{ [x: number]: string | number; }' is not assignable to type 'I'.
   Index signatures are incompatible.
-    Type '"" | 0' is not assignable to type 'boolean'.
-      Type '""' is not assignable to type 'boolean'.
+    Type 'string | number' is not assignable to type 'boolean'.
+      Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES5.ts (1 errors) ====
@@ -11,10 +11,10 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualTy
     
     var o: I = {
         ~
-!!! error TS2322: Type '{ [x: number]: "" | 0; }' is not assignable to type 'I'.
+!!! error TS2322: Type '{ [x: number]: string | number; }' is not assignable to type 'I'.
 !!! error TS2322:   Index signatures are incompatible.
-!!! error TS2322:     Type '"" | 0' is not assignable to type 'boolean'.
-!!! error TS2322:       Type '""' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'string | number' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
         [+"foo"]: "",
         [+"bar"]: 0
     }

--- a/tests/baselines/reference/computedPropertyNamesContextualType10_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType10_ES5.types
@@ -9,7 +9,7 @@ interface I {
 var o: I = {
 >o : I
 >I : I
->{    [+"foo"]: "",    [+"bar"]: 0} : { [x: number]: "" | 0; }
+>{    [+"foo"]: "",    [+"bar"]: 0} : { [x: number]: string | number; }
 
     [+"foo"]: "",
 >+"foo" : number

--- a/tests/baselines/reference/computedPropertyNamesContextualType10_ES6.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesContextualType10_ES6.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES6.ts(5,5): error TS2322: Type '{ [x: number]: "" | 0; }' is not assignable to type 'I'.
+tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES6.ts(5,5): error TS2322: Type '{ [x: number]: string | number; }' is not assignable to type 'I'.
   Index signatures are incompatible.
-    Type '"" | 0' is not assignable to type 'boolean'.
-      Type '""' is not assignable to type 'boolean'.
+    Type 'string | number' is not assignable to type 'boolean'.
+      Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES6.ts (1 errors) ====
@@ -11,10 +11,10 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualTy
     
     var o: I = {
         ~
-!!! error TS2322: Type '{ [x: number]: "" | 0; }' is not assignable to type 'I'.
+!!! error TS2322: Type '{ [x: number]: string | number; }' is not assignable to type 'I'.
 !!! error TS2322:   Index signatures are incompatible.
-!!! error TS2322:     Type '"" | 0' is not assignable to type 'boolean'.
-!!! error TS2322:       Type '""' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'string | number' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
         [+"foo"]: "",
         [+"bar"]: 0
     }

--- a/tests/baselines/reference/computedPropertyNamesContextualType10_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType10_ES6.types
@@ -9,7 +9,7 @@ interface I {
 var o: I = {
 >o : I
 >I : I
->{    [+"foo"]: "",    [+"bar"]: 0} : { [x: number]: "" | 0; }
+>{    [+"foo"]: "",    [+"bar"]: 0} : { [x: number]: string | number; }
 
     [+"foo"]: "",
 >+"foo" : number

--- a/tests/baselines/reference/computedPropertyNamesContextualType6_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType6_ES5.types
@@ -19,7 +19,7 @@ declare function foo<T>(obj: I<T>): T
 foo({
 >foo({    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | number | boolean | (() => void) | number[]
 >foo : <T>(obj: I<T>) => T
->{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: true | "" | (() => void) | 0 | number[]; [x: number]: (() => void) | 0 | number[]; p: ""; 0: () => void; }
+>{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | boolean | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
 
     p: "",
 >p : string

--- a/tests/baselines/reference/computedPropertyNamesContextualType6_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType6_ES6.types
@@ -19,7 +19,7 @@ declare function foo<T>(obj: I<T>): T
 foo({
 >foo({    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | number | boolean | (() => void) | number[]
 >foo : <T>(obj: I<T>) => T
->{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: true | "" | (() => void) | 0 | number[]; [x: number]: (() => void) | 0 | number[]; p: ""; 0: () => void; }
+>{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | boolean | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
 
     p: "",
 >p : string

--- a/tests/baselines/reference/computedPropertyNamesContextualType8_ES5.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesContextualType8_ES5.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES5.ts(6,5): error TS2322: Type '{ [x: string]: "" | 0; }' is not assignable to type 'I'.
+tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES5.ts(6,5): error TS2322: Type '{ [x: string]: string | number; }' is not assignable to type 'I'.
   Index signatures are incompatible.
-    Type '"" | 0' is not assignable to type 'boolean'.
-      Type '""' is not assignable to type 'boolean'.
+    Type 'string | number' is not assignable to type 'boolean'.
+      Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES5.ts (1 errors) ====
@@ -12,10 +12,10 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualTy
     
     var o: I = {
         ~
-!!! error TS2322: Type '{ [x: string]: "" | 0; }' is not assignable to type 'I'.
+!!! error TS2322: Type '{ [x: string]: string | number; }' is not assignable to type 'I'.
 !!! error TS2322:   Index signatures are incompatible.
-!!! error TS2322:     Type '"" | 0' is not assignable to type 'boolean'.
-!!! error TS2322:       Type '""' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'string | number' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
         [""+"foo"]: "",
         [""+"bar"]: 0
     }

--- a/tests/baselines/reference/computedPropertyNamesContextualType8_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType8_ES5.types
@@ -12,7 +12,7 @@ interface I {
 var o: I = {
 >o : I
 >I : I
->{    [""+"foo"]: "",    [""+"bar"]: 0} : { [x: string]: "" | 0; }
+>{    [""+"foo"]: "",    [""+"bar"]: 0} : { [x: string]: string | number; }
 
     [""+"foo"]: "",
 >""+"foo" : string

--- a/tests/baselines/reference/computedPropertyNamesContextualType8_ES6.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesContextualType8_ES6.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES6.ts(6,5): error TS2322: Type '{ [x: string]: "" | 0; }' is not assignable to type 'I'.
+tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES6.ts(6,5): error TS2322: Type '{ [x: string]: string | number; }' is not assignable to type 'I'.
   Index signatures are incompatible.
-    Type '"" | 0' is not assignable to type 'boolean'.
-      Type '""' is not assignable to type 'boolean'.
+    Type 'string | number' is not assignable to type 'boolean'.
+      Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES6.ts (1 errors) ====
@@ -12,10 +12,10 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualTy
     
     var o: I = {
         ~
-!!! error TS2322: Type '{ [x: string]: "" | 0; }' is not assignable to type 'I'.
+!!! error TS2322: Type '{ [x: string]: string | number; }' is not assignable to type 'I'.
 !!! error TS2322:   Index signatures are incompatible.
-!!! error TS2322:     Type '"" | 0' is not assignable to type 'boolean'.
-!!! error TS2322:       Type '""' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'string | number' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
         [""+"foo"]: "",
         [""+"bar"]: 0
     }

--- a/tests/baselines/reference/computedPropertyNamesContextualType8_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType8_ES6.types
@@ -12,7 +12,7 @@ interface I {
 var o: I = {
 >o : I
 >I : I
->{    [""+"foo"]: "",    [""+"bar"]: 0} : { [x: string]: "" | 0; }
+>{    [""+"foo"]: "",    [""+"bar"]: 0} : { [x: string]: string | number; }
 
     [""+"foo"]: "",
 >""+"foo" : string

--- a/tests/baselines/reference/computedPropertyNamesContextualType9_ES5.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesContextualType9_ES5.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES5.ts(6,5): error TS2322: Type '{ [x: number]: "" | 0; }' is not assignable to type 'I'.
+tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES5.ts(6,5): error TS2322: Type '{ [x: number]: string | number; }' is not assignable to type 'I'.
   Index signatures are incompatible.
-    Type '"" | 0' is not assignable to type 'boolean'.
-      Type '""' is not assignable to type 'boolean'.
+    Type 'string | number' is not assignable to type 'boolean'.
+      Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES5.ts (1 errors) ====
@@ -12,10 +12,10 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualTy
     
     var o: I = {
         ~
-!!! error TS2322: Type '{ [x: number]: "" | 0; }' is not assignable to type 'I'.
+!!! error TS2322: Type '{ [x: number]: string | number; }' is not assignable to type 'I'.
 !!! error TS2322:   Index signatures are incompatible.
-!!! error TS2322:     Type '"" | 0' is not assignable to type 'boolean'.
-!!! error TS2322:       Type '""' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'string | number' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
         [+"foo"]: "",
         [+"bar"]: 0
     }

--- a/tests/baselines/reference/computedPropertyNamesContextualType9_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType9_ES5.types
@@ -12,7 +12,7 @@ interface I {
 var o: I = {
 >o : I
 >I : I
->{    [+"foo"]: "",    [+"bar"]: 0} : { [x: number]: "" | 0; }
+>{    [+"foo"]: "",    [+"bar"]: 0} : { [x: number]: string | number; }
 
     [+"foo"]: "",
 >+"foo" : number

--- a/tests/baselines/reference/computedPropertyNamesContextualType9_ES6.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesContextualType9_ES6.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES6.ts(6,5): error TS2322: Type '{ [x: number]: "" | 0; }' is not assignable to type 'I'.
+tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES6.ts(6,5): error TS2322: Type '{ [x: number]: string | number; }' is not assignable to type 'I'.
   Index signatures are incompatible.
-    Type '"" | 0' is not assignable to type 'boolean'.
-      Type '""' is not assignable to type 'boolean'.
+    Type 'string | number' is not assignable to type 'boolean'.
+      Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES6.ts (1 errors) ====
@@ -12,10 +12,10 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualTy
     
     var o: I = {
         ~
-!!! error TS2322: Type '{ [x: number]: "" | 0; }' is not assignable to type 'I'.
+!!! error TS2322: Type '{ [x: number]: string | number; }' is not assignable to type 'I'.
 !!! error TS2322:   Index signatures are incompatible.
-!!! error TS2322:     Type '"" | 0' is not assignable to type 'boolean'.
-!!! error TS2322:       Type '""' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'string | number' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
         [+"foo"]: "",
         [+"bar"]: 0
     }

--- a/tests/baselines/reference/computedPropertyNamesContextualType9_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType9_ES6.types
@@ -12,7 +12,7 @@ interface I {
 var o: I = {
 >o : I
 >I : I
->{    [+"foo"]: "",    [+"bar"]: 0} : { [x: number]: "" | 0; }
+>{    [+"foo"]: "",    [+"bar"]: 0} : { [x: number]: string | number; }
 
     [+"foo"]: "",
 >+"foo" : number

--- a/tests/baselines/reference/constEnumPropertyAccess1.types
+++ b/tests/baselines/reference/constEnumPropertyAccess1.types
@@ -34,7 +34,7 @@ var o: {
 >idx : number
 
 } = {
->{        1: true    } : { 1: true; }
+>{        1: true    } : { 1: boolean; }
 
         1: true
 >true : true

--- a/tests/baselines/reference/contextualTypeWithTuple.types
+++ b/tests/baselines/reference/contextualTypeWithTuple.types
@@ -15,7 +15,7 @@ var numStrTuple2: [number, string] = [5, "foo", true];
 
 var numStrBoolTuple: [number, string, boolean] = [5, "foo", true];
 >numStrBoolTuple : [number, string, boolean]
->[5, "foo", true] : [number, string, true]
+>[5, "foo", true] : [number, string, boolean]
 >5 : 5
 >"foo" : "foo"
 >true : true

--- a/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.types
+++ b/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.types
@@ -38,11 +38,11 @@ var [a2, [b2, { x12, y12: c2 }]=["abc", { x12: 10, y12: false }]] = [1, ["hello"
 >10 : 10
 >y12 : boolean
 >false : false
->[1, ["hello", { x12: 5, y12: true }]] : [number, [string, { x12: number; y12: true; }]]
+>[1, ["hello", { x12: 5, y12: true }]] : [number, [string, { x12: number; y12: boolean; }]]
 >1 : 1
->["hello", { x12: 5, y12: true }] : [string, { x12: number; y12: true; }]
+>["hello", { x12: 5, y12: true }] : [string, { x12: number; y12: boolean; }]
 >"hello" : "hello"
->{ x12: 5, y12: true } : { x12: number; y12: true; }
+>{ x12: 5, y12: true } : { x12: number; y12: boolean; }
 >x12 : number
 >5 : 5
 >y12 : boolean

--- a/tests/baselines/reference/declarationsAndAssignments.errors.txt
+++ b/tests/baselines/reference/declarationsAndAssignments.errors.txt
@@ -17,10 +17,10 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,11): 
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,14): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,11): error TS2459: Type 'undefined[]' has no property 'a' and no string index signature.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,14): error TS2459: Type 'undefined[]' has no property 'b' and no string index signature.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,5): error TS2345: Argument of type '[number, [string, { y: false; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
-  Type '[string, { y: false; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
-    Type '{ y: false; }' is not assignable to type '{ x: any; y?: boolean; }'.
-      Property 'x' is missing in type '{ y: false; }'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,5): error TS2345: Argument of type '[number, [string, { y: boolean; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
+  Type '[string, { y: boolean; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
+    Type '{ y: boolean; }' is not assignable to type '{ x: any; y?: boolean; }'.
+      Property 'x' is missing in type '{ y: boolean; }'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,6): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): error TS2322: Type 'number' is not assignable to type 'string'.
 
@@ -171,10 +171,10 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): 
     f14([2, ["abc", { x: 0 }]]);
     f14([2, ["abc", { y: false }]]);  // Error, no x
         ~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '[number, [string, { y: false; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
-!!! error TS2345:   Type '[string, { y: false; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
-!!! error TS2345:     Type '{ y: false; }' is not assignable to type '{ x: any; y?: boolean; }'.
-!!! error TS2345:       Property 'x' is missing in type '{ y: false; }'.
+!!! error TS2345: Argument of type '[number, [string, { y: boolean; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
+!!! error TS2345:   Type '[string, { y: boolean; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
+!!! error TS2345:     Type '{ y: boolean; }' is not assignable to type '{ x: any; y?: boolean; }'.
+!!! error TS2345:       Property 'x' is missing in type '{ y: boolean; }'.
     
     module M {
         export var [a, b] = [1, 2];

--- a/tests/baselines/reference/declarationsAndAssignments.types
+++ b/tests/baselines/reference/declarationsAndAssignments.types
@@ -363,11 +363,11 @@ function f12() {
 >10 : 10
 >y : boolean
 >false : false
->[1, ["hello", { x: 5, y: true }]] : [number, [string, { x: number; y: true; }]]
+>[1, ["hello", { x: 5, y: true }]] : [number, [string, { x: number; y: boolean; }]]
 >1 : 1
->["hello", { x: 5, y: true }] : [string, { x: number; y: true; }]
+>["hello", { x: 5, y: true }] : [string, { x: number; y: boolean; }]
 >"hello" : "hello"
->{ x: 5, y: true } : { x: number; y: true; }
+>{ x: 5, y: true } : { x: number; y: boolean; }
 >x : number
 >5 : 5
 >y : boolean
@@ -433,11 +433,11 @@ function f14([a = 1, [b = "hello", { x, y: c = false }]]) {
 f14([2, ["abc", { x: 0, y: true }]]);
 >f14([2, ["abc", { x: 0, y: true }]]) : void
 >f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
->[2, ["abc", { x: 0, y: true }]] : [number, [string, { x: number; y: true; }]]
+>[2, ["abc", { x: 0, y: true }]] : [number, [string, { x: number; y: boolean; }]]
 >2 : 2
->["abc", { x: 0, y: true }] : [string, { x: number; y: true; }]
+>["abc", { x: 0, y: true }] : [string, { x: number; y: boolean; }]
 >"abc" : "abc"
->{ x: 0, y: true } : { x: number; y: true; }
+>{ x: 0, y: true } : { x: number; y: boolean; }
 >x : number
 >0 : 0
 >y : boolean
@@ -534,7 +534,7 @@ f17({ a: "hello" });
 f17({ c: true });
 >f17({ c: true }) : void
 >f17 : ({ a, b, c }: { a?: string; b?: number; c?: boolean; }) => void
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 
@@ -818,47 +818,47 @@ function f21() {
 >true : true
 
     [...a] = [1, "hello", true];
->[...a] = [1, "hello", true] : (true | 1 | "hello")[]
+>[...a] = [1, "hello", true] : (string | number | boolean)[]
 >[...a] : (string | number | boolean)[]
 >...a : string | number | boolean
 >a : (string | number | boolean)[]
->[1, "hello", true] : (true | 1 | "hello")[]
+>[1, "hello", true] : (string | number | boolean)[]
 >1 : 1
 >"hello" : "hello"
 >true : true
 
     [x, ...a] = [1, "hello", true];
->[x, ...a] = [1, "hello", true] : (true | 1 | "hello")[]
+>[x, ...a] = [1, "hello", true] : (string | number | boolean)[]
 >[x, ...a] : (string | number | boolean)[]
 >x : string | number | boolean
 >...a : string | number | boolean
 >a : (string | number | boolean)[]
->[1, "hello", true] : (true | 1 | "hello")[]
+>[1, "hello", true] : (string | number | boolean)[]
 >1 : 1
 >"hello" : "hello"
 >true : true
 
     [x, y, ...a] = [1, "hello", true];
->[x, y, ...a] = [1, "hello", true] : (true | 1 | "hello")[]
+>[x, y, ...a] = [1, "hello", true] : (string | number | boolean)[]
 >[x, y, ...a] : (string | number | boolean)[]
 >x : string | number | boolean
 >y : string | number | boolean
 >...a : string | number | boolean
 >a : (string | number | boolean)[]
->[1, "hello", true] : (true | 1 | "hello")[]
+>[1, "hello", true] : (string | number | boolean)[]
 >1 : 1
 >"hello" : "hello"
 >true : true
 
     [x, y, z, ...a] = [1, "hello", true];
->[x, y, z, ...a] = [1, "hello", true] : (true | 1 | "hello")[]
+>[x, y, z, ...a] = [1, "hello", true] : (string | number | boolean)[]
 >[x, y, z, ...a] : (string | number | boolean)[]
 >x : string | number | boolean
 >y : string | number | boolean
 >z : string | number | boolean
 >...a : string | number | boolean
 >a : (string | number | boolean)[]
->[1, "hello", true] : (true | 1 | "hello")[]
+>[1, "hello", true] : (string | number | boolean)[]
 >1 : 1
 >"hello" : "hello"
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], true]
+>[[1], true] : [[number], boolean]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], true]
+>[[1], true] : [[number], boolean]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES6.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], true]
+>[[1], true] : [[number], boolean]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.errors.txt
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(3,6): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(3,12): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(4,5): error TS2461: Type 'undefined' is not an array type.
-tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(9,5): error TS2322: Type '[number, 2, string]' is not assignable to type '[number, boolean, string]'.
-  Type '2' is not assignable to type 'boolean'.
+tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(9,5): error TS2322: Type '[number, number, string]' is not assignable to type '[number, boolean, string]'.
+  Type 'number' is not assignable to type 'boolean'.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(22,5): error TS2322: Type 'number[]' is not assignable to type '[number, number]'.
   Property '0' is missing in type 'number[]'.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(23,5): error TS2322: Type 'number[]' is not assignable to type '[string, string]'.
@@ -27,8 +27,8 @@ tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAss
     //        where N is the numeric index of E in the array assignment pattern, or
     var [b0, b1, b2]: [number, boolean, string] = [1, 2, "string"];  // Error
         ~~~~~~~~~~~~
-!!! error TS2322: Type '[number, 2, string]' is not assignable to type '[number, boolean, string]'.
-!!! error TS2322:   Type '2' is not assignable to type 'boolean'.
+!!! error TS2322: Type '[number, number, string]' is not assignable to type '[number, boolean, string]'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.
     interface J extends Array<Number> {
         2: number;
     }

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.types
@@ -18,7 +18,7 @@ var [b0, b1, b2]: [number, boolean, string] = [1, 2, "string"];  // Error
 >b0 : number
 >b1 : boolean
 >b2 : string
->[1, 2, "string"] : [number, 2, string]
+>[1, 2, "string"] : [number, number, string]
 >1 : 1
 >2 : 2
 >"string" : "string"
@@ -86,7 +86,7 @@ function foo(idx: number): F {
 >F : F
 
     return {
->{        2: true    } : { 2: true; }
+>{        2: true    } : { 2: boolean; }
 
         2: true
 >true : true

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
@@ -69,7 +69,7 @@ function foo(): F {
 >F : F
 
     return {
->{        1: true    } : { 1: true; }
+>{        1: true    } : { 1: boolean; }
 
         1: true
 >true : true
@@ -82,7 +82,7 @@ function bar(): F {
 >F : F
 
     return {
->{        2: true    } : { 2: true; }
+>{        2: true    } : { 2: boolean; }
 
         2: true
 >true : true

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
@@ -69,7 +69,7 @@ function foo(): F {
 >F : F
 
     return {
->{        1: true    } : { 1: true; }
+>{        1: true    } : { 1: boolean; }
 
         1: true
 >true : true
@@ -82,7 +82,7 @@ function bar(): F {
 >F : F
 
     return {
->{        2: true    } : { 2: true; }
+>{        2: true    } : { 2: boolean; }
 
         2: true
 >true : true

--- a/tests/baselines/reference/destructuringParameterProperties1.types
+++ b/tests/baselines/reference/destructuringParameterProperties1.types
@@ -104,7 +104,7 @@ var c3 = new C3({x: 0, y: "", z: false});
 >c3 : C3
 >new C3({x: 0, y: "", z: false}) : C3
 >C3 : typeof C3
->{x: 0, y: "", z: false} : { x: number; y: string; z: false; }
+>{x: 0, y: "", z: false} : { x: number; y: string; z: boolean; }
 >x : number
 >0 : 0
 >y : string
@@ -117,7 +117,7 @@ c3 = new C3({x: 0, "y": "y", z: true});
 >c3 : C3
 >new C3({x: 0, "y": "y", z: true}) : C3
 >C3 : typeof C3
->{x: 0, "y": "y", z: true} : { x: number; "y": string; z: true; }
+>{x: 0, "y": "y", z: true} : { x: number; "y": string; z: boolean; }
 >x : number
 >0 : 0
 >"y" : "y"

--- a/tests/baselines/reference/destructuringParameterProperties2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties2.errors.txt
@@ -5,8 +5,8 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(4
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(9,21): error TS2339: Property 'a' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(13,21): error TS2339: Property 'b' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(17,21): error TS2339: Property 'c' does not exist on type 'C1'.
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(21,27): error TS2345: Argument of type '[number, undefined, ""]' is not assignable to parameter of type '[number, string, boolean]'.
-  Type '""' is not assignable to type 'boolean'.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(21,27): error TS2345: Argument of type '[number, undefined, string]' is not assignable to parameter of type '[number, string, boolean]'.
+  Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts (8 errors) ====
@@ -46,8 +46,8 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(2
     
     var x = new C1(undefined, [0, undefined, ""]);
                               ~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '[number, undefined, ""]' is not assignable to parameter of type '[number, string, boolean]'.
-!!! error TS2345:   Type '""' is not assignable to type 'boolean'.
+!!! error TS2345: Argument of type '[number, undefined, string]' is not assignable to parameter of type '[number, string, boolean]'.
+!!! error TS2345:   Type 'string' is not assignable to type 'boolean'.
     var [x_a, x_b, x_c] = [x.getA(), x.getB(), x.getC()];
     
     var y = new C1(10, [0, "", true]);

--- a/tests/baselines/reference/destructuringParameterProperties2.types
+++ b/tests/baselines/reference/destructuringParameterProperties2.types
@@ -103,7 +103,7 @@ var y = new C1(10, [0, "", true]);
 >new C1(10, [0, "", true]) : C1
 >C1 : typeof C1
 >10 : 10
->[0, "", true] : [number, string, true]
+>[0, "", true] : [number, string, boolean]
 >0 : 0
 >"" : ""
 >true : true

--- a/tests/baselines/reference/destructuringParameterProperties3.types
+++ b/tests/baselines/reference/destructuringParameterProperties3.types
@@ -82,7 +82,7 @@ var x = new C1(undefined, [0, true, ""]);
 >new C1(undefined, [0, true, ""]) : C1<number, boolean, string>
 >C1 : typeof C1
 >undefined : undefined
->[0, true, ""] : [number, true, string]
+>[0, true, ""] : [number, boolean, string]
 >0 : 0
 >true : true
 >"" : ""
@@ -110,7 +110,7 @@ var y = new C1(10, [0, true, true]);
 >new C1(10, [0, true, true]) : C1<number, boolean, boolean>
 >C1 : typeof C1
 >10 : 10
->[0, true, true] : [number, true, true]
+>[0, true, true] : [number, boolean, boolean]
 >0 : 0
 >true : true
 >true : true

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], true]
+>[1, [["hello"]], true] : [number, [[string]], boolean]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,10 +52,10 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: false; t2: string; }
+>{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
 >t1 : boolean
 >false : false
 >t2 : string

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], true]
+>[1, [["hello"]], true] : [number, [[string]], boolean]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,10 +52,10 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: false; t2: string; }
+>{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
 >t1 : boolean
 >false : false
 >t2 : string

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES6.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES6.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], true]
+>[1, [["hello"]], true] : [number, [[string]], boolean]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,10 +52,10 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: false; t2: string; }
+>{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
 >t1 : boolean
 >false : false
 >t2 : string

--- a/tests/baselines/reference/destructuringVariableDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringVariableDeclaration2.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(3,5): error TS2322: Type '{ a1: boolean; a2: number; }' is not assignable to type '{ a1: number; a2: string; }'.
   Types of property 'a1' are incompatible.
     Type 'boolean' is not assignable to type 'number'.
-tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(4,5): error TS2322: Type '[number, [[boolean]], true]' is not assignable to type '[number, [[string]], boolean]'.
+tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(4,5): error TS2322: Type '[number, [[boolean]], boolean]' is not assignable to type '[number, [[string]], boolean]'.
   Type '[[boolean]]' is not assignable to type '[[string]]'.
     Type '[boolean]' is not assignable to type '[string]'.
       Type 'boolean' is not assignable to type 'string'.
@@ -19,7 +19,7 @@ tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(1
 !!! error TS2322:     Type 'boolean' is not assignable to type 'number'.
     var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [[false]], true];  // Error
         ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '[number, [[boolean]], true]' is not assignable to type '[number, [[string]], boolean]'.
+!!! error TS2322: Type '[number, [[boolean]], boolean]' is not assignable to type '[number, [[string]], boolean]'.
 !!! error TS2322:   Type '[[boolean]]' is not assignable to type '[[string]]'.
 !!! error TS2322:     Type '[boolean]' is not assignable to type '[string]'.
 !!! error TS2322:       Type 'boolean' is not assignable to type 'string'.

--- a/tests/baselines/reference/destructuringVariableDeclaration2.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration2.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [[false]], true];  // 
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [[false]], true] : [number, [[boolean]], true]
+>[1, [[false]], true] : [number, [[boolean]], boolean]
 >1 : 1
 >[[false]] : [[boolean]]
 >[false] : [boolean]
@@ -38,12 +38,12 @@ var [b0 = 3, b1 = true, b2 = temp] = [3, false, { t1: false, t2: 5}];  // Error
 >3 : 3
 >b1 : boolean
 >true : true
->b2 : { t1: boolean; t2: string; } | { t1: false; t2: number; }
+>b2 : { t1: boolean; t2: string; } | { t1: boolean; t2: number; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: 5}] : [number, false, { t1: false; t2: number; }]
+>[3, false, { t1: false, t2: 5}] : [number, boolean, { t1: boolean; t2: number; }]
 >3 : 3
 >false : false
->{ t1: false, t2: 5} : { t1: false; t2: number; }
+>{ t1: false, t2: 5} : { t1: boolean; t2: number; }
 >t1 : boolean
 >false : false
 >t2 : number

--- a/tests/baselines/reference/disallowLineTerminatorBeforeArrow.types
+++ b/tests/baselines/reference/disallowLineTerminatorBeforeArrow.types
@@ -150,7 +150,7 @@ function foo(func: () => boolean) { }
 foo(()
 >foo(()    => true) : void
 >foo : (func: () => boolean) => void
->()    => true : () => true
+>()    => true : () => boolean
 
     => true);
 >true : true
@@ -158,7 +158,7 @@ foo(()
 foo(()
 >foo(()    => { return false; }) : void
 >foo : (func: () => boolean) => void
->()    => { return false; } : () => false
+>()    => { return false; } : () => boolean
 
     => { return false; });
 >false : false

--- a/tests/baselines/reference/duplicateLocalVariable1.types
+++ b/tests/baselines/reference/duplicateLocalVariable1.types
@@ -230,7 +230,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Basic test", function () { return true; }) : TestCase
 >TestCase : typeof TestCase
 >"Basic test" : "Basic test"
->function () { return true; } : () => true
+>function () { return true; } : () => boolean
 >true : true
 
     testRunner.addTest(new TestCase("Test for any error", function () { throw new Error(); return false; }, ""));
@@ -241,7 +241,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Test for any error", function () { throw new Error(); return false; }, "") : TestCase
 >TestCase : typeof TestCase
 >"Test for any error" : "Test for any error"
->function () { throw new Error(); return false; } : () => false
+>function () { throw new Error(); return false; } : () => boolean
 >new Error() : Error
 >Error : ErrorConstructor
 >false : false
@@ -255,7 +255,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Test RegEx error message match", function () { throw new Error("Should also pass"); return false; }, "Should [also]+ pass") : TestCase
 >TestCase : typeof TestCase
 >"Test RegEx error message match" : "Test RegEx error message match"
->function () { throw new Error("Should also pass"); return false; } : () => false
+>function () { throw new Error("Should also pass"); return false; } : () => boolean
 >new Error("Should also pass") : Error
 >Error : ErrorConstructor
 >"Should also pass" : "Should also pass"
@@ -1104,7 +1104,7 @@ export var tests: TestRunner = (function () {
 >"Check saving a file" : "Check saving a file"
 
         function () {
->function () {            var filename = TestFileDir + "\\tmpUTF16LE.txt";            var fb = new FileManager.FileBuffer(14);            fb.writeUtf16leBom();            var chars = [0x0054, 0x00E8, 0x1D23, 0x2020, 0x000D, 0x000A];            chars.forEach(function (val) { fb.writeUtf16CodePoint(val, false); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf16le') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xFF, 0xFE, 0x54, 0x00, 0xE8, 0x00, 0x23, 0x1D, 0x20, 0x20, 0x0D, 0x00, 0x0A, 0x00]            savedFile.index = 0;            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\tmpUTF16LE.txt";            var fb = new FileManager.FileBuffer(14);            fb.writeUtf16leBom();            var chars = [0x0054, 0x00E8, 0x1D23, 0x2020, 0x000D, 0x000A];            chars.forEach(function (val) { fb.writeUtf16CodePoint(val, false); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf16le') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xFF, 0xFE, 0x54, 0x00, 0xE8, 0x00, 0x23, 0x1D, 0x20, 0x20, 0x0D, 0x00, 0x0A, 0x00]            savedFile.index = 0;            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\tmpUTF16LE.txt";
 >filename : string
@@ -1243,7 +1243,7 @@ export var tests: TestRunner = (function () {
 >"Check reading past buffer asserts" : "Check reading past buffer asserts"
 
     function () {
->function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        var result = fb.readByte(200);        return true;    } : () => true
+>function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        var result = fb.readByte(200);        return true;    } : () => boolean
 
         var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");
 >fb : any
@@ -1279,7 +1279,7 @@ export var tests: TestRunner = (function () {
 >"Check writing past buffer asserts" : "Check writing past buffer asserts"
 
     function () {
->function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        fb.writeByte(5, 200);        return true;    } : () => true
+>function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        fb.writeByte(5, 200);        return true;    } : () => boolean
 
         var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");
 >fb : any
@@ -1473,7 +1473,7 @@ export var tests: TestRunner = (function () {
 >"Write non-BMP utf8 chars" : "Write non-BMP utf8 chars"
 
         function () {
->function () {            var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";            var fb = new FileManager.FileBuffer(15);            var chars = [0x10480, 0x10481, 0x10482, 0x54, 0x68, 0x69];            chars.forEach(function (val) { fb.writeUtf8CodePoint(val); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf8') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xF0, 0x90, 0x92, 0x80, 0xF0, 0x90, 0x92, 0x81, 0xF0, 0x90, 0x92, 0x82, 0x54, 0x68, 0x69];            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";            var fb = new FileManager.FileBuffer(15);            var chars = [0x10480, 0x10481, 0x10482, 0x54, 0x68, 0x69];            chars.forEach(function (val) { fb.writeUtf8CodePoint(val); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf8') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xF0, 0x90, 0x92, 0x80, 0xF0, 0x90, 0x92, 0x81, 0xF0, 0x90, 0x92, 0x82, 0x54, 0x68, 0x69];            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";
 >filename : string
@@ -1599,7 +1599,7 @@ export var tests: TestRunner = (function () {
 >"Test invalid lead UTF8 byte" : "Test invalid lead UTF8 byte"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf8BadLeadByte.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\utf8BadLeadByte.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\utf8BadLeadByte.txt";
 >filename : string
@@ -1631,7 +1631,7 @@ export var tests: TestRunner = (function () {
 >"Test invalid tail UTF8 byte" : "Test invalid tail UTF8 byte"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf8InvalidTail.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\utf8InvalidTail.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\utf8InvalidTail.txt";
 >filename : string
@@ -1663,7 +1663,7 @@ export var tests: TestRunner = (function () {
 >"Test ANSI fails validation" : "Test ANSI fails validation"
 
         function () {
->function () {            var filename = TestFileDir + "\\ansi.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\ansi.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\ansi.txt";
 >filename : string
@@ -1695,7 +1695,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16LE with invalid surrogate trail fails" : "Test UTF-16LE with invalid surrogate trail fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";
 >filename : string
@@ -1727,7 +1727,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16BE with invalid surrogate head fails" : "Test UTF-16BE with invalid surrogate head fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";
 >filename : string
@@ -1759,7 +1759,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16LE with missing trail surrogate fails" : "Test UTF-16LE with missing trail surrogate fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";
 >filename : string
@@ -1851,7 +1851,7 @@ export var tests: TestRunner = (function () {
 >"Test file with control character" : "Test file with control character"
 
         function () {
->function () {            var filename = TestFileDir + "\\controlChar.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
+>function () {            var filename = TestFileDir + "\\controlChar.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
 
             var filename = TestFileDir + "\\controlChar.txt";
 >filename : string

--- a/tests/baselines/reference/emitArrowFunction.types
+++ b/tests/baselines/reference/emitArrowFunction.types
@@ -31,12 +31,12 @@ function foo(func: () => boolean) { }
 foo(() => true);
 >foo(() => true) : void
 >foo : (func: () => boolean) => void
->() => true : () => true
+>() => true : () => boolean
 >true : true
 
 foo(() => { return false; });
 >foo(() => { return false; }) : void
 >foo : (func: () => boolean) => void
->() => { return false; } : () => false
+>() => { return false; } : () => boolean
 >false : false
 

--- a/tests/baselines/reference/emitArrowFunctionES6.types
+++ b/tests/baselines/reference/emitArrowFunctionES6.types
@@ -31,13 +31,13 @@ function foo(func: () => boolean) { }
 foo(() => true);
 >foo(() => true) : void
 >foo : (func: () => boolean) => void
->() => true : () => true
+>() => true : () => boolean
 >true : true
 
 foo(() => { return false; });
 >foo(() => { return false; }) : void
 >foo : (func: () => boolean) => void
->() => { return false; } : () => false
+>() => { return false; } : () => boolean
 >false : false
 
 // Binding patterns in arrow functions

--- a/tests/baselines/reference/emitArrowFunctionThisCapturing.types
+++ b/tests/baselines/reference/emitArrowFunctionThisCapturing.types
@@ -32,7 +32,7 @@ function foo(func: () => boolean) { }
 foo(() => {
 >foo(() => {    this.age = 100;    return true;}) : void
 >foo : (func: () => boolean) => void
->() => {    this.age = 100;    return true;} : () => true
+>() => {    this.age = 100;    return true;} : () => boolean
 
     this.age = 100;
 >this.age = 100 : 100

--- a/tests/baselines/reference/emitArrowFunctionThisCapturingES6.types
+++ b/tests/baselines/reference/emitArrowFunctionThisCapturingES6.types
@@ -32,7 +32,7 @@ function foo(func: () => boolean){ }
 foo(() => {
 >foo(() => {    this.age = 100;    return true;}) : void
 >foo : (func: () => boolean) => void
->() => {    this.age = 100;    return true;} : () => true
+>() => {    this.age = 100;    return true;} : () => boolean
 
     this.age = 100;
 >this.age = 100 : 100

--- a/tests/baselines/reference/excessPropertyCheckWithUnions.errors.txt
+++ b/tests/baselines/reference/excessPropertyCheckWithUnions.errors.txt
@@ -13,8 +13,8 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(39,1): error TS2322: Type 
   Type '{ tag: "A"; }' is not assignable to type '{ tag: "C"; }'.
     Types of property 'tag' are incompatible.
       Type '"A"' is not assignable to type '"C"'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(40,1): error TS2322: Type '{ tag: "A"; z: true; }' is not assignable to type 'Ambiguous'.
-  Type '{ tag: "A"; z: true; }' is not assignable to type '{ tag: "C"; }'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(40,1): error TS2322: Type '{ tag: "A"; z: boolean; }' is not assignable to type 'Ambiguous'.
+  Type '{ tag: "A"; z: boolean; }' is not assignable to type '{ tag: "C"; }'.
     Types of property 'tag' are incompatible.
       Type '"A"' is not assignable to type '"C"'.
 tests/cases/compiler/excessPropertyCheckWithUnions.ts(49,35): error TS2322: Type '{ a: 1; b: 1; first: string; second: string; }' is not assignable to type 'Overlapping'.
@@ -86,8 +86,8 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(50,35): error TS2322: Type
 !!! error TS2322:       Type '"A"' is not assignable to type '"C"'.
     amb = { tag: "A", z: true }
     ~~~
-!!! error TS2322: Type '{ tag: "A"; z: true; }' is not assignable to type 'Ambiguous'.
-!!! error TS2322:   Type '{ tag: "A"; z: true; }' is not assignable to type '{ tag: "C"; }'.
+!!! error TS2322: Type '{ tag: "A"; z: boolean; }' is not assignable to type 'Ambiguous'.
+!!! error TS2322:   Type '{ tag: "A"; z: boolean; }' is not assignable to type '{ tag: "C"; }'.
 !!! error TS2322:     Types of property 'tag' are incompatible.
 !!! error TS2322:       Type '"A"' is not assignable to type '"C"'.
     

--- a/tests/baselines/reference/excessPropertyCheckWithUnions.types
+++ b/tests/baselines/reference/excessPropertyCheckWithUnions.types
@@ -139,9 +139,9 @@ amb = { tag: "A" }
 >"A" : "A"
 
 amb = { tag: "A", z: true }
->amb = { tag: "A", z: true } : { tag: "A"; z: true; }
+>amb = { tag: "A", z: true } : { tag: "A"; z: boolean; }
 >amb : Ambiguous
->{ tag: "A", z: true } : { tag: "A"; z: true; }
+>{ tag: "A", z: true } : { tag: "A"; z: boolean; }
 >tag : string
 >"A" : "A"
 >z : boolean

--- a/tests/baselines/reference/for-of36.types
+++ b/tests/baselines/reference/for-of36.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of36.ts ===
 var tuple: [string, boolean] = ["", true];
 >tuple : [string, boolean]
->["", true] : [string, true]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of37.types
+++ b/tests/baselines/reference/for-of37.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of38.types
+++ b/tests/baselines/reference/for-of38.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of39.errors.txt
+++ b/tests/baselines/reference/for-of39.errors.txt
@@ -1,28 +1,28 @@
-tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,19): error TS2345: Argument of type '([string, true] | [string, 0])[]' is not assignable to parameter of type 'Iterable<[string, boolean]>'.
+tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,19): error TS2345: Argument of type '([string, boolean] | [string, number])[]' is not assignable to parameter of type 'Iterable<[string, boolean]>'.
   Types of property '[Symbol.iterator]' are incompatible.
-    Type '() => IterableIterator<[string, true] | [string, 0]>' is not assignable to type '() => Iterator<[string, boolean]>'.
-      Type 'IterableIterator<[string, true] | [string, 0]>' is not assignable to type 'Iterator<[string, boolean]>'.
+    Type '() => IterableIterator<[string, boolean] | [string, number]>' is not assignable to type '() => Iterator<[string, boolean]>'.
+      Type 'IterableIterator<[string, boolean] | [string, number]>' is not assignable to type 'Iterator<[string, boolean]>'.
         Types of property 'next' are incompatible.
-          Type '(value?: any) => IteratorResult<[string, true] | [string, 0]>' is not assignable to type '(value?: any) => IteratorResult<[string, boolean]>'.
-            Type 'IteratorResult<[string, true] | [string, 0]>' is not assignable to type 'IteratorResult<[string, boolean]>'.
-              Type '[string, true] | [string, 0]' is not assignable to type '[string, boolean]'.
-                Type '[string, 0]' is not assignable to type '[string, boolean]'.
-                  Type '0' is not assignable to type 'boolean'.
+          Type '(value?: any) => IteratorResult<[string, boolean] | [string, number]>' is not assignable to type '(value?: any) => IteratorResult<[string, boolean]>'.
+            Type 'IteratorResult<[string, boolean] | [string, number]>' is not assignable to type 'IteratorResult<[string, boolean]>'.
+              Type '[string, boolean] | [string, number]' is not assignable to type '[string, boolean]'.
+                Type '[string, number]' is not assignable to type '[string, boolean]'.
+                  Type 'number' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/for-ofStatements/for-of39.ts (1 errors) ====
     var map = new Map([["", true], ["", 0]]);
                       ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '([string, true] | [string, 0])[]' is not assignable to parameter of type 'Iterable<[string, boolean]>'.
+!!! error TS2345: Argument of type '([string, boolean] | [string, number])[]' is not assignable to parameter of type 'Iterable<[string, boolean]>'.
 !!! error TS2345:   Types of property '[Symbol.iterator]' are incompatible.
-!!! error TS2345:     Type '() => IterableIterator<[string, true] | [string, 0]>' is not assignable to type '() => Iterator<[string, boolean]>'.
-!!! error TS2345:       Type 'IterableIterator<[string, true] | [string, 0]>' is not assignable to type 'Iterator<[string, boolean]>'.
+!!! error TS2345:     Type '() => IterableIterator<[string, boolean] | [string, number]>' is not assignable to type '() => Iterator<[string, boolean]>'.
+!!! error TS2345:       Type 'IterableIterator<[string, boolean] | [string, number]>' is not assignable to type 'Iterator<[string, boolean]>'.
 !!! error TS2345:         Types of property 'next' are incompatible.
-!!! error TS2345:           Type '(value?: any) => IteratorResult<[string, true] | [string, 0]>' is not assignable to type '(value?: any) => IteratorResult<[string, boolean]>'.
-!!! error TS2345:             Type 'IteratorResult<[string, true] | [string, 0]>' is not assignable to type 'IteratorResult<[string, boolean]>'.
-!!! error TS2345:               Type '[string, true] | [string, 0]' is not assignable to type '[string, boolean]'.
-!!! error TS2345:                 Type '[string, 0]' is not assignable to type '[string, boolean]'.
-!!! error TS2345:                   Type '0' is not assignable to type 'boolean'.
+!!! error TS2345:           Type '(value?: any) => IteratorResult<[string, boolean] | [string, number]>' is not assignable to type '(value?: any) => IteratorResult<[string, boolean]>'.
+!!! error TS2345:             Type 'IteratorResult<[string, boolean] | [string, number]>' is not assignable to type 'IteratorResult<[string, boolean]>'.
+!!! error TS2345:               Type '[string, boolean] | [string, number]' is not assignable to type '[string, boolean]'.
+!!! error TS2345:                 Type '[string, number]' is not assignable to type '[string, boolean]'.
+!!! error TS2345:                   Type 'number' is not assignable to type 'boolean'.
     for (var [k, v] of map) {
         k;
         v;

--- a/tests/baselines/reference/for-of40.types
+++ b/tests/baselines/reference/for-of40.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of44.types
+++ b/tests/baselines/reference/for-of44.types
@@ -1,11 +1,11 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of44.ts ===
 var array: [number, string | boolean | symbol][] = [[0, ""], [0, true], [1, Symbol()]]
 >array : [number, string | boolean | symbol][]
->[[0, ""], [0, true], [1, Symbol()]] : ([number, ""] | [number, true] | [number, symbol])[]
->[0, ""] : [number, ""]
+>[[0, ""], [0, true], [1, Symbol()]] : ([number, string] | [number, boolean] | [number, symbol])[]
+>[0, ""] : [number, string]
 >0 : 0
 >"" : ""
->[0, true] : [number, true]
+>[0, true] : [number, boolean]
 >0 : 0
 >true : true
 >[1, Symbol()] : [number, symbol]

--- a/tests/baselines/reference/for-of45.types
+++ b/tests/baselines/reference/for-of45.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of46.types
+++ b/tests/baselines/reference/for-of46.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of49.types
+++ b/tests/baselines/reference/for-of49.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of50.types
+++ b/tests/baselines/reference/for-of50.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/functionOverloads39.types
+++ b/tests/baselines/reference/functionOverloads39.types
@@ -19,8 +19,8 @@ var x = foo([{a:true}]);
 >x : number
 >foo([{a:true}]) : number
 >foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
->[{a:true}] : { a: true; }[]
->{a:true} : { a: true; }
+>[{a:true}] : { a: boolean; }[]
+>{a:true} : { a: boolean; }
 >a : boolean
 >true : true
 

--- a/tests/baselines/reference/functionOverloads40.errors.txt
+++ b/tests/baselines/reference/functionOverloads40.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/compiler/functionOverloads40.ts(4,13): error TS2345: Argument of type '{ a: "bar"; }[]' is not assignable to parameter of type '{ a: boolean; }[]'.
-  Type '{ a: "bar"; }' is not assignable to type '{ a: boolean; }'.
+tests/cases/compiler/functionOverloads40.ts(4,13): error TS2345: Argument of type '{ a: string; }[]' is not assignable to parameter of type '{ a: boolean; }[]'.
+  Type '{ a: string; }' is not assignable to type '{ a: boolean; }'.
     Types of property 'a' are incompatible.
-      Type '"bar"' is not assignable to type 'boolean'.
+      Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/compiler/functionOverloads40.ts (1 errors) ====
@@ -10,8 +10,8 @@ tests/cases/compiler/functionOverloads40.ts(4,13): error TS2345: Argument of typ
     function foo(bar:{a:any;}[]):any{ return bar }
     var x = foo([{a:'bar'}]);
                 ~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ a: "bar"; }[]' is not assignable to parameter of type '{ a: boolean; }[]'.
-!!! error TS2345:   Type '{ a: "bar"; }' is not assignable to type '{ a: boolean; }'.
+!!! error TS2345: Argument of type '{ a: string; }[]' is not assignable to parameter of type '{ a: boolean; }[]'.
+!!! error TS2345:   Type '{ a: string; }' is not assignable to type '{ a: boolean; }'.
 !!! error TS2345:     Types of property 'a' are incompatible.
-!!! error TS2345:       Type '"bar"' is not assignable to type 'boolean'.
+!!! error TS2345:       Type 'string' is not assignable to type 'boolean'.
     

--- a/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.types
+++ b/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.types
@@ -64,7 +64,7 @@ _.all([true], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
->[true] : true[]
+>[true] : boolean[]
 >true : true
 >_.identity : <T>(value: T) => T
 >_ : Underscore.Static

--- a/tests/baselines/reference/genericTypeArgumentInference1.types
+++ b/tests/baselines/reference/genericTypeArgumentInference1.types
@@ -62,7 +62,7 @@ var r2 = _.all([true], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
->[true] : true[]
+>[true] : boolean[]
 >true : true
 >_.identity : <T>(value: T) => T
 >_ : Underscore.Static

--- a/tests/baselines/reference/getAndSetAsMemberNames.types
+++ b/tests/baselines/reference/getAndSetAsMemberNames.types
@@ -40,7 +40,7 @@ class C5 {
 
     public set: () => boolean = function () { return true; };
 >set : () => boolean
->function () { return true; } : () => true
+>function () { return true; } : () => boolean
 >true : true
 
     get (): boolean { return true; }

--- a/tests/baselines/reference/getterSetterNonAccessor.types
+++ b/tests/baselines/reference/getterSetterNonAccessor.types
@@ -16,8 +16,8 @@ Object.defineProperty({}, "0", <PropertyDescriptor>({
 >"0" : "0"
 ><PropertyDescriptor>({          get: getFunc,          set: setFunc,          configurable: true      }) : PropertyDescriptor
 >PropertyDescriptor : PropertyDescriptor
->({          get: getFunc,          set: setFunc,          configurable: true      }) : { get: () => any; set: (v: any) => void; configurable: true; }
->{          get: getFunc,          set: setFunc,          configurable: true      } : { get: () => any; set: (v: any) => void; configurable: true; }
+>({          get: getFunc,          set: setFunc,          configurable: true      }) : { get: () => any; set: (v: any) => void; configurable: boolean; }
+>{          get: getFunc,          set: setFunc,          configurable: true      } : { get: () => any; set: (v: any) => void; configurable: boolean; }
 
           get: getFunc,
 >get : () => any

--- a/tests/baselines/reference/indexerWithTuple.types
+++ b/tests/baselines/reference/indexerWithTuple.types
@@ -21,7 +21,7 @@ var unionTuple1: [number, string| number] = [10, "foo"];
 
 var unionTuple2: [boolean, string| number] = [true, "foo"]; 
 >unionTuple2 : [boolean, string | number]
->[true, "foo"] : [true, string]
+>[true, "foo"] : [boolean, string]
 >true : true
 >"foo" : "foo"
 

--- a/tests/baselines/reference/interfaceContextualType.types
+++ b/tests/baselines/reference/interfaceContextualType.types
@@ -34,13 +34,13 @@ class Bug {
 >{} : {}
 
         this.values['comments'] = { italic: true };
->this.values['comments'] = { italic: true } : { italic: true; }
+>this.values['comments'] = { italic: true } : { italic: boolean; }
 >this.values['comments'] : IOptions
 >this.values : IMap
 >this : this
 >values : IMap
 >'comments' : "comments"
->{ italic: true } : { italic: true; }
+>{ italic: true } : { italic: boolean; }
 >italic : boolean
 >true : true
     }
@@ -48,15 +48,15 @@ class Bug {
 >shouldBeOK : () => void
 
         this.values = {
->this.values = {            comments: { italic: true }        } : { comments: { italic: true; }; }
+>this.values = {            comments: { italic: true }        } : { comments: { italic: boolean; }; }
 >this.values : IMap
 >this : this
 >values : IMap
->{            comments: { italic: true }        } : { comments: { italic: true; }; }
+>{            comments: { italic: true }        } : { comments: { italic: boolean; }; }
 
             comments: { italic: true }
->comments : { italic: true; }
->{ italic: true } : { italic: true; }
+>comments : { italic: boolean; }
+>{ italic: true } : { italic: boolean; }
 >italic : boolean
 >true : true
 

--- a/tests/baselines/reference/interfaceWithPropertyOfEveryType.types
+++ b/tests/baselines/reference/interfaceWithPropertyOfEveryType.types
@@ -80,7 +80,7 @@ interface Foo {
 var a: Foo = {
 >a : Foo
 >Foo : Foo
->{    a: 1,    b: '',    c: true,    d: {},    e: null ,    f: [1],    g: {},    h: (x: number) => 1,    i: <T>(x: T) => x,    j: <Foo>null,    k: new C(),    l: f1,    m: M,    n: {},    o: E.A} : { a: number; b: string; c: true; d: {}; e: null; f: number[]; g: {}; h: (x: number) => number; i: <T>(x: T) => T; j: Foo; k: C; l: () => void; m: typeof M; n: {}; o: E; }
+>{    a: 1,    b: '',    c: true,    d: {},    e: null ,    f: [1],    g: {},    h: (x: number) => 1,    i: <T>(x: T) => x,    j: <Foo>null,    k: new C(),    l: f1,    m: M,    n: {},    o: E.A} : { a: number; b: string; c: boolean; d: {}; e: null; f: number[]; g: {}; h: (x: number) => number; i: <T>(x: T) => T; j: Foo; k: C; l: () => void; m: typeof M; n: {}; o: E; }
 
     a: 1,
 >a : number

--- a/tests/baselines/reference/isomorphicMappedTypeInference.types
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.types
@@ -245,7 +245,7 @@ function f3() {
 >assignBoxified(b, { c: false }) : void
 >assignBoxified : <T>(obj: Boxified<T>, values: T) => void
 >b : { a: Box<number>; b: Box<string>; c: Box<boolean>; }
->{ c: false } : { c: false; }
+>{ c: false } : { c: boolean; }
 >c : boolean
 >false : false
 }

--- a/tests/baselines/reference/iterableArrayPattern23.types
+++ b/tests/baselines/reference/iterableArrayPattern23.types
@@ -4,11 +4,11 @@ var a: string, b: boolean;
 >b : boolean
 
 [a, b] = { 0: "", 1: true };
->[a, b] = { 0: "", 1: true } : { 0: string; 1: true; }
+>[a, b] = { 0: "", 1: true } : { 0: string; 1: boolean; }
 >[a, b] : [string, boolean]
 >a : string
 >b : boolean
->{ 0: "", 1: true } : { 0: string; 1: true; }
+>{ 0: "", 1: true } : { 0: string; 1: boolean; }
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern24.types
+++ b/tests/baselines/reference/iterableArrayPattern24.types
@@ -4,12 +4,12 @@ var a: string, b: boolean[];
 >b : boolean[]
 
 [a, ...b] = { 0: "", 1: true };
->[a, ...b] = { 0: "", 1: true } : { 0: ""; 1: true; }
+>[a, ...b] = { 0: "", 1: true } : { 0: string; 1: boolean; }
 >[a, ...b] : (string | boolean)[]
 >a : string
 >...b : boolean
 >b : boolean[]
->{ 0: "", 1: true } : { 0: ""; 1: true; }
+>{ 0: "", 1: true } : { 0: string; 1: boolean; }
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern29.types
+++ b/tests/baselines/reference/iterableArrayPattern29.types
@@ -12,11 +12,11 @@ takeFirstTwoEntries(...new Map([["", true], ["hello", true]]));
 >...new Map([["", true], ["hello", true]]) : [string, boolean]
 >new Map([["", true], ["hello", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true], ["hello", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true], ["hello", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
->["hello", true] : [string, true]
+>["hello", true] : [string, boolean]
 >"hello" : "hello"
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern30.types
+++ b/tests/baselines/reference/iterableArrayPattern30.types
@@ -6,11 +6,11 @@ const [[k1, v1], [k2, v2]] = new Map([["", true], ["hello", true]])
 >v2 : boolean
 >new Map([["", true], ["hello", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true], ["hello", true]] : [string, true][]
->["", true] : [string, true]
+>[["", true], ["hello", true]] : [string, boolean][]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
->["hello", true] : [string, true]
+>["hello", true] : [string, boolean]
 >"hello" : "hello"
 >true : true
 

--- a/tests/baselines/reference/jsdocParamTagTypeLiteral.types
+++ b/tests/baselines/reference/jsdocParamTagTypeLiteral.types
@@ -149,17 +149,17 @@ function foo5(opts5) {
 foo5([{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }]);
 >foo5([{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }]) : void
 >foo5 : (opts5: { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }[]) => void
->[{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }] : { help: string; what: { a: string; bad: { idea: string; oh: false; }[]; }; unnest: number; }[]
->{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 } : { help: string; what: { a: string; bad: { idea: string; oh: false; }[]; }; unnest: number; }
+>[{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }] : { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }[]
+>{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 } : { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }
 >help : string
 >"help" : "help"
->what : { a: string; bad: { idea: string; oh: false; }[]; }
->{ a: 'a', bad: [{ idea: 'idea', oh: false }] } : { a: string; bad: { idea: string; oh: false; }[]; }
+>what : { a: string; bad: { idea: string; oh: boolean; }[]; }
+>{ a: 'a', bad: [{ idea: 'idea', oh: false }] } : { a: string; bad: { idea: string; oh: boolean; }[]; }
 >a : string
 >'a' : "a"
->bad : { idea: string; oh: false; }[]
->[{ idea: 'idea', oh: false }] : { idea: string; oh: false; }[]
->{ idea: 'idea', oh: false } : { idea: string; oh: false; }
+>bad : { idea: string; oh: boolean; }[]
+>[{ idea: 'idea', oh: false }] : { idea: string; oh: boolean; }[]
+>{ idea: 'idea', oh: false } : { idea: string; oh: boolean; }
 >idea : string
 >'idea' : "idea"
 >oh : boolean

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -572,7 +572,7 @@ function f31<K extends keyof Shape>(key: K) {
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
 >shape : Shape
 >Shape : Shape
->{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: true; }
+>{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: boolean; }
 >name : string
 >"foo" : "foo"
 >width : number
@@ -597,7 +597,7 @@ function f32<K extends "width" | "height">(key: K) {
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
 >shape : Shape
 >Shape : Shape
->{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: true; }
+>{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: boolean; }
 >name : string
 >"foo" : "foo"
 >width : number
@@ -952,7 +952,7 @@ function f71(func: <T, U>(x: T, y: U) => Partial<T & U>) {
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 
@@ -999,7 +999,7 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 >'a' : "a"
@@ -1013,7 +1013,7 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 >'b' : "b"
@@ -1027,7 +1027,7 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 >'c' : "c"
@@ -1060,7 +1060,7 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 >'a' : "a"
@@ -1074,7 +1074,7 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 >'b' : "b"
@@ -1088,7 +1088,7 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 >'c' : "c"
@@ -1121,7 +1121,7 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ a: 2, b: true } : { a: number; b: true; }
+>{ a: 2, b: true } : { a: number; b: boolean; }
 >a : number
 >2 : 2
 >b : boolean
@@ -1137,7 +1137,7 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ a: 2, b: true } : { a: number; b: true; }
+>{ a: 2, b: true } : { a: number; b: boolean; }
 >a : number
 >2 : 2
 >b : boolean

--- a/tests/baselines/reference/literalTypes2.types
+++ b/tests/baselines/reference/literalTypes2.types
@@ -501,7 +501,7 @@ function f6() {
 >0 : 0
 >x3 : string
 >"foo" : "foo"
->{ x1: false, x2: 1, x3: "bar" } : { x1?: false; x2?: number; x3?: string; }
+>{ x1: false, x2: 1, x3: "bar" } : { x1?: boolean; x2?: number; x3?: string; }
 >x1 : boolean
 >false : false
 >x2 : number

--- a/tests/baselines/reference/mappedTypeErrors.types
+++ b/tests/baselines/reference/mappedTypeErrors.types
@@ -613,7 +613,7 @@ type O = {x: number, y: boolean};
 let o: O = {x: 5, y: false};
 >o : O
 >O : O
->{x: 5, y: false} : { x: number; y: false; }
+>{x: 5, y: false} : { x: number; y: boolean; }
 >x : number
 >5 : 5
 >y : boolean

--- a/tests/baselines/reference/objectLiteralNormalization.errors.txt
+++ b/tests/baselines/reference/objectLiteralNormalization.errors.txt
@@ -4,9 +4,9 @@ tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(8,1): error TS2322: Type '{ b: string; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
   Type '{ b: string; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
     Property 'a' is missing in type '{ b: string; }'.
-tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(9,1): error TS2322: Type '{ c: true; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
-  Type '{ c: true; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
-    Property 'a' is missing in type '{ c: true; }'.
+tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(9,1): error TS2322: Type '{ c: boolean; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
+  Type '{ c: boolean; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
+    Property 'a' is missing in type '{ c: boolean; }'.
 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(17,1): error TS2322: Type '{ a: string; b: number; }' is not assignable to type '{ a: number; b: number; } | { a: string; b?: undefined; } | { a?: undefined; b?: undefined; }'.
   Type '{ a: string; b: number; }' is not assignable to type '{ a?: undefined; b?: undefined; }'.
     Types of property 'a' are incompatible.
@@ -36,9 +36,9 @@ tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
 !!! error TS2322:     Property 'a' is missing in type '{ b: string; }'.
     a1 = { c: true };  // Error
     ~~
-!!! error TS2322: Type '{ c: true; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
-!!! error TS2322:   Type '{ c: true; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
-!!! error TS2322:     Property 'a' is missing in type '{ c: true; }'.
+!!! error TS2322: Type '{ c: boolean; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
+!!! error TS2322:   Type '{ c: boolean; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
+!!! error TS2322:     Property 'a' is missing in type '{ c: boolean; }'.
     
     let a2 = [{ a: 1, b: 2 }, { a: "abc" }, {}][0];
     a2.a;  // string | number | undefined

--- a/tests/baselines/reference/objectLiteralNormalization.types
+++ b/tests/baselines/reference/objectLiteralNormalization.types
@@ -60,9 +60,9 @@ a1 = { b: "y" };  // Error
 >"y" : "y"
 
 a1 = { c: true };  // Error
->a1 = { c: true } : { c: true; }
+>a1 = { c: true } : { c: boolean; }
 >a1 : { a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }
->{ c: true } : { c: true; }
+>{ c: true } : { c: boolean; }
 >c : boolean
 >true : true
 

--- a/tests/baselines/reference/objectLiteralParameterResolution.types
+++ b/tests/baselines/reference/objectLiteralParameterResolution.types
@@ -29,7 +29,7 @@ var s = $.extend({
 >$.extend : { <T>(target: T, ...objs: any[]): T; <T>(deep: boolean, target: T, ...objs: any[]): T; }
 >$ : Foo
 >extend : { <T>(target: T, ...objs: any[]): T; <T>(deep: boolean, target: T, ...objs: any[]): T; }
->{    type: "GET" ,    data: "data" ,    success: wrapSuccessCallback(requestContext, callback) ,    error: wrapErrorCallback(requestContext, errorCallback) ,    dataType: "json" ,    converters: { "text json": "" },    traditional: true ,    timeout: 12,    } : { type: string; data: string; success: any; error: any; dataType: string; converters: { "text json": string; }; traditional: true; timeout: number; }
+>{    type: "GET" ,    data: "data" ,    success: wrapSuccessCallback(requestContext, callback) ,    error: wrapErrorCallback(requestContext, errorCallback) ,    dataType: "json" ,    converters: { "text json": "" },    traditional: true ,    timeout: 12,    } : { type: string; data: string; success: any; error: any; dataType: string; converters: { "text json": string; }; traditional: boolean; timeout: number; }
 
     type: "GET" ,
 >type : string

--- a/tests/baselines/reference/objectSpread.types
+++ b/tests/baselines/reference/objectSpread.types
@@ -31,7 +31,7 @@ let addAfter: { a: number, b: string, c: boolean } =
 >c : boolean
 
     { ...o, c: false }
->{ ...o, c: false } : { c: false; a: number; b: string; }
+>{ ...o, c: false } : { c: boolean; a: number; b: string; }
 >o : { a: number; b: string; }
 >c : boolean
 >false : false
@@ -43,7 +43,7 @@ let addBefore: { a: number, b: string, c: boolean } =
 >c : boolean
 
     { c: false, ...o }
->{ c: false, ...o } : { a: number; b: string; c: false; }
+>{ c: false, ...o } : { a: number; b: string; c: boolean; }
 >c : boolean
 >false : false
 >o : { a: number; b: string; }
@@ -78,11 +78,11 @@ let nested: { a: number, b: boolean, c: string } =
 >c : string
 
     { ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' }
->{ ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' } : { c: string; b: false; a: number; }
->{ a: 3, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
+>{ ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' } : { c: string; b: boolean; a: number; }
+>{ a: 3, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
 >a : number
 >3 : 3
->{ b: false, c: 'overriden' } : { b: false; c: string; }
+>{ b: false, c: 'overriden' } : { b: boolean; c: string; }
 >b : boolean
 >false : false
 >c : string
@@ -148,11 +148,11 @@ let combinedNested: { a: number, b: boolean, c: string, d: string } =
 >d : string
 
     { ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } }
->{ ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } } : { a: number; d: string; b: false; c: string; }
->{ a: 4, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
+>{ ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } } : { a: number; d: string; b: boolean; c: string; }
+>{ a: 4, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
 >a : number
 >4 : 4
->{ b: false, c: 'overriden' } : { b: false; c: string; }
+>{ b: false, c: 'overriden' } : { b: boolean; c: string; }
 >b : boolean
 >false : false
 >c : string
@@ -172,11 +172,11 @@ let combinedNestedChangeType: { a: number, b: boolean, c: number } =
 >c : number
 
     { ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 }
->{ ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 } : { c: number; b: false; a: number; }
->{ a: 1, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
+>{ ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 } : { c: number; b: boolean; a: number; }
+>{ a: 1, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
 >a : number
 >1 : 1
->{ b: false, c: 'overriden' } : { b: false; c: string; }
+>{ b: false, c: 'overriden' } : { b: boolean; c: string; }
 >b : boolean
 >false : false
 >c : string

--- a/tests/baselines/reference/objectSpreadNegative.types
+++ b/tests/baselines/reference/objectSpreadNegative.types
@@ -278,7 +278,7 @@ let exclusive: { id: string, a: number, b: string, c: string, d: boolean } =
 >1 : 1
 >b : string
 >'yes' : "yes"
->{ c: 'no', d: false } : { c: string; d: false; }
+>{ c: 'no', d: false } : { c: string; d: boolean; }
 >c : string
 >'no' : "no"
 >d : boolean
@@ -327,7 +327,7 @@ let overwriteId: { id: string, a: number, c: number, d: string } =
     f({ a: 1, id: true }, { c: 1, d: 'no' })
 >f({ a: 1, id: true }, { c: 1, d: 'no' }) : any
 >f : <T, U>(t: T, u: U) => any
->{ a: 1, id: true } : { a: number; id: true; }
+>{ a: 1, id: true } : { a: number; id: boolean; }
 >a : number
 >1 : 1
 >id : boolean

--- a/tests/baselines/reference/optionalBindingParameters1.errors.txt
+++ b/tests/baselines/reference/optionalBindingParameters1.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts(1,14): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
-tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts(7,5): error TS2345: Argument of type '[boolean, number, ""]' is not assignable to parameter of type '[string, number, boolean]'.
+tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts(7,5): error TS2345: Argument of type '[boolean, number, string]' is not assignable to parameter of type '[string, number, boolean]'.
   Type 'boolean' is not assignable to type 'string'.
 
 
@@ -14,5 +14,5 @@ tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts(7,5): er
     
     foo([false, 0, ""]);
         ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '[boolean, number, ""]' is not assignable to parameter of type '[string, number, boolean]'.
+!!! error TS2345: Argument of type '[boolean, number, string]' is not assignable to parameter of type '[string, number, boolean]'.
 !!! error TS2345:   Type 'boolean' is not assignable to type 'string'.

--- a/tests/baselines/reference/optionalBindingParameters1.types
+++ b/tests/baselines/reference/optionalBindingParameters1.types
@@ -10,7 +10,7 @@ function foo([x,y,z]?: [string, number, boolean]) {
 foo(["", 0, false]);
 >foo(["", 0, false]) : void
 >foo : ([x, y, z]?: [string, number, boolean]) => void
->["", 0, false] : [string, number, false]
+>["", 0, false] : [string, number, boolean]
 >"" : ""
 >0 : 0
 >false : false

--- a/tests/baselines/reference/optionalBindingParameters2.errors.txt
+++ b/tests/baselines/reference/optionalBindingParameters2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/es6/destructuring/optionalBindingParameters2.ts(1,14): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
-tests/cases/conformance/es6/destructuring/optionalBindingParameters2.ts(7,5): error TS2345: Argument of type '{ x: boolean; y: number; z: ""; }' is not assignable to parameter of type '{ x: string; y: number; z: boolean; }'.
+tests/cases/conformance/es6/destructuring/optionalBindingParameters2.ts(7,5): error TS2345: Argument of type '{ x: boolean; y: number; z: string; }' is not assignable to parameter of type '{ x: string; y: number; z: boolean; }'.
   Types of property 'x' are incompatible.
     Type 'boolean' is not assignable to type 'string'.
 
@@ -15,6 +15,6 @@ tests/cases/conformance/es6/destructuring/optionalBindingParameters2.ts(7,5): er
     
     foo({ x: false, y: 0, z: "" });
         ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ x: boolean; y: number; z: ""; }' is not assignable to parameter of type '{ x: string; y: number; z: boolean; }'.
+!!! error TS2345: Argument of type '{ x: boolean; y: number; z: string; }' is not assignable to parameter of type '{ x: string; y: number; z: boolean; }'.
 !!! error TS2345:   Types of property 'x' are incompatible.
 !!! error TS2345:     Type 'boolean' is not assignable to type 'string'.

--- a/tests/baselines/reference/optionalBindingParameters2.types
+++ b/tests/baselines/reference/optionalBindingParameters2.types
@@ -13,7 +13,7 @@ function foo({ x, y, z }?: { x: string; y: number; z: boolean }) {
 foo({ x: "", y: 0, z: false });
 >foo({ x: "", y: 0, z: false }) : void
 >foo : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => void
->{ x: "", y: 0, z: false } : { x: string; y: number; z: false; }
+>{ x: "", y: 0, z: false } : { x: string; y: number; z: boolean; }
 >x : string
 >"" : ""
 >y : number

--- a/tests/baselines/reference/optionalBindingParametersInOverloads1.errors.txt
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts(8,5): error TS2345: Argument of type '[boolean, number, ""]' is not assignable to parameter of type '[string, number, boolean]'.
+tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts(8,5): error TS2345: Argument of type '[boolean, number, string]' is not assignable to parameter of type '[string, number, boolean]'.
   Type 'boolean' is not assignable to type 'string'.
 
 
@@ -12,5 +12,5 @@ tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.
     
     foo([false, 0, ""]);
         ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '[boolean, number, ""]' is not assignable to parameter of type '[string, number, boolean]'.
+!!! error TS2345: Argument of type '[boolean, number, string]' is not assignable to parameter of type '[string, number, boolean]'.
 !!! error TS2345:   Type 'boolean' is not assignable to type 'string'.

--- a/tests/baselines/reference/optionalBindingParametersInOverloads1.types
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads1.types
@@ -14,7 +14,7 @@ function foo(...rest: any[]) {
 foo(["", 0, false]);
 >foo(["", 0, false]) : any
 >foo : ([x, y, z]?: [string, number, boolean]) => any
->["", 0, false] : [string, number, false]
+>["", 0, false] : [string, number, boolean]
 >"" : ""
 >0 : 0
 >false : false

--- a/tests/baselines/reference/optionalBindingParametersInOverloads2.errors.txt
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts(8,5): error TS2345: Argument of type '{ x: boolean; y: number; z: ""; }' is not assignable to parameter of type '{ x: string; y: number; z: boolean; }'.
+tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts(8,5): error TS2345: Argument of type '{ x: boolean; y: number; z: string; }' is not assignable to parameter of type '{ x: string; y: number; z: boolean; }'.
   Types of property 'x' are incompatible.
     Type 'boolean' is not assignable to type 'string'.
 
@@ -13,6 +13,6 @@ tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.
     
     foo({ x: false, y: 0, z: "" });
         ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ x: boolean; y: number; z: ""; }' is not assignable to parameter of type '{ x: string; y: number; z: boolean; }'.
+!!! error TS2345: Argument of type '{ x: boolean; y: number; z: string; }' is not assignable to parameter of type '{ x: string; y: number; z: boolean; }'.
 !!! error TS2345:   Types of property 'x' are incompatible.
 !!! error TS2345:     Type 'boolean' is not assignable to type 'string'.

--- a/tests/baselines/reference/optionalBindingParametersInOverloads2.types
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads2.types
@@ -17,7 +17,7 @@ function foo(...rest: any[]) {
 foo({ x: "", y: 0, z: false });
 >foo({ x: "", y: 0, z: false }) : any
 >foo : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => any
->{ x: "", y: 0, z: false } : { x: string; y: number; z: false; }
+>{ x: "", y: 0, z: false } : { x: string; y: number; z: boolean; }
 >x : string
 >"" : ""
 >y : number

--- a/tests/baselines/reference/overloadResolutionTest1.errors.txt
+++ b/tests/baselines/reference/overloadResolutionTest1.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/compiler/overloadResolutionTest1.ts(7,16): error TS2345: Argument of type '{ a: "s"; }[]' is not assignable to parameter of type '{ a: boolean; }[]'.
-  Type '{ a: "s"; }' is not assignable to type '{ a: boolean; }'.
+tests/cases/compiler/overloadResolutionTest1.ts(7,16): error TS2345: Argument of type '{ a: string; }[]' is not assignable to parameter of type '{ a: boolean; }[]'.
+  Type '{ a: string; }' is not assignable to type '{ a: boolean; }'.
     Types of property 'a' are incompatible.
-      Type '"s"' is not assignable to type 'boolean'.
-tests/cases/compiler/overloadResolutionTest1.ts(18,15): error TS2345: Argument of type '{ a: "s"; }' is not assignable to parameter of type '{ a: boolean; }'.
+      Type 'string' is not assignable to type 'boolean'.
+tests/cases/compiler/overloadResolutionTest1.ts(18,15): error TS2345: Argument of type '{ a: string; }' is not assignable to parameter of type '{ a: boolean; }'.
   Types of property 'a' are incompatible.
-    Type '"s"' is not assignable to type 'boolean'.
+    Type 'string' is not assignable to type 'boolean'.
 tests/cases/compiler/overloadResolutionTest1.ts(24,14): error TS2345: Argument of type '{ a: boolean; }' is not assignable to parameter of type '{ a: string; }'.
   Types of property 'a' are incompatible.
     Type 'boolean' is not assignable to type 'string'.
@@ -19,10 +19,10 @@ tests/cases/compiler/overloadResolutionTest1.ts(24,14): error TS2345: Argument o
     var x11 = foo([{a:0}]); // works
     var x111 = foo([{a:"s"}]); // error - does not match any signature
                    ~~~~~~~~~
-!!! error TS2345: Argument of type '{ a: "s"; }[]' is not assignable to parameter of type '{ a: boolean; }[]'.
-!!! error TS2345:   Type '{ a: "s"; }' is not assignable to type '{ a: boolean; }'.
+!!! error TS2345: Argument of type '{ a: string; }[]' is not assignable to parameter of type '{ a: boolean; }[]'.
+!!! error TS2345:   Type '{ a: string; }' is not assignable to type '{ a: boolean; }'.
 !!! error TS2345:     Types of property 'a' are incompatible.
-!!! error TS2345:       Type '"s"' is not assignable to type 'boolean'.
+!!! error TS2345:       Type 'string' is not assignable to type 'boolean'.
     var x1111 = foo([{a:null}]); // works - ambiguous call is resolved to be the first in the overload set so this returns a string
     
     
@@ -35,9 +35,9 @@ tests/cases/compiler/overloadResolutionTest1.ts(24,14): error TS2345: Argument o
     var x3 = foo2({a:true}); // works
     var x4 = foo2({a:"s"}); // error
                   ~~~~~~~
-!!! error TS2345: Argument of type '{ a: "s"; }' is not assignable to parameter of type '{ a: boolean; }'.
+!!! error TS2345: Argument of type '{ a: string; }' is not assignable to parameter of type '{ a: boolean; }'.
 !!! error TS2345:   Types of property 'a' are incompatible.
-!!! error TS2345:     Type '"s"' is not assignable to type 'boolean'.
+!!! error TS2345:     Type 'string' is not assignable to type 'boolean'.
     
     
     function foo4(bar:{a:number;}):number;

--- a/tests/baselines/reference/overloadResolutionTest1.types
+++ b/tests/baselines/reference/overloadResolutionTest1.types
@@ -19,8 +19,8 @@ var x1 = foo([{a:true}]); // works
 >x1 : number
 >foo([{a:true}]) : number
 >foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
->[{a:true}] : { a: true; }[]
->{a:true} : { a: true; }
+>[{a:true}] : { a: boolean; }[]
+>{a:true} : { a: boolean; }
 >a : boolean
 >true : true
 
@@ -81,7 +81,7 @@ var x3 = foo2({a:true}); // works
 >x3 : number
 >foo2({a:true}) : number
 >foo2 : { (bar: { a: number; }): string; (bar: { a: boolean; }): number; }
->{a:true} : { a: true; }
+>{a:true} : { a: boolean; }
 >a : boolean
 >true : true
 

--- a/tests/baselines/reference/parserUsingConstructorAsIdentifier.types
+++ b/tests/baselines/reference/parserUsingConstructorAsIdentifier.types
@@ -97,7 +97,7 @@
 >constructor : any
 >prototype : any
 >"constructor" : "constructor"
->{ value: constructor, writable: true, configurable: true, enumerable: true } : { value: any; writable: true; configurable: true; enumerable: true; }
+>{ value: constructor, writable: true, configurable: true, enumerable: true } : { value: any; writable: boolean; configurable: boolean; enumerable: boolean; }
 >value : any
 >constructor : any
 >writable : boolean

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -1581,7 +1581,7 @@ module Harness {
                     var metadata: IScenarioMetadata = { id: undefined, desc: this.description, pass: false, bugs: assert.bugIds };
 >metadata : IScenarioMetadata
 >IScenarioMetadata : IScenarioMetadata
->{ id: undefined, desc: this.description, pass: false, bugs: assert.bugIds } : { id: undefined; desc: any; pass: false; bugs: any; }
+>{ id: undefined, desc: this.description, pass: false, bugs: assert.bugIds } : { id: undefined; desc: any; pass: boolean; bugs: any; }
 >id : undefined
 >undefined : undefined
 >desc : any

--- a/tests/baselines/reference/privacyCheckAnonymousFunctionParameter.types
+++ b/tests/baselines/reference/privacyCheckAnonymousFunctionParameter.types
@@ -31,7 +31,7 @@ module Query {
         return fromDoWhile(test => {
 >fromDoWhile(test => {            return true;        }) : Iterator<{}>
 >fromDoWhile : <T>(doWhile: (test: Iterator<T>) => boolean) => Iterator<T>
->test => {            return true;        } : (test: Iterator<{}>) => true
+>test => {            return true;        } : (test: Iterator<{}>) => boolean
 >test : Iterator<{}>
 
             return true;

--- a/tests/baselines/reference/symbolProperty21.errors.txt
+++ b/tests/baselines/reference/symbolProperty21.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
 
 
@@ -14,7 +14,7 @@ tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Arg
         [Symbol.isConcatSpreadable]: "",
         [Symbol.toPrimitive]: 0,
         ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
+!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
 !!! error TS2345:   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
         [Symbol.unscopables]: true
     });

--- a/tests/baselines/reference/targetTypeArgs.types
+++ b/tests/baselines/reference/targetTypeArgs.types
@@ -35,7 +35,7 @@ foo(function(x) { x });
 >["hello"] : string[]
 >"hello" : "hello"
 >every : (callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any) => boolean
->function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => true
+>function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => boolean
 >v : string
 >i : number
 >a : string[]
@@ -47,7 +47,7 @@ foo(function(x) { x });
 >[1] : number[]
 >1 : 1
 >every : (callbackfn: (value: number, index: number, array: number[]) => boolean, thisArg?: any) => boolean
->function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => true
+>function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => boolean
 >v : number
 >i : number
 >a : number[]
@@ -59,7 +59,7 @@ foo(function(x) { x });
 >[1] : number[]
 >1 : 1
 >every : (callbackfn: (value: number, index: number, array: number[]) => boolean, thisArg?: any) => boolean
->function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => true
+>function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => boolean
 >v : number
 >i : number
 >a : number[]
@@ -71,7 +71,7 @@ foo(function(x) { x });
 >["s"] : string[]
 >"s" : "s"
 >every : (callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any) => boolean
->function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => true
+>function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => boolean
 >v : string
 >i : number
 >a : string[]

--- a/tests/baselines/reference/thisTypeInFunctions2.types
+++ b/tests/baselines/reference/thisTypeInFunctions2.types
@@ -58,7 +58,7 @@ declare function simple(arg: SimpleInterface): void;
 extend1({
 >extend1({    init() {        this // this: IndexedWithThis because of contextual typing.        // this.mine        this.willDestroy    },    mine: 12,    foo() {        this.url; // this: any because 'foo' matches the string indexer        this.willDestroy;    }}) : void
 >extend1 : (args: IndexedWithThis) => void
->{    init() {        this // this: IndexedWithThis because of contextual typing.        // this.mine        this.willDestroy    },    mine: 12,    foo() {        this.url; // this: any because 'foo' matches the string indexer        this.willDestroy;    }} : { init(this: IndexedWithThis): void; mine: 12; foo(this: any): void; }
+>{    init() {        this // this: IndexedWithThis because of contextual typing.        // this.mine        this.willDestroy    },    mine: 12,    foo() {        this.url; // this: any because 'foo' matches the string indexer        this.willDestroy;    }} : { init(this: IndexedWithThis): void; mine: number; foo(this: any): void; }
 
     init() {
 >init : (this: IndexedWithThis) => void

--- a/tests/baselines/reference/typeAliases.types
+++ b/tests/baselines/reference/typeAliases.types
@@ -231,7 +231,7 @@ f16(x);
 var y: StringAndBoolean = ["1", false];
 >y : [string, boolean]
 >StringAndBoolean : [string, boolean]
->["1", false] : [string, false]
+>["1", false] : [string, boolean]
 >"1" : "1"
 >false : false
 

--- a/tests/baselines/reference/typeGuardsOnClassProperty.types
+++ b/tests/baselines/reference/typeGuardsOnClassProperty.types
@@ -67,7 +67,7 @@ var o: {
 >prop2 : string | boolean
 
 } = {
->{        prop1: "string" ,        prop2: true    } : { prop1: string; prop2: true; }
+>{        prop1: "string" ,        prop2: true    } : { prop1: string; prop2: boolean; }
 
         prop1: "string" ,
 >prop1 : string

--- a/tests/baselines/reference/typeInferenceLiteralUnion.types
+++ b/tests/baselines/reference/typeInferenceLiteralUnion.types
@@ -79,7 +79,7 @@ extentMixed = extent([new NumCoercible(10), 13, '12', true]);
 >extentMixed : [undefined, undefined] | [string | number | boolean | Date | NumCoercible, string | number | boolean | Date | NumCoercible]
 >extent([new NumCoercible(10), 13, '12', true]) : [undefined, undefined] | [string | number | boolean | Date | NumCoercible, string | number | boolean | Date | NumCoercible]
 >extent : <T extends Numeric>(array: (string | number | boolean | Date | T)[]) => [string | number | boolean | Date | T, string | number | boolean | Date | T] | [undefined, undefined]
->[new NumCoercible(10), 13, '12', true] : (true | NumCoercible | 13 | "12")[]
+>[new NumCoercible(10), 13, '12', true] : (string | number | boolean | NumCoercible)[]
 >new NumCoercible(10) : NumCoercible
 >NumCoercible : typeof NumCoercible
 >10 : 10

--- a/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively.types
+++ b/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively.types
@@ -62,7 +62,7 @@ foo({ x: 1 }, { x: 1, y: '' }, { x: 2, y: '', z: true });
 >1 : 1
 >y : string
 >'' : ""
->{ x: 2, y: '', z: true } : { x: number; y: string; z: true; }
+>{ x: 2, y: '', z: true } : { x: number; y: string; z: boolean; }
 >x : number
 >2 : 2
 >y : string
@@ -82,7 +82,7 @@ foo(a, b, { foo: 1, bar: '', hm: true });
 >foo : <T, U, V>(x: T, y: U, z: V) => V
 >a : A
 >b : B
->{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: true; }
+>{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: boolean; }
 >foo : number
 >1 : 1
 >bar : string

--- a/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively2.types
+++ b/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively2.types
@@ -62,7 +62,7 @@ foo({ x: 1 }, { x: 1, y: '' }, { x: 2, y: 2, z: true });
 >1 : 1
 >y : string
 >'' : ""
->{ x: 2, y: 2, z: true } : { x: number; y: number; z: true; }
+>{ x: 2, y: 2, z: true } : { x: number; y: number; z: boolean; }
 >x : number
 >2 : 2
 >y : number
@@ -81,7 +81,7 @@ foo(a, { foo: 1, bar: '', hm: true }, b);
 >foo(a, { foo: 1, bar: '', hm: true }, b) : B
 >foo : <T, U, V>(x: T, y: U, z: V) => V
 >a : A
->{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: true; }
+>{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: boolean; }
 >foo : number
 >1 : 1
 >bar : string

--- a/tests/baselines/reference/underscoreTest1.types
+++ b/tests/baselines/reference/underscoreTest1.types
@@ -249,7 +249,7 @@ _.any([null, 0, 'yes', false]);
 >_.any : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
 >_ : Underscore.Static
 >any : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
->[null, 0, 'yes', false] : (false | 0 | "yes")[]
+>[null, 0, 'yes', false] : (string | number | boolean)[]
 >null : null
 >0 : 0
 >'yes' : "yes"
@@ -512,7 +512,7 @@ _.compact([0, 1, false, 2, '', 3]);
 >_.compact : <T>(list: T[]) => T[]
 >_ : Underscore.Static
 >compact : <T>(list: T[]) => T[]
->[0, 1, false, 2, '', 3] : (false | 1 | 2 | 3 | 0 | "")[]
+>[0, 1, false, 2, '', 3] : (string | number | boolean)[]
 >0 : 0
 >1 : 1
 >false : false

--- a/tests/baselines/reference/unionTypeInference.types
+++ b/tests/baselines/reference/unionTypeInference.types
@@ -77,7 +77,7 @@ var b1 = g(["string", true]);
 >b1 : boolean
 >g(["string", true]) : boolean
 >g : <T>(value: [string, T]) => T
->["string", true] : [string, true]
+>["string", true] : [string, boolean]
 >"string" : "string"
 >true : true
 

--- a/tests/baselines/reference/useObjectValuesAndEntries1.types
+++ b/tests/baselines/reference/useObjectValuesAndEntries1.types
@@ -42,7 +42,7 @@ var entries2 = Object.entries({a: true, b: 2}) // ['a' | 'b', number | boolean][
 >Object.entries : { <T>(o: { [s: string]: T; } | { [n: number]: T; }): [string, T][]; (o: any): [string, any][]; }
 >Object : ObjectConstructor
 >entries : { <T>(o: { [s: string]: T; } | { [n: number]: T; }): [string, T][]; (o: any): [string, any][]; }
->{a: true, b: 2} : { a: true; b: 2; }
+>{a: true, b: 2} : { a: boolean; b: number; }
 >a : boolean
 >true : true
 >b : number


### PR DESCRIPTION
With this PR we create fewer intermediate object literal and array literal types. We now preserve literal types for object literal properties and array literal elements only when the corresponding contextual type contains literals of the same primitive type. Previously, we would preserve literal types for properties in object literals and elements in array literals when the corresponding contextual type contained *any* literal type. This for example meant that we would preserve string literal types for object literal properties and array literal elements if the contextual type contained one (or both) of the literals `true` or `false`--in other words, whenever the contextual type contained `boolean`. Generally this was harmless and only affected types shown in error messages, but on rare occasions (e.g. #20279) it could cause huge numbers of intermediate object literal or array literal types to be created which would subsequently slow down subtype reduction and type relationship checking.

The only changes in to the real world code tests are in error messages.

Fixes #20279.