### PR TITLE
Allow multiple star-star globs in one pattern

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1907,21 +1907,6 @@ namespace ts {
     const invalidTrailingRecursionPattern = /(^|\/)\*\*\/?$/;
 
     /**
-     * Tests for a path with multiple recursive directory wildcards.
-     * Matches **\** and **\a\**, but not **\a**b.
-     *
-     * NOTE: used \ in place of / above to avoid issues with multiline comments.
-     *
-     * Breakdown:
-     *  (^|\/)      # matches either the beginning of the string or a directory separator.
-     *  \*\*\/      # matches a recursive directory wildcard "**" followed by a directory separator.
-     *  (.*\/)?     # optionally matches any number of characters followed by a directory separator.
-     *  \*\*        # matches a recursive directory wildcard "**"
-     *  ($|\/)      # matches either the end of the string or a directory separator.
-     */
-    const invalidMultipleRecursionPatterns = /(^|\/)\*\*\/(.*\/)?\*\*($|\/)/;
-
-    /**
      * Tests for a path where .. appears after a recursive directory wildcard.
      * Matches **\..\*, **\a\..\*, and **\.., but not ..\**\*
      *
@@ -2114,9 +2099,6 @@ namespace ts {
     function specToDiagnostic(spec: string, allowTrailingRecursion: boolean): ts.DiagnosticMessage | undefined {
         if (!allowTrailingRecursion && invalidTrailingRecursionPattern.test(spec)) {
             return Diagnostics.File_specification_cannot_end_in_a_recursive_directory_wildcard_Asterisk_Asterisk_Colon_0;
-        }
-        else if (invalidMultipleRecursionPatterns.test(spec)) {
-            return Diagnostics.File_specification_cannot_contain_multiple_recursive_directory_wildcards_Asterisk_Asterisk_Colon_0;
         }
         else if (invalidDotDotAfterRecursiveWildcardPattern.test(spec)) {
             return Diagnostics.File_specification_cannot_contain_a_parent_directory_that_appears_after_a_recursive_directory_wildcard_Asterisk_Asterisk_Colon_0;

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2374,7 +2374,6 @@ namespace ts {
 
     function getSubPatternFromSpec(spec: string, basePath: string, usage: "files" | "directories" | "exclude", { singleAsteriskRegexFragment, doubleAsteriskRegexFragment, replaceWildcardCharacter }: WildcardMatcher): string | undefined {
         let subpattern = "";
-        let hasRecursiveDirectoryWildcard = false;
         let hasWrittenComponent = false;
         const components = getNormalizedPathComponents(spec, basePath);
         const lastComponent = lastOrUndefined(components);
@@ -2393,12 +2392,7 @@ namespace ts {
         let optionalCount = 0;
         for (let component of components) {
             if (component === "**") {
-                if (hasRecursiveDirectoryWildcard) {
-                    return undefined;
-                }
-
                 subpattern += doubleAsteriskRegexFragment;
-                hasRecursiveDirectoryWildcard = true;
             }
             else {
                 if (usage === "directories") {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2623,10 +2623,6 @@
         "category": "Error",
         "code": 5010
     },
-    "File specification cannot contain multiple recursive directory wildcards ('**'): '{0}'.": {
-        "category": "Error",
-        "code": 5011
-    },
     "Cannot read file '{0}': {1}.": {
         "category": "Error",
         "code": 5012

--- a/src/harness/unittests/matchFiles.ts
+++ b/src/harness/unittests/matchFiles.ts
@@ -50,6 +50,7 @@ namespace ts {
         "/dev/x/b.ts",
         "/dev/x/y/a.ts",
         "/dev/x/y/b.ts",
+        "/dev/q/a/c/b/d.ts",
         "/dev/js/a.js",
         "/dev/js/b.js",
     ]);
@@ -1443,6 +1444,7 @@ namespace ts {
                         "/dev/a.ts",
                         "/dev/b.ts",
                         "/dev/c.d.ts",
+                        "/dev/q/a/c/b/d.ts",
                         "/dev/z/a.ts",
                         "/dev/z/aba.ts",
                         "/dev/z/abz.ts",
@@ -1459,7 +1461,8 @@ namespace ts {
             it("can include dirs whose pattern starts with **", () => {
                 const json = {
                     include: [
-                        "**/x"
+                        "**/x",
+                        "**/a/**/b"
                     ]
                 };
                 const expected: ts.ParsedCommandLine = {
@@ -1470,6 +1473,7 @@ namespace ts {
                         "/dev/x/b.ts",
                         "/dev/x/y/a.ts",
                         "/dev/x/y/b.ts",
+                        "/dev/q/a/c/b/d.ts",
                     ],
                     wildcardDirectories: {
                         "/dev": ts.WatchDirectoryFlags.Recursive

--- a/src/harness/unittests/matchFiles.ts
+++ b/src/harness/unittests/matchFiles.ts
@@ -1171,13 +1171,17 @@ namespace ts {
                     };
                     const expected: ts.ParsedCommandLine = {
                         options: {},
-                        errors: [
-                            createDiagnosticForConfigFile(json, 12, 11, ts.Diagnostics.File_specification_cannot_contain_multiple_recursive_directory_wildcards_Asterisk_Asterisk_Colon_0, "**/x/**/*"),
-                            ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
+                        errors: [],
+                        fileNames: [
+                            "c:/dev/x/a.ts",
+                            "c:/dev/x/aa.ts",
+                            "c:/dev/x/b.ts",
+                            "c:/dev/x/y/a.ts",
+                            "c:/dev/x/y/b.ts",
                         ],
-                        fileNames: [],
-                        wildcardDirectories: {}
+                        wildcardDirectories: {
+                            "c:/dev": ts.WatchDirectoryFlags.Recursive
+                        }
                     };
                     validateMatches(expected, json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                 });
@@ -1192,13 +1196,9 @@ namespace ts {
                     };
                     const expected: ts.ParsedCommandLine = {
                         options: {},
-                        errors: [
-                            createDiagnosticForConfigFile(json, 34, 9, ts.Diagnostics.File_specification_cannot_contain_multiple_recursive_directory_wildcards_Asterisk_Asterisk_Colon_0, "**/x/**")
-                        ],
+                        errors: [],
                         fileNames: [
                             "c:/dev/a.ts",
-                            "c:/dev/x/a.ts",
-                            "c:/dev/x/y/a.ts",
                             "c:/dev/z/a.ts"
                         ],
                         wildcardDirectories: {
@@ -1424,6 +1424,58 @@ namespace ts {
                     };
                     validateMatches(expected, json, caseInsensitiveDottedFoldersHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                 });
+            });
+        });
+
+        describe("exclude or include patterns which start with **", () => {
+            it("can exclude dirs whose pattern starts with **", () => {
+                const json = {
+                    exclude: [
+                        "**/x"
+                    ]
+                };
+                const expected: ts.ParsedCommandLine = {
+                    options: {},
+                    errors: [],
+                    fileNames: [
+                        "/dev/A.ts",
+                        "/dev/B.ts",
+                        "/dev/a.ts",
+                        "/dev/b.ts",
+                        "/dev/c.d.ts",
+                        "/dev/z/a.ts",
+                        "/dev/z/aba.ts",
+                        "/dev/z/abz.ts",
+                        "/dev/z/b.ts",
+                        "/dev/z/bba.ts",
+                        "/dev/z/bbz.ts",
+                    ],
+                    wildcardDirectories: {
+                        "/dev": ts.WatchDirectoryFlags.Recursive
+                    }
+                };
+                validateMatches(expected, json, caseSensitiveHost, caseSensitiveBasePath);
+            });
+            it("can include dirs whose pattern starts with **", () => {
+                const json = {
+                    include: [
+                        "**/x"
+                    ]
+                };
+                const expected: ts.ParsedCommandLine = {
+                    options: {},
+                    errors: [],
+                    fileNames: [
+                        "/dev/x/a.ts",
+                        "/dev/x/b.ts",
+                        "/dev/x/y/a.ts",
+                        "/dev/x/y/b.ts",
+                    ],
+                    wildcardDirectories: {
+                        "/dev": ts.WatchDirectoryFlags.Recursive
+                    }
+                };
+                validateMatches(expected, json, caseSensitiveHost, caseSensitiveBasePath);
             });
         });
     });


### PR DESCRIPTION
Fixes #16115

The original issue was because when we saw a pattern like `/foo`, we appended `/**/*` to the end to build a correct regex. Now, if the input pattern was `**/foo`, we'd do the same (with no error, since there weren't multiple star-star globs in the original pattern), except then we'd bail out on manufacturing the regex when we saw there were multiple `**` patterns (since we added `/**/*` to the end).

Now, I can't figure out why you'd forbid multiple `**`'s in a glob pattern in the first place (`node-glob` and `bash` seem to handle it just fine), so I just removed the restriction (and the early-bail clause in the regex generation code). I looked at the history, and the restriction's been in place since @rbuckton 's first iteration of the feature, so I think that it's still here was just a holdover from before we built a regex from the pattern.

Everything that's not a change to the tests in this PR is just removing lines of code, so this seems like a pretty good change!