### PR TITLE
Reduce dependencies of typingsInstaller

### DIFF
--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,6 +1,5 @@
 /// <reference path="../compiler/types.ts"/>
 /// <reference path="../compiler/sys.ts"/>
-/// <reference path="../services/jsTyping.ts"/>
 
 declare namespace ts.server {
     export interface CompressedData {

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -222,6 +222,22 @@ namespace ts.server.typingsInstaller {
         });
     }
 
+    // Duplicate of the same function in utilities.ts, but we don't want dependencies to keep typingsInstaller.js small
+    function forEachAncestorDirectory<T>(directory: string, callback: (directory: string) => T | undefined): T | undefined {
+        while (true) {
+            const result = callback(directory);
+            if (result !== undefined) {
+                return result;
+            }
+
+            const parentPath = getDirectoryPath(directory);
+            if (parentPath === directory) {
+                return undefined;
+            }
+            directory = parentPath;
+        }
+    }
+
     const logFilePath = findArgument(server.Arguments.LogFile);
     const globalTypingsCacheLocation = findArgument(server.Arguments.GlobalCacheLocation);
     const typingSafeListLocation = findArgument(server.Arguments.TypingSafeListLocation);

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -1,8 +1,4 @@
-/// <reference path="../../compiler/core.ts" />
-/// <reference path="../../compiler/moduleNameResolver.ts" />
 /// <reference path="../../services/jsTyping.ts"/>
-/// <reference path="../types.ts"/>
-/// <reference path="../shared.ts"/>
 
 namespace ts.server.typingsInstaller {
     interface NpmConfig {
@@ -19,17 +15,16 @@ namespace ts.server.typingsInstaller {
         writeLine: noop
     };
 
-    function typingToFileName(cachePath: string, packageName: string, installTypingHost: InstallTypingHost, log: Log): string {
-        try {
-            const result = resolveModuleName(packageName, combinePaths(cachePath, "index.d.ts"), { moduleResolution: ModuleResolutionKind.NodeJs }, installTypingHost);
-            return result.resolvedModule && result.resolvedModule.resolvedFileName;
+    function typingToFileName(cachePath: string, packageName: string, installTypingHost: InstallTypingHost, log: Log): string | undefined {
+        // @types packages should always use 'index.d.ts', so no need to go through full module resolution.
+        const file = [cachePath, "node_modules", "@types", packageName, "index.d.ts"].reduce(combinePaths);
+        if (installTypingHost.fileExists(file)) {
+            return file;
         }
-        catch (e) {
-            if (log.isEnabled()) {
-                log.writeLine(`Failed to resolve ${packageName} in folder '${cachePath}': ${(<Error>e).message}`);
-            }
-            return undefined;
+        if (log.isEnabled()) {
+            log.writeLine(`Failed to resolve ${packageName} in folder '${cachePath}': ${file} does not exist`);
         }
+        return undefined;
     }
 
 


### PR DESCRIPTION
Removes references to other files to reduce the size of `typingsInstaller.js` down from 1.1MB to 244KB.

It is still relying on `core.ts` via `sys.ts` (via `server/types.ts`). I think we could break the following out of `core.ts` into their own files:
* Data structure helpers (`createMap`, `mapDefined`, etc.)
* Path helpers (`combinePaths`, `FileSystemEntries`, `matchFiles`, etc.)

If we did that we wouldn't need a dependency on `core.ts` any more. Thoughts?