### PR TITLE
listener argument is mandatory

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -3723,9 +3723,9 @@ declare var Event: {
 };
 
 interface EventTarget {
-    addEventListener(type: string, listener?: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     dispatchEvent(evt: Event): boolean;
-    removeEventListener(type: string, listener?: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var EventTarget: {


### PR DESCRIPTION
Weird to be the first :\
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

```
login-page.tsx:31 Uncaught (in promise) TypeError: Failed to execute 'removeEventListener' on 'EventTarget': 2 arguments required, but only 1 present.
    at Login.componentWillUnmount (login-page.tsx:31)
    at unmountComponent (preact.esm.js:879)
    at unmountComponent (preact.esm.js:886)
    at unmountComponent (preact.esm.js:886)
    at renderComponent (preact.esm.js:786)
    at rerender (preact.esm.js:163)
    at <anonymous>
```

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
