### PR TITLE
Call back into getTypeOfFuncClassEnumModule in getTypeOfVariableOrParameterOrProperty

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4685,7 +4685,11 @@ namespace ts {
                     || isIdentifier(declaration)
                     || (isMethodDeclaration(declaration) && !isObjectLiteralMethod(declaration))
                     || isMethodSignature(declaration)) {
-                    // TODO: Mimics old behavior from incorrect usage of getWidenedTypeForVariableLikeDeclaration, but seems incorrect
+
+                    // Symbol is property of some kind that is merged with something - should use `getTypeOfFuncClassEnumModule` and not `getTypeOfVariableOrParameterOrProperty`
+                    if (symbol.flags & (SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule)) {
+                        return getTypeOfFuncClassEnumModule(symbol);
+                    }
                     type = tryGetTypeFromEffectiveTypeNode(declaration) || anyType;
                 }
                 else if (isPropertyAssignment(declaration)) {
@@ -21644,7 +21648,7 @@ namespace ts {
                 return;
             }
             const symbol = getSymbolOfNode(node);
-            const type = convertAutoToAny(getTypeOfVariableOrParameterOrProperty(symbol));
+            const type = convertAutoToAny(getTypeOfSymbol(symbol));
             if (node === symbol.valueDeclaration) {
                 // Node is the primary declaration of the symbol, just validate the initializer
                 // Don't validate for-in initializer as it is already an error

--- a/tests/baselines/reference/classWithDuplicateIdentifier.errors.txt
+++ b/tests/baselines/reference/classWithDuplicateIdentifier.errors.txt
@@ -1,16 +1,19 @@
 tests/cases/compiler/classWithDuplicateIdentifier.ts(3,5): error TS2300: Duplicate identifier 'a'.
+tests/cases/compiler/classWithDuplicateIdentifier.ts(3,5): error TS2717: Subsequent property declarations must have the same type.  Property 'a' must be of type '() => number', but here has type 'number'.
 tests/cases/compiler/classWithDuplicateIdentifier.ts(6,5): error TS2300: Duplicate identifier 'b'.
 tests/cases/compiler/classWithDuplicateIdentifier.ts(7,5): error TS2300: Duplicate identifier 'b'.
 tests/cases/compiler/classWithDuplicateIdentifier.ts(11,5): error TS2300: Duplicate identifier 'c'.
 tests/cases/compiler/classWithDuplicateIdentifier.ts(11,5): error TS2717: Subsequent property declarations must have the same type.  Property 'c' must be of type 'number', but here has type 'string'.
 
 
-==== tests/cases/compiler/classWithDuplicateIdentifier.ts (5 errors) ====
+==== tests/cases/compiler/classWithDuplicateIdentifier.ts (6 errors) ====
     class C {
         a(): number { return 0; } // error: duplicate identifier
         a: number;
         ~
 !!! error TS2300: Duplicate identifier 'a'.
+        ~
+!!! error TS2717: Subsequent property declarations must have the same type.  Property 'a' must be of type '() => number', but here has type 'number'.
     }
     class K {
         b: number; // error: duplicate identifier

--- a/tests/baselines/reference/classWithDuplicateIdentifier.types
+++ b/tests/baselines/reference/classWithDuplicateIdentifier.types
@@ -3,11 +3,11 @@ class C {
 >C : C
 
     a(): number { return 0; } // error: duplicate identifier
->a : number
+>a : () => number
 >0 : 0
 
     a: number;
->a : number
+>a : () => number
 }
 class K {
 >K : K

--- a/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.errors.txt
+++ b/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts(6,5): error TS2717: Subsequent property declarations must have the same type.  Property 'bold' must be of type '() => string', but here has type 'string'.
+
+
+==== tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts (1 errors) ====
+    interface Foo {
+        bold(): string;
+    }
+    
+    interface Foo {
+        bold: string;
+        ~~~~
+!!! error TS2717: Subsequent property declarations must have the same type.  Property 'bold' must be of type '() => string', but here has type 'string'.
+    }
+    
+    

--- a/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.types
+++ b/tests/baselines/reference/methodSignatureHandledDeclarationKindForSymbol.types
@@ -3,14 +3,14 @@ interface Foo {
 >Foo : Foo
 
     bold(): string;
->bold : string
+>bold : () => string
 }
 
 interface Foo {
 >Foo : Foo
 
     bold: string;
->bold : string
+>bold : () => string
 }
 
 

--- a/tests/baselines/reference/multipleDeclarations.types
+++ b/tests/baselines/reference/multipleDeclarations.types
@@ -43,16 +43,16 @@ class X {
 
         this.mistake = 'frankly, complete nonsense';
 >this.mistake = 'frankly, complete nonsense' : "frankly, complete nonsense"
->this.mistake : any
+>this.mistake : () => void
 >this : this
->mistake : any
+>mistake : () => void
 >'frankly, complete nonsense' : "frankly, complete nonsense"
     }
     m() {
 >m : () => void
     }
     mistake() {
->mistake : any
+>mistake : () => void
     }
 }
 let x = new X();
@@ -62,11 +62,11 @@ let x = new X();
 
 X.prototype.mistake = false;
 >X.prototype.mistake = false : false
->X.prototype.mistake : any
+>X.prototype.mistake : () => void
 >X.prototype : X
 >X : typeof X
 >prototype : X
->mistake : any
+>mistake : () => void
 >false : false
 
 x.m();
@@ -76,15 +76,15 @@ x.m();
 >m : () => void
 
 x.mistake;
->x.mistake : any
+>x.mistake : () => void
 >x : X
->mistake : any
+>mistake : () => void
 
 class Y {
 >Y : Y
 
     mistake() {
->mistake : any
+>mistake : () => void
     }
     m() {
 >m : () => void
@@ -105,19 +105,19 @@ class Y {
 
         this.mistake = 'even more nonsense';
 >this.mistake = 'even more nonsense' : "even more nonsense"
->this.mistake : any
+>this.mistake : () => void
 >this : this
->mistake : any
+>mistake : () => void
 >'even more nonsense' : "even more nonsense"
     }
 }
 Y.prototype.mistake = true;
 >Y.prototype.mistake = true : true
->Y.prototype.mistake : any
+>Y.prototype.mistake : () => void
 >Y.prototype : Y
 >Y : typeof Y
 >prototype : Y
->mistake : any
+>mistake : () => void
 >true : true
 
 let y = new Y();
@@ -132,8 +132,8 @@ y.m();
 >m : () => void
 
 y.mistake();
->y.mistake() : any
->y.mistake : any
+>y.mistake() : void
+>y.mistake : () => void
 >y : Y
->mistake : any
+>mistake : () => void
 

--- a/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.symbols
@@ -1,16 +1,22 @@
 === tests/cases/conformance/salsa/index.js ===
 Common.Item = class I {}
+>Common.Item : Symbol(Common.Item, Decl(index.js, 0, 0))
 >Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
+>Item : Symbol(Common.Item, Decl(index.js, 0, 0))
 >I : Symbol(I, Decl(index.js, 0, 13))
 
 Common.Object = class extends Common.Item {}
+>Common.Object : Symbol(Common.Object, Decl(index.js, 0, 24))
 >Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
+>Object : Symbol(Common.Object, Decl(index.js, 0, 24))
 >Common.Item : Symbol(Common.Item, Decl(index.js, 0, 0))
 >Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
 >Item : Symbol(Common.Item, Decl(index.js, 0, 0))
 
 Workspace.Object = class extends Common.Object {}
+>Workspace.Object : Symbol(Workspace.Object, Decl(index.js, 1, 44))
 >Workspace : Symbol(Workspace, Decl(index.js, 1, 44), Decl(roots.js, 1, 3))
+>Object : Symbol(Workspace.Object, Decl(index.js, 1, 44))
 >Common.Object : Symbol(Common.Object, Decl(index.js, 0, 24))
 >Common : Symbol(Common, Decl(index.js, 0, 0), Decl(roots.js, 0, 3))
 >Object : Symbol(Common.Object, Decl(index.js, 0, 24))

--- a/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.types
+++ b/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.types
@@ -1,31 +1,31 @@
 === tests/cases/conformance/salsa/index.js ===
 Common.Item = class I {}
 >Common.Item = class I {} : typeof I
->Common.Item : any
->Common : any
->Item : any
+>Common.Item : typeof I
+>Common : typeof Common
+>Item : typeof I
 >class I {} : typeof I
 >I : typeof I
 
 Common.Object = class extends Common.Item {}
 >Common.Object = class extends Common.Item {} : typeof (Anonymous class)
->Common.Object : any
->Common : any
->Object : any
+>Common.Object : typeof (Anonymous class)
+>Common : typeof Common
+>Object : typeof (Anonymous class)
 >class extends Common.Item {} : typeof (Anonymous class)
->Common.Item : any
->Common : any
->Item : any
+>Common.Item : I
+>Common : typeof Common
+>Item : typeof I
 
 Workspace.Object = class extends Common.Object {}
 >Workspace.Object = class extends Common.Object {} : typeof (Anonymous class)
->Workspace.Object : any
->Workspace : any
->Object : any
+>Workspace.Object : typeof (Anonymous class)
+>Workspace : typeof Workspace
+>Object : typeof (Anonymous class)
 >class extends Common.Object {} : typeof (Anonymous class)
->Common.Object : any
->Common : any
->Object : any
+>Common.Object : (Anonymous class)
+>Common : typeof Common
+>Object : typeof (Anonymous class)
 
 /** @type {Workspace.Object} */
 var am;
@@ -33,10 +33,10 @@ var am;
 
 === tests/cases/conformance/salsa/roots.js ===
 var Common = {};
->Common : any
+>Common : typeof Common
 >{} : { [x: string]: any; }
 
 var Workspace = {};
->Workspace : any
+>Workspace : typeof Workspace
 >{} : { [x: string]: any; }
 


### PR DESCRIPTION
If the symbol's valueDeclaration is of an irregular kind.


Fixes #20826. The root of the issue was that the merged symbol for the `bold` property had flags for both `Property` and `Method` - inside `getTypeOfSymbol`, we take this to mean that the symbol should be looked at as a `Property`, but the method signature was the authoritative `valueDeclaration`, since it came first. This mismatch resulted in `getTypeOfVariableOrParameterOrProperty` not knowing how to look up the symbol's type correctly, resulting in it pulling the overall type of the symbol from _the return type of the method signature_ (since that is at the declaration's `.type` member). This changes `getTypeOfVariableOrParameterOrProperty` in the case of value declarations that it really did not know what was correct to now check if the symbol had other valid flags, and look at the symbol as that instead.