### PR TITLE
If declaration emit input is a module, output should be a module

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -148,8 +148,8 @@ namespace ts {
                 moduleElementDeclarationEmitInfo = [];
             }
 
-            if (!isBundledEmit && isExternalModule(sourceFile) && sourceFile.moduleAugmentations.length && !resultHasExternalModuleIndicator) {
-                // if file was external module with augmentations - this fact should be preserved in .d.ts as well.
+            if (!isBundledEmit && isExternalModule(sourceFile) && !resultHasExternalModuleIndicator) {
+                // if file was external module this fact should be preserved in .d.ts as well.
                 // in case if we didn't write any external module specifiers in .d.ts we need to emit something
                 // that will force compiler to think that this file is an external module - 'export {}' is a reasonable choice here.
                 write("export {};");
@@ -651,6 +651,9 @@ namespace ts {
         }
 
         function emitExportAssignment(node: ExportAssignment) {
+            if (isSourceFile(node.parent)) {
+                resultHasExternalModuleIndicator = true; // Top-level exports are external module indicators
+            }
             if (node.expression.kind === SyntaxKind.Identifier) {
                 write(node.isExportEquals ? "export = " : "export default ");
                 writeTextOfNode(currentText, node.expression);
@@ -745,6 +748,7 @@ namespace ts {
                 const modifiers = getModifierFlags(node);
                 // If the node is exported
                 if (modifiers & ModifierFlags.Export) {
+                    resultHasExternalModuleIndicator = true; // Top-level exports are external module indicators
                     write("export ");
                 }
 
@@ -901,6 +905,7 @@ namespace ts {
         }
 
         function emitExportDeclaration(node: ExportDeclaration) {
+            resultHasExternalModuleIndicator = true; // Top-level exports are external module indicators
             emitJsDocComments(node);
             write("export ");
             if (node.exportClause) {

--- a/tests/baselines/reference/bindingPatternOmittedExpressionNesting.js
+++ b/tests/baselines/reference/bindingPatternOmittedExpressionNesting.js
@@ -9,3 +9,4 @@ var _b, _c, _d, _e;
 
 
 //// [bindingPatternOmittedExpressionNesting.d.ts]
+export {};

--- a/tests/baselines/reference/commentsExternalModules.js
+++ b/tests/baselines/reference/commentsExternalModules.js
@@ -169,3 +169,4 @@ export declare module m4 {
     function fooExport(): number;
 }
 //// [commentsExternalModules_1.d.ts]
+export {};

--- a/tests/baselines/reference/commonSourceDirectory.js
+++ b/tests/baselines/reference/commonSourceDirectory.js
@@ -28,3 +28,4 @@ foo_1.x + bar_1.y;
 
 //// [/app/bin/index.d.ts]
 /// <reference path="../../types/bar.d.ts" />
+export {};

--- a/tests/baselines/reference/commonjsSafeImport.js
+++ b/tests/baselines/reference/commonjsSafeImport.js
@@ -24,3 +24,4 @@ _10_lib_1.Foo();
 //// [10_lib.d.ts]
 export declare function Foo(): void;
 //// [main.d.ts]
+export {};

--- a/tests/baselines/reference/emptyDeclarationEmitIsModule.js
+++ b/tests/baselines/reference/emptyDeclarationEmitIsModule.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/emptyDeclarationEmitIsModule.ts] ////
+
+//// [module.ts]
+import * as i from "./index";
+class Foo {}
+//// [index.ts]
+import {} from "./module";
+export interface Bar {
+    x: string
+}
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+//// [module.js]
+"use strict";
+exports.__esModule = true;
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    return Foo;
+}());
+
+
+//// [index.d.ts]
+export interface Bar {
+    x: string;
+}
+//// [module.d.ts]
+export {};

--- a/tests/baselines/reference/emptyDeclarationEmitIsModule.symbols
+++ b/tests/baselines/reference/emptyDeclarationEmitIsModule.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/module.ts ===
+import * as i from "./index";
+>i : Symbol(i, Decl(module.ts, 0, 6))
+
+class Foo {}
+>Foo : Symbol(Foo, Decl(module.ts, 0, 29))
+
+=== tests/cases/compiler/index.ts ===
+import {} from "./module";
+export interface Bar {
+>Bar : Symbol(Bar, Decl(index.ts, 0, 26))
+
+    x: string
+>x : Symbol(Bar.x, Decl(index.ts, 1, 22))
+}

--- a/tests/baselines/reference/emptyDeclarationEmitIsModule.types
+++ b/tests/baselines/reference/emptyDeclarationEmitIsModule.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/module.ts ===
+import * as i from "./index";
+>i : typeof i
+
+class Foo {}
+>Foo : Foo
+
+=== tests/cases/compiler/index.ts ===
+import {} from "./module";
+export interface Bar {
+>Bar : Bar
+
+    x: string
+>x : string
+}

--- a/tests/baselines/reference/es6ImportDefaultBinding.js
+++ b/tests/baselines/reference/es6ImportDefaultBinding.js
@@ -22,3 +22,4 @@ var x = defaultBinding;
 declare var a: number;
 export default a;
 //// [es6ImportDefaultBinding_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingAmd.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingAmd.js
@@ -29,3 +29,4 @@ define(["require", "exports", "es6ImportDefaultBindingAmd_0"], function (require
 declare var a: number;
 export default a;
 //// [es6ImportDefaultBindingAmd_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.js
@@ -51,3 +51,4 @@ export declare var m: number;
 declare const _default: {};
 export default _default;
 //// [es6ImportDefaultBindingFollowedWithNamedImport_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport1.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport1.js
@@ -41,3 +41,4 @@ var x1 = defaultBinding6;
 declare var a: number;
 export default a;
 //// [es6ImportDefaultBindingFollowedWithNamedImport1_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport1InEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport1InEs5.js
@@ -45,3 +45,4 @@ var x = es6ImportDefaultBindingFollowedWithNamedImport1InEs5_0_6.default;
 declare var a: number;
 export default a;
 //// [es6ImportDefaultBindingFollowedWithNamedImport1InEs5_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImportInEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImportInEs5.js
@@ -47,3 +47,4 @@ export declare var a: number;
 export declare var x: number;
 export declare var m: number;
 //// [es6ImportDefaultBindingFollowedWithNamedImportInEs5_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding.js
@@ -17,3 +17,4 @@ var x = nameSpaceBinding.a;
 //// [es6ImportDefaultBindingFollowedWithNamespaceBinding_0.d.ts]
 export declare var a: number;
 //// [es6ImportDefaultBindingFollowedWithNamespaceBinding_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding1.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding1.js
@@ -20,3 +20,4 @@ var x = defaultBinding;
 declare var a: number;
 export default a;
 //// [es6ImportDefaultBindingFollowedWithNamespaceBinding_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding1InEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding1InEs5.js
@@ -24,3 +24,4 @@ var x = es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0_1.default;
 declare var a: number;
 export default a;
 //// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.js
@@ -21,3 +21,4 @@ var x = nameSpaceBinding.a;
 //// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0.d.ts]
 export declare var a: number;
 //// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportDefaultBindingInEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingInEs5.js
@@ -20,3 +20,4 @@ Object.defineProperty(exports, "__esModule", { value: true });
 declare var a: number;
 export = a;
 //// [es6ImportDefaultBindingInEs5_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportNameSpaceImport.js
+++ b/tests/baselines/reference/es6ImportNameSpaceImport.js
@@ -23,3 +23,4 @@ var x = nameSpaceBinding.a;
 //// [es6ImportNameSpaceImport_0.d.ts]
 export declare var a: number;
 //// [es6ImportNameSpaceImport_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportNameSpaceImportAmd.js
+++ b/tests/baselines/reference/es6ImportNameSpaceImportAmd.js
@@ -26,3 +26,4 @@ define(["require", "exports", "es6ImportNameSpaceImportAmd_0"], function (requir
 //// [es6ImportNameSpaceImportAmd_0.d.ts]
 export declare var a: number;
 //// [es6ImportNameSpaceImportAmd_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportNameSpaceImportInEs5.js
+++ b/tests/baselines/reference/es6ImportNameSpaceImportInEs5.js
@@ -23,3 +23,4 @@ var x = nameSpaceBinding.a;
 //// [es6ImportNameSpaceImportInEs5_0.d.ts]
 export declare var a: number;
 //// [es6ImportNameSpaceImportInEs5_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportNamedImport.js
+++ b/tests/baselines/reference/es6ImportNamedImport.js
@@ -87,3 +87,4 @@ export declare var z1: number;
 export declare var z2: number;
 export declare var aaaa: number;
 //// [es6ImportNamedImport_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportNamedImportAmd.js
+++ b/tests/baselines/reference/es6ImportNamedImportAmd.js
@@ -82,3 +82,4 @@ export declare var z1: number;
 export declare var z2: number;
 export declare var aaaa: number;
 //// [es6ImportNamedImportAmd_1.d.ts]
+export {};

--- a/tests/baselines/reference/es6ImportNamedImportInEs5.js
+++ b/tests/baselines/reference/es6ImportNamedImportInEs5.js
@@ -87,3 +87,4 @@ export declare var z1: number;
 export declare var z2: number;
 export declare var aaaa: number;
 //// [es6ImportNamedImportInEs5_1.d.ts]
+export {};

--- a/tests/baselines/reference/exportClassExtendingIntersection.js
+++ b/tests/baselines/reference/exportClassExtendingIntersection.js
@@ -119,3 +119,4 @@ export declare class MyExtendedClass extends MyExtendedClass_base<string> {
     extendedClassProperty: number;
 }
 //// [Main.d.ts]
+export {};

--- a/tests/baselines/reference/exportStarFromEmptyModule.js
+++ b/tests/baselines/reference/exportStarFromEmptyModule.js
@@ -68,3 +68,4 @@ export declare class A {
     static q: any;
 }
 //// [exportStarFromEmptyModule_module4.d.ts]
+export {};

--- a/tests/baselines/reference/moduleAugmentationGlobal4.js
+++ b/tests/baselines/reference/moduleAugmentationGlobal4.js
@@ -36,7 +36,6 @@ declare global  {
     }
 }
 export {  };
-export {};
 //// [f2.d.ts]
 declare global  {
     interface Something {
@@ -44,7 +43,6 @@ declare global  {
     }
 }
 export {  };
-export {};
 //// [f3.d.ts]
 import "./f1";
 import "./f2";

--- a/tests/baselines/reference/moduleAugmentationInAmbientModule1.js
+++ b/tests/baselines/reference/moduleAugmentationInAmbientModule1.js
@@ -36,3 +36,4 @@ x.foo().x;
 
 //// [main.d.ts]
 /// <reference path="O.d.ts" />
+export {};

--- a/tests/baselines/reference/multiImportExport.js
+++ b/tests/baselines/reference/multiImportExport.js
@@ -67,3 +67,4 @@ export = Math;
 //// [Drawing.d.ts]
 export import Math = require('./Math/Math');
 //// [consumer.d.ts]
+export {};

--- a/tests/baselines/reference/shorthand-property-es5-es6.js
+++ b/tests/baselines/reference/shorthand-property-es5-es6.js
@@ -11,3 +11,4 @@ var bar = { foo: foo, baz: baz };
 
 
 //// [test.d.ts]
+export {};

--- a/tests/baselines/reference/shorthand-property-es6-amd.js
+++ b/tests/baselines/reference/shorthand-property-es6-amd.js
@@ -14,3 +14,4 @@ define(["require", "exports", "./foo"], function (require, exports, foo_1) {
 
 
 //// [test.d.ts]
+export {};

--- a/tests/baselines/reference/shorthand-property-es6-es6.js
+++ b/tests/baselines/reference/shorthand-property-es6-es6.js
@@ -11,3 +11,4 @@ const bar = { foo, baz };
 
 
 //// [test.d.ts]
+export {};

--- a/tests/baselines/reference/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.js
+++ b/tests/baselines/reference/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.js
@@ -29,3 +29,4 @@ f.foo();
 //// [file1.d.ts]
 export declare function foo(): any;
 //// [file2.d.ts]
+export {};

--- a/tests/baselines/reference/unusedImportDeclaration.js
+++ b/tests/baselines/reference/unusedImportDeclaration.js
@@ -38,3 +38,4 @@ declare class TesterB {
 }
 export = TesterB;
 //// [unusedImportDeclaration_testerA.d.ts]
+export {};

--- a/tests/baselines/reference/withImportDecl.js
+++ b/tests/baselines/reference/withImportDecl.js
@@ -91,3 +91,4 @@ export declare class A {
 }
 //// [withImportDecl_1.d.ts]
 /// <reference path="withImportDecl_0.d.ts" />
+export {};

--- a/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
+++ b/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
@@ -1,0 +1,9 @@
+// @declaration: true
+// @filename: module.ts
+import * as i from "./index";
+class Foo {}
+// @filename: index.ts
+import {} from "./module";
+export interface Bar {
+    x: string
+}


### PR DESCRIPTION
Fixes #20496

We tried to ensure this if the module contained module augmentations, but the code for that missed a lot of module indicator nodes (and would emit `export {}` too eagerly), so in addition to removing the restriction of only doing it for files with module augmentations, I had to tighten that up a bit. There's still a bunch of tests with changes to add `export {}`, but they _should_ have them since the input file was a module.