### PR TITLE
Enable typings cache entries to expire and be updated

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3999,16 +3999,6 @@ namespace ts {
         [option: string]: string[] | boolean | undefined;
     }
 
-    export interface DiscoverTypingsInfo {
-        fileNames: string[];                            // The file names that belong to the same project.
-        projectRootPath: string;                        // The path to the project root directory
-        safeListPath: string;                           // The path used to retrieve the safe list
-        packageNameToTypingLocation: Map<string>;       // The map of package names to their cached typing locations
-        typeAcquisition: TypeAcquisition;               // Used to customize the type acquisition process
-        compilerOptions: CompilerOptions;               // Used as a source for typing inference
-        unresolvedImports: ReadonlyArray<string>;       // List of unresolved module ids from imports
-    }
-
     export enum ModuleKind {
         None = 0,
         CommonJS = 1,

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -243,9 +243,11 @@ namespace ts.projectSystem {
         }
     }
 
-    export function createSession(host: server.ServerHost, opts: Partial<server.SessionOptions> = {}) {
+    export function createSession(host: TestServerHost, opts: Partial<server.SessionOptions> = {}) {
         if (opts.typingsInstaller === undefined) {
-            opts.typingsInstaller = new TestTypingsInstaller("/a/data/", /*throttleLimit*/ 5, host);
+            const globalTypingsCacheLocation = "/a/data";
+            host.ensureFileOrFolder({ path: globalTypingsCacheLocation });
+            opts.typingsInstaller = new TestTypingsInstaller(globalTypingsCacheLocation, /*throttleLimit*/ 5, host);
         }
 
         if (opts.eventHandler !== undefined) {

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -63,7 +63,7 @@ namespace ts.projectSystem {
             readonly globalTypingsCacheLocation: string,
             throttleLimit: number,
             installTypingHost: server.ServerHost,
-            readonly typesRegistry = createMap<void>(),
+            readonly typesRegistry = createMap<MapLike<string>>(),
             log?: TI.Log) {
             super(installTypingHost, globalTypingsCacheLocation, safeList.path, customTypesMap.path, throttleLimit, log);
         }

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -245,7 +245,7 @@ namespace ts.projectSystem {
 
     export function createSession(host: server.ServerHost, opts: Partial<server.SessionOptions> = {}) {
         if (opts.typingsInstaller === undefined) {
-            opts.typingsInstaller = new TestTypingsInstaller("/a/data", /*throttleLimit*/ 5, host);
+            opts.typingsInstaller = new TestTypingsInstaller("/a/data/", /*throttleLimit*/ 5, host);
         }
 
         if (opts.eventHandler !== undefined) {
@@ -6532,7 +6532,7 @@ namespace ts.projectSystem {
             const files = [file, packageJsonInCurrentDirectory, packageJsonOfPkgcurrentdirectory, indexOfPkgcurrentdirectory, typingsCachePackageJson];
             const host = createServerHost(files, { currentDirectory });
 
-            const typesRegistry = createMap<void>();
+            const typesRegistry = createMap<MapLike<string>>();
             typesRegistry.set("pkgcurrentdirectory", void 0);
             const typingsInstaller = new TestTypingsInstaller(typingsCache, /*throttleLimit*/ 5, host, typesRegistry);
 

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -243,11 +243,9 @@ namespace ts.projectSystem {
         }
     }
 
-    export function createSession(host: TestServerHost, opts: Partial<server.SessionOptions> = {}) {
+    export function createSession(host: server.ServerHost, opts: Partial<server.SessionOptions> = {}) {
         if (opts.typingsInstaller === undefined) {
-            const globalTypingsCacheLocation = "/a/data";
-            host.ensureFileOrFolder({ path: globalTypingsCacheLocation });
-            opts.typingsInstaller = new TestTypingsInstaller(globalTypingsCacheLocation, /*throttleLimit*/ 5, host);
+            opts.typingsInstaller = new TestTypingsInstaller("/a/data", /*throttleLimit*/ 5, host);
         }
 
         if (opts.eventHandler !== undefined) {

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -126,6 +126,25 @@ namespace ts.projectSystem {
         return JSON.stringify({ dependencies });
     }
 
+    export function createTypesRegistry(...list: string[]): Map<MapLike<string>> {
+        const versionMap = {
+            "latest": "1.3.0",
+            "ts2.0": "1.0.0",
+            "ts2.1": "1.0.0",
+            "ts2.2": "1.2.0",
+            "ts2.3": "1.3.0",
+            "ts2.4": "1.3.0",
+            "ts2.5": "1.3.0",
+            "ts2.6": "1.3.0",
+            "ts2.7": "1.3.0"
+        };
+        const map = createMap<MapLike<string>>();
+        for (const l of list) {
+            map.set(l, versionMap);
+        }
+        return map;
+    }
+
     export function toExternalFile(fileName: string): protocol.ExternalFile {
         return { fileName };
     }
@@ -6528,12 +6547,18 @@ namespace ts.projectSystem {
                     },
                 })
             };
+            const typingsCachePackageLockJson: FileOrFolder = {
+                path: `${typingsCache}/package-lock.json`,
+                content: JSON.stringify({
+                    dependencies: {
+                    },
+                })
+            };
 
-            const files = [file, packageJsonInCurrentDirectory, packageJsonOfPkgcurrentdirectory, indexOfPkgcurrentdirectory, typingsCachePackageJson];
+            const files = [file, packageJsonInCurrentDirectory, packageJsonOfPkgcurrentdirectory, indexOfPkgcurrentdirectory, typingsCachePackageJson, typingsCachePackageLockJson];
             const host = createServerHost(files, { currentDirectory });
 
-            const typesRegistry = createMap<MapLike<string>>();
-            typesRegistry.set("pkgcurrentdirectory", void 0);
+            const typesRegistry = createTypesRegistry("pkgcurrentdirectory");
             const typingsInstaller = new TestTypingsInstaller(typingsCache, /*throttleLimit*/ 5, host, typesRegistry);
 
             const projectService = createProjectService(host, { typingsInstaller });

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -34,8 +34,7 @@ namespace ts.projectSystem {
     }
 
     class Installer extends TestTypingsInstaller {
-        constructor(host: TestServerHost, p?: InstallerParams, log?: TI.Log) {
-            host.ensureFileOrFolder({ path: (p && p.globalTypingsCacheLocation) || "/a/data" });
+        constructor(host: server.ServerHost, p?: InstallerParams, log?: TI.Log) {
             super(
                 (p && p.globalTypingsCacheLocation) || "/a/data",
                 (p && p.throttleLimit) || 5,

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -14,25 +14,6 @@ namespace ts.projectSystem {
         typesRegistry?: Map<MapLike<string>>;
     }
 
-    function createTypesRegistry(...list: string[]): Map<MapLike<string>> {
-        const versionMap = {
-            "latest": "1.3.0",
-            "ts2.0": "1.0.0",
-            "ts2.1": "1.0.0",
-            "ts2.2": "1.2.0",
-            "ts2.3": "1.3.0",
-            "ts2.4": "1.3.0",
-            "ts2.5": "1.3.0",
-            "ts2.6": "1.3.0",
-            "ts2.7": "1.3.0"
-        };
-        const map = createMap<MapLike<string>>();
-        for (const l of list) {
-            map.set(l, versionMap);
-        }
-        return map;
-    }
-
     class Installer extends TestTypingsInstaller {
         constructor(host: server.ServerHost, p?: InstallerParams, log?: TI.Log) {
             super(

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -2,10 +2,6 @@
 /// <reference path="./tsserverProjectSystem.ts" />
 /// <reference path="../../server/typingsInstaller/typingsInstaller.ts" />
 
-
-
-
-
 namespace ts.projectSystem {
     import TI = server.typingsInstaller;
     import validatePackageName = JsTyping.validatePackageName;

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1148,7 +1148,7 @@ namespace ts.projectSystem {
                 content: ""
             };
             const host = createServerHost([f]);
-            const cache = createMap<string>();
+            const cache = createMap<JsTyping.CachedTyping>();
 
             for (const name of JsTyping.nodeCoreModuleList) {
                 const logger = trackingLogger();
@@ -1171,7 +1171,7 @@ namespace ts.projectSystem {
                 content: ""
             };
             const host = createServerHost([f, node]);
-            const cache = createMapFromTemplate<string>({ node: node.path });
+            const cache = createMapFromTemplate<JsTyping.CachedTyping>({ node: { typingLocation: node.path, timestamp: Date.now() } });
             const logger = trackingLogger();
             const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(<Path>f.path), emptySafeList, cache, { enable: true }, ["fs", "bar"]);
             assert.deepEqual(logger.finish(), [
@@ -1196,7 +1196,7 @@ namespace ts.projectSystem {
                 content: JSON.stringify({ name: "b" }),
             };
             const host = createServerHost([app, a, b]);
-            const cache = createMap<string>();
+            const cache = createMap<JsTyping.CachedTyping>();
             const logger = trackingLogger();
             const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(<Path>app.path), emptySafeList, cache, { enable: true }, /*unresolvedImports*/ []);
             assert.deepEqual(logger.finish(), [

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1,6 +1,10 @@
 /// <reference path="../harness.ts" />
 /// <reference path="./tsserverProjectSystem.ts" />
-/// <reference path="../../server/typingsInstaller/typingsInstaller.ts" />
+/// <reference path="../../server/typingsInstaller/typingsInstaller.ts" />import { deepEqual } from "assert";import { deepEqual } from "assert";
+
+
+
+
 
 namespace ts.projectSystem {
     import TI = server.typingsInstaller;
@@ -1117,6 +1121,7 @@ namespace ts.projectSystem {
 
             checkNumberOfProjects(projectService, { inferredProjects: 1 });
             checkProjectActualFiles(p, [file1.path, jquery.path]);
+            assert(host.readFile(timestamps.path) !== JSON.stringify({ entries: { "@types/jquery": date.getTime() } }), "timestamps content should be updated");
         });
 
         it("non-expired cache entry (inferred project, should not install typings)", () => {

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1,6 +1,6 @@
 /// <reference path="../harness.ts" />
 /// <reference path="./tsserverProjectSystem.ts" />
-/// <reference path="../../server/typingsInstaller/typingsInstaller.ts" />import { deepEqual } from "assert";import { deepEqual } from "assert";
+/// <reference path="../../server/typingsInstaller/typingsInstaller.ts" />
 
 
 

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -383,9 +383,11 @@ interface Array<T> {}`
         ensureFileOrFolder(fileOrDirectory: FileOrFolder, ignoreWatchInvokedWithTriggerAsFileCreate?: boolean) {
             if (isString(fileOrDirectory.content)) {
                 const file = this.toFile(fileOrDirectory);
-                Debug.assert(!this.fs.get(file.path));
-                const baseFolder = this.ensureFolder(getDirectoryPath(file.fullPath));
-                this.addFileOrFolderInFolder(baseFolder, file, ignoreWatchInvokedWithTriggerAsFileCreate);
+                // file may already exist when updating existing type declaration file
+                if (!this.fs.get(file.path)) {
+                    const baseFolder = this.ensureFolder(getDirectoryPath(file.fullPath));
+                    this.addFileOrFolderInFolder(baseFolder, file, ignoreWatchInvokedWithTriggerAsFileCreate);
+                }
             }
             else {
                 const fullPath = getNormalizedAbsolutePath(fileOrDirectory.path, this.currentDirectory);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -252,7 +252,7 @@ namespace ts.server {
         private requestMap = createMap<QueuedOperation>(); // Maps operation ID to newest requestQueue entry with that ID
         /** We will lazily request the types registry on the first call to `isKnownTypesPackageName` and store it in `typesRegistryCache`. */
         private requestedRegistry: boolean;
-        private typesRegistryCache: Map<void> | undefined;
+        private typesRegistryCache: Map<MapLike<string>> | undefined;
 
         // This number is essentially arbitrary.  Processing more than one typings request
         // at a time makes sense, but having too many in the pipe results in a hang

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -128,6 +128,5 @@ declare namespace ts.server {
         writeFile(path: string, content: string): void;
         createDirectory(path: string): void;
         watchFile?(path: string, callback: FileWatcherCallback, pollingInterval?: number): FileWatcher;
-        getModifiedTime?(path: string): Date;
     }
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -128,5 +128,6 @@ declare namespace ts.server {
         writeFile(path: string, content: string): void;
         createDirectory(path: string): void;
         watchFile?(path: string, callback: FileWatcherCallback, pollingInterval?: number): FileWatcher;
+        getModifiedTime?(path: string): Date;
     }
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -77,7 +77,7 @@ declare namespace ts.server {
     /* @internal */
     export interface TypesRegistryResponse extends TypingInstallerResponse {
         readonly kind: EventTypesRegistry;
-        readonly typesRegistry: MapLike<void>;
+        readonly typesRegistry: MapLike<MapLike<string>>;
     }
 
     export interface PackageInstalledResponse extends ProjectResponse {

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -41,15 +41,15 @@ namespace ts.server.typingsInstaller {
     }
 
     interface TypesRegistryFile {
-        entries: MapLike<void>;
+        entries: MapLike<MapLike<string>>;
     }
 
-    function loadTypesRegistryFile(typesRegistryFilePath: string, host: InstallTypingHost, log: Log): Map<void> {
+    function loadTypesRegistryFile(typesRegistryFilePath: string, host: InstallTypingHost, log: Log): Map<MapLike<string>> {
         if (!host.fileExists(typesRegistryFilePath)) {
             if (log.isEnabled()) {
                 log.writeLine(`Types registry file '${typesRegistryFilePath}' does not exist`);
             }
-            return createMap<void>();
+            return createMap<MapLike<string>>();
         }
         try {
             const content = <TypesRegistryFile>JSON.parse(host.readFile(typesRegistryFilePath));
@@ -59,7 +59,7 @@ namespace ts.server.typingsInstaller {
             if (log.isEnabled()) {
                 log.writeLine(`Error when loading types registry file '${typesRegistryFilePath}': ${(<Error>e).message}, ${(<Error>e).stack}`);
             }
-            return createMap<void>();
+            return createMap<MapLike<string>>();
         }
     }
 
@@ -77,7 +77,7 @@ namespace ts.server.typingsInstaller {
     export class NodeTypingsInstaller extends TypingsInstaller {
         private readonly nodeExecSync: ExecSync;
         private readonly npmPath: string;
-        readonly typesRegistry: Map<void>;
+        readonly typesRegistry: Map<MapLike<string>>;
 
         private delayedInitializationError: InitializationFailedResponse | undefined;
 
@@ -141,7 +141,7 @@ namespace ts.server.typingsInstaller {
                         this.closeProject(req);
                         break;
                     case "typesRegistry": {
-                        const typesRegistry: { [key: string]: void } = {};
+                        const typesRegistry: { [key: string]: MapLike<string> } = {};
                         this.typesRegistry.forEach((value, key) => {
                             typesRegistry[key] = value;
                         });

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -185,7 +185,7 @@ namespace ts.server.typingsInstaller {
             if (this.log.isEnabled()) {
                 this.log.writeLine(`#${requestId} with arguments'${JSON.stringify(packageNames)}'.`);
             }
-            const command = `${this.npmPath} install@latest --ignore-scripts ${packageNames.join(" ")} --save-dev --force --user-agent="typesInstaller/${version}"`;
+            const command = `${this.npmPath} install --ignore-scripts ${packageNames.join(" ")} --save-dev --user-agent="typesInstaller/${version}"`;
             const start = Date.now();
             const hasError = this.execSyncAndLog(command, { cwd });
             if (this.log.isEnabled()) {

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -185,7 +185,7 @@ namespace ts.server.typingsInstaller {
             if (this.log.isEnabled()) {
                 this.log.writeLine(`#${requestId} with arguments'${JSON.stringify(packageNames)}'.`);
             }
-            const command = `${this.npmPath} install --ignore-scripts ${packageNames.join(" ")} --save-dev --user-agent="typesInstaller/${version}"`;
+            const command = `${this.npmPath} install@latest --ignore-scripts ${packageNames.join(" ")} --save-dev --force --user-agent="typesInstaller/${version}"`;
             const start = Date.now();
             const hasError = this.execSyncAndLog(command, { cwd });
             if (this.log.isEnabled()) {

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -311,7 +311,7 @@ namespace ts.server.typingsInstaller {
 
                         // packageName is guaranteed to exist in typesRegistry by filterTypings
                         const distTags = this.typesRegistry.get(packageName);
-                        const newVersion = Semver.parse(distTags[`ts${ts.versionMajorMinor}`] || distTags["latest"]);
+                        const newVersion = Semver.parse(distTags[`ts${ts.versionMajorMinor}`] || distTags[latestDistTag]);
                         const newTyping: JsTyping.CachedTyping = { typingLocation: typingFile, version: newVersion };
                         this.packageNameToTypingLocation.set(packageName, newTyping);
                         installedTypingFiles.push(typingFile);
@@ -407,4 +407,6 @@ namespace ts.server.typingsInstaller {
     export function typingsName(packageName: string): string {
         return `@types/${packageName}@ts${versionMajorMinor}`;
     }
+
+    const latestDistTag = "latest";
 }

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -182,6 +182,10 @@ namespace ts.server.typingsInstaller {
                 }
                 if (npmConfig.devDependencies && npmLock.dependencies) {
                     for (const key in npmConfig.devDependencies) {
+                        if (!hasProperty(npmLock.dependencies, key)) {
+                            // if package in package.json but not package-lock.json, skip adding to cache so it is reinstalled on next use
+                            continue;
+                        }
                         // key is @types/<package name>
                         const packageName = getBaseFileName(key);
                         if (!packageName) {

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -55,7 +55,7 @@ namespace ts.server.typingsInstaller {
         try {
             if (fileExists) {
                 const content = <TypeDeclarationTimestampFile>JSON.parse(host.readFile(typeDeclarationTimestampFilePath));
-                return content.entries;
+                return content.entries || {};
             }
             else {
                 host.writeFile(typeDeclarationTimestampFilePath, "{}");
@@ -247,10 +247,11 @@ namespace ts.server.typingsInstaller {
                             continue;
                         }
                         const existingTypingFile = this.packageNameToTypingLocation.get(packageName);
-                        if (existingTypingFile.typingLocation === typingFile) {
-                            continue;
-                        }
                         if (existingTypingFile) {
+                            if (existingTypingFile.typingLocation === typingFile) {
+                                continue;
+                            }
+
                             if (this.log.isEnabled()) {
                                 this.log.writeLine(`New typing for package ${packageName} from '${typingFile}' conflicts with existing typing file '${existingTypingFile}'`);
                             }

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -309,7 +309,9 @@ namespace ts.server.typingsInstaller {
                             continue;
                         }
 
-                        const newVersion = Semver.parse(this.typesRegistry.get(packageName)[`ts${ts.versionMajorMinor}`]);
+                        // packageName is guaranteed to exist in typesRegistry by filterTypings
+                        const distTags = this.typesRegistry.get(packageName);
+                        const newVersion = Semver.parse(distTags[`ts${ts.versionMajorMinor}`] || distTags["latest"]);
                         const newTyping: JsTyping.CachedTyping = { typingLocation: typingFile, version: newVersion };
                         this.packageNameToTypingLocation.set(packageName, newTyping);
                         installedTypingFiles.push(typingFile);

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -34,7 +34,7 @@ namespace ts.JsTyping {
 
     /* @internal */
     export function isTypingUpToDate(cachedTyping: JsTyping.CachedTyping, availableTypingVersions: MapLike<string>) {
-        const availableVersion = Semver.parse(getProperty(availableTypingVersions, `ts${ts.versionMajorMinor}`));
+        const availableVersion = Semver.parse(getProperty(availableTypingVersions, `ts${ts.versionMajorMinor}`) || getProperty(availableTypingVersions, "latest"));
         return !availableVersion.greaterThan(cachedTyping.version);
     }
 

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -32,16 +32,8 @@ namespace ts.JsTyping {
     }
 
     export function isTypingExpired(typing: JsTyping.CachedTyping | undefined) {
-        const comparisonDate = new Date();
-        const currentMonth = comparisonDate.getMonth();
-        if (currentMonth) {
-            comparisonDate.setMonth(11);
-            comparisonDate.setFullYear(comparisonDate.getFullYear() - 1);
-        }
-        else {
-            comparisonDate.setMonth(currentMonth - 1);
-        }
-        return !typing || typing.timestamp < comparisonDate.getTime();
+        const msPerMonth = 1000 * 60 * 60 * 24 * 30; // ms/second * second/minute * minutes/hour * hours/day * days/month
+        return !typing || typing.timestamp < Date.now() - msPerMonth;
     }
 
     /* @internal */

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -37,7 +37,8 @@ namespace ts.JsTyping {
         if (currentMonth) {
             comparisonDate.setMonth(11);
             comparisonDate.setFullYear(comparisonDate.getFullYear() - 1);
-        } else {
+        }
+        else {
             comparisonDate.setMonth(currentMonth - 1);
         }
         return !typing || typing.timestamp < comparisonDate.getTime();

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -4,6 +4,7 @@
 /// <reference path='../compiler/types.ts' />
 /// <reference path='../compiler/core.ts' />
 /// <reference path='../compiler/commandLineParser.ts' />
+/// <reference path='../services/semver.ts' />
 
 /* @internal */
 namespace ts.JsTyping {
@@ -29,6 +30,7 @@ namespace ts.JsTyping {
     export interface CachedTyping {
         typingLocation: string;
         timestamp: number;
+        version: Semver;
     }
 
     export function isTypingExpired(typing: JsTyping.CachedTyping | undefined) {
@@ -70,7 +72,7 @@ namespace ts.JsTyping {
      * @param fileNames are the file names that belong to the same project
      * @param projectRootPath is the path to the project root directory
      * @param safeListPath is the path used to retrieve the safe list
-     * @param packageNameToTypingLocation is the map of package names to their cached typing locations and time of caching
+     * @param packageNameToTypingLocation is the map of package names to their cached typing locations and time of caching and versions
      * @param typeAcquisition is used to customize the typing acquisition process
      * @param compilerOptions are used as a source for typing inference
      */

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -31,10 +31,16 @@ namespace ts.JsTyping {
         timestamp: number;
     }
 
-    const typingLifetime = new Date(0, 1);
-
     export function isTypingExpired(typing: JsTyping.CachedTyping | undefined) {
-        return typing && Date.now() - typingLifetime.getTime() < typing.timestamp;
+        const comparisonDate = new Date();
+        const currentMonth = comparisonDate.getMonth();
+        if (currentMonth) {
+            comparisonDate.setMonth(11);
+            comparisonDate.setFullYear(comparisonDate.getFullYear() - 1);
+        } else {
+            comparisonDate.setMonth(currentMonth - 1);
+        }
+        return !typing || typing.timestamp < comparisonDate.getTime();
     }
 
     /* @internal */

--- a/src/services/semver.ts
+++ b/src/services/semver.ts
@@ -23,7 +23,7 @@ namespace ts {
         }
 
         // This must parse the output of `versionString`.
-        static tryParse(semver: string, isPrerelease: boolean): Semver | undefined {
+        private static tryParse(semver: string, isPrerelease: boolean): Semver | undefined {
             // Per the semver spec <http://semver.org/#spec-item-2>:
             // "A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes."
             const rgx = isPrerelease ? /^(\d+)\.(\d+)\.0-next.(\d+)$/ : /^(\d+)\.(\d+)\.(\d+)$/;

--- a/src/services/semver.ts
+++ b/src/services/semver.ts
@@ -1,6 +1,6 @@
 /* @internal */
 namespace ts {
-    function intOfString(str: string): number {
+    function stringToInt(str: string): number {
         const n = parseInt(str, 10);
         if (isNaN(n)) {
             throw new Error(`Error in parseInt(${JSON.stringify(str)})`);
@@ -28,10 +28,10 @@ namespace ts {
             // "A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes."
             const rgx = isPrerelease ? /^(\d+)\.(\d+)\.0-next.(\d+)$/ : /^(\d+)\.(\d+)\.(\d+)$/;
             const match = rgx.exec(semver);
-            return match ? new Semver(intOfString(match[1]), intOfString(match[2]), intOfString(match[3]), isPrerelease) : undefined;
+            return match ? new Semver(stringToInt(match[1]), stringToInt(match[2]), stringToInt(match[3]), isPrerelease) : undefined;
         }
 
-        constructor(
+        private constructor(
             readonly major: number, readonly minor: number, readonly patch: number,
             /**
              * If true, this is `major.minor.0-next.patch`.
@@ -49,7 +49,9 @@ namespace ts {
 
         greaterThan(sem: Semver): boolean {
             return this.major > sem.major || this.major === sem.major
-                && (this.minor > sem.minor || this.minor === sem.minor && this.patch > sem.patch);
+                && (this.minor > sem.minor || this.minor === sem.minor
+                && (!this.isPrerelease && sem.isPrerelease || this.isPrerelease === sem.isPrerelease
+                && this.patch > sem.patch));
         }
     }
 }

--- a/src/services/semver.ts
+++ b/src/services/semver.ts
@@ -8,9 +8,13 @@ namespace ts {
         return n;
     }
 
+    const isPrereleaseRegex = /^(.*)-next.\d+/;
+    const prereleaseSemverRegex = /^(\d+)\.(\d+)\.0-next.(\d+)$/;
+    const semverRegex = /^(\d+)\.(\d+)\.(\d+)$/;
+
     export class Semver {
         static parse(semver: string): Semver {
-            const isPrerelease = /^(.*)-next.\d+/.test(semver);
+            const isPrerelease = isPrereleaseRegex.test(semver);
             const result = Semver.tryParse(semver, isPrerelease);
             if (!result) {
                 throw new Error(`Unexpected semver: ${semver} (isPrerelease: ${isPrerelease})`);
@@ -26,7 +30,7 @@ namespace ts {
         private static tryParse(semver: string, isPrerelease: boolean): Semver | undefined {
             // Per the semver spec <http://semver.org/#spec-item-2>:
             // "A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes."
-            const rgx = isPrerelease ? /^(\d+)\.(\d+)\.0-next.(\d+)$/ : /^(\d+)\.(\d+)\.(\d+)$/;
+            const rgx = isPrerelease ? prereleaseSemverRegex : semverRegex;
             const match = rgx.exec(semver);
             return match ? new Semver(stringToInt(match[1]), stringToInt(match[2]), stringToInt(match[3]), isPrerelease) : undefined;
         }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -24,6 +24,16 @@ let debugObjectHost: { CollectGarbage(): void } = (function (this: any) { return
 
 /* @internal */
 namespace ts {
+    interface DiscoverTypingsInfo {
+        fileNames: string[];                            // The file names that belong to the same project.
+        projectRootPath: string;                        // The path to the project root directory
+        safeListPath: string;                           // The path used to retrieve the safe list
+        packageNameToTypingLocation: Map<JsTyping.CachedTyping>;       // The map of package names to their cached typing locations
+        typeAcquisition: TypeAcquisition;               // Used to customize the type acquisition process
+        compilerOptions: CompilerOptions;               // Used as a source for typing inference
+        unresolvedImports: ReadonlyArray<string>;       // List of unresolved module ids from imports
+    }
+
     export interface ScriptSnapshotShim {
         /** Gets a portion of the script snapshot specified by [start, end). */
         getText(start: number, end: number): string;

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -28,10 +28,11 @@ namespace ts {
         fileNames: string[];                            // The file names that belong to the same project.
         projectRootPath: string;                        // The path to the project root directory
         safeListPath: string;                           // The path used to retrieve the safe list
-        packageNameToTypingLocation: Map<JsTyping.CachedTyping>;       // The map of package names to their cached typing locations
+        packageNameToTypingLocation: Map<JsTyping.CachedTyping>;       // The map of package names to their cached typing locations and installed versions
         typeAcquisition: TypeAcquisition;               // Used to customize the type acquisition process
         compilerOptions: CompilerOptions;               // Used as a source for typing inference
         unresolvedImports: ReadonlyArray<string>;       // List of unresolved module ids from imports
+        typesRegistry: ReadonlyMap<MapLike<string>>;    // The map of available typings in npm to maps of TS versions to their latest supported versions
     }
 
     export interface ScriptSnapshotShim {
@@ -1171,7 +1172,8 @@ namespace ts {
                     this.safeList,
                     info.packageNameToTypingLocation,
                     info.typeAcquisition,
-                    info.unresolvedImports);
+                    info.unresolvedImports,
+                    info.typesRegistry);
             });
         }
     }

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -61,6 +61,7 @@
         "services.ts",
         "transform.ts",
         "transpile.ts",
+        "semver.ts",
         "shims.ts",
         "signatureHelp.ts",
         "symbolDisplay.ts",

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2308,15 +2308,6 @@ declare namespace ts {
         exclude?: string[];
         [option: string]: string[] | boolean | undefined;
     }
-    interface DiscoverTypingsInfo {
-        fileNames: string[];
-        projectRootPath: string;
-        safeListPath: string;
-        packageNameToTypingLocation: Map<string>;
-        typeAcquisition: TypeAcquisition;
-        compilerOptions: CompilerOptions;
-        unresolvedImports: ReadonlyArray<string>;
-    }
     enum ModuleKind {
         None = 0,
         CommonJS = 1,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2308,15 +2308,6 @@ declare namespace ts {
         exclude?: string[];
         [option: string]: string[] | boolean | undefined;
     }
-    interface DiscoverTypingsInfo {
-        fileNames: string[];
-        projectRootPath: string;
-        safeListPath: string;
-        packageNameToTypingLocation: Map<string>;
-        typeAcquisition: TypeAcquisition;
-        compilerOptions: CompilerOptions;
-        unresolvedImports: ReadonlyArray<string>;
-    }
     enum ModuleKind {
         None = 0,
         CommonJS = 1,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Currently, type declaration files acquired via ATA are installed once and never updated.
This change associates timestamps with the type declaration files, and when the typings installer runs, it will attempt to update any existing type declaration files that have not been updated in the past month.
These timestamps are stored in a new file, timestamps.json, which is located at `globalTypingsCacheLocation`.

UPDATE: Now instead of using timestamps and writing a new file, we use version information added to `types-registry` by https://github.com/Microsoft/types-publisher/pull/425. When the typings installer runs, it will check the installed version of each requested package (as defined in the cache's `package-lock.json`) against the most up-to-date compatible version on npm as listed in the types registry. 