### PR TITLE
Use TypeFlags.UnionOrIntersection in isLiteralOfContextualType not TypeFlags.Union

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19094,7 +19094,7 @@ namespace ts {
 
         function isLiteralOfContextualType(candidateType: Type, contextualType: Type): boolean {
             if (contextualType) {
-                if (contextualType.flags & TypeFlags.Union && !(contextualType.flags & TypeFlags.Boolean)) {
+                if (contextualType.flags & TypeFlags.UnionOrIntersection && !(contextualType.flags & TypeFlags.Boolean)) {
                     // If the contextual type is a union containing both of the 'true' and 'false' types we
                     // don't consider it a literal context for boolean literals.
                     const types = (<UnionType>contextualType).types;

--- a/tests/baselines/reference/literalIntersectionYieldsLiteral.js
+++ b/tests/baselines/reference/literalIntersectionYieldsLiteral.js
@@ -1,0 +1,23 @@
+//// [literalIntersectionYieldsLiteral.ts]
+export type BaseAttribute<T> = {
+    type?: string;
+}
+export type StringAttribute = BaseAttribute<string> & {
+    type: "string";
+}
+export type NumberAttribute = BaseAttribute<string> & {
+    type: "number";
+}
+export type Attribute = StringAttribute | NumberAttribute;
+
+const foo: Attribute = {
+    type: "string"
+}
+
+
+//// [literalIntersectionYieldsLiteral.js]
+"use strict";
+exports.__esModule = true;
+var foo = {
+    type: "string"
+};

--- a/tests/baselines/reference/literalIntersectionYieldsLiteral.symbols
+++ b/tests/baselines/reference/literalIntersectionYieldsLiteral.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/literalIntersectionYieldsLiteral.ts ===
+export type BaseAttribute<T> = {
+>BaseAttribute : Symbol(BaseAttribute, Decl(literalIntersectionYieldsLiteral.ts, 0, 0))
+>T : Symbol(T, Decl(literalIntersectionYieldsLiteral.ts, 0, 26))
+
+    type?: string;
+>type : Symbol(type, Decl(literalIntersectionYieldsLiteral.ts, 0, 32))
+}
+export type StringAttribute = BaseAttribute<string> & {
+>StringAttribute : Symbol(StringAttribute, Decl(literalIntersectionYieldsLiteral.ts, 2, 1))
+>BaseAttribute : Symbol(BaseAttribute, Decl(literalIntersectionYieldsLiteral.ts, 0, 0))
+
+    type: "string";
+>type : Symbol(type, Decl(literalIntersectionYieldsLiteral.ts, 3, 55))
+}
+export type NumberAttribute = BaseAttribute<string> & {
+>NumberAttribute : Symbol(NumberAttribute, Decl(literalIntersectionYieldsLiteral.ts, 5, 1))
+>BaseAttribute : Symbol(BaseAttribute, Decl(literalIntersectionYieldsLiteral.ts, 0, 0))
+
+    type: "number";
+>type : Symbol(type, Decl(literalIntersectionYieldsLiteral.ts, 6, 55))
+}
+export type Attribute = StringAttribute | NumberAttribute;
+>Attribute : Symbol(Attribute, Decl(literalIntersectionYieldsLiteral.ts, 8, 1))
+>StringAttribute : Symbol(StringAttribute, Decl(literalIntersectionYieldsLiteral.ts, 2, 1))
+>NumberAttribute : Symbol(NumberAttribute, Decl(literalIntersectionYieldsLiteral.ts, 5, 1))
+
+const foo: Attribute = {
+>foo : Symbol(foo, Decl(literalIntersectionYieldsLiteral.ts, 11, 5))
+>Attribute : Symbol(Attribute, Decl(literalIntersectionYieldsLiteral.ts, 8, 1))
+
+    type: "string"
+>type : Symbol(type, Decl(literalIntersectionYieldsLiteral.ts, 11, 24))
+}
+

--- a/tests/baselines/reference/literalIntersectionYieldsLiteral.types
+++ b/tests/baselines/reference/literalIntersectionYieldsLiteral.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/literalIntersectionYieldsLiteral.ts ===
+export type BaseAttribute<T> = {
+>BaseAttribute : BaseAttribute<T>
+>T : T
+
+    type?: string;
+>type : string
+}
+export type StringAttribute = BaseAttribute<string> & {
+>StringAttribute : StringAttribute
+>BaseAttribute : BaseAttribute<T>
+
+    type: "string";
+>type : "string"
+}
+export type NumberAttribute = BaseAttribute<string> & {
+>NumberAttribute : NumberAttribute
+>BaseAttribute : BaseAttribute<T>
+
+    type: "number";
+>type : "number"
+}
+export type Attribute = StringAttribute | NumberAttribute;
+>Attribute : Attribute
+>StringAttribute : StringAttribute
+>NumberAttribute : NumberAttribute
+
+const foo: Attribute = {
+>foo : Attribute
+>Attribute : Attribute
+>{    type: "string"} : { type: "string"; }
+
+    type: "string"
+>type : string
+>"string" : "string"
+}
+

--- a/tests/cases/compiler/literalIntersectionYieldsLiteral.ts
+++ b/tests/cases/compiler/literalIntersectionYieldsLiteral.ts
@@ -1,0 +1,14 @@
+export type BaseAttribute<T> = {
+    type?: string;
+}
+export type StringAttribute = BaseAttribute<string> & {
+    type: "string";
+}
+export type NumberAttribute = BaseAttribute<string> & {
+    type: "number";
+}
+export type Attribute = StringAttribute | NumberAttribute;
+
+const foo: Attribute = {
+    type: "string"
+}


### PR DESCRIPTION
We mistakenly used `TypeFlags.Union` and not `TypeFlags.UnionOrIntersection` for checking if this function needed to iterate over a type, so no intersection type could ever contribute to the literalness of a position. This fixes that.

Fixes #20653
