### PR TITLE
Include '@types/node' in ATA if commonjs modules are used

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3968,6 +3968,7 @@ namespace ts {
         typeAcquisition: TypeAcquisition;               // Used to customize the type acquisition process
         compilerOptions: CompilerOptions;               // Used as a source for typing inference
         unresolvedImports: ReadonlyArray<string>;       // List of unresolved module ids from imports
+        containsCommonJsRequire: boolean;               // True if there is a `require()` call somewhere in the program
     }
 
     export enum ModuleKind {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -172,6 +172,10 @@ namespace ts.server {
 
         private readonly cancellationToken: ThrottledCancellationToken;
 
+        /* @internal */ public containsCommonJsRequire(): boolean {
+            return this.program.getSourceFiles().some(file => file.commonJsModuleIndicator !== undefined);
+        }
+
         public isNonTsProject() {
             this.updateGraph();
             return allFilesAreJsOrDts(this);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -41,6 +41,7 @@ declare namespace ts.server {
         readonly compilerOptions: CompilerOptions;
         readonly typeAcquisition: TypeAcquisition;
         readonly unresolvedImports: SortedReadonlyArray<string>;
+        readonly containsCommonJsRequire: boolean;
         readonly cachePath?: string;
         readonly kind: "discover";
     }

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -117,7 +117,8 @@ namespace ts.server.typingsInstaller {
                 this.safeList,
                 this.packageNameToTypingLocation,
                 req.typeAcquisition,
-                req.unresolvedImports);
+                req.unresolvedImports,
+                req.containsCommonJsRequire);
 
             if (this.log.isEnabled()) {
                 this.log.writeLine(`Finished typings discovery: ${JSON.stringify(discoverTypingsResult)}`);

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -56,7 +56,8 @@ namespace ts.server {
             unresolvedImports,
             projectRootPath: getProjectRootPath(project),
             cachePath,
-            kind: "discover"
+            kind: "discover",
+            containsCommonJsRequire: project.containsCommonJsRequire(),
         };
     }
 

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -1163,7 +1163,8 @@ namespace ts {
                     this.safeList,
                     info.packageNameToTypingLocation,
                     info.typeAcquisition,
-                    info.unresolvedImports);
+                    info.unresolvedImports,
+                    info.containsCommonJsRequire);
             });
         }
     }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2311,6 +2311,7 @@ declare namespace ts {
         typeAcquisition: TypeAcquisition;
         compilerOptions: CompilerOptions;
         unresolvedImports: ReadonlyArray<string>;
+        containsCommonJsRequire: boolean;
     }
     enum ModuleKind {
         None = 0,
@@ -4708,6 +4709,7 @@ declare namespace ts.server {
         readonly compilerOptions: CompilerOptions;
         readonly typeAcquisition: TypeAcquisition;
         readonly unresolvedImports: SortedReadonlyArray<string>;
+        readonly containsCommonJsRequire: boolean;
         readonly cachePath?: string;
         readonly kind: "discover";
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2311,6 +2311,7 @@ declare namespace ts {
         typeAcquisition: TypeAcquisition;
         compilerOptions: CompilerOptions;
         unresolvedImports: ReadonlyArray<string>;
+        containsCommonJsRequire: boolean;
     }
     enum ModuleKind {
         None = 0,


### PR DESCRIPTION
@DanielRosenwasser had recommended doing this.