### PR TITLE
Have Set and Map constructors take ReadonlyArrays

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -10,7 +10,7 @@ interface Map<K, V> {
 
 interface MapConstructor {
     new (): Map<any, any>;
-    new <K, V>(entries?: [K, V][]): Map<K, V>;
+    new <K, V>(entries?: ReadonlyArray<[K, V]>): Map<K, V>;
     readonly prototype: Map<any, any>;
 }
 declare var Map: MapConstructor;
@@ -31,7 +31,7 @@ interface WeakMap<K extends object, V> {
 
 interface WeakMapConstructor {
     new (): WeakMap<object, any>;
-    new <K extends object, V>(entries?: [K, V][]): WeakMap<K, V>;
+    new <K extends object, V>(entries?: ReadonlyArray<[K, V]>): WeakMap<K, V>;
     readonly prototype: WeakMap<object, any>;
 }
 declare var WeakMap: WeakMapConstructor;
@@ -47,7 +47,7 @@ interface Set<T> {
 
 interface SetConstructor {
     new (): Set<any>;
-    new <T>(values?: T[]): Set<T>;
+    new <T>(values?: ReadonlyArray<T>): Set<T>;
     readonly prototype: Set<any>;
 }
 declare var Set: SetConstructor;
@@ -66,7 +66,7 @@ interface WeakSet<T> {
 
 interface WeakSetConstructor {
     new (): WeakSet<object>;
-    new <T extends object>(values?: T[]): WeakSet<T>;
+    new <T extends object>(values?: ReadonlyArray<T>): WeakSet<T>;
     readonly prototype: WeakSet<object>;
 }
 declare var WeakSet: WeakSetConstructor;


### PR DESCRIPTION
These don't alter their inputs; they just copy them into a new collection.