### PR TITLE
Non-primitive spreads to empty object

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8327,10 +8327,7 @@ namespace ts {
             if (right.flags & TypeFlags.Union) {
                 return mapType(right, t => getSpreadType(left, t, symbol, propagatedFlags));
             }
-            if (right.flags & TypeFlags.NonPrimitive) {
-                return nonPrimitiveType;
-            }
-            if (right.flags & (TypeFlags.BooleanLike | TypeFlags.NumberLike | TypeFlags.StringLike | TypeFlags.EnumLike)) {
+            if (right.flags & (TypeFlags.BooleanLike | TypeFlags.NumberLike | TypeFlags.StringLike | TypeFlags.EnumLike | TypeFlags.NonPrimitive)) {
                 return left;
             }
 

--- a/tests/baselines/reference/objectSpread.types
+++ b/tests/baselines/reference/objectSpread.types
@@ -571,8 +571,8 @@ let shortCutted: { a: number, b: string } = { ...o, a }
 
 // non primitive
 let spreadNonPrimitive = { ...<object>{}};
->spreadNonPrimitive : object
->{ ...<object>{}} : object
+>spreadNonPrimitive : {}
+>{ ...<object>{}} : {}
 ><object>{} : object
 >{} : {}
 

--- a/tests/baselines/reference/objectSpreadNegative.errors.txt
+++ b/tests/baselines/reference/objectSpreadNegative.errors.txt
@@ -15,7 +15,7 @@ tests/cases/conformance/types/spread/objectSpreadNegative.ts(38,19): error TS269
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(43,1): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '{}' has no compatible call signatures.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(47,12): error TS2339: Property 'b' does not exist on type '{}'.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(53,9): error TS2339: Property 'm' does not exist on type '{ p: number; }'.
-tests/cases/conformance/types/spread/objectSpreadNegative.ts(58,11): error TS2339: Property 'a' does not exist on type 'object'.
+tests/cases/conformance/types/spread/objectSpreadNegative.ts(58,11): error TS2339: Property 'a' does not exist on type '{}'.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(62,14): error TS2698: Spread types may only be created from object types.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(65,14): error TS2698: Spread types may only be created from object types.
 tests/cases/conformance/types/spread/objectSpreadNegative.ts(79,37): error TS2322: Type '{ a: string; b: string; extra: string; }' is not assignable to type 'A'.
@@ -117,7 +117,7 @@ tests/cases/conformance/types/spread/objectSpreadNegative.ts(84,7): error TS2322
     let spreadObj = { ...obj };
     spreadObj.a; // error 'a' is not in {}
               ~
-!!! error TS2339: Property 'a' does not exist on type 'object'.
+!!! error TS2339: Property 'a' does not exist on type '{}'.
     
     // generics
     function f<T, U>(t: T, u: U) {

--- a/tests/baselines/reference/objectSpreadNegative.types
+++ b/tests/baselines/reference/objectSpreadNegative.types
@@ -222,13 +222,13 @@ let obj: object = { a: 123 };
 >123 : 123
 
 let spreadObj = { ...obj };
->spreadObj : object
->{ ...obj } : object
+>spreadObj : {}
+>{ ...obj } : {}
 >obj : object
 
 spreadObj.a; // error 'a' is not in {}
 >spreadObj.a : any
->spreadObj : object
+>spreadObj : {}
 >a : any
 
 // generics

--- a/tests/baselines/reference/spreadNonPrimitive.js
+++ b/tests/baselines/reference/spreadNonPrimitive.js
@@ -1,0 +1,15 @@
+//// [spreadNonPrimitive.ts]
+declare let o: object;
+const x: { a: number, b: number } = { a: 1, ...o, b: 2 };
+
+
+//// [spreadNonPrimitive.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+var x = __assign({ a: 1 }, o, { b: 2 });

--- a/tests/baselines/reference/spreadNonPrimitive.symbols
+++ b/tests/baselines/reference/spreadNonPrimitive.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/types/spread/spreadNonPrimitive.ts ===
+declare let o: object;
+>o : Symbol(o, Decl(spreadNonPrimitive.ts, 0, 11))
+
+const x: { a: number, b: number } = { a: 1, ...o, b: 2 };
+>x : Symbol(x, Decl(spreadNonPrimitive.ts, 1, 5))
+>a : Symbol(a, Decl(spreadNonPrimitive.ts, 1, 10))
+>b : Symbol(b, Decl(spreadNonPrimitive.ts, 1, 21))
+>a : Symbol(a, Decl(spreadNonPrimitive.ts, 1, 37))
+>o : Symbol(o, Decl(spreadNonPrimitive.ts, 0, 11))
+>b : Symbol(b, Decl(spreadNonPrimitive.ts, 1, 49))
+

--- a/tests/baselines/reference/spreadNonPrimitive.types
+++ b/tests/baselines/reference/spreadNonPrimitive.types
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/types/spread/spreadNonPrimitive.ts ===
+declare let o: object;
+>o : object
+
+const x: { a: number, b: number } = { a: 1, ...o, b: 2 };
+>x : { a: number; b: number; }
+>a : number
+>b : number
+>{ a: 1, ...o, b: 2 } : { b: number; a: number; }
+>a : number
+>1 : 1
+>o : object
+>b : number
+>2 : 2
+

--- a/tests/cases/conformance/types/spread/spreadNonPrimitive.ts
+++ b/tests/cases/conformance/types/spread/spreadNonPrimitive.ts
@@ -1,0 +1,2 @@
+declare let o: object;
+const x: { a: number, b: number } = { a: 1, ...o, b: 2 };


### PR DESCRIPTION
Fixes #20635 

Specifically, when spreading `object` on the right, spread now returns the left of the spread; previously it returned `object`, which loses everything to the left.

The type baselines are not quite as nice now, but that isn't actually visible to users.