### PR TITLE
Handle `!` following a keyword in isClassMemberStart

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5462,6 +5462,7 @@ namespace ts {
                 switch (token()) {
                     case SyntaxKind.OpenParenToken:     // Method declaration
                     case SyntaxKind.LessThanToken:      // Generic Method declaration
+                    case SyntaxKind.ExclamationToken:   // Non-null assertion on property name
                     case SyntaxKind.ColonToken:         // Type Annotation for declaration
                     case SyntaxKind.EqualsToken:        // Initializer for declaration
                     case SyntaxKind.QuestionToken:      // Not valid, but permitted so that it gets caught later on.

--- a/tests/baselines/reference/parserIsClassMemberStart.js
+++ b/tests/baselines/reference/parserIsClassMemberStart.js
@@ -1,6 +1,6 @@
 //// [parserIsClassMemberStart.ts]
 class C {
-    type: number;
+    type!: number;
 }
 
 

--- a/tests/baselines/reference/parserIsClassMemberStart.js
+++ b/tests/baselines/reference/parserIsClassMemberStart.js
@@ -1,0 +1,12 @@
+//// [parserIsClassMemberStart.ts]
+class C {
+    type: number;
+}
+
+
+//// [parserIsClassMemberStart.js]
+var C = /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());

--- a/tests/baselines/reference/parserIsClassMemberStart.symbols
+++ b/tests/baselines/reference/parserIsClassMemberStart.symbols
@@ -2,7 +2,7 @@
 class C {
 >C : Symbol(C, Decl(parserIsClassMemberStart.ts, 0, 0))
 
-    type: number;
+    type!: number;
 >type : Symbol(C.type, Decl(parserIsClassMemberStart.ts, 0, 9))
 }
 

--- a/tests/baselines/reference/parserIsClassMemberStart.symbols
+++ b/tests/baselines/reference/parserIsClassMemberStart.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/parserIsClassMemberStart.ts ===
+class C {
+>C : Symbol(C, Decl(parserIsClassMemberStart.ts, 0, 0))
+
+    type: number;
+>type : Symbol(C.type, Decl(parserIsClassMemberStart.ts, 0, 9))
+}
+

--- a/tests/baselines/reference/parserIsClassMemberStart.types
+++ b/tests/baselines/reference/parserIsClassMemberStart.types
@@ -2,7 +2,7 @@
 class C {
 >C : C
 
-    type: number;
+    type!: number;
 >type : number
 }
 

--- a/tests/baselines/reference/parserIsClassMemberStart.types
+++ b/tests/baselines/reference/parserIsClassMemberStart.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/parserIsClassMemberStart.ts ===
+class C {
+>C : C
+
+    type: number;
+>type : number
+}
+

--- a/tests/cases/compiler/parserIsClassMemberStart.ts
+++ b/tests/cases/compiler/parserIsClassMemberStart.ts
@@ -1,3 +1,3 @@
 class C {
-    type: number;
+    type!: number;
 }

--- a/tests/cases/compiler/parserIsClassMemberStart.ts
+++ b/tests/cases/compiler/parserIsClassMemberStart.ts
@@ -1,0 +1,3 @@
+class C {
+    type: number;
+}


### PR DESCRIPTION
Fixes #20604
