### PR TITLE
error if import empty object form module not existed

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23852,7 +23852,10 @@ namespace ts {
                             checkImportBinding(importClause.namedBindings);
                         }
                         else {
-                            forEach(importClause.namedBindings.elements, checkImportBinding);
+                            const moduleExisted = resolveExternalModuleName(node, node.moduleSpecifier);
+                            if (moduleExisted) {
+                                forEach(importClause.namedBindings.elements, checkImportBinding);
+                            }
                         }
                     }
                 }

--- a/tests/baselines/reference/importEmptyFromModuleNotExisted.errors.txt
+++ b/tests/baselines/reference/importEmptyFromModuleNotExisted.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts(1,16): error TS2307: Cannot find module 'module-not-existed'.
+
+
+==== tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts (1 errors) ====
+    import {} from 'module-not-existed'
+                   ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'module-not-existed'.
+    

--- a/tests/baselines/reference/importEmptyFromModuleNotExisted.js
+++ b/tests/baselines/reference/importEmptyFromModuleNotExisted.js
@@ -1,0 +1,7 @@
+//// [importEmptyFromModuleNotExisted.ts]
+import {} from 'module-not-existed'
+
+
+//// [importEmptyFromModuleNotExisted.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/importEmptyFromModuleNotExisted.symbols
+++ b/tests/baselines/reference/importEmptyFromModuleNotExisted.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts ===
+import {} from 'module-not-existed'
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/importEmptyFromModuleNotExisted.types
+++ b/tests/baselines/reference/importEmptyFromModuleNotExisted.types
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts ===
+import {} from 'module-not-existed'
+No type information for this code.
+No type information for this code.

--- a/tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts
+++ b/tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts
@@ -1,0 +1,1 @@
+import {} from 'module-not-existed'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #20576 
