### PR TITLE
Not all extended types have symbols, one should not be expected

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22743,7 +22743,7 @@ namespace ts {
                                 checkTypeAssignableTo(typeWithThis,
                                     getTypeWithThisArgument(t, type.thisType),
                                     node.name || node,
-                                    t.symbol.flags & SymbolFlags.Class ?
+                                    t.symbol && t.symbol.flags & SymbolFlags.Class ?
                                         Diagnostics.Class_0_incorrectly_implements_class_1_Did_you_mean_to_extend_1_and_inherit_its_members_as_a_subclass :
                                         Diagnostics.Class_0_incorrectly_implements_interface_1);
                             }

--- a/tests/baselines/reference/implementsIncorrectlyNoAssertion.errors.txt
+++ b/tests/baselines/reference/implementsIncorrectlyNoAssertion.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(8,7): error TS2420: Class 'Baz' incorrectly implements interface 'Foo & Bar'.
+  Type 'Baz' is not assignable to type 'Foo'.
+    Types of property 'x' are incompatible.
+      Type 'number' is not assignable to type 'string'.
+
+
+==== tests/cases/compiler/implementsIncorrectlyNoAssertion.ts (1 errors) ====
+    declare class Foo {
+        x: string;
+    }
+    declare class Bar {
+        y: string;
+    }
+    type Wrapper = Foo & Bar;
+    class Baz implements Wrapper {
+          ~~~
+!!! error TS2420: Class 'Baz' incorrectly implements interface 'Foo & Bar'.
+!!! error TS2420:   Type 'Baz' is not assignable to type 'Foo'.
+!!! error TS2420:     Types of property 'x' are incompatible.
+!!! error TS2420:       Type 'number' is not assignable to type 'string'.
+        x: number;
+        y: string;
+    }
+    

--- a/tests/baselines/reference/implementsIncorrectlyNoAssertion.js
+++ b/tests/baselines/reference/implementsIncorrectlyNoAssertion.js
@@ -1,0 +1,20 @@
+//// [implementsIncorrectlyNoAssertion.ts]
+declare class Foo {
+    x: string;
+}
+declare class Bar {
+    y: string;
+}
+type Wrapper = Foo & Bar;
+class Baz implements Wrapper {
+    x: number;
+    y: string;
+}
+
+
+//// [implementsIncorrectlyNoAssertion.js]
+var Baz = /** @class */ (function () {
+    function Baz() {
+    }
+    return Baz;
+}());

--- a/tests/baselines/reference/implementsIncorrectlyNoAssertion.symbols
+++ b/tests/baselines/reference/implementsIncorrectlyNoAssertion.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/implementsIncorrectlyNoAssertion.ts ===
+declare class Foo {
+>Foo : Symbol(Foo, Decl(implementsIncorrectlyNoAssertion.ts, 0, 0))
+
+    x: string;
+>x : Symbol(Foo.x, Decl(implementsIncorrectlyNoAssertion.ts, 0, 19))
+}
+declare class Bar {
+>Bar : Symbol(Bar, Decl(implementsIncorrectlyNoAssertion.ts, 2, 1))
+
+    y: string;
+>y : Symbol(Bar.y, Decl(implementsIncorrectlyNoAssertion.ts, 3, 19))
+}
+type Wrapper = Foo & Bar;
+>Wrapper : Symbol(Wrapper, Decl(implementsIncorrectlyNoAssertion.ts, 5, 1))
+>Foo : Symbol(Foo, Decl(implementsIncorrectlyNoAssertion.ts, 0, 0))
+>Bar : Symbol(Bar, Decl(implementsIncorrectlyNoAssertion.ts, 2, 1))
+
+class Baz implements Wrapper {
+>Baz : Symbol(Baz, Decl(implementsIncorrectlyNoAssertion.ts, 6, 25))
+>Wrapper : Symbol(Wrapper, Decl(implementsIncorrectlyNoAssertion.ts, 5, 1))
+
+    x: number;
+>x : Symbol(Baz.x, Decl(implementsIncorrectlyNoAssertion.ts, 7, 30))
+
+    y: string;
+>y : Symbol(Baz.y, Decl(implementsIncorrectlyNoAssertion.ts, 8, 14))
+}
+

--- a/tests/baselines/reference/implementsIncorrectlyNoAssertion.types
+++ b/tests/baselines/reference/implementsIncorrectlyNoAssertion.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/implementsIncorrectlyNoAssertion.ts ===
+declare class Foo {
+>Foo : Foo
+
+    x: string;
+>x : string
+}
+declare class Bar {
+>Bar : Bar
+
+    y: string;
+>y : string
+}
+type Wrapper = Foo & Bar;
+>Wrapper : Wrapper
+>Foo : Foo
+>Bar : Bar
+
+class Baz implements Wrapper {
+>Baz : Baz
+>Wrapper : Wrapper
+
+    x: number;
+>x : number
+
+    y: string;
+>y : string
+}
+

--- a/tests/cases/compiler/implementsIncorrectlyNoAssertion.ts
+++ b/tests/cases/compiler/implementsIncorrectlyNoAssertion.ts
@@ -1,0 +1,11 @@
+declare class Foo {
+    x: string;
+}
+declare class Bar {
+    y: string;
+}
+type Wrapper = Foo & Bar;
+class Baz implements Wrapper {
+    x: number;
+    y: string;
+}


### PR DESCRIPTION
Fixes a bug introduced in #19797 which was shown in a failing test in our RWC suite.
