### PR TITLE
 Revert merge pull request #20429 (removing chai)

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -795,7 +795,7 @@ compileFile(
     /*prereqs*/[builtLocalDirectory, tscFile, tsserverLibraryFile].concat(libraryTargets).concat(servicesSources).concat(harnessSources),
     /*prefixes*/[],
     /*useBuiltCompiler:*/ true,
-    /*opts*/ { types: ["node", "mocha"], lib: "es6" });
+    /*opts*/ { types: ["node", "mocha", "chai"], lib: "es6" });
 
 var internalTests = "internal/";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
             "dev": true,
             "requires": {
-                "acorn": "5.1.2",
+                "acorn": "5.2.1",
                 "css": "2.2.1",
                 "normalize-path": "2.1.1",
                 "source-map": "0.5.7",
@@ -18,9 +18,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-                    "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+                    "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
                     "dev": true
                 }
             }
@@ -35,6 +35,12 @@
                 "through2": "2.0.3"
             }
         },
+        "@types/arrify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/arrify/-/arrify-1.0.2.tgz",
+            "integrity": "sha512-gB1Oqypj/WbMjnWyCcvQdynRyfusKtqzUpt+EN/OtgFcjikC7ZV4qzS3SLbO1Ai2B0iVSgWvwR9A49lZGfivYg==",
+            "dev": true
+        },
         "@types/browserify": {
             "version": "12.0.33",
             "resolved": "https://registry.npmjs.org/@types/browserify/-/browserify-12.0.33.tgz",
@@ -42,13 +48,13 @@
             "dev": true,
             "requires": {
                 "@types/insert-module-globals": "7.0.0",
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/chai": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.4.tgz",
-            "integrity": "sha512-cvU0HomQ7/aGDQJZsbtJXqBQ7w4J4TqLB0Z/h8mKrpRjfeZEvTbygkfJEb7fWdmwpIeDeFmIVwAEqS0OYuUv3Q==",
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+            "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
             "dev": true
         },
         "@types/colors": {
@@ -58,9 +64,9 @@
             "dev": true
         },
         "@types/convert-source-map": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-1.5.0.tgz",
-            "integrity": "sha512-4OHKJEw70U59CN24TLRxU3W+B/9GPp0P6g+eNIsObZLAIqw6NTEBorkjIpei4xsvUCx+YzFwUtt4MBZbfSLvbQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "integrity": "sha512-laiDIXqqthjJlyAMYAXOtN3N8+UlbM+KvZi4BaY5ZOekmVkBs/UxfK5O0HWeJVG2eW8F+Mu2ww13fTX+kY1FlQ==",
             "dev": true
         },
         "@types/del": {
@@ -69,66 +75,79 @@
             "integrity": "sha512-18mSs54BvzV8+TTQxt0ancig6tsuPZySnhp3cQkWFFDmDMavU4pmWwR+bHHqRBWODYqpzIzVkqKLuk/fP6yypQ==",
             "dev": true,
             "requires": {
-                "@types/glob": "5.0.33"
+                "@types/glob": "5.0.34"
             }
         },
+        "@types/diff": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
+            "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
+            "dev": true
+        },
+        "@types/events": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+            "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+            "dev": true
+        },
         "@types/glob": {
-            "version": "5.0.33",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-            "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+            "version": "5.0.34",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+            "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
             "dev": true,
             "requires": {
+                "@types/events": "1.1.0",
                 "@types/minimatch": "3.0.1",
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/gulp": {
-            "version": "3.8.33",
-            "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-3.8.33.tgz",
-            "integrity": "sha512-3UpA2pkKO40cNPe/8bxMQFWSASR9Jx67JfN9Z2Cf6ogfDMwXgEHm2XjKmuLYEtrp1IHYApOWlYMLYNgtTJgSAw==",
+            "version": "3.8.35",
+            "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-3.8.35.tgz",
+            "integrity": "sha512-h9clNJu8X6+zW74ZLa5zhh5HP0LxnvlelVXdXby6pM/DDEj/gKqmmFXKwjzvupZKlMpof02jr6c3JokPbHXQgg==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46",
-                "@types/orchestrator": "0.3.0",
+                "@types/node": "8.0.58",
+                "@types/orchestrator": "0.3.2",
                 "@types/vinyl": "2.0.1"
             }
         },
         "@types/gulp-concat": {
-            "version": "0.0.31",
-            "resolved": "https://registry.npmjs.org/@types/gulp-concat/-/gulp-concat-0.0.31.tgz",
-            "integrity": "sha512-F14zRcKn15HC59RXRlHpcxj79WoLjkJBJBPfN0NBZOgkRCfDZYVu8rs0Y/CH4CJGUbbc/nHczD2LmepDS+ARaA==",
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/gulp-concat/-/gulp-concat-0.0.32.tgz",
+            "integrity": "sha512-CUCFADlITzzBfBa2bdGzhKtvBr4eFh+evb+4igVbvPoO5RyPfHifmyQlZl6lM7q19+OKncRlFXDU7B4X9Ayo2g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/gulp-help": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/@types/gulp-help/-/gulp-help-0.0.33.tgz",
-            "integrity": "sha1-ZejGUSQQkiVTf6OQA8S6UfT9GsU=",
+            "version": "0.0.34",
+            "resolved": "https://registry.npmjs.org/@types/gulp-help/-/gulp-help-0.0.34.tgz",
+            "integrity": "sha512-MkW7psZznxxJg2MBk2P2qHE+T8jEZVFz3FG/qGjUYazkyJt7hBJWx5Nuewmay5RVNtUvSWPrdZLr/WTXY3T/6A==",
             "dev": true,
             "requires": {
-                "@types/gulp": "3.8.33",
-                "@types/node": "8.0.46",
-                "@types/orchestrator": "0.3.0"
+                "@types/gulp": "3.8.35",
+                "@types/node": "8.0.58",
+                "@types/orchestrator": "0.3.2"
             }
         },
         "@types/gulp-newer": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/gulp-newer/-/gulp-newer-0.0.30.tgz",
-            "integrity": "sha1-bqn7oVsFdr5CTpl31IlCAEZKFR4=",
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/@types/gulp-newer/-/gulp-newer-0.0.31.tgz",
+            "integrity": "sha512-e7J/Zv5Wd7CC0WpuA2syWVitgwrkG0u221e41w7r07XUR6hMH6kHPkq9tUrusHkbeW8QbuLbis5fODOwQCyggQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/gulp-sourcemaps": {
-            "version": "0.0.31",
-            "resolved": "https://registry.npmjs.org/@types/gulp-sourcemaps/-/gulp-sourcemaps-0.0.31.tgz",
-            "integrity": "sha512-kJD1byVNx+sdQlaBzZpSGeFH/4l99TXTY4XSGW+aRk27eOnVyk6VknXJpsb1Jk5E4ThKxZ8GYy6ais7MtprK1w==",
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/gulp-sourcemaps/-/gulp-sourcemaps-0.0.32.tgz",
+            "integrity": "sha512-+7BAmptW2bxyJnJcCEuie7vLoop3FwWgCdBMzyv7MYXED/HeNMeQuX7uPCkp4vfU1TTu4CYFH0IckNPvo0VePA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/insert-module-globals": {
@@ -137,16 +156,16 @@
             "integrity": "sha512-zudCJPwluh1VUDB6Gl/OQdRp+fYy3+47huJB/JMQubMS2p+sH18MCVK4WUz3FqaWLB12yh5ELxVR/+tqwlm/qA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/merge2": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@types/merge2/-/merge2-1.1.2.tgz",
-            "integrity": "sha512-Xy54xPmFQ8oAx0S3ku46i/zXE4dvfxl5M8n4p2M62IwxPau8IpobiRtL4jkrUzX6Kgeyb34BHOh0i70SDjKHeA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@types/merge2/-/merge2-1.1.4.tgz",
+            "integrity": "sha512-GjaXY4OultxbaOOk7lCLO7xvEcFpdjExC605YmfI6X29vhHKpJfMWKCDZd3x+BITrZaXKg97DgV/SdGVSwdzxA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/minimatch": {
@@ -162,59 +181,72 @@
             "dev": true
         },
         "@types/mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha512-XA4vNO6GCBz8Smq0hqSRo4yRWMqr4FPQrWjhJt6nKskzly4/p87SfuJMFYGRyYb6jo2WNIQU2FDBsY5r1BibUA==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+            "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/mocha": {
-            "version": "2.2.43",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz",
-            "integrity": "sha512-xNlAmH+lRJdUMXClMTI9Y0pRqIojdxfm7DHsIxoB2iTzu3fnPmSMEN8SsSx0cdwV36d02PWCWaDUoZPDSln+xw==",
+            "version": "2.2.44",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
+            "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
             "dev": true
         },
         "@types/node": {
-            "version": "8.0.46",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.46.tgz",
-            "integrity": "sha512-rRkP4kb5JYIfAoRKaDbcdPZBcTNOgzSApyzhPN9e6rhViSJAWQGlSXIX5gc75iR02jikhpzy3usu31wMHllfFw==",
+            "version": "8.0.58",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.58.tgz",
+            "integrity": "sha512-V746iUU7eHNdzQipoACuguDlVhC7IHK8CES1jSkuFt352wwA84BCWPXaGekBd7R5XdNK5ReHONDVKxlL9IreAw==",
             "dev": true
         },
         "@types/orchestrator": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@types/orchestrator/-/orchestrator-0.3.0.tgz",
-            "integrity": "sha1-v4ShaZyTMNT+ic2BJj6PwJ+zKXg=",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@types/orchestrator/-/orchestrator-0.3.2.tgz",
+            "integrity": "sha512-cKB4yTX0wGaRCSkdHDX2fkGQbMAA8UOshC2U7DQky1CE5o+5q2iQQ8VkbPbE/88uaTtsusvBPMcCX7dgmjxBhQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46",
-                "@types/q": "0.0.37"
-            },
-            "dependencies": {
-                "@types/q": {
-                    "version": "0.0.37",
-                    "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.37.tgz",
-                    "integrity": "sha512-vjFGX1zMTMz/kUp3xgfJcxMVLkMWVMrdlyc0RwVyve1y9jxwqNaT8wTcv6M51ylq2a/zn5lm8g7qPSoIS4uvZQ==",
-                    "dev": true
-                }
+                "@types/node": "8.0.58",
+                "@types/q": "1.0.6"
             }
         },
         "@types/q": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.5.tgz",
-            "integrity": "sha512-sudQPADzmQjXYS1fS2TxbWA/N/vbbfaO4Y7luPaAEyRWZVXC8jHwKV8KgNDbT7IHQaONNZWy9BYsodxY7IyDXQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.6.tgz",
+            "integrity": "sha512-LSx7jkcXoXWB+kkfwG5zc9Okbgn51BrjLMtKwbmnqfQlCGttTnTxvDVwQanHxkK6CLKb9yEfxQ1ID6pqDpeURw==",
             "dev": true
         },
         "@types/run-sequence": {
-            "version": "0.0.29",
-            "resolved": "https://registry.npmjs.org/@types/run-sequence/-/run-sequence-0.0.29.tgz",
-            "integrity": "sha1-atD3ODE24TklMi5p/EHbd7MLIHU=",
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/run-sequence/-/run-sequence-0.0.30.tgz",
+            "integrity": "sha512-XwGr1b4yCGUILKeBkzmeWcxmGHQ0vFFFpA6D6y1yLO6gKmYorF+PHqdU5KG+nWt38OvtrkDptmrSmlHX/XtpLw==",
             "dev": true,
             "requires": {
-                "@types/gulp": "3.8.33",
-                "@types/node": "8.0.46"
+                "@types/gulp": "3.8.35",
+                "@types/node": "8.0.58"
             }
+        },
+        "@types/source-map-support": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.4.0.tgz",
+            "integrity": "sha512-9oVAi1Jlr274pbMGPEe0S3IPImV9knVNafa6E4MookD/fjOZAE6EmLkFX5ZjtZ9OXNPi2FCIZzUSMvwAUUKeSg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "8.0.58"
+            }
+        },
+        "@types/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
+            "dev": true
+        },
+        "@types/strip-json-comments": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+            "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+            "dev": true
         },
         "@types/through2": {
             "version": "2.0.33",
@@ -222,8 +254,12 @@
             "integrity": "sha1-H/LoihAN+1sUDnu5h5HxGUQA0TE=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
+        },
+        "@types/v8flags": {
+            "version": "github:types/npm-v8flags#de224ae1cd5fd7dbb4e7158a6cc7a29e5315930d",
+            "dev": true
         },
         "@types/vinyl": {
             "version": "2.0.1",
@@ -231,17 +267,21 @@
             "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
         },
         "@types/xml2js": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.0.tgz",
-            "integrity": "sha512-3gw0UqFMq7PsfMDwsawD0/L48soXfzOEh0NSAWVO99IZXnhx9LD3nOldHIpGYzZBsrS9NV2vaRFvEdWe+UweXQ==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
+            "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.46"
+                "@types/node": "8.0.58"
             }
+        },
+        "@types/yn": {
+            "version": "github:types/npm-yn#ca75f6c82940fae6a06fb41d2d37a6aa9b4ea8e9",
+            "dev": true
         },
         "abbrev": {
             "version": "1.0.9",
@@ -272,6 +312,15 @@
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
             "dev": true
         },
+        "ansi-gray": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -282,6 +331,12 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
             "dev": true
         },
         "archy": {
@@ -351,9 +406,9 @@
             "dev": true
         },
         "array-slice": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
-            "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
             "dev": true
         },
         "array-union": {
@@ -384,9 +439,9 @@
             "dev": true
         },
         "asn1.js": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-            "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+            "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
             "dev": true,
             "requires": {
                 "bn.js": "4.11.8",
@@ -535,7 +590,7 @@
                 "concat-stream": "1.5.2",
                 "console-browserify": "1.1.0",
                 "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.11.1",
+                "crypto-browserify": "3.12.0",
                 "defined": "1.0.0",
                 "deps-sort": "2.0.0",
                 "domain-browser": "1.1.7",
@@ -573,35 +628,12 @@
                 "util": "0.10.3",
                 "vm-browserify": "0.0.4",
                 "xtend": "4.0.1"
-            },
-            "dependencies": {
-                "browserify-zlib": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-                    "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-                    "dev": true,
-                    "requires": {
-                        "pako": "1.0.6"
-                    }
-                },
-                "os-browserify": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-                    "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-                    "dev": true
-                },
-                "pako": {
-                    "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-                    "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
-                    "dev": true
-                }
             }
         },
         "browserify-aes": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
-            "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+            "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
             "dev": true,
             "requires": {
                 "buffer-xor": "1.0.3",
@@ -618,7 +650,7 @@
             "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.0.8",
+                "browserify-aes": "1.1.1",
                 "browserify-des": "1.0.0",
                 "evp_bytestokey": "1.0.3"
             }
@@ -657,6 +689,15 @@
                 "elliptic": "6.4.0",
                 "inherits": "2.0.3",
                 "parse-asn1": "5.1.0"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "requires": {
+                "pako": "1.0.6"
             }
         },
         "buffer": {
@@ -737,7 +778,7 @@
                 "deep-eql": "3.0.1",
                 "get-func-name": "2.0.0",
                 "pathval": "1.1.0",
-                "type-detect": "4.0.3"
+                "type-detect": "4.0.5"
             }
         },
         "chalk": {
@@ -791,9 +832,9 @@
             }
         },
         "clone": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
             "dev": true
         },
         "clone-buffer": {
@@ -820,9 +861,9 @@
             }
         },
         "color-convert": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-            "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
                 "color-name": "1.1.3"
@@ -930,9 +971,9 @@
             "dev": true
         },
         "convert-source-map": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-            "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
             "dev": true
         },
         "core-util-is": {
@@ -978,9 +1019,9 @@
             }
         },
         "crypto-browserify": {
-            "version": "3.11.1",
-            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-            "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
                 "browserify-cipher": "1.0.0",
@@ -992,7 +1033,8 @@
                 "inherits": "2.0.3",
                 "pbkdf2": "3.0.14",
                 "public-encrypt": "4.0.0",
-                "randombytes": "2.0.5"
+                "randombytes": "2.0.5",
+                "randomfill": "1.0.3"
             }
         },
         "css": {
@@ -1033,7 +1075,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.31"
+                "es5-ext": "0.10.37"
             }
         },
         "date-now": {
@@ -1058,9 +1100,9 @@
             }
         },
         "debug-fabulous": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.2.1.tgz",
-            "integrity": "sha512-u0TV6HcfLsZ03xLBhdhSViQMldaiQ2o+8/nSILaXkuNSWvxkx66vYJUAam0Eu7gAilJRX/69J4kKdqajQPaPyw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.0.0.tgz",
+            "integrity": "sha512-dsd50qQ1atDeurcxL7XOjPp4nZCGZzWIONDujDXzl1atSyC3hMbZD+v6440etw+Vt0Pr8ce4TQzHfX3KZM05Mw==",
             "dev": true,
             "requires": {
                 "debug": "3.1.0",
@@ -1080,7 +1122,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "4.0.3"
+                "type-detect": "4.0.5"
             }
         },
         "deep-is": {
@@ -1095,7 +1137,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.2"
+                "clone": "1.0.3"
             }
         },
         "defined": {
@@ -1162,13 +1204,21 @@
             "dev": true
         },
         "detective": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-            "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.0.tgz",
+            "integrity": "sha512-4mBqSEdMfBpRAo/DQZnTcAXenpiSIJmVKbCMSotS+SFWWcrP/CKM6iBRPdTiEO+wZhlfEsoZlGqpG6ycl5vTqw==",
             "dev": true,
             "requires": {
-                "acorn": "4.0.13",
+                "acorn": "5.2.1",
                 "defined": "1.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+                    "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+                    "dev": true
+                }
             }
         },
         "diff": {
@@ -1271,23 +1321,23 @@
             }
         },
         "es5-ext": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.31.tgz",
-            "integrity": "sha1-e7k4yVp/G59ygJLcCcQe3MOY7v4=",
+            "version": "0.10.37",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+            "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.1",
+                "es6-iterator": "2.0.3",
                 "es6-symbol": "3.1.1"
             }
         },
         "es6-iterator": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-            "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.31",
+                "es5-ext": "0.10.37",
                 "es6-symbol": "3.1.1"
             }
         },
@@ -1304,7 +1354,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.31"
+                "es5-ext": "0.10.37"
             }
         },
         "es6-weak-map": {
@@ -1314,8 +1364,8 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.31",
-                "es6-iterator": "2.0.1",
+                "es5-ext": "0.10.37",
+                "es6-iterator": "2.0.3",
                 "es6-symbol": "3.1.1"
             }
         },
@@ -1375,7 +1425,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.31"
+                "es5-ext": "0.10.37"
             }
         },
         "events": {
@@ -1446,12 +1496,12 @@
             }
         },
         "fancy-log": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.1.tgz",
+            "integrity": "sha1-xKNGK6FK3137q3lzH9OESiBpy7s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
+                "ansi-gray": "0.1.1",
                 "time-stamp": "1.1.0"
             }
         },
@@ -1755,7 +1805,7 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "1.0.1",
-                "ini": "1.3.4",
+                "ini": "1.3.5",
                 "is-windows": "0.2.0",
                 "which": "1.3.0"
             }
@@ -1842,7 +1892,7 @@
             "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
             "dev": true,
             "requires": {
-                "natives": "1.1.0"
+                "natives": "1.1.1"
             }
         },
         "growl": {
@@ -1861,7 +1911,7 @@
                 "chalk": "1.1.3",
                 "deprecated": "0.0.1",
                 "gulp-util": "3.0.8",
-                "interpret": "1.0.4",
+                "interpret": "1.1.0",
                 "liftoff": "2.3.0",
                 "minimist": "1.2.0",
                 "orchestrator": "0.3.8",
@@ -2099,40 +2149,6 @@
                 "concat-with-sourcemaps": "1.0.4",
                 "through2": "2.0.3",
                 "vinyl": "2.1.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-                    "dev": true
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.0.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
-                    }
-                }
             }
         },
         "gulp-help": {
@@ -2209,9 +2225,9 @@
                 "@gulp-sourcemaps/identity-map": "1.0.1",
                 "@gulp-sourcemaps/map-sources": "1.0.0",
                 "acorn": "4.0.13",
-                "convert-source-map": "1.5.0",
+                "convert-source-map": "1.5.1",
                 "css": "2.2.1",
-                "debug-fabulous": "0.2.1",
+                "debug-fabulous": "1.0.0",
                 "detect-newline": "2.1.0",
                 "graceful-fs": "4.1.11",
                 "source-map": "0.5.7",
@@ -2232,7 +2248,7 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.2",
+                        "clone": "1.0.3",
                         "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
@@ -2240,9 +2256,9 @@
             }
         },
         "gulp-typescript": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.2.tgz",
-            "integrity": "sha1-t+Xh08s193LlPmBAJmAYJuK+d/w=",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.3.tgz",
+            "integrity": "sha512-Np2sJXgtDUwIAoMtlJ9uXsVmpu1FWXlKZw164hLuo56uJa7qo5W2KZ0yAYiYH/HUsaz5L0O2toMOcLIokpFCPg==",
             "dev": true,
             "requires": {
                 "gulp-util": "3.0.8",
@@ -2326,7 +2342,7 @@
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "dev": true,
                     "requires": {
-                        "convert-source-map": "1.5.0",
+                        "convert-source-map": "1.5.1",
                         "graceful-fs": "4.1.11",
                         "strip-bom": "2.0.0",
                         "through2": "2.0.3",
@@ -2404,7 +2420,7 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.2",
+                        "clone": "1.0.3",
                         "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
@@ -2447,7 +2463,7 @@
                 "beeper": "1.1.1",
                 "chalk": "1.1.3",
                 "dateformat": "2.2.0",
-                "fancy-log": "1.3.0",
+                "fancy-log": "1.3.1",
                 "gulplog": "1.0.0",
                 "has-gulplog": "0.1.0",
                 "lodash._reescape": "3.0.0",
@@ -2467,6 +2483,17 @@
                     "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                     "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
                     "dev": true
+                },
+                "vinyl": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
                 }
             }
         },
@@ -2480,9 +2507,9 @@
             }
         },
         "handlebars": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-            "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+            "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
                 "async": "1.5.2",
@@ -2642,9 +2669,9 @@
             "dev": true
         },
         "ini": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-            "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
         "inline-source-map": {
@@ -2664,7 +2691,7 @@
             "requires": {
                 "combine-source-map": "0.7.2",
                 "concat-stream": "1.5.2",
-                "is-buffer": "1.1.5",
+                "is-buffer": "1.1.6",
                 "JSONStream": "1.3.1",
                 "lexical-scope": "1.2.0",
                 "process": "0.11.10",
@@ -2673,9 +2700,9 @@
             }
         },
         "interpret": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-            "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
             "dev": true
         },
         "is-absolute": {
@@ -2695,9 +2722,9 @@
             "dev": true
         },
         "is-buffer": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
         "is-builtin-module": {
@@ -2775,13 +2802,13 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.0"
+                "is-path-inside": "1.0.1"
             }
         },
         "is-path-inside": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-            "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
                 "path-is-inside": "1.0.2"
@@ -2896,7 +2923,7 @@
                 "escodegen": "1.8.1",
                 "esprima": "2.7.3",
                 "glob": "5.0.15",
-                "handlebars": "4.0.10",
+                "handlebars": "4.0.11",
                 "js-yaml": "3.10.0",
                 "mkdirp": "0.5.1",
                 "nopt": "3.0.6",
@@ -3042,7 +3069,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
             }
         },
         "labeled-stream-splicer": {
@@ -3454,7 +3481,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.31"
+                "es5-ext": "0.10.37"
             }
         },
         "make-error": {
@@ -3504,7 +3531,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.31",
+                "es5-ext": "0.10.37",
                 "es6-weak-map": "2.0.2",
                 "event-emitter": "0.3.5",
                 "is-promise": "2.1.0",
@@ -3672,7 +3699,7 @@
                 "cached-path-relative": "1.0.1",
                 "concat-stream": "1.5.2",
                 "defined": "1.0.0",
-                "detective": "4.5.0",
+                "detective": "4.7.0",
                 "duplexer2": "0.1.4",
                 "inherits": "2.0.3",
                 "JSONStream": "1.3.1",
@@ -3736,9 +3763,9 @@
             }
         },
         "natives": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-            "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+            "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
             "dev": true
         },
         "next-tick": {
@@ -3802,7 +3829,7 @@
             "dev": true,
             "requires": {
                 "array-each": "1.0.1",
-                "array-slice": "1.0.0",
+                "array-slice": "1.1.0",
                 "for-own": "1.0.0",
                 "isobject": "3.0.1"
             },
@@ -3915,6 +3942,12 @@
             "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
             "dev": true
         },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -3925,6 +3958,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+            "dev": true
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
             "dev": true
         },
         "parents": {
@@ -3942,8 +3981,8 @@
             "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
             "dev": true,
             "requires": {
-                "asn1.js": "4.9.1",
-                "browserify-aes": "1.0.8",
+                "asn1.js": "4.9.2",
+                "browserify-aes": "1.1.1",
                 "create-hash": "1.1.3",
                 "evp_bytestokey": "1.0.3",
                 "pbkdf2": "3.0.14"
@@ -4204,7 +4243,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -4215,7 +4254,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -4226,6 +4265,16 @@
             "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
             "dev": true,
             "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+            "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+            "dev": true,
+            "requires": {
+                "randombytes": "2.0.5",
                 "safe-buffer": "5.1.1"
             }
         },
@@ -4515,12 +4564,20 @@
             }
         },
         "source-map-support": {
-            "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+            "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
             }
         },
         "source-map-url": {
@@ -4811,7 +4868,7 @@
             "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.31",
+                "es5-ext": "0.10.37",
                 "next-tick": "1.0.0"
             }
         },
@@ -4843,19 +4900,27 @@
             "dev": true
         },
         "ts-node": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
-            "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.0.1.tgz",
+            "integrity": "sha512-F9AHAfL7QO+W8QPnEY4dzjCV2RPDK76mzYkQVB/7BuGOJWFxJgGezdyvCdtfVtE1QOOen3DnJONsenzIqIKqYQ==",
             "dev": true,
             "requires": {
+                "@types/arrify": "1.0.2",
+                "@types/diff": "3.2.2",
+                "@types/minimist": "1.2.0",
+                "@types/mkdirp": "0.5.2",
+                "@types/node": "8.0.58",
+                "@types/source-map-support": "0.4.0",
+                "@types/v8flags": "github:types/npm-v8flags#de224ae1cd5fd7dbb4e7158a6cc7a29e5315930d",
+                "@types/yn": "github:types/npm-yn#ca75f6c82940fae6a06fb41d2d37a6aa9b4ea8e9",
                 "arrify": "1.0.1",
-                "chalk": "2.2.0",
+                "chalk": "2.3.0",
                 "diff": "3.3.1",
                 "make-error": "1.3.0",
                 "minimist": "1.2.0",
                 "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18",
-                "tsconfig": "6.0.0",
+                "source-map-support": "0.5.0",
+                "tsconfig": "7.0.0",
                 "v8flags": "3.0.1",
                 "yn": "2.0.0"
             },
@@ -4866,13 +4931,13 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-                    "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.0",
@@ -4907,11 +4972,13 @@
             }
         },
         "tsconfig": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
-            "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+            "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
             "dev": true,
             "requires": {
+                "@types/strip-bom": "3.0.0",
+                "@types/strip-json-comments": "0.0.30",
                 "strip-bom": "3.0.0",
                 "strip-json-comments": "2.0.1"
             },
@@ -4925,9 +4992,9 @@
             }
         },
         "tslib": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-            "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+            "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
             "dev": true
         },
         "tslint": {
@@ -4938,15 +5005,15 @@
             "requires": {
                 "babel-code-frame": "6.26.0",
                 "builtin-modules": "1.1.1",
-                "chalk": "2.2.0",
+                "chalk": "2.3.0",
                 "commander": "2.11.0",
                 "diff": "3.3.1",
                 "glob": "7.1.2",
                 "minimatch": "3.0.4",
-                "resolve": "1.4.0",
+                "resolve": "1.5.0",
                 "semver": "5.4.1",
-                "tslib": "1.8.0",
-                "tsutils": "2.12.1"
+                "tslib": "1.8.1",
+                "tsutils": "2.13.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -4955,13 +5022,13 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-                    "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.0",
@@ -4976,9 +5043,9 @@
                     "dev": true
                 },
                 "resolve": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-                    "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+                    "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
                     "dev": true,
                     "requires": {
                         "path-parse": "1.0.5"
@@ -5002,12 +5069,12 @@
             }
         },
         "tsutils": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz",
-            "integrity": "sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.0.tgz",
+            "integrity": "sha512-FuWzNJbMsp3gcZMbI3b5DomhW4Ia41vMxjN63nKWI0t7f+I3UmHfRl0TrXJTwI2LUduDG+eR1Mksp3pvtlyCFQ==",
             "dev": true,
             "requires": {
-                "tslib": "1.8.0"
+                "tslib": "1.8.1"
             }
         },
         "tty-browserify": {
@@ -5026,9 +5093,9 @@
             }
         },
         "type-detect": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-            "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+            "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
             "dev": true
         },
         "typedarray": {
@@ -5038,9 +5105,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.7.0-dev.20171020",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171020.tgz",
-            "integrity": "sha512-Sy1F2YVw7nj2pcMP2bE6YK5dviaY2WRJb12t27EUiW4wkD8GiaZ0sgNBdTKRcvTNFJ8KXjwnl+Ysi5+J5BlcHw==",
+            "version": "2.7.0-dev.20171212",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171212.tgz",
+            "integrity": "sha512-D9eP7T4QjfsoFNi35iOYTgLgwQE+OrVkWFQ2p+MbgKd0W2Qupqe6COyyQPoUeXvOrB5rbaIkeomh+VFMOPjtKg==",
             "dev": true
         },
         "uglify-js": {
@@ -5165,14 +5232,37 @@
             }
         },
         "vinyl": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+            "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
             "dev": true,
             "requires": {
-                "clone": "1.0.2",
-                "clone-stats": "0.0.1",
-                "replace-ext": "0.0.1"
+                "clone": "2.1.1",
+                "clone-buffer": "1.0.0",
+                "clone-stats": "1.0.0",
+                "cloneable-readable": "1.0.0",
+                "remove-trailing-separator": "1.1.0",
+                "replace-ext": "1.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                }
             }
         },
         "vinyl-fs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
             "dev": true,
             "requires": {
-                "acorn": "5.2.1",
+                "acorn": "5.1.2",
                 "css": "2.2.1",
                 "normalize-path": "2.1.1",
                 "source-map": "0.5.7",
@@ -18,9 +18,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-                    "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+                    "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
                     "dev": true
                 }
             }
@@ -42,13 +42,13 @@
             "dev": true,
             "requires": {
                 "@types/insert-module-globals": "7.0.0",
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/chai": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.7.tgz",
-            "integrity": "sha512-OsFOcyJH0SViMMHzDKZdapG8sfoH7qcpYgKhgyw9xn5MgkCvAplkf0FUaRFB+HTrVH6gQ/GU7sbIUDM1usVEUA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.4.tgz",
+            "integrity": "sha512-cvU0HomQ7/aGDQJZsbtJXqBQ7w4J4TqLB0Z/h8mKrpRjfeZEvTbygkfJEb7fWdmwpIeDeFmIVwAEqS0OYuUv3Q==",
             "dev": true
         },
         "@types/colors": {
@@ -58,9 +58,9 @@
             "dev": true
         },
         "@types/convert-source-map": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "integrity": "sha512-laiDIXqqthjJlyAMYAXOtN3N8+UlbM+KvZi4BaY5ZOekmVkBs/UxfK5O0HWeJVG2eW8F+Mu2ww13fTX+kY1FlQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-1.5.0.tgz",
+            "integrity": "sha512-4OHKJEw70U59CN24TLRxU3W+B/9GPp0P6g+eNIsObZLAIqw6NTEBorkjIpei4xsvUCx+YzFwUtt4MBZbfSLvbQ==",
             "dev": true
         },
         "@types/del": {
@@ -72,12 +72,6 @@
                 "@types/glob": "5.0.33"
             }
         },
-        "@types/events": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-            "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
-            "dev": true
-        },
         "@types/glob": {
             "version": "5.0.33",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
@@ -85,56 +79,56 @@
             "dev": true,
             "requires": {
                 "@types/minimatch": "3.0.1",
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/gulp": {
-            "version": "3.8.35",
-            "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-3.8.35.tgz",
-            "integrity": "sha512-h9clNJu8X6+zW74ZLa5zhh5HP0LxnvlelVXdXby6pM/DDEj/gKqmmFXKwjzvupZKlMpof02jr6c3JokPbHXQgg==",
+            "version": "3.8.33",
+            "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-3.8.33.tgz",
+            "integrity": "sha512-3UpA2pkKO40cNPe/8bxMQFWSASR9Jx67JfN9Z2Cf6ogfDMwXgEHm2XjKmuLYEtrp1IHYApOWlYMLYNgtTJgSAw==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54",
-                "@types/orchestrator": "0.3.2",
+                "@types/node": "8.0.46",
+                "@types/orchestrator": "0.3.0",
                 "@types/vinyl": "2.0.1"
             }
         },
         "@types/gulp-concat": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/gulp-concat/-/gulp-concat-0.0.32.tgz",
-            "integrity": "sha512-CUCFADlITzzBfBa2bdGzhKtvBr4eFh+evb+4igVbvPoO5RyPfHifmyQlZl6lM7q19+OKncRlFXDU7B4X9Ayo2g==",
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/@types/gulp-concat/-/gulp-concat-0.0.31.tgz",
+            "integrity": "sha512-F14zRcKn15HC59RXRlHpcxj79WoLjkJBJBPfN0NBZOgkRCfDZYVu8rs0Y/CH4CJGUbbc/nHczD2LmepDS+ARaA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/gulp-help": {
-            "version": "0.0.34",
-            "resolved": "https://registry.npmjs.org/@types/gulp-help/-/gulp-help-0.0.34.tgz",
-            "integrity": "sha512-MkW7psZznxxJg2MBk2P2qHE+T8jEZVFz3FG/qGjUYazkyJt7hBJWx5Nuewmay5RVNtUvSWPrdZLr/WTXY3T/6A==",
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/gulp-help/-/gulp-help-0.0.33.tgz",
+            "integrity": "sha1-ZejGUSQQkiVTf6OQA8S6UfT9GsU=",
             "dev": true,
             "requires": {
-                "@types/gulp": "3.8.35",
-                "@types/node": "8.0.54",
-                "@types/orchestrator": "0.3.2"
+                "@types/gulp": "3.8.33",
+                "@types/node": "8.0.46",
+                "@types/orchestrator": "0.3.0"
             }
         },
         "@types/gulp-newer": {
-            "version": "0.0.31",
-            "resolved": "https://registry.npmjs.org/@types/gulp-newer/-/gulp-newer-0.0.31.tgz",
-            "integrity": "sha512-e7J/Zv5Wd7CC0WpuA2syWVitgwrkG0u221e41w7r07XUR6hMH6kHPkq9tUrusHkbeW8QbuLbis5fODOwQCyggQ==",
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/gulp-newer/-/gulp-newer-0.0.30.tgz",
+            "integrity": "sha1-bqn7oVsFdr5CTpl31IlCAEZKFR4=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/gulp-sourcemaps": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/gulp-sourcemaps/-/gulp-sourcemaps-0.0.32.tgz",
-            "integrity": "sha512-+7BAmptW2bxyJnJcCEuie7vLoop3FwWgCdBMzyv7MYXED/HeNMeQuX7uPCkp4vfU1TTu4CYFH0IckNPvo0VePA==",
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/@types/gulp-sourcemaps/-/gulp-sourcemaps-0.0.31.tgz",
+            "integrity": "sha512-kJD1byVNx+sdQlaBzZpSGeFH/4l99TXTY4XSGW+aRk27eOnVyk6VknXJpsb1Jk5E4ThKxZ8GYy6ais7MtprK1w==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/insert-module-globals": {
@@ -143,16 +137,16 @@
             "integrity": "sha512-zudCJPwluh1VUDB6Gl/OQdRp+fYy3+47huJB/JMQubMS2p+sH18MCVK4WUz3FqaWLB12yh5ELxVR/+tqwlm/qA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/merge2": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@types/merge2/-/merge2-1.1.4.tgz",
-            "integrity": "sha512-GjaXY4OultxbaOOk7lCLO7xvEcFpdjExC605YmfI6X29vhHKpJfMWKCDZd3x+BITrZaXKg97DgV/SdGVSwdzxA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@types/merge2/-/merge2-1.1.2.tgz",
+            "integrity": "sha512-Xy54xPmFQ8oAx0S3ku46i/zXE4dvfxl5M8n4p2M62IwxPau8IpobiRtL4jkrUzX6Kgeyb34BHOh0i70SDjKHeA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/minimatch": {
@@ -168,53 +162,58 @@
             "dev": true
         },
         "@types/mkdirp": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
-            "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha512-XA4vNO6GCBz8Smq0hqSRo4yRWMqr4FPQrWjhJt6nKskzly4/p87SfuJMFYGRyYb6jo2WNIQU2FDBsY5r1BibUA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/mocha": {
-            "version": "2.2.44",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
-            "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
+            "version": "2.2.43",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz",
+            "integrity": "sha512-xNlAmH+lRJdUMXClMTI9Y0pRqIojdxfm7DHsIxoB2iTzu3fnPmSMEN8SsSx0cdwV36d02PWCWaDUoZPDSln+xw==",
             "dev": true
         },
         "@types/node": {
-            "version": "8.0.54",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.54.tgz",
-            "integrity": "sha512-qetMdTv3Ytz9u9ESLdcYs45LPI0mczYZIbC184n7kY0jczOqPNQsabBfVCh+na3B2shAfvC459JqHV771A8Rxg==",
-            "dev": true,
-            "requires": {
-                "@types/events": "1.1.0"
-            }
+            "version": "8.0.46",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.46.tgz",
+            "integrity": "sha512-rRkP4kb5JYIfAoRKaDbcdPZBcTNOgzSApyzhPN9e6rhViSJAWQGlSXIX5gc75iR02jikhpzy3usu31wMHllfFw==",
+            "dev": true
         },
         "@types/orchestrator": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@types/orchestrator/-/orchestrator-0.3.2.tgz",
-            "integrity": "sha512-cKB4yTX0wGaRCSkdHDX2fkGQbMAA8UOshC2U7DQky1CE5o+5q2iQQ8VkbPbE/88uaTtsusvBPMcCX7dgmjxBhQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@types/orchestrator/-/orchestrator-0.3.0.tgz",
+            "integrity": "sha1-v4ShaZyTMNT+ic2BJj6PwJ+zKXg=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54",
-                "@types/q": "1.0.6"
+                "@types/node": "8.0.46",
+                "@types/q": "0.0.37"
+            },
+            "dependencies": {
+                "@types/q": {
+                    "version": "0.0.37",
+                    "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.37.tgz",
+                    "integrity": "sha512-vjFGX1zMTMz/kUp3xgfJcxMVLkMWVMrdlyc0RwVyve1y9jxwqNaT8wTcv6M51ylq2a/zn5lm8g7qPSoIS4uvZQ==",
+                    "dev": true
+                }
             }
         },
         "@types/q": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.6.tgz",
-            "integrity": "sha512-LSx7jkcXoXWB+kkfwG5zc9Okbgn51BrjLMtKwbmnqfQlCGttTnTxvDVwQanHxkK6CLKb9yEfxQ1ID6pqDpeURw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.5.tgz",
+            "integrity": "sha512-sudQPADzmQjXYS1fS2TxbWA/N/vbbfaO4Y7luPaAEyRWZVXC8jHwKV8KgNDbT7IHQaONNZWy9BYsodxY7IyDXQ==",
             "dev": true
         },
         "@types/run-sequence": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/run-sequence/-/run-sequence-0.0.30.tgz",
-            "integrity": "sha512-XwGr1b4yCGUILKeBkzmeWcxmGHQ0vFFFpA6D6y1yLO6gKmYorF+PHqdU5KG+nWt38OvtrkDptmrSmlHX/XtpLw==",
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/run-sequence/-/run-sequence-0.0.29.tgz",
+            "integrity": "sha1-atD3ODE24TklMi5p/EHbd7MLIHU=",
             "dev": true,
             "requires": {
-                "@types/gulp": "3.8.35",
-                "@types/node": "8.0.54"
+                "@types/gulp": "3.8.33",
+                "@types/node": "8.0.46"
             }
         },
         "@types/through2": {
@@ -223,7 +222,7 @@
             "integrity": "sha1-H/LoihAN+1sUDnu5h5HxGUQA0TE=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/vinyl": {
@@ -232,26 +231,16 @@
             "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.0.46"
             }
         },
         "@types/xml2js": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
-            "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.0.tgz",
+            "integrity": "sha512-3gw0UqFMq7PsfMDwsawD0/L48soXfzOEh0NSAWVO99IZXnhx9LD3nOldHIpGYzZBsrS9NV2vaRFvEdWe+UweXQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
-            }
-        },
-        "JSONStream": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-            "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-            "dev": true,
-            "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
+                "@types/node": "8.0.46"
             }
         },
         "abbrev": {
@@ -362,9 +351,9 @@
             "dev": true
         },
         "array-slice": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+            "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8=",
             "dev": true
         },
         "array-union": {
@@ -395,9 +384,9 @@
             "dev": true
         },
         "asn1.js": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-            "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+            "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
             "dev": true,
             "requires": {
                 "bn.js": "4.11.8",
@@ -509,9 +498,9 @@
             "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
                 "combine-source-map": "0.7.2",
                 "defined": "1.0.0",
+                "JSONStream": "1.3.1",
                 "through2": "2.0.3",
                 "umd": "3.0.1"
             }
@@ -537,7 +526,6 @@
             "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
                 "assert": "1.4.1",
                 "browser-pack": "6.0.2",
                 "browser-resolve": "1.11.2",
@@ -547,7 +535,7 @@
                 "concat-stream": "1.5.2",
                 "console-browserify": "1.1.0",
                 "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
+                "crypto-browserify": "3.11.1",
                 "defined": "1.0.0",
                 "deps-sort": "2.0.0",
                 "domain-browser": "1.1.7",
@@ -559,6 +547,7 @@
                 "https-browserify": "1.0.0",
                 "inherits": "2.0.3",
                 "insert-module-globals": "7.0.1",
+                "JSONStream": "1.3.1",
                 "labeled-stream-splicer": "2.0.0",
                 "module-deps": "4.1.1",
                 "os-browserify": "0.3.0",
@@ -584,12 +573,35 @@
                 "util": "0.10.3",
                 "vm-browserify": "0.0.4",
                 "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "browserify-zlib": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+                    "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+                    "dev": true,
+                    "requires": {
+                        "pako": "1.0.6"
+                    }
+                },
+                "os-browserify": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+                    "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+                    "dev": true
+                },
+                "pako": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+                    "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+                    "dev": true
+                }
             }
         },
         "browserify-aes": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-            "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
+            "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
             "dev": true,
             "requires": {
                 "buffer-xor": "1.0.3",
@@ -606,7 +618,7 @@
             "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.1.1",
+                "browserify-aes": "1.0.8",
                 "browserify-des": "1.0.0",
                 "evp_bytestokey": "1.0.3"
             }
@@ -645,15 +657,6 @@
                 "elliptic": "6.4.0",
                 "inherits": "2.0.3",
                 "parse-asn1": "5.1.0"
-            }
-        },
-        "browserify-zlib": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-            "dev": true,
-            "requires": {
-                "pako": "1.0.6"
             }
         },
         "buffer": {
@@ -734,7 +737,7 @@
                 "deep-eql": "3.0.1",
                 "get-func-name": "2.0.0",
                 "pathval": "1.1.0",
-                "type-detect": "4.0.5"
+                "type-detect": "4.0.3"
             }
         },
         "chalk": {
@@ -788,9 +791,9 @@
             }
         },
         "clone": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
             "dev": true
         },
         "clone-buffer": {
@@ -817,9 +820,9 @@
             }
         },
         "color-convert": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+            "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
             "dev": true,
             "requires": {
                 "color-name": "1.1.3"
@@ -927,9 +930,9 @@
             "dev": true
         },
         "convert-source-map": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+            "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
             "dev": true
         },
         "core-util-is": {
@@ -975,9 +978,9 @@
             }
         },
         "crypto-browserify": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+            "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
             "dev": true,
             "requires": {
                 "browserify-cipher": "1.0.0",
@@ -989,8 +992,7 @@
                 "inherits": "2.0.3",
                 "pbkdf2": "3.0.14",
                 "public-encrypt": "4.0.0",
-                "randombytes": "2.0.5",
-                "randomfill": "1.0.3"
+                "randombytes": "2.0.5"
             }
         },
         "css": {
@@ -1031,7 +1033,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.37"
+                "es5-ext": "0.10.31"
             }
         },
         "date-now": {
@@ -1078,7 +1080,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "4.0.5"
+                "type-detect": "4.0.3"
             }
         },
         "deep-is": {
@@ -1093,7 +1095,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.3"
+                "clone": "1.0.2"
             }
         },
         "defined": {
@@ -1160,21 +1162,13 @@
             "dev": true
         },
         "detective": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.0.tgz",
-            "integrity": "sha512-4mBqSEdMfBpRAo/DQZnTcAXenpiSIJmVKbCMSotS+SFWWcrP/CKM6iBRPdTiEO+wZhlfEsoZlGqpG6ycl5vTqw==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+            "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
             "dev": true,
             "requires": {
-                "acorn": "5.2.1",
+                "acorn": "4.0.13",
                 "defined": "1.0.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-                    "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
-                    "dev": true
-                }
             }
         },
         "diff": {
@@ -1277,23 +1271,23 @@
             }
         },
         "es5-ext": {
-            "version": "0.10.37",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
-            "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.31.tgz",
+            "integrity": "sha1-e7k4yVp/G59ygJLcCcQe3MOY7v4=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
+                "es6-iterator": "2.0.1",
                 "es6-symbol": "3.1.1"
             }
         },
         "es6-iterator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+            "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.37",
+                "es5-ext": "0.10.31",
                 "es6-symbol": "3.1.1"
             }
         },
@@ -1310,7 +1304,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.37"
+                "es5-ext": "0.10.31"
             }
         },
         "es6-weak-map": {
@@ -1320,8 +1314,8 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.37",
-                "es6-iterator": "2.0.3",
+                "es5-ext": "0.10.31",
+                "es6-iterator": "2.0.1",
                 "es6-symbol": "3.1.1"
             }
         },
@@ -1381,7 +1375,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.37"
+                "es5-ext": "0.10.31"
             }
         },
         "events": {
@@ -1761,7 +1755,7 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
+                "ini": "1.3.4",
                 "is-windows": "0.2.0",
                 "which": "1.3.0"
             }
@@ -1867,7 +1861,7 @@
                 "chalk": "1.1.3",
                 "deprecated": "0.0.1",
                 "gulp-util": "3.0.8",
-                "interpret": "1.1.0",
+                "interpret": "1.0.4",
                 "liftoff": "2.3.0",
                 "minimist": "1.2.0",
                 "orchestrator": "0.3.8",
@@ -2105,6 +2099,40 @@
                 "concat-with-sourcemaps": "1.0.4",
                 "through2": "2.0.3",
                 "vinyl": "2.1.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.0.0",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
+                    }
+                }
             }
         },
         "gulp-help": {
@@ -2181,7 +2209,7 @@
                 "@gulp-sourcemaps/identity-map": "1.0.1",
                 "@gulp-sourcemaps/map-sources": "1.0.0",
                 "acorn": "4.0.13",
-                "convert-source-map": "1.5.1",
+                "convert-source-map": "1.5.0",
                 "css": "2.2.1",
                 "debug-fabulous": "0.2.1",
                 "detect-newline": "2.1.0",
@@ -2204,7 +2232,7 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
+                        "clone": "1.0.2",
                         "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
@@ -2212,9 +2240,9 @@
             }
         },
         "gulp-typescript": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.3.tgz",
-            "integrity": "sha512-Np2sJXgtDUwIAoMtlJ9uXsVmpu1FWXlKZw164hLuo56uJa7qo5W2KZ0yAYiYH/HUsaz5L0O2toMOcLIokpFCPg==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.2.tgz",
+            "integrity": "sha1-t+Xh08s193LlPmBAJmAYJuK+d/w=",
             "dev": true,
             "requires": {
                 "gulp-util": "3.0.8",
@@ -2298,7 +2326,7 @@
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "dev": true,
                     "requires": {
-                        "convert-source-map": "1.5.1",
+                        "convert-source-map": "1.5.0",
                         "graceful-fs": "4.1.11",
                         "strip-bom": "2.0.0",
                         "through2": "2.0.3",
@@ -2376,7 +2404,7 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
+                        "clone": "1.0.2",
                         "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
@@ -2439,17 +2467,6 @@
                     "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                     "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
                     "dev": true
-                },
-                "vinyl": {
-                    "version": "0.5.3",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
                 }
             }
         },
@@ -2463,9 +2480,9 @@
             }
         },
         "handlebars": {
-            "version": "4.0.11",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-            "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+            "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
             "dev": true,
             "requires": {
                 "async": "1.5.2",
@@ -2625,9 +2642,9 @@
             "dev": true
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+            "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
             "dev": true
         },
         "inline-source-map": {
@@ -2645,10 +2662,10 @@
             "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
                 "combine-source-map": "0.7.2",
                 "concat-stream": "1.5.2",
-                "is-buffer": "1.1.6",
+                "is-buffer": "1.1.5",
+                "JSONStream": "1.3.1",
                 "lexical-scope": "1.2.0",
                 "process": "0.11.10",
                 "through2": "2.0.3",
@@ -2656,9 +2673,9 @@
             }
         },
         "interpret": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+            "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
             "dev": true
         },
         "is-absolute": {
@@ -2678,9 +2695,9 @@
             "dev": true
         },
         "is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
             "dev": true
         },
         "is-builtin-module": {
@@ -2758,13 +2775,13 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "1.0.0"
             }
         },
         "is-path-inside": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+            "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
             "dev": true,
             "requires": {
                 "path-is-inside": "1.0.2"
@@ -2879,7 +2896,7 @@
                 "escodegen": "1.8.1",
                 "esprima": "2.7.3",
                 "glob": "5.0.15",
-                "handlebars": "4.0.11",
+                "handlebars": "4.0.10",
                 "js-yaml": "3.10.0",
                 "mkdirp": "0.5.1",
                 "nopt": "3.0.6",
@@ -3003,6 +3020,16 @@
             "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
             "dev": true
         },
+        "JSONStream": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+            "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+            "dev": true,
+            "requires": {
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
+            }
+        },
         "kew": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
@@ -3015,7 +3042,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "1.1.5"
             }
         },
         "labeled-stream-splicer": {
@@ -3427,7 +3454,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.37"
+                "es5-ext": "0.10.31"
             }
         },
         "make-error": {
@@ -3477,7 +3504,7 @@
             "dev": true,
             "requires": {
                 "d": "1.0.0",
-                "es5-ext": "0.10.37",
+                "es5-ext": "0.10.31",
                 "es6-weak-map": "2.0.2",
                 "event-emitter": "0.3.5",
                 "is-promise": "2.1.0",
@@ -3641,14 +3668,14 @@
             "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
                 "browser-resolve": "1.11.2",
                 "cached-path-relative": "1.0.1",
                 "concat-stream": "1.5.2",
                 "defined": "1.0.0",
-                "detective": "4.7.0",
+                "detective": "4.5.0",
                 "duplexer2": "0.1.4",
                 "inherits": "2.0.3",
+                "JSONStream": "1.3.1",
                 "parents": "1.0.1",
                 "readable-stream": "2.3.3",
                 "resolve": "1.1.7",
@@ -3775,7 +3802,7 @@
             "dev": true,
             "requires": {
                 "array-each": "1.0.1",
-                "array-slice": "1.1.0",
+                "array-slice": "1.0.0",
                 "for-own": "1.0.0",
                 "isobject": "3.0.1"
             },
@@ -3888,12 +3915,6 @@
             "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
             "dev": true
         },
-        "os-browserify": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-            "dev": true
-        },
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -3904,12 +3925,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-            "dev": true
-        },
-        "pako": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
             "dev": true
         },
         "parents": {
@@ -3927,8 +3942,8 @@
             "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
             "dev": true,
             "requires": {
-                "asn1.js": "4.9.2",
-                "browserify-aes": "1.1.1",
+                "asn1.js": "4.9.1",
+                "browserify-aes": "1.0.8",
                 "create-hash": "1.1.3",
                 "evp_bytestokey": "1.0.3",
                 "pbkdf2": "3.0.14"
@@ -4189,7 +4204,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "1.1.5"
                             }
                         }
                     }
@@ -4200,7 +4215,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "1.1.5"
                     }
                 }
             }
@@ -4211,16 +4226,6 @@
             "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
-        "randomfill": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-            "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
-            "dev": true,
-            "requires": {
-                "randombytes": "2.0.5",
                 "safe-buffer": "5.1.1"
             }
         },
@@ -4510,20 +4515,12 @@
             }
         },
         "source-map-support": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-            "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
+                "source-map": "0.5.7"
             }
         },
         "source-map-url": {
@@ -4814,7 +4811,7 @@
             "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.37",
+                "es5-ext": "0.10.31",
                 "next-tick": "1.0.0"
             }
         },
@@ -4852,7 +4849,7 @@
             "dev": true,
             "requires": {
                 "arrify": "1.0.1",
-                "chalk": "2.3.0",
+                "chalk": "2.2.0",
                 "diff": "3.3.1",
                 "make-error": "1.3.0",
                 "minimist": "1.2.0",
@@ -4869,13 +4866,13 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "1.9.0"
                     }
                 },
                 "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
+                    "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.0",
@@ -4888,15 +4885,6 @@
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
                     "dev": true
-                },
-                "source-map-support": {
-                    "version": "0.4.18",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-                    "dev": true,
-                    "requires": {
-                        "source-map": "0.5.7"
-                    }
                 },
                 "supports-color": {
                     "version": "4.5.0",
@@ -4950,15 +4938,15 @@
             "requires": {
                 "babel-code-frame": "6.26.0",
                 "builtin-modules": "1.1.1",
-                "chalk": "2.3.0",
+                "chalk": "2.2.0",
                 "commander": "2.11.0",
                 "diff": "3.3.1",
                 "glob": "7.1.2",
                 "minimatch": "3.0.4",
-                "resolve": "1.5.0",
+                "resolve": "1.4.0",
                 "semver": "5.4.1",
                 "tslib": "1.8.0",
-                "tsutils": "2.13.0"
+                "tsutils": "2.12.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -4967,13 +4955,13 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "1.9.0"
                     }
                 },
                 "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
+                    "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.0",
@@ -4988,9 +4976,9 @@
                     "dev": true
                 },
                 "resolve": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-                    "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+                    "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
                     "dev": true,
                     "requires": {
                         "path-parse": "1.0.5"
@@ -5014,9 +5002,9 @@
             }
         },
         "tsutils": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.0.tgz",
-            "integrity": "sha512-FuWzNJbMsp3gcZMbI3b5DomhW4Ia41vMxjN63nKWI0t7f+I3UmHfRl0TrXJTwI2LUduDG+eR1Mksp3pvtlyCFQ==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz",
+            "integrity": "sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=",
             "dev": true,
             "requires": {
                 "tslib": "1.8.0"
@@ -5038,9 +5026,9 @@
             }
         },
         "type-detect": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-            "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+            "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
             "dev": true
         },
         "typedarray": {
@@ -5050,9 +5038,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.7.0-dev.20171203",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171203.tgz",
-            "integrity": "sha512-FyhV7OvieIXzjktOb9YmixEIR8olL8IrnonCmJQWGnj8Wt6eoQQKQlkXWPy8mpwEaSIXw/nQO0NpGQ+nWokhRw==",
+            "version": "2.7.0-dev.20171020",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171020.tgz",
+            "integrity": "sha512-Sy1F2YVw7nj2pcMP2bE6YK5dviaY2WRJb12t27EUiW4wkD8GiaZ0sgNBdTKRcvTNFJ8KXjwnl+Ysi5+J5BlcHw==",
             "dev": true
         },
         "uglify-js": {
@@ -5177,37 +5165,14 @@
             }
         },
         "vinyl": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-            "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "2.1.1",
-                "clone-buffer": "1.0.0",
-                "clone-stats": "1.0.0",
-                "cloneable-readable": "1.0.0",
-                "remove-trailing-separator": "1.1.0",
-                "replace-ext": "1.0.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-                    "dev": true
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-                    "dev": true
-                }
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
             }
         },
         "vinyl-fs": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     },
     "devDependencies": {
         "@types/browserify": "latest",
+        "@types/chai": "latest",
         "@types/colors": "latest",
         "@types/convert-source-map": "latest",
         "@types/del": "latest",
@@ -52,6 +53,7 @@
         "xml2js": "^0.4.19",
         "browser-resolve": "^1.11.2",
         "browserify": "latest",
+        "chai": "latest",
         "convert-source-map": "latest",
         "del": "latest",
         "gulp": "3.X",

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -297,7 +297,7 @@ namespace FourSlash {
                 const host = new Utils.MockParseConfigHost(baseDir, /*ignoreCase*/ false, this.inputFiles);
 
                 const configJsonObj = ts.parseConfigFileTextToJson(configFileName, this.inputFiles.get(configFileName));
-                assert(configJsonObj.config !== undefined);
+                assert.isTrue(configJsonObj.config !== undefined);
 
                 const { options, errors } = ts.parseJsonConfigFileContent(configJsonObj.config, host, baseDir);
 
@@ -443,7 +443,7 @@ namespace FourSlash {
 
         public goToEachMarker(action: () => void) {
             const markers = this.getMarkers();
-            assert(markers.length !== 0);
+            assert(markers.length);
             for (const marker of markers) {
                 this.goToMarker(marker);
                 action();
@@ -452,7 +452,7 @@ namespace FourSlash {
 
         public goToEachRange(action: () => void) {
             const ranges = this.getRanges();
-            assert(ranges.length !== 0);
+            assert(ranges.length);
             for (const range of ranges) {
                 this.goToRangeStart(range);
                 action();
@@ -799,7 +799,7 @@ namespace FourSlash {
             }
 
             const entries = this.getCompletionListAtCaret().entries;
-            assert(items.length <= entries.length, `Amount of expected items in completion list [ ${items.length} ] is greater than actual number of items in list [ ${entries.length} ]`);
+            assert.isTrue(items.length <= entries.length, `Amount of expected items in completion list [ ${items.length} ] is greater than actual number of items in list [ ${entries.length} ]`);
             ts.zipWith(entries, items, (entry, item) => {
                 assert.equal(entry.name, item, `Unexpected item in completion list`);
             });
@@ -953,7 +953,7 @@ namespace FourSlash {
         public verifyCompletionEntryDetails(entryName: string, expectedText: string, expectedDocumentation?: string, kind?: string, tags?: ts.JSDocTagInfo[]) {
             const details = this.getCompletionEntryDetails(entryName);
 
-            assert.isDefined(details, "no completion entry available");
+            assert(details, "no completion entry available");
 
             assert.equal(ts.displayPartsToString(details.displayParts), expectedText, this.assertionMessageAtLastKnownMarker("completion entry details text"));
 
@@ -1088,7 +1088,7 @@ namespace FourSlash {
 
         public verifyRangesReferenceEachOther(ranges?: Range[]) {
             ranges = ranges || this.getRanges();
-            assert(ranges.length !== 0);
+            assert(ranges.length);
             for (const range of ranges) {
                 this.verifyReferencesOf(range, ranges);
             }
@@ -1374,6 +1374,7 @@ Actual: ${stringify(fullActual)}`);
 
         public verifyCurrentParameterIsVariable(isVariable: boolean) {
             const signature = this.getActiveSignatureHelpItem();
+            assert.isOk(signature);
             assert.equal(isVariable, signature.isVariadic);
         }
 
@@ -2024,7 +2025,7 @@ Actual: ${stringify(fullActual)}`);
             const implementations = this.languageService.getImplementationAtPosition(this.activeFile.fileName, this.currentCaretPosition);
 
             if (negative) {
-                assert(implementations && implementations.length > 0, "Expected at least one implementation but got 0");
+                assert.isTrue(implementations && implementations.length > 0, "Expected at least one implementation but got 0");
             }
             else {
                 assert.isUndefined(implementations, "Expected implementation list to be empty but implementations returned");
@@ -3128,7 +3129,7 @@ Actual: ${stringify(fullActual)}`);
 
             if (spanIndex !== undefined) {
                 const span = this.getTextSpanForRangeAtIndex(spanIndex);
-                assert(TestState.textSpansEqual(span, item.replacementSpan), this.assertionMessageAtLastKnownMarker(stringify(span) + " does not equal " + stringify(item.replacementSpan) + " replacement span for " + entryId));
+                assert.isTrue(TestState.textSpansEqual(span, item.replacementSpan), this.assertionMessageAtLastKnownMarker(stringify(span) + " does not equal " + stringify(item.replacementSpan) + " replacement span for " + entryId));
             }
 
             assert.equal(item.hasAction, hasAction);

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -23,60 +23,18 @@
 /// <reference path="virtualFileSystem.ts" />
 /// <reference types="node" />
 /// <reference types="mocha" />
+/// <reference types="chai" />
+
 
 // Block scoped definitions work poorly for global variables, temporarily enable var
 /* tslint:disable:no-var-keyword */
 
-function assert(expr: boolean, msg?: string | (() => string)): void {
-    if (!expr) {
-        throw new Error(typeof msg === "string" ? msg : msg());
-    }
-}
-namespace assert {
-    export function isFalse(expr: boolean, msg = "Expected value to be false."): void {
-        assert(!expr, msg);
-    }
-    export function equal<T>(a: T, b: T, msg?: string): void {
-        assert(a === b, msg || (() => `Expected to be equal:\nExpected:\n${JSON.stringify(a)}\nActual:\n${JSON.stringify(b)}`));
-    }
-    export function notEqual<T>(a: T, b: T, msg = "Expected values to not be equal."): void {
-        assert(a !== b, msg);
-    }
-    export function isDefined(x: {} | null | undefined, msg = "Expected value to be defined."): void {
-        assert(x !== undefined && x !== null, msg);
-    }
-    export function isUndefined(x: {} | null | undefined, msg = "Expected value to be undefined."): void {
-        assert(x === undefined, msg);
-    }
-    export function deepEqual<T>(a: T, b: T, msg?: string): void {
-        assert(isDeepEqual(a, b), msg || (() => `Expected values to be deeply equal:\nExpected:\n${JSON.stringify(a, undefined, 4)}\nActual:\n${JSON.stringify(b, undefined, 4)}`));
-    }
-    export function lengthOf(a: ReadonlyArray<{}>, length: number, msg = "Expected length to match."): void {
-        assert(a.length === length, msg);
-    }
-    export function throws(cb: () => void, msg = "Expected callback to throw"): void {
-        let threw = false;
-        try {
-            cb();
-        }
-        catch {
-            threw = true;
-        }
-        assert(threw, msg);
-    }
-
-    function isDeepEqual<T>(a: T, b: T): boolean {
-        if (a === b) {
-            return true;
-        }
-        if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
-            return false;
-        }
-        const aKeys = Object.keys(a).sort();
-        const bKeys = Object.keys(b).sort();
-        return aKeys.length === bKeys.length && aKeys.every((key, i) => bKeys[i] === key && isDeepEqual((a as any)[key], (b as any)[key]));
-    }
-}
+// this will work in the browser via browserify
+var _chai: typeof chai = require("chai");
+var assert: typeof _chai.assert = _chai.assert;
+// chai's builtin `assert.isFalse` is featureful but slow - we don't use those features,
+// so we'll just overwrite it as an alterative to migrating a bunch of code off of chai
+assert.isFalse = (expr, msg) => { if (expr as any as boolean !== false) throw new Error(msg); };
 declare var __dirname: string; // Node-specific
 var global: NodeJS.Global = <any>Function("return this").call(undefined);
 
@@ -389,8 +347,8 @@ namespace Utils {
             return;
         }
 
-        assert(!!array1, "array1");
-        assert(!!array2, "array2");
+        assert(array1, "array1");
+        assert(array2, "array2");
 
         assert.equal(array1.length, array2.length, "array1.length !== array2.length");
 
@@ -413,8 +371,8 @@ namespace Utils {
             return;
         }
 
-        assert(!!node1, "node1");
-        assert(!!node2, "node2");
+        assert(node1, "node1");
+        assert(node2, "node2");
         assert.equal(node1.pos, node2.pos, "node1.pos !== node2.pos");
         assert.equal(node1.end, node2.end, "node1.end !== node2.end");
         assert.equal(node1.kind, node2.kind, "node1.kind !== node2.kind");
@@ -444,8 +402,8 @@ namespace Utils {
             return;
         }
 
-        assert(!!array1, "array1");
-        assert(!!array2, "array2");
+        assert(array1, "array1");
+        assert(array2, "array2");
         assert.equal(array1.pos, array2.pos, "array1.pos !== array2.pos");
         assert.equal(array1.end, array2.end, "array1.end !== array2.end");
         assert.equal(array1.length, array2.length, "array1.length !== array2.length");
@@ -1301,7 +1259,7 @@ namespace Harness {
 
             function findResultCodeFile(fileName: string) {
                 const sourceFile = result.program.getSourceFile(fileName);
-                assert.isDefined(sourceFile, "Program has no source file with name '" + fileName + "'");
+                assert(sourceFile, "Program has no source file with name '" + fileName + "'");
                 // Is this file going to be emitted separately
                 let sourceFileName: string;
                 const outFile = options.outFile || options.out;
@@ -1984,7 +1942,7 @@ namespace Harness {
                 const data = testUnitData[i];
                 if (ts.getBaseFileName(data.name).toLowerCase() === "tsconfig.json") {
                     const configJson = ts.parseJsonText(data.name, data.content);
-                    assert(configJson.endOfFileToken !== undefined);
+                    assert.isTrue(configJson.endOfFileToken !== undefined);
                     let baseDir = ts.normalizePath(ts.getDirectoryPath(data.name));
                     if (rootDir) {
                         baseDir = ts.getNormalizedAbsolutePath(baseDir, rootDir);

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -176,7 +176,8 @@ namespace Harness.LanguageService {
          */
         public positionToLineAndCharacter(fileName: string, position: number): ts.LineAndCharacter {
             const script: ScriptInfo = this.getScriptInfo(fileName);
-            assert(!!script);
+            assert.isOk(script);
+
             return ts.computeLineAndCharacterOfPosition(script.getLineMap(), position);
         }
     }
@@ -378,7 +379,7 @@ namespace Harness.LanguageService {
                     classification: parseInt(result[i + 1])
                 };
 
-                assert(t.length > 0, "Result length should be greater than 0, got :" + t.length);
+                assert.isTrue(t.length > 0, "Result length should be greater than 0, got :" + t.length);
                 position += t.length;
             }
             const finalLexState = parseInt(result[result.length - 1]);

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -285,10 +285,10 @@ namespace Harness.SourceMapRecorder {
         }
 
         export function recordNewSourceFileSpan(sourceMapSpan: ts.SourceMapSpan, newSourceFileCode: string) {
-            assert(spansOnSingleLine.length === 0 || spansOnSingleLine[0].sourceMapSpan.emittedLine !== sourceMapSpan.emittedLine, "new file source map span should be on new line. We currently handle only that scenario");
+            assert.isTrue(spansOnSingleLine.length === 0 || spansOnSingleLine[0].sourceMapSpan.emittedLine !== sourceMapSpan.emittedLine, "new file source map span should be on new line. We currently handle only that scenario");
             recordSourceMapSpan(sourceMapSpan);
 
-            assert(spansOnSingleLine.length === 1);
+            assert.isTrue(spansOnSingleLine.length === 1);
             sourceMapRecorder.WriteLine("-------------------------------------------------------------------");
             sourceMapRecorder.WriteLine("emittedFile:" + jsFile.fileName);
             sourceMapRecorder.WriteLine("sourceFile:" + sourceMapSources[spansOnSingleLine[0].sourceMapSpan.sourceIndex]);
@@ -331,7 +331,7 @@ namespace Harness.SourceMapRecorder {
             function getMarkerId(markerIndex: number) {
                 let markerId = "";
                 if (spanMarkerContinues) {
-                    assert(markerIndex === 0);
+                    assert.isTrue(markerIndex === 0);
                     markerId = "1->";
                 }
                 else {

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -5,7 +5,7 @@
         "outFile": "../../built/local/run.js",
         "declaration": false,
         "types": [
-            "node", "mocha"
+            "node", "mocha", "chai"
         ],
         "lib": [
             "es6",

--- a/src/harness/unittests/commandLineParsing.ts
+++ b/src/harness/unittests/commandLineParsing.ts
@@ -12,7 +12,7 @@ namespace ts {
 
             const parsedErrors = parsed.errors;
             const expectedErrors = expectedParsedCommandLine.errors;
-            assert(parsedErrors.length === expectedErrors.length, `Expected error: ${JSON.stringify(expectedErrors)}. Actual error: ${JSON.stringify(parsedErrors)}.`);
+            assert.isTrue(parsedErrors.length === expectedErrors.length, `Expected error: ${JSON.stringify(expectedErrors)}. Actual error: ${JSON.stringify(parsedErrors)}.`);
             for (let i = 0; i < parsedErrors.length; i++) {
                 const parsedError = parsedErrors[i];
                 const expectedError = expectedErrors[i];
@@ -23,7 +23,7 @@ namespace ts {
 
             const parsedFileNames = parsed.fileNames;
             const expectedFileNames = expectedParsedCommandLine.fileNames;
-            assert(parsedFileNames.length === expectedFileNames.length, `Expected fileNames: [${JSON.stringify(expectedFileNames)}]. Actual fileNames: [${JSON.stringify(parsedFileNames)}].`);
+            assert.isTrue(parsedFileNames.length === expectedFileNames.length, `Expected fileNames: [${JSON.stringify(expectedFileNames)}]. Actual fileNames: [${JSON.stringify(parsedFileNames)}].`);
             for (let i = 0; i < parsedFileNames.length; i++) {
                 const parsedFileName = parsedFileNames[i];
                 const expectedFileName = expectedFileNames[i];

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -25,7 +25,7 @@ namespace ts.projectSystem {
 
                 const actualResultSingleProjectFileNameList = actualResultSingleProject.fileNames.sort();
                 const expectedResultSingleProjectFileNameList = map(expectedResultSingleProject.files, f => f.path).sort();
-                assert(
+                assert.isTrue(
                     arrayIsEqualTo(actualResultSingleProjectFileNameList, expectedResultSingleProjectFileNameList),
                     `For project ${actualResultSingleProject.projectFileName}, the actual result is ${actualResultSingleProjectFileNameList}, while expected ${expectedResultSingleProjectFileNameList}`);
             }
@@ -563,7 +563,7 @@ namespace ts.projectSystem {
             session.executeCommand(compileFileRequest);
 
             const expectedEmittedFileName = "/a/b/f1.js";
-            assert(host.fileExists(expectedEmittedFileName));
+            assert.isTrue(host.fileExists(expectedEmittedFileName));
             assert.equal(host.readFile(expectedEmittedFileName), `"use strict";\r\nexports.__esModule = true;\r\nfunction Foo() { return 10; }\r\nexports.Foo = Foo;\r\n`);
         });
 
@@ -600,11 +600,11 @@ namespace ts.projectSystem {
             session.executeCommand(emitRequest);
 
             const expectedOutFileName = "/a/b/dist.js";
-            assert(host.fileExists(expectedOutFileName));
+            assert.isTrue(host.fileExists(expectedOutFileName));
             const outFileContent = host.readFile(expectedOutFileName);
-            assert(outFileContent.indexOf(file1.content) !== -1);
-            assert(outFileContent.indexOf(file2.content) === -1);
-            assert(outFileContent.indexOf(file3.content) === -1);
+            assert.isTrue(outFileContent.indexOf(file1.content) !== -1);
+            assert.isTrue(outFileContent.indexOf(file2.content) === -1);
+            assert.isTrue(outFileContent.indexOf(file3.content) === -1);
         });
 
         it("should use project root as current directory so that compile on save results in correct file mapping", () => {
@@ -634,19 +634,19 @@ namespace ts.projectSystem {
 
             // Verify js file
             const expectedOutFileName = "/root/TypeScriptProject3/TypeScriptProject3/" + outFileName;
-            assert(host.fileExists(expectedOutFileName));
+            assert.isTrue(host.fileExists(expectedOutFileName));
             const outFileContent = host.readFile(expectedOutFileName);
             verifyContentHasString(outFileContent, file1.content);
             verifyContentHasString(outFileContent, `//# ${"sourceMappingURL"}=${outFileName}.map`); // Sometimes tools can sometimes see this line as a source mapping url comment, so we obfuscate it a little
 
             // Verify map file
             const expectedMapFileName = expectedOutFileName + ".map";
-            assert(host.fileExists(expectedMapFileName));
+            assert.isTrue(host.fileExists(expectedMapFileName));
             const mapFileContent = host.readFile(expectedMapFileName);
             verifyContentHasString(mapFileContent, `"sources":["${inputFileName}"]`);
 
             function verifyContentHasString(content: string, str: string) {
-                assert(stringContains(content, str), `Expected "${content}" to have "${str}"`);
+                assert.isTrue(stringContains(content, str), `Expected "${content}" to have "${str}"`);
             }
         });
     });

--- a/src/harness/unittests/configurationExtension.ts
+++ b/src/harness/unittests/configurationExtension.ts
@@ -113,7 +113,7 @@ namespace ts {
     const caseSensitiveHost = new Utils.MockParseConfigHost(caseSensitiveBasePath, /*useCaseSensitiveFileNames*/ true, testContents);
 
     function verifyDiagnostics(actual: Diagnostic[], expected: {code: number, category: DiagnosticCategory, messageText: string}[]) {
-        assert(expected.length === actual.length, `Expected error: ${JSON.stringify(expected)}. Actual error: ${JSON.stringify(actual)}.`);
+        assert.isTrue(expected.length === actual.length, `Expected error: ${JSON.stringify(expected)}. Actual error: ${JSON.stringify(actual)}.`);
         for (let i = 0; i < actual.length; i++) {
             const actualError = actual[i];
             const expectedError = expected[i];

--- a/src/harness/unittests/convertCompilerOptionsFromJson.ts
+++ b/src/harness/unittests/convertCompilerOptionsFromJson.ts
@@ -16,7 +16,7 @@ namespace ts {
             assert.equal(parsedCompilerOptions, expectedCompilerOptions);
 
             const expectedErrors = expectedResult.errors;
-            assert(expectedResult.errors.length === actualErrors.length, `Expected error: ${JSON.stringify(expectedResult.errors)}. Actual error: ${JSON.stringify(actualErrors)}.`);
+            assert.isTrue(expectedResult.errors.length === actualErrors.length, `Expected error: ${JSON.stringify(expectedResult.errors)}. Actual error: ${JSON.stringify(actualErrors)}.`);
             for (let i = 0; i < actualErrors.length; i++) {
                 const actualError = actualErrors[i];
                 const expectedError = expectedErrors[i];
@@ -42,15 +42,15 @@ namespace ts {
 
             const actualErrors = filter(actualParseErrors, error => error.code !== Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2.code);
             const expectedErrors = expectedResult.errors;
-            assert(expectedResult.errors.length === actualErrors.length, `Expected error: ${JSON.stringify(expectedResult.errors)}. Actual error: ${JSON.stringify(actualErrors)}.`);
+            assert.isTrue(expectedResult.errors.length === actualErrors.length, `Expected error: ${JSON.stringify(expectedResult.errors)}. Actual error: ${JSON.stringify(actualErrors)}.`);
             for (let i = 0; i < actualErrors.length; i++) {
                 const actualError = actualErrors[i];
                 const expectedError = expectedErrors[i];
                 assert.equal(actualError.code, expectedError.code, `Expected error-code: ${JSON.stringify(expectedError.code)}. Actual error-code: ${JSON.stringify(actualError.code)}.`);
                 assert.equal(actualError.category, expectedError.category, `Expected error-category: ${JSON.stringify(expectedError.category)}. Actual error-category: ${JSON.stringify(actualError.category)}.`);
-                assert.isDefined(actualError.file);
-                assert(actualError.start > 0);
-                assert(actualError.length > 0);
+                assert(actualError.file);
+                assert(actualError.start);
+                assert(actualError.length);
             }
         }
 

--- a/src/harness/unittests/convertTypeAcquisitionFromJson.ts
+++ b/src/harness/unittests/convertTypeAcquisitionFromJson.ts
@@ -17,16 +17,16 @@ namespace ts {
 
         function verifyErrors(actualErrors: Diagnostic[], expectedResult: ExpectedResult, hasLocation?: boolean) {
             const expectedErrors = expectedResult.errors;
-            assert(expectedResult.errors.length === actualErrors.length, `Expected error: ${JSON.stringify(expectedResult.errors)}. Actual error: ${JSON.stringify(actualErrors)}.`);
+            assert.isTrue(expectedResult.errors.length === actualErrors.length, `Expected error: ${JSON.stringify(expectedResult.errors)}. Actual error: ${JSON.stringify(actualErrors)}.`);
             for (let i = 0; i < actualErrors.length; i++) {
                 const actualError = actualErrors[i];
                 const expectedError = expectedErrors[i];
                 assert.equal(actualError.code, expectedError.code, `Expected error-code: ${JSON.stringify(expectedError.code)}. Actual error-code: ${JSON.stringify(actualError.code)}.`);
                 assert.equal(actualError.category, expectedError.category, `Expected error-category: ${JSON.stringify(expectedError.category)}. Actual error-category: ${JSON.stringify(actualError.category)}.`);
                 if (hasLocation) {
-                    assert.isDefined(actualError.file);
-                    assert(actualError.start > 0);
-                    assert(actualError.length > 0);
+                    assert(actualError.file);
+                    assert(actualError.start);
+                    assert(actualError.length);
                 }
             }
         }

--- a/src/harness/unittests/extractRanges.ts
+++ b/src/harness/unittests/extractRanges.ts
@@ -39,7 +39,7 @@ namespace ts {
             assert.equal(end, expectedRange.end, "incorrect end of range");
         }
         else {
-            assert(!result.targetRange, `expected range to extract to be undefined`);
+            assert.isTrue(!result.targetRange, `expected range to extract to be undefined`);
         }
     }
 

--- a/src/harness/unittests/hostNewLineSupport.ts
+++ b/src/harness/unittests/hostNewLineSupport.ts
@@ -47,7 +47,7 @@ namespace ts {
             assert(!result.emitSkipped, "emit was skipped");
             assert(result.outputFiles.length === 1, "a number of files other than 1 was output");
             assert(result.outputFiles[0].name === "input.js", `Expected output file name input.js, but got ${result.outputFiles[0].name}`);
-            assert.isDefined(result.outputFiles[0].text.match(options.newLine === NewLineKind.CarriageReturnLineFeed ? /\r\n/ : /[^\r]\n/), "expected to find appropriate newlines");
+            assert(result.outputFiles[0].text.match(options.newLine === NewLineKind.CarriageReturnLineFeed ? /\r\n/ : /[^\r]\n/), "expected to find appropriate newlines");
             assert(!result.outputFiles[0].text.match(options.newLine === NewLineKind.CarriageReturnLineFeed ? /[^\r]\n/ : /\r\n/), "expected not to find inappropriate newlines");
         }
 

--- a/src/harness/unittests/incrementalParser.ts
+++ b/src/harness/unittests/incrementalParser.ts
@@ -66,7 +66,7 @@ namespace ts {
         assertSameDiagnostics(newTree, incrementalNewTree);
 
         // There should be no reused nodes between two trees that are fully parsed.
-        assert(reusedElements(oldTree, newTree) === 0);
+        assert.isTrue(reusedElements(oldTree, newTree) === 0);
 
         assert.equal(newTree.fileName, incrementalNewTree.fileName, "newTree.fileName !== incrementalNewTree.fileName");
         assert.equal(newTree.text, incrementalNewTree.text, "newTree.text !== incrementalNewTree.text");

--- a/src/harness/unittests/jsDocParsing.ts
+++ b/src/harness/unittests/jsDocParsing.ts
@@ -7,7 +7,7 @@ namespace ts {
             function parsesCorrectly(name: string, content: string) {
                 it(name, () => {
                     const typeAndDiagnostics = ts.parseJSDocTypeExpressionForTests(content);
-                    assert(typeAndDiagnostics && typeAndDiagnostics.diagnostics.length === 0, "no errors issued");
+                    assert.isTrue(typeAndDiagnostics && typeAndDiagnostics.diagnostics.length === 0, "no errors issued");
 
                     Harness.Baseline.runBaseline("JSDocParsing/TypeExpressions.parsesCorrectly." + name + ".json",
                         () => Utils.sourceFileToJSON(typeAndDiagnostics.jsDocTypeExpression.type));
@@ -17,7 +17,7 @@ namespace ts {
             function parsesIncorrectly(name: string, content: string) {
                 it(name, () => {
                     const type = ts.parseJSDocTypeExpressionForTests(content);
-                    assert(!type || type.diagnostics.length > 0);
+                    assert.isTrue(!type || type.diagnostics.length > 0);
                 });
             }
 
@@ -106,7 +106,7 @@ namespace ts {
             function parsesIncorrectly(name: string, content: string) {
                 it(name, () => {
                     const type = parseIsolatedJSDocComment(content);
-                    assert(!type || type.diagnostics.length > 0);
+                    assert.isTrue(!type || type.diagnostics.length > 0);
                 });
             }
 

--- a/src/harness/unittests/languageService.ts
+++ b/src/harness/unittests/languageService.ts
@@ -42,7 +42,7 @@ export function Component(x: Config): any;`
                 },
             });
             const definitions = languageService.getDefinitionAtPosition("foo.ts", 160); // 160 is the latter `vueTemplateHtml` position
-            assert.isDefined(definitions);
+            expect(definitions).to.exist; // tslint:disable-line no-unused-expression
         });
     });
 }

--- a/src/harness/unittests/moduleResolution.ts
+++ b/src/harness/unittests/moduleResolution.ts
@@ -4,9 +4,9 @@ namespace ts {
     export function checkResolvedModule(expected: ResolvedModuleFull, actual: ResolvedModuleFull): boolean {
         if (!expected === !actual) {
             if (expected) {
-                assert(expected.resolvedFileName === actual.resolvedFileName, `'resolvedFileName': expected '${expected.resolvedFileName}' to be equal to '${actual.resolvedFileName}'`);
-                assert(expected.extension === actual.extension, `'ext': expected '${expected.extension}' to be equal to '${actual.extension}'`);
-                assert(expected.isExternalLibraryImport === actual.isExternalLibraryImport, `'isExternalLibraryImport': expected '${expected.isExternalLibraryImport}' to be equal to '${actual.isExternalLibraryImport}'`);
+                assert.isTrue(expected.resolvedFileName === actual.resolvedFileName, `'resolvedFileName': expected '${expected.resolvedFileName}' to be equal to '${actual.resolvedFileName}'`);
+                assert.isTrue(expected.extension === actual.extension, `'ext': expected '${expected.extension}' to be equal to '${actual.extension}'`);
+                assert.isTrue(expected.isExternalLibraryImport === actual.isExternalLibraryImport, `'isExternalLibraryImport': expected '${expected.isExternalLibraryImport}' to be equal to '${actual.isExternalLibraryImport}'`);
             }
             return true;
         }
@@ -14,7 +14,7 @@ namespace ts {
     }
 
     export function checkResolvedModuleWithFailedLookupLocations(actual: ResolvedModuleWithFailedLookupLocations, expectedResolvedModule: ResolvedModuleFull, expectedFailedLookupLocations: string[]): void {
-        assert(actual.resolvedModule !== undefined, "module should be resolved");
+        assert.isTrue(actual.resolvedModule !== undefined, "module should be resolved");
         checkResolvedModule(actual.resolvedModule, expectedResolvedModule);
         assert.deepEqual(actual.failedLookupLocations, expectedFailedLookupLocations);
     }
@@ -58,7 +58,7 @@ namespace ts {
                 realpath,
                 directoryExists: path => directories.has(path),
                 fileExists: path => {
-                    assert(directories.has(getDirectoryPath(path)), `'fileExists' '${path}' request in non-existing directory`);
+                    assert.isTrue(directories.has(getDirectoryPath(path)), `'fileExists' '${path}' request in non-existing directory`);
                     return map.has(path);
                 }
             };
@@ -351,7 +351,7 @@ namespace ts {
 
             // try to get file using a relative name
             for (const relativeFileName of relativeNamesToCheck) {
-                assert(program.getSourceFile(relativeFileName) !== undefined, `expected to get file by relative name, got undefined`);
+                assert.isTrue(program.getSourceFile(relativeFileName) !== undefined, `expected to get file by relative name, got undefined`);
             }
         }
 
@@ -1074,7 +1074,7 @@ import b = require("./moduleB");
             assert.equal(diagnostics1.length, 1, "expected one diagnostic");
 
             createProgram(names, {}, compilerHost, program1);
-            assert(program1.structureIsReused === StructureIsReused.Completely);
+            assert.isTrue(program1.structureIsReused === StructureIsReused.Completely);
             const diagnostics2 = program1.getFileProcessingDiagnostics().getDiagnostics();
             assert.equal(diagnostics2.length, 1, "expected one diagnostic");
             assert.equal(diagnostics1[0].messageText, diagnostics2[0].messageText, "expected one diagnostic");

--- a/src/harness/unittests/programMissingFiles.ts
+++ b/src/harness/unittests/programMissingFiles.ts
@@ -6,7 +6,7 @@ namespace ts {
         const map = arrayToSet(expected) as Map<boolean>;
         for (const missing of missingPaths) {
             const value = map.get(missing);
-            assert(value, `${missing} to be ${value === undefined ? "not present" : "present only once"}, in actual: ${missingPaths} expected: ${expected}`);
+            assert.isTrue(value, `${missing} to be ${value === undefined ? "not present" : "present only once"}, in actual: ${missingPaths} expected: ${expected}`);
             map.set(missing, false);
         }
         const notFound = arrayFrom(mapDefinedIterator(map.keys(), k => map.get(k) === true ? k : undefined));

--- a/src/harness/unittests/projectErrors.ts
+++ b/src/harness/unittests/projectErrors.ts
@@ -5,7 +5,7 @@
 namespace ts.projectSystem {
     describe("Project errors", () => {
         function checkProjectErrors(projectFiles: server.ProjectFilesWithTSDiagnostics, expectedErrors: ReadonlyArray<string>): void {
-            assert(projectFiles !== undefined, "missing project files");
+            assert.isTrue(projectFiles !== undefined, "missing project files");
             checkProjectErrorsWorker(projectFiles.projectErrors, expectedErrors);
         }
 
@@ -15,7 +15,7 @@ namespace ts.projectSystem {
                 for (let i = 0; i < errors.length; i++) {
                     const actualMessage = flattenDiagnosticMessageText(errors[i].messageText, "\n");
                     const expectedMessage = expectedErrors[i];
-                    assert(actualMessage.indexOf(expectedMessage) === 0, `error message does not match, expected ${actualMessage} to start with ${expectedMessage}`);
+                    assert.isTrue(actualMessage.indexOf(expectedMessage) === 0, `error message does not match, expected ${actualMessage} to start with ${expectedMessage}`);
                 }
             }
         }
@@ -24,7 +24,7 @@ namespace ts.projectSystem {
             assert.equal(errors ? errors.length : 0, expectedErrors.length, `expected ${expectedErrors.length} error in the list`);
             if (expectedErrors.length) {
                 zipWith(errors, expectedErrors, ({ message: actualMessage }, expectedMessage) => {
-                    assert(startsWith(actualMessage, actualMessage), `error message does not match, expected ${actualMessage} to start with ${expectedMessage}`);
+                    assert.isTrue(startsWith(actualMessage, actualMessage), `error message does not match, expected ${actualMessage} to start with ${expectedMessage}`);
                 });
             }
         }
@@ -137,13 +137,13 @@ namespace ts.projectSystem {
             {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
-                assert(configuredProject !== undefined, "should find configured project");
+                assert.isTrue(configuredProject !== undefined, "should find configured project");
                 checkProjectErrors(configuredProject, []);
                 const projectErrors = configuredProjectAt(projectService, 0).getAllProjectErrors();
                 checkProjectErrorsWorker(projectErrors, [
                     "'{' expected."
                 ]);
-                assert.isDefined(projectErrors[0].file);
+                assert.isNotNull(projectErrors[0].file);
                 assert.equal(projectErrors[0].file.fileName, corruptedConfig.path);
             }
             // fix config and trigger watcher
@@ -151,7 +151,7 @@ namespace ts.projectSystem {
             {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
-                assert(configuredProject !== undefined, "should find configured project");
+                assert.isTrue(configuredProject !== undefined, "should find configured project");
                 checkProjectErrors(configuredProject, []);
                 const projectErrors = configuredProjectAt(projectService, 0).getAllProjectErrors();
                 checkProjectErrorsWorker(projectErrors, []);
@@ -182,7 +182,7 @@ namespace ts.projectSystem {
             {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
-                assert(configuredProject !== undefined, "should find configured project");
+                assert.isTrue(configuredProject !== undefined, "should find configured project");
                 checkProjectErrors(configuredProject, []);
                 const projectErrors = configuredProjectAt(projectService, 0).getAllProjectErrors();
                 checkProjectErrorsWorker(projectErrors, []);
@@ -192,13 +192,13 @@ namespace ts.projectSystem {
             {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
-                assert(configuredProject !== undefined, "should find configured project");
+                assert.isTrue(configuredProject !== undefined, "should find configured project");
                 checkProjectErrors(configuredProject, []);
                 const projectErrors = configuredProjectAt(projectService, 0).getAllProjectErrors();
                 checkProjectErrorsWorker(projectErrors, [
                     "'{' expected."
                 ]);
-                assert.isDefined(projectErrors[0].file);
+                assert.isNotNull(projectErrors[0].file);
                 assert.equal(projectErrors[0].file.fileName, corruptedConfig.path);
             }
         });

--- a/src/harness/unittests/reuseProgramStructure.ts
+++ b/src/harness/unittests/reuseProgramStructure.ts
@@ -193,14 +193,14 @@ namespace ts {
 
     function checkCache<T>(caption: string, program: Program, fileName: string, expectedContent: Map<T>, getCache: (f: SourceFile) => Map<T>, entryChecker: (expected: T, original: T) => boolean): void {
         const file = program.getSourceFile(fileName);
-        assert(file !== undefined, `cannot find file ${fileName}`);
+        assert.isTrue(file !== undefined, `cannot find file ${fileName}`);
         const cache = getCache(file);
         if (expectedContent === undefined) {
-            assert(cache === undefined, `expected ${caption} to be undefined`);
+            assert.isTrue(cache === undefined, `expected ${caption} to be undefined`);
         }
         else {
-            assert(cache !== undefined, `expected ${caption} to be set`);
-            assert(mapsAreEqual(expectedContent, cache, entryChecker), `contents of ${caption} did not match the expected contents.`);
+            assert.isTrue(cache !== undefined, `expected ${caption} to be set`);
+            assert.isTrue(mapsAreEqual(expectedContent, cache, entryChecker), `contents of ${caption} did not match the expected contents.`);
         }
     }
 
@@ -329,7 +329,7 @@ namespace ts {
             const options: CompilerOptions = { target, noLib: true };
 
             const program1 = newProgram(files, ["a.ts"], options);
-            assert(program1.getMissingFilePaths().length !== 0);
+            assert.notDeepEqual(emptyArray, program1.getMissingFilePaths());
 
             const program2 = updateProgram(program1, ["a.ts"], options, noop);
             assert.deepEqual(program1.getMissingFilePaths(), program2.getMissingFilePaths());
@@ -341,11 +341,11 @@ namespace ts {
             const options: CompilerOptions = { target, noLib: true };
 
             const program1 = newProgram(files, ["a.ts"], options);
-            assert(program1.getMissingFilePaths().length !== 0);
+            assert.notDeepEqual(emptyArray, program1.getMissingFilePaths());
 
             const newTexts: NamedSourceText[] = files.concat([{ name: "non-existing-file.ts", text: SourceText.New("", "", `var x = 1`) }]);
             const program2 = updateProgram(program1, ["a.ts"], options, noop, newTexts);
-            assert.lengthOf(program2.getMissingFilePaths(), 0);
+            assert.deepEqual(emptyArray, program2.getMissingFilePaths());
 
             assert.equal(StructureIsReused.Not, program1.structureIsReused);
         });
@@ -839,12 +839,12 @@ namespace ts {
                     updateProgramText(files, root, "const x = 1;");
                 });
                 assert.equal(program1.structureIsReused, StructureIsReused.Completely);
-                assert.lengthOf(program2.getSemanticDiagnostics(), 0);
+                assert.deepEqual(program2.getSemanticDiagnostics(), emptyArray);
             });
 
             it("Target changes -> redirect broken", () => {
                 const program1 = createRedirectProgram();
-                assert.lengthOf(program1.getSemanticDiagnostics(), 0);
+                assert.deepEqual(program1.getSemanticDiagnostics(), emptyArray);
 
                 const program2 = updateRedirectProgram(program1, files => {
                     updateProgramText(files, axIndex, "export default class X { private x: number; private y: number; }");
@@ -873,7 +873,7 @@ namespace ts {
                     updateProgramText(files, bxPackage, JSON.stringify({ name: "x", version: "1.2.3" }));
                 });
                 assert.equal(program1.structureIsReused, StructureIsReused.Not);
-                assert.lengthOf(program2.getSemanticDiagnostics(), 0);
+                assert.deepEqual(program2.getSemanticDiagnostics(), []);
             });
         });
     });
@@ -901,7 +901,7 @@ namespace ts {
                 /*hasInvalidatedResolution*/ returnFalse,
                 /*hasChangedAutomaticTypeDirectiveNames*/ false
             );
-            assert(actual);
+            assert.isTrue(actual);
         }
 
         function duplicate(options: CompilerOptions): CompilerOptions;

--- a/src/harness/unittests/services/colorization.ts
+++ b/src/harness/unittests/services/colorization.ts
@@ -50,7 +50,7 @@ describe("Colorization", () => {
 
                 const actualEntry = getEntryAtPosition(result, actualEntryPosition);
 
-                assert.isDefined(actualEntry, "Could not find classification entry for '" + expectedEntry.value + "' at position: " + actualEntryPosition);
+                assert(actualEntry, "Could not find classification entry for '" + expectedEntry.value + "' at position: " + actualEntryPosition);
                 assert.equal(actualEntry.classification, expectedEntry.classification, "Classification class does not match expected. Expected: " + ts.TokenClass[expectedEntry.classification] + ", Actual: " + ts.TokenClass[actualEntry.classification]);
                 assert.equal(actualEntry.length, expectedEntry.value.length, "Classification length does not match expected. Expected: " + ts.TokenClass[expectedEntry.value.length] + ", Actual: " + ts.TokenClass[actualEntry.length]);
             }

--- a/src/harness/unittests/services/patternMatcher.ts
+++ b/src/harness/unittests/services/patternMatcher.ts
@@ -140,25 +140,25 @@ describe("PatternMatcher", () => {
         it("PreferCaseSensitiveCamelCaseMatchToLongPattern1", () => {
             const match = getFirstMatch("FogBar", "FBB");
 
-            assert(match === undefined);
+            assert.isTrue(match === undefined);
         });
 
         it("PreferCaseSensitiveCamelCaseMatchToLongPattern2", () => {
             const match = getFirstMatch("FogBar", "FoooB");
 
-            assert(match === undefined);
+            assert.isTrue(match === undefined);
         });
 
         it("CamelCaseMatchPartiallyUnmatched", () => {
             const match = getFirstMatch("FogBarBaz", "FZ");
 
-            assert(match === undefined);
+            assert.isTrue(match === undefined);
         });
 
         it("CamelCaseMatchCompletelyUnmatched", () => {
             const match = getFirstMatch("FogBarBaz", "ZZ");
 
-            assert(match === undefined);
+            assert.isTrue(match === undefined);
         });
 
         it("TwoUppercaseCharacters", () => {
@@ -220,7 +220,7 @@ describe("PatternMatcher", () => {
         it("PreferCaseSensitiveMiddleUnderscore3", () => {
             const match = getFirstMatch("Fog_Bar", "F__B");
 
-            assert(undefined === match);
+            assert.isTrue(undefined === match);
         });
 
         it("PreferCaseSensitiveMiddleUnderscore4", () => {
@@ -264,25 +264,25 @@ describe("PatternMatcher", () => {
         it("AllLowerPattern1", () => {
             const match = getFirstMatch("FogBarChangedEventArgs", "changedeventargs");
 
-            assert(undefined !== match);
+            assert.isTrue(undefined !== match);
         });
 
         it("AllLowerPattern2", () => {
             const match = getFirstMatch("FogBarChangedEventArgs", "changedeventarrrgh");
 
-            assert(undefined === match);
+            assert.isTrue(undefined === match);
         });
 
         it("AllLowerPattern3", () => {
             const match = getFirstMatch("ABCDEFGH", "bcd");
 
-            assert(undefined !== match);
+            assert.isTrue(undefined !== match);
         });
 
         it("AllLowerPattern4", () => {
             const match = getFirstMatch("AbcdefghijEfgHij", "efghij");
 
-            assert(undefined === match);
+            assert.isTrue(undefined === match);
         });
     });
 
@@ -370,13 +370,13 @@ describe("PatternMatcher", () => {
         it("BlankPattern", () => {
             const matches = getAllMatches("AddMetadataReference", "");
 
-            assert(matches === undefined);
+            assert.isTrue(matches === undefined);
         });
 
         it("WhitespaceOnlyPattern", () => {
             const matches = getAllMatches("AddMetadataReference", " ");
 
-            assert(matches === undefined);
+            assert.isTrue(matches === undefined);
         });
 
         it("EachWordSeparately1", () => {
@@ -403,13 +403,13 @@ describe("PatternMatcher", () => {
         it("MixedCasing", () => {
             const matches = getAllMatches("AddMetadataReference", "mEta");
 
-            assert(matches === undefined);
+            assert.isTrue(matches === undefined);
         });
 
         it("MixedCasing2", () => {
             const matches = getAllMatches("AddMetadataReference", "Data");
 
-            assert(matches === undefined);
+            assert.isTrue(matches === undefined);
         });
 
         it("AsteriskSplit", () => {
@@ -421,7 +421,7 @@ describe("PatternMatcher", () => {
         it("LowercaseSubstring1", () => {
             const matches = getAllMatches("Operator", "a");
 
-            assert(matches === undefined);
+            assert.isTrue(matches === undefined);
         });
 
         it("LowercaseSubstring2", () => {
@@ -441,7 +441,7 @@ describe("PatternMatcher", () => {
 
         it("DottedPattern2", () => {
             const match = getFirstMatchForDottedPattern("Foo.Bar.Baz", "Quux", "C.Q");
-            assert(match === undefined);
+            assert.isTrue(match === undefined);
         });
 
         it("DottedPattern3", () => {
@@ -464,13 +464,13 @@ describe("PatternMatcher", () => {
 
         it("DottedPattern6", () => {
             const match = getFirstMatchForDottedPattern("Foo.Bar.Baz", "Quux", "F.F.B.B.Quux");
-            assert(match === undefined);
+            assert.isTrue(match === undefined);
         });
 
         it("DottedPattern7", () => {
             let match = getFirstMatch("UIElement", "UIElement");
             match = getFirstMatch("GetKeyword", "UIElement");
-            assert(match === undefined);
+            assert.isTrue(match === undefined);
         });
     });
 
@@ -508,8 +508,8 @@ describe("PatternMatcher", () => {
     }
 
     function assertInRange(val: number, low: number, high: number) {
-        assert(val >= low);
-        assert(val <= high);
+        assert.isTrue(val >= low);
+        assert.isTrue(val <= high);
     }
 
     function verifyBreakIntoCharacterSpans(original: string, ...parts: string[]): void {
@@ -521,6 +521,6 @@ describe("PatternMatcher", () => {
     }
 
     function assertContainsKind(kind: ts.PatternMatchKind, results: ts.PatternMatch[]) {
-        assert(ts.forEach(results, r => r.kind === kind));
+        assert.isTrue(ts.forEach(results, r => r.kind === kind));
     }
 });

--- a/src/harness/unittests/services/preProcessFile.ts
+++ b/src/harness/unittests/services/preProcessFile.ts
@@ -18,7 +18,7 @@ describe("PreProcessFile:", () => {
             return;
         }
         if (!expected) {
-            assert(false, `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+            assert.isTrue(false, `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
         }
         assert.equal(actual.length, expected.length, `[${kind}] Actual array's length does not match expected length. Expected files: ${JSON.stringify(expected)}, actual files: ${JSON.stringify(actual)}`);
 

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -1,5 +1,7 @@
 /// <reference path="..\harness.ts" />
 
+const expect: typeof _chai.expect = _chai.expect;
+
 namespace ts.server {
     let lastWrittenToHost: string;
     const mockHost: ServerHost = {
@@ -80,7 +82,7 @@ namespace ts.server {
                     }
                 };
 
-                assert.throws(() => session.executeCommand(req));
+                expect(() => session.executeCommand(req)).to.throw();
             });
             it("should output an error response when a command does not exist", () => {
                 const req: protocol.Request = {
@@ -99,7 +101,7 @@ namespace ts.server {
                     request_seq: 0,
                     success: false
                 };
-                assert.deepEqual(lastSent, expected);
+                expect(lastSent).to.deep.equal(expected);
             });
             it("should return a tuple containing the response and if a response is required on success", () => {
                 const req: protocol.ConfigureRequest = {
@@ -114,18 +116,17 @@ namespace ts.server {
                     }
                 };
 
-                assert.deepEqual(session.executeCommand(req), {
+                expect(session.executeCommand(req)).to.deep.equal({
                     responseRequired: false
                 });
-                const expected: protocol.Response = {
+                expect(lastSent).to.deep.equal({
                     command: CommandNames.Configure,
                     type: "response",
                     success: true,
                     request_seq: 0,
                     seq: 0,
                     body: undefined
-                };
-                assert.deepEqual(lastSent, expected);
+                });
             });
             it("should handle literal types in request", () => {
                 const configureRequest: protocol.ConfigureRequest = {
@@ -310,15 +311,14 @@ namespace ts.server {
 
                 session.onMessage(JSON.stringify(req));
 
-                const expected: protocol.ConfigureResponse = {
+                expect(lastSent).to.deep.equal(<protocol.ConfigureResponse>{
                     command: CommandNames.Configure,
                     type: "response",
                     success: true,
                     request_seq: 0,
                     seq: 0,
                     body: undefined
-                };
-                assert.deepEqual(lastSent, expected);
+                });
             });
         });
 
@@ -330,9 +330,9 @@ namespace ts.server {
                 const resultMsg = `Content-Length: ${len}\r\n\r\n${strmsg}\n`;
 
                 session.send = Session.prototype.send;
-                assert.isDefined(session.send);
-                session.send(msg);
-                assert.equal(lastWrittenToHost, resultMsg);
+                assert(session.send);
+                expect(session.send(msg)).to.not.exist; // tslint:disable-line no-unused-expression
+                expect(lastWrittenToHost).to.equal(resultMsg);
             });
         });
 
@@ -349,7 +349,11 @@ namespace ts.server {
 
                 session.addProtocolHandler(command, () => result);
 
-                assert.deepEqual(session.executeCommand({ command, seq: 0, type: "request" }), result);
+                expect(session.executeCommand({
+                    command,
+                    seq: 0,
+                    type: "request"
+                })).to.deep.equal(result);
             });
             it("throws when a duplicate handler is passed", () => {
                 const respBody = {
@@ -363,7 +367,8 @@ namespace ts.server {
 
                 session.addProtocolHandler(command, () => resp);
 
-                assert.throws(() => session.addProtocolHandler(command, () => resp), `Protocol handler already exists for command "${command}"`);
+                expect(() => session.addProtocolHandler(command, () => resp))
+                    .to.throw(`Protocol handler already exists for command "${command}"`);
             });
         });
 
@@ -376,13 +381,12 @@ namespace ts.server {
 
                 session.event(info, evt);
 
-                const expected: protocol.Event = {
+                expect(lastSent).to.deep.equal({
                     type: "event",
                     seq: 0,
                     event: evt,
                     body: info
-                };
-                assert.deepEqual(lastSent, expected);
+                });
             });
         });
 
@@ -397,15 +401,14 @@ namespace ts.server {
 
                 session.output(body, command, /*reqSeq*/ 0);
 
-                const expected: protocol.Response = {
+                expect(lastSent).to.deep.equal({
                     seq: 0,
                     request_seq: 0,
                     type: "response",
                     command,
                     body,
                     success: true
-                };
-                assert.deepEqual(lastSent, expected);
+                });
             });
         });
     });
@@ -466,16 +469,14 @@ namespace ts.server {
             session.onMessage(JSON.stringify(request));
             const lastSent = session.lastSent as protocol.Response;
 
-            assert.deepEqual({ ...lastSent, message: undefined }, {
-                request_seq: 0,
+            expect(lastSent).to.contain({
                 seq: 0,
                 type: "response",
                 command,
-                success: false,
-                message: undefined,
+                success: false
             });
 
-            assert(ts.stringContains(lastSent.message, "myMessage") && ts.stringContains(lastSent.message, "f1"));
+            expect(lastSent.message).has.string("myMessage").and.has.string("f1");
         });
     });
 
@@ -515,24 +516,23 @@ namespace ts.server {
 
             session.output(body, command, /*reqSeq*/ 0);
 
-            const expected: protocol.Response = {
+            expect(session.lastSent).to.deep.equal({
                 seq: 0,
                 request_seq: 0,
                 type: "response",
                 command,
                 body,
                 success: true
-            };
-            assert.deepEqual(session.lastSent, expected);
+            });
         });
         it("can add and respond to new protocol handlers", () => {
             const session = new TestSession();
 
-            assert.deepEqual(session.executeCommand({
+            expect(session.executeCommand({
                 seq: 0,
                 type: "request",
                 command: session.customHandler
-            }), {
+            })).to.deep.equal({
                 response: undefined,
                 responseRequired: true
             });
@@ -542,7 +542,8 @@ namespace ts.server {
             new class extends TestSession {
                 constructor() {
                     super();
-                    assert(this.projectService instanceof ProjectService);
+                    assert(this.projectService);
+                    expect(this.projectService).to.be.instanceOf(ProjectService);
                 }
             }();
         });
@@ -666,9 +667,9 @@ namespace ts.server {
 
             // Add an event handler
             cli.on("testevent", (eventinfo) => {
-                assert.equal(eventinfo, toEvent);
+                expect(eventinfo).to.equal(toEvent);
                 responses++;
-                assert.equal(responses, 1);
+                expect(responses).to.equal(1);
             });
 
             // Trigger said event from the server
@@ -678,8 +679,8 @@ namespace ts.server {
             cli.execute("echo", toEcho, (resp) => {
                 assert(resp.success, resp.message);
                 responses++;
-                assert.equal(responses, 2);
-                assert.deepEqual(resp.body, toEcho);
+                expect(responses).to.equal(2);
+                expect(resp.body).to.deep.equal(toEcho);
             });
 
             // Queue a configure command
@@ -691,7 +692,7 @@ namespace ts.server {
             }, (resp) => {
                 assert(resp.success, resp.message);
                 responses++;
-                assert.equal(responses, 3);
+                expect(responses).to.equal(3);
                 done();
             });
 

--- a/src/harness/unittests/textStorage.ts
+++ b/src/harness/unittests/textStorage.ts
@@ -33,20 +33,20 @@ namespace ts.textStorage {
                 for (let offset = 0; offset < end - start; offset++) {
                     const pos1 = ts1.lineOffsetToPosition(line + 1, offset + 1);
                     const pos2 = ts2.lineOffsetToPosition(line + 1, offset + 1);
-                    assert(pos1 === pos2, `lineOffsetToPosition ${line + 1}-${offset + 1}: expected ${pos1} to equal ${pos2}`);
+                    assert.isTrue(pos1 === pos2, `lineOffsetToPosition ${line + 1}-${offset + 1}: expected ${pos1} to equal ${pos2}`);
                 }
 
                 const {start: start1, length: length1 } = ts1.lineToTextSpan(line);
                 const {start: start2, length: length2 } = ts2.lineToTextSpan(line);
-                assert(start1 === start2, `lineToTextSpan ${line}::start:: expected ${start1} to equal ${start2}`);
-                assert(length1 === length2, `lineToTextSpan ${line}::length:: expected ${length1} to equal ${length2}`);
+                assert.isTrue(start1 === start2, `lineToTextSpan ${line}::start:: expected ${start1} to equal ${start2}`);
+                assert.isTrue(length1 === length2, `lineToTextSpan ${line}::length:: expected ${length1} to equal ${length2}`);
             }
 
             for (let pos = 0; pos < f.content.length; pos++) {
                 const { line: line1, offset: offset1 } = ts1.positionToLineOffset(pos);
                 const { line: line2, offset: offset2 } = ts2.positionToLineOffset(pos);
-                assert(line1 === line2, `positionToLineOffset ${pos}::line:: expected ${line1} to equal ${line2}`);
-                assert(offset1 === offset2, `positionToLineOffset ${pos}::offset:: expected ${offset1} to equal ${offset2}`);
+                assert.isTrue(line1 === line2, `positionToLineOffset ${pos}::line:: expected ${line1} to equal ${line2}`);
+                assert.isTrue(offset1 === offset2, `positionToLineOffset ${pos}::offset:: expected ${offset1} to equal ${offset2}`);
             }
         });
 
@@ -55,16 +55,16 @@ namespace ts.textStorage {
             const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path));
 
             ts1.getSnapshot();
-            assert(!ts1.hasScriptVersionCache_TestOnly(), "should not have script version cache - 1");
+            assert.isTrue(!ts1.hasScriptVersionCache_TestOnly(), "should not have script version cache - 1");
 
             ts1.edit(0, 5, "   ");
-            assert(ts1.hasScriptVersionCache_TestOnly(), "have script version cache - 1");
+            assert.isTrue(ts1.hasScriptVersionCache_TestOnly(), "have script version cache - 1");
 
             ts1.useText();
-            assert(!ts1.hasScriptVersionCache_TestOnly(), "should not have script version cache - 2");
+            assert.isTrue(!ts1.hasScriptVersionCache_TestOnly(), "should not have script version cache - 2");
 
             ts1.getLineInfo(0);
-            assert(ts1.hasScriptVersionCache_TestOnly(), "have script version cache - 2");
+            assert.isTrue(ts1.hasScriptVersionCache_TestOnly(), "have script version cache - 2");
         });
     });
 }

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -133,7 +133,7 @@ namespace ts.tscWatch {
 
     function assertWatchDiagnosticAt(host: WatchedSystem, outputAt: number, diagnosticMessage: DiagnosticMessage) {
         const output = host.getOutput()[outputAt];
-        assert(endsWith(output, getWatchDiagnosticWithoutDate(host, diagnosticMessage)), "outputs[" + outputAt + "] is " + output);
+        assert.isTrue(endsWith(output, getWatchDiagnosticWithoutDate(host, diagnosticMessage)), "outputs[" + outputAt + "] is " + output);
     }
 
     function getWatchDiagnosticWithoutDate(host: WatchedSystem, diagnosticMessage: DiagnosticMessage) {
@@ -1543,11 +1543,11 @@ namespace ts.tscWatch {
         function verifyEmittedFiles(host: WatchedSystem, emittedFiles: EmittedFile[]) {
             for (const { path, content, shouldBeWritten } of emittedFiles) {
                 if (shouldBeWritten) {
-                    assert(host.fileExists(path), `Expected file ${path} to be present`);
+                    assert.isTrue(host.fileExists(path), `Expected file ${path} to be present`);
                     assert.equal(host.readFile(path), content, `Contents of file ${path} do not match`);
                 }
                 else {
-                    assert(!host.fileExists(path), `Expected file ${path} to be absent`);
+                    assert.isNotTrue(host.fileExists(path), `Expected file ${path} to be absent`);
                 }
             }
         }
@@ -1723,7 +1723,7 @@ namespace ts.tscWatch {
                         return false;
                     }
                     fileExistsIsCalled = true;
-                    assert(fileName.indexOf("/f2.") !== -1);
+                    assert.isTrue(fileName.indexOf("/f2.") !== -1);
                     return originalFileExists.call(host, fileName);
                 };
 
@@ -1738,7 +1738,7 @@ namespace ts.tscWatch {
                     getDiagnosticModuleNotFoundOfFile(watch(), root, "f2")
                 ], /*errorsPosition*/ ExpectedOutputErrorsPosition.AfterFileChangeDetected);
 
-                assert(fileExistsIsCalled);
+                assert.isTrue(fileExistsIsCalled);
             }
             {
                 let fileExistsCalled = false;
@@ -1747,7 +1747,7 @@ namespace ts.tscWatch {
                         return false;
                     }
                     fileExistsCalled = true;
-                    assert(fileName.indexOf("/f1.") !== -1);
+                    assert.isTrue(fileName.indexOf("/f1.") !== -1);
                     return originalFileExists.call(host, fileName);
                 };
 
@@ -1758,7 +1758,7 @@ namespace ts.tscWatch {
                 host.runQueuedTimeoutCallbacks();
 
                 checkOutputErrors(host, [f1IsNotModule, cannotFindFoo], /*errorsPosition*/ ExpectedOutputErrorsPosition.AfterFileChangeDetected);
-                assert(fileExistsCalled);
+                assert.isTrue(fileExistsCalled);
             }
         });
 
@@ -1791,7 +1791,7 @@ namespace ts.tscWatch {
 
             const watch = createWatchModeWithoutConfigFile([root.path], host, { module: ModuleKind.AMD });
 
-            assert(fileExistsCalledForBar, "'fileExists' should be called");
+            assert.isTrue(fileExistsCalledForBar, "'fileExists' should be called");
             checkOutputErrors(host, [
                 getDiagnosticModuleNotFoundOfFile(watch(), root, "bar")
             ], /*errorsPosition*/ ExpectedOutputErrorsPosition.AfterCompilationStarting);
@@ -1802,7 +1802,7 @@ namespace ts.tscWatch {
 
             host.runQueuedTimeoutCallbacks();
             checkOutputErrors(host, emptyArray, /*errorsPosition*/ ExpectedOutputErrorsPosition.AfterFileChangeDetected);
-            assert(fileExistsCalledForBar, "'fileExists' should be called.");
+            assert.isTrue(fileExistsCalledForBar, "'fileExists' should be called.");
         });
 
         it("should compile correctly when resolved module goes missing and then comes back (module is not part of the root)", () => {
@@ -1833,13 +1833,13 @@ namespace ts.tscWatch {
 
             const watch = createWatchModeWithoutConfigFile([root.path], host, { module: ModuleKind.AMD });
 
-            assert(fileExistsCalledForBar, "'fileExists' should be called");
+            assert.isTrue(fileExistsCalledForBar, "'fileExists' should be called");
             checkOutputErrors(host, emptyArray, /*errorsPosition*/ ExpectedOutputErrorsPosition.AfterCompilationStarting);
 
             fileExistsCalledForBar = false;
             host.reloadFS(files);
             host.runQueuedTimeoutCallbacks();
-            assert(fileExistsCalledForBar, "'fileExists' should be called.");
+            assert.isTrue(fileExistsCalledForBar, "'fileExists' should be called.");
             checkOutputErrors(host, [
                 getDiagnosticModuleNotFoundOfFile(watch(), root, "bar")
             ], /*errorsPosition*/ ExpectedOutputErrorsPosition.AfterFileChangeDetected);
@@ -1848,7 +1848,7 @@ namespace ts.tscWatch {
             host.reloadFS(filesWithImported);
             host.checkTimeoutQueueLengthAndRun(1);
             checkOutputErrors(host, emptyArray, /*errorsPosition*/ ExpectedOutputErrorsPosition.AfterFileChangeDetected);
-            assert(fileExistsCalledForBar, "'fileExists' should be called.");
+            assert.isTrue(fileExistsCalledForBar, "'fileExists' should be called.");
         });
 
         it("works when module resolution changes to ambient module", () => {
@@ -2050,7 +2050,7 @@ declare module "fs" {
 
             checkProgramActualFiles(watch(), mapDefined(files, f => f === configFile ? undefined : f.path));
             const outputFile1 = changeExtension((outputFolder + getBaseFileName(file1.path)), ".js");
-            assert(host.fileExists(outputFile1));
+            assert.isTrue(host.fileExists(outputFile1));
             assert.equal(host.readFile(outputFile1), file1.content + host.newLine);
         });
     });

--- a/src/harness/unittests/tsconfigParsing.ts
+++ b/src/harness/unittests/tsconfigParsing.ts
@@ -11,20 +11,20 @@ namespace ts {
         function assertParseError(jsonText: string) {
              const parsed = ts.parseConfigFileTextToJson("/apath/tsconfig.json", jsonText);
              assert.deepEqual(parsed.config, {});
-             assert(undefined !== parsed.error);
+             assert.isTrue(undefined !== parsed.error);
         }
 
         function assertParseErrorWithExcludesKeyword(jsonText: string) {
             {
                 const parsed = ts.parseConfigFileTextToJson("/apath/tsconfig.json", jsonText);
                 const parsedCommand = ts.parseJsonConfigFileContent(parsed.config, ts.sys, "tests/cases/unittests");
-                assert(parsedCommand.errors && parsedCommand.errors.length === 1 &&
+                assert.isTrue(parsedCommand.errors && parsedCommand.errors.length === 1 &&
                     parsedCommand.errors[0].code === ts.Diagnostics.Unknown_option_excludes_Did_you_mean_exclude.code);
             }
             {
                 const parsed = ts.parseJsonText("/apath/tsconfig.json", jsonText);
                 const parsedCommand = ts.parseJsonSourceFileConfigFileContent(parsed, ts.sys, "tests/cases/unittests");
-                assert(parsedCommand.errors && parsedCommand.errors.length === 1 &&
+                assert.isTrue(parsedCommand.errors && parsedCommand.errors.length === 1 &&
                     parsedCommand.errors[0].code === ts.Diagnostics.Unknown_option_excludes_Did_you_mean_exclude.code);
             }
         }
@@ -44,26 +44,26 @@ namespace ts {
         function assertParseFileList(jsonText: string, configFileName: string, basePath: string, allFileList: string[], expectedFileList: string[]) {
             {
                 const parsed = getParsedCommandJson(jsonText, configFileName, basePath, allFileList);
-                assert(arrayIsEqualTo(parsed.fileNames.sort(), expectedFileList.sort()));
+                assert.isTrue(arrayIsEqualTo(parsed.fileNames.sort(), expectedFileList.sort()));
             }
             {
                 const parsed = getParsedCommandJsonNode(jsonText, configFileName, basePath, allFileList);
-                assert(arrayIsEqualTo(parsed.fileNames.sort(), expectedFileList.sort()));
+                assert.isTrue(arrayIsEqualTo(parsed.fileNames.sort(), expectedFileList.sort()));
             }
         }
 
         function assertParseFileDiagnostics(jsonText: string, configFileName: string, basePath: string, allFileList: string[], expectedDiagnosticCode: number, noLocation?: boolean) {
             {
                 const parsed = getParsedCommandJson(jsonText, configFileName, basePath, allFileList);
-                assert(parsed.errors.length >= 0);
-                assert(parsed.errors.filter(e => e.code === expectedDiagnosticCode).length > 0, `Expected error code ${expectedDiagnosticCode} to be in ${JSON.stringify(parsed.errors)}`);
+                assert.isTrue(parsed.errors.length >= 0);
+                assert.isTrue(parsed.errors.filter(e => e.code === expectedDiagnosticCode).length > 0, `Expected error code ${expectedDiagnosticCode} to be in ${JSON.stringify(parsed.errors)}`);
             }
             {
                 const parsed = getParsedCommandJsonNode(jsonText, configFileName, basePath, allFileList);
-                assert(parsed.errors.length >= 0);
-                assert(parsed.errors.filter(e => e.code === expectedDiagnosticCode).length > 0, `Expected error code ${expectedDiagnosticCode} to be in ${JSON.stringify(parsed.errors)}`);
+                assert.isTrue(parsed.errors.length >= 0);
+                assert.isTrue(parsed.errors.filter(e => e.code === expectedDiagnosticCode).length > 0, `Expected error code ${expectedDiagnosticCode} to be in ${JSON.stringify(parsed.errors)}`);
                 if (!noLocation) {
-                    assert(parsed.errors.filter(e => e.code === expectedDiagnosticCode && e.file && e.start && e.length).length > 0, `Expected error code ${expectedDiagnosticCode} to be in ${JSON.stringify(parsed.errors)} with location information`);
+                    assert.isTrue(parsed.errors.filter(e => e.code === expectedDiagnosticCode && e.file && e.start && e.length).length > 0, `Expected error code ${expectedDiagnosticCode} to be in ${JSON.stringify(parsed.errors)} with location information`);
                 }
             }
         }
@@ -241,7 +241,7 @@ namespace ts {
                 },
                 files: ["file1.ts"]
             };
-            assert(diagnostics.length === 2);
+            assert.isTrue(diagnostics.length === 2);
             assert.equal(JSON.stringify(configJsonObject), JSON.stringify(expectedResult));
         });
 

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -468,8 +468,8 @@ namespace ts.projectSystem {
         assert.equal(outputs[index], server.formatMessage(expectedEvent, nullLogger, Utils.byteLength, session.host.newLine));
 
         if (isMostRecent) {
-            assert.equal(events.length, index + 1, JSON.stringify(events));
-            assert.equal(outputs.length, index + 1, JSON.stringify(outputs));
+            assert.strictEqual(events.length, index + 1, JSON.stringify(events));
+            assert.strictEqual(outputs.length, index + 1, JSON.stringify(outputs));
         }
     }
 
@@ -572,8 +572,8 @@ namespace ts.projectSystem {
             const projectService = createProjectService(host);
             const { configFileName, configFileErrors } = projectService.openClientFile(file1.path);
 
-            assert.isDefined(configFileName, "should find config file");
-            assert(!configFileErrors || configFileErrors.length === 0, `expect no errors in config file, got ${JSON.stringify(configFileErrors)}`);
+            assert(configFileName, "should find config file");
+            assert.isTrue(!configFileErrors || configFileErrors.length === 0, `expect no errors in config file, got ${JSON.stringify(configFileErrors)}`);
             checkNumberOfInferredProjects(projectService, 0);
             checkNumberOfConfiguredProjects(projectService, 1);
 
@@ -612,8 +612,8 @@ namespace ts.projectSystem {
             const projectService = createProjectService(host);
             const { configFileName, configFileErrors } = projectService.openClientFile(file1.path);
 
-            assert.isDefined(configFileName, "should find config file");
-            assert(!configFileErrors || configFileErrors.length === 0, `expect no errors in config file, got ${JSON.stringify(configFileErrors)}`);
+            assert(configFileName, "should find config file");
+            assert.isTrue(!configFileErrors || configFileErrors.length === 0, `expect no errors in config file, got ${JSON.stringify(configFileErrors)}`);
             checkNumberOfInferredProjects(projectService, 0);
             checkNumberOfConfiguredProjects(projectService, 1);
 
@@ -821,7 +821,7 @@ namespace ts.projectSystem {
             host.reloadFS([file1, commonFile2, libFile]);
             host.runQueuedTimeoutCallbacks();
             checkNumberOfInferredProjects(projectService, 1);
-            assert.equal(projectService.inferredProjects[0], project, "Inferred project should be same");
+            assert.strictEqual(projectService.inferredProjects[0], project, "Inferred project should be same");
             checkProjectRootFiles(project, [file1.path]);
             checkProjectActualFiles(project, [file1.path, libFile.path, commonFile2.path]);
             diags = session.executeCommand(getErrRequest).response as server.protocol.Diagnostic[];
@@ -1024,11 +1024,11 @@ namespace ts.projectSystem {
 
             projectService.openExternalProject({ rootFiles: toExternalFiles([file1.path]), options: {}, projectFileName: proj1name });
             const proj1 = projectService.findProject(proj1name);
-            assert(proj1.languageServiceEnabled);
+            assert.isTrue(proj1.languageServiceEnabled);
 
             projectService.openExternalProject({ rootFiles: toExternalFiles([file2.path]), options: {}, projectFileName: proj2name });
             const proj2 = projectService.findProject(proj2name);
-            assert(proj2.languageServiceEnabled);
+            assert.isTrue(proj2.languageServiceEnabled);
 
             projectService.openExternalProject({ rootFiles: toExternalFiles([file3.path]), options: {}, projectFileName: proj3name });
             const proj3 = projectService.findProject(proj3name);
@@ -1100,18 +1100,18 @@ namespace ts.projectSystem {
             projectService.openClientFile(file1.path);
             checkNumberOfConfiguredProjects(projectService, 1);
             const project = projectService.configuredProjects.get(configFile.path);
-            assert(project.hasOpenRef()); // file1
+            assert.isTrue(project.hasOpenRef()); // file1
 
             projectService.closeClientFile(file1.path);
             checkNumberOfConfiguredProjects(projectService, 1);
-            assert.equal(projectService.configuredProjects.get(configFile.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
             assert.isFalse(project.hasOpenRef()); // No open files
             assert.isFalse(project.isClosed());
 
             projectService.openClientFile(file2.path);
             checkNumberOfConfiguredProjects(projectService, 1);
-            assert.equal(projectService.configuredProjects.get(configFile.path), project);
-            assert(project.hasOpenRef()); // file2
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
+            assert.isTrue(project.hasOpenRef()); // file2
             assert.isFalse(project.isClosed());
         });
 
@@ -1134,18 +1134,18 @@ namespace ts.projectSystem {
             projectService.openClientFile(file1.path);
             checkNumberOfConfiguredProjects(projectService, 1);
             const project = projectService.configuredProjects.get(configFile.path);
-            assert(project.hasOpenRef()); // file1
+            assert.isTrue(project.hasOpenRef()); // file1
 
             projectService.closeClientFile(file1.path);
             checkNumberOfConfiguredProjects(projectService, 1);
-            assert.equal(projectService.configuredProjects.get(configFile.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
             assert.isFalse(project.hasOpenRef()); // No files
             assert.isFalse(project.isClosed());
 
             projectService.openClientFile(libFile.path);
             checkNumberOfConfiguredProjects(projectService, 0);
             assert.isFalse(project.hasOpenRef()); // No files + project closed
-            assert(project.isClosed());
+            assert.isTrue(project.isClosed());
         });
 
         it("should not close external project with no open files", () => {
@@ -1233,28 +1233,28 @@ namespace ts.projectSystem {
             // open client file - should not lead to creation of inferred project
             projectService.openClientFile(file1.path, file1.content);
             checkNumberOfProjects(projectService, { configuredProjects: 2 });
-            assert.equal(projectService.configuredProjects.get(config1.path), proj1);
-            assert.equal(projectService.configuredProjects.get(config2.path), proj2);
+            assert.strictEqual(projectService.configuredProjects.get(config1.path), proj1);
+            assert.strictEqual(projectService.configuredProjects.get(config2.path), proj2);
 
             projectService.openClientFile(file3.path, file3.content);
             checkNumberOfProjects(projectService, { configuredProjects: 2, inferredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(config1.path), proj1);
-            assert.equal(projectService.configuredProjects.get(config2.path), proj2);
+            assert.strictEqual(projectService.configuredProjects.get(config1.path), proj1);
+            assert.strictEqual(projectService.configuredProjects.get(config2.path), proj2);
 
             projectService.closeExternalProject(externalProjectName);
             // open file 'file1' from configured project keeps project alive
             checkNumberOfProjects(projectService, { configuredProjects: 1, inferredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(config1.path), proj1);
+            assert.strictEqual(projectService.configuredProjects.get(config1.path), proj1);
             assert.isUndefined(projectService.configuredProjects.get(config2.path));
 
             projectService.closeClientFile(file3.path);
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(config1.path), proj1);
+            assert.strictEqual(projectService.configuredProjects.get(config1.path), proj1);
             assert.isUndefined(projectService.configuredProjects.get(config2.path));
 
             projectService.closeClientFile(file1.path);
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(config1.path), proj1);
+            assert.strictEqual(projectService.configuredProjects.get(config1.path), proj1);
             assert.isUndefined(projectService.configuredProjects.get(config2.path));
 
             projectService.openClientFile(file2.path, file2.content);
@@ -1286,14 +1286,14 @@ namespace ts.projectSystem {
 
             const completions1 = service.externalProjects[0].getLanguageService().getCompletionsAtPosition(f1.path, 2, { includeExternalModuleExports: false });
             // should contain completions for string
-            assert(completions1.entries.some(e => e.name === "charAt"), "should contain 'charAt'");
+            assert.isTrue(completions1.entries.some(e => e.name === "charAt"), "should contain 'charAt'");
             assert.isFalse(completions1.entries.some(e => e.name === "toExponential"), "should not contain 'toExponential'");
 
             service.closeClientFile(f2.path);
             const completions2 = service.externalProjects[0].getLanguageService().getCompletionsAtPosition(f1.path, 2, { includeExternalModuleExports: false });
             // should contain completions for string
             assert.isFalse(completions2.entries.some(e => e.name === "charAt"), "should not contain 'charAt'");
-            assert(completions2.entries.some(e => e.name === "toExponential"), "should contain 'toExponential'");
+            assert.isTrue(completions2.entries.some(e => e.name === "toExponential"), "should contain 'toExponential'");
         });
 
         it("clear mixed content file after closing", () => {
@@ -1317,7 +1317,7 @@ namespace ts.projectSystem {
             checkProjectActualFiles(service.externalProjects[0], [f1.path, f2.path, libFile.path]);
 
             const completions1 = service.externalProjects[0].getLanguageService().getCompletionsAtPosition(f1.path, 0, { includeExternalModuleExports: false });
-            assert(completions1.entries.some(e => e.name === "somelongname"), "should contain 'somelongname'");
+            assert.isTrue(completions1.entries.some(e => e.name === "somelongname"), "should contain 'somelongname'");
 
             service.closeClientFile(f2.path);
             const completions2 = service.externalProjects[0].getLanguageService().getCompletionsAtPosition(f1.path, 0, { includeExternalModuleExports: false });
@@ -1387,16 +1387,16 @@ namespace ts.projectSystem {
             });
 
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(configFile.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
 
             projectService.closeExternalProject(externalProjectName);
             // configured project is alive since file is still open
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(configFile.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
 
             projectService.closeClientFile(file1.path);
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(configFile.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
 
             projectService.openClientFile(file2.path);
             checkNumberOfProjects(projectService, { inferredProjects: 1 });
@@ -1910,7 +1910,7 @@ namespace ts.projectSystem {
 
             // The configured project should now be updated to include html file
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(configuredProjectAt(projectService, 0), configuredProj, "Same configured project should be updated");
+            assert.strictEqual(configuredProjectAt(projectService, 0), configuredProj, "Same configured project should be updated");
             checkProjectActualFiles(configuredProjectAt(projectService, 0), [file1.path, file2.path, config.path]);
 
             // Open HTML file
@@ -2176,18 +2176,18 @@ namespace ts.projectSystem {
             projectService.openClientFile(file2.path);
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
             const project1 = projectService.configuredProjects.get(tsconfig1.path);
-            assert(project1.hasOpenRef(), "Has open ref count in project1 - 1"); // file2
+            assert.isTrue(project1.hasOpenRef(), "Has open ref count in project1 - 1"); // file2
             assert.equal(project1.getScriptInfo(file2.path).containingProjects.length, 1, "containing projects count");
             assert.isFalse(project1.isClosed());
 
             projectService.openClientFile(file1.path);
             checkNumberOfProjects(projectService, { configuredProjects: 2 });
-            assert(project1.hasOpenRef(), "Has open ref count in project1 - 2"); // file2
-            assert.equal(projectService.configuredProjects.get(tsconfig1.path), project1);
+            assert.isTrue(project1.hasOpenRef(), "Has open ref count in project1 - 2"); // file2
+            assert.strictEqual(projectService.configuredProjects.get(tsconfig1.path), project1);
             assert.isFalse(project1.isClosed());
 
             const project2 = projectService.configuredProjects.get(tsconfig2.path);
-            assert(project2.hasOpenRef(), "Has open ref count in project2 - 2"); // file1
+            assert.isTrue(project2.hasOpenRef(), "Has open ref count in project2 - 2"); // file1
             assert.isFalse(project2.isClosed());
 
             assert.equal(project1.getScriptInfo(file1.path).containingProjects.length, 2, `${file1.path} containing projects count`);
@@ -2196,9 +2196,9 @@ namespace ts.projectSystem {
             projectService.closeClientFile(file2.path);
             checkNumberOfProjects(projectService, { configuredProjects: 2 });
             assert.isFalse(project1.hasOpenRef(), "Has open ref count in project1 - 3"); // No files
-            assert(project2.hasOpenRef(), "Has open ref count in project2 - 3"); // file1
-            assert.equal(projectService.configuredProjects.get(tsconfig1.path), project1);
-            assert.equal(projectService.configuredProjects.get(tsconfig2.path), project2);
+            assert.isTrue(project2.hasOpenRef(), "Has open ref count in project2 - 3"); // file1
+            assert.strictEqual(projectService.configuredProjects.get(tsconfig1.path), project1);
+            assert.strictEqual(projectService.configuredProjects.get(tsconfig2.path), project2);
             assert.isFalse(project1.isClosed());
             assert.isFalse(project2.isClosed());
 
@@ -2206,18 +2206,18 @@ namespace ts.projectSystem {
             checkNumberOfProjects(projectService, { configuredProjects: 2 });
             assert.isFalse(project1.hasOpenRef(), "Has open ref count in project1 - 4"); // No files
             assert.isFalse(project2.hasOpenRef(), "Has open ref count in project2 - 4"); // No files
-            assert.equal(projectService.configuredProjects.get(tsconfig1.path), project1);
-            assert.equal(projectService.configuredProjects.get(tsconfig2.path), project2);
+            assert.strictEqual(projectService.configuredProjects.get(tsconfig1.path), project1);
+            assert.strictEqual(projectService.configuredProjects.get(tsconfig2.path), project2);
             assert.isFalse(project1.isClosed());
             assert.isFalse(project2.isClosed());
 
             projectService.openClientFile(file2.path);
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(tsconfig1.path), project1);
+            assert.strictEqual(projectService.configuredProjects.get(tsconfig1.path), project1);
             assert.isUndefined(projectService.configuredProjects.get(tsconfig2.path));
-            assert(project1.hasOpenRef(), "Has open ref count in project1 - 5"); // file2
+            assert.isTrue(project1.hasOpenRef(), "Has open ref count in project1 - 5"); // file2
             assert.isFalse(project1.isClosed());
-            assert(project2.isClosed());
+            assert.isTrue(project2.isClosed());
         });
 
         it("Open ref of configured project when open file gets added to the project as part of configured file update", () => {
@@ -2255,7 +2255,7 @@ namespace ts.projectSystem {
             checkOpenFiles(projectService, files);
             checkNumberOfProjects(projectService, { configuredProjects: 1, inferredProjects: 2 });
             const configProject1 = projectService.configuredProjects.get(configFile.path);
-            assert(configProject1.hasOpenRef()); // file1 and file3
+            assert.isTrue(configProject1.hasOpenRef()); // file1 and file3
             checkProjectActualFiles(configProject1, [file1.path, file3.path, configFile.path]);
             const inferredProject1 = projectService.inferredProjects[0];
             checkProjectActualFiles(inferredProject1, [file2.path]);
@@ -2272,7 +2272,7 @@ namespace ts.projectSystem {
             checkNumberOfInferredProjects(projectService, 1);
             const inferredProject3 = projectService.inferredProjects[0];
             checkProjectActualFiles(inferredProject3, [file4.path]);
-            assert.equal(inferredProject3, inferredProject2);
+            assert.strictEqual(inferredProject3, inferredProject2);
 
             projectService.closeClientFile(file1.path);
             projectService.closeClientFile(file2.path);
@@ -2298,7 +2298,7 @@ namespace ts.projectSystem {
             checkNumberOfInferredProjects(projectService, 1);
             const inferredProject5 = projectService.inferredProjects[0];
             checkProjectActualFiles(inferredProject4, [file4.path]);
-            assert.equal(inferredProject5, inferredProject4);
+            assert.strictEqual(inferredProject5, inferredProject4);
 
             const file5: FileOrFolder = {
                 path: "/file5.ts",
@@ -2307,13 +2307,13 @@ namespace ts.projectSystem {
             host.reloadFS(files.concat(configFile, file5));
             projectService.openClientFile(file5.path);
             verifyScriptInfosAreUndefined([file1, file2, file3]);
-            assert.equal(projectService.getScriptInfoForPath(file4.path as Path), find(infos, info => info.path === file4.path));
+            assert.strictEqual(projectService.getScriptInfoForPath(file4.path as Path), find(infos, info => info.path === file4.path));
             assert.isDefined(projectService.getScriptInfoForPath(file5.path as Path));
             checkOpenFiles(projectService, [file4, file5]);
             checkNumberOfConfiguredProjects(projectService, 0);
 
             function verifyScriptInfos() {
-                infos.forEach(info => assert.equal(projectService.getScriptInfoForPath(info.path), info));
+                infos.forEach(info => assert.strictEqual(projectService.getScriptInfoForPath(info.path), info));
             }
 
             function verifyScriptInfosAreUndefined(files: FileOrFolder[]) {
@@ -2325,7 +2325,7 @@ namespace ts.projectSystem {
             function verifyConfiguredProjectStateAfterUpdate(hasOpenRef: boolean) {
                 checkNumberOfConfiguredProjects(projectService, 1);
                 const configProject2 = projectService.configuredProjects.get(configFile.path);
-                assert.equal(configProject2, configProject1);
+                assert.strictEqual(configProject2, configProject1);
                 checkProjectActualFiles(configProject2, [file1.path, file2.path, file3.path, configFile.path]);
                 assert.equal(configProject2.hasOpenRef(), hasOpenRef);
             }
@@ -2364,7 +2364,7 @@ namespace ts.projectSystem {
 
             checkNumberOfProjects(projectService, { configuredProjects: 1, inferredProjects: 1 });
             const configuredProject = projectService.configuredProjects.get(configFile.path);
-            assert(configuredProject.hasOpenRef()); // file1 and file3
+            assert.isTrue(configuredProject.hasOpenRef()); // file1 and file3
             checkProjectActualFiles(configuredProject, [file1.path, file3.path, configFile.path]);
             const inferredProject1 = projectService.inferredProjects[0];
             checkProjectActualFiles(inferredProject1, [file2.path]);
@@ -2376,23 +2376,23 @@ namespace ts.projectSystem {
             configFile.content = "{}";
             host.reloadFS(files.concat(configFile));
             // Time out is not yet run so there is project update pending
-            assert(configuredProject.hasOpenRef()); // Pending update and file2 might get into the project
+            assert.isTrue(configuredProject.hasOpenRef()); // Pending update and file2 might get into the project
 
             projectService.openClientFile(file4.path);
 
             checkNumberOfProjects(projectService, { configuredProjects: 1, inferredProjects: 2 });
-            assert.equal(projectService.configuredProjects.get(configFile.path), configuredProject);
-            assert(configuredProject.hasOpenRef()); // Pending update and F2 might get into the project
-            assert.equal(projectService.inferredProjects[0], inferredProject1);
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), configuredProject);
+            assert.isTrue(configuredProject.hasOpenRef()); // Pending update and F2 might get into the project
+            assert.strictEqual(projectService.inferredProjects[0], inferredProject1);
             const inferredProject2 = projectService.inferredProjects[1];
             checkProjectActualFiles(inferredProject2, [file4.path]);
 
             host.runQueuedTimeoutCallbacks();
             checkNumberOfProjects(projectService, { configuredProjects: 1, inferredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(configFile.path), configuredProject);
-            assert(configuredProject.hasOpenRef()); // file2
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), configuredProject);
+            assert.isTrue(configuredProject.hasOpenRef()); // file2
             checkProjectActualFiles(configuredProject, [file1.path, file2.path, file3.path, configFile.path]);
-            assert.equal(projectService.inferredProjects[0], inferredProject2);
+            assert.strictEqual(projectService.inferredProjects[0], inferredProject2);
             checkProjectActualFiles(inferredProject2, [file4.path]);
         });
 
@@ -2427,7 +2427,7 @@ namespace ts.projectSystem {
                 options: {}
             });
             service.checkNumberOfProjects({ externalProjects: 1 });
-            assert(service.externalProjects[0].languageServiceEnabled, "language service should be enabled");
+            assert.isTrue(service.externalProjects[0].languageServiceEnabled, "language service should be enabled");
 
             service.openExternalProject({
                 projectFileName,
@@ -2464,12 +2464,12 @@ namespace ts.projectSystem {
             projectService.openClientFile(f1.path);
             projectService.checkNumberOfProjects({ configuredProjects: 1 });
             const project = projectService.configuredProjects.get(config.path);
-            assert(project.hasOpenRef()); // f1
+            assert.isTrue(project.hasOpenRef()); // f1
             assert.isFalse(project.isClosed());
 
             projectService.closeClientFile(f1.path);
             projectService.checkNumberOfProjects({ configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(config.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(config.path), project);
             assert.isFalse(project.hasOpenRef()); // No files
             assert.isFalse(project.isClosed());
 
@@ -2488,7 +2488,7 @@ namespace ts.projectSystem {
             projectService.openClientFile(f4.path);
             projectService.checkNumberOfProjects({ inferredProjects: 1 });
             assert.isFalse(project.hasOpenRef()); // No files
-            assert(project.isClosed());
+            assert.isTrue(project.isClosed());
 
             for (const f of [f1, f2, f3]) {
                 // All the script infos should not be present since the project is closed and orphan script infos are collected
@@ -2540,7 +2540,7 @@ namespace ts.projectSystem {
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
             const project = configuredProjectAt(projectService, 0);
             assert.isFalse(project.languageServiceEnabled, "Language service enabled");
-            assert(!!lastEvent, "should receive event");
+            assert.isTrue(!!lastEvent, "should receive event");
             assert.equal(lastEvent.data.project, project, "project name");
             assert.equal(lastEvent.data.project.getProjectName(), config.path, "config path");
             assert.isFalse(lastEvent.data.languageServiceEnabled, "Language service state");
@@ -2548,9 +2548,9 @@ namespace ts.projectSystem {
             host.reloadFS([f1, f2, configWithExclude]);
             host.checkTimeoutQueueLengthAndRun(2);
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert(project.languageServiceEnabled, "Language service enabled");
+            assert.isTrue(project.languageServiceEnabled, "Language service enabled");
             assert.equal(lastEvent.data.project, project, "project");
-            assert(lastEvent.data.languageServiceEnabled, "Language service state");
+            assert.isTrue(lastEvent.data.languageServiceEnabled, "Language service state");
         });
 
         it("syntactic features work even if language service is disabled", () => {
@@ -2592,7 +2592,7 @@ namespace ts.projectSystem {
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
             const project = configuredProjectAt(projectService, 0);
             assert.isFalse(project.languageServiceEnabled, "Language service enabled");
-            assert(!!lastEvent, "should receive event");
+            assert.isTrue(!!lastEvent, "should receive event");
             assert.equal(lastEvent.data.project, project, "project name");
             assert.isFalse(lastEvent.data.languageServiceEnabled, "Language service state");
 
@@ -2747,7 +2747,7 @@ namespace ts.projectSystem {
             host.runQueuedTimeoutCallbacks();
             watchedRecursiveDirectories.pop();
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(configFile.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
             checkProjectActualFiles(project, mapDefined(files, file => file === file2a ? undefined : file.path));
             checkWatchedFiles(host, mapDefined(files, file => file === file1 ? undefined : file.path));
             checkWatchedDirectories(host, [], /*recursive*/ false);
@@ -2756,7 +2756,7 @@ namespace ts.projectSystem {
             // On next file open the files file2a should be closed and not watched any more
             projectService.openClientFile(file2.path);
             checkNumberOfProjects(projectService, { configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(configFile.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(configFile.path), project);
             checkProjectActualFiles(project, mapDefined(files, file => file === file2a ? undefined : file.path));
             checkWatchedFiles(host, [libFile.path, configFile.path]);
             checkWatchedDirectories(host, [], /*recursive*/ false);
@@ -2979,7 +2979,7 @@ namespace ts.projectSystem {
             });
             projectService.checkNumberOfProjects({ externalProjects: 1 });
             const typeAcquisition = projectService.externalProjects[0].getTypeAcquisition();
-            assert(typeAcquisition.enable, "Typine acquisition should be enabled");
+            assert.isTrue(typeAcquisition.enable, "Typine acquisition should be enabled");
         });
     });
 
@@ -3050,7 +3050,7 @@ namespace ts.projectSystem {
 
             const localFunctionNavToRequst = makeSessionRequest<protocol.NavtoRequestArgs>(CommandNames.Navto, { searchValue: "foo", file: file1.path, projectFileName: configFile.path });
             const items2 = session.executeCommand(localFunctionNavToRequst).response as protocol.NavtoItem[];
-            assert(containsNavToItem(items2, "foo", "function"), `Cannot find function symbol "foo".`);
+            assert.isTrue(containsNavToItem(items2, "foo", "function"), `Cannot find function symbol "foo".`);
         });
     });
 
@@ -3264,18 +3264,18 @@ namespace ts.projectSystem {
             projectService.openClientFile(f.path);
             projectService.checkNumberOfProjects({ configuredProjects: 1 });
             const project = projectService.configuredProjects.get(config.path);
-            assert(project.hasOpenRef()); // f
+            assert.isTrue(project.hasOpenRef()); // f
 
             projectService.closeClientFile(f.path);
             projectService.checkNumberOfProjects({ configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(config.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(config.path), project);
             assert.isFalse(project.hasOpenRef()); // No files
             assert.isFalse(project.isClosed());
 
             projectService.openClientFile(f.path);
             projectService.checkNumberOfProjects({ configuredProjects: 1 });
-            assert.equal(projectService.configuredProjects.get(config.path), project);
-            assert(project.hasOpenRef()); // f
+            assert.strictEqual(projectService.configuredProjects.get(config.path), project);
+            assert.isTrue(project.hasOpenRef()); // f
             assert.isFalse(project.isClosed());
         });
     });
@@ -3872,16 +3872,16 @@ namespace ts.projectSystem {
                 { file: file2.path }
             );
             let errorResult = <protocol.Diagnostic[]>session.executeCommand(file2GetErrRequest).response;
-            assert(errorResult.length === 0);
+            assert.isTrue(errorResult.length === 0);
 
             const closeFileRequest = makeSessionRequest<protocol.FileRequestArgs>(CommandNames.Close, { file: file1.path });
             session.executeCommand(closeFileRequest);
             errorResult = <protocol.Diagnostic[]>session.executeCommand(file2GetErrRequest).response;
-            assert(errorResult.length !== 0);
+            assert.isTrue(errorResult.length !== 0);
 
             openFilesForSession([file1], session);
             errorResult = <protocol.Diagnostic[]>session.executeCommand(file2GetErrRequest).response;
-            assert(errorResult.length === 0);
+            assert.isTrue(errorResult.length === 0);
         });
 
         it("should be turned on for js-only external projects", () => {
@@ -3917,7 +3917,7 @@ namespace ts.projectSystem {
                 { file: dTsFile.path }
             );
             const errorResult = <protocol.Diagnostic[]>session.executeCommand(dTsFileGetErrRequest).response;
-            assert(errorResult.length === 0);
+            assert.isTrue(errorResult.length === 0);
         });
 
         it("should be turned on for js-only external projects with skipLibCheck=false", () => {
@@ -3953,7 +3953,7 @@ namespace ts.projectSystem {
                 { file: dTsFile.path }
             );
             const errorResult = <protocol.Diagnostic[]>session.executeCommand(dTsFileGetErrRequest).response;
-            assert(errorResult.length === 0);
+            assert.isTrue(errorResult.length === 0);
         });
 
         it("should not report bind errors for declaration files with skipLibCheck=true", () => {
@@ -3984,14 +3984,14 @@ namespace ts.projectSystem {
                 { file: dTsFile1.path }
             );
             const error1Result = <protocol.Diagnostic[]>session.executeCommand(dTsFile1GetErrRequest).response;
-            assert(error1Result.length === 0);
+            assert.isTrue(error1Result.length === 0);
 
             const dTsFile2GetErrRequest = makeSessionRequest<protocol.SemanticDiagnosticsSyncRequestArgs>(
                 CommandNames.SemanticDiagnosticsSync,
                 { file: dTsFile2.path }
             );
             const error2Result = <protocol.Diagnostic[]>session.executeCommand(dTsFile2GetErrRequest).response;
-            assert(error2Result.length === 0);
+            assert.isTrue(error2Result.length === 0);
         });
 
         it("should report semanitc errors for loose JS files with '// @ts-check' and skipLibCheck=true", () => {
@@ -4012,7 +4012,7 @@ namespace ts.projectSystem {
                 { file: jsFile.path }
             );
             const errorResult = <protocol.Diagnostic[]>session.executeCommand(getErrRequest).response;
-            assert(errorResult.length === 1);
+            assert.isTrue(errorResult.length === 1);
             assert.equal(errorResult[0].code, Diagnostics.Operator_0_cannot_be_applied_to_types_1_and_2.code);
         });
 
@@ -4039,7 +4039,7 @@ namespace ts.projectSystem {
                 { file: jsFile.path }
             );
             const errorResult = <protocol.Diagnostic[]>session.executeCommand(getErrRequest).response;
-            assert(errorResult.length === 1);
+            assert.isTrue(errorResult.length === 1);
             assert.equal(errorResult[0].code, Diagnostics.Operator_0_cannot_be_applied_to_types_1_and_2.code);
         });
 
@@ -4068,7 +4068,7 @@ namespace ts.projectSystem {
                 { file: jsFile.path }
             );
             const errorResult = <protocol.Diagnostic[]>session.executeCommand(getErrRequest).response;
-            assert(errorResult.length === 1);
+            assert.isTrue(errorResult.length === 1);
             assert.equal(errorResult[0].code, Diagnostics.Operator_0_cannot_be_applied_to_types_1_and_2.code);
         });
     });
@@ -4096,7 +4096,7 @@ namespace ts.projectSystem {
             checkNumberOfInferredProjects(projectService, 1);
 
             const inferredProject = projectService.inferredProjects[0];
-            assert(inferredProject.containsFile(<server.NormalizedPath>file1.path));
+            assert.isTrue(inferredProject.containsFile(<server.NormalizedPath>file1.path));
         });
 
         it("should be able to handle @types if input file list is empty", () => {
@@ -4236,7 +4236,7 @@ namespace ts.projectSystem {
                 arguments: { file: f1.path }
             });
             checkScriptInfoAndProjects(0, f1.content, "contents of closed file");
-            assert.equal(info.getSnapshot(), snap);
+            assert.strictEqual(info.getSnapshot(), snap);
 
             // reload from temp file
             session.executeCommandSeq(<server.protocol.ReloadRequest>{
@@ -4244,7 +4244,7 @@ namespace ts.projectSystem {
                 arguments: { file: f1.path, tmpfile: tmp.path }
             });
             checkScriptInfoAndProjects(0, tmp.content, "contents of temp file");
-            assert.notEqual(info.getSnapshot(), snap);
+            assert.notStrictEqual(info.getSnapshot(), snap);
 
             // reload from own file
             session.executeCommandSeq(<server.protocol.ReloadRequest>{
@@ -4252,11 +4252,11 @@ namespace ts.projectSystem {
                 arguments: { file: f1.path }
             });
             checkScriptInfoAndProjects(0, f1.content, "contents of closed file");
-            assert.notEqual(info.getSnapshot(), snap);
+            assert.notStrictEqual(info.getSnapshot(), snap);
 
             function checkScriptInfoAndProjects(inferredProjects: number, contentsOfInfo: string, captionForContents: string) {
                 checkNumberOfProjects(projectService, { inferredProjects });
-                assert.equal(projectService.getScriptInfo(f1.path), info);
+                assert.strictEqual(projectService.getScriptInfo(f1.path), info);
                 checkScriptInfoContents(contentsOfInfo, captionForContents);
             }
 
@@ -4515,7 +4515,7 @@ namespace ts.projectSystem {
                 seq: 2,
                 arguments: { projectFileName: projectName }
             }).response as ReadonlyArray<protocol.DiagnosticWithLinePosition>;
-            assert(diags.length === 0);
+            assert.isTrue(diags.length === 0);
 
             session.executeCommand(<server.protocol.SetCompilerOptionsForInferredProjectsRequest>{
                 type: "request",
@@ -4529,7 +4529,7 @@ namespace ts.projectSystem {
                 seq: 4,
                 arguments: { projectFileName: projectName }
             }).response as ReadonlyArray<protocol.DiagnosticWithLinePosition>;
-            assert(diagsAfterUpdate.length === 0);
+            assert.isTrue(diagsAfterUpdate.length === 0);
         });
 
         it("for external project", () => {
@@ -4556,7 +4556,7 @@ namespace ts.projectSystem {
                 seq: 2,
                 arguments: { projectFileName }
             }).response as ReadonlyArray<ts.server.protocol.DiagnosticWithLinePosition>;
-            assert(diags.length === 0);
+            assert.isTrue(diags.length === 0);
 
             session.executeCommand(<server.protocol.OpenExternalProjectRequest>{
                 type: "request",
@@ -4574,7 +4574,7 @@ namespace ts.projectSystem {
                 seq: 4,
                 arguments: { projectFileName }
             }).response as ReadonlyArray<ts.server.protocol.DiagnosticWithLinePosition>;
-            assert(diagsAfterUpdate.length === 0);
+            assert.isTrue(diagsAfterUpdate.length === 0);
         });
     });
 
@@ -4758,7 +4758,7 @@ namespace ts.projectSystem {
                 isCancellationRequested: () => false,
                 setRequest: requestId => {
                     if (expectedRequestId === undefined) {
-                        assert(false, "unexpected call");
+                        assert.isTrue(false, "unexpected call");
                     }
                     assert.equal(requestId, expectedRequestId);
                 },
@@ -5017,7 +5017,7 @@ namespace ts.projectSystem {
                 );
                 const highlightResponse = session.executeCommand(highlightRequest).response as protocol.OccurrencesResponseItem[];
                 const firstOccurence = highlightResponse[0];
-                assert(firstOccurence.isInString, "Highlights should be marked with isInString");
+                assert.isTrue(firstOccurence.isInString, "Highlights should be marked with isInString");
             }
 
             {
@@ -5026,7 +5026,7 @@ namespace ts.projectSystem {
                     { file: file1.path, line: 3, offset: 13 }
                 );
                 const highlightResponse = session.executeCommand(highlightRequest).response as protocol.OccurrencesResponseItem[];
-                assert(highlightResponse.length === 2);
+                assert.isTrue(highlightResponse.length === 2);
                 const firstOccurence = highlightResponse[0];
                 assert.isUndefined(firstOccurence.isInString, "Highlights should not be marked with isInString if on property name");
             }
@@ -5037,7 +5037,7 @@ namespace ts.projectSystem {
                     { file: file1.path, line: 4, offset: 14 }
                 );
                 const highlightResponse = session.executeCommand(highlightRequest).response as protocol.OccurrencesResponseItem[];
-                assert(highlightResponse.length === 2);
+                assert.isTrue(highlightResponse.length === 2);
                 const firstOccurence = highlightResponse[0];
                 assert.isUndefined(firstOccurence.isInString, "Highlights should not be marked with isInString if on indexer");
             }
@@ -5061,13 +5061,13 @@ namespace ts.projectSystem {
 
             let project = projectService.inferredProjects[0];
             let options = project.getCompilationSettings();
-            assert(options.maxNodeModuleJsDepth === 2);
+            assert.isTrue(options.maxNodeModuleJsDepth === 2);
 
             // Assert the option sticks
             projectService.setCompilerOptionsForInferredProjects({ target: ScriptTarget.ES2016 });
             project = projectService.inferredProjects[0];
             options = project.getCompilationSettings();
-            assert(options.maxNodeModuleJsDepth === 2);
+            assert.isTrue(options.maxNodeModuleJsDepth === 2);
         });
 
         it("should return to normal state when all js root files are removed from project", () => {
@@ -5090,7 +5090,7 @@ namespace ts.projectSystem {
 
             projectService.openClientFile(file2.path);
             project = projectService.inferredProjects[0];
-            assert(project.getCompilationSettings().maxNodeModuleJsDepth === 2);
+            assert.isTrue(project.getCompilationSettings().maxNodeModuleJsDepth === 2);
 
             projectService.closeClientFile(file2.path);
             project = projectService.inferredProjects[0];
@@ -5134,7 +5134,7 @@ namespace ts.projectSystem {
                 seq: 2,
                 arguments: { file: configFile.path, projectFileName: projectName, includeLinePosition: true }
             }).response as ReadonlyArray<server.protocol.DiagnosticWithLinePosition>;
-            assert(diags.length === 2);
+            assert.isTrue(diags.length === 2);
 
             configFile.content = configFileContentWithoutCommentLine;
             host.reloadFS([file, configFile]);
@@ -5145,7 +5145,7 @@ namespace ts.projectSystem {
                 seq: 2,
                 arguments: { file: configFile.path, projectFileName: projectName, includeLinePosition: true }
             }).response as ReadonlyArray<server.protocol.DiagnosticWithLinePosition>;
-            assert(diagsAfterEdit.length === 2);
+            assert.isTrue(diagsAfterEdit.length === 2);
 
             verifyDiagnostic(diags[0], diagsAfterEdit[0]);
             verifyDiagnostic(diags[1], diagsAfterEdit[1]);
@@ -5271,7 +5271,7 @@ namespace ts.projectSystem {
             function verifyCalledOn(callback: CalledMaps, name: string) {
                 const calledMap = calledMaps[callback];
                 const result = calledMap.get(name);
-                assert(result && !!result.length, `${callback} should be called with name: ${name}: ${arrayFrom(calledMap.keys())}`);
+                assert.isTrue(result && !!result.length, `${callback} should be called with name: ${name}: ${arrayFrom(calledMap.keys())}`);
             }
 
             function verifyNoCall(callback: CalledMaps) {
@@ -5283,7 +5283,7 @@ namespace ts.projectSystem {
                 const calledMap = calledMaps[callback];
                 ts.TestFSWithWatch.verifyMapSize(callback, calledMap, arrayFrom(expectedKeys.keys()));
                 expectedKeys.forEach((called, name) => {
-                    assert(calledMap.has(name), `${callback} is expected to contain ${name}, actual keys: ${arrayFrom(calledMap.keys())}`);
+                    assert.isTrue(calledMap.has(name), `${callback} is expected to contain ${name}, actual keys: ${arrayFrom(calledMap.keys())}`);
                     assert.equal(calledMap.get(name).length, called, `${callback} is expected to be called ${called} times with ${name}. Actual entry: ${calledMap.get(name)}`);
                 });
             }
@@ -5356,10 +5356,10 @@ namespace ts.projectSystem {
             try {
                 // trigger synchronization to make sure that LSHost will try to find 'f2' module on disk
                 verifyImportedDiagnostics();
-                assert(false, `should not find file '${imported.path}'`);
+                assert.isTrue(false, `should not find file '${imported.path}'`);
             }
             catch (e) {
-                assert(e.message.indexOf(`Could not find file: '${imported.path}'.`) === 0);
+                assert.isTrue(e.message.indexOf(`Could not find file: '${imported.path}'.`) === 0);
             }
             const f2Lookups = getLocationsForModuleLookup("f2");
             callsTrackingHost.verifyCalledOnEachEntryNTimes(CalledMapsWithSingleArg.fileExists, f2Lookups, 1);
@@ -5544,7 +5544,7 @@ namespace ts.projectSystem {
             callsTrackingHost.verifyNoHostCallsExceptFileExistsOnce(["/a/b/models/tsconfig.json", "/a/b/models/jsconfig.json"]);
 
             checkNumberOfConfiguredProjects(projectService, 1);
-            assert.equal(projectService.configuredProjects.get(tsconfigFile.path), project);
+            assert.strictEqual(projectService.configuredProjects.get(tsconfigFile.path), project);
         });
 
         describe("WatchDirectories for config file with", () => {
@@ -5631,7 +5631,7 @@ namespace ts.projectSystem {
                 callsTrackingHost.verifyNoCall(CalledMapsWithFiveArgs.readDirectory);
 
                 checkNumberOfConfiguredProjects(projectService, 1);
-                assert.equal(projectService.configuredProjects.get(canonicalConfigPath), project);
+                assert.strictEqual(projectService.configuredProjects.get(canonicalConfigPath), project);
                 verifyProjectAndWatchedDirectories();
 
                 callsTrackingHost.clear();
@@ -5640,7 +5640,7 @@ namespace ts.projectSystem {
                 assert.equal(configFile2, configFileName);
 
                 checkNumberOfConfiguredProjects(projectService, 1);
-                assert.equal(projectService.configuredProjects.get(canonicalConfigPath), project);
+                assert.strictEqual(projectService.configuredProjects.get(canonicalConfigPath), project);
                 verifyProjectAndWatchedDirectories();
                 callsTrackingHost.verifyNoHostCalls();
 
@@ -5842,7 +5842,7 @@ namespace ts.projectSystem {
             forEach(actual, f => {
                 assert.isFalse(seen.has(f), `${caption}: Found duplicate ${f}. Actual: ${actual} Expected: ${expected}`);
                 seen.set(f, true);
-                assert(contains(expected, f), `${caption}: Expected not to contain ${f}. Actual: ${actual} Expected: ${expected}`);
+                assert.isTrue(contains(expected, f), `${caption}: Expected not to contain ${f}. Actual: ${actual} Expected: ${expected}`);
             });
         }
 
@@ -6313,7 +6313,7 @@ namespace ts.projectSystem {
                     else {
                         // file2 addition wont be detected
                         projectFiles.pop();
-                        assert(host.fileExists(file2.path));
+                        assert.isTrue(host.fileExists(file2.path));
                     }
                     verifyProject();
 
@@ -6380,7 +6380,7 @@ namespace ts.projectSystem {
                     assert.equal(projectChangedEvents.length, expectedEvents.length, `Incorrect number of events Actual: ${eventsToString(projectChangedEvents)} Expected: ${eventsToString(expectedEvents)}`);
                     forEach(projectChangedEvents, (actualEvent, i) => {
                         const expectedEvent = expectedEvents[i];
-                        assert.equal(actualEvent.eventName, expectedEvent.eventName);
+                        assert.strictEqual(actualEvent.eventName, expectedEvent.eventName);
                         verifyFiles("openFiles", actualEvent.data.openFiles, expectedEvent.data.openFiles);
                     });
 

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -323,7 +323,7 @@ namespace ts.projectSystem {
                 typeAcquisition: { enable: true, include: ["jquery"] }
             });
 
-            assert(enqueueIsCalled, "expected enqueueIsCalled to be true");
+            assert.isTrue(enqueueIsCalled, "expected enqueueIsCalled to be true");
             installer.installAll(/*expectedCount*/ 1);
 
             // auto is set in type acquisition - use it even if project contains only .ts files
@@ -629,7 +629,7 @@ namespace ts.projectSystem {
             installer.executePendingCommands();
             // expected all typings file to exist
             for (const f of typingFiles) {
-                assert(host.fileExists(f.path), `expected file ${f.path} to exist`);
+                assert.isTrue(host.fileExists(f.path), `expected file ${f.path} to exist`);
             }
             host.checkTimeoutQueueLengthAndRun(2);
             checkNumberOfProjects(projectService, { externalProjects: 1 });
@@ -965,8 +965,8 @@ namespace ts.projectSystem {
 
             installer.installAll(/*expectedCount*/1);
 
-            assert(host.fileExists(node.path), "typings for 'node' should be created");
-            assert(host.fileExists(commander.path), "typings for 'commander' should be created");
+            assert.isTrue(host.fileExists(node.path), "typings for 'node' should be created");
+            assert.isTrue(host.fileExists(commander.path), "typings for 'commander' should be created");
 
             checkProjectActualFiles(service.inferredProjects[0], [file.path, node.path, commander.path]);
         });
@@ -1107,7 +1107,7 @@ namespace ts.projectSystem {
             projectService.openClientFile(f1.path);
 
             installer.checkPendingCommands(/*expectedCount*/ 0);
-            assert(messages.indexOf("Package name '; say ‘Hello from TypeScript!’ #' contains non URI safe characters") > 0, "should find package with invalid name");
+            assert.isTrue(messages.indexOf("Package name '; say ‘Hello from TypeScript!’ #' contains non URI safe characters") > 0, "should find package with invalid name");
         });
     });
 
@@ -1256,7 +1256,7 @@ namespace ts.projectSystem {
 
             installer.installAll(/*expectedCount*/ 1);
 
-            assert(seenTelemetryEvent);
+            assert.isTrue(seenTelemetryEvent);
             host.checkTimeoutQueueLengthAndRun(2);
             checkNumberOfProjects(projectService, { inferredProjects: 1 });
             checkProjectActualFiles(projectService.inferredProjects[0], [f1.path, commander.path]);
@@ -1307,10 +1307,10 @@ namespace ts.projectSystem {
 
             installer.installAll(/*expectedCount*/ 1);
 
-            assert(!!beginEvent);
-            assert(!!endEvent);
-            assert(beginEvent.eventId === endEvent.eventId);
-            assert(endEvent.installSuccess);
+            assert.isTrue(!!beginEvent);
+            assert.isTrue(!!endEvent);
+            assert.isTrue(beginEvent.eventId === endEvent.eventId);
+            assert.isTrue(endEvent.installSuccess);
             host.checkTimeoutQueueLengthAndRun(2);
             checkNumberOfProjects(projectService, { inferredProjects: 1 });
             checkProjectActualFiles(projectService.inferredProjects[0], [f1.path, commander.path]);
@@ -1353,9 +1353,9 @@ namespace ts.projectSystem {
 
             installer.installAll(/*expectedCount*/ 1);
 
-            assert(!!beginEvent);
-            assert(!!endEvent);
-            assert(beginEvent.eventId === endEvent.eventId);
+            assert.isTrue(!!beginEvent);
+            assert.isTrue(!!endEvent);
+            assert.isTrue(beginEvent.eventId === endEvent.eventId);
             assert.isFalse(endEvent.installSuccess);
             checkNumberOfProjects(projectService, { inferredProjects: 1 });
             checkProjectActualFiles(projectService.inferredProjects[0], [f1.path]);

--- a/src/harness/unittests/versionCache.ts
+++ b/src/harness/unittests/versionCache.ts
@@ -34,7 +34,7 @@ var p:Point=new Point();
 var q:Point=<Point>p;`;
 
             const { lines } = server.LineIndex.linesFromText(testContent);
-            assert(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
+            assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
             const lineIndex = new server.LineIndex();
             lineIndex.load(lines);
@@ -94,7 +94,7 @@ that was purple at the tips
 and grew 1cm per day`;
 
             ({ lines, lineMap } = server.LineIndex.linesFromText(testContent));
-            assert(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
+            assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
             const lineIndex = new server.LineIndex();
             lineIndex.load(lines);
@@ -203,10 +203,10 @@ and grew 1cm per day`;
             const testFileName = "src/compiler/scanner.ts";
             testContent = Harness.IO.readFile(testFileName);
             const totalChars = testContent.length;
-            assert(totalChars > 0, "Failed to read test file.");
+            assert.isTrue(totalChars > 0, "Failed to read test file.");
 
             ({ lines, lineMap } = server.LineIndex.linesFromText(testContent));
-            assert(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
+            assert.isTrue(lines.length > 0, "Failed to initialize test text. Expected text to have at least one line");
 
             lineIndex = new server.LineIndex();
             lineIndex.load(lines);

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -139,7 +139,7 @@ interface Array<T> {}`
     function checkMapKeys(caption: string, map: Map<any>, expectedKeys: ReadonlyArray<string>) {
         verifyMapSize(caption, map, expectedKeys);
         for (const name of expectedKeys) {
-            assert(map.has(name), `${caption} is expected to contain ${name}, actual keys: ${arrayFrom(map.keys())}`);
+            assert.isTrue(map.has(name), `${caption} is expected to contain ${name}, actual keys: ${arrayFrom(map.keys())}`);
         }
     }
 


### PR DESCRIPTION
Chai removing the namespace from their types was a [bug](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21946), which has been [fixed](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21924) - the correct fix from us would have been pinning our version until a fix was out, but instead we went way overboard and removed the dependency, and I'll be honest, while the assertions are no different when all tests are passing, that's _not what there're there for_. Failure messages like this one:
![image](https://user-images.githubusercontent.com/2932786/33909263-ed2a888e-df3f-11e7-9715-e1dca6c677cb.png)

Are straight bad compared to what `chai` gives (a useful comparison of both inputs to `equals`). Object diffs for deep equals are also much worse (or rather, non-extant). We didn't use an assertion library for no reason, we used it to be more productive when debugging. I don't want to need to open a debugger just to see every small discrepancy! And while I could spend hours of effort making our custom assertion library become up-to-par with what I'd expect for a decent debugging experience (and I know @rbuckton already has his own assertion framework, but he's not ready AFAIK), it's much easy to not have a NIH mindset and continue using the tested and featureful assertion library we've been using for years. Especially since there's not a single issue with it.
