### PR TITLE
fix #20449, insert space between decorators

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -198,7 +198,7 @@ namespace ts.formatting {
                 RuleAction.Delete),
 
             // decorators
-            rule("SpaceBeforeAt", anyToken, SyntaxKind.AtToken, [isNonJsxSameLineTokenContext], RuleAction.Space),
+            rule("SpaceBeforeAt", [SyntaxKind.CloseParenToken, SyntaxKind.Identifier], SyntaxKind.AtToken, [isNonJsxSameLineTokenContext], RuleAction.Space),
             rule("NoSpaceAfterAt", SyntaxKind.AtToken, anyToken, [isNonJsxSameLineTokenContext], RuleAction.Delete),
             // Insert space after @ in decorator
             rule("SpaceAfterDecorator",

--- a/tests/cases/fourslash/formattingDecorators.ts
+++ b/tests/cases/fourslash/formattingDecorators.ts
@@ -41,6 +41,8 @@
 /////*29*/    property1;
 ////
 /////*30*/        @    decorator33    @            decorator34 @decorator35            property2;
+/////*31*/function test(@decorator36@decorator37 param) {};
+/////*32*/function test2(@decorator38()@decorator39()param) {};
 ////}
 
 format.document();
@@ -104,3 +106,7 @@ goTo.marker("29");
 verify.currentLineContentIs("    property1;");
 goTo.marker("30");
 verify.currentLineContentIs("    @decorator33 @decorator34 @decorator35 property2;");
+goTo.marker("31");
+verify.currentLineContentIs("function test(@decorator36 @decorator37 param) { };");
+goTo.marker("32");
+verify.currentLineContentIs("function test2(@decorator38() @decorator39() param) { };");


### PR DESCRIPTION
Fixes #20449 

In practice, spaces are only inserted between decorators, so we can change beforeToken from`anyToken` to `identifier` or `closeParenToken`.

I noticed the original issue has another pull request  #20488 after I created this PR. :(
But the solution is quite different. cc @Kingwl 