### PR TITLE
Make jsx attributes considered mutable locations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14802,6 +14802,12 @@ namespace ts {
             }
         }
 
+        function checkJsxAttribute(node: JsxAttribute, checkMode?: CheckMode) {
+            return node.initializer
+                ? checkExpressionForMutableLocation(node.initializer, checkMode)
+                : trueType;  // <Elem attr /> is sugar for <Elem attr={true} />
+        }
+
         /**
          * Get attributes type of the JSX opening-like element. The result is from resolving "attributes" property of the opening-like element.
          *
@@ -14824,9 +14830,7 @@ namespace ts {
             for (const attributeDecl of attributes.properties) {
                 const member = attributeDecl.symbol;
                 if (isJsxAttribute(attributeDecl)) {
-                    const exprType = attributeDecl.initializer ?
-                        checkExpression(attributeDecl.initializer, checkMode) :
-                        trueType;  // <Elem attr /> is sugar for <Elem attr={true} />
+                    const exprType = checkJsxAttribute(attributeDecl, checkMode);
 
                     const attributeSymbol = <TransientSymbol>createSymbol(SymbolFlags.Property | SymbolFlags.Transient | member.flags, member.escapedName);
                     attributeSymbol.declarations = member.declarations;

--- a/tests/baselines/reference/checkJsxChildrenProperty14.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty14.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(42,27): error TS2322: Type '{ a: 10; b: "hi"; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
-  Type '{ a: 10; b: "hi"; children: Element[]; }' is not assignable to type 'SingleChildProp'.
+tests/cases/conformance/jsx/file.tsx(42,27): error TS2322: Type '{ a: number; b: string; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
+  Type '{ a: number; b: string; children: Element[]; }' is not assignable to type 'SingleChildProp'.
     Types of property 'children' are incompatible.
       Type 'Element[]' is not assignable to type 'Element'.
         Property 'type' is missing in type 'Element[]'.
@@ -49,8 +49,8 @@ tests/cases/conformance/jsx/file.tsx(42,27): error TS2322: Type '{ a: 10; b: "hi
     // Error
     let k5 = <SingleChildComp a={10} b="hi"><></><Button /><AnotherButton /></SingleChildComp>;
                               ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: Element[]; }' is not assignable to type 'SingleChildProp'.
+!!! error TS2322: Type '{ a: number; b: string; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
+!!! error TS2322:   Type '{ a: number; b: string; children: Element[]; }' is not assignable to type 'SingleChildProp'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type 'Element[]' is not assignable to type 'Element'.
 !!! error TS2322:         Property 'type' is missing in type 'Element[]'.

--- a/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
@@ -1,27 +1,27 @@
-tests/cases/conformance/jsx/file.tsx(14,15): error TS2322: Type '{ a: 10; b: "hi"; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; }' is not assignable to type 'Prop'.
-    Property 'children' is missing in type '{ a: 10; b: "hi"; }'.
+tests/cases/conformance/jsx/file.tsx(14,15): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+    Property 'children' is missing in type '{ a: number; b: string; }'.
 tests/cases/conformance/jsx/file.tsx(17,11): error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
-tests/cases/conformance/jsx/file.tsx(31,11): error TS2322: Type '{ a: 10; b: "hi"; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(31,11): error TS2322: Type '{ a: number; b: string; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
         Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
           Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
-tests/cases/conformance/jsx/file.tsx(37,11): error TS2322: Type '{ a: 10; b: "hi"; children: (Element | 1000000)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: (Element | 1000000)[]; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(37,11): error TS2322: Type '{ a: number; b: string; children: (Element | 1000000)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: (Element | 1000000)[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(Element | 1000000)[]' is not assignable to type 'string | Element'.
         Type '(Element | 1000000)[]' is not assignable to type 'Element'.
           Property 'type' is missing in type '(Element | 1000000)[]'.
-tests/cases/conformance/jsx/file.tsx(43,11): error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(43,11): error TS2322: Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'string | Element'.
         Type '(string | Element)[]' is not assignable to type 'Element'.
           Property 'type' is missing in type '(string | Element)[]'.
-tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: 10; b: "hi"; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: Element[]; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: number; b: string; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: Element[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type 'Element[]' is not assignable to type 'string | Element'.
         Type 'Element[]' is not assignable to type 'Element'.
@@ -44,9 +44,9 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: 10; b: "hi
     // Error: missing children
     let k = <Comp a={10} b="hi" />;
                   ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Property 'children' is missing in type '{ a: 10; b: "hi"; }'.
+!!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Property 'children' is missing in type '{ a: number; b: string; }'.
     
     let k0 =
         <Comp a={10} b="hi" children="Random" >
@@ -67,8 +67,8 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: 10; b: "hi
     let k2 =
         <Comp a={10} b="hi">
               ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
 !!! error TS2322:         Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
@@ -80,8 +80,8 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: 10; b: "hi
     let k3 =
         <Comp a={10} b="hi">
               ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: (Element | 1000000)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: (Element | 1000000)[]; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: (Element | 1000000)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: (Element | 1000000)[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(Element | 1000000)[]' is not assignable to type 'string | Element'.
 !!! error TS2322:         Type '(Element | 1000000)[]' is not assignable to type 'Element'.
@@ -93,8 +93,8 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: 10; b: "hi
     let k4 =
         <Comp a={10} b="hi" >
               ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'string | Element'.
 !!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element'.
@@ -106,8 +106,8 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: 10; b: "hi
     let k5 =
         <Comp a={10} b="hi" >
               ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: Element[]; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: Element[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type 'Element[]' is not assignable to type 'string | Element'.
 !!! error TS2322:         Type 'Element[]' is not assignable to type 'Element'.

--- a/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/conformance/jsx/file.tsx(20,15): error TS2322: Type '{ a: 10; b: "hi"; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; }' is not assignable to type 'Prop'.
-    Property 'children' is missing in type '{ a: 10; b: "hi"; }'.
-tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ a: 10; b: "hi"; children: Element; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: Element; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(20,15): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+    Property 'children' is missing in type '{ a: number; b: string; }'.
+tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ a: number; b: string; children: Element; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: Element; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type 'Element' is not assignable to type 'Button'.
         Property 'render' is missing in type 'Element'.
-tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{ a: 10; b: "hi"; children: typeof Button; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: typeof Button; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{ a: number; b: string; children: typeof Button; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: typeof Button; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type 'typeof Button' is not assignable to type 'Button'.
         Property 'render' is missing in type 'typeof Button'.
@@ -35,16 +35,16 @@ tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{ a: 10; b: "hi
     // Error: no children specified
     let k = <Comp a={10} b="hi" />;
                   ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Property 'children' is missing in type '{ a: 10; b: "hi"; }'.
+!!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Property 'children' is missing in type '{ a: number; b: string; }'.
     
     // Error: JSX.element is not the same as JSX.ElementClass
     let k1 =
         <Comp a={10} b="hi">
               ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: Element; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: Element; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: Element; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: Element; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type 'Element' is not assignable to type 'Button'.
 !!! error TS2322:         Property 'render' is missing in type 'Element'.
@@ -53,8 +53,8 @@ tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{ a: 10; b: "hi
     let k2 =
         <Comp a={10} b="hi">
               ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: typeof Button; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: typeof Button; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: typeof Button; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: typeof Button; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type 'typeof Button' is not assignable to type 'Button'.
 !!! error TS2322:         Property 'render' is missing in type 'typeof Button'.

--- a/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
@@ -1,17 +1,17 @@
-tests/cases/conformance/jsx/file.tsx(24,16): error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(24,16): error TS2322: Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
         Type '(string | Element)[]' is not assignable to type 'Element[]'.
           Type 'string | Element' is not assignable to type 'Element'.
             Type 'string' is not assignable to type 'Element'.
-tests/cases/conformance/jsx/file.tsx(25,16): error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(25,16): error TS2322: Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
         Type '(string | Element)[]' is not assignable to type 'Element[]'.
-tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+  Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
         Type '(string | Element)[]' is not assignable to type 'Element[]'.
@@ -43,8 +43,8 @@ tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ a: 10; b: "hi
     // Error: whitespaces matters
     let k1 = <Comp a={10} b="hi"><Button />  <AnotherButton /></Comp>;
                    ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
 !!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
@@ -52,16 +52,16 @@ tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ a: 10; b: "hi
 !!! error TS2322:             Type 'string' is not assignable to type 'Element'.
     let k2 = <Comp a={10} b="hi"><Button />
                    ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
 !!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
         <AnotherButton />  </Comp>;
     let k3 = <Comp a={10} b="hi">    <Button />
                    ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: 10; b: "hi"; children: (string | Element)[]; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+!!! error TS2322:   Type '{ a: number; b: string; children: (string | Element)[]; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
 !!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.

--- a/tests/baselines/reference/tsxAttributeErrors.errors.txt
+++ b/tests/baselines/reference/tsxAttributeErrors.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/jsx/tsxAttributeErrors.tsx(14,6): error TS2322: Type '{ text: 42; }' is not assignable to type '{ text?: string; width?: number; }'.
+tests/cases/conformance/jsx/tsxAttributeErrors.tsx(14,6): error TS2322: Type '{ text: number; }' is not assignable to type '{ text?: string; width?: number; }'.
   Types of property 'text' are incompatible.
-    Type '42' is not assignable to type 'string'.
-tests/cases/conformance/jsx/tsxAttributeErrors.tsx(17,6): error TS2322: Type '{ width: "foo"; }' is not assignable to type '{ text?: string; width?: number; }'.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/tsxAttributeErrors.tsx(17,6): error TS2322: Type '{ width: string; }' is not assignable to type '{ text?: string; width?: number; }'.
   Types of property 'width' are incompatible.
-    Type '"foo"' is not assignable to type 'number'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/jsx/tsxAttributeErrors.tsx(21,6): error TS2322: Type '{ text: number; }' is not assignable to type '{ text?: string; width?: number; }'.
   Types of property 'text' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -25,16 +25,16 @@ tests/cases/conformance/jsx/tsxAttributeErrors.tsx(21,6): error TS2322: Type '{ 
     // Error, number is not assignable to string
     <div text={42} />;
          ~~~~~~~~~
-!!! error TS2322: Type '{ text: 42; }' is not assignable to type '{ text?: string; width?: number; }'.
+!!! error TS2322: Type '{ text: number; }' is not assignable to type '{ text?: string; width?: number; }'.
 !!! error TS2322:   Types of property 'text' are incompatible.
-!!! error TS2322:     Type '42' is not assignable to type 'string'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     
     // Error, string is not assignable to number
     <div width={'foo'} />;
          ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ width: "foo"; }' is not assignable to type '{ text?: string; width?: number; }'.
+!!! error TS2322: Type '{ width: string; }' is not assignable to type '{ text?: string; width?: number; }'.
 !!! error TS2322:   Types of property 'width' are incompatible.
-!!! error TS2322:     Type '"foo"' is not assignable to type 'number'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     
     // Error, number is not assignable to string
     var attribs = { text: 100 };

--- a/tests/baselines/reference/tsxAttributeResolution1.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution1.errors.txt
@@ -1,17 +1,17 @@
-tests/cases/conformance/jsx/file.tsx(23,8): error TS2322: Type '{ x: "0"; }' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(23,8): error TS2322: Type '{ x: string; }' is not assignable to type 'Attribs1'.
   Types of property 'x' are incompatible.
-    Type '"0"' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(24,8): error TS2559: Type '{ y: 0; }' has no properties in common with type 'Attribs1'.
-tests/cases/conformance/jsx/file.tsx(25,8): error TS2559: Type '{ y: "foo"; }' has no properties in common with type 'Attribs1'.
-tests/cases/conformance/jsx/file.tsx(26,8): error TS2322: Type '{ x: "32"; }' is not assignable to type 'Attribs1'.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(24,8): error TS2559: Type '{ y: number; }' has no properties in common with type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(25,8): error TS2559: Type '{ y: string; }' has no properties in common with type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(26,8): error TS2322: Type '{ x: string; }' is not assignable to type 'Attribs1'.
   Types of property 'x' are incompatible.
-    Type '"32"' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(27,8): error TS2559: Type '{ var: "10"; }' has no properties in common with type 'Attribs1'.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(27,8): error TS2559: Type '{ var: string; }' has no properties in common with type 'Attribs1'.
 tests/cases/conformance/jsx/file.tsx(29,1): error TS2322: Type '{}' is not assignable to type '{ reqd: string; }'.
   Property 'reqd' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: 10; }' is not assignable to type '{ reqd: string; }'.
+tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: number; }' is not assignable to type '{ reqd: string; }'.
   Types of property 'reqd' are incompatible.
-    Type '10' is not assignable to type 'string'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (7 errors) ====
@@ -39,23 +39,23 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: 10; }' i
     // Errors
     <test1 x={'0'} />; // Error, '0' is not number
            ~~~~~~~
-!!! error TS2322: Type '{ x: "0"; }' is not assignable to type 'Attribs1'.
+!!! error TS2322: Type '{ x: string; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type '"0"' is not assignable to type 'number'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     <test1 y={0} />; // Error, no property "y"
            ~~~~~
-!!! error TS2559: Type '{ y: 0; }' has no properties in common with type 'Attribs1'.
+!!! error TS2559: Type '{ y: number; }' has no properties in common with type 'Attribs1'.
     <test1 y="foo" />; // Error, no property "y"
            ~~~~~~~
-!!! error TS2559: Type '{ y: "foo"; }' has no properties in common with type 'Attribs1'.
+!!! error TS2559: Type '{ y: string; }' has no properties in common with type 'Attribs1'.
     <test1 x="32" />; // Error, "32" is not number
            ~~~~~~
-!!! error TS2322: Type '{ x: "32"; }' is not assignable to type 'Attribs1'.
+!!! error TS2322: Type '{ x: string; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type '"32"' is not assignable to type 'number'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     <test1 var="10" />; // Error, no 'var' property
            ~~~~~~~~
-!!! error TS2559: Type '{ var: "10"; }' has no properties in common with type 'Attribs1'.
+!!! error TS2559: Type '{ var: string; }' has no properties in common with type 'Attribs1'.
     
     <test2 />; // Error, missing reqd
     ~~~~~~~~~
@@ -63,9 +63,9 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: 10; }' i
 !!! error TS2322:   Property 'reqd' is missing in type '{}'.
     <test2 reqd={10} />; // Error, reqd is not string
            ~~~~~~~~~
-!!! error TS2322: Type '{ reqd: 10; }' is not assignable to type '{ reqd: string; }'.
+!!! error TS2322: Type '{ reqd: number; }' is not assignable to type '{ reqd: string; }'.
 !!! error TS2322:   Types of property 'reqd' are incompatible.
-!!! error TS2322:     Type '10' is not assignable to type 'string'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     
     // Should be OK
     <var var='var' />;

--- a/tests/baselines/reference/tsxAttributeResolution10.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution10.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/jsx/file.tsx(11,14): error TS2322: Type '{ bar: "world"; }' is not assignable to type '{ [s: string]: boolean; }'.
+tests/cases/conformance/jsx/file.tsx(11,14): error TS2322: Type '{ bar: string; }' is not assignable to type '{ [s: string]: boolean; }'.
   Property 'bar' is incompatible with index signature.
-    Type '"world"' is not assignable to type 'boolean'.
+    Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -26,9 +26,9 @@ tests/cases/conformance/jsx/file.tsx(11,14): error TS2322: Type '{ bar: "world";
     // Should be an error
     <MyComponent bar='world' />;
                  ~~~~~~~~~~~
-!!! error TS2322: Type '{ bar: "world"; }' is not assignable to type '{ [s: string]: boolean; }'.
+!!! error TS2322: Type '{ bar: string; }' is not assignable to type '{ [s: string]: boolean; }'.
 !!! error TS2322:   Property 'bar' is incompatible with index signature.
-!!! error TS2322:     Type '"world"' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'string' is not assignable to type 'boolean'.
     
     // Should be OK
     <MyComponent bar={true} />;

--- a/tests/baselines/reference/tsxAttributeResolution11.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution11.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,22): error TS2559: Type '{ bar: "world"; }' has no properties in common with type 'IntrinsicAttributes & { ref?: string; }'.
+tests/cases/conformance/jsx/file.tsx(11,22): error TS2559: Type '{ bar: string; }' has no properties in common with type 'IntrinsicAttributes & { ref?: string; }'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -27,6 +27,6 @@ tests/cases/conformance/jsx/file.tsx(11,22): error TS2559: Type '{ bar: "world";
     // Should be an OK
     var x = <MyComponent bar='world' />;
                          ~~~~~~~~~~~
-!!! error TS2559: Type '{ bar: "world"; }' has no properties in common with type 'IntrinsicAttributes & { ref?: string; }'.
+!!! error TS2559: Type '{ bar: string; }' has no properties in common with type 'IntrinsicAttributes & { ref?: string; }'.
     
     

--- a/tests/baselines/reference/tsxAttributeResolution14.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution14.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/jsx/file.tsx(13,28): error TS2322: Type '{ primaryText: 2; }' is not assignable to type 'IProps'.
+tests/cases/conformance/jsx/file.tsx(13,28): error TS2322: Type '{ primaryText: number; }' is not assignable to type 'IProps'.
   Types of property 'primaryText' are incompatible.
-    Type '2' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(15,28): error TS2322: Type '{ justRandomProp1: true; primaryText: "hello"; }' is not assignable to type 'IProps'.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(15,28): error TS2322: Type '{ justRandomProp1: boolean; primaryText: string; }' is not assignable to type 'IProps'.
   Property 'justRandomProp1' is incompatible with index signature.
-    Type 'true' is not assignable to type 'string | number'.
+    Type 'boolean' is not assignable to type 'string | number'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -30,15 +30,15 @@ tests/cases/conformance/jsx/file.tsx(15,28): error TS2322: Type '{ justRandomPro
         <div>
           <VerticalNavMenuItem primaryText={2} />  // error
                                ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ primaryText: 2; }' is not assignable to type 'IProps'.
+!!! error TS2322: Type '{ primaryText: number; }' is not assignable to type 'IProps'.
 !!! error TS2322:   Types of property 'primaryText' are incompatible.
-!!! error TS2322:     Type '2' is not assignable to type 'string'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
           <VerticalNavMenuItem justRandomProp={2} primaryText={"hello"} />  // ok
           <VerticalNavMenuItem justRandomProp1={true} primaryText={"hello"} />  // error
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ justRandomProp1: true; primaryText: "hello"; }' is not assignable to type 'IProps'.
+!!! error TS2322: Type '{ justRandomProp1: boolean; primaryText: string; }' is not assignable to type 'IProps'.
 !!! error TS2322:   Property 'justRandomProp1' is incompatible with index signature.
-!!! error TS2322:     Type 'true' is not assignable to type 'string | number'.
+!!! error TS2322:     Type 'boolean' is not assignable to type 'string | number'.
         </div>
       )
     } 

--- a/tests/baselines/reference/tsxAttributeResolution15.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution15.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,21): error TS2559: Type '{ prop1: "hello"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(11,21): error TS2559: Type '{ prop1: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -14,7 +14,7 @@ tests/cases/conformance/jsx/file.tsx(11,21): error TS2559: Type '{ prop1: "hello
     // Error
     let a = <BigGreeter prop1="hello" />
                         ~~~~~~~~~~~~~
-!!! error TS2559: Type '{ prop1: "hello"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
+!!! error TS2559: Type '{ prop1: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
     
     // OK
     let b = <BigGreeter ref={(input) => { this.textInput = input; }} />

--- a/tests/baselines/reference/tsxAttributeResolution6.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution6.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/conformance/jsx/file.tsx(10,8): error TS2322: Type '{ s: true; }' is not assignable to type '{ n?: boolean; s?: string; }'.
   Types of property 's' are incompatible.
     Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(11,8): error TS2322: Type '{ n: "true"; }' is not assignable to type '{ n?: boolean; s?: string; }'.
+tests/cases/conformance/jsx/file.tsx(11,8): error TS2322: Type '{ n: string; }' is not assignable to type '{ n?: boolean; s?: string; }'.
   Types of property 'n' are incompatible.
-    Type '"true"' is not assignable to type 'boolean'.
+    Type 'string' is not assignable to type 'boolean'.
 tests/cases/conformance/jsx/file.tsx(12,1): error TS2322: Type '{}' is not assignable to type '{ n: boolean; }'.
   Property 'n' is missing in type '{}'.
 
@@ -25,9 +25,9 @@ tests/cases/conformance/jsx/file.tsx(12,1): error TS2322: Type '{}' is not assig
 !!! error TS2322:     Type 'true' is not assignable to type 'string'.
     <test1 n='true' />;
            ~~~~~~~~
-!!! error TS2322: Type '{ n: "true"; }' is not assignable to type '{ n?: boolean; s?: string; }'.
+!!! error TS2322: Type '{ n: string; }' is not assignable to type '{ n?: boolean; s?: string; }'.
 !!! error TS2322:   Types of property 'n' are incompatible.
-!!! error TS2322:     Type '"true"' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'string' is not assignable to type 'boolean'.
     <test2 />;
     ~~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type '{ n: boolean; }'.

--- a/tests/baselines/reference/tsxAttributeResolution7.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution7.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/jsx/file.tsx(9,8): error TS2322: Type '{ data-foo: 32; }' is not assignable to type '{ "data-foo"?: string; }'.
+tests/cases/conformance/jsx/file.tsx(9,8): error TS2322: Type '{ data-foo: number; }' is not assignable to type '{ "data-foo"?: string; }'.
   Types of property '"data-foo"' are incompatible.
-    Type '32' is not assignable to type 'string'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -14,9 +14,9 @@ tests/cases/conformance/jsx/file.tsx(9,8): error TS2322: Type '{ data-foo: 32; }
     // Error
     <test1 data-foo={32} />;
            ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ data-foo: 32; }' is not assignable to type '{ "data-foo"?: string; }'.
+!!! error TS2322: Type '{ data-foo: number; }' is not assignable to type '{ "data-foo"?: string; }'.
 !!! error TS2322:   Types of property '"data-foo"' are incompatible.
-!!! error TS2322:     Type '32' is not assignable to type 'string'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     
     // OK
     <test1 data-foo={'32'} />;

--- a/tests/baselines/reference/tsxAttributeResolution9.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution9.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/jsx/file.tsx(9,14): error TS2322: Type '{ foo: 0; }' is not assignable to type '{ foo: string; }'.
+tests/cases/conformance/jsx/file.tsx(9,14): error TS2322: Type '{ foo: number; }' is not assignable to type '{ foo: string; }'.
   Types of property 'foo' are incompatible.
-    Type '0' is not assignable to type 'string'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -28,7 +28,7 @@ tests/cases/conformance/jsx/file.tsx(9,14): error TS2322: Type '{ foo: 0; }' is 
     <MyComponent foo="bar" />; // ok  
     <MyComponent foo={0} />; // should be an error
                  ~~~~~~~
-!!! error TS2322: Type '{ foo: 0; }' is not assignable to type '{ foo: string; }'.
+!!! error TS2322: Type '{ foo: number; }' is not assignable to type '{ foo: string; }'.
 !!! error TS2322:   Types of property 'foo' are incompatible.
-!!! error TS2322:     Type '0' is not assignable to type 'string'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/tsxElementResolution11.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution11.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(17,7): error TS2559: Type '{ x: 10; }' has no properties in common with type '{ q?: number; }'.
+tests/cases/conformance/jsx/file.tsx(17,7): error TS2559: Type '{ x: number; }' has no properties in common with type '{ q?: number; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -20,7 +20,7 @@ tests/cases/conformance/jsx/file.tsx(17,7): error TS2559: Type '{ x: 10; }' has 
     var Obj2: Obj2type;
     <Obj2 x={10} />; // Error
           ~~~~~~
-!!! error TS2559: Type '{ x: 10; }' has no properties in common with type '{ q?: number; }'.
+!!! error TS2559: Type '{ x: number; }' has no properties in common with type '{ q?: number; }'.
     
     interface Obj3type {
     	new(n: string): { x: number; };

--- a/tests/baselines/reference/tsxElementResolution12.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution12.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/conformance/jsx/file.tsx(23,1): error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
 tests/cases/conformance/jsx/file.tsx(25,1): error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
-tests/cases/conformance/jsx/file.tsx(33,7): error TS2322: Type '{ x: "10"; }' is not assignable to type '{ x: number; }'.
+tests/cases/conformance/jsx/file.tsx(33,7): error TS2322: Type '{ x: string; }' is not assignable to type '{ x: number; }'.
   Types of property 'x' are incompatible.
-    Type '"10"' is not assignable to type 'number'.
+    Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -44,7 +44,7 @@ tests/cases/conformance/jsx/file.tsx(33,7): error TS2322: Type '{ x: "10"; }' is
     <Obj4 x={10} />; // OK
     <Obj4 x={'10'} />; // Error
           ~~~~~~~~
-!!! error TS2322: Type '{ x: "10"; }' is not assignable to type '{ x: number; }'.
+!!! error TS2322: Type '{ x: string; }' is not assignable to type '{ x: number; }'.
 !!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type '"10"' is not assignable to type 'number'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     

--- a/tests/baselines/reference/tsxElementResolution3.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution3.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: "err"; }' is not assignable to type '{ n: string; }'.
-  Property 'n' is missing in type '{ w: "err"; }'.
+tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
+  Property 'n' is missing in type '{ w: string; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -16,5 +16,5 @@ tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: "err"; }' i
     // Error
     <span w='err' />;
           ~~~~~~~
-!!! error TS2322: Type '{ w: "err"; }' is not assignable to type '{ n: string; }'.
-!!! error TS2322:   Property 'n' is missing in type '{ w: "err"; }'.
+!!! error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
+!!! error TS2322:   Property 'n' is missing in type '{ w: string; }'.

--- a/tests/baselines/reference/tsxElementResolution4.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution4.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: ""; }' is not assignable to type '{ m: string; }'.
-  Property 'm' is missing in type '{ q: ""; }'.
+tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
+  Property 'm' is missing in type '{ q: string; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -20,6 +20,6 @@ tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: ""; }' is n
     // Error
     <span q='' />;
           ~~~~
-!!! error TS2322: Type '{ q: ""; }' is not assignable to type '{ m: string; }'.
-!!! error TS2322:   Property 'm' is missing in type '{ q: ""; }'.
+!!! error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
+!!! error TS2322:   Property 'm' is missing in type '{ q: string; }'.
     

--- a/tests/baselines/reference/tsxInferenceShouldNotYieldAnyOnUnions.types
+++ b/tests/baselines/reference/tsxInferenceShouldNotYieldAnyOnUnions.types
@@ -96,12 +96,12 @@ const f2 = <ShouldInferFromData data={"1"} convert={n => "" + n} />;
 >ShouldInferFromData : <T>(props: Props<T>) => JSX.Element
 >data : string
 >"1" : "1"
->convert : (n: "1") => string
->n => "" + n : (n: "1") => string
->n : "1"
+>convert : (n: string) => string
+>n => "" + n : (n: string) => string
+>n : string
 >"" + n : string
 >"" : ""
->n : "1"
+>n : string
 
 const f3 = <ShouldInferFromData data={2} convert={n => "" + n} />;
 >f3 : JSX.Element
@@ -109,10 +109,10 @@ const f3 = <ShouldInferFromData data={2} convert={n => "" + n} />;
 >ShouldInferFromData : <T>(props: Props<T>) => JSX.Element
 >data : number
 >2 : 2
->convert : (n: 2) => string
->n => "" + n : (n: 2) => string
->n : 2
+>convert : (n: number) => string
+>n => "" + n : (n: number) => string
+>n : number
 >"" + n : string
 >"" : ""
->n : 2
+>n : number
 

--- a/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter2.errors.txt
+++ b/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter2.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/conformance/jsx/file.tsx(13,9): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
   Type '{}' is not assignable to type 'Prop'.
     Property 'a' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(14,18): error TS2322: Type '{ a: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-  Type '{ a: "hi"; }' is not assignable to type 'Prop'.
-    Property 'b' is missing in type '{ a: "hi"; }'.
+tests/cases/conformance/jsx/file.tsx(14,18): error TS2322: Type '{ a: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
+  Type '{ a: string; }' is not assignable to type 'Prop'.
+    Property 'b' is missing in type '{ a: string; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -26,6 +26,6 @@ tests/cases/conformance/jsx/file.tsx(14,18): error TS2322: Type '{ a: "hi"; }' i
 !!! error TS2322:     Property 'a' is missing in type '{}'.
     let x1 = <MyComp a="hi"/>
                      ~~~~~~
-!!! error TS2322: Type '{ a: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ a: "hi"; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Property 'b' is missing in type '{ a: "hi"; }'.
+!!! error TS2322: Type '{ a: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ a: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Property 'b' is missing in type '{ a: string; }'.

--- a/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
+++ b/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(16,17): error TS2559: Type '{ a: 10; b: "hi"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
-tests/cases/conformance/jsx/file.tsx(17,18): error TS2559: Type '{ a: "hi"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(16,17): error TS2559: Type '{ a: number; b: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(17,18): error TS2559: Type '{ a: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -20,7 +20,7 @@ tests/cases/conformance/jsx/file.tsx(17,18): error TS2559: Type '{ a: "hi"; }' h
     // Error
     let x = <MyComp a={10} b="hi" />
                     ~~~~~~~~~~~~~
-!!! error TS2559: Type '{ a: 10; b: "hi"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
+!!! error TS2559: Type '{ a: number; b: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
     let x2 = <MyComp a="hi"/>
                      ~~~~~~
-!!! error TS2559: Type '{ a: "hi"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
+!!! error TS2559: Type '{ a: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution10.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution10.errors.txt
@@ -2,10 +2,10 @@ tests/cases/conformance/jsx/file.tsx(19,14): error TS2322: Type '{ x: 3; }' is n
   Type '{ x: 3; }' is not assignable to type 'OptionProp'.
     Types of property 'x' are incompatible.
       Type '3' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(20,15): error TS2322: Type '{ x: "Hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-  Type '{ x: "Hi"; }' is not assignable to type 'OptionProp'.
+tests/cases/conformance/jsx/file.tsx(20,15): error TS2322: Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
+  Type '{ x: string; }' is not assignable to type 'OptionProp'.
     Types of property 'x' are incompatible.
-      Type '"Hi"' is not assignable to type '2'.
+      Type 'string' is not assignable to type '2'.
 tests/cases/conformance/jsx/file.tsx(21,15): error TS2322: Type '{ x: 3; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
   Type '{ x: 3; }' is not assignable to type 'OptionProp'.
     Types of property 'x' are incompatible.
@@ -43,10 +43,10 @@ tests/cases/conformance/jsx/file.tsx(22,15): error TS2322: Type '{ x: true; }' i
 !!! error TS2322:       Type '3' is not assignable to type '2'.
     let y1 = <Opt {...obj1} x="Hi"/>;
                   ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ x: "Hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: "Hi"; }' is not assignable to type 'OptionProp'.
+!!! error TS2322: Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ x: string; }' is not assignable to type 'OptionProp'.
 !!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type '"Hi"' is not assignable to type '2'.
+!!! error TS2322:       Type 'string' is not assignable to type '2'.
     let y2 = <Opt {...obj1} x={3}/>;
                   ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ x: 3; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/conformance/jsx/file.tsx(27,24): error TS2322: Type '{ x: 2; y: true; overwrite: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-  Type '{ x: 2; y: true; overwrite: "hi"; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(27,24): error TS2322: Type '{ x: 2; y: true; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+  Type '{ x: 2; y: true; overwrite: string; }' is not assignable to type 'Prop'.
     Types of property 'y' are incompatible.
       Type 'true' is not assignable to type 'false'.
-tests/cases/conformance/jsx/file.tsx(28,25): error TS2322: Type '{ y: true; x: 3; overwrite: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-  Type '{ y: true; x: 3; overwrite: "hi"; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(28,25): error TS2322: Type '{ y: true; x: 3; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+  Type '{ y: true; x: 3; overwrite: string; }' is not assignable to type 'Prop'.
     Types of property 'x' are incompatible.
       Type '3' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(30,25): error TS2322: Type '{ y: true; x: 2; overwrite: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-  Type '{ y: true; x: 2; overwrite: "hi"; }' is not assignable to type 'Prop'.
+tests/cases/conformance/jsx/file.tsx(30,25): error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+  Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
     Types of property 'y' are incompatible.
       Type 'true' is not assignable to type 'false'.
 
@@ -41,21 +41,21 @@ tests/cases/conformance/jsx/file.tsx(30,25): error TS2322: Type '{ y: true; x: 2
     // Error
     let x = <OverWriteAttr {...obj} y overwrite="hi" {...obj1} />
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ x: 2; y: true; overwrite: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: 2; y: true; overwrite: "hi"; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ x: 2; y: true; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ x: 2; y: true; overwrite: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'y' are incompatible.
 !!! error TS2322:       Type 'true' is not assignable to type 'false'.
     let x1 = <OverWriteAttr overwrite="hi" {...obj1} x={3} {...{y: true}} />
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y: true; x: 3; overwrite: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ y: true; x: 3; overwrite: "hi"; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ y: true; x: 3; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ y: true; x: 3; overwrite: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'x' are incompatible.
 !!! error TS2322:       Type '3' is not assignable to type '2'.
     let x2 = <OverWriteAttr {...anyobj} x={3} />
     let x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{y: true}} />
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y: true; x: 2; overwrite: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ y: true; x: 2; overwrite: "hi"; }' is not assignable to type 'Prop'.
+!!! error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'y' are incompatible.
 !!! error TS2322:       Type 'true' is not assignable to type 'false'.
     

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -12,8 +12,8 @@ tests/cases/conformance/jsx/file.tsx(20,19): error TS2322: Type '{ x: number; y:
   Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
     Types of property 'x' are incompatible.
       Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(21,20): error TS2322: Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-  Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+tests/cases/conformance/jsx/file.tsx(21,20): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+  Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
     Types of property 'x' are incompatible.
       Type 'number' is not assignable to type 'string'.
 
@@ -59,7 +59,7 @@ tests/cases/conformance/jsx/file.tsx(21,20): error TS2322: Type '{ X: "hi"; x: n
 !!! error TS2322:       Type 'number' is not assignable to type 'string'.
     let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
 !!! error TS2322:     Types of property 'x' are incompatible.
 !!! error TS2322:       Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
-  Type '{ editable: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
-    Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
-      Property 'onEdit' is missing in type '{ editable: true; }'.
+tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ editable: boolean; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
+  Type '{ editable: boolean; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
+    Type '{ editable: boolean; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
+      Property 'onEdit' is missing in type '{ editable: boolean; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,10 +19,10 @@ tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ editable: tru
     // Error
     let x = <TextComponent editable={true} />
                            ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
-!!! error TS2322:   Type '{ editable: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
-!!! error TS2322:     Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
-!!! error TS2322:       Property 'onEdit' is missing in type '{ editable: true; }'.
+!!! error TS2322: Type '{ editable: boolean; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
+!!! error TS2322:   Type '{ editable: boolean; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
+!!! error TS2322:     Type '{ editable: boolean; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
+!!! error TS2322:       Property 'onEdit' is missing in type '{ editable: boolean; }'.
     
     const textProps: TextProps = {
         editable: false

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/conformance/jsx/file.tsx(12,22): error TS2322: Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
   Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
     Property 'yy' is missing in type '{ extraProp: true; }'.
-tests/cases/conformance/jsx/file.tsx(13,22): error TS2322: Type '{ yy: 10; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-  Type '{ yy: 10; }' is not assignable to type '{ yy: number; yy1: string; }'.
-    Property 'yy1' is missing in type '{ yy: 10; }'.
+tests/cases/conformance/jsx/file.tsx(13,22): error TS2322: Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+  Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
+    Property 'yy1' is missing in type '{ yy: number; }'.
 tests/cases/conformance/jsx/file.tsx(14,22): error TS2322: Type '{ yy1: true; yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
   Type '{ yy1: true; yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
     Types of property 'yy1' are incompatible.
@@ -16,24 +16,24 @@ tests/cases/conformance/jsx/file.tsx(17,22): error TS2322: Type '{ yy: boolean; 
 tests/cases/conformance/jsx/file.tsx(25,29): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
   Type '{}' is not assignable to type '{ yy: string; direction?: number; }'.
     Property 'yy' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(26,29): error TS2322: Type '{ yy: "hello"; direction: "left"; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
-  Type '{ yy: "hello"; direction: "left"; }' is not assignable to type '{ yy: string; direction?: number; }'.
+tests/cases/conformance/jsx/file.tsx(26,29): error TS2322: Type '{ yy: string; direction: string; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
+  Type '{ yy: string; direction: string; }' is not assignable to type '{ yy: string; direction?: number; }'.
     Types of property 'direction' are incompatible.
-      Type '"left"' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(33,29): error TS2322: Type '{ y1: true; y3: "hello"; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Type '{ y1: true; y3: "hello"; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+      Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(33,29): error TS2322: Type '{ y1: true; y3: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+  Type '{ y1: true; y3: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
     Types of property 'y3' are incompatible.
-      Type '"hello"' is not assignable to type 'boolean'.
-tests/cases/conformance/jsx/file.tsx(34,29): error TS2322: Type '{ y1: "hello"; y2: 1000; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Type '{ y1: "hello"; y2: 1000; y3: true; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+      Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(34,29): error TS2322: Type '{ y1: string; y2: number; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+  Type '{ y1: string; y2: number; y3: true; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
     Types of property 'y1' are incompatible.
-      Type '"hello"' is not assignable to type 'boolean'.
-tests/cases/conformance/jsx/file.tsx(35,29): error TS2322: Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-    Property 'y3' is missing in type '{ y1: "hello"; y2: 1000; children: "hi"; }'.
-tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-    Property 'y3' is missing in type '{ y1: "hello"; y2: 1000; children: string; }'.
+      Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(35,29): error TS2322: Type '{ y1: string; y2: number; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+  Type '{ y1: string; y2: number; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+    Property 'y3' is missing in type '{ y1: string; y2: number; children: string; }'.
+tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: string; y2: number; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+  Type '{ y1: string; y2: number; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+    Property 'y3' is missing in type '{ y1: string; y2: number; children: string; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (11 errors) ====
@@ -55,9 +55,9 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; 
 !!! error TS2322:     Property 'yy' is missing in type '{ extraProp: true; }'.
     const c1 = <OneThing yy={10}/>;  // missing property;
                          ~~~~~~~
-!!! error TS2322: Type '{ yy: 10; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2322:   Type '{ yy: 10; }' is not assignable to type '{ yy: number; yy1: string; }'.
-!!! error TS2322:     Property 'yy1' is missing in type '{ yy: 10; }'.
+!!! error TS2322: Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+!!! error TS2322:   Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
+!!! error TS2322:     Property 'yy1' is missing in type '{ yy: number; }'.
     const c2 = <OneThing {...obj} yy1 />; // type incompatible;
                          ~~~~~~~~~~~~
 !!! error TS2322: Type '{ yy1: true; yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
@@ -88,10 +88,10 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; 
 !!! error TS2322:     Property 'yy' is missing in type '{}'.
     const d2 = <TestingOneThing yy="hello" direction="left" />
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ yy: "hello"; direction: "left"; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
-!!! error TS2322:   Type '{ yy: "hello"; direction: "left"; }' is not assignable to type '{ yy: string; direction?: number; }'.
+!!! error TS2322: Type '{ yy: string; direction: string; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
+!!! error TS2322:   Type '{ yy: string; direction: string; }' is not assignable to type '{ yy: string; direction?: number; }'.
 !!! error TS2322:     Types of property 'direction' are incompatible.
-!!! error TS2322:       Type '"left"' is not assignable to type 'number'.
+!!! error TS2322:       Type 'string' is not assignable to type 'number'.
     
     declare function TestingOptional(a: {y1?: string, y2?: number}): JSX.Element;
     declare function TestingOptional(a: {y1?: string, y2?: number, children: JSX.Element}): JSX.Element;
@@ -100,24 +100,24 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; 
     // Error
     const e1 = <TestingOptional y1 y3="hello"/>
                                 ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y1: true; y3: "hello"; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Type '{ y1: true; y3: "hello"; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322: Type '{ y1: true; y3: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:   Type '{ y1: true; y3: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
 !!! error TS2322:     Types of property 'y3' are incompatible.
-!!! error TS2322:       Type '"hello"' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
     const e2 = <TestingOptional y1="hello" y2={1000} y3 />
                                 ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y1: "hello"; y2: 1000; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Type '{ y1: "hello"; y2: 1000; y3: true; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322: Type '{ y1: string; y2: number; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:   Type '{ y1: string; y2: number; y3: true; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
 !!! error TS2322:     Types of property 'y1' are incompatible.
-!!! error TS2322:       Type '"hello"' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
     const e3 = <TestingOptional y1="hello" y2={1000} children="hi" />
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:     Property 'y3' is missing in type '{ y1: "hello"; y2: 1000; children: "hi"; }'.
+!!! error TS2322: Type '{ y1: string; y2: number; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:   Type '{ y1: string; y2: number; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:     Property 'y3' is missing in type '{ y1: string; y2: number; children: string; }'.
     const e4 = <TestingOptional y1="hello" y2={1000}>Hi</TestingOptional>
                                 ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:     Property 'y3' is missing in type '{ y1: "hello"; y2: 1000; children: string; }'.
+!!! error TS2322: Type '{ y1: string; y2: number; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:   Type '{ y1: string; y2: number; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:     Property 'y3' is missing in type '{ y1: string; y2: number; children: string; }'.
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/jsx/file.tsx(48,24): error TS2322: Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }'.
+tests/cases/conformance/jsx/file.tsx(48,24): error TS2322: Type '{ to: string; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ to: string; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ to: string; onClick: (e: MouseEvent<any>) => void; children: string; }'.
 tests/cases/conformance/jsx/file.tsx(49,24): error TS2322: Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ to: string; onClick: (e: any) => void; children: string; }'.
@@ -13,12 +13,12 @@ tests/cases/conformance/jsx/file.tsx(51,24): error TS2322: Type '{ onClick: (k: 
 tests/cases/conformance/jsx/file.tsx(53,24): error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
-tests/cases/conformance/jsx/file.tsx(54,24): error TS2322: Type '{ children: 10; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ children: 10; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ children: 10; onClick(e: any): void; }'.
-tests/cases/conformance/jsx/file.tsx(55,24): error TS2322: Type '{ children: "hello"; className: true; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ children: "hello"; className: true; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ children: "hello"; className: true; onClick(e: any): void; }'.
+tests/cases/conformance/jsx/file.tsx(54,24): error TS2322: Type '{ children: number; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ children: number; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ children: number; onClick(e: any): void; }'.
+tests/cases/conformance/jsx/file.tsx(55,24): error TS2322: Type '{ children: string; className: true; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ children: string; className: true; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ children: string; className: true; onClick(e: any): void; }'.
 tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: true; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ data-format: true; }' is not assignable to type 'HyphenProps'.
     Types of property '"data-format"' are incompatible.
@@ -75,9 +75,9 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: 
     // Error
     const b0 = <MainButton to='/some/path' onClick={(e)=>{}}>GO</MainButton>;  // extra property;
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }'.
+!!! error TS2322: Type '{ to: string; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ to: string; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ to: string; onClick: (e: MouseEvent<any>) => void; children: string; }'.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
@@ -101,14 +101,14 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: 
 !!! error TS2322:     Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
     const b6 = <MainButton {...{ onClick(e: any){} }} children={10} />;  // incorrect type for optional attribute
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ children: 10; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ children: 10; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ children: 10; onClick(e: any): void; }'.
+!!! error TS2322: Type '{ children: number; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ children: number; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ children: number; onClick(e: any): void; }'.
     const b7 = <MainButton {...{ onClick(e: any){} }} children="hello" className />;  // incorrect type for optional attribute
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ children: "hello"; className: true; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ children: "hello"; className: true; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ children: "hello"; className: true; onClick(e: any): void; }'.
+!!! error TS2322: Type '{ children: string; className: true; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ children: string; className: true; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ children: string; className: true; onClick(e: any): void; }'.
     const b8 = <MainButton data-format />;  // incorrect type for specified hyphanated name
                            ~~~~~~~~~~~
 !!! error TS2322: Type '{ data-format: true; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentWithDefaultTypeParameter2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentWithDefaultTypeParameter2.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ values: 5; }' is not assignable to type 'IntrinsicAttributes & MyComponentProp'.
-  Type '{ values: 5; }' is not assignable to type 'MyComponentProp'.
+tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ values: number; }' is not assignable to type 'IntrinsicAttributes & MyComponentProp'.
+  Type '{ values: number; }' is not assignable to type 'MyComponentProp'.
     Types of property 'values' are incompatible.
-      Type '5' is not assignable to type 'string'.
+      Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,7 +19,7 @@ tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ values: 5; }'
     // Error
     let i1 = <MyComponent1 values={5}/>;
                            ~~~~~~~~~~
-!!! error TS2322: Type '{ values: 5; }' is not assignable to type 'IntrinsicAttributes & MyComponentProp'.
-!!! error TS2322:   Type '{ values: 5; }' is not assignable to type 'MyComponentProp'.
+!!! error TS2322: Type '{ values: number; }' is not assignable to type 'IntrinsicAttributes & MyComponentProp'.
+!!! error TS2322:   Type '{ values: number; }' is not assignable to type 'MyComponentProp'.
 !!! error TS2322:     Types of property 'values' are incompatible.
-!!! error TS2322:       Type '5' is not assignable to type 'string'.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/jsx/file.tsx(19,16): error TS2322: Type '{ naaame: "world"; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
-  Type '{ naaame: "world"; }' is not assignable to type '{ name: string; }'.
-    Property 'name' is missing in type '{ naaame: "world"; }'.
-tests/cases/conformance/jsx/file.tsx(27,15): error TS2322: Type '{ name: 42; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-  Type '{ name: 42; }' is not assignable to type '{ name?: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,16): error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
+  Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
+    Property 'name' is missing in type '{ naaame: string; }'.
+tests/cases/conformance/jsx/file.tsx(27,15): error TS2322: Type '{ name: number; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
+  Type '{ name: number; }' is not assignable to type '{ name?: string; }'.
     Types of property 'name' are incompatible.
-      Type '42' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(29,15): error TS2559: Type '{ naaaaaaame: "no"; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
+      Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(29,15): error TS2559: Type '{ naaaaaaame: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
 tests/cases/conformance/jsx/file.tsx(34,23): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { "prop-name": string; }'.
   Type '{}' is not assignable to type '{ "prop-name": string; }'.
     Property '"prop-name"' is missing in type '{}'.
@@ -36,9 +36,9 @@ tests/cases/conformance/jsx/file.tsx(45,24): error TS2559: Type '{ prop1: boolea
     // Error
     let b = <Greet naaame='world' />;
                    ~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ naaame: "world"; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
-!!! error TS2322:   Type '{ naaame: "world"; }' is not assignable to type '{ name: string; }'.
-!!! error TS2322:     Property 'name' is missing in type '{ naaame: "world"; }'.
+!!! error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
+!!! error TS2322:   Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
+!!! error TS2322:     Property 'name' is missing in type '{ naaame: string; }'.
     
     // OK
     let c = <Meet />;
@@ -48,14 +48,14 @@ tests/cases/conformance/jsx/file.tsx(45,24): error TS2559: Type '{ prop1: boolea
     // Error
     let e = <Meet name={42} />;
                   ~~~~~~~~~
-!!! error TS2322: Type '{ name: 42; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-!!! error TS2322:   Type '{ name: 42; }' is not assignable to type '{ name?: string; }'.
+!!! error TS2322: Type '{ name: number; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
+!!! error TS2322:   Type '{ name: number; }' is not assignable to type '{ name?: string; }'.
 !!! error TS2322:     Types of property 'name' are incompatible.
-!!! error TS2322:       Type '42' is not assignable to type 'string'.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.
     // Error
     let f = <Meet naaaaaaame='no' />;
                   ~~~~~~~~~~~~~~~
-!!! error TS2559: Type '{ naaaaaaame: "no"; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
+!!! error TS2559: Type '{ naaaaaaame: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
     
     // OK
     let g = <MeetAndGreet prop-name="Bob" />;

--- a/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(19,16): error TS2559: Type '{ ref: "myRef"; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,16): error TS2559: Type '{ ref: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
 tests/cases/conformance/jsx/file.tsx(25,42): error TS2551: Property 'subtr' does not exist on type 'string'. Did you mean 'substr'?
 tests/cases/conformance/jsx/file.tsx(27,33): error TS2339: Property 'notARealProperty' does not exist on type 'BigGreeter'.
 tests/cases/conformance/jsx/file.tsx(35,26): error TS2339: Property 'propertyNotOnHtmlDivElement' does not exist on type 'HTMLDivElement'.
@@ -25,7 +25,7 @@ tests/cases/conformance/jsx/file.tsx(35,26): error TS2339: Property 'propertyNot
     // Error - not allowed to specify 'ref' on SFCs
     let c = <Greet ref="myRef" />;
                    ~~~~~~~~~~~
-!!! error TS2559: Type '{ ref: "myRef"; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
+!!! error TS2559: Type '{ ref: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
     
     
     // OK - ref is valid for classes

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(8,34): error TS2322: Type 'T & { ignore-prop: 10; }' is not assignable to type 'IntrinsicAttributes & { prop: number; "ignore-prop": string; }'.
-  Type 'T & { ignore-prop: 10; }' is not assignable to type '{ prop: number; "ignore-prop": string; }'.
+tests/cases/conformance/jsx/file.tsx(8,34): error TS2322: Type 'T & { ignore-prop: number; }' is not assignable to type 'IntrinsicAttributes & { prop: number; "ignore-prop": string; }'.
+  Type 'T & { ignore-prop: number; }' is not assignable to type '{ prop: number; "ignore-prop": string; }'.
     Types of property '"ignore-prop"' are incompatible.
-      Type '10' is not assignable to type 'string'.
+      Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(13,34): error TS2322: Type 'T' is not assignable to type 'IntrinsicAttributes & { prop: {}; "ignore-prop": string; }'.
   Type 'T' is not assignable to type '{ prop: {}; "ignore-prop": string; }'.
 tests/cases/conformance/jsx/file.tsx(20,19): error TS2322: Type '{ func: (a: number, b: string) => void; }' is not assignable to type 'IntrinsicAttributes & { func: (arg: number) => void; }'.
@@ -26,10 +26,10 @@ tests/cases/conformance/jsx/file.tsx(31,30): error TS2322: Type '{ values: numbe
     function Bar<T extends {prop: number}>(arg: T) {
         let a1 = <ComponentSpecific1 {...arg} ignore-prop={10} />;
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'T & { ignore-prop: 10; }' is not assignable to type 'IntrinsicAttributes & { prop: number; "ignore-prop": string; }'.
-!!! error TS2322:   Type 'T & { ignore-prop: 10; }' is not assignable to type '{ prop: number; "ignore-prop": string; }'.
+!!! error TS2322: Type 'T & { ignore-prop: number; }' is not assignable to type 'IntrinsicAttributes & { prop: number; "ignore-prop": string; }'.
+!!! error TS2322:   Type 'T & { ignore-prop: number; }' is not assignable to type '{ prop: number; "ignore-prop": string; }'.
 !!! error TS2322:     Types of property '"ignore-prop"' are incompatible.
-!!! error TS2322:       Type '10' is not assignable to type 'string'.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.
      }
     
     // Error

--- a/tests/baselines/reference/tsxUnionElementType2.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType2.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/jsx/file.tsx(12,10): error TS2322: Type '{ x: "hi"; }' is not assignable to type '(IntrinsicAttributes & { x: number; }) | (IntrinsicAttributes & { x: boolean; })'.
-  Type '{ x: "hi"; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-    Type '{ x: "hi"; }' is not assignable to type '{ x: boolean; }'.
+tests/cases/conformance/jsx/file.tsx(12,10): error TS2322: Type '{ x: string; }' is not assignable to type '(IntrinsicAttributes & { x: number; }) | (IntrinsicAttributes & { x: boolean; })'.
+  Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
+    Type '{ x: string; }' is not assignable to type '{ x: boolean; }'.
       Types of property 'x' are incompatible.
-        Type '"hi"' is not assignable to type 'boolean'.
+        Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,8 +19,8 @@ tests/cases/conformance/jsx/file.tsx(12,10): error TS2322: Type '{ x: "hi"; }' i
     var SFCComp = SFC1 || SFC2;
     <SFCComp x={"hi"}/>
              ~~~~~~~~
-!!! error TS2322: Type '{ x: "hi"; }' is not assignable to type '(IntrinsicAttributes & { x: number; }) | (IntrinsicAttributes & { x: boolean; })'.
-!!! error TS2322:   Type '{ x: "hi"; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-!!! error TS2322:     Type '{ x: "hi"; }' is not assignable to type '{ x: boolean; }'.
+!!! error TS2322: Type '{ x: string; }' is not assignable to type '(IntrinsicAttributes & { x: number; }) | (IntrinsicAttributes & { x: boolean; })'.
+!!! error TS2322:   Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
+!!! error TS2322:     Type '{ x: string; }' is not assignable to type '{ x: boolean; }'.
 !!! error TS2322:       Types of property 'x' are incompatible.
-!!! error TS2322:         Type '"hi"' is not assignable to type 'boolean'.
+!!! error TS2322:         Type 'string' is not assignable to type 'boolean'.

--- a/tests/baselines/reference/tsxUnionElementType4.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType4.errors.txt
@@ -3,7 +3,7 @@ tests/cases/conformance/jsx/file.tsx(32,17): error TS2322: Type '{ x: true; }' i
     Type '{ x: true; }' is not assignable to type '{ x: string; }'.
       Types of property 'x' are incompatible.
         Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(33,21): error TS2559: Type '{ x: 10; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(33,21): error TS2559: Type '{ x: number; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
 tests/cases/conformance/jsx/file.tsx(34,22): error TS2559: Type '{ prop: true; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
 
 
@@ -48,7 +48,7 @@ tests/cases/conformance/jsx/file.tsx(34,22): error TS2559: Type '{ prop: true; }
 !!! error TS2322:         Type 'true' is not assignable to type 'string'.
     let b = <PartRCComp x={10} />
                         ~~~~~~
-!!! error TS2559: Type '{ x: 10; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
+!!! error TS2559: Type '{ x: number; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
     let c = <EmptyRCComp prop />;
                          ~~~~
 !!! error TS2559: Type '{ prop: true; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxUnionElementType6.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType6.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/conformance/jsx/file.tsx(18,23): error TS2559: Type '{ x: true; }' has no properties in common with type 'IntrinsicAttributes'.
-tests/cases/conformance/jsx/file.tsx(19,27): error TS2322: Type '{ x: "hi"; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-  Type '{ x: "hi"; }' is not assignable to type '{ x: boolean; }'.
+tests/cases/conformance/jsx/file.tsx(19,27): error TS2322: Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
+  Type '{ x: string; }' is not assignable to type '{ x: boolean; }'.
     Types of property 'x' are incompatible.
-      Type '"hi"' is not assignable to type 'boolean'.
+      Type 'string' is not assignable to type 'boolean'.
 tests/cases/conformance/jsx/file.tsx(20,9): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
   Type '{}' is not assignable to type '{ x: boolean; }'.
     Property 'x' is missing in type '{}'.
@@ -34,10 +34,10 @@ tests/cases/conformance/jsx/file.tsx(21,27): error TS2322: Type '{}' is not assi
 !!! error TS2559: Type '{ x: true; }' has no properties in common with type 'IntrinsicAttributes'.
     let b = <SFC2AndEmptyComp x="hi" />;
                               ~~~~~~
-!!! error TS2322: Type '{ x: "hi"; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-!!! error TS2322:   Type '{ x: "hi"; }' is not assignable to type '{ x: boolean; }'.
+!!! error TS2322: Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
+!!! error TS2322:   Type '{ x: string; }' is not assignable to type '{ x: boolean; }'.
 !!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type '"hi"' is not assignable to type 'boolean'.
+!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
     let c = <SFC2AndEmptyComp />;
             ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.

--- a/tests/cases/fourslash/tsxQuickInfo6.ts
+++ b/tests/cases/fourslash/tsxQuickInfo6.ts
@@ -15,5 +15,5 @@
 
 verify.quickInfos({
     1: "function ComponentSpecific<number>(l: {\n    prop: number;\n}): any",
-    2: "function ComponentSpecific<number & \"hello\">(l: {\n    prop: number & \"hello\";\n}): any"
+    2: "function ComponentSpecific<number & string>(l: {\n    prop: number & string;\n}): any"
 });


### PR DESCRIPTION
This brings their behavior with respect to literal types in line with their object-literal cousins.

Fixes #20705
