### PR TITLE
Unshallow submodule clones, update submodule ref

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,24 +2,19 @@
 	path = tests/cases/user/TypeScript-React-Starter/TypeScript-React-Starter
 	url = https://github.com/Microsoft/TypeScript-React-Starter
 	ignore = all
-	shallow = true
 [submodule "tests/cases/user/TypeScript-Node-Starter/TypeScript-Node-Starter"]
 	path = tests/cases/user/TypeScript-Node-Starter/TypeScript-Node-Starter
 	url = https://github.com/Microsoft/TypeScript-Node-Starter.git
 	ignore = all
-	shallow = true
 [submodule "tests/cases/user/TypeScript-React-Native-Starter/TypeScript-React-Native-Starter"]
 	path = tests/cases/user/TypeScript-React-Native-Starter/TypeScript-React-Native-Starter
 	url = https://github.com/Microsoft/TypeScript-React-Native-Starter.git
 	ignore = all
-	shallow = true
 [submodule "tests/cases/user/TypeScript-Vue-Starter/TypeScript-Vue-Starter"]
 	path = tests/cases/user/TypeScript-Vue-Starter/TypeScript-Vue-Starter
 	url = https://github.com/Microsoft/TypeScript-Vue-Starter.git
 	ignore = all
-	shallow = true
 [submodule "tests/cases/user/TypeScript-WeChat-Starter/TypeScript-WeChat-Starter"]
 	path = tests/cases/user/TypeScript-WeChat-Starter/TypeScript-WeChat-Starter
 	url = https://github.com/Microsoft/TypeScript-WeChat-Starter.git
 	ignore = all
-	shallow = true


### PR DESCRIPTION
Travis builds in #20631 failed at the clone stage because it looks like github is no longer allowing the fetching of nonhead commit objects directly. (At least that's what it looks like). This is reproducible locally with a fresh clone of TS by running `git submodule update --init --recursive` in that new clone.

Updating the offending submodule ref should fix the issue (and our builds) in the near-term, and un-shallowing submodule the clones should hopefully make it not an issue in the longer-term (since if a normal clone fails there are bigger issues).
