### PR TITLE
Spec overload resolution

### DIFF
--- a/doc/spec/Expressions.md
+++ b/doc/spec/Expressions.md
@@ -434,34 +434,30 @@ If *func* has apparent call signatures (section [#apparent-members]<!--3.11.1-->
 
 ### Overload Resolution { #overload-resolution }
 
-The purpose of overload resolution in a function call is to ensure that at least one signature is applicable, to provide contextual types for the arguments, and to determine the result type of the function call, which could differ between the multiple applicable signatures. Overload resolution has no impact on the run-time behavior of a function call. Since JavaScript doesn't support function overloading, all that matters at run-time is the name of the function.
+The purpose of overload resolution in a function call is to ensure that at least one signature is applicable, to provide contextual types for the arguments, and to determine the result type of the function call, which could differ between the multiple applicable signatures.
+Overload resolution has no impact on the run-time behavior of a function call.
+Since JavaScript doesn't support function overloading, all that matters at run-time is the name of the function.
 
 *TODO: Describe use of [wildcard function types](https://github.com/Microsoft/TypeScript/issues/3970) in overload resolution*.
+(Jason meant "anyFunctionType", which has weird effects all over overload resolution and inference)
 
-The compile-time processing of a typed function call consists of the following steps:
+Processing a typed function call consists of the following steps:
 
-* First, a list of candidate signatures is constructed from the call signatures in the function type in declaration order. For classes and interfaces, inherited signatures are considered to follow explicitly declared signatures in `extends` clause order.
-  * A non-generic signature is a candidate when
-    * the function call has no type arguments, and
-    * the signature is applicable with respect to the argument list of the function call.
-  * A generic signature is a candidate in a function call without type arguments when
-    * type inference (section [#type-argument-inference]<!--4.15.2-->) succeeds for each type parameter,
-    * once the inferred type arguments are substituted for their associated type parameters, the signature is applicable with respect to the argument list of the function call.
-  * A generic signature is a candidate in a function call with type arguments when
-    * The signature has the same number of type parameters as were supplied in the type argument list,
-    * the type arguments satisfy their constraints, and
-    * once the type arguments are substituted for their associated type parameters, the signature is applicable with respect to the argument list of the function call.
-* If the list of candidate signatures is empty, the function call is an error.
-* Otherwise, if the candidate list contains one or more signatures for which the type of each argument expression is a subtype of each corresponding parameter type, the return type of the first of those signatures becomes the return type of the function call.
-* Otherwise, the return type of the first signature in the candidate list becomes the return type of the function call.
+* A list of signatures is constructed from the call signatures in the function type in declaration order. For classes and interfaces, inherited signatures are considered to follow explicitly declared signatures in `extends` clause order.
+* Signatures that are not applicable are removed.
+* If the list of signatures is empty, the function call is an error.
+* Otherwise, if the list contains one or more signatures for which the type of each argument expression is a subtype of each corresponding parameter type after type arguments are substituted for their associated type parameters, the return type of the first of those signatures becomes the type of the function call.
+* Otherwise, the return type of the first signature in the list becomes the type of the function call.
 
 A signature is said to be an ***applicable signature*** with respect to an argument list when
 
 * the number of arguments is not less than the number of required parameters,
-* the number of arguments is not greater than the number of parameters, and
-* for each argument expression *e* and its corresponding parameter *P,* when *e* is contextually typed (section [#contextually-typed-expressions]<!--4.23-->) by the type of *P*, no errors ensue and the type of *e* is assignable to (section [#assignment-compatibility]<!--3.11.4-->) the type of *P*.
+* the number of arguments is not greater than the number of parameters, or the last parameter is a rest parameter.
+* the number of type arguments, if provided, is not less than the number of required type parameters,
+* the number of type arguments, if provided, is not greater than the number of type parameters,
+* for each argument expression *e* and its corresponding parameter *p,* when *e* is contextually typed (section [#contextually-typed-expressions]<!--4.23-->) by the *T*, no errors ensue and the type of *e* is assignable to (section [#assignment-compatibility]<!--3.11.4-->) *T*, where *T* is the type of *p* for signatures without type parameters, and the type of *p* after type arguments are substituted for their associated type parameters otherwise.
 
-*TODO: [Spread operator in function calls](https://github.com/Microsoft/TypeScript/pull/1931) and spreading an [iterator](https://github.com/Microsoft/TypeScript/pull/2498) into a function call*.
+*TODO: Spreading an [iterator](https://github.com/Microsoft/TypeScript/pull/2498) into a function call*.
 
 ### Type Argument Inference { #type-argument-inference }
 

--- a/doc/spec/Expressions.md
+++ b/doc/spec/Expressions.md
@@ -438,12 +438,11 @@ The purpose of overload resolution in a function call is to ensure that at least
 Overload resolution has no impact on the run-time behavior of a function call.
 Since JavaScript doesn't support function overloading, all that matters at run-time is the name of the function.
 
-*TODO: Describe use of [wildcard function types](https://github.com/Microsoft/TypeScript/issues/3970) in overload resolution*.
-(Jason meant "anyFunctionType", which has weird effects all over overload resolution and inference)
+*TODO: Describe use of [wildcard function types](https://github.com/Microsoft/TypeScript/issues/3970) in overload resolution, as well as progressive inference of contextually typed arguments generally*.
 
 Processing a typed function call consists of the following steps:
 
-* A list of signatures is constructed from the call signatures in the function type in declaration order. For classes and interfaces, inherited signatures are considered to follow explicitly declared signatures in `extends` clause order.
+* A list of signatures is constructed from the call signatures in the function type in declaration order. For classes and interfaces, inherited signatures are considered to follow explicitly declared signatures in `extends` clause order. Signatures that contain literal types always come before signatures that do not.
 * Signatures that are not applicable are removed.
 * If the list of signatures is empty, the function call is an error.
 * Otherwise, if the list contains one or more signatures for which the type of each argument expression is a subtype of each corresponding parameter type after type arguments are substituted for their associated type parameters, the return type of the first of those signatures becomes the type of the function call.
@@ -456,8 +455,6 @@ A signature is said to be an ***applicable signature*** with respect to an argum
 * the number of type arguments, if provided, is not less than the number of required type parameters,
 * the number of type arguments, if provided, is not greater than the number of type parameters,
 * for each argument expression *e* and its corresponding parameter *p,* when *e* is contextually typed (section [#contextually-typed-expressions]<!--4.23-->) by the *T*, no errors ensue and the type of *e* is assignable to (section [#assignment-compatibility]<!--3.11.4-->) *T*, where *T* is the type of *p* for signatures without type parameters, and the type of *p* after type arguments are substituted for their associated type parameters otherwise.
-
-*TODO: Spreading an [iterator](https://github.com/Microsoft/TypeScript/pull/2498) into a function call*.
 
 ### Type Argument Inference { #type-argument-inference }
 

--- a/doc/spec/Functions.md
+++ b/doc/spec/Functions.md
@@ -21,7 +21,10 @@ When a function has both overloads and an implementation, the overloads must pre
 
 ## Function Overloads { #function-overloads }
 
-Function overloads allow a more accurate specification of the patterns of invocation supported by a function than is possible with a single signature. The compile-time processing of a call to an overloaded function chooses the best candidate overload for the particular arguments and the return type of that overload becomes the result type the function call expression. Thus, using overloads it is possible to statically describe the manner in which a function's return type varies based on its arguments. Overload resolution in function calls is described further in section [#function-calls]<!--4.15-->.
+Function overloads allow a more accurate specification of the patterns of invocation supported by a function than is possible with a single signature.
+The compile-time processing of a call to an overloaded function chooses the best candidate overload for the particular arguments and the return type of that overload becomes the result type the function call expression.
+Thus, using overloads it is possible to statically describe the manner in which a function's return type varies based on its arguments.
+Overload resolution in function calls is described further in section [#function-calls]<!--4.15-->.
 
 Function overloads are purely a compile-time construct. They have no impact on the emitted JavaScript and thus no run-time cost.
 

--- a/doc/spec/Functions.md
+++ b/doc/spec/Functions.md
@@ -22,13 +22,15 @@ When a function has both overloads and an implementation, the overloads must pre
 ## Function Overloads { #function-overloads }
 
 Function overloads allow a more accurate specification of the patterns of invocation supported by a function than is possible with a single signature.
-The compile-time processing of a call to an overloaded function chooses the best candidate overload for the particular arguments and the return type of that overload becomes the result type the function call expression.
-Thus, using overloads it is possible to statically describe the manner in which a function's return type varies based on its arguments.
+A call to an overloaded function chooses the best overload for the provided arguments and the return type of that overload becomes the type of the function call expression.
+Thus, using overloads, it is possible to statically describe the way a function's return type varies based on its arguments.
 Overload resolution in function calls is described further in section [#function-calls]<!--4.15-->.
 
-Function overloads are purely a compile-time construct. They have no impact on the emitted JavaScript and thus no run-time cost.
+Function overloads are purely a compile-time construct.
+They have no impact on the emitted JavaScript and thus no run-time cost.
 
-The parameter list of a function overload cannot specify default values for parameters. In other words, an overload may use only the `?` form when specifying optional parameters.
+The parameter list of a function overload cannot specify default values for parameters.
+In other words, an overload may use only the `?` form when specifying optional parameters.
 
 The following is an example of a function with overloads.
 
@@ -46,7 +48,8 @@ function attr(nameOrMap: any, value?: string): any {
 }
 ```
 
-Note that each overload and the final implementation specify the same identifier. The type of the local variable 'attr' introduced by this declaration is
+Each overload and the final implementation specify the same identifier.
+The type of the local variable 'attr' introduced by this declaration is
 
 ```TypeScript
 var attr: {
@@ -56,7 +59,7 @@ var attr: {
 };
 ```
 
-Note that the signature of the actual function implementation is not included in the type.
+The signature of the function implementation is not included in the type.
 
 ## Function Implementations { #function-implementations }
 

--- a/doc/spec/Intro.md
+++ b/doc/spec/Intro.md
@@ -404,8 +404,6 @@ In the following screen shot, a programming tool combines information from overl
 
 &emsp;&emsp;![](images/image4.png)
 
-Section [#specialized-signatures]<!--3.9.2.4--> provides details on how to use string literals in function signatures.
-
 ## Generic Types and Functions { #generic-types-and-functions }
 
 Like overloading on string parameters, *generic types* make it easier for TypeScript to accurately capture the behavior of JavaScript libraries. Because they enable type information to flow from client code, through library code, and back into client code, generic types may do more than any other TypeScript feature to support detailed API descriptions.

--- a/doc/spec/Types.md
+++ b/doc/spec/Types.md
@@ -993,9 +993,12 @@ interface Document {
 
 states that calls to 'createElement' with the string literals "div", "span", and "canvas" return values of type 'HTMLDivElement', 'HTMLSpanElement', and 'HTMLCanvasElement' respectively, and that calls with all other string expressions return values of type 'HTMLElement'.
 
-When writing overloaded declarations such as the one above it is important to list the non-specialized signature last. This is because overload resolution (section [#overload-resolution]<!--4.15.1-->) processes the candidates in declaration order and picks the first one that matches.
+When writing overloaded declarations such as the one above it is important to list the non-specialized signature last.
+This is because overload resolution (section [#overload-resolution]<!--4.15.1-->) processes the candidates in declaration order and picks the first one that matches.
 
-Every specialized call or construct signature in an object type must be assignable to at least one non-specialized call or construct signature in the same object type (where a call signature *A* is considered assignable to another call signature *B* if an object type containing only *A* would be assignable to an object type containing only *B*). For example, the 'createElement' property in the example above is of a type that contains three specialized signatures, all of which are assignable to the non-specialized signature in the type.
+TODO: This part might be wrong now
+Every specialized call or construct signature in an object type must be assignable to at least one non-specialized call or construct signature in the same object type (where a call signature *A* is considered assignable to another call signature *B* if an object type containing only *A* would be assignable to an object type containing only *B*).
+For example, the 'createElement' property in the example above is of a type that contains three specialized signatures, all of which are assignable to the non-specialized signature in the type.
 
 ### Construct Signatures { #construct-signatures }
 

--- a/doc/spec/Types.md
+++ b/doc/spec/Types.md
@@ -163,8 +163,6 @@ Enum types are assignable to the Number primitive type, and vice versa, but diff
 
 ### String Literal Types { #string-literal-types }
 
-Specialized signatures (section [#specialized-signatures]<!--3.9.2.4-->) permit string literals to be used as types in parameter type annotations. String literal types are permitted only in that context and nowhere else.
-
 All string literal types are subtypes of the String primitive type.
 
 *TODO: Update to reflect [expanded support for string literal types](https://github.com/Microsoft/TypeScript/pull/5185)*.
@@ -274,8 +272,6 @@ Properties are either ***public***, ***private***, or ***protected*** and are ei
 
 * Properties in a class declaration may be designated public, private, or protected, while properties declared in other contexts are always considered public. Private members are only accessible within their declaring class, as described in section [#accessibility]<!--8.2.2-->, and private properties match only themselves in subtype and assignment compatibility checks, as described in section [#type-relationships]<!--3.11-->. Protected members are only accessible within their declaring class and classes derived from it, as described in section [#accessibility]<!--8.2.2-->, and protected properties match only themselves and overrides in subtype and assignment compatibility checks, as described in section [#type-relationships]<!--3.11-->.
 * Properties in an object type literal or interface declaration may be designated required or optional, while properties declared in other contexts are always considered required. Properties that are optional in the target type of an assignment may be omitted from source objects, as described in section [#assignment-compatibility]<!--3.11.4-->.
-
-Call and construct signatures may be ***specialized*** (section [#specialized-signatures]<!--3.9.2.4-->) by including parameters with string literal types. Specialized signatures are used to express patterns where specific string values for some parameters cause the types of other parameters or the function result to become further specialized.
 
 ## Union Types { #union-types }
 
@@ -962,8 +958,6 @@ A parameter is permitted to include a `public`, `private`, or `protected` modifi
 
 A type annotation for a rest parameter must denote an array type.
 
-When a parameter type annotation specifies a string literal type, the containing signature is a specialized signature (section [#specialized-signatures]<!--3.9.2.4-->). Specialized signatures are not permitted in conjunction with a function body, i.e. the *FunctionExpression*, *FunctionImplementation*, *MemberFunctionImplementation*, and *ConstructorImplementation* grammar productions do not permit parameters with string literal types.
-
 A parameter can be marked optional by following its name or binding pattern with a question mark (`?`) or by including an initializer. Initializers (including binding property or element initializers) are permitted only when the parameter list occurs in conjunction with a function body, i.e. only in a *FunctionExpression*, *FunctionImplementation*, *MemberFunctionImplementation*, or *ConstructorImplementation* grammar production.
 
 *TODO: Update to reflect [binding parameter cannot be optional in implementation signature](https://github.com/Microsoft/TypeScript/issues/2797)*.
@@ -977,28 +971,6 @@ If present, a call signature's return type annotation specifies the type of the 
 When a call signature with no return type annotation occurs in a context without a function body, the return type is assumed to be the Any type.
 
 When a call signature with no return type annotation occurs in a context that has a function body (specifically, a function implementation, a member function implementation, or a member accessor declaration), the return type is inferred from the function body as described in section [#function-implementations]<!--6.3-->.
-
-#### Specialized Signatures { #specialized-signatures }
-
-When a parameter type annotation specifies a string literal type (section [#string-literal-types]<!--3.2.9-->), the containing signature is considered a specialized signature. Specialized signatures are used to express patterns where specific string values for some parameters cause the types of other parameters or the function result to become further specialized. For example, the declaration
-
-```TypeScript
-interface Document {
-    createElement(tagName: "div"): HTMLDivElement;
-    createElement(tagName: "span"): HTMLSpanElement;
-    createElement(tagName: "canvas"): HTMLCanvasElement;
-    createElement(tagName: string): HTMLElement;
-}
-```
-
-states that calls to 'createElement' with the string literals "div", "span", and "canvas" return values of type 'HTMLDivElement', 'HTMLSpanElement', and 'HTMLCanvasElement' respectively, and that calls with all other string expressions return values of type 'HTMLElement'.
-
-When writing overloaded declarations such as the one above it is important to list the non-specialized signature last.
-This is because overload resolution (section [#overload-resolution]<!--4.15.1-->) processes the candidates in declaration order and picks the first one that matches.
-
-TODO: This part might be wrong now
-Every specialized call or construct signature in an object type must be assignable to at least one non-specialized call or construct signature in the same object type (where a call signature *A* is considered assignable to another call signature *B* if an object type containing only *A* would be assignable to an object type containing only *B*).
-For example, the 'createElement' property in the example above is of a type that contains three specialized signatures, all of which are assignable to the non-specialized signature in the type.
 
 ### Construct Signatures { #construct-signatures }
 
@@ -1258,7 +1230,7 @@ the variables 'a' and 'b' are of identical types because the two type references
     * the type of *N* is a subtype of that of *M*,
     * if *M* is a required property, *N* is also a required property, and
     * *M* and *N* are both public, *M* and *N* are both private and originate in the same declaration, *M* and *N* are both protected and originate in the same declaration, or *M* is protected and *N* is declared in a class derived from the class in which *M* is declared.
-  * *M* is a non-specialized call or construct signature and *S* has an apparent call or construct signature *N* where, when *M* and *N* are instantiated using type Any as the type argument for all type parameters declared by *M* and *N* (if any),
+  * *M* is a call or construct signature and *S* has an apparent call or construct signature *N* where, when *M* and *N* are instantiated using type Any as the type argument for all type parameters declared by *M* and *N* (if any),
     * the signatures are of the same kind (call or construct),
     * *M* has a rest parameter or the number of non-optional parameters in *N* is less than or equal to the total number of parameters in *M*,
     * for parameter positions that are present in both signatures, each parameter type in *N* is a subtype or supertype of the corresponding parameter type in *M*, and
@@ -1267,8 +1239,6 @@ the variables 'a' and 'b' are of identical types because the two type references
   * *M* is a numeric index signature of type *U*, and *U* is the Any type or *S* has an apparent string or numeric index signature of a type that is a subtype of *U*.
 
 When comparing call or construct signatures, parameter names are ignored and rest parameters correspond to an unbounded expansion of optional parameters of the rest parameter element type.
-
-Note that specialized call and construct signatures (section [#specialized-signatures]<!--3.9.2.4-->) are not significant when determining subtype and supertype relationships.
 
 Also note that type parameters are not considered object types. Thus, the only subtypes of a type parameter *T* are *T* itself and other type parameters that are directly or indirectly constrained to *T*.
 
@@ -1296,7 +1266,7 @@ Types are required to be assignment compatible in certain circumstances, such as
     * if *M* is a required property, *N* is also a required property, and
     * *M* and *N* are both public, *M* and *N* are both private and originate in the same declaration, *M* and *N* are both protected and originate in the same declaration, or *M* is protected and *N* is declared in a class derived from the class in which *M* is declared.
   * *M* is an optional property and *S* has no apparent property of the same name as *M*.
-  * *M* is a non-specialized call or construct signature and *S* has an apparent call or construct signature *N* where, when *M* and *N* are instantiated using type Any as the type argument for all type parameters declared by *M* and *N* (if any),
+  * *M* is a call or construct signature and *S* has an apparent call or construct signature *N* where, when *M* and *N* are instantiated using type Any as the type argument for all type parameters declared by *M* and *N* (if any),
     * the signatures are of the same kind (call or construct),
     * *M* has a rest parameter or the number of non-optional parameters in *N* is less than or equal to the total number of parameters in *M*,
     * for parameter positions that are present in both signatures, each parameter type in *N* is assignable to or from the corresponding parameter type in *M*, and
@@ -1305,8 +1275,6 @@ Types are required to be assignment compatible in certain circumstances, such as
   * *M* is a numeric index signature of type *U*, and *U* is the Any type or *S* has an apparent string or numeric index signature of a type that is assignable to *U*.
 
 When comparing call or construct signatures, parameter names are ignored and rest parameters correspond to an unbounded expansion of optional parameters of the rest parameter element type.
-
-Note that specialized call and construct signatures (section [#specialized-signatures]<!--3.9.2.4-->) are not significant when determining assignment compatibility.
 
 The assignment compatibility and subtyping rules differ only in that
 


### PR DESCRIPTION
Also remove the concept of specialised signatures, which are overload sets that have string literal types.
Note that this does not update the rules on overload assignability, nor does it describe the interaction of `anyFunctionType` with contextual typing when called from type inference.