### PR TITLE
For `export default foo`, use 'foo' for the completion identifier name, not the module name

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -456,7 +456,9 @@ namespace ts.Completions {
 
     function getSymbolName(symbol: Symbol, origin: SymbolOriginInfo | undefined, target: ScriptTarget): string {
         return origin && origin.isDefaultExport && symbol.escapedName === InternalSymbolName.Default
-            ? codefix.moduleSymbolToValidIdentifier(origin.moduleSymbol, target)
+            // Name of "export default foo;" is "foo". Name of "export default 0" is the filename converted to camelCase.
+            ? firstDefined(symbol.declarations, d => isExportAssignment(d) && isIdentifier(d.expression) ? d.expression.text : undefined)
+                || codefix.moduleSymbolToValidIdentifier(origin.moduleSymbol, target)
             : symbol.name;
     }
 
@@ -1113,8 +1115,6 @@ namespace ts.Completions {
 
             codefix.forEachExternalModuleToImportFrom(typeChecker, sourceFile, allSourceFiles, moduleSymbol => {
                 for (let symbol of typeChecker.getExportsOfModule(moduleSymbol)) {
-                    let { name } = symbol;
-
                     // Don't add a completion for a re-export, only for the original.
                     // If `symbol.parent !== moduleSymbol`, this comes from an `export * from "foo"` re-export. Those don't create new symbols.
                     // If `some(...)`, this comes from an `export { foo } from "foo"` re-export, which creates a new symbol (thus isn't caught by the first check).
@@ -1122,19 +1122,13 @@ namespace ts.Completions {
                         continue;
                     }
 
-                    const isDefaultExport = name === InternalSymbolName.Default;
+                    const isDefaultExport = symbol.name === InternalSymbolName.Default;
                     if (isDefaultExport) {
-                        const localSymbol = getLocalSymbolForExportDefault(symbol);
-                        if (localSymbol) {
-                            symbol = localSymbol;
-                            name = localSymbol.name;
-                        }
-                        else {
-                            name = codefix.moduleSymbolToValidIdentifier(moduleSymbol, target);
-                        }
+                        symbol = getLocalSymbolForExportDefault(symbol) || symbol;
                     }
 
-                    if (stringContainsCharactersInOrder(name.toLowerCase(), tokenTextLowerCase)) {
+                    const origin: SymbolOriginInfo = { moduleSymbol, isDefaultExport };
+                    if (stringContainsCharactersInOrder(getSymbolName(symbol, origin, target).toLowerCase(), tokenTextLowerCase)) {
                         symbols.push(symbol);
                         symbolToOriginInfoMap[getSymbolId(symbol)] = { moduleSymbol, isDefaultExport };
                     }

--- a/tests/cases/fourslash/completionsImport_default_exportDefaultIdentifier.ts
+++ b/tests/cases/fourslash/completionsImport_default_exportDefaultIdentifier.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts" />
+
+// Tests that we use the name "foo".
+
+// @Filename: /a.ts
+////const foo = 0;
+////export default foo;
+
+// @Filename: /b.ts
+////f/**/;
+
+goTo.marker("");
+verify.completionListContains({ name: "foo", source: "/a" }, "export default foo", "", "alias", /*spanIndex*/ undefined, /*hasAction*/ true, {
+    includeExternalModuleExports: true,
+    sourceDisplay: "./a",
+});
+
+verify.applyCodeActionFromCompletion("", {
+    name: "foo",
+    source: "/a",
+    description: `Import 'foo' from module "./a"`,
+    // TODO: GH#18445
+    newFileContent: `import foo from "./a";\r
+\r
+f;`,
+});


### PR DESCRIPTION
Fixes #20967