### PR TITLE
Switch the pretty output to use colons to separate file:line:char so that lines are clickable in terminals

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -331,11 +331,11 @@ namespace ts {
                 }
 
                 output += formatColorAndReset(relativeFileName, ForegroundColorEscapeSequences.Cyan);
-                output += "(";
+                output += ":";
                 output += formatColorAndReset(`${ firstLine + 1 }`, ForegroundColorEscapeSequences.Yellow);
-                output += ",";
+                output += ":";
                 output += formatColorAndReset(`${ firstLineChar + 1 }`, ForegroundColorEscapeSequences.Yellow);
-                output += "): ";
+                output += " - ";
             }
 
             const categoryColor = getCategoryFormat(diagnostic.category);

--- a/tests/baselines/reference/prettyContextNotDebugAssertion.errors.txt
+++ b/tests/baselines/reference/prettyContextNotDebugAssertion.errors.txt
@@ -1,4 +1,4 @@
-[96mtests/cases/compiler/index.ts[0m([93m2[0m,[93m1[0m): [91merror[0m[90m TS1005: [0m'}' expected.
+[96mtests/cases/compiler/index.ts[0m:[93m2[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m'}' expected.
 
 [30;47m2[0m 
 [30;47m [0m [91m[0m


### PR DESCRIPTION
When `tsc`, with `pretty` enabled, gives an error messages they look like this:

```sh
source/commands/init/state-setup.ts(21,40): error TS2339: Property 'bold' does not exist on type 'typeof "/Users/orta/dev/projects/danger/danger-js/node_modules/chalk/types/index"'.

21     header: (msg: String) => say(chalk.bold("\n## " + msg + "\n")),
```

You cannot directly click on`source/commands/init/state-setup.ts(21,40):` to jump directly to the line of code, which is ideal. The format, by convention, for that syntax is `file:line:char` - which this PR switches the message format to.

For example, most testing libraries will output in this format (though I think this just comes from node's exception handling, but you get the point) 
<img width="1157" alt="screen shot 2017-12-16 at 5 52 08 pm" src="https://user-images.githubusercontent.com/49038/34075150-a3c1f174-e28b-11e7-88b5-8accad32ecbf.png">

---

I couldn't find an issue for this, happy to write one up, but it seemed simple enough to just write a PR instead.