### PR TITLE
Refine Extract Local

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -171,6 +171,7 @@ namespace ts {
                 node = getParseTreeNode(node, isExpression);
                 return node ? getContextualType(node) : undefined;
             },
+            isContextSensitive,
             getFullyQualifiedName,
             getResolvedSignature: (node, candidatesOutArray, theArgumentCount) => {
                 node = getParseTreeNode(node, isCallLikeExpression);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2739,6 +2739,8 @@ namespace ts {
         getAugmentedPropertiesOfType(type: Type): Symbol[];
         getRootSymbols(symbol: Symbol): Symbol[];
         getContextualType(node: Expression): Type | undefined;
+        /* @internal */ isContextSensitive(node: Expression | MethodDeclaration | ObjectLiteralElementLike | JsxAttributeLike): boolean;
+
         /**
          * returns unknownSignature in the case of an error.
          * @param argumentCount Apparent number of arguments, passed in case of a possibly incomplete call. This should come from an ArgumentListInfo. See `signatureHelp.ts`.

--- a/src/harness/unittests/extractConstants.ts
+++ b/src/harness/unittests/extractConstants.ts
@@ -268,6 +268,12 @@ namespace N { // Force this test to be TS-only
 interface I { a: 1 | 2 | 3 }
 let i: I = [#|{ a: 1 }|];
 `);
+
+        testExtractConstant("extractConstant_ContextualType_Lambda", `
+const myObj: { member(x: number, y: string): void } = {
+    member: [#|(x, y) => x + y|],
+}
+`);
     });
 
     function testExtractConstant(caption: string, text: string) {

--- a/src/harness/unittests/extractConstants.ts
+++ b/src/harness/unittests/extractConstants.ts
@@ -262,6 +262,12 @@ namespace N { // Force this test to be TS-only
         y = [#|this.x|];
     }
 }`);
+
+        // TODO (https://github.com/Microsoft/TypeScript/issues/20727): the extracted constant should have a type annotation.
+        testExtractConstant("extractConstant_ContextualType", `
+interface I { a: 1 | 2 | 3 }
+let i: I = [#|{ a: 1 }|];
+`);
     });
 
     function testExtractConstant(caption: string, text: string) {

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -279,7 +279,7 @@ namespace ts.codefix {
                 changeTracker.insertNodeAfter(sourceFile, lastImportDeclaration, importDecl);
             }
             else {
-                changeTracker.insertNodeAtTopOfFile(sourceFile, importDecl);
+                changeTracker.insertNodeAtTopOfFile(sourceFile, importDecl, /*blankLineBetween*/ true);
             }
         });
 

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1004,7 +1004,7 @@ namespace ts.refactor.extractSymbol {
         const localNameText = getUniqueName(isClassLike(scope) ? "newProperty" : "newLocal", file.text);
         const isJS = isInJavaScriptFile(scope);
 
-        const variableType = isJS
+        const variableType = isJS || !checker.isContextSensitive(node)
             ? undefined
             : checker.typeToTypeNode(checker.getContextualType(node), scope, NodeBuilderFlags.NoTruncation);
 

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1077,7 +1077,7 @@ namespace ts.refactor.extractSymbol {
                 // Declare
                 const nodeToInsertBefore = getNodeToInsertConstantBefore(node, scope);
                 if (nodeToInsertBefore.pos === 0) {
-                    changeTracker.insertNodeAtTopOfFile(context.file, newVariableStatement);
+                    changeTracker.insertNodeAtTopOfFile(context.file, newVariableStatement, /*blankLineBetween*/ false);
                 }
                 else {
                     changeTracker.insertNodeBefore(context.file, nodeToInsertBefore, newVariableStatement, /*blankLineBetween*/ false);

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1080,7 +1080,7 @@ namespace ts.refactor.extractSymbol {
                     changeTracker.insertNodeAtTopOfFile(context.file, newVariableStatement);
                 }
                 else {
-                    changeTracker.insertNodeBefore(context.file, nodeToInsertBefore, newVariableStatement, /*blankLineBetween*/ true);
+                    changeTracker.insertNodeBefore(context.file, nodeToInsertBefore, newVariableStatement, /*blankLineBetween*/ false);
                 }
 
                 // Consume

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -332,11 +332,11 @@ namespace ts.textChanges {
             return this;
         }
 
-        public insertNodeAtTopOfFile(sourceFile: SourceFile, newNode: Statement): void {
+        public insertNodeAtTopOfFile(sourceFile: SourceFile, newNode: Statement, blankLineBetween: boolean): void {
             const pos = getInsertionPositionAtSourceFileTop(sourceFile);
             this.insertNodeAt(sourceFile, pos, newNode, {
                 prefix: pos === 0 ? undefined : this.newLineCharacter,
-                suffix: isLineBreak(sourceFile.text.charCodeAt(pos)) ? this.newLineCharacter : this.newLineCharacter + this.newLineCharacter,
+                suffix: (isLineBreak(sourceFile.text.charCodeAt(pos)) ? "" : this.newLineCharacter) + (blankLineBetween ? this.newLineCharacter : ""),
             });
         }
 

--- a/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Block.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Block.js
@@ -11,7 +11,6 @@ const f = () => {
 };
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 const f = () => {
     return /*RENAME*/newLocal;
 };

--- a/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Block.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Block.js
@@ -7,7 +7,6 @@ const f = () => {
 
 const f = () => {
     const newLocal = 2 + 1;
-
     return /*RENAME*/newLocal;
 };
 // ==SCOPE::Extract to constant in global scope==

--- a/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Block.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Block.ts
@@ -11,7 +11,6 @@ const f = () => {
 };
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 const f = () => {
     return /*RENAME*/newLocal;
 };

--- a/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Block.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Block.ts
@@ -7,7 +7,6 @@ const f = () => {
 
 const f = () => {
     const newLocal = 2 + 1;
-
     return /*RENAME*/newLocal;
 };
 // ==SCOPE::Extract to constant in global scope==

--- a/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Expression.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Expression.js
@@ -2,5 +2,4 @@
 const f = () => /*[#|*/2 + 1/*|]*/;
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 const f = () => /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Expression.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ArrowFunction_Expression.ts
@@ -2,5 +2,4 @@
 const f = () => /*[#|*/2 + 1/*|]*/;
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 const f = () => /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_BlockScopeMismatch.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_BlockScopeMismatch.js
@@ -11,7 +11,6 @@ for (let i = 0; i < 10; i++) {
 for (let i = 0; i < 10; i++) {
     for (let j = 0; j < 10; j++) {
         const newLocal = i + 1;
-
         const x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_BlockScopeMismatch.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_BlockScopeMismatch.ts
@@ -11,7 +11,6 @@ for (let i = 0; i < 10; i++) {
 for (let i = 0; i < 10; i++) {
     for (let j = 0; j < 10; j++) {
         const newLocal = i + 1;
-
         const x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_BlockScopes_NoDependencies.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_BlockScopes_NoDependencies.js
@@ -8,7 +8,6 @@ for (let i = 0; i < 10; i++) {
 for (let i = 0; i < 10; i++) {
     for (let j = 0; j < 10; j++) {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_BlockScopes_NoDependencies.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_BlockScopes_NoDependencies.ts
@@ -8,7 +8,6 @@ for (let i = 0; i < 10; i++) {
 for (let i = 0; i < 10; i++) {
     for (let j = 0; j < 10; j++) {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_Class.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Class.js
@@ -4,7 +4,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_Class.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Class.ts
@@ -10,7 +10,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.js
@@ -16,7 +16,6 @@ class C {
     M2() { }
     M3() {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.js
@@ -21,7 +21,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     a = 1;
     b = 2;

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.ts
@@ -33,7 +33,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     a = 1;
     b = 2;

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.ts
@@ -16,7 +16,6 @@ class C {
     M2() { }
     M3() {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.js
@@ -21,7 +21,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     a = 1;
     M1() { }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.js
@@ -16,7 +16,6 @@ class C {
     M2() { }
     M3() {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.ts
@@ -16,7 +16,6 @@ class C {
     M2() { }
     M3() {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.ts
@@ -33,7 +33,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     a = 1;
     M1() { }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.js
@@ -21,7 +21,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     M1() { }
     a = 1;

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.js
@@ -16,7 +16,6 @@ class C {
     M2() { }
     M3() {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.ts
@@ -16,7 +16,6 @@ class C {
     M2() { }
     M3() {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.ts
@@ -33,7 +33,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     M1() { }
     a = 1;

--- a/tests/baselines/reference/extractConstant/extractConstant_ContextualType.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ContextualType.ts
@@ -1,0 +1,10 @@
+// ==ORIGINAL==
+
+interface I { a: 1 | 2 | 3 }
+let i: I = /*[#|*/{ a: 1 }/*|]*/;
+
+// ==SCOPE::Extract to constant in enclosing scope==
+
+interface I { a: 1 | 2 | 3 }
+const newLocal = { a: 1 };
+let i: I = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_ContextualType_Lambda.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ContextualType_Lambda.ts
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+const myObj: { member(x: number, y: string): void } = {
+    member: /*[#|*/(x, y) => x + y/*|]*/,
+}
+
+// ==SCOPE::Extract to constant in enclosing scope==
+const newLocal: (x: number, y: string) => void = (x, y) => x + y;
+const myObj: { member(x: number, y: string): void } = {
+    member: /*RENAME*/newLocal,
+}

--- a/tests/baselines/reference/extractConstant/extractConstant_Directive.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Directive.js
@@ -9,6 +9,5 @@ const x = /*[#|*/2 + 1/*|]*/;
 "strict";
 
 const newLocal = 2 + 1;
-
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_Directive.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Directive.ts
@@ -9,6 +9,5 @@ const x = /*[#|*/2 + 1/*|]*/;
 "strict";
 
 const newLocal = 2 + 1;
-
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_ExpressionStatementInNestedScope.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ExpressionStatementInNestedScope.js
@@ -16,7 +16,6 @@ function F() {
 
 let i = 0;
 const /*RENAME*/newLocal = i++;
-
 function F() {
     
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_ExpressionStatementInNestedScope.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ExpressionStatementInNestedScope.ts
@@ -16,7 +16,6 @@ function F() {
 
 let i = 0;
 const /*RENAME*/newLocal = i++;
-
 function F() {
     
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_Function.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Function.js
@@ -9,7 +9,6 @@ function F() {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 function F() {
     let x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_Function.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Function.js
@@ -5,7 +5,6 @@ function F() {
 // ==SCOPE::Extract to constant in enclosing scope==
 function F() {
     const newLocal = 1;
-
     let x = /*RENAME*/newLocal;
 }
 // ==SCOPE::Extract to constant in global scope==

--- a/tests/baselines/reference/extractConstant/extractConstant_Function.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Function.ts
@@ -9,7 +9,6 @@ function F() {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 function F() {
     let x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_Function.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Function.ts
@@ -5,7 +5,6 @@ function F() {
 // ==SCOPE::Extract to constant in enclosing scope==
 function F() {
     const newLocal = 1;
-
     let x = /*RENAME*/newLocal;
 }
 // ==SCOPE::Extract to constant in global scope==

--- a/tests/baselines/reference/extractConstant/extractConstant_Method.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Method.js
@@ -8,7 +8,6 @@ class C {
 class C {
     M() {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_Method.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Method.js
@@ -13,7 +13,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     M() {
         let x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_Method.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Method.ts
@@ -21,7 +21,6 @@ class C {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 class C {
     M() {
         let x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_Method.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Method.ts
@@ -8,7 +8,6 @@ class C {
 class C {
     M() {
         const newLocal = 1;
-
         let x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_MultipleHeaders.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_MultipleHeaders.js
@@ -17,6 +17,5 @@ const x = /*[#|*/2 + 1/*|]*/;
 "strict";
 
 const newLocal = 2 + 1;
-
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_MultipleHeaders.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_MultipleHeaders.ts
@@ -17,6 +17,5 @@ const x = /*[#|*/2 + 1/*|]*/;
 "strict";
 
 const newLocal = 2 + 1;
-
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_Namespace.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Namespace.ts
@@ -9,7 +9,6 @@ namespace N {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 1;
-
 namespace N {
     let x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_Namespace.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Namespace.ts
@@ -5,7 +5,6 @@ namespace N {
 // ==SCOPE::Extract to constant in enclosing scope==
 namespace N {
     const newLocal = 1;
-
     let x = /*RENAME*/newLocal;
 }
 // ==SCOPE::Extract to constant in global scope==

--- a/tests/baselines/reference/extractConstant/extractConstant_Parameters.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_Parameters.js
@@ -7,6 +7,5 @@ function F() {
 function F() {
     let w = 1;
     const newLocal = w + 1;
-
     let x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_Parameters.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_Parameters.ts
@@ -7,6 +7,5 @@ function F() {
 function F() {
     let w = 1;
     const newLocal = w + 1;
-
     let x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_PinnedComment.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_PinnedComment.js
@@ -9,6 +9,5 @@ const x = /*[#|*/2 + 1/*|]*/;
 /*! Copyright */
 
 const newLocal = 2 + 1;
-
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_PinnedComment.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_PinnedComment.ts
@@ -9,6 +9,5 @@ const x = /*[#|*/2 + 1/*|]*/;
 /*! Copyright */
 
 const newLocal = 2 + 1;
-
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_PinnedCommentAndDocComment.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_PinnedCommentAndDocComment.js
@@ -10,7 +10,6 @@ const x = /*[#|*/2 + 1/*|]*/;
 /*! Copyright */
 
 const newLocal = 2 + 1;
-
 /* About x */
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_PinnedCommentAndDocComment.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_PinnedCommentAndDocComment.ts
@@ -10,7 +10,6 @@ const x = /*[#|*/2 + 1/*|]*/;
 /*! Copyright */
 
 const newLocal = 2 + 1;
-
 /* About x */
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_PreserveTrivia.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_PreserveTrivia.js
@@ -10,7 +10,6 @@ var q = /*b*/ //c
 const newLocal = 1 /*e*/ //f
     /*g*/ + /*h*/ //i
         /*j*/ 2;
-
 // a
 var q = /*b*/ //c
     /*d*/ /*RENAME*/newLocal /*k*/ //l

--- a/tests/baselines/reference/extractConstant/extractConstant_PreserveTrivia.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_PreserveTrivia.ts
@@ -10,7 +10,6 @@ var q = /*b*/ //c
 const newLocal = 1 /*e*/ //f
     /*g*/ + /*h*/ //i
         /*j*/ 2;
-
 // a
 var q = /*b*/ //c
     /*d*/ /*RENAME*/newLocal /*k*/ //l

--- a/tests/baselines/reference/extractConstant/extractConstant_RepeatedSubstitution.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_RepeatedSubstitution.ts
@@ -7,7 +7,6 @@ namespace X {
 namespace X {
     export const j = 10;
     const newLocal = j * j;
-
     export const y = /*RENAME*/newLocal;
 }
 // ==SCOPE::Extract to constant in global scope==

--- a/tests/baselines/reference/extractConstant/extractConstant_RepeatedSubstitution.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_RepeatedSubstitution.ts
@@ -11,7 +11,6 @@ namespace X {
 }
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = X.j * X.j;
-
 namespace X {
     export const j = 10;
     export const y = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition1.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition1.js
@@ -10,7 +10,6 @@ for (let j = 0; j < 10; j++) {
 const i = 0;
 for (let j = 0; j < 10; j++) {
     const newLocal = i + 1;
-
     const x = /*RENAME*/newLocal;
 }
         

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition1.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition1.ts
@@ -10,7 +10,6 @@ for (let j = 0; j < 10; j++) {
 const i = 0;
 for (let j = 0; j < 10; j++) {
     const newLocal = i + 1;
-
     const x = /*RENAME*/newLocal;
 }
         

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition2.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition2.js
@@ -13,7 +13,6 @@ const i = 0;
 function F() {
     for (let j = 0; j < 10; j++) {
         const newLocal = i + 1;
-
         const x = /*RENAME*/newLocal;
     }
 }
@@ -22,7 +21,6 @@ function F() {
 
 const i = 0;
 const newLocal = i + 1;
-
 function F() {
     for (let j = 0; j < 10; j++) {
         const x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition2.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition2.ts
@@ -13,7 +13,6 @@ const i = 0;
 function F() {
     for (let j = 0; j < 10; j++) {
         const newLocal = i + 1;
-
         const x = /*RENAME*/newLocal;
     }
 }
@@ -22,7 +21,6 @@ function F() {
 
 const i = 0;
 const newLocal = i + 1;
-
 function F() {
     for (let j = 0; j < 10; j++) {
         const x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition3.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition3.js
@@ -8,7 +8,6 @@ for (let j = 0; j < 10; j++) {
 
 for (let j = 0; j < 10; j++) {
     const newLocal = 2 + 1;
-
     const x = /*RENAME*/newLocal;
 }
         

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition3.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition3.ts
@@ -8,7 +8,6 @@ for (let j = 0; j < 10; j++) {
 
 for (let j = 0; j < 10; j++) {
     const newLocal = 2 + 1;
-
     const x = /*RENAME*/newLocal;
 }
         

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition4.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition4.js
@@ -17,7 +17,6 @@ function F() {
         
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 function F() {
     for (let j = 0; j < 10; j++) {
         const x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition4.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition4.js
@@ -11,7 +11,6 @@ function F() {
 function F() {
     for (let j = 0; j < 10; j++) {
         const newLocal = 2 + 1;
-
         const x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition4.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition4.ts
@@ -17,7 +17,6 @@ function F() {
         
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 function F() {
     for (let j = 0; j < 10; j++) {
         const x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition4.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition4.ts
@@ -11,7 +11,6 @@ function F() {
 function F() {
     for (let j = 0; j < 10; j++) {
         const newLocal = 2 + 1;
-
         const x = /*RENAME*/newLocal;
     }
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition5.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition5.js
@@ -12,7 +12,6 @@ function F0() {
 function F0() {
     function F1() {
         const newLocal = 2 + 1;
-
         function F2(x = /*RENAME*/newLocal) {
         }
     }
@@ -22,7 +21,6 @@ function F0() {
 
 function F0() {
     const newLocal = 2 + 1;
-
     function F1() {
         function F2(x = /*RENAME*/newLocal) {
         }

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition5.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition5.js
@@ -29,7 +29,6 @@ function F0() {
         
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 function F0() {
     function F1() {
         function F2(x = /*RENAME*/newLocal) {

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition5.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition5.ts
@@ -12,7 +12,6 @@ function F0() {
 function F0() {
     function F1() {
         const newLocal = 2 + 1;
-
         function F2(x = /*RENAME*/newLocal) {
         }
     }
@@ -22,7 +21,6 @@ function F0() {
 
 function F0() {
     const newLocal = 2 + 1;
-
     function F1() {
         function F2(x = /*RENAME*/newLocal) {
         }

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition5.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition5.ts
@@ -29,7 +29,6 @@ function F0() {
         
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 function F0() {
     function F1() {
         function F2(x = /*RENAME*/newLocal) {

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition6.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition6.js
@@ -6,7 +6,6 @@ class C {
         
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 class C {
     x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition6.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition6.ts
@@ -14,7 +14,6 @@ class C {
         
 // ==SCOPE::Extract to constant in global scope==
 const newLocal = 2 + 1;
-
 class C {
     x = /*RENAME*/newLocal;
 }

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition7.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition7.js
@@ -16,7 +16,6 @@ class C {
     M() {
         for (let j = 0; j < 10; j++) {
             const newLocal = i + 1;
-
             x = /*RENAME*/newLocal;
         }
     }
@@ -26,7 +25,6 @@ class C {
 
 const i = 0;
 const newLocal = i + 1;
-
 class C {
     M() {
         for (let j = 0; j < 10; j++) {

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition7.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition7.ts
@@ -16,7 +16,6 @@ class C {
     M() {
         for (let j = 0; j < 10; j++) {
             const newLocal: any = i + 1;
-
             x = /*RENAME*/newLocal;
         }
     }
@@ -39,7 +38,6 @@ class C {
 
 const i = 0;
 const newLocal: any = i + 1;
-
 class C {
     M() {
         for (let j = 0; j < 10; j++) {

--- a/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition7.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_StatementInsertionPosition7.ts
@@ -15,7 +15,7 @@ const i = 0;
 class C {
     M() {
         for (let j = 0; j < 10; j++) {
-            const newLocal: any = i + 1;
+            const newLocal = i + 1;
             x = /*RENAME*/newLocal;
         }
     }
@@ -25,7 +25,7 @@ class C {
 
 const i = 0;
 class C {
-    private readonly newProperty: any = i + 1;
+    private readonly newProperty = i + 1;
 
     M() {
         for (let j = 0; j < 10; j++) {
@@ -37,7 +37,7 @@ class C {
 // ==SCOPE::Extract to constant in global scope==
 
 const i = 0;
-const newLocal: any = i + 1;
+const newLocal = i + 1;
 class C {
     M() {
         for (let j = 0; j < 10; j++) {

--- a/tests/baselines/reference/extractConstant/extractConstant_TopLevel.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_TopLevel.js
@@ -2,5 +2,4 @@
 let x = /*[#|*/1/*|]*/;
 // ==SCOPE::Extract to constant in enclosing scope==
 const newLocal = 1;
-
 let x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_TopLevel.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_TopLevel.ts
@@ -2,5 +2,4 @@
 let x = /*[#|*/1/*|]*/;
 // ==SCOPE::Extract to constant in enclosing scope==
 const newLocal = 1;
-
 let x = /*RENAME*/newLocal;

--- a/tests/baselines/reference/extractConstant/extractConstant_TripleSlash.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_TripleSlash.js
@@ -9,6 +9,5 @@ const x = /*[#|*/2 + 1/*|]*/;
 /// <reference path="path.js"/>
 
 const newLocal = 2 + 1;
-
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_TripleSlash.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_TripleSlash.ts
@@ -9,6 +9,5 @@ const x = /*[#|*/2 + 1/*|]*/;
 /// <reference path="path.js"/>
 
 const newLocal = 2 + 1;
-
 const x = /*RENAME*/newLocal;
         

--- a/tests/baselines/reference/extractConstant/extractConstant_TypeParameters.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_TypeParameters.ts
@@ -5,6 +5,5 @@ function F<T>(t: T) {
 // ==SCOPE::Extract to constant in enclosing scope==
 function F<T>(t: T) {
     const newLocal = t + 1;
-
     let x = /*RENAME*/newLocal;
 }

--- a/tests/cases/fourslash/extract-const1.ts
+++ b/tests/cases/fourslash/extract-const1.ts
@@ -9,6 +9,5 @@ edit.applyRefactor({
     actionDescription: "Extract to constant in enclosing scope",
     newContent:
 `const newLocal = 0;
-
 const x = /*RENAME*/newLocal;`
 });


### PR DESCRIPTION
 1. Don't insert a blank line after extracted locals
 2. Don't add a type annotation unless the expression is context-sensitive.

Fixes #19839.