### PR TITLE
Correct super() Code Fix Formatting on Single-Line Constructor

### DIFF
--- a/tests/cases/fourslash/codeFixSuperCallSingleLine.ts
+++ b/tests/cases/fourslash/codeFixSuperCallSingleLine.ts
@@ -3,8 +3,7 @@
 ////class Base{
 ////}
 ////class C extends Base{
-////    constructor() [|{
-////    }|]
+////    constructor() [|{}|]
 ////}
 // TODO: GH#18445
 verify.rangeAfterCodeFix(`{\r

--- a/tests/cases/fourslash/codeFixSuperCallSingleLineWithBody.ts
+++ b/tests/cases/fourslash/codeFixSuperCallSingleLineWithBody.ts
@@ -3,10 +3,10 @@
 ////class Base{
 ////}
 ////class C extends Base{
-////    constructor() [|{
-////    }|]
+////    constructor() [|{ const t = 0; }|]
 ////}
 // TODO: GH#18445
 verify.rangeAfterCodeFix(`{\r
         super();\r
+        const t = 0;\r
     }`, /*includeWhitespace*/ true);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #20073 

Updates Code Fix to correctly set `multiline` on constructor body when adding `super()` call.
