### PR TITLE
imporve conditional operator if  missing colon

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3472,7 +3472,9 @@ namespace ts {
             node.whenTrue = doOutsideOfContext(disallowInAndDecoratorContext, parseAssignmentExpressionOrHigher);
             node.colonToken = parseExpectedToken(SyntaxKind.ColonToken, /*reportAtCurrentPosition*/ false,
                 Diagnostics._0_expected, tokenToString(SyntaxKind.ColonToken));
-            node.whenFalse = parseAssignmentExpressionOrHigher();
+            node.whenFalse = nodeIsPresent(node.colonToken)
+                ? parseAssignmentExpressionOrHigher()
+                : createMissingNode(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ false, Diagnostics._0_expected, tokenToString(SyntaxKind.ColonToken));
             return finishNode(node);
         }
 

--- a/tests/baselines/reference/jsxAndTypeAssertion.errors.txt
+++ b/tests/baselines/reference/jsxAndTypeAssertion.errors.txt
@@ -10,13 +10,11 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(14,45): error TS1005: '}' ex
 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(18,2): error TS17008: JSX element 'foo' has no corresponding closing tag.
 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(18,8): error TS17008: JSX element 'foo' has no corresponding closing tag.
 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(18,13): error TS17008: JSX element 'foo' has no corresponding closing tag.
-tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(18,83): error TS1109: Expression expected.
 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: ':' expected.
 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' expected.
-tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '}' expected.
 
 
-==== tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx (16 errors) ====
+==== tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx (14 errors) ====
     declare var createElement: any;
     
     class foo {}
@@ -59,8 +57,6 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '}' exp
 !!! error TS17008: JSX element 'foo' has no corresponding closing tag.
                 ~~~
 !!! error TS17008: JSX element 'foo' has no corresponding closing tag.
-                                                                                      
-!!! error TS1109: Expression expected.
     
         
     
@@ -68,5 +64,3 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '}' exp
 !!! error TS1005: ':' expected.
     
 !!! error TS1005: '</' expected.
-    
-!!! error TS1005: '}' expected.

--- a/tests/cases/fourslash/completionWithConditionalOperatorMissingColon.ts
+++ b/tests/cases/fourslash/completionWithConditionalOperatorMissingColon.ts
@@ -1,0 +1,6 @@
+/// <reference path="fourslash.ts" /> 
+////1 ? fun/*1*/ 
+////function func () {} 
+ 
+goTo.marker("1"); 
+verify.completionListContains("func");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #6127 

ps: 
1. `createMissingNode` with `Identifier` type if `colonToken` is missing because `parseAssignmentExpressionOrHigher` with empty return it.  have there got any better solution？ 
2. `jsxAndTypeAssertion` is changed but i have no idea about that  
