### PR TITLE
Add helper functions to simplify getCompletionEntryDisplayNameForSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8045,7 +8045,7 @@ namespace ts {
         }
 
         function getLiteralTypeFromPropertyName(prop: Symbol) {
-            return getDeclarationModifierFlagsFromSymbol(prop) & ModifierFlags.NonPublicAccessibilityModifier || startsWith(prop.escapedName as string, "__@") ?
+            return getDeclarationModifierFlagsFromSymbol(prop) & ModifierFlags.NonPublicAccessibilityModifier || isKnownSymbol(prop) ?
                 neverType :
                 getLiteralType(symbolName(prop));
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2118,6 +2118,10 @@ namespace ts {
         return "__@" + symbolName as __String;
     }
 
+    export function isKnownSymbol(symbol: Symbol): boolean {
+        return startsWith(symbol.escapedName as string, "__@");
+    }
+
     /**
      * Includes the word "Symbol" with unicode escapes
      */

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1949,36 +1949,17 @@ namespace ts.Completions {
 
     /**
      * Get the name to be display in completion from a given symbol.
-     *
-     * @return undefined if the name is of external module
      */
     function getCompletionEntryDisplayNameForSymbol(symbol: Symbol, target: ScriptTarget, performCharacterChecks: boolean, allowStringLiteral: boolean, origin: SymbolOriginInfo | undefined): string | undefined {
         const name = getSymbolName(symbol, origin, target);
-        if (!name) return undefined;
-
-        // First check of the displayName is not external module; if it is an external module, it is not valid entry
-        if (symbol.flags & SymbolFlags.Namespace) {
-            const firstCharCode = name.charCodeAt(0);
-            if (isSingleOrDoubleQuote(firstCharCode)) {
-                // If the symbol is external module, don't show it in the completion list
-                // (i.e declare module "http" { const x; } | // <= request completion here, "http" should not be there)
-                return undefined;
-            }
-        }
-
-        // If the symbol is for a member of an object type and is the internal name of an ES
-        // symbol, it is not a valid entry. Internal names for ES symbols start with "__@"
-        if (symbol.flags & SymbolFlags.ClassMember) {
-            const escapedName = symbol.escapedName as string;
-            if (escapedName.length >= 3 &&
-                escapedName.charCodeAt(0) === CharacterCodes._ &&
-                escapedName.charCodeAt(1) === CharacterCodes._ &&
-                escapedName.charCodeAt(2) === CharacterCodes.at) {
-                return undefined;
-            }
-        }
-
-        return getCompletionEntryDisplayName(name, target, performCharacterChecks, allowStringLiteral);
+        return name === undefined
+            // If the symbol is external module, don't show it in the completion list
+            // (i.e declare module "http" { const x; } | // <= request completion here, "http" should not be there)
+            || symbol.flags & SymbolFlags.Module && startsWithQuote(name)
+            // If the symbol is the internal name of an ES symbol, it is not a valid entry. Internal names for ES symbols start with "__@"
+            || isKnownSymbol(symbol)
+            ? undefined
+            : getCompletionEntryDisplayName(name, target, performCharacterChecks, allowStringLiteral);
     }
 
     /**

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1310,10 +1310,14 @@ namespace ts {
      */
     export function stripQuotes(name: string) {
         const length = name.length;
-        if (length >= 2 && name.charCodeAt(0) === name.charCodeAt(length - 1) && isSingleOrDoubleQuote(name.charCodeAt(0))) {
+        if (length >= 2 && name.charCodeAt(0) === name.charCodeAt(length - 1) && startsWithQuote(name)) {
             return name.substring(1, length - 1);
         }
         return name;
+    }
+
+    export function startsWithQuote(name: string): boolean {
+        return isSingleOrDoubleQuote(name.charCodeAt(0));
     }
 
     export function scriptKindIs(fileName: string, host: LanguageServiceHost, ...scriptKinds: ScriptKind[]): boolean {


### PR DESCRIPTION
Reusing code from the compiler.