### PR TITLE
Add method signature handler to getTypeOfVariableOrParameterOrProperty

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4683,7 +4683,8 @@ namespace ts {
                 else if (isJSDocPropertyTag(declaration)
                     || isPropertyAccessExpression(declaration)
                     || isIdentifier(declaration)
-                    || isMethodDeclaration(declaration) && !isObjectLiteralMethod(declaration)) {
+                    || (isMethodDeclaration(declaration) && !isObjectLiteralMethod(declaration))
+                    || isMethodSignature(declaration)) {
                     // TODO: Mimics old behavior from incorrect usage of getWidenedTypeForVariableLikeDeclaration, but seems incorrect
                     type = tryGetTypeFromEffectiveTypeNode(declaration) || anyType;
                 }

--- a/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.js
+++ b/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.js
@@ -1,0 +1,12 @@
+//// [methodSignatureHandledDeclarationKindForSymbol.ts]
+interface Foo {
+    bold(): string;
+}
+
+interface Foo {
+    bold: string;
+}
+
+
+
+//// [methodSignatureHandledDeclarationKindForSymbol.js]

--- a/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.symbols
+++ b/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts ===
+interface Foo {
+>Foo : Symbol(Foo, Decl(methodSignatureHandledDeclarationKindForSymbol.ts, 0, 0), Decl(methodSignatureHandledDeclarationKindForSymbol.ts, 2, 1))
+
+    bold(): string;
+>bold : Symbol(Foo.bold, Decl(methodSignatureHandledDeclarationKindForSymbol.ts, 0, 15), Decl(methodSignatureHandledDeclarationKindForSymbol.ts, 4, 15))
+}
+
+interface Foo {
+>Foo : Symbol(Foo, Decl(methodSignatureHandledDeclarationKindForSymbol.ts, 0, 0), Decl(methodSignatureHandledDeclarationKindForSymbol.ts, 2, 1))
+
+    bold: string;
+>bold : Symbol(Foo.bold, Decl(methodSignatureHandledDeclarationKindForSymbol.ts, 0, 15), Decl(methodSignatureHandledDeclarationKindForSymbol.ts, 4, 15))
+}
+
+

--- a/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.types
+++ b/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts ===
+interface Foo {
+>Foo : Foo
+
+    bold(): string;
+>bold : string
+}
+
+interface Foo {
+>Foo : Foo
+
+    bold: string;
+>bold : string
+}
+
+

--- a/tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts
+++ b/tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts
@@ -1,0 +1,8 @@
+interface Foo {
+    bold(): string;
+}
+
+interface Foo {
+    bold: string;
+}
+


### PR DESCRIPTION
#20706 Made the declaration kinds handled by `getTypeOfVariableOrParameterOrProperty` more explicit, but didn't include `MethodSignature`, which we have no normal tests covering. It being missing caused a DT test to trigger an assertion. There's a good chance this shouldn't be possible in the first place, but I need to open another issue to track that.