### PR TITLE
Only drop a UMD symbol for visibility consideration if all declarations are UMD declarations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2198,7 +2198,7 @@ namespace ts {
             }
 
             function isUMDExportSymbol(symbol: Symbol) {
-                return symbol && symbol.declarations && symbol.declarations[0] && isNamespaceExportDeclaration(symbol.declarations[0]);
+                return symbol && symbol.declarations && symbol.declarations.length && every(symbol.declarations, d => isNamespaceExportDeclaration(d));
             }
 
             function trySymbolTable(symbols: SymbolTable) {

--- a/tests/baselines/reference/globalAugmentationOverridingUMDNamespaceDeclarationEmit.js
+++ b/tests/baselines/reference/globalAugmentationOverridingUMDNamespaceDeclarationEmit.js
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/globalAugmentationOverridingUMDNamespaceDeclarationEmit.ts] ////
+
+//// [package.d.ts]
+declare namespace thing {
+    export interface MyInterface {}
+}
+declare var thing: {
+    x: thing.MyInterface;
+};
+export = thing;
+export as namespace thing;
+//// [globalize.d.ts]
+import * as thingAlias from "./package";
+declare global {
+    namespace thing {
+        export type MyInterface = thingAlias.MyInterface;
+    }
+    const thing: typeof thingAlias;
+}
+//// [usage.ts]
+export const num = thing.x;
+
+
+//// [usage.js]
+"use strict";
+exports.__esModule = true;
+exports.num = thing.x;
+
+
+//// [usage.d.ts]
+export declare const num: thing.MyInterface;

--- a/tests/baselines/reference/globalAugmentationOverridingUMDNamespaceDeclarationEmit.symbols
+++ b/tests/baselines/reference/globalAugmentationOverridingUMDNamespaceDeclarationEmit.symbols
@@ -1,0 +1,48 @@
+=== tests/cases/compiler/package.d.ts ===
+declare namespace thing {
+>thing : Symbol(thing, Decl(package.d.ts, 0, 0), Decl(package.d.ts, 3, 11))
+
+    export interface MyInterface {}
+>MyInterface : Symbol(MyInterface, Decl(package.d.ts, 0, 25))
+}
+declare var thing: {
+>thing : Symbol(thing, Decl(package.d.ts, 0, 0), Decl(package.d.ts, 3, 11))
+
+    x: thing.MyInterface;
+>x : Symbol(x, Decl(package.d.ts, 3, 20))
+>thing : Symbol(thing, Decl(package.d.ts, 0, 0), Decl(package.d.ts, 3, 11))
+>MyInterface : Symbol(thing.MyInterface, Decl(package.d.ts, 0, 25))
+
+};
+export = thing;
+>thing : Symbol(thing, Decl(package.d.ts, 0, 0), Decl(package.d.ts, 3, 11))
+
+export as namespace thing;
+>thing : Symbol(thing, Decl(package.d.ts, 6, 15), Decl(globalize.d.ts, 1, 16), Decl(globalize.d.ts, 5, 9))
+
+=== tests/cases/compiler/globalize.d.ts ===
+import * as thingAlias from "./package";
+>thingAlias : Symbol(thingAlias, Decl(globalize.d.ts, 0, 6))
+
+declare global {
+>global : Symbol(global, Decl(globalize.d.ts, 0, 40))
+
+    namespace thing {
+>thing : Symbol(thing, Decl(package.d.ts, 6, 15), Decl(globalize.d.ts, 1, 16), Decl(globalize.d.ts, 5, 9))
+
+        export type MyInterface = thingAlias.MyInterface;
+>MyInterface : Symbol(MyInterface, Decl(globalize.d.ts, 2, 21))
+>thingAlias : Symbol(thingAlias, Decl(globalize.d.ts, 0, 6))
+>MyInterface : Symbol(thingAlias.MyInterface, Decl(package.d.ts, 0, 25))
+    }
+    const thing: typeof thingAlias;
+>thing : Symbol(thing, Decl(package.d.ts, 6, 15), Decl(globalize.d.ts, 1, 16), Decl(globalize.d.ts, 5, 9))
+>thingAlias : Symbol(thingAlias, Decl(globalize.d.ts, 0, 6))
+}
+=== tests/cases/compiler/usage.ts ===
+export const num = thing.x;
+>num : Symbol(num, Decl(usage.ts, 0, 12))
+>thing.x : Symbol(x, Decl(package.d.ts, 3, 20))
+>thing : Symbol(thing, Decl(package.d.ts, 6, 15), Decl(globalize.d.ts, 1, 16), Decl(globalize.d.ts, 5, 9))
+>x : Symbol(x, Decl(package.d.ts, 3, 20))
+

--- a/tests/baselines/reference/globalAugmentationOverridingUMDNamespaceDeclarationEmit.types
+++ b/tests/baselines/reference/globalAugmentationOverridingUMDNamespaceDeclarationEmit.types
@@ -1,0 +1,48 @@
+=== tests/cases/compiler/package.d.ts ===
+declare namespace thing {
+>thing : { x: MyInterface; }
+
+    export interface MyInterface {}
+>MyInterface : MyInterface
+}
+declare var thing: {
+>thing : { x: thing.MyInterface; }
+
+    x: thing.MyInterface;
+>x : thing.MyInterface
+>thing : any
+>MyInterface : thing.MyInterface
+
+};
+export = thing;
+>thing : { x: thing.MyInterface; }
+
+export as namespace thing;
+>thing : { x: thing.MyInterface; }
+
+=== tests/cases/compiler/globalize.d.ts ===
+import * as thingAlias from "./package";
+>thingAlias : { x: thingAlias.MyInterface; }
+
+declare global {
+>global : typeof global
+
+    namespace thing {
+>thing : { x: thingAlias.MyInterface; }
+
+        export type MyInterface = thingAlias.MyInterface;
+>MyInterface : thingAlias.MyInterface
+>thingAlias : any
+>MyInterface : thingAlias.MyInterface
+    }
+    const thing: typeof thingAlias;
+>thing : { x: thingAlias.MyInterface; }
+>thingAlias : { x: thingAlias.MyInterface; }
+}
+=== tests/cases/compiler/usage.ts ===
+export const num = thing.x;
+>num : thing.MyInterface
+>thing.x : thing.MyInterface
+>thing : { x: thing.MyInterface; }
+>x : thing.MyInterface
+

--- a/tests/cases/compiler/globalAugmentationOverridingUMDNamespaceDeclarationEmit.ts
+++ b/tests/cases/compiler/globalAugmentationOverridingUMDNamespaceDeclarationEmit.ts
@@ -1,0 +1,20 @@
+// @declaration: true
+// @filename: package.d.ts
+declare namespace thing {
+    export interface MyInterface {}
+}
+declare var thing: {
+    x: thing.MyInterface;
+};
+export = thing;
+export as namespace thing;
+// @filename: globalize.d.ts
+import * as thingAlias from "./package";
+declare global {
+    namespace thing {
+        export type MyInterface = thingAlias.MyInterface;
+    }
+    const thing: typeof thingAlias;
+}
+// @filename: usage.ts
+export const num = thing.x;


### PR DESCRIPTION
Since another global declaration of the symbol, if compatible, would mean that it is reachable globally outside of a script context.
Fixes our half of #20749
