### PR TITLE
fix #20018, allow skip constraint when merging interfaces

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22633,9 +22633,11 @@ namespace ts {
                     // type parameter at this position, we report an error.
                     const sourceConstraint = source.constraint && getTypeFromTypeNode(source.constraint);
                     const targetConstraint = getConstraintFromTypeParameter(target);
-                    if ((sourceConstraint || targetConstraint) &&
-                        (!sourceConstraint || !targetConstraint || !isTypeIdenticalTo(sourceConstraint, targetConstraint))) {
-                        return false;
+                    if (sourceConstraint) {
+                        // relax check if later interface augmentation has no constraint
+                        if (!targetConstraint || !isTypeIdenticalTo(sourceConstraint, targetConstraint)) {
+                            return false;
+                        }
                     }
 
                     // If the type parameter node has a default and it is not identical to the default

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
@@ -4,9 +4,11 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
 tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(14,15): error TS2428: All declarations of 'B' must have identical type parameters.
 tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(32,22): error TS2428: All declarations of 'A' must have identical type parameters.
 tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(38,22): error TS2428: All declarations of 'A' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(53,11): error TS2428: All declarations of 'C' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(57,11): error TS2428: All declarations of 'C' must have identical type parameters.
 
 
-==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts (6 errors) ====
+==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts (8 errors) ====
     interface A<T extends Date> {
               ~
 !!! error TS2428: All declarations of 'A' must have identical type parameters.
@@ -60,3 +62,28 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
             y: T;
         }
     }
+    
+    interface B<T extends number> {
+      u: T;
+      v: Constraint<T>; // ok
+    }
+    
+    interface B<T> { // ok
+      x: T;
+      y: Constraint<T>; // ok
+    }
+    
+    interface C<T> {
+              ~
+!!! error TS2428: All declarations of 'C' must have identical type parameters.
+      x: T;
+    }
+    
+    interface C<T extends number> { // error
+              ~
+!!! error TS2428: All declarations of 'C' must have identical type parameters.
+      y: T;
+    }
+    
+    interface Constraint<T extends number> {}
+    

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.js
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.js
@@ -41,4 +41,25 @@ module M3 {
     }
 }
 
+interface B<T extends number> {
+  u: T;
+  v: Constraint<T>; // ok
+}
+
+interface B<T> { // ok
+  x: T;
+  y: Constraint<T>; // ok
+}
+
+interface C<T> {
+  x: T;
+}
+
+interface C<T extends number> { // error
+  y: T;
+}
+
+interface Constraint<T extends number> {}
+
+
 //// [twoGenericInterfacesWithDifferentConstraints.js]

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.symbols
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.symbols
@@ -99,3 +99,54 @@ module M3 {
 >T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 31, 23), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 37, 23))
     }
 }
+
+interface B<T extends number> {
+>B : Symbol(B, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 40, 1), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 45, 1))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 42, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 47, 12))
+
+  u: T;
+>u : Symbol(B.u, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 42, 31))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 42, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 47, 12))
+
+  v: Constraint<T>; // ok
+>v : Symbol(B.v, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 43, 7))
+>Constraint : Symbol(Constraint, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 58, 1))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 42, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 47, 12))
+}
+
+interface B<T> { // ok
+>B : Symbol(B, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 40, 1), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 45, 1))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 42, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 47, 12))
+
+  x: T;
+>x : Symbol(B.x, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 47, 16))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 42, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 47, 12))
+
+  y: Constraint<T>; // ok
+>y : Symbol(B.y, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 48, 7))
+>Constraint : Symbol(Constraint, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 58, 1))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 42, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 47, 12))
+}
+
+interface C<T> {
+>C : Symbol(C, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 50, 1), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 54, 1))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 52, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 56, 12))
+
+  x: T;
+>x : Symbol(C.x, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 52, 16))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 52, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 56, 12))
+}
+
+interface C<T extends number> { // error
+>C : Symbol(C, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 50, 1), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 54, 1))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 52, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 56, 12))
+
+  y: T;
+>y : Symbol(C.y, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 56, 31))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 52, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 56, 12))
+}
+
+interface Constraint<T extends number> {}
+>Constraint : Symbol(Constraint, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 58, 1))
+>T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 60, 21))
+

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.types
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.types
@@ -99,3 +99,54 @@ module M3 {
 >T : T
     }
 }
+
+interface B<T extends number> {
+>B : B<T>
+>T : T
+
+  u: T;
+>u : T
+>T : T
+
+  v: Constraint<T>; // ok
+>v : Constraint<T>
+>Constraint : Constraint<T>
+>T : T
+}
+
+interface B<T> { // ok
+>B : B<T>
+>T : T
+
+  x: T;
+>x : T
+>T : T
+
+  y: Constraint<T>; // ok
+>y : Constraint<T>
+>Constraint : Constraint<T>
+>T : T
+}
+
+interface C<T> {
+>C : C<T>
+>T : T
+
+  x: T;
+>x : T
+>T : T
+}
+
+interface C<T extends number> { // error
+>C : C<T>
+>T : T
+
+  y: T;
+>y : T
+>T : T
+}
+
+interface Constraint<T extends number> {}
+>Constraint : Constraint<T>
+>T : T
+

--- a/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts
+++ b/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts
@@ -39,3 +39,23 @@ module M3 {
         y: T;
     }
 }
+
+interface B<T extends number> {
+  u: T;
+  v: Constraint<T>; // ok
+}
+
+interface B<T> { // ok
+  x: T;
+  y: Constraint<T>; // ok
+}
+
+interface C<T> {
+  x: T;
+}
+
+interface C<T extends number> { // error
+  y: T;
+}
+
+interface Constraint<T extends number> {}


### PR DESCRIPTION
Fixes #20018

This fix is order sensitive: only interface declared later can skip constraint. Interface declared at first must specify constraint. 

Current code base assumes  all interfaces have same constraints, so interface types and their typenodes are immutable. Supporting order independent constraint skipping would involve much mutation so I didn't attempt it at first try.