### PR TITLE
Add kindModifier to mark if a completion item is for an optional field

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -91,9 +91,14 @@ namespace ts.SymbolDisplay {
     }
 
     export function getSymbolModifiers(symbol: Symbol): string {
-        return symbol && symbol.declarations && symbol.declarations.length > 0
+        const nodeModifiers = symbol && symbol.declarations && symbol.declarations.length > 0
             ? getNodeModifiers(symbol.declarations[0])
             : ScriptElementKindModifier.none;
+
+        const symbolModifiers = symbol && symbol.flags & SymbolFlags.Optional ?
+            ScriptElementKindModifier.optionalModifier
+            : ScriptElementKindModifier.none;
+        return nodeModifiers && symbolModifiers ? nodeModifiers + "," + symbolModifiers : nodeModifiers || symbolModifiers;
     }
 
     interface SymbolDisplayPartsDocumentationAndSymbolKind {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -954,6 +954,7 @@ namespace ts {
         ambientModifier = "declare",
         staticModifier = "static",
         abstractModifier = "abstract",
+        optionalModifier = "optional"
     }
 
     export const enum ClassificationTypeNames {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4505,6 +4505,7 @@ declare namespace ts {
         ambientModifier = "declare",
         staticModifier = "static",
         abstractModifier = "abstract",
+        optionalModifier = "optional",
     }
     enum ClassificationTypeNames {
         comment = "comment",

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4505,6 +4505,7 @@ declare namespace ts {
         ambientModifier = "declare",
         staticModifier = "static",
         abstractModifier = "abstract",
+        optionalModifier = "optional",
     }
     enum ClassificationTypeNames {
         comment = "comment",

--- a/tests/cases/fourslash/completionsOptionalKindModifier.ts
+++ b/tests/cases/fourslash/completionsOptionalKindModifier.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////interface A { a?: number; };
+////function f(x: A) {
+////x./**/;
+////}
+
+goTo.marker();
+verify.completionListContains("a", /* text */ undefined, /* documentation */ undefined, { kindModifiers: "optional" });

--- a/tests/cases/fourslash/completionsOptionalKindModifier.ts
+++ b/tests/cases/fourslash/completionsOptionalKindModifier.ts
@@ -1,9 +1,10 @@
 /// <reference path="fourslash.ts" />
 
-////interface A { a?: number; };
+////interface A { a?: number; method?(): number; };
 ////function f(x: A) {
-////x./**/;
+////x./*a*/;
 ////}
 
-goTo.marker();
+goTo.marker("a");
 verify.completionListContains("a", /* text */ undefined, /* documentation */ undefined, { kindModifiers: "optional" });
+verify.completionListContains("method", /* text */ undefined, /* documentation */ undefined, { kindModifiers: "optional" });

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -145,7 +145,7 @@ declare namespace FourSlashInterface {
             entryId: string | { name: string, source?: string },
             text?: string,
             documentation?: string,
-            kind?: string,
+            kind?: string | { kind?: string, kindModifiers?: string },
             spanIndex?: number,
             hasAction?: boolean,
             options?: { includeExternalModuleExports?: boolean, sourceDisplay?: string, isRecommended?: true },


### PR DESCRIPTION
For #12458

Adds a new KindModifier for completion items to mark when a property is optional. This can be used by editors to either change the completion item icon or add a `?` to the completion item text

