### PR TITLE
Jsx spread attribute formatting

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -619,7 +619,7 @@ namespace ts.formatting {
     }
 
     function isJsxExpressionContext(context: FormattingContext): boolean {
-        return context.contextNode.kind === SyntaxKind.JsxExpression;
+        return context.contextNode.kind === SyntaxKind.JsxExpression || context.contextNode.kind === SyntaxKind.JsxSpreadAttribute;
     }
 
     function isNextTokenParentJsxAttribute(context: FormattingContext): boolean {

--- a/tests/cases/fourslash/formattingOptionsChangeJsx.ts
+++ b/tests/cases/fourslash/formattingOptionsChangeJsx.ts
@@ -1,37 +1,39 @@
 ///<reference path="fourslash.ts"/>
 
 //@Filename: file.tsx
-/////*InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces1*/<Madoka homu={                true    } saya={   (true)  } />;
+/////*1*/<Madoka homu={                true    } saya={   (true)  } />;
 ////
 ////<PrimaryButton
-////    /*InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces2*/{    ...this._getButtonProps()    }
+////    /*2*/{    ...this._getButtonProps()    }
 /////>
 
-runTest("InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces1", "<Madoka homu={ true } saya={ (true) } />;", "<Madoka homu={true} saya={(true)} />;");
-runTest("InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces2", "    { ...this._getButtonProps() }", "    {...this._getButtonProps()}");
+runTest("1", "<Madoka homu={ true } saya={ (true) } />;", "<Madoka homu={true} saya={(true)} />;");
+runTest("2", "    { ...this._getButtonProps() }", "    {...this._getButtonProps()}");
 
 
-function runTest(propertyName: string, expectedStringWhenTrue: string, expectedStringWhenFalse: string) {
+function runTest(markerName: string, expectedStringWhenTrue: string, expectedStringWhenFalse: string) {
+    const propertyName = "InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces";
+
     // Go to the correct file
-    goTo.marker(propertyName);
+    goTo.marker(markerName);
 
     // Set the option to false first
-    format.setOption(propertyName.slice(0, -1), false);
+    format.setOption(propertyName, false);
 
     // Format
     format.document();
 
     // Verify
-    goTo.marker(propertyName);
+    goTo.marker(markerName);
     verify.currentLineContentIs(expectedStringWhenFalse);
 
     // Set the option to true
-    format.setOption(propertyName.slice(0, -1), true);
+    format.setOption(propertyName, true);
 
     // Format
     format.document();
 
     // Verify
-    goTo.marker(propertyName);
+    goTo.marker(markerName);
     verify.currentLineContentIs(expectedStringWhenTrue);
 }

--- a/tests/cases/fourslash/formattingOptionsChangeJsx.ts
+++ b/tests/cases/fourslash/formattingOptionsChangeJsx.ts
@@ -1,9 +1,14 @@
 ///<reference path="fourslash.ts"/>
 
 //@Filename: file.tsx
-/////*InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces*/<Madoka homu={                true    } saya={   (true)  } />;
+/////*InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces1*/<Madoka homu={                true    } saya={   (true)  } />;
+////
+////<PrimaryButton
+////    /*InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces2*/{    ...this._getButtonProps()    }
+/////>
 
-runTest("InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces", "<Madoka homu={ true } saya={ (true) } />;", "<Madoka homu={true} saya={(true)} />;");
+runTest("InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces1", "<Madoka homu={ true } saya={ (true) } />;", "<Madoka homu={true} saya={(true)} />;");
+runTest("InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces2", "    { ...this._getButtonProps() }", "    {...this._getButtonProps()}");
 
 
 function runTest(propertyName: string, expectedStringWhenTrue: string, expectedStringWhenFalse: string) {
@@ -11,7 +16,7 @@ function runTest(propertyName: string, expectedStringWhenTrue: string, expectedS
     goTo.marker(propertyName);
 
     // Set the option to false first
-    format.setOption(propertyName, false);
+    format.setOption(propertyName.slice(0, -1), false);
 
     // Format
     format.document();
@@ -21,7 +26,7 @@ function runTest(propertyName: string, expectedStringWhenTrue: string, expectedS
     verify.currentLineContentIs(expectedStringWhenFalse);
 
     // Set the option to true
-    format.setOption(propertyName, true);
+    format.setOption(propertyName.slice(0, -1), true);
 
     // Format
     format.document();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #20759.

This change updates the formatting option for including a space after the opening brace and before the closing brace of a JSX expression to also affect spread attributes.
