### PR TITLE
Add textChanges methods to insert nodes at the start of multiline bodies

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2472,7 +2472,7 @@ Actual: ${stringify(fullActual)}`);
         }
 
         private verifyNewContent(options: FourSlashInterface.NewContentOptions) {
-            if (options.newFileContent) {
+            if (options.newFileContent !== undefined) {
                 assert(!options.newRangeContent);
                 this.verifyCurrentFileContent(options.newFileContent);
             }

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -62,7 +62,6 @@ namespace ts.codefix {
         }
 
         const classDeclarationSourceFile = getSourceFileOfNode(classDeclaration);
-        const classOpenBrace = getOpenBraceOfClassLike(classDeclaration, classDeclarationSourceFile);
 
         return isInJavaScriptFile(classDeclarationSourceFile) ?
             getActionsForAddMissingMemberInJavaScriptFile(classDeclaration, makeStatic) :
@@ -154,7 +153,7 @@ namespace ts.codefix {
                 typeNode,
                 /*initializer*/ undefined);
             const propertyChangeTracker = textChanges.ChangeTracker.fromContext(context);
-            propertyChangeTracker.insertNodeAfter(classDeclarationSourceFile, classOpenBrace, property, { suffix: context.newLineCharacter });
+            propertyChangeTracker.insertNodeAtClassStart(classDeclarationSourceFile, classDeclaration, property, context.newLineCharacter);
 
             const diag = makeStatic ? Diagnostics.Declare_static_property_0 : Diagnostics.Declare_property_0;
             actions = append(actions, {
@@ -180,7 +179,7 @@ namespace ts.codefix {
                     typeNode);
 
                 const indexSignatureChangeTracker = textChanges.ChangeTracker.fromContext(context);
-                indexSignatureChangeTracker.insertNodeAfter(classDeclarationSourceFile, classOpenBrace, indexSignature, { suffix: context.newLineCharacter });
+                indexSignatureChangeTracker.insertNodeAtClassStart(classDeclarationSourceFile, classDeclaration, indexSignature, context.newLineCharacter);
 
                 actions.push({
                     description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Add_index_signature_for_property_0), [tokenName]),
@@ -197,7 +196,7 @@ namespace ts.codefix {
                 const methodDeclaration = createMethodFromCallExpression(callExpression, tokenName, includeTypeScriptSyntax, makeStatic);
 
                 const methodDeclarationChangeTracker = textChanges.ChangeTracker.fromContext(context);
-                methodDeclarationChangeTracker.insertNodeAfter(classDeclarationSourceFile, classOpenBrace, methodDeclaration, { suffix: context.newLineCharacter });
+                methodDeclarationChangeTracker.insertNodeAtClassStart(classDeclarationSourceFile, classDeclaration, methodDeclaration, context.newLineCharacter);
                 const diag = makeStatic ? Diagnostics.Declare_static_method_0 : Diagnostics.Declare_method_0;
                 return {
                     description: formatStringFromArgs(getLocaleSpecificMessage(diag), [tokenName]),

--- a/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
+++ b/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
@@ -12,7 +12,7 @@ namespace ts.codefix {
 
             const changeTracker = textChanges.ChangeTracker.fromContext(context);
             const superCall = createStatement(createCall(createSuper(), /*typeArguments*/ undefined, /*argumentsArray*/ emptyArray));
-            changeTracker.insertNodeAfter(sourceFile, getOpenBrace(<ConstructorDeclaration>token.parent, sourceFile), superCall, { suffix: context.newLineCharacter });
+            changeTracker.insertNodeAtConstructorStart(sourceFile, <ConstructorDeclaration>token.parent, superCall, context.newLineCharacter);
 
             return [{
                 description: getLocaleSpecificMessage(Diagnostics.Add_missing_super_call),

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -338,16 +338,18 @@ namespace ts.textChanges {
         }
 
         public insertNodeAtConstructorStart(sourceFile: SourceFile, ctr: ConstructorDeclaration, newStatement: Statement, newLineCharacter: string): void {
-            if (ctr.body.statements.length === 0) {
-                this.replaceNode(sourceFile, ctr.body, createBlock([newStatement], /*multiLine*/ true), { useNonAdjustedEndPosition: true });
+            const firstStatement = firstOrUndefined(ctr.body.statements);
+            if (!firstStatement || !ctr.body.multiLine) {
+                this.replaceNode(sourceFile, ctr.body, createBlock([newStatement, ...ctr.body.statements], /*multiLine*/ true), { useNonAdjustedEndPosition: true });
             }
             else {
-                this.insertNodeAfter(sourceFile, getOpenBrace(ctr, sourceFile), newStatement, { suffix: newLineCharacter });
+                this.insertNodeBefore(sourceFile, firstStatement, newStatement, { suffix: newLineCharacter });
             }
         }
 
         public insertNodeAtClassStart(sourceFile: SourceFile, cls: ClassLikeDeclaration, newElement: ClassElement, newLineCharacter: string): void {
-            if (cls.members.length === 0) {
+            const firstMember = firstOrUndefined(cls.members);
+            if (!firstMember) {
                 const members = [newElement];
                 const newCls = cls.kind === SyntaxKind.ClassDeclaration
                     ? updateClassDeclaration(cls, cls.decorators, cls.modifiers, cls.name, cls.typeParameters, cls.heritageClauses, members)
@@ -355,7 +357,7 @@ namespace ts.textChanges {
                 this.replaceNode(sourceFile, cls, newCls, { useNonAdjustedEndPosition: true });
             }
             else {
-                this.insertNodeAfter(sourceFile, getOpenBraceOfClassLike(cls, sourceFile), newElement, { suffix: newLineCharacter });
+                this.insertNodeBefore(sourceFile, firstMember, newElement, { suffix: newLineCharacter });
             }
         }
 

--- a/tests/cases/fourslash/codeFixSuperCall.ts
+++ b/tests/cases/fourslash/codeFixSuperCall.ts
@@ -3,10 +3,18 @@
 ////class Base{
 ////}
 ////class C extends Base{
-////    constructor() {[|
-////    |]}
+////    constructor() {}
 ////}
-// TODO: GH#18445
-verify.rangeAfterCodeFix(`
+
+verify.codeFix({
+    description: "Add missing 'super()' call",
+    // TODO: GH#18445
+    newFileContent:
+`class Base{
+}
+class C extends Base{
+    constructor() {\r
         super();\r
-    `, /*includeWhitespace*/ true);
+    }
+}`,
+});


### PR DESCRIPTION
Fixes #20073

Calling `insertNodeAfter` to insert a node after an open brace is hacky anyway and caused problems when there wasn't already a newline after the open brace. This adds new `ChangeTracker` methods to insert a node at the beginning of a constructor or class.