### PR TITLE
Fix quick info for require template string

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24452,6 +24452,7 @@ namespace ts {
                     return undefined;
 
                 case SyntaxKind.StringLiteral:
+                case SyntaxKind.NoSubstitutionTemplateLiteral:
                     // 1). import x = require("./mo/*gotToDefinitionHere*/d")
                     // 2). External module name in an import declaration
                     // 3). Dynamic import call or require in javascript

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -286,7 +286,7 @@ namespace ts.FindAllReferences.Core {
     }
 
     function isModuleReferenceLocation(node: ts.Node): boolean {
-        if (node.kind !== SyntaxKind.StringLiteral) {
+        if (node.kind !== SyntaxKind.StringLiteral && node.kind !== SyntaxKind.NoSubstitutionTemplateLiteral) {
             return false;
         }
         switch (node.parent.kind) {

--- a/tests/cases/fourslash/completionsPaths.ts
+++ b/tests/cases/fourslash/completionsPaths.ts
@@ -17,5 +17,14 @@
 // @Filename: /src/folder/b.ts
 ////import {} from "x//*2*/";
 
+// @Filename: /src/folder/c.ts
+////const foo = require("x//*3*/");
+
+// @Filename: /src/folder/4.ts
+////const foo = require(`x//*4*/`);
+
 verify.completionsAt("1", ["y", "x"]);
 verify.completionsAt("2", ["bar", "foo"]);
+verify.completionsAt("3", ["bar", "foo"]);
+verify.completionsAt("4", ["bar", "foo"]);
+

--- a/tests/cases/fourslash/quickInfoForRequire.ts
+++ b/tests/cases/fourslash/quickInfoForRequire.ts
@@ -5,6 +5,11 @@
 
 //@Filename: quickInfoForRequire_input.ts
 ////import a = require("./AA/B/*1*/B");
+////import b = require(`./AA/B/*2*/B`);
+
 
 goTo.marker("1");
+verify.quickInfoIs("module a");
+
+goTo.marker("2");
 verify.quickInfoIs("module a");


### PR DESCRIPTION
Fixes #20850

Enables quick info for `require` calls that use template strings without any substitutions 