### PR TITLE
Try to resolve module before checking imports

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23439,17 +23439,20 @@ namespace ts {
                 grammarErrorOnFirstToken(node, Diagnostics.An_import_declaration_cannot_have_modifiers);
             }
             if (checkExternalImportOrExportDeclaration(node)) {
-                const importClause = node.importClause;
-                if (importClause) {
-                    if (importClause.name) {
-                        checkImportBinding(importClause);
-                    }
-                    if (importClause.namedBindings) {
-                        if (importClause.namedBindings.kind === SyntaxKind.NamespaceImport) {
-                            checkImportBinding(<NamespaceImport>importClause.namedBindings);
+                const resolvedModule = resolveExternalModuleName(node, node.moduleSpecifier);
+                if (resolvedModule) {
+                    const importClause = node.importClause;
+                    if (importClause) {
+                        if (importClause.name) {
+                            checkImportBinding(importClause);
                         }
-                        else {
-                            forEach((<NamedImports>importClause.namedBindings).elements, checkImportBinding);
+                        if (importClause.namedBindings) {
+                            if (importClause.namedBindings.kind === SyntaxKind.NamespaceImport) {
+                                checkImportBinding(<NamespaceImport>importClause.namedBindings);
+                            }
+                            else {
+                                forEach((<NamedImports>importClause.namedBindings).elements, checkImportBinding);
+                            }
                         }
                     }
                 }

--- a/tests/baselines/reference/ambientExportDefaultErrors.errors.txt
+++ b/tests/baselines/reference/ambientExportDefaultErrors.errors.txt
@@ -1,16 +1,22 @@
+tests/cases/compiler/consumer.ts(4,8): error TS2307: Cannot find module 'foo'.
+tests/cases/compiler/consumer.ts(6,8): error TS2307: Cannot find module 'foo2'.
 tests/cases/compiler/foo.d.ts(1,16): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
 tests/cases/compiler/foo2.d.ts(1,10): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
 tests/cases/compiler/indirection.d.ts(3,20): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
 tests/cases/compiler/indirection2.d.ts(3,14): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
 
 
-==== tests/cases/compiler/consumer.ts (0 errors) ====
+==== tests/cases/compiler/consumer.ts (2 errors) ====
     /// <reference path="./indirection.d.ts" />
     /// <reference path="./indirection2.d.ts" />
     import "indirect";
     import "foo";
+           ~~~~~
+!!! error TS2307: Cannot find module 'foo'.
     import "indirect2";
     import "foo2";
+           ~~~~~~
+!!! error TS2307: Cannot find module 'foo2'.
 ==== tests/cases/compiler/foo.d.ts (1 errors) ====
     export default 2 + 2;
                    ~~~~~

--- a/tests/baselines/reference/amdDependencyCommentName4.errors.txt
+++ b/tests/baselines/reference/amdDependencyCommentName4.errors.txt
@@ -1,16 +1,20 @@
+tests/cases/compiler/amdDependencyCommentName4.ts(6,8): error TS2307: Cannot find module 'unaliasedModule1'.
 tests/cases/compiler/amdDependencyCommentName4.ts(8,21): error TS2307: Cannot find module 'aliasedModule1'.
 tests/cases/compiler/amdDependencyCommentName4.ts(11,26): error TS2307: Cannot find module 'aliasedModule2'.
 tests/cases/compiler/amdDependencyCommentName4.ts(14,15): error TS2307: Cannot find module 'aliasedModule3'.
 tests/cases/compiler/amdDependencyCommentName4.ts(17,21): error TS2307: Cannot find module 'aliasedModule4'.
+tests/cases/compiler/amdDependencyCommentName4.ts(20,8): error TS2307: Cannot find module 'unaliasedModule2'.
 
 
-==== tests/cases/compiler/amdDependencyCommentName4.ts (4 errors) ====
+==== tests/cases/compiler/amdDependencyCommentName4.ts (6 errors) ====
     ///<amd-dependency path='aliasedModule5' name='n1'/>
     ///<amd-dependency path='unaliasedModule3'/>
     ///<amd-dependency path='aliasedModule6' name='n2'/>
     ///<amd-dependency path='unaliasedModule4'/>
     
     import "unaliasedModule1";
+           ~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'unaliasedModule1'.
     
     import r1 = require("aliasedModule1");
                         ~~~~~~~~~~~~~~~~
@@ -33,3 +37,5 @@ tests/cases/compiler/amdDependencyCommentName4.ts(17,21): error TS2307: Cannot f
     ns;
     
     import "unaliasedModule2";
+           ~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'unaliasedModule2'.

--- a/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.js
+++ b/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.js
@@ -4,7 +4,7 @@
 export var a = 10;
 
 //// [es6ImportWithoutFromClauseInEs5_1.ts]
-import "es6ImportWithoutFromClauseInEs5_0";
+import "./es6ImportWithoutFromClauseInEs5_0";
 
 //// [es6ImportWithoutFromClauseInEs5_0.js]
 "use strict";
@@ -13,10 +13,10 @@ exports.a = 10;
 //// [es6ImportWithoutFromClauseInEs5_1.js]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-require("es6ImportWithoutFromClauseInEs5_0");
+require("./es6ImportWithoutFromClauseInEs5_0");
 
 
 //// [es6ImportWithoutFromClauseInEs5_0.d.ts]
 export declare var a: number;
 //// [es6ImportWithoutFromClauseInEs5_1.d.ts]
-import "es6ImportWithoutFromClauseInEs5_0";
+import "./es6ImportWithoutFromClauseInEs5_0";

--- a/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.symbols
+++ b/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.symbols
@@ -3,5 +3,5 @@ export var a = 10;
 >a : Symbol(a, Decl(es6ImportWithoutFromClauseInEs5_0.ts, 0, 10))
 
 === tests/cases/compiler/es6ImportWithoutFromClauseInEs5_1.ts ===
-import "es6ImportWithoutFromClauseInEs5_0";
+import "./es6ImportWithoutFromClauseInEs5_0";
 No type information for this code.

--- a/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.types
+++ b/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.types
@@ -4,5 +4,5 @@ export var a = 10;
 >10 : 10
 
 === tests/cases/compiler/es6ImportWithoutFromClauseInEs5_1.ts ===
-import "es6ImportWithoutFromClauseInEs5_0";
+import "./es6ImportWithoutFromClauseInEs5_0";
 No type information for this code.

--- a/tests/baselines/reference/es6ImportWithoutFromClauseWithExport.errors.txt
+++ b/tests/baselines/reference/es6ImportWithoutFromClauseWithExport.errors.txt
@@ -1,10 +1,13 @@
 tests/cases/compiler/client.ts(1,1): error TS1191: An import declaration cannot have modifiers.
+tests/cases/compiler/client.ts(1,15): error TS2307: Cannot find module 'server'.
 
 
 ==== tests/cases/compiler/server.ts (0 errors) ====
     export var a = 10;
     
-==== tests/cases/compiler/client.ts (1 errors) ====
+==== tests/cases/compiler/client.ts (2 errors) ====
     export import "server";
     ~~~~~~
 !!! error TS1191: An import declaration cannot have modifiers.
+                  ~~~~~~~~
+!!! error TS2307: Cannot find module 'server'.

--- a/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.errors.txt
+++ b/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/compiler/index.tsx(1,8): error TS2307: Cannot find module './jsx'.
+
+
+==== tests/cases/compiler/index.tsx (1 errors) ====
+    import "./jsx";
+           ~~~~~~~
+!!! error TS2307: Cannot find module './jsx'.
+    
+    var skate: any;
+    const React = { createElement: skate.h };
+    
+    class Component {
+        renderCallback() {
+            return <div>test</div>;
+        }
+    };

--- a/tests/baselines/reference/moduleResolutionWithExtensions_unexpected.errors.txt
+++ b/tests/baselines/reference/moduleResolutionWithExtensions_unexpected.errors.txt
@@ -1,0 +1,16 @@
+/a.ts(1,8): error TS2307: Cannot find module 'normalize.css'.
+
+
+==== /a.ts (1 errors) ====
+    import "normalize.css";
+           ~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'normalize.css'.
+    
+==== /node_modules/normalize.css/normalize.css (0 errors) ====
+    // This tests that a package.json "main" with an unexpected extension is ignored.
+    
+    This file is not read.
+    
+==== /node_modules/normalize.css/package.json (0 errors) ====
+    { "main": "normalize.css" }
+    

--- a/tests/baselines/reference/moduleResolutionWithExtensions_unexpected2.errors.txt
+++ b/tests/baselines/reference/moduleResolutionWithExtensions_unexpected2.errors.txt
@@ -1,0 +1,16 @@
+/a.ts(1,8): error TS2307: Cannot find module 'foo'.
+
+
+==== /a.ts (1 errors) ====
+    import "foo";
+           ~~~~~
+!!! error TS2307: Cannot find module 'foo'.
+    
+==== /node_modules/foo/foo.js (0 errors) ====
+    // This tests that a package.json "types" with an unexpected extension is ignored.
+    
+    This file is not read.
+    
+==== /node_modules/foo/package.json (0 errors) ====
+    { "types": "foo.js" }
+    

--- a/tests/baselines/reference/systemModule9.errors.txt
+++ b/tests/baselines/reference/systemModule9.errors.txt
@@ -1,12 +1,13 @@
 tests/cases/compiler/systemModule9.ts(1,21): error TS2307: Cannot find module 'file1'.
 tests/cases/compiler/systemModule9.ts(2,25): error TS2307: Cannot find module 'file2'.
 tests/cases/compiler/systemModule9.ts(3,15): error TS2307: Cannot find module 'file3'.
+tests/cases/compiler/systemModule9.ts(4,8): error TS2307: Cannot find module 'file4'.
 tests/cases/compiler/systemModule9.ts(5,25): error TS2307: Cannot find module 'file5'.
 tests/cases/compiler/systemModule9.ts(6,22): error TS2307: Cannot find module 'file6'.
 tests/cases/compiler/systemModule9.ts(16,15): error TS2307: Cannot find module 'file7'.
 
 
-==== tests/cases/compiler/systemModule9.ts (6 errors) ====
+==== tests/cases/compiler/systemModule9.ts (7 errors) ====
     import * as ns from 'file1';
                         ~~~~~~~
 !!! error TS2307: Cannot find module 'file1'.
@@ -17,6 +18,8 @@ tests/cases/compiler/systemModule9.ts(16,15): error TS2307: Cannot find module '
                   ~~~~~~~
 !!! error TS2307: Cannot find module 'file3'.
     import 'file4'
+           ~~~~~~~
+!!! error TS2307: Cannot find module 'file4'.
     import e, * as ns2 from 'file5';
                             ~~~~~~~
 !!! error TS2307: Cannot find module 'file5'.

--- a/tests/cases/compiler/es6ImportWithoutFromClauseInEs5.ts
+++ b/tests/cases/compiler/es6ImportWithoutFromClauseInEs5.ts
@@ -6,4 +6,4 @@
 export var a = 10;
 
 // @filename: es6ImportWithoutFromClauseInEs5_1.ts
-import "es6ImportWithoutFromClauseInEs5_0";
+import "./es6ImportWithoutFromClauseInEs5_0";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #20576


**Use-case 1:**

```
import "./foo";
```

No `importClause.name` nor `importClause.namedBindings`, no branch is reached that tries to resolve the module.


**Use-case 2:**

```
import {} from "./foo";
```

No `importClause.name`, has `importClause.namedBindings` but it's empty, no branch is reached that tries to resolve the module.

Notes:

1. The only test changed is what seems to have been a false positive.
2. Other tests have their baseline updated, as all new errors thrown are valid and correct, without impairing the underlying test cases as far as I can tell
3. Although the in the issue it is stated use-case 1 is handled correctly by emitting an error, I confirmed in both `2.6.2` and `2.7.0-dev.20171213` that it is not the case.
