### PR TITLE
Log TS Server version and process args 

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -979,11 +979,9 @@ namespace ts.server {
         allowLocalPluginLoads
     };
 
-    if (logger.hasLevel(LogLevel.normal)) {
-        logger.info(`Starting TS Server`);
-        logger.info(`Version: ${versionMajorMinor}`);
-        logger.info(`Arguments: ${process.argv.join(" ")}`);
-    }
+    logger.info(`Starting TS Server`);
+    logger.info(`Version: ${versionMajorMinor}`);
+    logger.info(`Arguments: ${process.argv.join(" ")}`);
 
     const ioSession = new IOSession(options);
     process.on("uncaughtException", err => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -979,6 +979,12 @@ namespace ts.server {
         allowLocalPluginLoads
     };
 
+    if (logger.hasLevel(LogLevel.normal)) {
+        logger.info(`Starting TS Server`);
+        logger.info(`Version: ${versionMajorMinor}`);
+        logger.info(`Arguments: ${process.argv.join(" ")}`);
+    }
+
     const ioSession = new IOSession(options);
     process.on("uncaughtException", err => {
         ioSession.logError(err, "unknown");


### PR DESCRIPTION
Fixes #18867

Adds basic logging of the version of tsserver being run and the full command line arguments used to run it

