### PR TITLE
Fix devtools test

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4677,6 +4677,7 @@ namespace ts {
                 }
                 else if (isJSDocPropertyTag(declaration)
                     || isPropertyAccessExpression(declaration)
+                    || isIdentifier(declaration)
                     || isMethodDeclaration(declaration) && !isObjectLiteralMethod(declaration)) {
                     // TODO: Mimics old behavior from incorrect usage of getWidenedTypeForVariableLikeDeclaration, but seems incorrect
                     type = tryGetTypeFromEffectiveTypeNode(declaration) || anyType;

--- a/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/salsa/index.js ===
+Common.Item = class I {}
+>Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
+>I : Symbol(I, Decl(index.js, 0, 13))
+
+Common.Object = class extends Common.Item {}
+>Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
+>Common.Item : Symbol(Common.Item, Decl(index.js, 0, 0))
+>Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
+>Item : Symbol(Common.Item, Decl(index.js, 0, 0))
+
+Workspace.Object = class extends Common.Object {}
+>Workspace : Symbol(Workspace, Decl(index.js, 1, 44), Decl(roots.js, 1, 3))
+>Common.Object : Symbol(Common.Object, Decl(index.js, 0, 24))
+>Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
+>Object : Symbol(Common.Object, Decl(index.js, 0, 24))
+
+/** @type {Workspace.Object} */
+var am;
+>am : Symbol(am, Decl(index.js, 6, 3))
+
+=== tests/cases/conformance/salsa/roots.js ===
+var Common = {};
+>Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
+
+var Workspace = {};
+>Workspace : Symbol(Workspace, Decl(index.js, 1, 44), Decl(roots.js, 1, 3))
+

--- a/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.types
+++ b/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.types
@@ -1,0 +1,42 @@
+=== tests/cases/conformance/salsa/index.js ===
+Common.Item = class I {}
+>Common.Item = class I {} : typeof I
+>Common.Item : any
+>Common : any
+>Item : any
+>class I {} : typeof I
+>I : typeof I
+
+Common.Object = class extends Common.Item {}
+>Common.Object = class extends Common.Item {} : typeof (Anonymous class)
+>Common.Object : any
+>Common : any
+>Object : any
+>class extends Common.Item {} : typeof (Anonymous class)
+>Common.Item : any
+>Common : any
+>Item : any
+
+Workspace.Object = class extends Common.Object {}
+>Workspace.Object = class extends Common.Object {} : typeof (Anonymous class)
+>Workspace.Object : any
+>Workspace : any
+>Object : any
+>class extends Common.Object {} : typeof (Anonymous class)
+>Common.Object : any
+>Common : any
+>Object : any
+
+/** @type {Workspace.Object} */
+var am;
+>am : (Anonymous class)
+
+=== tests/cases/conformance/salsa/roots.js ===
+var Common = {};
+>Common : any
+>{} : { [x: string]: any; }
+
+var Workspace = {};
+>Workspace : any
+>{} : { [x: string]: any; }
+

--- a/tests/baselines/reference/user/chrome-devtools-frontend.log
+++ b/tests/baselines/reference/user/chrome-devtools-frontend.log
@@ -12,8 +12,8 @@ Standard output:
 ../../../../built/local/lib.dom.d.ts(9253,13): error TS2300: Duplicate identifier 'Request'.
 ../../../../built/local/lib.dom.d.ts(13511,11): error TS2300: Duplicate identifier 'Window'.
 ../../../../built/local/lib.dom.d.ts(13700,13): error TS2300: Duplicate identifier 'Window'.
-../../../../built/local/lib.es5.d.ts(1322,11): error TS2300: Duplicate identifier 'ArrayLike'.
-../../../../built/local/lib.es5.d.ts(1351,6): error TS2300: Duplicate identifier 'Record'.
+../../../../built/local/lib.es5.d.ts(1321,11): error TS2300: Duplicate identifier 'ArrayLike'.
+../../../../built/local/lib.es5.d.ts(1350,6): error TS2300: Duplicate identifier 'Record'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(43,8): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(95,28): error TS2339: Property 'response' does not exist on type 'EventTarget'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(147,37): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignmentOutOfOrder.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignmentOutOfOrder.ts
@@ -1,0 +1,16 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @target: es3
+// @filename: index.js
+Common.Item = class I {}
+Common.Object = class extends Common.Item {}
+
+Workspace.Object = class extends Common.Object {}
+
+/** @type {Workspace.Object} */
+var am;
+
+// @filename: roots.js
+var Common = {};
+var Workspace = {};


### PR DESCRIPTION
https://github.com/Microsoft/TypeScript/pull/20706 Made the declaration kinds handled by `getSymbolAtLocation` more explicit, but didn't include `Identifier`, which we have no normal tests covering. It being missing caused the test to trigger an assertion. Additionally, we made a change to the lib that slightly affects the baseline file.