### PR TITLE
Start linting for double spaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
             "dev": true,
             "requires": {
                 "@types/insert-module-globals": "7.0.0",
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/chai": {
@@ -63,7 +63,7 @@
             "integrity": "sha512-18mSs54BvzV8+TTQxt0ancig6tsuPZySnhp3cQkWFFDmDMavU4pmWwR+bHHqRBWODYqpzIzVkqKLuk/fP6yypQ==",
             "dev": true,
             "requires": {
-                "@types/glob": "5.0.33"
+                "@types/glob": "5.0.34"
             }
         },
         "@types/events": {
@@ -73,13 +73,14 @@
             "dev": true
         },
         "@types/glob": {
-            "version": "5.0.33",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-            "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+            "version": "5.0.34",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+            "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
             "dev": true,
             "requires": {
-                "@types/minimatch": "3.0.1",
-                "@types/node": "8.0.54"
+                "@types/events": "1.1.0",
+                "@types/minimatch": "3.0.2",
+                "@types/node": "8.5.2"
             }
         },
         "@types/gulp": {
@@ -88,7 +89,7 @@
             "integrity": "sha512-h9clNJu8X6+zW74ZLa5zhh5HP0LxnvlelVXdXby6pM/DDEj/gKqmmFXKwjzvupZKlMpof02jr6c3JokPbHXQgg==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54",
+                "@types/node": "8.5.2",
                 "@types/orchestrator": "0.3.2",
                 "@types/vinyl": "2.0.1"
             }
@@ -99,7 +100,7 @@
             "integrity": "sha512-CUCFADlITzzBfBa2bdGzhKtvBr4eFh+evb+4igVbvPoO5RyPfHifmyQlZl6lM7q19+OKncRlFXDU7B4X9Ayo2g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/gulp-help": {
@@ -109,7 +110,7 @@
             "dev": true,
             "requires": {
                 "@types/gulp": "3.8.35",
-                "@types/node": "8.0.54",
+                "@types/node": "8.5.2",
                 "@types/orchestrator": "0.3.2"
             }
         },
@@ -119,7 +120,7 @@
             "integrity": "sha512-e7J/Zv5Wd7CC0WpuA2syWVitgwrkG0u221e41w7r07XUR6hMH6kHPkq9tUrusHkbeW8QbuLbis5fODOwQCyggQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/gulp-sourcemaps": {
@@ -128,7 +129,7 @@
             "integrity": "sha512-+7BAmptW2bxyJnJcCEuie7vLoop3FwWgCdBMzyv7MYXED/HeNMeQuX7uPCkp4vfU1TTu4CYFH0IckNPvo0VePA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/insert-module-globals": {
@@ -137,7 +138,7 @@
             "integrity": "sha512-zudCJPwluh1VUDB6Gl/OQdRp+fYy3+47huJB/JMQubMS2p+sH18MCVK4WUz3FqaWLB12yh5ELxVR/+tqwlm/qA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/merge2": {
@@ -146,13 +147,13 @@
             "integrity": "sha512-GjaXY4OultxbaOOk7lCLO7xvEcFpdjExC605YmfI6X29vhHKpJfMWKCDZd3x+BITrZaXKg97DgV/SdGVSwdzxA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/minimatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-            "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
+            "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
             "dev": true
         },
         "@types/minimist": {
@@ -167,7 +168,7 @@
             "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/mocha": {
@@ -177,13 +178,10 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.0.54",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.54.tgz",
-            "integrity": "sha512-qetMdTv3Ytz9u9ESLdcYs45LPI0mczYZIbC184n7kY0jczOqPNQsabBfVCh+na3B2shAfvC459JqHV771A8Rxg==",
-            "dev": true,
-            "requires": {
-                "@types/events": "1.1.0"
-            }
+            "version": "8.5.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
+            "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+            "dev": true
         },
         "@types/orchestrator": {
             "version": "0.3.2",
@@ -191,7 +189,7 @@
             "integrity": "sha512-cKB4yTX0wGaRCSkdHDX2fkGQbMAA8UOshC2U7DQky1CE5o+5q2iQQ8VkbPbE/88uaTtsusvBPMcCX7dgmjxBhQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54",
+                "@types/node": "8.5.2",
                 "@types/q": "1.0.6"
             }
         },
@@ -208,8 +206,20 @@
             "dev": true,
             "requires": {
                 "@types/gulp": "3.8.35",
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
+        },
+        "@types/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
+            "dev": true
+        },
+        "@types/strip-json-comments": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+            "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+            "dev": true
         },
         "@types/through2": {
             "version": "2.0.33",
@@ -217,7 +227,7 @@
             "integrity": "sha1-H/LoihAN+1sUDnu5h5HxGUQA0TE=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/vinyl": {
@@ -226,7 +236,7 @@
             "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "@types/xml2js": {
@@ -235,13 +245,13 @@
             "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.54"
+                "@types/node": "8.5.2"
             }
         },
         "JSONStream": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-            "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+            "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
             "dev": true,
             "requires": {
                 "jsonparse": "1.3.1",
@@ -269,6 +279,17 @@
                 "kind-of": "3.2.2",
                 "longest": "1.0.1",
                 "repeat-string": "1.6.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
             }
         },
         "amdefine": {
@@ -276,6 +297,15 @@
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
             "dev": true
+        },
+        "ansi-gray": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -291,6 +321,12 @@
             "requires": {
                 "color-convert": "1.9.1"
             }
+        },
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+            "dev": true
         },
         "archy": {
             "version": "1.0.0",
@@ -308,18 +344,21 @@
             }
         },
         "arr-diff": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true,
-            "requires": {
-                "arr-flatten": "1.1.0"
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
         },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
         "array-differ": {
@@ -380,9 +419,9 @@
             "dev": true
         },
         "array-unique": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
         },
         "arrify": {
@@ -417,6 +456,12 @@
             "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
             "dev": true
         },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
         "astw": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
@@ -433,9 +478,9 @@
             "dev": true
         },
         "atob": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-            "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+            "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
             "dev": true
         },
         "babel-code-frame": {
@@ -482,6 +527,21 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.5",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.0",
+                "pascalcase": "0.1.1"
+            }
+        },
         "base64-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
@@ -511,14 +571,22 @@
             }
         },
         "braces": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
+            "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.1",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.1"
             }
         },
         "brorand": {
@@ -533,7 +601,7 @@
             "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
+                "JSONStream": "1.3.2",
                 "combine-source-map": "0.7.2",
                 "defined": "1.0.0",
                 "through2": "2.0.3",
@@ -561,7 +629,7 @@
             "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
+                "JSONStream": "1.3.2",
                 "assert": "1.4.1",
                 "browser-pack": "6.0.2",
                 "browser-resolve": "1.11.2",
@@ -714,6 +782,23 @@
             "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
             "dev": true
         },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
+            }
+        },
         "cached-path-relative": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
@@ -745,6 +830,15 @@
             "requires": {
                 "align-text": "0.1.4",
                 "lazy-cache": "1.0.4"
+            },
+            "dependencies": {
+                "lazy-cache": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                    "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                    "dev": true,
+                    "optional": true
+                }
             }
         },
         "chai": {
@@ -786,6 +880,47 @@
             "requires": {
                 "inherits": "2.0.3",
                 "safe-buffer": "5.1.1"
+            }
+        },
+        "class-utils": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz",
+            "integrity": "sha1-F+eTEDdQ+WJ7IXbqNM/RtWWQPIA=",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "lazy-cache": "2.0.2",
+                "static-extend": "0.1.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
             }
         },
         "cliui": {
@@ -838,6 +973,16 @@
                 "through2": "2.0.3"
             }
         },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+            }
+        },
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -851,6 +996,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "dev": true
         },
         "combine-source-map": {
@@ -877,6 +1028,12 @@
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
             "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
             "dev": true
         },
         "concat-map": {
@@ -946,6 +1103,12 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
             "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
         "core-util-is": {
@@ -1021,6 +1184,12 @@
                 "urix": "0.1.0"
             },
             "dependencies": {
+                "atob": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+                    "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
+                    "dev": true
+                },
                 "source-map": {
                     "version": "0.1.43",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
@@ -1029,6 +1198,24 @@
                     "requires": {
                         "amdefine": "1.0.1"
                     }
+                },
+                "source-map-resolve": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+                    "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+                    "dev": true,
+                    "requires": {
+                        "atob": "1.1.3",
+                        "resolve-url": "0.2.1",
+                        "source-map-url": "0.3.0",
+                        "urix": "0.1.0"
+                    }
+                },
+                "source-map-url": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+                    "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+                    "dev": true
                 }
             }
         },
@@ -1063,29 +1250,46 @@
             "dev": true
         },
         "debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
             }
         },
         "debug-fabulous": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.2.1.tgz",
-            "integrity": "sha512-u0TV6HcfLsZ03xLBhdhSViQMldaiQ2o+8/nSILaXkuNSWvxkx66vYJUAam0Eu7gAilJRX/69J4kKdqajQPaPyw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.0.0.tgz",
+            "integrity": "sha512-dsd50qQ1atDeurcxL7XOjPp4nZCGZzWIONDujDXzl1atSyC3hMbZD+v6440etw+Vt0Pr8ce4TQzHfX3KZM05Mw==",
             "dev": true,
             "requires": {
                 "debug": "3.1.0",
                 "memoizee": "0.4.11",
                 "object-assign": "4.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
         "deep-eql": {
@@ -1110,6 +1314,15 @@
             "dev": true,
             "requires": {
                 "clone": "1.0.3"
+            }
+        },
+        "define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "1.0.1"
             }
         },
         "defined": {
@@ -1144,7 +1357,7 @@
             "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
+                "JSONStream": "1.3.2",
                 "shasum": "1.0.2",
                 "subarg": "1.0.0",
                 "through2": "2.0.3"
@@ -1161,13 +1374,10 @@
             }
         },
         "detect-file": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-            "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-            "dev": true,
-            "requires": {
-                "fs-exists-sync": "0.1.0"
-            }
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
         },
         "detect-newline": {
             "version": "2.1.0",
@@ -1176,9 +1386,9 @@
             "dev": true
         },
         "detective": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.0.tgz",
-            "integrity": "sha512-4mBqSEdMfBpRAo/DQZnTcAXenpiSIJmVKbCMSotS+SFWWcrP/CKM6iBRPdTiEO+wZhlfEsoZlGqpG6ycl5vTqw==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+            "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
             "dev": true,
             "requires": {
                 "acorn": "5.2.1",
@@ -1417,12 +1627,46 @@
             }
         },
         "expand-brackets": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.0",
+                "snapdragon": "0.8.1",
+                "to-regex": "3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
             }
         },
         "expand-range": {
@@ -1432,15 +1676,57 @@
             "dev": true,
             "requires": {
                 "fill-range": "2.2.3"
+            },
+            "dependencies": {
+                "fill-range": {
+                    "version": "2.2.3",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.7",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.6.1"
+                    }
+                },
+                "is-number": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                },
+                "isobject": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
             }
         },
         "expand-tilde": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-            "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "homedir-polyfill": "1.0.1"
             }
         },
         "extend": {
@@ -1459,49 +1745,30 @@
             }
         },
         "extglob": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.2.tgz",
+            "integrity": "sha512-I0+eZBH+jFGL8F5BnIz2ON2nKCjTS3AS3H/5PeSmCp7UVC70Ym8IhdRiQly2juKYQ//f7z1aj1BRpQniFJoU1w==",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.0",
+                "snapdragon": "0.8.1",
+                "to-regex": "3.0.1"
             }
         },
         "fancy-log": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
+                "ansi-gray": "0.1.1",
+                "color-support": "1.1.3",
                 "time-stamp": "1.1.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
             }
         },
         "fast-levenshtein": {
@@ -1535,16 +1802,15 @@
             "dev": true
         },
         "fill-range": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
             }
         },
         "find-index": {
@@ -1564,15 +1830,15 @@
             }
         },
         "findup-sync": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-            "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "0.1.0",
-                "is-glob": "2.0.1",
-                "micromatch": "2.3.11",
-                "resolve-dir": "0.1.1"
+                "detect-file": "1.0.0",
+                "is-glob": "3.1.0",
+                "micromatch": "3.1.4",
+                "resolve-dir": "1.0.1"
             }
         },
         "fined": {
@@ -1585,18 +1851,7 @@
                 "is-plain-object": "2.0.4",
                 "object.defaults": "1.1.0",
                 "object.pick": "1.3.0",
-                "parse-filepath": "1.0.1"
-            },
-            "dependencies": {
-                "expand-tilde": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-                    "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-                    "dev": true,
-                    "requires": {
-                        "homedir-polyfill": "1.0.1"
-                    }
-                }
+                "parse-filepath": "1.0.2"
             }
         },
         "first-chunk-stream": {
@@ -1606,9 +1861,9 @@
             "dev": true
         },
         "flagged-respawn": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-            "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+            "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
             "dev": true
         },
         "for-in": {
@@ -1618,19 +1873,22 @@
             "dev": true
         },
         "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+            "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "dev": true,
             "requires": {
                 "for-in": "1.0.2"
             }
         },
-        "fs-exists-sync": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-            "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-            "dev": true
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "0.2.2"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -1665,6 +1923,12 @@
             "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
             "dev": true
         },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -1687,15 +1951,42 @@
             "requires": {
                 "glob-parent": "2.0.0",
                 "is-glob": "2.0.1"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "2.0.1"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                }
             }
         },
         "glob-parent": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             }
         },
         "glob-stream": {
@@ -1788,24 +2079,26 @@
             }
         },
         "global-modules": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-            "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "0.1.5",
-                "is-windows": "0.2.0"
+                "global-prefix": "1.0.2",
+                "is-windows": "1.0.1",
+                "resolve-dir": "1.0.1"
             }
         },
         "global-prefix": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-            "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
+                "expand-tilde": "2.0.2",
                 "homedir-polyfill": "1.0.1",
                 "ini": "1.3.5",
-                "is-windows": "0.2.0",
+                "is-windows": "1.0.1",
                 "which": "1.3.0"
             }
         },
@@ -1891,7 +2184,7 @@
             "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
             "dev": true,
             "requires": {
-                "natives": "1.1.0"
+                "natives": "1.1.1"
             }
         },
         "growl": {
@@ -1911,7 +2204,7 @@
                 "deprecated": "0.0.1",
                 "gulp-util": "3.0.8",
                 "interpret": "1.1.0",
-                "liftoff": "2.3.0",
+                "liftoff": "2.5.0",
                 "minimist": "1.2.0",
                 "orchestrator": "0.3.8",
                 "pretty-hrtime": "1.0.3",
@@ -2278,7 +2571,7 @@
                 "acorn": "4.0.13",
                 "convert-source-map": "1.5.1",
                 "css": "2.2.1",
-                "debug-fabulous": "0.2.1",
+                "debug-fabulous": "1.0.0",
                 "detect-newline": "2.1.0",
                 "graceful-fs": "4.1.11",
                 "source-map": "0.5.7",
@@ -2318,6 +2611,50 @@
                 "vinyl-fs": "2.4.4"
             },
             "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
                 "glob": {
                     "version": "5.0.15",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -2329,16 +2666,6 @@
                         "minimatch": "3.0.4",
                         "once": "1.4.0",
                         "path-is-absolute": "1.0.1"
-                    }
-                },
-                "glob-parent": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
                     }
                 },
                 "glob-stream": {
@@ -2401,18 +2728,18 @@
                     }
                 },
                 "is-extglob": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
                     "dev": true
                 },
                 "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "isarray": {
@@ -2428,6 +2755,36 @@
                     "dev": true,
                     "requires": {
                         "jsonify": "0.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
                     }
                 },
                 "ordered-read-streams": {
@@ -2514,7 +2871,7 @@
                 "beeper": "1.1.1",
                 "chalk": "1.1.3",
                 "dateformat": "2.2.0",
-                "fancy-log": "1.3.0",
+                "fancy-log": "1.3.2",
                 "gulplog": "1.0.0",
                 "has-gulplog": "0.1.0",
                 "lodash._reescape": "3.0.0",
@@ -2630,9 +2987,9 @@
             "dev": true
         },
         "has-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
         "has-gulplog": {
@@ -2642,6 +2999,38 @@
             "dev": true,
             "requires": {
                 "sparkles": "1.0.0"
+            }
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
             }
         },
         "hash-base": {
@@ -2765,7 +3154,7 @@
             "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
+                "JSONStream": "1.3.2",
                 "combine-source-map": "0.7.2",
                 "concat-stream": "1.5.2",
                 "is-buffer": "1.1.6",
@@ -2782,13 +3171,33 @@
             "dev": true
         },
         "is-absolute": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-            "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "0.2.1",
-                "is-windows": "0.2.0"
+                "is-relative": "1.0.0",
+                "is-windows": "1.0.1"
+            }
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
             }
         },
         "is-arrayish": {
@@ -2810,6 +3219,45 @@
             "dev": true,
             "requires": {
                 "builtin-modules": "1.1.1"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-descriptor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
+            "integrity": "sha512-G3fFVFTqfaqu7r4YuSBHKBAuOaLz8Sy7ekklUpFEliaLMP1Y2ZjoN9jS62YWCAPQrQpMUQSitRlrzibbuCZjdA==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
             }
         },
         "is-dotfile": {
@@ -2834,9 +3282,9 @@
             "dev": true
         },
         "is-extglob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
         "is-finite": {
@@ -2849,21 +3297,41 @@
             }
         },
         "is-glob": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "2.1.1"
             }
         },
         "is-number": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
                 "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-odd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
+            "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0"
             }
         },
         "is-path-cwd": {
@@ -2897,14 +3365,6 @@
             "dev": true,
             "requires": {
                 "isobject": "3.0.1"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
         },
         "is-posix-bracket": {
@@ -2926,12 +3386,12 @@
             "dev": true
         },
         "is-relative": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-            "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "0.1.2"
+                "is-unc-path": "1.0.0"
             }
         },
         "is-stream": {
@@ -2941,9 +3401,9 @@
             "dev": true
         },
         "is-unc-path": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-            "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
                 "unc-path-regex": "0.1.2"
@@ -2962,9 +3422,9 @@
             "dev": true
         },
         "is-windows": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-            "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+            "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
             "dev": true
         },
         "isarray": {
@@ -2980,13 +3440,10 @@
             "dev": true
         },
         "isobject": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true,
-            "requires": {
-                "isarray": "1.0.0"
-            }
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
         },
         "istanbul": {
             "version": "0.4.5",
@@ -3022,6 +3479,12 @@
                         "once": "1.4.0",
                         "path-is-absolute": "1.0.1"
                     }
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "3.2.3",
@@ -3130,13 +3593,10 @@
             "dev": true
         },
         "kind-of": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-            "dev": true,
-            "requires": {
-                "is-buffer": "1.1.6"
-            }
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "dev": true
         },
         "labeled-stream-splicer": {
             "version": "2.0.0",
@@ -3158,11 +3618,13 @@
             }
         },
         "lazy-cache": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
             "dev": true,
-            "optional": true
+            "requires": {
+                "set-getter": "0.1.0"
+            }
         },
         "lazystream": {
             "version": "1.0.0",
@@ -3193,18 +3655,17 @@
             }
         },
         "liftoff": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-            "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
                 "extend": "3.0.1",
-                "findup-sync": "0.4.3",
+                "findup-sync": "2.0.0",
                 "fined": "1.1.0",
-                "flagged-respawn": "0.3.2",
-                "lodash.isplainobject": "4.0.6",
-                "lodash.isstring": "4.0.1",
-                "lodash.mapvalues": "4.6.0",
+                "flagged-respawn": "1.0.0",
+                "is-plain-object": "2.0.4",
+                "object.map": "1.0.1",
                 "rechoir": "0.6.2",
                 "resolve": "1.1.7"
             }
@@ -3429,18 +3890,6 @@
                 "lodash._objecttypes": "2.4.1"
             }
         },
-        "lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-            "dev": true
-        },
-        "lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-            "dev": true
-        },
         "lodash.keys": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -3451,12 +3900,6 @@
                 "lodash.isarguments": "3.1.0",
                 "lodash.isarray": "3.0.4"
             }
-        },
-        "lodash.mapvalues": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-            "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-            "dev": true
         },
         "lodash.memoize": {
             "version": "3.0.4",
@@ -3556,6 +3999,26 @@
             "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
             "dev": true
         },
+        "make-iterator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
+            "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -3567,6 +4030,15 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "1.0.1"
+            }
         },
         "md5.js": {
             "version": "1.3.4",
@@ -3640,24 +4112,24 @@
             "dev": true
         },
         "micromatch": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.4.tgz",
+            "integrity": "sha512-kFRtviKYoAJT+t7HggMl0tBFGNAKLw/S7N+CO9qfEQyisob1Oy4pao+geRbkyeEd+V9aOkvZ4mhuyPvI/q9Sfg==",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.0",
+                "define-property": "1.0.0",
+                "extend-shallow": "2.0.1",
+                "extglob": "2.0.2",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.6",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.0",
+                "snapdragon": "0.8.1",
+                "to-regex": "3.0.1"
             }
         },
         "miller-rabin": {
@@ -3697,6 +4169,27 @@
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
         },
+        "mixin-deep": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
+            "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -3732,11 +4225,14 @@
                 "supports-color": "4.4.0"
             },
             "dependencies": {
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-                    "dev": true
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "supports-color": {
                     "version": "4.4.0",
@@ -3761,12 +4257,12 @@
             "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
+                "JSONStream": "1.3.2",
                 "browser-resolve": "1.11.2",
                 "cached-path-relative": "1.0.1",
                 "concat-stream": "1.5.2",
                 "defined": "1.0.0",
-                "detective": "4.7.0",
+                "detective": "4.7.1",
                 "duplexer2": "0.1.4",
                 "inherits": "2.0.3",
                 "parents": "1.0.1",
@@ -3828,10 +4324,37 @@
                 }
             }
         },
+        "nanomatch": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.6.tgz",
+            "integrity": "sha512-WJ6XTCbvWXUFPbi/bDwKcYkCeOGUHzaJj72KbuPqGn78Ba/F5Vu26Zlo6SuMQbCIst1RGKL1zfWBCOGAlbRLAg==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "is-odd": "1.0.0",
+                "kind-of": "5.1.0",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.0",
+                "snapdragon": "0.8.1",
+                "to-regex": "3.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
         "natives": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-            "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+            "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
             "dev": true
         },
         "next-tick": {
@@ -3882,11 +4405,70 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
         },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
         "object-keys": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
             "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
             "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            }
         },
         "object.defaults": {
             "version": "1.1.0",
@@ -3898,23 +4480,16 @@
                 "array-slice": "1.1.0",
                 "for-own": "1.0.0",
                 "isobject": "3.0.1"
-            },
-            "dependencies": {
-                "for-own": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-                    "dev": true,
-                    "requires": {
-                        "for-in": "1.0.2"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
+            }
+        },
+        "object.map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+            "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+            "dev": true,
+            "requires": {
+                "for-own": "1.0.0",
+                "make-iterator": "1.0.0"
             }
         },
         "object.omit": {
@@ -3925,6 +4500,17 @@
             "requires": {
                 "for-own": "0.1.5",
                 "is-extendable": "0.1.1"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "1.0.2"
+                    }
+                }
             }
         },
         "object.pick": {
@@ -3934,14 +4520,6 @@
             "dev": true,
             "requires": {
                 "isobject": "3.0.1"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
         },
         "once": {
@@ -4055,12 +4633,12 @@
             }
         },
         "parse-filepath": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
-            "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+            "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "0.2.6",
+                "is-absolute": "1.0.0",
                 "map-cache": "0.2.2",
                 "path-root": "0.1.1"
             }
@@ -4075,6 +4653,23 @@
                 "is-dotfile": "1.0.3",
                 "is-extglob": "1.0.0",
                 "is-glob": "2.0.1"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                }
             }
         },
         "parse-json": {
@@ -4090,6 +4685,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
             "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
             "dev": true
         },
         "path-browserify": {
@@ -4217,6 +4818,12 @@
                 "pinkie": "2.0.4"
             }
         },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -4294,26 +4901,6 @@
                 "kind-of": "4.0.0"
             },
             "dependencies": {
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "1.1.6"
-                            }
-                        }
-                    }
-                },
                 "kind-of": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -4417,6 +5004,15 @@
                 "is-equal-shallow": "0.1.3"
             }
         },
+        "regex-not": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+            "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4457,13 +5053,13 @@
             "dev": true
         },
         "resolve-dir": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-            "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "1.2.2",
-                "global-modules": "0.2.3"
+                "expand-tilde": "2.0.2",
+                "global-modules": "1.0.0"
             }
         },
         "resolve-url": {
@@ -4582,6 +5178,27 @@
             "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
             "dev": true
         },
+        "set-getter": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+            "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+            "dev": true,
+            "requires": {
+                "to-object-path": "0.3.0"
+            }
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+            }
+        },
         "sha.js": {
             "version": "2.4.9",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
@@ -4626,6 +5243,81 @@
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
+        "snapdragon": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+            "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+            "dev": true,
+            "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.1",
+                "use": "2.0.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
         "sorcery": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
@@ -4645,14 +5337,15 @@
             "dev": true
         },
         "source-map-resolve": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-            "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
             "dev": true,
             "requires": {
-                "atob": "1.1.3",
+                "atob": "2.0.3",
+                "decode-uri-component": "0.2.0",
                 "resolve-url": "0.2.1",
-                "source-map-url": "0.3.0",
+                "source-map-url": "0.4.0",
                 "urix": "0.1.0"
             }
         },
@@ -4674,9 +5367,9 @@
             }
         },
         "source-map-url": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-            "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
         "sourcemap-codec": {
@@ -4715,11 +5408,79 @@
             "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
             "dev": true
         },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
+                    }
+                },
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
         },
         "stream-browserify": {
             "version": "2.0.1",
@@ -4897,14 +5658,6 @@
             "dev": true,
             "requires": {
                 "has-flag": "2.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-                    "dev": true
-                }
             }
         },
         "syntax-error": {
@@ -4991,6 +5744,75 @@
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
             "dev": true
         },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
+            "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+            "dev": true,
+            "requires": {
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "regex-not": "1.0.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+            }
+        },
         "travis-fold": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/travis-fold/-/travis-fold-0.1.2.tgz",
@@ -5004,9 +5826,9 @@
             "dev": true
         },
         "ts-node": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
-            "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.0.2.tgz",
+            "integrity": "sha512-mg7l6ON8asjnfzkTi1LFWKaOGHl5Jf1+5ij0MQ502YfC6+4FBgh/idJgw9aN9kei1Rf4/pmFpNuFE1YbcQdOTA==",
             "dev": true,
             "requires": {
                 "arrify": "1.0.1",
@@ -5015,56 +5837,12 @@
                 "make-error": "1.3.0",
                 "minimist": "1.2.0",
                 "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18",
-                "tsconfig": "6.0.0",
+                "source-map-support": "0.5.0",
+                "tsconfig": "7.0.0",
                 "v8flags": "3.0.1",
                 "yn": "2.0.0"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-                    "dev": true
-                },
-                "source-map-support": {
-                    "version": "0.4.18",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-                    "dev": true,
-                    "requires": {
-                        "source-map": "0.5.7"
-                    }
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                },
                 "v8flags": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
@@ -5077,11 +5855,13 @@
             }
         },
         "tsconfig": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
-            "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+            "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
             "dev": true,
             "requires": {
+                "@types/strip-bom": "3.0.0",
+                "@types/strip-json-comments": "0.0.30",
                 "strip-bom": "3.0.0",
                 "strip-json-comments": "2.0.1"
             },
@@ -5095,9 +5875,9 @@
             }
         },
         "tslib": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-            "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+            "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
             "dev": true
         },
         "tslint": {
@@ -5115,36 +5895,10 @@
                 "minimatch": "3.0.4",
                 "resolve": "1.5.0",
                 "semver": "5.4.1",
-                "tslib": "1.8.0",
-                "tsutils": "2.13.0"
+                "tslib": "1.8.1",
+                "tsutils": "2.13.1"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-                    "dev": true
-                },
                 "resolve": {
                     "version": "1.5.0",
                     "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -5159,25 +5913,16 @@
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
                     "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
                     "dev": true
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
                 }
             }
         },
         "tsutils": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.0.tgz",
-            "integrity": "sha512-FuWzNJbMsp3gcZMbI3b5DomhW4Ia41vMxjN63nKWI0t7f+I3UmHfRl0TrXJTwI2LUduDG+eR1Mksp3pvtlyCFQ==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.1.tgz",
+            "integrity": "sha512-XMOEvc2TiYesVSOJMI7OYPnBMSgcvERuGW5Li/J+2A0TuH607BPQnOLQ82oSPZCssB8c9+QGi6qhTBa/f1xQRA==",
             "dev": true,
             "requires": {
-                "tslib": "1.8.0"
+                "tslib": "1.8.1"
             }
         },
         "tty-browserify": {
@@ -5208,9 +5953,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.7.0-dev.20171209",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171209.tgz",
-            "integrity": "sha512-4ETBmIehQBmJOVwb/awg+EHMjpq3esymYD+tKRvxHv3cW+1s9+t8kdozn3/Fk50vAH13YtOHxuOcvU7OXrdG5Q==",
+            "version": "2.7.0-dev.20171221",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171221.tgz",
+            "integrity": "sha512-PM09fTK1T0WSZHNDXqrB/P6lTaQkzAnXlx23Q5J/21oQ8kgU7B7TtUFTX7zzdSZnH78j49aUx5bVuQCRJkBowg==",
             "dev": true
         },
         "uglify-js": {
@@ -5244,11 +5989,77 @@
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
             "dev": true
         },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
+            },
+            "dependencies": {
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
+                    }
+                }
+            }
+        },
         "unique-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
             "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
             "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                }
+            }
         },
         "urix": {
             "version": "0.1.0",
@@ -5270,6 +6081,45 @@
                     "version": "1.3.2",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                     "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "use": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+            "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+            "dev": true,
+            "requires": {
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "lazy-cache": "2.0.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
                     "dev": true
                 }
             }

--- a/scripts/tslint/rules/noDoubleSpaceRule.ts
+++ b/scripts/tslint/rules/noDoubleSpaceRule.ts
@@ -19,7 +19,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
         }
         // Allow common uses of double spaces
         // * To align `=` or `!=` signs
-        // * To alling comments at the end of lines
+        // * To align comments at the end of lines
         // * To indent inside a comment
         // * To use two spaces after a period
         // * To include aligned `->` in a comment
@@ -28,7 +28,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
         const doubleSpace = rgx.exec(line);
         // Also allow to align comments after `@param`
         // If there are more than 5 double spaces on a line, probably intentional
-        if (doubleSpace !== null && !line.includes("@param") && countDoubleSpaces(line) <= 5) {
+        if (doubleSpace !== null && !line.includes("@param") && countDoubleSpaces(line.slice(firstNonSpace.index)) <= 5) {
             const pos = lines.slice(0, idx).reduce((len, line) => len + 1 + line.length, 0) + doubleSpace.index;
             if (!strings.some(s => s.getStart() <= pos && s.end > pos)) {
                 ctx.addFailureAt(pos + 1, 2, "Use only one space.");
@@ -38,17 +38,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
 }
 
 function countDoubleSpaces(line: string): number {
-    let count = 0;
-    let idx = 0;
-    while (true) {
-        idx = line.indexOf("  ", idx);
-        if (idx === -1) {
-            return count;
-        }
-        // Start searching at the *next* character
-        idx++;
-        count++;
-    }
+    return (line.match(/\s\s/g) || []).length;
 }
 
 function getLiterals(sourceFile: ts.SourceFile): ReadonlyArray<ts.Node> {

--- a/scripts/tslint/rules/noDoubleSpaceRule.ts
+++ b/scripts/tslint/rules/noDoubleSpaceRule.ts
@@ -27,18 +27,13 @@ function walk(ctx: Lint.WalkContext<void>): void {
         rgx.lastIndex = firstNonSpace.index;
         const doubleSpace = rgx.exec(line);
         // Also allow to align comments after `@param`
-        // If there are more than 5 double spaces on a line, probably intentional
-        if (doubleSpace !== null && !line.includes("@param") && countDoubleSpaces(line.slice(firstNonSpace.index)) <= 5) {
+        if (doubleSpace !== null && !line.includes("@param")) {
             const pos = lines.slice(0, idx).reduce((len, line) => len + 1 + line.length, 0) + doubleSpace.index;
             if (!strings.some(s => s.getStart() <= pos && s.end > pos)) {
                 ctx.addFailureAt(pos + 1, 2, "Use only one space.");
             }
         }
     });
-}
-
-function countDoubleSpaces(line: string): number {
-    return (line.match(/\s\s/g) || []).length;
 }
 
 function getLiterals(sourceFile: ts.SourceFile): ReadonlyArray<ts.Node> {

--- a/scripts/tslint/rules/noDoubleSpaceRule.ts
+++ b/scripts/tslint/rules/noDoubleSpaceRule.ts
@@ -1,0 +1,69 @@
+import * as Lint from "tslint/lib";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>): void {
+    const { sourceFile } = ctx;
+    const lines = sourceFile.text.split("\n");
+    const strings = getLiterals(sourceFile);
+    lines.forEach((line, idx) => {
+        // Skip indentation.
+        const firstNonSpace = /\S/.exec(line);
+        if (firstNonSpace === null) {
+            return;
+        }
+        // Allow common uses of double spaces
+        // * To align `=` or `!=` signs
+        // * To alling comments at the end of lines
+        // * To indent inside a comment
+        // * To use two spaces after a period
+        // * To include aligned `->` in a comment
+        const rgx =  /[^/*. ]  [^-!/= ]/g;
+        rgx.lastIndex = firstNonSpace.index;
+        const doubleSpace = rgx.exec(line);
+        // Also allow to align comments after `@param`
+        // If there are more than 5 double spaces on a line, probably intentional
+        if (doubleSpace !== null && !line.includes("@param") && countDoubleSpaces(line) <= 5) {
+            const pos = lines.slice(0, idx).reduce((len, line) => len + 1 + line.length, 0) + doubleSpace.index;
+            if (!strings.some(s => s.getStart() <= pos && s.end > pos)) {
+                ctx.addFailureAt(pos + 1, 2, "Use only one space.");
+            }
+        }
+    });
+}
+
+function countDoubleSpaces(line: string): number {
+    let count = 0;
+    let idx = 0;
+    while (true) {
+        idx = line.indexOf("  ", idx);
+        if (idx === -1) {
+            return count;
+        }
+        // Start searching at the *next* character
+        idx++;
+        count++;
+    }
+}
+
+function getLiterals(sourceFile: ts.SourceFile): ReadonlyArray<ts.Node> {
+    const out: ts.Node[] = [];
+    sourceFile.forEachChild(function cb(node) {
+        switch (node.kind) {
+            case ts.SyntaxKind.StringLiteral:
+            case ts.SyntaxKind.TemplateHead:
+            case ts.SyntaxKind.TemplateMiddle:
+            case ts.SyntaxKind.TemplateTail:
+            case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+            case ts.SyntaxKind.RegularExpressionLiteral:
+                out.push(node);
+        }
+        node.forEachChild(cb);
+    });
+    return out;
+}

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1633,7 +1633,7 @@ namespace ts {
             // to the one we would get for: { <...>(...): T }
             //
             // We do that by making an anonymous type literal symbol, and then setting the function
-            // symbol as its sole member. To the rest of the system, this symbol will be  indistinguishable
+            // symbol as its sole member. To the rest of the system, this symbol will be indistinguishable
             // from an actual type literal symbol you would have gotten had you used the long form.
             const symbol = createSymbol(SymbolFlags.Signature, getDeclarationName(node));
             addDeclarationToSymbol(symbol, node, SymbolFlags.Signature);
@@ -2431,7 +2431,7 @@ namespace ts {
             if (!isPrototypeProperty && (!targetSymbol || !(targetSymbol.flags & SymbolFlags.Namespace)) && isLegalPosition) {
                 Debug.assert(isIdentifier(propertyAccess.expression));
                 const identifier = propertyAccess.expression as Identifier;
-                const flags =  SymbolFlags.Module | SymbolFlags.JSContainer;
+                const flags = SymbolFlags.Module | SymbolFlags.JSContainer;
                 const excludeFlags = SymbolFlags.ValueModuleExcludes & ~SymbolFlags.JSContainer;
                 if (targetSymbol) {
                     addDeclarationToSymbol(symbol, identifier, flags);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1217,7 +1217,7 @@ namespace ts {
                         !checkAndReportErrorForExtendingInterface(errorLocation) &&
                         !checkAndReportErrorForUsingTypeAsNamespace(errorLocation, name, meaning) &&
                         !checkAndReportErrorForUsingTypeAsValue(errorLocation, name, meaning) &&
-                        !checkAndReportErrorForUsingNamespaceModuleAsValue(errorLocation, name, meaning))  {
+                        !checkAndReportErrorForUsingNamespaceModuleAsValue(errorLocation, name, meaning)) {
                         let suggestion: string | undefined;
                         if (suggestedNameNotFoundMessage && suggestionCount < maximumSuggestionCount) {
                             suggestion = getSuggestionForNonexistentSymbol(originalLocation, name, meaning);
@@ -9612,7 +9612,7 @@ namespace ts {
                     }
                     if (target.flags & TypeFlags.Union) {
                         const discriminantType = findMatchingDiscriminantType(source, target as UnionType);
-                        if (discriminantType)  {
+                        if (discriminantType) {
                             // check excess properties against discriminant type only, not the entire union
                             return hasExcessProperties(source, discriminantType, reportErrors);
                         }
@@ -11785,7 +11785,7 @@ namespace ts {
                 const container = (node as BindingElement).parent.parent;
                 const key = container.kind === SyntaxKind.BindingElement ? getFlowCacheKey(container) : (container.initializer && getFlowCacheKey(container.initializer));
                 const text = getBindingElementNameText(node as BindingElement);
-                const result =  key && text && (key + "." + text);
+                const result = key && text && (key + "." + text);
                 return result;
             }
             return undefined;
@@ -12708,7 +12708,7 @@ namespace ts {
                         firstAntecedentType = flowType;
                     }
                     const type = getTypeFromFlowType(flowType);
-                    // If we see a value appear in the cache it is a sign that control flow  analysis
+                    // If we see a value appear in the cache it is a sign that control flow analysis
                     // was restarted and completed by checkExpressionCached. We can simply pick up
                     // the resulting type and bail out.
                     const cached = cache.get(key);
@@ -21862,7 +21862,7 @@ namespace ts {
             checkGrammarForInOrForOfStatement(node);
 
             const rightType = checkNonNullExpression(node.expression);
-            // TypeScript 1.0 spec  (April 2014): 5.4
+            // TypeScript 1.0 spec (April 2014): 5.4
             // In a 'for-in' statement of the form
             // for (let VarDecl in Expr) Statement
             //   VarDecl must be a variable declaration without a type annotation that declares a variable of type Any,
@@ -24800,7 +24800,7 @@ namespace ts {
                             // AND
                             //   - binding is not declared in loop, should be renamed to avoid name reuse across siblings
                             //     let a, b
-                            //     { let x = 1; a = () => x;  }
+                            //     { let x = 1; a = () => x; }
                             //     { let x = 100; b = () => x; }
                             //     console.log(a()); // should print '1'
                             //     console.log(b()); // should print '100'
@@ -25261,7 +25261,7 @@ namespace ts {
 
                 // walk the parent chain for symbols to make sure that top level parent symbol is in the global scope
                 // external modules cannot define or contribute to type declaration files
-                let current =  symbol;
+                let current = symbol;
                 while (true) {
                     const parent = getParentOfSymbol(current);
                     if (parent) {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1863,7 +1863,7 @@ namespace ts {
         return normalizeNonListOptionValue(option, basePath, value);
     }
 
-    function normalizeNonListOptionValue(option: CommandLineOption, basePath: string, value: any): CompilerOptionsValue  {
+    function normalizeNonListOptionValue(option: CommandLineOption, basePath: string, value: any): CompilerOptionsValue {
         if (option.isFilePath) {
             value = normalizePath(combinePaths(basePath, value));
             if (value === "") {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2080,7 +2080,7 @@ namespace ts {
 
     function getNormalizedPathComponentsOfUrl(url: string) {
         // Get root length of http://www.website.com/folder1/folder2/
-        // In this example the root is:  http://www.website.com/
+        // In this example the root is: http://www.website.com/
         // normalized path components should be ["http://www.website.com/", "folder1", "folder2"]
 
         const urlLength = url.length;
@@ -2113,7 +2113,7 @@ namespace ts {
         }
         else {
             // Can't find the host assume the rest of the string as component
-            // but make sure we append "/"  to it as root is not joined using "/"
+            // but make sure we append "/" to it as root is not joined using "/"
             // eg. if url passed in was http://website.com we want to use root as [http://website.com/]
             // so that other path manipulations will be correct and it can be merged with relative paths correctly
             return [url + directorySeparator];
@@ -2134,7 +2134,7 @@ namespace ts {
         const directoryComponents = getNormalizedPathOrUrlComponents(directoryPathOrUrl, currentDirectory);
         if (directoryComponents.length > 1 && lastOrUndefined(directoryComponents) === "") {
             // If the directory path given was of type test/cases/ then we really need components of directory to be only till its name
-            // that is  ["test", "cases", ""] needs to be actually ["test", "cases"]
+            // that is ["test", "cases", ""] needs to be actually ["test", "cases"]
             directoryComponents.pop();
         }
 

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -1866,6 +1866,7 @@ namespace ts {
                     // it allows emitSeparatedList to write separator appropriately)
                     // Example:
                     //      original: function foo([, x, ,]) {}
+                    //      tslint:disable-next-line no-double-space
                     //      emit    : function foo([ , x,  , ]) {}
                     write(" ");
                 }

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -1199,7 +1199,7 @@ namespace ts {
                         write(">");
                     }
                 }
-                else  {
+                else {
                     emitHeritageClause([baseTypeNode], /*isImplementsList*/ false);
                 }
             }

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -3831,13 +3831,13 @@ namespace ts {
                 if (isLeftSideOfBinary) {
                     // No need to parenthesize the left operand when the binary operator is
                     // left associative:
-                    //  (a*b)/x    ->  a*b/x
-                    //  (a**b)/x   ->  a**b/x
+                    //  (a*b)/x    -> a*b/x
+                    //  (a**b)/x   -> a**b/x
                     //
                     // Parentheses are needed for the left operand when the binary operator is
                     // right associative:
-                    //  (a/b)**x   ->  (a/b)**x
-                    //  (a**b)**x  ->  (a**b)**x
+                    //  (a/b)**x   -> (a/b)**x
+                    //  (a**b)**x  -> (a**b)**x
                     return binaryOperatorAssociativity === Associativity.Right;
                 }
                 else {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3946,7 +3946,7 @@ namespace ts {
             // treated as the invocation of "new Foo".  We disambiguate that in code (to match
             // the original grammar) by making sure that if we see an ObjectCreationExpression
             // we always consume arguments if they are there. So we treat "new Foo()" as an
-            // object creation only, and not at all as an invocation). Another way to think
+            // object creation only, and not at all as an invocation.  Another way to think
             // about this is that for every "new" that we see, we will consume an argument list if
             // it is there as part of the *associated* object creation node.  Any additional
             // argument lists we see, will become invocation expressions.

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -585,7 +585,7 @@ namespace ts {
         // 'disallow-in' set to 'false'.  Otherwise, if we had 'allowsIn' set to 'true', then almost
         // all nodes would need extra state on them to store this info.
         //
-        // Note:  'allowIn' and 'allowYield' track 1:1 with the [in] and [yield] concepts in the ES6
+        // Note: 'allowIn' and 'allowYield' track 1:1 with the [in] and [yield] concepts in the ES6
         // grammar specification.
         //
         // An important thing about these context concepts.  By default they are effectively inherited
@@ -701,7 +701,7 @@ namespace ts {
 
         function getLanguageVariant(scriptKind: ScriptKind) {
             // .tsx and .jsx files are treated as jsx language variant.
-            return scriptKind === ScriptKind.TSX || scriptKind === ScriptKind.JSX || scriptKind === ScriptKind.JS  || scriptKind === ScriptKind.JSON ? LanguageVariant.JSX : LanguageVariant.Standard;
+            return scriptKind === ScriptKind.TSX || scriptKind === ScriptKind.JSX || scriptKind === ScriptKind.JS || scriptKind === ScriptKind.JSON ? LanguageVariant.JSX : LanguageVariant.Standard;
         }
 
         function initializeState(_sourceText: string, languageVersion: ScriptTarget, _syntaxCursor: IncrementalParser.SyntaxCursor, scriptKind: ScriptKind) {
@@ -1453,7 +1453,7 @@ namespace ts {
         function isValidHeritageClauseObjectLiteral() {
             Debug.assert(token() === SyntaxKind.OpenBraceToken);
             if (nextToken() === SyntaxKind.CloseBraceToken) {
-                // if we see  "extends {}" then only treat the {} as what we're extending (and not
+                // if we see "extends {}" then only treat the {} as what we're extending (and not
                 // the class body) if we have:
                 //
                 //      extends {} {
@@ -1549,7 +1549,7 @@ namespace ts {
 
         function isVariableDeclaratorListTerminator(): boolean {
             // If we can consume a semicolon (either explicitly, or with ASI), then consider us done
-            // with parsing the list of  variable declarators.
+            // with parsing the list of variable declarators.
             if (canParseSemicolon()) {
                 return true;
             }
@@ -2269,7 +2269,7 @@ namespace ts {
                     //
                     //      <T extends "">
                     //
-                    // We do *not* want to consume the  >  as we're consuming the expression for "".
+                    // We do *not* want to consume the `>` as we're consuming the expression for "".
                     node.expression = parseUnaryExpressionOrHigher();
                 }
             }
@@ -3089,7 +3089,7 @@ namespace ts {
             // And production (2) is parsed in "tryParseParenthesizedArrowFunctionExpression".
             //
             // If we do successfully parse arrow-function, we must *not* recurse for productions 1, 2 or 3. An ArrowFunction is
-            // not a  LeftHandSideExpression, nor does it start a ConditionalExpression.  So we are done
+            // not a LeftHandSideExpression, nor does it start a ConditionalExpression.  So we are done
             // with AssignmentExpression if we see one.
             const arrowExpression = tryParseParenthesizedArrowFunctionExpression() || tryParseAsyncSimpleArrowFunctionExpression();
             if (arrowExpression) {
@@ -3119,7 +3119,7 @@ namespace ts {
             // we're in '2' or '3'. Consume the assignment and return.
             //
             // Note: we call reScanGreaterToken so that we get an appropriately merged token
-            // for cases like > > =  becoming >>=
+            // for cases like `> > =` becoming `>>=`
             if (isLeftHandSideExpression(expr) && isAssignmentOperator(reScanGreaterToken())) {
                 return makeBinaryExpression(expr, <BinaryOperatorToken>parseTokenNode(), parseAssignmentExpressionOrHigher());
             }
@@ -3275,7 +3275,7 @@ namespace ts {
 
             if (first === SyntaxKind.OpenParenToken) {
                 if (second === SyntaxKind.CloseParenToken) {
-                    // Simple cases: "() =>", "(): ", and  "() {".
+                    // Simple cases: "() =>", "(): ", and "() {".
                     // This is an arrow function with no parameters.
                     // The last one is not actually an arrow function,
                     // but this is probably what the user intended.
@@ -3895,7 +3895,8 @@ namespace ts {
                 // We don't want to eagerly consume all import keyword as import call expression so we look a head to find "("
                 // For example:
                 //      var foo3 = require("subfolder
-                //      import * as foo1 from "module-from-node  -> we want this import to be a statement rather than import call expression
+                //      import * as foo1 from "module-from-node
+                // We want this import to be a statement rather than import call expression
                 sourceFile.flags |= NodeFlags.PossiblyContainsDynamicImport;
                 expression = parseTokenNode<PrimaryExpression>();
             }
@@ -3945,7 +3946,7 @@ namespace ts {
             // treated as the invocation of "new Foo".  We disambiguate that in code (to match
             // the original grammar) by making sure that if we see an ObjectCreationExpression
             // we always consume arguments if they are there. So we treat "new Foo()" as an
-            // object creation only, and not at all as an invocation)  Another way to think
+            // object creation only, and not at all as an invocation). Another way to think
             // about this is that for every "new" that we see, we will consume an argument list if
             // it is there as part of the *associated* object creation node.  Any additional
             // argument lists we see, will become invocation expressions.
@@ -4361,7 +4362,7 @@ namespace ts {
 
             const typeArguments = parseDelimitedList(ParsingContext.TypeArguments, parseType);
             if (!parseExpected(SyntaxKind.GreaterThanToken)) {
-                // If it doesn't have the closing >  then it's definitely not an type argument list.
+                // If it doesn't have the closing `>` then it's definitely not an type argument list.
                 return undefined;
             }
 
@@ -5394,8 +5395,8 @@ namespace ts {
             // off. The grammar would look something like this:
             //
             //    MemberVariableDeclaration[Yield]:
-            //        AccessibilityModifier_opt   PropertyName   TypeAnnotation_opt   Initializer_opt[In];
-            //        AccessibilityModifier_opt  static_opt  PropertyName   TypeAnnotation_opt   Initializer_opt[In, ?Yield];
+            //        AccessibilityModifier_opt PropertyName TypeAnnotation_opt Initializer_opt[In];
+            //        AccessibilityModifier_opt static_opt PropertyName TypeAnnotation_opt Initializer_opt[In, ?Yield];
             //
             // The checker may still error in the static case to explicitly disallow the yield expression.
             node.initializer = hasModifier(node, ModifierFlags.Static)
@@ -7077,7 +7078,7 @@ namespace ts {
 
             // If the 'pos' is before the start of the change, then we don't need to touch it.
             // If it isn't, then the 'pos' must be inside the change.  How we update it will
-            // depend if delta is  positive or negative.  If delta is positive then we have
+            // depend if delta is positive or negative. If delta is positive then we have
             // something like:
             //
             //  -------------------AAA-----------------
@@ -7102,7 +7103,7 @@ namespace ts {
 
             // If the 'end' is after the change range, then we always adjust it by the delta
             // amount.  However, if the end is in the change range, then how we adjust it
-            // will depend on if delta is  positive or negative.  If delta is positive then we
+            // will depend on if delta is positive or negative.  If delta is positive then we
             // have something like:
             //
             //  -------------------AAA-----------------

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -193,7 +193,7 @@ namespace ts {
     /*
         As per ECMAScript Language Specification 3th Edition, Section 7.6: Identifiers
         IdentifierStart ::
-            Can contain Unicode 3.0.0  categories:
+            Can contain Unicode 3.0.0 categories:
             Uppercase letter (Lu),
             Lowercase letter (Ll),
             Titlecase letter (Lt),
@@ -201,7 +201,7 @@ namespace ts {
             Other letter (Lo), or
             Letter number (Nl).
         IdentifierPart :: =
-            Can contain IdentifierStart + Unicode 3.0.0  categories:
+            Can contain IdentifierStart + Unicode 3.0.0 categories:
             Non-spacing mark (Mn),
             Combining spacing mark (Mc),
             Decimal number (Nd), or
@@ -216,7 +216,7 @@ namespace ts {
     /*
         As per ECMAScript Language Specification 5th Edition, Section 7.6: ISyntaxToken Names and Identifiers
         IdentifierStart ::
-            Can contain Unicode 6.2  categories:
+            Can contain Unicode 6.2 categories:
             Uppercase letter (Lu),
             Lowercase letter (Ll),
             Titlecase letter (Lt),
@@ -224,7 +224,7 @@ namespace ts {
             Other letter (Lo), or
             Letter number (Nl).
         IdentifierPart ::
-            Can contain IdentifierStart + Unicode 6.2  categories:
+            Can contain IdentifierStart + Unicode 6.2 categories:
             Non-spacing mark (Mn),
             Combining spacing mark (Mc),
             Decimal number (Nd),
@@ -1594,7 +1594,7 @@ namespace ts {
                         return token = SyntaxKind.NumericLiteral;
                     case CharacterCodes.colon:
                         pos++;
-                        return  token = SyntaxKind.ColonToken;
+                        return token = SyntaxKind.ColonToken;
                     case CharacterCodes.semicolon:
                         pos++;
                         return token = SyntaxKind.SemicolonToken;

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -3190,8 +3190,8 @@ namespace ts {
     // `throw` methods that step through the generator when invoked.
     //
     // parameters:
-    //  thisArg  The value to use as the `this` binding for the transformed generator body.
-    //  body     A function that acts as the transformed generator body.
+    //  @param thisArg  The value to use as the `this` binding for the transformed generator body.
+    //  @param body     A function that acts as the transformed generator body.
     //
     // variables:
     //  _       Persistent state for the generator that is shared between the helper and the

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -81,7 +81,7 @@ namespace ts {
         let classAliases: Identifier[];
 
         /**
-         * Keeps track of whether  we are within any containing namespaces when performing
+         * Keeps track of whether we are within any containing namespaces when performing
          * just-in-time substitution while printing an expression identifier.
          */
         let applicableSubstitutions: TypeScriptSubstitutionFlags;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -438,24 +438,24 @@ namespace ts {
     }
 
     export const enum NodeFlags {
-        None =               0,
-        Let =                1 << 0,  // Variable declaration
-        Const =              1 << 1,  // Variable declaration
-        NestedNamespace =    1 << 2,  // Namespace declaration
-        Synthesized =        1 << 3,  // Node was synthesized during transformation
-        Namespace =          1 << 4,  // Namespace declaration
-        ExportContext =      1 << 5,  // Export context (initialized by binding)
-        ContainsThis =       1 << 6,  // Interface contains references to "this"
-        HasImplicitReturn =  1 << 7,  // If function implicitly returns on one of codepaths (initialized by binding)
-        HasExplicitReturn =  1 << 8,  // If function has explicit reachable return on one of codepaths (initialized by binding)
+        None               = 0,
+        Let                = 1 << 0,  // Variable declaration
+        Const              = 1 << 1,  // Variable declaration
+        NestedNamespace    = 1 << 2,  // Namespace declaration
+        Synthesized        = 1 << 3,  // Node was synthesized during transformation
+        Namespace          = 1 << 4,  // Namespace declaration
+        ExportContext      = 1 << 5,  // Export context (initialized by binding)
+        ContainsThis       = 1 << 6,  // Interface contains references to "this"
+        HasImplicitReturn  = 1 << 7,  // If function implicitly returns on one of codepaths (initialized by binding)
+        HasExplicitReturn  = 1 << 8,  // If function has explicit reachable return on one of codepaths (initialized by binding)
         GlobalAugmentation = 1 << 9,  // Set if module declaration is an augmentation for the global scope
-        HasAsyncFunctions =  1 << 10, // If the file has async functions (initialized by binding)
-        DisallowInContext =  1 << 11, // If node was parsed in a context where 'in-expressions' are not allowed
-        YieldContext =       1 << 12, // If node was parsed in the 'yield' context created when parsing a generator
-        DecoratorContext =   1 << 13, // If node was parsed as part of a decorator
-        AwaitContext =       1 << 14, // If node was parsed in the 'await' context created when parsing an async function
-        ThisNodeHasError =   1 << 15, // If the parser encountered an error when parsing the code that created this node
-        JavaScriptFile =     1 << 16, // If node was parsed in a JavaScript
+        HasAsyncFunctions  = 1 << 10, // If the file has async functions (initialized by binding)
+        DisallowInContext  = 1 << 11, // If node was parsed in a context where 'in-expressions' are not allowed
+        YieldContext       = 1 << 12, // If node was parsed in the 'yield' context created when parsing a generator
+        DecoratorContext   = 1 << 13, // If node was parsed as part of a decorator
+        AwaitContext       = 1 << 14, // If node was parsed in the 'await' context created when parsing an async function
+        ThisNodeHasError   = 1 << 15, // If the parser encountered an error when parsing the code that created this node
+        JavaScriptFile     = 1 << 16, // If node was parsed in a JavaScript
         ThisNodeOrAnySubNodesHasError = 1 << 17, // If this node or any of its children had an error
         HasAggregatedChildData = 1 << 18, // If we've computed data from children and cached it in this node
 
@@ -1394,7 +1394,7 @@ namespace ts {
 
     export type BinaryOperatorToken = Token<BinaryOperator>;
 
-    export interface BinaryExpression extends Expression, Declaration  {
+    export interface BinaryExpression extends Expression, Declaration {
         kind: SyntaxKind.BinaryExpression;
         left: Expression;
         operatorToken: BinaryOperatorToken;
@@ -2977,9 +2977,9 @@ namespace ts {
         None = 0x00000000,
 
         // Write symbols's type argument if it is instantiated symbol
-        // eg. class C<T> { p: T }   <-- Show p as C<T>.p here
+        // eg. class C<T> { p: T } <-- Show p as C<T>.p here
         //     var a: C<number>;
-        //     var p = a.p;  <--- Here p is property of C<number> so show it as C<number>.p instead of just C.p
+        //     var p = a.p; <--- Here p is property of C<number> so show it as C<number>.p instead of just C.p
         WriteTypeParametersOrArguments = 0x00000001,
 
         // Use only external alias information to get the symbol name in the given context
@@ -3614,7 +3614,7 @@ namespace ts {
 
     /* @internal */
     // Object literals are initially marked fresh. Freshness disappears following an assignment,
-    // before a type assertion, or when  an object literal's type is widened. The regular
+    // before a type assertion, or when an object literal's type is widened. The regular
     // version of a fresh type is identical except for the TypeFlags.FreshObjectLiteral flag.
     export interface FreshObjectLiteralType extends ResolvedType {
         regularType: ResolvedType;  // Regular version of fresh type

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3916,8 +3916,8 @@ namespace ts {
             //
             // {
             //      oldStart3: Min(oldStart1, oldStart2),
-            //      oldEnd3  : Max(oldEnd1, oldEnd1 + (oldEnd2 - newEnd1)),
-            //      newEnd3  : Max(newEnd2, newEnd2 + (newEnd1 - oldEnd2))
+            //      oldEnd3: Max(oldEnd1, oldEnd1 + (oldEnd2 - newEnd1)),
+            //      newEnd3: Max(newEnd2, newEnd2 + (newEnd1 - oldEnd2))
             // }
 
             const oldStart1 = oldStartN;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -63,7 +63,7 @@ declare var window: {};
 declare var XMLHttpRequest: {
     new(): XMLHttpRequest;
 };
-interface XMLHttpRequest  {
+interface XMLHttpRequest {
     readonly readyState: number;
     readonly responseText: string;
     readonly status: number;
@@ -874,7 +874,7 @@ namespace Harness {
         // Cache of lib files from "built/local"
         let libFileNameSourceFileMap: ts.Map<ts.SourceFile> | undefined;
 
-        // Cache of lib files from  "tests/lib/"
+        // Cache of lib files from "tests/lib/"
         const testLibFileNameSourceFileMap = ts.createMap<ts.SourceFile>();
         const es6TestLibFileNameSourceFileMap = ts.createMap<ts.SourceFile>();
 

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -186,7 +186,7 @@ class ProjectRunner extends RunnerBase {
                     getCanonicalFileName: Harness.Compiler.getCanonicalFileName,
                     useCaseSensitiveFileNames: () => Harness.IO.useCaseSensitiveFileNames(),
                     getNewLine: () => Harness.IO.newLine(),
-                    fileExists: fileName => fileName === Harness.Compiler.defaultLibFileName ||  getSourceFileText(fileName) !== undefined,
+                    fileExists: fileName => fileName === Harness.Compiler.defaultLibFileName || getSourceFileText(fileName) !== undefined,
                     readFile: fileName => Harness.IO.readFile(fileName),
                     getDirectories: path => Harness.IO.getDirectories(path)
                 };

--- a/src/harness/unittests/builder.ts
+++ b/src/harness/unittests/builder.ts
@@ -43,7 +43,7 @@ namespace ts {
         });
     });
 
-    function makeAssertChanges(getProgram: () => Program): (fileNames: ReadonlyArray<string>) => void  {
+    function makeAssertChanges(getProgram: () => Program): (fileNames: ReadonlyArray<string>) => void {
         const builder = createBuilder({
             getCanonicalFileName: identity,
             computeHash: identity

--- a/src/harness/unittests/moduleResolution.ts
+++ b/src/harness/unittests/moduleResolution.ts
@@ -441,7 +441,7 @@ export = C;
                 "/a/b/c.ts": `/// <reference path="d.ts"/>`,
                 "/a/b/d.ts": "var x"
             });
-            test(files, { module: ts.ModuleKind.AMD },  "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "/a/b/d.ts"], []);
+            test(files, { module: ts.ModuleKind.AMD }, "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "/a/b/d.ts"], []);
         });
 
         it("should fail when two files used in program differ only in casing (tripleslash references)", () => {
@@ -449,7 +449,7 @@ export = C;
                 "/a/b/c.ts": `/// <reference path="D.ts"/>`,
                 "/a/b/d.ts": "var x"
             });
-            test(files, { module: ts.ModuleKind.AMD, forceConsistentCasingInFileNames: true },  "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "d.ts"], [1149]);
+            test(files, { module: ts.ModuleKind.AMD, forceConsistentCasingInFileNames: true }, "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "d.ts"], [1149]);
         });
 
         it("should fail when two files used in program differ only in casing (imports)", () => {
@@ -457,7 +457,7 @@ export = C;
                 "/a/b/c.ts": `import {x} from "D"`,
                 "/a/b/d.ts": "export var x"
             });
-            test(files, { module: ts.ModuleKind.AMD, forceConsistentCasingInFileNames: true },  "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "d.ts"], [1149]);
+            test(files, { module: ts.ModuleKind.AMD, forceConsistentCasingInFileNames: true }, "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "d.ts"], [1149]);
         });
 
         it("should fail when two files used in program differ only in casing (imports, relative module names)", () => {
@@ -465,7 +465,7 @@ export = C;
                 "moduleA.ts": `import {x} from "./ModuleB"`,
                 "moduleB.ts": "export var x"
             });
-            test(files, { module: ts.ModuleKind.CommonJS, forceConsistentCasingInFileNames: true },  "", /*useCaseSensitiveFileNames*/ false, ["moduleA.ts", "moduleB.ts"], [1149]);
+            test(files, { module: ts.ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "", /*useCaseSensitiveFileNames*/ false, ["moduleA.ts", "moduleB.ts"], [1149]);
         });
 
         it("should fail when two files exist on disk that differs only in casing", () => {
@@ -474,7 +474,7 @@ export = C;
                 "/a/b/D.ts": "export var x",
                 "/a/b/d.ts": "export var y"
             });
-            test(files, { module: ts.ModuleKind.AMD },  "/a/b", /*useCaseSensitiveFileNames*/ true, ["c.ts", "d.ts"], [1149]);
+            test(files, { module: ts.ModuleKind.AMD }, "/a/b", /*useCaseSensitiveFileNames*/ true, ["c.ts", "d.ts"], [1149]);
         });
 
         it("should fail when module name in 'require' calls has inconsistent casing", () => {
@@ -483,7 +483,7 @@ export = C;
                 "moduleB.ts": `import a = require("./moduleC")`,
                 "moduleC.ts": "export var x"
             });
-            test(files, { module: ts.ModuleKind.CommonJS, forceConsistentCasingInFileNames: true },  "", /*useCaseSensitiveFileNames*/ false, ["moduleA.ts", "moduleB.ts", "moduleC.ts"], [1149, 1149]);
+            test(files, { module: ts.ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "", /*useCaseSensitiveFileNames*/ false, ["moduleA.ts", "moduleB.ts", "moduleC.ts"], [1149, 1149]);
         });
 
         it("should fail when module names in 'require' calls has inconsistent casing and current directory has uppercase chars", () => {
@@ -496,7 +496,7 @@ import a = require("./moduleA");
 import b = require("./moduleB");
                 `
             });
-            test(files, { module: ts.ModuleKind.CommonJS, forceConsistentCasingInFileNames: true },  "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], [1149]);
+            test(files, { module: ts.ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], [1149]);
         });
         it("should not fail when module names in 'require' calls has consistent casing and current directory has uppercase chars", () => {
             const files = createMapFromTemplate({
@@ -508,7 +508,7 @@ import a = require("./moduleA");
 import b = require("./moduleB");
                 `
             });
-            test(files, { module: ts.ModuleKind.CommonJS, forceConsistentCasingInFileNames: true },  "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], []);
+            test(files, { module: ts.ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], []);
         });
     });
 

--- a/src/harness/virtualFileSystem.ts
+++ b/src/harness/virtualFileSystem.ts
@@ -162,7 +162,7 @@ namespace Utils {
         /**
          * Reads the directory at the given path and retrieves a list of file names and a list
          * of directory names within it. Suitable for use with ts.matchFiles()
-         * @param path  The path to the directory to be read
+         * @param path The path to the directory to be read
          */
         getAccessibleFileSystemEntries(path: string) {
             const entry = this.traversePath(path);

--- a/src/server/cancellationToken/cancellationToken.ts
+++ b/src/server/cancellationToken/cancellationToken.ts
@@ -46,7 +46,7 @@ function createCancellationToken(args: string[]): ServerCancellationToken {
         let perRequestPipeName: string;
         let currentRequestId: number;
         return {
-            isCancellationRequested: () =>  perRequestPipeName !== undefined && pipeExists(perRequestPipeName),
+            isCancellationRequested: () => perRequestPipeName !== undefined && pipeExists(perRequestPipeName),
             setRequest(requestId: number) {
                 currentRequestId = requestId;
                 perRequestPipeName = namePrefix + requestId;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -566,7 +566,7 @@ namespace ts.server.protocol {
 
     // TODO: GH#20538
     /* @internal */
-    export interface GetCombinedCodeFixResponse  extends Response {
+    export interface GetCombinedCodeFixResponse extends Response {
         body: CombinedCodeActions;
     }
 

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -257,7 +257,7 @@ namespace ts.server {
     export class ScriptVersionCache {
         private changes: TextChange[] = [];
         private readonly versions: LineIndexSnapshot[] = new Array<LineIndexSnapshot>(ScriptVersionCache.maxVersions);
-        private minVersion = 0;  // no versions earlier than min version will maintain change history
+        private minVersion = 0; // no versions earlier than min version will maintain change history
 
         private currentVersion = 0;
 

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -262,8 +262,8 @@ namespace ts.BreakpointResolver {
                         }
 
                         // Set breakpoint on identifier element of destructuring pattern
-                        // a or ...c  or d: x from
-                        // [a, b, ...c] or { a, b } or { d: x } from destructuring pattern
+                        // `a` or `...c` or `d: x` from
+                        // `[a, b, ...c]` or `{ a, b }` or `{ d: x }` from destructuring pattern
                         if ((node.kind === SyntaxKind.Identifier ||
                             node.kind === SyntaxKind.SpreadElement ||
                             node.kind === SyntaxKind.PropertyAssignment ||

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -837,7 +837,7 @@ namespace ts {
                 return ClassificationType.keyword;
             }
 
-            // Special case < and >  If they appear in a generic context they are punctuation,
+            // Special case `<` and `>`: If they appear in a generic context they are punctuation,
             // not operators.
             if (tokenKind === SyntaxKind.LessThanToken || tokenKind === SyntaxKind.GreaterThanToken) {
                 // If the node owning the token has a type argument list or type parameter list, then

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -9,7 +9,7 @@ namespace ts.codefix {
         errorCodes,
         getCodeActions(context) {
             const { sourceFile } = context;
-            const info = getInfo(sourceFile, context.span.start,  context.program.getTypeChecker());
+            const info = getInfo(sourceFile, context.span.start, context.program.getTypeChecker());
             if (!info) return undefined;
             const { node, suggestion } = info;
             const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, node, suggestion));

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -121,7 +121,7 @@ namespace ts.codefix {
             createStubbedMethodBody());
     }
 
-    function createDummyParameters(argCount: number,  names: string[] | undefined, minArgumentCount: number | undefined, inJs: boolean): ParameterDeclaration[] {
+    function createDummyParameters(argCount: number, names: string[] | undefined, minArgumentCount: number | undefined, inJs: boolean): ParameterDeclaration[] {
         const parameters: ParameterDeclaration[] = [];
         for (let i = 0; i < argCount; i++) {
             const newParameter = createParameter(

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -57,7 +57,8 @@ namespace ts.Completions {
             // In the TypeScript JSX element, if such element is not defined. When users query for completion at closing tag,
             // instead of simply giving unknown value, the completion will return the tag-name of an associated opening-element.
             // For example:
-            //     var x = <div> </ /*1*/>  completion list at "1" will contain "div" with type any
+            //     var x = <div> </ /*1*/>
+            // The completion list at "1" will contain "div" with type any
             const tagName = (<JsxElement>location.parent.parent).openingElement.tagName;
             return { isGlobalCompletion: false, isMemberCompletion: true, isNewIdentifierLocation: false,
                 entries: [{
@@ -76,7 +77,7 @@ namespace ts.Completions {
                 // If the current position is a jsDoc tag, only tags should be provided for completion
                 ? JsDoc.getJSDocTagCompletions()
                 : JsDoc.getJSDocParameterNameCompletions(request.tag);
-            return { isGlobalCompletion: false, isMemberCompletion: false, isNewIdentifierLocation: false,  entries };
+            return { isGlobalCompletion: false, isMemberCompletion: false, isNewIdentifierLocation: false, entries };
         }
 
         const entries: CompletionEntry[] = [];
@@ -1558,7 +1559,7 @@ namespace ts.Completions {
                 switch (contextToken.kind) {
                     case SyntaxKind.OpenParenToken:
                     case SyntaxKind.CommaToken:
-                        return  isConstructorDeclaration(contextToken.parent) && contextToken.parent;
+                        return isConstructorDeclaration(contextToken.parent) && contextToken.parent;
 
                     default:
                         if (isConstructorParameterCompletion(contextToken)) {

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -69,10 +69,10 @@ namespace ts.formatting {
             rule("NoSpaceBeforeUnaryPostdecrementOperator", unaryPostdecrementExpressions, SyntaxKind.MinusMinusToken, [isNonJsxSameLineTokenContext], RuleAction.Delete),
 
             // More unary operator special-casing.
-            // DevDiv 181814:  Be careful when removing leading whitespace
+            // DevDiv 181814: Be careful when removing leading whitespace
             // around unary operators.  Examples:
-            //      1 - -2  --X-->  1--2
-            //      a + ++b --X-->  a+++b
+            //      1 - -2  --X--> 1--2
+            //      a + ++b --X--> a+++b
             rule("SpaceAfterPostincrementWhenFollowedByAdd", SyntaxKind.PlusPlusToken, SyntaxKind.PlusToken, [isNonJsxSameLineTokenContext, isBinaryOpContext], RuleAction.Space),
             rule("SpaceAfterAddWhenFollowedByUnaryPlus", SyntaxKind.PlusToken, SyntaxKind.PlusToken, [isNonJsxSameLineTokenContext, isBinaryOpContext], RuleAction.Space),
             rule("SpaceAfterAddWhenFollowedByPreincrement", SyntaxKind.PlusToken, SyntaxKind.PlusPlusToken, [isNonJsxSameLineTokenContext, isBinaryOpContext], RuleAction.Space),

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -616,7 +616,7 @@ namespace ts.FindAllReferences {
 
     /** If at an export specifier, go to the symbol it refers to. */
     function skipExportSpecifierSymbol(symbol: Symbol, checker: TypeChecker): Symbol {
-        // For `export { foo } from './bar", there's nothing to skip, because it does  not create a new alias. But `export { foo } does.
+        // For `export { foo } from './bar", there's nothing to skip, because it does not create a new alias. But `export { foo } does.
         if (symbol.declarations) {
             for (const declaration of symbol.declarations) {
                 if (isExportSpecifier(declaration) && !(declaration as ExportSpecifier).propertyName && !(declaration as ExportSpecifier).parent.parent.moduleSpecifier) {

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -46,7 +46,7 @@ namespace ts.NavigateTo {
                 continue;
             }
 
-            // It was a match!  If the pattern has dots in it, then also see if the
+            // It was a match! If the pattern has dots in it, then also see if the
             // declaration container matches as well.
             let containerMatches = matches;
             if (patternMatcher.patternContainsDots) {

--- a/src/services/preProcess.ts
+++ b/src/services/preProcess.ts
@@ -295,7 +295,7 @@ namespace ts {
             //    import "mod";
             //    import d from "mod"
             //    import {a as A } from "mod";
-            //    import * as NS  from "mod"
+            //    import * as NS from "mod"
             //    import d, {a, b as B} from "mod"
             //    import i = require("mod");
             //    import("mod");

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2053,7 +2053,7 @@ namespace ts {
             }
 
             function getTodoCommentsRegExp(): RegExp {
-                // NOTE: ?:  means 'non-capture group'.  It allows us to have groups without having to
+                // NOTE: `?:` means 'non-capture group'.  It allows us to have groups without having to
                 // filter them out later in the final result array.
 
                 // TODO comments can appear in one of the following forms:

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -197,7 +197,7 @@ namespace ts.SignatureHelp {
     function getArgumentIndex(argumentsList: Node, node: Node) {
         // The list we got back can include commas.  In the presence of errors it may
         // also just have nodes without commas.  For example "Foo(a b c)" will have 3
-        // args without commas.   We want to find what index we're at.  So we count
+        // args without commas. We want to find what index we're at.  So we count
         // forward until we hit ourselves, only incrementing the index if it isn't a
         // comma.
         //
@@ -224,12 +224,12 @@ namespace ts.SignatureHelp {
         // The argument count for a list is normally the number of non-comma children it has.
         // For example, if you have "Foo(a,b)" then there will be three children of the arg
         // list 'a' '<comma>' 'b'.  So, in this case the arg count will be 2.  However, there
-        // is a small subtlety.  If you have  "Foo(a,)", then the child list will just have
+        // is a small subtlety.  If you have "Foo(a,)", then the child list will just have
         // 'a' '<comma>'.  So, in the case where the last child is a comma, we increase the
         // arg count by one to compensate.
         //
-        // Note: this subtlety only applies to the last comma.  If you had "Foo(a,,"  then
-        // we'll have:  'a' '<comma>' '<missing>'
+        // Note: this subtlety only applies to the last comma.  If you had "Foo(a,," then
+        // we'll have: 'a' '<comma>' '<missing>'
         // That will give us 2 non-commas.  We then add one for the last comma, giving us an
         // arg count of 3.
         const listChildren = argumentsList.getChildren();
@@ -309,7 +309,6 @@ namespace ts.SignatureHelp {
         //
         //      `  ${ 1 + 1        foo(10)
         //       |        |
-        //
         // This is because a Missing node has no width. However, what we actually want is to include trivia
         // leading up to the next token in case the user is about to type in a TemplateMiddle or TemplateTail.
         if (template.kind === SyntaxKind.TemplateExpression) {

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -253,9 +253,11 @@ namespace ts.SignatureHelp {
         //          not enough to put us in the substitution expression; we should consider ourselves part of
         //          the *next* span's expression by offsetting the index (argIndex = (spanIndex + 1) + 1).
         //
+        // tslint:disable no-double-space
         // Example: f  `# abcd $#{#  1 + 1#  }# efghi ${ #"#hello"#  }  #  `
         //              ^       ^ ^       ^   ^          ^ ^      ^     ^
         // Case:        1       1 3       2   1          3 2      2     1
+        // tslint:enable no-double-space
         Debug.assert(position >= node.getStart(), "Assumed 'position' could not occur before node.");
         if (isTemplateLiteralKind(node.kind)) {
             if (isInsideTemplateLiteral(<LiteralExpression>node, position)) {
@@ -307,8 +309,8 @@ namespace ts.SignatureHelp {
         // Otherwise, we will not show signature help past the expression.
         // For example,
         //
-        //      `  ${ 1 + 1        foo(10)
-        //       |        |
+        //      ` ${ 1 + 1 foo(10)
+        //       |       |
         // This is because a Missing node has no width. However, what we actually want is to include trivia
         // leading up to the next token in case the user is about to type in a TemplateMiddle or TemplateTail.
         if (template.kind === SyntaxKind.TemplateExpression) {

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -328,7 +328,7 @@ namespace ts.SymbolDisplay {
                     else if (declaration.kind === SyntaxKind.TypeAliasDeclaration) {
                         // Type alias type parameter
                         // For example
-                        //      type list<T> = T[];  // Both T will go through same code path
+                        //      type list<T> = T[]; // Both T will go through same code path
                         addInPrefix();
                         displayParts.push(keywordPart(SyntaxKind.TypeKeyword));
                         displayParts.push(spacePart());

--- a/tslint.json
+++ b/tslint.json
@@ -31,6 +31,7 @@
             "check-else"
         ],
         "no-bom": true,
+        "no-double-space": true,
         "no-in-operator": true,
         "no-increment-decrement": true,
         "no-inferrable-types": true,


### PR DESCRIPTION
I think @sandersn mentioned before that he expected the linter to catch double spaces in code. A rule outright banning that would result in a lot of lint failures, so I've added exceptions for our frequent alignment of `=` signs and other common uses of double spaces.