### PR TITLE
LanguageServiceShim.getCompletionEntryDetails: Support undefined options

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -141,6 +141,7 @@ namespace ts {
         getEncodedSemanticClassifications(fileName: string, start: number, length: number): string;
 
         getCompletionsAtPosition(fileName: string, position: number, options: GetCompletionsAtPositionOptions | undefined): string;
+        // tslint:disable-next-line type-operator-spacing (false positive)
         getCompletionEntryDetails(fileName: string, position: number, entryName: string, options: string/*Services.FormatCodeOptions*/ | undefined, source: string | undefined): string;
 
         getQuickInfoAtPosition(fileName: string, position: number): string;
@@ -906,6 +907,7 @@ namespace ts {
         }
 
         /** Get a string based representation of a completion list entry details */
+        // tslint:disable-next-line type-operator-spacing (false positive)
         public getCompletionEntryDetails(fileName: string, position: number, entryName: string, options: string/*Services.FormatCodeOptions*/ | undefined, source: string | undefined) {
             return this.forwardJSONCall(
                 `getCompletionEntryDetails('${fileName}', ${position}, '${entryName}')`,

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -141,7 +141,7 @@ namespace ts {
         getEncodedSemanticClassifications(fileName: string, start: number, length: number): string;
 
         getCompletionsAtPosition(fileName: string, position: number, options: GetCompletionsAtPositionOptions | undefined): string;
-        getCompletionEntryDetails(fileName: string, position: number, entryName: string, options: string/*Services.FormatCodeOptions*/, source: string | undefined): string;
+        getCompletionEntryDetails(fileName: string, position: number, entryName: string, options: string/*Services.FormatCodeOptions*/ | undefined, source: string | undefined): string;
 
         getQuickInfoAtPosition(fileName: string, position: number): string;
 
@@ -906,11 +906,11 @@ namespace ts {
         }
 
         /** Get a string based representation of a completion list entry details */
-        public getCompletionEntryDetails(fileName: string, position: number, entryName: string, options: string/*Services.FormatCodeOptions*/, source: string | undefined) {
+        public getCompletionEntryDetails(fileName: string, position: number, entryName: string, options: string/*Services.FormatCodeOptions*/ | undefined, source: string | undefined) {
             return this.forwardJSONCall(
                 `getCompletionEntryDetails('${fileName}', ${position}, '${entryName}')`,
                 () => {
-                    const localOptions: ts.FormatCodeOptions = JSON.parse(options);
+                    const localOptions: ts.FormatCodeOptions = options === undefined ? undefined : JSON.parse(options);
                     return this.languageService.getCompletionEntryDetails(fileName, position, entryName, localOptions, source);
                 }
             );


### PR DESCRIPTION
Based on an email from @billti 
The commit that added the `JSON.parse` call was 2b566b9a536e082fc05896a0ddbae2eab165f86a, not 0f32f55b753ec7473c0966bdbae5ae91705eeeeb which only changed type declarations.