### PR TITLE
Prettified timestamps and error reports in --pretty

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -242,22 +242,22 @@ namespace ts {
     }
 
     /** @internal */
-    export const foregroundColorEscapeSequences = {
-        grey: "\u001b[90m",
-        red: "\u001b[91m",
-        yellow: "\u001b[93m",
-        blue: "\u001b[94m",
-        cyan: "\u001b[96m"
-    };
+    export enum ForegroundColorEscapeSequences {
+        Grey = "\u001b[90m",
+        Red = "\u001b[91m",
+        Yellow = "\u001b[93m",
+        Blue = "\u001b[94m",
+        Cyan = "\u001b[96m"
+    }
     const gutterStyleSequence = "\u001b[30;47m";
     const gutterSeparator = " ";
     const resetEscapeSequence = "\u001b[0m";
     const ellipsis = "...";
     function getCategoryFormat(category: DiagnosticCategory): string {
         switch (category) {
-            case DiagnosticCategory.Warning: return foregroundColorEscapeSequences.yellow;
-            case DiagnosticCategory.Error: return foregroundColorEscapeSequences.red;
-            case DiagnosticCategory.Message: return foregroundColorEscapeSequences.blue;
+            case DiagnosticCategory.Warning: return ForegroundColorEscapeSequences.Yellow;
+            case DiagnosticCategory.Error: return ForegroundColorEscapeSequences.Red;
+            case DiagnosticCategory.Message: return ForegroundColorEscapeSequences.Blue;
         }
     }
 
@@ -311,7 +311,7 @@ namespace ts {
 
                     // Output the gutter and the error span for the line using tildes.
                     context += formatColorAndReset(padLeft("", gutterWidth), gutterStyleSequence) + gutterSeparator;
-                    context += foregroundColorEscapeSequences.red;
+                    context += ForegroundColorEscapeSequences.Red;
                     if (i === firstLine) {
                         // If we're on the last line, then limit it to the last character of the last line.
                         // Otherwise, we'll just squiggle the rest of the line, giving 'slice' no end position.
@@ -330,18 +330,18 @@ namespace ts {
                     context += resetEscapeSequence;
                 }
 
-                output += formatColorAndReset(relativeFileName, foregroundColorEscapeSequences.cyan);
+                output += formatColorAndReset(relativeFileName, ForegroundColorEscapeSequences.Cyan);
                 output += "(";
-                output += formatColorAndReset(`${ firstLine + 1 }`, foregroundColorEscapeSequences.yellow);
+                output += formatColorAndReset(`${ firstLine + 1 }`, ForegroundColorEscapeSequences.Yellow);
                 output += ",";
-                output += formatColorAndReset(`${ firstLineChar + 1 }`, foregroundColorEscapeSequences.yellow);
+                output += formatColorAndReset(`${ firstLineChar + 1 }`, ForegroundColorEscapeSequences.Yellow);
                 output += "): ";
             }
 
             const categoryColor = getCategoryFormat(diagnostic.category);
             const category = DiagnosticCategory[diagnostic.category].toLowerCase();
             output += formatColorAndReset(category, categoryColor);
-            output += formatColorAndReset(` TS${ diagnostic.code }: `, foregroundColorEscapeSequences.grey);
+            output += formatColorAndReset(` TS${ diagnostic.code }: `, ForegroundColorEscapeSequences.Grey);
             output += flattenDiagnosticMessageText(diagnostic.messageText, host.getNewLine());
 
             if (diagnostic.file) {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -246,6 +246,7 @@ namespace ts {
         grey: "\u001b[90m",
         red: "\u001b[91m",
         yellow: "\u001b[93m",
+        blue: "\u001b[94m",
         cyan: "\u001b[96m"
     };
     const gutterStyleSequence = "\u001b[30;47m";
@@ -256,7 +257,7 @@ namespace ts {
         switch (category) {
             case DiagnosticCategory.Warning: return foregroundColorEscapeSequences.yellow;
             case DiagnosticCategory.Error: return foregroundColorEscapeSequences.red;
-            case DiagnosticCategory.Message: return foregroundColorEscapeSequences.yellow;
+            case DiagnosticCategory.Message: return foregroundColorEscapeSequences.blue;
         }
     }
 

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -48,9 +48,10 @@ namespace ts {
         };
     }
 
+    /** @internal */
     export function createWatchDiagnosticReporterWithColor(system = sys): DiagnosticReporter {
         return diagnostic => {
-            let output = `[${ formatColorAndReset(new Date().toLocaleTimeString(), foregroundColorEscapeSequences.grey) }] `;
+            let output = `[${ formatColorAndReset(new Date().toLocaleTimeString(), ForegroundColorEscapeSequences.Grey) }] `;
             output += `${flattenDiagnosticMessageText(diagnostic.messageText, system.newLine)}${system.newLine + system.newLine + system.newLine}`;
             system.write(output);
         };

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -48,6 +48,14 @@ namespace ts {
         };
     }
 
+    export function createWatchDiagnosticReporterWithColor(system = sys): DiagnosticReporter {
+        return diagnostic => {
+            let output = `[${ formatColorAndReset(new Date().toLocaleTimeString(), foregroundColorEscapeSequences.grey) }] `;
+            output += `${flattenDiagnosticMessageText(diagnostic.messageText, system.newLine)}${system.newLine + system.newLine + system.newLine}`;
+            system.write(output);
+        };
+    }
+
     export function reportDiagnostics(diagnostics: Diagnostic[], reportDiagnostic: DiagnosticReporter): void {
         for (const diagnostic of diagnostics) {
             reportDiagnostic(diagnostic);
@@ -131,7 +139,7 @@ namespace ts {
         reportWatchDiagnostic?: DiagnosticReporter
     ): WatchingSystemHost {
         reportDiagnostic = reportDiagnostic || createDiagnosticReporter(system, pretty ? reportDiagnosticWithColorAndContext : reportDiagnosticSimply);
-        reportWatchDiagnostic = reportWatchDiagnostic || createWatchDiagnosticReporter(system);
+        reportWatchDiagnostic = reportWatchDiagnostic || pretty ? createWatchDiagnosticReporterWithColor(system) : createWatchDiagnosticReporter(system);
         parseConfigFile = parseConfigFile || ts.parseConfigFile;
         return {
             system,

--- a/tests/baselines/reference/prettyContextNotDebugAssertion.errors.txt
+++ b/tests/baselines/reference/prettyContextNotDebugAssertion.errors.txt
@@ -1,8 +1,8 @@
-
-tests/cases/compiler/index.ts(2,1): [91merror[0m TS1005: '}' expected.
+[96mtests/cases/compiler/index.ts[0m([93m2[0m,[93m1[0m): [91merror[0m[90m TS1005: [0m'}' expected.
 
 [30;47m2[0m 
 [30;47m [0m [91m[0m
+
 
 
 ==== tests/cases/compiler/index.ts (1 errors) ====


### PR DESCRIPTION
Timestamps look like Gulp's, with grey times inside white brackets.
Files have cyan filenames, yellow line and column numbers, and grey TS{####} errors. I wonder if those are actually useful for folks using the --pretty CLI: are they used for anything outside Visual Studio... Can we just get rid of them?

Re-uses compiler/program's color logic in compiler/watch. The relevant variables are now exported and marked `@internal`. Is there a preferred way of re-using this code in both those files?

~~_Todo: fix test failures_~~

Here are the after and before photos in Windows cmd...
![image](https://user-images.githubusercontent.com/3335181/33522549-316ce0bc-d7a4-11e7-8222-713dfc7f60ed.png)
![image](https://user-images.githubusercontent.com/3335181/33522554-402362e8-d7a4-11e7-9cdc-6321bbc3ddc4.png)

...and cmder:
![image](https://user-images.githubusercontent.com/3335181/33522579-bf500760-d7a4-11e7-98c1-599605203164.png)
![image](https://user-images.githubusercontent.com/3335181/33522580-cbd12b4a-d7a4-11e7-90a1-01d66d1fc665.png)
