### PR TITLE
Improve find-all-references for redeclared property in a derived interface

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -876,6 +876,8 @@ namespace ts.FindAllReferences.Core {
             case SpecialSearchKind.Class:
                 addClassStaticThisReferences(referenceLocation, search, state);
                 break;
+            default:
+                Debug.assertNever(state.specialSearchKind);
         }
 
         getImportOrExportReferences(referenceLocation, referenceSymbol, search, state);
@@ -1436,7 +1438,7 @@ namespace ts.FindAllReferences.Core {
     // This is not needed when searching for re-exports.
     function populateSearchSymbolSet(symbol: Symbol, location: Node, checker: TypeChecker, implementations: boolean): Symbol[] {
         // The search set contains at least the current symbol
-        const result = [symbol];
+        const result: Symbol[] = [];
 
         const containingObjectLiteralElement = getContainingObjectLiteralElement(location);
         if (containingObjectLiteralElement) {
@@ -1453,9 +1455,9 @@ namespace ts.FindAllReferences.Core {
             // If the location is in a context sensitive location (i.e. in an object literal) try
             // to get a contextual type for it, and add the property symbol from the contextual
             // type to the search set
-            forEach(getPropertySymbolsFromContextualType(containingObjectLiteralElement, checker), contextualSymbol => {
-                addRange(result, checker.getRootSymbols(contextualSymbol));
-            });
+            for (const contextualSymbol of getPropertySymbolsFromContextualType(containingObjectLiteralElement, checker)) {
+                addRootSymbols(contextualSymbol);
+            }
 
             /* Because in short-hand property assignment, location has two meaning : property name and as value of the property
              * When we do findAllReference at the position of the short-hand property assignment, we would want to have references to position of
@@ -1496,9 +1498,7 @@ namespace ts.FindAllReferences.Core {
             // If this is a union property, add all the symbols from all its source symbols in all unioned types.
             // If the symbol is an instantiation from a another symbol (e.g. widened symbol) , add the root the list
             for (const rootSymbol of checker.getRootSymbols(sym)) {
-                if (rootSymbol !== sym) {
-                    result.push(rootSymbol);
-                }
+                result.push(rootSymbol);
 
                 // Add symbol of properties/methods of the same name in base classes and implemented interfaces definitions
                 if (!implementations && rootSymbol.parent && rootSymbol.parent.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
@@ -1522,7 +1522,7 @@ namespace ts.FindAllReferences.Core {
      * @param previousIterationSymbolsCache a cache of symbol from previous iterations of calling this function to prevent infinite revisiting of the same symbol.
      *                                The value of previousIterationSymbol is undefined when the function is first called.
      */
-    function getPropertySymbolsFromBaseTypes(symbol: Symbol, propertyName: string, result: Symbol[], previousIterationSymbolsCache: SymbolTable, checker: TypeChecker): void {
+    function getPropertySymbolsFromBaseTypes(symbol: Symbol, propertyName: string, result: Push<Symbol>, previousIterationSymbolsCache: SymbolTable, checker: TypeChecker): void {
         if (!symbol) {
             return;
         }
@@ -1591,9 +1591,7 @@ namespace ts.FindAllReferences.Core {
         // compare to our searchSymbol
         const containingObjectLiteralElement = getContainingObjectLiteralElement(referenceLocation);
         if (containingObjectLiteralElement) {
-            const contextualSymbol = forEach(getPropertySymbolsFromContextualType(containingObjectLiteralElement, checker), contextualSymbol =>
-                find(checker.getRootSymbols(contextualSymbol), search.includes));
-
+            const contextualSymbol = firstDefined(getPropertySymbolsFromContextualType(containingObjectLiteralElement, checker), findRootSymbol);
             if (contextualSymbol) {
                 return contextualSymbol;
             }
@@ -1622,7 +1620,7 @@ namespace ts.FindAllReferences.Core {
         function findRootSymbol(sym: Symbol): Symbol | undefined {
             // Unwrap symbols to get to the root (e.g. transient symbols as a result of widening)
             // Or a union property, use its underlying unioned symbols
-            return forEach(state.checker.getRootSymbols(sym), rootSymbol => {
+            return firstDefined(checker.getRootSymbols(sym), rootSymbol => {
                 // if it is in the list, then we are done
                 if (search.includes(rootSymbol)) {
                     return rootSymbol;
@@ -1633,12 +1631,12 @@ namespace ts.FindAllReferences.Core {
                 // parent symbol
                 if (rootSymbol.parent && rootSymbol.parent.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
                     // Parents will only be defined if implementations is true
-                    if (search.parents && !some(search.parents, parent => explicitlyInheritsFrom(rootSymbol.parent, parent, state.inheritsFromCache, state.checker))) {
+                    if (search.parents && !some(search.parents, parent => explicitlyInheritsFrom(rootSymbol.parent, parent, state.inheritsFromCache, checker))) {
                         return undefined;
                     }
 
                     const result: Symbol[] = [];
-                    getPropertySymbolsFromBaseTypes(rootSymbol.parent, rootSymbol.name, result, /*previousIterationSymbolsCache*/ createSymbolTable(), state.checker);
+                    getPropertySymbolsFromBaseTypes(rootSymbol.parent, rootSymbol.name, result, /*previousIterationSymbolsCache*/ createSymbolTable(), checker);
                     return find(result, search.includes);
                 }
 
@@ -1660,28 +1658,12 @@ namespace ts.FindAllReferences.Core {
     }
 
     /** Gets all symbols for one property. Does not get symbols for every property. */
-    function getPropertySymbolsFromContextualType(node: ObjectLiteralElement, checker: TypeChecker): Symbol[] | undefined {
-        const objectLiteral = <ObjectLiteralExpression>node.parent;
-        const contextualType = checker.getContextualType(objectLiteral);
+    function getPropertySymbolsFromContextualType(node: ObjectLiteralElement, checker: TypeChecker): ReadonlyArray<Symbol> {
+        const contextualType = checker.getContextualType(<ObjectLiteralExpression>node.parent);
         const name = getNameFromObjectLiteralElement(node);
-        if (name && contextualType) {
-            const result: Symbol[] = [];
-            const symbol = contextualType.getProperty(name);
-            if (symbol) {
-                result.push(symbol);
-            }
-
-            if (contextualType.flags & TypeFlags.Union) {
-                forEach((<UnionType>contextualType).types, t => {
-                    const symbol = t.getProperty(name);
-                    if (symbol) {
-                        result.push(symbol);
-                    }
-                });
-            }
-            return result;
-        }
-        return undefined;
+        const symbol = contextualType && name && contextualType.getProperty(name);
+        return symbol ? [symbol] :
+            contextualType && contextualType.flags & TypeFlags.Union ? mapDefined((<UnionType>contextualType).types, t => t.getProperty(name)) : emptyArray;
     }
 
     /**

--- a/tests/cases/fourslash/cancellationWhenfindingAllRefsOnDefinition.ts
+++ b/tests/cases/fourslash/cancellationWhenfindingAllRefsOnDefinition.ts
@@ -36,8 +36,5 @@ function checkRefs() {
     const ranges = test.ranges();
     const [r0, r1] = ranges;
     verify.referenceGroups(r0, [{ definition: "(method) Test.start(): this", ranges }]);
-    verify.referenceGroups(r1, [
-        { definition: "(method) Second.Test.start(): Second.Test", ranges: [r0] },
-        { definition: "(method) Second.Test.start(): Second.Test", ranges: [r1] }
-    ]);
+    verify.referenceGroups(r1, [{ definition: "(method) Second.Test.start(): Second.Test", ranges }]);
 }

--- a/tests/cases/fourslash/findAllRefsForObjectLiteralProperties.ts
+++ b/tests/cases/fourslash/findAllRefsForObjectLiteralProperties.ts
@@ -8,10 +8,4 @@
 ////
 ////let {[|property|]: pVar} = x;
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups(r0, [{ definition: "(property) property: {}", ranges }]);
-verify.referenceGroups([r1, r2], [
-    { definition: "(property) property: {}", ranges: [r0] },
-    { definition: "(property) property: {}", ranges: [r1, r2] }
-]);
+verify.singleReferenceGroup("(property) property: {}");

--- a/tests/cases/fourslash/findAllRefsForObjectSpread.ts
+++ b/tests/cases/fourslash/findAllRefsForObjectSpread.ts
@@ -16,9 +16,8 @@ verify.referenceGroups(r1, [{ definition: "(property) A2.a: number", ranges: [r1
 
 // but the resulting property refers to everything
 verify.referenceGroups(r2, [
-    { definition: "(property) A1.a: string", ranges: [r0, r3] },
+    { definition: "(property) A1.a: string", ranges: [r0, r2, r3] },
     { definition: "(property) A2.a: number", ranges: [r1] },
-    { definition: "(property) a: string | number", ranges: [r2] }
 ]);
 
 verify.referenceGroups(r3, [{ definition: "(property) A1.a: string", ranges: [r0, r2, r3] }]);

--- a/tests/cases/fourslash/findAllRefsInheritedProperties1.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties1.ts
@@ -10,9 +10,5 @@
 //// v.[|propName|];
 
 const [r0, r1, r2, r3] = test.ranges();
-verify.referenceGroups(r0, [{ definition: "(method) class1.doStuff(): void", ranges: [r0, r2] }]);
-verify.referenceGroups(r2, [
-    { definition: "(method) class1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) class1.doStuff(): void", ranges: [r2] }
-]);
+verify.singleReferenceGroup("(method) class1.doStuff(): void", [r0, r2]);
 verify.singleReferenceGroup("(property) class1.propName: string", [r1, r3]);

--- a/tests/cases/fourslash/findAllRefsInheritedProperties3.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties3.ts
@@ -22,7 +22,7 @@ verify.referenceGroups(r0, [{ definition: "(method) class1.doStuff(): void", ran
 verify.referenceGroups(r1, [{ definition: "(property) class1.propName: string", ranges: [r1, r5, r7] }]);
 verify.referenceGroups(r2, [{ definition: "(method) interface1.doStuff(): void", ranges: [r2, r4, r6] }]);
 verify.referenceGroups(r3, [{ definition: "(property) interface1.propName: string", ranges: [r3, r5, r7] }]);
-verify.referenceGroups(r4, [
+verify.referenceGroups([r4, r6], [
     { definition: "(method) class1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface1.doStuff(): void", ranges: [r2] },
     { definition: "(method) class2.doStuff(): void", ranges: [r4, r6] }
@@ -31,10 +31,4 @@ verify.referenceGroups([r5, r7], [
     { definition: "(property) class1.propName: string", ranges: [r1] },
     { definition: "(property) interface1.propName: string", ranges: [r3] },
     { definition: "(property) class2.propName: string", ranges: [r5, r7] }
-]);
-verify.referenceGroups(r6, [
-    { definition: "(method) class1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) interface1.doStuff(): void", ranges: [r2] },
-    { definition: "(method) class2.doStuff(): void", ranges: [r4] },
-    { definition: "(method) class2.doStuff(): void", ranges: [r6] }
 ]);

--- a/tests/cases/fourslash/findAllRefsMappedType.ts
+++ b/tests/cases/fourslash/findAllRefsMappedType.ts
@@ -7,9 +7,4 @@
 ////declare const u: U;
 ////u.[|a|];
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups([r0, r1], [{ definition: "(property) T.a: number", ranges }]);
-verify.referenceGroups(r2, [
-    { definition: "(property) T.a: number", ranges: [r0, r1] },
-    { definition: "(property) a: string", ranges: [r2] }]);
+verify.singleReferenceGroup("(property) T.a: number");

--- a/tests/cases/fourslash/findAllRefsOnDefinition.ts
+++ b/tests/cases/fourslash/findAllRefsOnDefinition.ts
@@ -26,7 +26,4 @@
 const ranges = test.ranges();
 const [r0, r1] = ranges;
 verify.referenceGroups(r0, [{ definition: "(method) Test.start(): this", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) Second.Test.start(): Second.Test", ranges: [r0] },
-    { definition: "(method) Second.Test.start(): Second.Test", ranges: [r1] },
-]);
+verify.referenceGroups(r1, [{ definition: "(method) Second.Test.start(): Second.Test", ranges }]);

--- a/tests/cases/fourslash/findAllRefsRedeclaredPropertyInDerivedInterface.ts
+++ b/tests/cases/fourslash/findAllRefsRedeclaredPropertyInDerivedInterface.ts
@@ -1,0 +1,30 @@
+/// <reference path='fourslash.ts' />
+
+// @noLib: true
+
+////interface A {
+////    readonly [|{| "isWriteAccess": true, "isDefinition": true |}x|]: number | string;
+////}
+////interface B extends A {
+////    readonly [|{| "isWriteAccess": true, "isDefinition": true |}x|]: number;
+////}
+////const a: A = { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: 0 };
+////const b: B = { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: 0 };
+
+const [r0, r1, r2, r3] = test.ranges();
+verify.referenceGroups(r0, [
+    { definition: "(property) A.x: string | number", ranges: [r0, r1, r2, r3] },
+]);
+verify.referenceGroups(r1, [
+    { definition: "(property) A.x: string | number", ranges: [r0, r2] },
+    { definition: "(property) B.x: number", ranges: [r1, r3] },
+]);
+verify.referenceGroups(r2, [
+    { definition: "(property) A.x: string | number", ranges: [r0, r1, r3] },
+    { definition: "(property) x: number", ranges: [r2] },
+]);
+verify.referenceGroups(r3, [
+    { definition: "(property) A.x: string | number", ranges: [r0, r2] },
+    { definition: "(property) B.x: number", ranges: [r1] },
+    { definition: "(property) x: number", ranges: [r3] },
+]);

--- a/tests/cases/fourslash/findAllRefsRootSymbols.ts
+++ b/tests/cases/fourslash/findAllRefsRootSymbols.ts
@@ -10,8 +10,7 @@ verify.referenceGroups(r0, [{ definition: "(property) I.x: {}", ranges: [r0, r3]
 verify.referenceGroups(r1, [{ definition: "(property) J.x: {}", ranges: [r1, r3] }]);
 verify.referenceGroups(r2, [{ definition: "(property) x: string", ranges: [r2, r3] }]);
 verify.referenceGroups(r3, [
-	{ definition: "(property) I.x: {}", ranges: [r0] },
+	{ definition: "(property) I.x: {}", ranges: [r0, r3] },
 	{ definition: "(property) J.x: {}", ranges: [r1] },
 	{ definition: "(property) x: string", ranges: [r2] },
-	{ definition: "(property) x: string & {}", ranges: [r3] },
 ]);

--- a/tests/cases/fourslash/findAllRefsThisKeyword.ts
+++ b/tests/cases/fourslash/findAllRefsThisKeyword.ts
@@ -32,8 +32,4 @@ verify.referenceGroups(g0, [{ definition: "(parameter) this: any", ranges: [g0, 
 verify.referenceGroups(g1, [{ definition: "this: any", ranges: [g0, g1] }]);
 verify.singleReferenceGroup("this: typeof C", [x, y]);
 verify.singleReferenceGroup("this: this", [constructor, method]);
-verify.referenceGroups(propDef, [{ definition: "(property) this: number", ranges: [propDef, propUse] }]);
-verify.referenceGroups(propUse, [
-    { definition: "(property) this: number", ranges: [propDef] },
-    { definition: "(property) this: number", ranges: [propUse] },
-]);
+verify.singleReferenceGroup("(property) this: number", [propDef, propUse]);

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames1.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames1.ts
@@ -7,10 +7,4 @@
 ////var x: Foo;
 ////x.[|_bar|];
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) Foo._bar(): number", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) Foo._bar(): number", ranges: [r0] },
-    { definition: "(method) Foo._bar(): number", ranges: [r1] }
-]);
+verify.singleReferenceGroup("(method) Foo._bar(): number");

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames2.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames2.ts
@@ -7,10 +7,4 @@
 ////var x: Foo;
 ////x.[|__bar|];
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) Foo.__bar(): number", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) Foo.__bar(): number", ranges: [r0] },
-    { definition: "(method) Foo.__bar(): number", ranges: [r1] }
-]);
+verify.singleReferenceGroup("(method) Foo.__bar(): number");

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames3.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames3.ts
@@ -7,10 +7,4 @@
 ////var x: Foo;
 ////x.[|___bar|];
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) Foo.___bar(): number", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) Foo.___bar(): number", ranges: [r0] },
-    { definition: "(method) Foo.___bar(): number", ranges: [r1] }
-]);
+verify.singleReferenceGroup("(method) Foo.___bar(): number");

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames4.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames4.ts
@@ -7,10 +7,4 @@
 ////var x: Foo;
 ////x.[|____bar|];
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) Foo.____bar(): number", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) Foo.____bar(): number", ranges: [r0] },
-    { definition: "(method) Foo.____bar(): number", ranges: [r1] }
-]);
+verify.singleReferenceGroup("(method) Foo.____bar(): number");

--- a/tests/cases/fourslash/findAllRefsWithShorthandPropertyAssignment.ts
+++ b/tests/cases/fourslash/findAllRefsWithShorthandPropertyAssignment.ts
@@ -13,7 +13,4 @@ verify.referenceGroups(r1, [
     { definition: "(property) name: string", ranges: [r1, r4] }
 ]);
 verify.singleReferenceGroup("(property) name: string", [r2]);
-verify.referenceGroups(r4, [
-    { definition: "(property) name: string", ranges: [r1] },
-    { definition: "(property) name: string", ranges: [r4] },
-]);
+verify.referenceGroups(r4, [{ definition: "(property) name: string", ranges: [r1, r4] }]);

--- a/tests/cases/fourslash/findAllRefsWithShorthandPropertyAssignment2.ts
+++ b/tests/cases/fourslash/findAllRefsWithShorthandPropertyAssignment2.ts
@@ -16,7 +16,4 @@ verify.referenceGroups(r2, [
     { definition: "var M.dx: any", ranges: [r1] },
     { definition: "(property) dx: any", ranges: [r2, r3] }
 ]);
-verify.referenceGroups(r3, [
-    { definition: "(property) dx: any", ranges: [r2] },
-    { definition: "(property) dx: any", ranges: [r3] }
-]);
+verify.referenceGroups(r3, [{ definition: "(property) dx: any", ranges: [r2, r3] }]);

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
@@ -3,11 +3,4 @@
 ////let y = o.[|foo|];
 ////let z = o['[|foo|]'];
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups(r0, [{ definition: '(property) ["foo"]: number', ranges }]);
-verify.referenceGroups([r1, r2], [
-	// TODO: these are the same thing, should be in the same group.
-	{ definition: "(property) [\"foo\"]: number", ranges: [r0] },
-	{ definition: "(property) [\"foo\"]: number", ranges: [r1, r2] },
-]);
+verify.singleReferenceGroup('(property) ["foo"]: number');

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfNumberNamedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfNumberNamedProperty.ts
@@ -2,10 +2,4 @@
 ////let o = { [|{| "isWriteAccess": true, "isDefinition": true |}1|]: 12 };
 ////let y = o[[|1|]];
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(property) 1: number", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(property) 1: number", ranges: [r0] },
-    { definition: "(property) 1: number", ranges: [r1] }
-]);
+verify.singleReferenceGroup("(property) 1: number");

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfStringNamedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfStringNamedProperty.ts
@@ -2,10 +2,4 @@
 ////let o = { "[|{| "isWriteAccess": true, "isDefinition": true |}x|]": 12 };
 ////let y = o.[|x|];
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: '(property) "x": number', ranges }]);
-verify.referenceGroups(r1, [
-    { definition: '(property) "x": number', ranges: [r0] },
-    { definition: '(property) "x": number', ranges: [r1] },
-]);
+verify.singleReferenceGroup('(property) "x": number');

--- a/tests/cases/fourslash/referencesBloomFilters.ts
+++ b/tests/cases/fourslash/referencesBloomFilters.ts
@@ -17,10 +17,7 @@
 const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
 verify.referenceGroups(r0, [{ definition: "(property) searchProp: number", ranges }]);
-verify.referenceGroups([r1, r2], [
-    { definition: "(property) searchProp: number", ranges: [r0, r3] },
-    { definition: "(property) searchProp: number", ranges: [r1, r2] }
-]);
+verify.referenceGroups([r1, r2], [{ definition: "(property) searchProp: number", ranges }]);
 verify.referenceGroups(r3, [
     { definition: "(property) searchProp: number", ranges: [r0, r1, r2] },
     { definition: '(property) "searchProp": number', ranges: [r3] }

--- a/tests/cases/fourslash/referencesBloomFilters2.ts
+++ b/tests/cases/fourslash/referencesBloomFilters2.ts
@@ -16,11 +16,7 @@
 
 const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
-verify.referenceGroups(r0, [{ definition: "(property) 42: number", ranges }]);
-verify.referenceGroups([r1, r2], [
-    { definition: "(property) 42: number", ranges: [r0, r3] },
-    { definition: "(property) 42: number", ranges: [r1, r2] }
-]);
+verify.referenceGroups([r0, r1, r2], [{ definition: "(property) 42: number", ranges }]);
 verify.referenceGroups(r3, [
     { definition: "(property) 42: number", ranges: [r0, r1, r2] },
     { definition: '(property) "42": number', ranges: [r3] }

--- a/tests/cases/fourslash/referencesForClassMembers.ts
+++ b/tests/cases/fourslash/referencesForClassMembers.ts
@@ -25,12 +25,7 @@ verify.referenceGroups([a1, a2], [
 const methods = ranges.get("method");
 const [m0, m1, m2] = methods;
 verify.referenceGroups(m0, [{ definition: "(method) Base.method(): void", ranges: methods }]);
-verify.referenceGroups(m1, [
+verify.referenceGroups([m1, m2], [
     { definition: "(method) Base.method(): void", ranges: [m0] },
     { definition: "(method) MyClass.method(): void", ranges: [m1, m2] }
-]);
-verify.referenceGroups(m2, [
-    { definition: "(method) Base.method(): void", ranges: [m0] },
-    { definition: "(method) MyClass.method(): void", ranges: [m1] },
-    { definition: "(method) MyClass.method(): void", ranges: [m2] }
 ]);

--- a/tests/cases/fourslash/referencesForClassMembersExtendingAbstractClass.ts
+++ b/tests/cases/fourslash/referencesForClassMembersExtendingAbstractClass.ts
@@ -25,12 +25,7 @@ verify.referenceGroups([a1, a2], [
 const methods = ranges.get("method");
 const [m0, m1, m2] = methods;
 verify.referenceGroups(m0, [{ definition: "(method) Base.method(): void", ranges: methods }]);
-verify.referenceGroups(m1, [
+verify.referenceGroups([m1, m2], [
     { definition: "(method) Base.method(): void", ranges: [m0] },
     { definition: "(method) MyClass.method(): void", ranges: [m1, m2] }
-]);
-verify.referenceGroups(m2, [
-    { definition: "(method) Base.method(): void", ranges: [m0] },
-    { definition: "(method) MyClass.method(): void", ranges: [m1] },
-    { definition: "(method) MyClass.method(): void", ranges: [m2] }
 ]);

--- a/tests/cases/fourslash/referencesForClassMembersExtendingGenericClass.ts
+++ b/tests/cases/fourslash/referencesForClassMembersExtendingGenericClass.ts
@@ -25,12 +25,7 @@ verify.referenceGroups([a1, a2], [
 const methods = ranges.get("method");
 const [m0, m1, m2] = methods;
 verify.referenceGroups(m0, [{ definition: "(method) Base<T>.method<U>(a?: T, b?: U): this", ranges: methods }]);
-verify.referenceGroups(m1, [
+verify.referenceGroups([m1, m2], [
     { definition: "(method) Base<T>.method<U>(a?: T, b?: U): this", ranges: [m0] },
     { definition: "(method) MyClass.method(): void", ranges: [m1, m2] }
-]);
-verify.referenceGroups(m2, [
-    { definition: "(method) Base<T>.method<U>(a?: T, b?: U): this", ranges: [m0] },
-    { definition: "(method) MyClass.method(): void", ranges: [m1] },
-    { definition: "(method) MyClass.method(): void", ranges: [m2] }
 ]);

--- a/tests/cases/fourslash/referencesForClassParameter.ts
+++ b/tests/cases/fourslash/referencesForClassParameter.ts
@@ -19,10 +19,4 @@
 ////var n = new foo(undefined);
 ////n.[|{| "isWriteAccess": true |}p|] = null;
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups([r0, r1], [{ definition: "(property) foo.p: any", ranges }]);
-verify.referenceGroups(r2, [
-    { definition: "(property) foo.p: any", ranges: [r0, r1] },
-    { definition: "(property) foo.p: any", ranges: [r2] }
-]);
+verify.singleReferenceGroup("(property) foo.p: any");

--- a/tests/cases/fourslash/referencesForInheritedProperties.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties.ts
@@ -28,14 +28,8 @@ verify.referenceGroups(r1, [
     { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface2.doStuff(): void", ranges: [r1, r2, r3] }
 ]);
-verify.referenceGroups(r2, [
+verify.referenceGroups([r2, r3], [
     { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface2.doStuff(): void", ranges: [r1] },
     { definition: "(method) class1.doStuff(): void", ranges: [r2, r3] }
-]);
-verify.referenceGroups(r3, [
-    { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) interface2.doStuff(): void", ranges: [r1] },
-    { definition: "(method) class1.doStuff(): void", ranges: [r2] },
-    { definition: "(method) class1.doStuff(): void", ranges: [r3] }
 ]);

--- a/tests/cases/fourslash/referencesForInheritedProperties2.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties2.ts
@@ -33,14 +33,8 @@ verify.referenceGroups(r1, [
     { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface2.doStuff(): void", ranges: [r1, r2, r3] }
 ]);
-verify.referenceGroups(r2, [
+verify.referenceGroups([r2, r3], [
     { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface2.doStuff(): void", ranges: [r1] },
     { definition: "(method) class1.doStuff(): void", ranges: [r2, r3] }
-]);
-verify.referenceGroups(r3, [
-    { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) interface2.doStuff(): void", ranges: [r1] },
-    { definition: "(method) class1.doStuff(): void", ranges: [r2] },
-    { definition: "(method) class1.doStuff(): void", ranges: [r3] }
 ]);

--- a/tests/cases/fourslash/referencesForInheritedProperties4.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties4.ts
@@ -11,11 +11,5 @@
 
 const ranges = test.rangesByText();
 const [r0, r1] = ranges.get("doStuff");
-verify.referenceGroups(r0, [
-    { definition: "(method) class1.doStuff(): void", ranges: [r0, r1] },
-]);
-verify.referenceGroups(r1, [
-    { definition: "(method) class1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) class1.doStuff(): void", ranges: [r1] },
-]);
+verify.singleReferenceGroup("(method) class1.doStuff(): void", ranges.get("doStuff"));
 verify.singleReferenceGroup("(property) class1.propName: string", ranges.get("propName"));

--- a/tests/cases/fourslash/referencesForInheritedProperties6.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties6.ts
@@ -16,12 +16,7 @@
 const ranges = test.rangesByText();
 const [m0, m1, m2] = ranges.get("doStuff");
 verify.referenceGroups(m0, [{ definition: "(method) class1.doStuff(): void", ranges: [m0, m1, m2] }]);
-verify.referenceGroups(m1, [
+verify.referenceGroups([m1, m2], [
     { definition: "(method) class1.doStuff(): void", ranges: [m0] },
     { definition: "(method) class2.doStuff(): void", ranges: [m1, m2] }
-]);
-verify.referenceGroups(m2, [
-    { definition: "(method) class1.doStuff(): void", ranges: [m0] },
-    { definition: "(method) class2.doStuff(): void", ranges: [m1] },
-    { definition: "(method) class2.doStuff(): void", ranges: [m2] }
 ]);

--- a/tests/cases/fourslash/referencesForInheritedProperties7.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties7.ts
@@ -35,6 +35,5 @@ verify.referenceGroups([r5, r7], [
 verify.referenceGroups(r6, [
     { definition: "(method) class1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface1.doStuff(): void", ranges: [r2] },
-    { definition: "(method) class2.doStuff(): void", ranges: [r4] },
-    { definition: "(method) class2.doStuff(): void", ranges: [r6] }
+    { definition: "(method) class2.doStuff(): void", ranges: [r4, r6] },
 ]);

--- a/tests/cases/fourslash/referencesForObjectLiteralProperties.ts
+++ b/tests/cases/fourslash/referencesForObjectLiteralProperties.ts
@@ -8,10 +8,4 @@
 ////var y = x;
 ////y.[|add|];
 
-const ranges = test.ranges();
-const [r0, r1, r2, r3] = ranges;
-verify.referenceGroups(r0, [{ definition: "(property) add: number", ranges }]);
-verify.referenceGroups([r1, r2, r3], [
-    { definition: "(property) add: number", ranges: [r0] },
-    { definition: "(property) add: number", ranges: [r1, r2, r3] }
-]);
+verify.singleReferenceGroup("(property) add: number");

--- a/tests/cases/fourslash/referencesForPropertiesOfGenericType.ts
+++ b/tests/cases/fourslash/referencesForPropertiesOfGenericType.ts
@@ -13,11 +13,5 @@
 const ranges = test.ranges();
 const [r0, r1, r2] = ranges;
 verify.referenceGroups(r0, [{ definition: "(method) IFoo<T>.doSomething(v: T): T", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) IFoo<T>.doSomething(v: string): string", ranges: [r0, r2] },
-    { definition: "(method) IFoo<string>.doSomething(v: string): string", ranges: [r1] }
-]);
-verify.referenceGroups(r2, [
-    { definition: "(method) IFoo<T>.doSomething(v: number): number", ranges: [r0, r1] },
-    { definition: "(method) IFoo<number>.doSomething(v: number): number", ranges: [r2] }
-]);
+verify.referenceGroups(r1, [{ definition: "(method) IFoo<T>.doSomething(v: string): string", ranges }]);
+verify.referenceGroups(r2, [{ definition: "(method) IFoo<T>.doSomething(v: number): number", ranges }]);

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames2.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames2.ts
@@ -7,11 +7,4 @@
 ////var x: Foo;
 ////x.[|blah|];
 
-//verify.singleReferenceGroup('(method) Foo["blah"](): number');
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: '(method) Foo["blah"](): number', ranges }]);
-verify.referenceGroups(r1, [
-    { definition: '(method) Foo["blah"](): number', ranges: [r0] },
-    { definition: '(method) Foo["blah"](): number', ranges: [r1] }
-]);
+verify.singleReferenceGroup('(method) Foo["blah"](): number');

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames3.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames3.ts
@@ -8,10 +8,4 @@
 ////var y: Foo2;
 ////y[[|42|]];
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups([r0, r1], [{ definition: '(property) Foo2["42"]: number', ranges }]);
-verify.referenceGroups(r2, [
-    { definition: '(property) Foo2["42"]: number', ranges: [r0, r1] },
-    { definition: '(property) Foo2["42"]: number', ranges: [r2] },
-]);
+verify.singleReferenceGroup('(property) Foo2["42"]: number');

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames4.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames4.ts
@@ -8,6 +8,5 @@ const ranges = test.ranges();
 const [r0, r1, r2] = ranges;
 verify.referenceGroups(r0, [{ definition: '(property) "someProperty": number', ranges }]);
 verify.referenceGroups([r1, r2], [
-    { definition: '(property) "someProperty": number', ranges: [r0] },
-    { definition: '(property) "someProperty": number', ranges: [r1, r2] },
+    { definition: '(property) "someProperty": number', ranges: [r0, r1, r2] },
 ]);

--- a/tests/cases/fourslash/referencesForUnionProperties.ts
+++ b/tests/cases/fourslash/referencesForUnionProperties.ts
@@ -30,8 +30,7 @@ verify.referenceGroups(hasAOrB, [
     { definition: "(property) HasAOrB.a: string", ranges: [hasAOrB, x] }
 ]);
 verify.referenceGroups(x, [
-    { definition: "(property) a: number", ranges: [one] },
+    { definition: "(property) a: number", ranges: [one, x] },
     { definition: "(property) Base.a: string", ranges: [base] },
     { definition: "(property) HasAOrB.a: string", ranges: [hasAOrB] },
-    { definition: "(property) a: string | number", ranges: [x] }
 ]);

--- a/tests/cases/fourslash/shims-pp/getReferencesAtPosition.ts
+++ b/tests/cases/fourslash/shims-pp/getReferencesAtPosition.ts
@@ -26,7 +26,4 @@
 const ranges = test.ranges();
 const [r0, r1] = ranges;
 verify.referenceGroups(r0, [{ definition: "(method) Test.start(): this", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) Second.Test.start(): Second.Test", ranges: [r0] },
-    { definition: "(method) Second.Test.start(): Second.Test", ranges: [r1] }
-]);
+verify.referenceGroups(r1, [{ definition: "(method) Second.Test.start(): Second.Test", ranges }]);

--- a/tests/cases/fourslash/shims/getReferencesAtPosition.ts
+++ b/tests/cases/fourslash/shims/getReferencesAtPosition.ts
@@ -26,7 +26,4 @@
 const ranges = test.ranges();
 const [r0, r1] = ranges;
 verify.referenceGroups(r0, [{ definition: "(method) Test.start(): this", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) Second.Test.start(): Second.Test", ranges: [r0] },
-    { definition: "(method) Second.Test.start(): Second.Test", ranges: [r1] }
-]);
+verify.referenceGroups(r1, [{ definition: "(method) Second.Test.start(): Second.Test", ranges }]);


### PR DESCRIPTION
Fixes #18866
  