### PR TITLE
Allowed trailing commas in type parameter/argument lists

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25545,10 +25545,6 @@ namespace ts {
         }
 
         function checkGrammarTypeParameterList(typeParameters: NodeArray<TypeParameterDeclaration>, file: SourceFile): boolean {
-            if (checkGrammarForDisallowedTrailingComma(typeParameters)) {
-                return true;
-            }
-
             if (typeParameters && typeParameters.length === 0) {
                 const start = typeParameters.pos - "<".length;
                 const end = skipTrivia(file.text, typeParameters.end) + ">".length;

--- a/tests/baselines/reference/typeParameterListWithTrailingComma1.errors.txt
+++ b/tests/baselines/reference/typeParameterListWithTrailingComma1.errors.txt
@@ -1,8 +1,0 @@
-tests/cases/compiler/typeParameterListWithTrailingComma1.ts(1,10): error TS1009: Trailing comma not allowed.
-
-
-==== tests/cases/compiler/typeParameterListWithTrailingComma1.ts (1 errors) ====
-    class C<T,> {
-             ~
-!!! error TS1009: Trailing comma not allowed.
-    }


### PR DESCRIPTION
This change is only one source file and one error file... there must be something I'm missing!?

Fixes #16152