### PR TITLE
Expose `getImmediateAliasedSymbol`

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2756,7 +2756,7 @@ namespace ts {
         /** Follow all aliases to get the original symbol. */
         getAliasedSymbol(symbol: Symbol): Symbol;
         /** Follow a *single* alias to get the immediately aliased symbol. */
-        /* @internal */ getImmediateAliasedSymbol(symbol: Symbol): Symbol;
+        getImmediateAliasedSymbol(symbol: Symbol): Symbol;
         getExportsOfModule(moduleSymbol: Symbol): Symbol[];
         /** Unlike `getExportsOfModule`, this includes properties of an `export =` value. */
         /* @internal */ getExportsAndPropertiesOfModule(moduleSymbol: Symbol): Symbol[];


### PR DESCRIPTION
This method seems useful for generating docs/flow types from typescript code. I don't know why it was marked as internal only.