### PR TITLE
use noop FileWatcher when watchDirectory is not available (#16776)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,14 +42,8 @@
             "dev": true,
             "requires": {
                 "@types/insert-module-globals": "7.0.0",
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
-        },
-        "@types/chai": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.7.tgz",
-            "integrity": "sha512-OsFOcyJH0SViMMHzDKZdapG8sfoH7qcpYgKhgyw9xn5MgkCvAplkf0FUaRFB+HTrVH6gQ/GU7sbIUDM1usVEUA==",
-            "dev": true
         },
         "@types/colors": {
             "version": "1.1.3",
@@ -72,12 +66,6 @@
                 "@types/glob": "5.0.33"
             }
         },
-        "@types/events": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-            "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
-            "dev": true
-        },
         "@types/glob": {
             "version": "5.0.33",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
@@ -85,7 +73,7 @@
             "dev": true,
             "requires": {
                 "@types/minimatch": "3.0.1",
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/gulp": {
@@ -94,7 +82,7 @@
             "integrity": "sha512-h9clNJu8X6+zW74ZLa5zhh5HP0LxnvlelVXdXby6pM/DDEj/gKqmmFXKwjzvupZKlMpof02jr6c3JokPbHXQgg==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54",
+                "@types/node": "8.0.56",
                 "@types/orchestrator": "0.3.2",
                 "@types/vinyl": "2.0.1"
             }
@@ -105,7 +93,7 @@
             "integrity": "sha512-CUCFADlITzzBfBa2bdGzhKtvBr4eFh+evb+4igVbvPoO5RyPfHifmyQlZl6lM7q19+OKncRlFXDU7B4X9Ayo2g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/gulp-help": {
@@ -115,7 +103,7 @@
             "dev": true,
             "requires": {
                 "@types/gulp": "3.8.35",
-                "@types/node": "8.0.54",
+                "@types/node": "8.0.56",
                 "@types/orchestrator": "0.3.2"
             }
         },
@@ -125,7 +113,7 @@
             "integrity": "sha512-e7J/Zv5Wd7CC0WpuA2syWVitgwrkG0u221e41w7r07XUR6hMH6kHPkq9tUrusHkbeW8QbuLbis5fODOwQCyggQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/gulp-sourcemaps": {
@@ -134,7 +122,7 @@
             "integrity": "sha512-+7BAmptW2bxyJnJcCEuie7vLoop3FwWgCdBMzyv7MYXED/HeNMeQuX7uPCkp4vfU1TTu4CYFH0IckNPvo0VePA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/insert-module-globals": {
@@ -143,7 +131,7 @@
             "integrity": "sha512-zudCJPwluh1VUDB6Gl/OQdRp+fYy3+47huJB/JMQubMS2p+sH18MCVK4WUz3FqaWLB12yh5ELxVR/+tqwlm/qA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/merge2": {
@@ -152,7 +140,7 @@
             "integrity": "sha512-GjaXY4OultxbaOOk7lCLO7xvEcFpdjExC605YmfI6X29vhHKpJfMWKCDZd3x+BITrZaXKg97DgV/SdGVSwdzxA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/minimatch": {
@@ -173,7 +161,7 @@
             "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/mocha": {
@@ -183,13 +171,10 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.0.54",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.54.tgz",
-            "integrity": "sha512-qetMdTv3Ytz9u9ESLdcYs45LPI0mczYZIbC184n7kY0jczOqPNQsabBfVCh+na3B2shAfvC459JqHV771A8Rxg==",
-            "dev": true,
-            "requires": {
-                "@types/events": "1.1.0"
-            }
+            "version": "8.0.56",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.56.tgz",
+            "integrity": "sha512-JAlQv3hUWbrnruuTiLDf1scd4F/TBT0LgGEe+BBeF3p/Rc3yL6RV57WJN2nK5i+BshEz1sDllwH0Fzbuo7G4QA==",
+            "dev": true
         },
         "@types/orchestrator": {
             "version": "0.3.2",
@@ -197,7 +182,7 @@
             "integrity": "sha512-cKB4yTX0wGaRCSkdHDX2fkGQbMAA8UOshC2U7DQky1CE5o+5q2iQQ8VkbPbE/88uaTtsusvBPMcCX7dgmjxBhQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54",
+                "@types/node": "8.0.56",
                 "@types/q": "1.0.6"
             }
         },
@@ -214,7 +199,7 @@
             "dev": true,
             "requires": {
                 "@types/gulp": "3.8.35",
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/through2": {
@@ -223,7 +208,7 @@
             "integrity": "sha1-H/LoihAN+1sUDnu5h5HxGUQA0TE=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/vinyl": {
@@ -232,7 +217,7 @@
             "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "@types/xml2js": {
@@ -241,7 +226,7 @@
             "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.56"
             }
         },
         "JSONStream": {
@@ -413,12 +398,6 @@
             "requires": {
                 "util": "0.10.3"
             }
-        },
-        "assertion-error": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-            "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-            "dev": true
         },
         "astw": {
             "version": "2.2.0",
@@ -723,20 +702,6 @@
                 "lazy-cache": "1.0.4"
             }
         },
-        "chai": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-            "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
-            "dev": true,
-            "requires": {
-                "assertion-error": "1.0.2",
-                "check-error": "1.0.2",
-                "deep-eql": "3.0.1",
-                "get-func-name": "2.0.0",
-                "pathval": "1.1.0",
-                "type-detect": "4.0.5"
-            }
-        },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -749,12 +714,6 @@
                 "strip-ansi": "3.0.1",
                 "supports-color": "2.0.0"
             }
-        },
-        "check-error": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-            "dev": true
         },
         "cipher-base": {
             "version": "1.0.4",
@@ -1071,15 +1030,6 @@
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
-        },
-        "deep-eql": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-            "dev": true,
-            "requires": {
-                "type-detect": "4.0.5"
-            }
         },
         "deep-is": {
             "version": "0.1.3",
@@ -1609,12 +1559,6 @@
             "requires": {
                 "globule": "0.1.0"
             }
-        },
-        "get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-            "dev": true
         },
         "get-stdin": {
             "version": "4.0.1",
@@ -4057,12 +4001,6 @@
                 }
             }
         },
-        "pathval": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-            "dev": true
-        },
         "pbkdf2": {
             "version": "3.0.14",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
@@ -5037,12 +4975,6 @@
                 "prelude-ls": "1.1.2"
             }
         },
-        "type-detect": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-            "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
-            "dev": true
-        },
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -5050,9 +4982,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.7.0-dev.20171203",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171203.tgz",
-            "integrity": "sha512-FyhV7OvieIXzjktOb9YmixEIR8olL8IrnonCmJQWGnj8Wt6eoQQKQlkXWPy8mpwEaSIXw/nQO0NpGQ+nWokhRw==",
+            "version": "2.7.0-dev.20171206",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171206.tgz",
+            "integrity": "sha512-sq6ZlGCblvrxxbdOik5E/aDnw0+2nclNy3u8zeE+rZRqxFObzmpwrgLQP8Xa4xo23GMuBNuvjSEolucxJOuGyg==",
             "dev": true
         },
         "uglify-js": {

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -2,6 +2,12 @@
 
 /* @internal */
 namespace ts {
+    class NoopFileWatcher implements FileWatcher {
+        close() { /* empty */ }
+    }
+
+    const noopFileWatcher = new NoopFileWatcher();
+
     export enum ConfigFileProgramReloadLevel {
         None,
         /** Update the file name list from the disk */
@@ -112,6 +118,10 @@ namespace ts {
     }
 
     export function addDirectoryWatcher(host: System, directory: string, cb: DirectoryWatcherCallback, flags: WatchDirectoryFlags): FileWatcher {
+        if (!host.watchDirectory) {
+            return noopFileWatcher;
+        }
+
         const recursive = (flags & WatchDirectoryFlags.Recursive) !== 0;
         return host.watchDirectory(directory, cb, recursive);
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

**WIP**

Fixes #16776

----

So, my initial though was to use `NoopFileWatcher` as a part of interface, but TypeScript does not support default implementations, so I've created a separate class. I've also placed it at the only usage point (`watchUtilities`). Otherwise I will be forced to change public API for `ts`, which I'm not sure about.

Q: which tests should I provide? I've searched for usages and there are no low-level tests. Should I create them or there are some high-level one which I should extend?