### PR TITLE
Omnibus fixes for telemetry-sourced crashes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3951,7 +3951,12 @@ namespace ts {
                     writePunctuation(writer, SyntaxKind.CloseBracketToken);
                     writePunctuation(writer, SyntaxKind.ColonToken);
                     writeSpace(writer);
-                    buildTypeDisplay(info.type, writer, enclosingDeclaration, globalFlags, symbolStack);
+                    if (info.type) {
+                        buildTypeDisplay(info.type, writer, enclosingDeclaration, globalFlags, symbolStack);
+                    }
+                    else {
+                        writeKeyword(writer, SyntaxKind.AnyKeyword);
+                    }
                     writePunctuation(writer, SyntaxKind.SemicolonToken);
                     writer.writeLine();
                 }

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -148,6 +148,11 @@ namespace ts.codefix {
             containingFunction.parameters.map(p => isIdentifier(p.name) ? inferTypeForVariableFromUsage(p.name, sourceFile, program, cancellationToken) : undefined);
         if (!types) return undefined;
 
+        // We didn't actually find a set of type inference positions matching each parameter position
+        if (containingFunction.parameters.length !== types.length) {
+            return undefined;
+        }
+        
         const textChanges = arrayFrom(mapDefinedIterator(zipToIterator(containingFunction.parameters, types), ([parameter, type]) =>
             type && !parameter.type && !parameter.initializer ? makeChange(containingFunction, parameter.end, type, program) : undefined));
         return textChanges.length ? { declaration: parameterDeclaration, textChanges } : undefined;

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -196,8 +196,9 @@ namespace ts.codefix {
             sourceFile,
             token.getStart(sourceFile));
 
-        Debug.assert(!!references, "Found no references!");
-        Debug.assert(references.length === 1, "Found more references than expected");
+        if (!references || references.length !== 1) {
+            return [];
+        }
 
         return references[0].references.map(r => <Identifier>getTokenAtPosition(program.getSourceFile(r.fileName), r.textSpan.start, /*includeJsDocComment*/ false));
     }
@@ -286,6 +287,10 @@ namespace ts.codefix {
         }
 
         export function inferTypeForParametersFromReferences(references: Identifier[], declaration: FunctionLikeDeclaration, checker: TypeChecker, cancellationToken: CancellationToken): (Type | undefined)[] | undefined {
+            if (references.length === 0) {
+                return undefined;
+            }
+
             if (declaration.parameters) {
                 const usageContext: UsageContext = {};
                 for (const reference of references) {

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -70,11 +70,6 @@ namespace ts.codefix {
             return undefined;
         }
 
-        const containingFunction = getContainingFunction(token);
-        if (containingFunction === undefined) {
-            // Possible in certain syntax error cases
-            return undefined;
-        }
         switch (errorCode) {
             // Variable and Property declarations
             case Diagnostics.Member_0_implicitly_has_an_1_type.code:
@@ -85,6 +80,13 @@ namespace ts.codefix {
                 const symbol = program.getTypeChecker().getSymbolAtLocation(token);
                 return symbol && symbol.valueDeclaration && getCodeActionForVariableDeclaration(<VariableDeclaration>symbol.valueDeclaration, sourceFile, program, cancellationToken);
             }
+        }
+
+        const containingFunction = getContainingFunction(token);
+        if (containingFunction === undefined) {
+            return undefined;
+        }
+        switch (errorCode) {
 
             // Parameter declarations
             case Diagnostics.Parameter_0_implicitly_has_an_1_type.code:
@@ -156,7 +158,7 @@ namespace ts.codefix {
         if (containingFunction.parameters.length !== types.length) {
             return undefined;
         }
-        
+
         const textChanges = arrayFrom(mapDefinedIterator(zipToIterator(containingFunction.parameters, types), ([parameter, type]) =>
             type && !parameter.type && !parameter.initializer ? makeChange(containingFunction, parameter.end, type, program) : undefined));
         return textChanges.length ? { declaration: parameterDeclaration, textChanges } : undefined;

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -71,6 +71,10 @@ namespace ts.codefix {
         }
 
         const containingFunction = getContainingFunction(token);
+        if (containingFunction === undefined) {
+            // Possible in certain syntax error cases
+            return undefined;
+        }
         switch (errorCode) {
             // Variable and Property declarations
             case Diagnostics.Member_0_implicitly_has_an_1_type.code:

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -496,7 +496,7 @@ namespace ts.SymbolDisplay {
             addNewLineIfDisplayPartsExist();
             if (symbolKind) {
                 pushTypePart(symbolKind);
-                if (!some(symbol.declarations, d => isArrowFunction(d) || (isFunctionExpression(d) || isClassExpression(d)) && !d.name)) {
+                if (symbol && !some(symbol.declarations, d => isArrowFunction(d) || (isFunctionExpression(d) || isClassExpression(d)) && !d.name)) {
                     displayParts.push(spacePart());
                     addFullSymbolName(symbol);
                 }

--- a/tests/cases/fourslash/incompleteFunctionCallCodefix.ts
+++ b/tests/cases/fourslash/incompleteFunctionCallCodefix.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitAny: true
+//// function f(/*1*/x) {
+//// }
+//// f(
+
+verify.not.codeFixAvailable([]);
+

--- a/tests/cases/fourslash/incompleteFunctionCallCodefix2.ts
+++ b/tests/cases/fourslash/incompleteFunctionCallCodefix2.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitAny: true
+//// function f(new C(100, 3, undefined)
+
+verify.not.codeFixAvailable([]);
+

--- a/tests/cases/fourslash/incompleteFunctionCallCodefix3.ts
+++ b/tests/cases/fourslash/incompleteFunctionCallCodefix3.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitAny: true
+//// function ...q) {}} f(10);
+
+verify.not.codeFixAvailable([]);
+

--- a/tests/cases/fourslash/typeToStringCrashInCodeFix.ts
+++ b/tests/cases/fourslash/typeToStringCrashInCodeFix.ts
@@ -1,0 +1,6 @@
+/// <reference path="fourslash.ts" />
+
+// @noImplicitAny: true
+//// function f(y, z = { p: y[
+
+verify.getAndApplyCodeFix();


### PR DESCRIPTION
Fixes #20523 - occurs when the number of references found didn't match the function arity
Fixes #20520 - "impossible" case as described by asserts actually does occur, but can be handled safely
Fixes #20527, #20474, #20472 - containing function may be undefined in the presence of syntax errors
Fixes #20542 - symbol writer may sometimes encounter index signature with no types
Fixes #20475 - symbol writer may sometimes encounter types with no symbol

Recommend reviewing commit-by-commit. Some of these crashes are from telemetry and we've been unable to reconstruct a repro for them.