### PR TITLE
Remove unnecessary `getFirstChildOfKind` helper function

### DIFF
--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -170,7 +170,7 @@ namespace ts.codefix {
         }
 
         const type = inferTypeForVariableFromUsage(getAccessorDeclaration.name, sourceFile, program, cancellationToken);
-        const closeParenToken = getFirstChildOfKind(getAccessorDeclaration, sourceFile, SyntaxKind.CloseParenToken);
+        const closeParenToken = findChildOfKind(getAccessorDeclaration, SyntaxKind.CloseParenToken, sourceFile);
         return makeFix(getAccessorDeclaration, closeParenToken.getEnd(), type, program);
     }
 
@@ -209,7 +209,7 @@ namespace ts.codefix {
             case SyntaxKind.MethodDeclaration:
                 const isConstructor = containingFunction.kind === SyntaxKind.Constructor;
                 const searchToken = isConstructor ?
-                    <Token<SyntaxKind.ConstructorKeyword>>getFirstChildOfKind(containingFunction, sourceFile, SyntaxKind.ConstructorKeyword) :
+                    findChildOfKind<Token<SyntaxKind.ConstructorKeyword>>(containingFunction, SyntaxKind.ConstructorKeyword, sourceFile) :
                     containingFunction.name;
                 if (searchToken) {
                     return InferFromReference.inferTypeForParametersFromReferences(getReferences(searchToken, sourceFile, program, cancellationToken), containingFunction, program.getTypeChecker(), cancellationToken);

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -992,7 +992,7 @@ namespace ts.FindAllReferences.Core {
      */
     function findOwnConstructorReferences(classSymbol: Symbol, sourceFile: SourceFile, addNode: (node: Node) => void): void {
         for (const decl of classSymbol.members.get(InternalSymbolName.Constructor).declarations) {
-            const ctrKeyword = ts.findChildOfKind(decl, ts.SyntaxKind.ConstructorKeyword, sourceFile)!;
+            const ctrKeyword = findChildOfKind(decl, ts.SyntaxKind.ConstructorKeyword, sourceFile)!;
             Debug.assert(decl.kind === SyntaxKind.Constructor && !!ctrKeyword);
             addNode(ctrKeyword);
         }


### PR DESCRIPTION
`findChildOfKind` offers identical functionality.