### PR TITLE
Support find-all-references starting from a `reference path` or `reference types` comment

### DIFF
--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -2,19 +2,15 @@
 namespace ts.DocumentHighlights {
     export function getDocumentHighlights(program: Program, cancellationToken: CancellationToken, sourceFile: SourceFile, position: number, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] | undefined {
         const node = getTouchingWord(sourceFile, position, /*includeJsDocComment*/ true);
-        // Note that getTouchingWord indicates failure by returning the sourceFile node.
-        if (node === sourceFile) return undefined;
 
-        Debug.assert(node.parent !== undefined);
-
-        if (isJsxOpeningElement(node.parent) && node.parent.tagName === node || isJsxClosingElement(node.parent)) {
+        if (node.parent && (isJsxOpeningElement(node.parent) && node.parent.tagName === node || isJsxClosingElement(node.parent))) {
             // For a JSX element, just highlight the matching tag, not all references.
             const { openingElement, closingElement } = node.parent.parent;
             const highlightSpans = [openingElement, closingElement].map(({ tagName }) => getHighlightSpanForNode(tagName, sourceFile));
             return [{ fileName: sourceFile.fileName, highlightSpans }];
         }
 
-        return getSemanticDocumentHighlights(node, program, cancellationToken, sourceFilesToSearch) || getSyntacticDocumentHighlights(node, sourceFile);
+        return getSemanticDocumentHighlights(position, node, program, cancellationToken, sourceFilesToSearch) || getSyntacticDocumentHighlights(node, sourceFile);
     }
 
     function getHighlightSpanForNode(node: Node, sourceFile: SourceFile): HighlightSpan {
@@ -25,8 +21,8 @@ namespace ts.DocumentHighlights {
         };
     }
 
-    function getSemanticDocumentHighlights(node: Node, program: Program, cancellationToken: CancellationToken, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] {
-        const referenceEntries = FindAllReferences.getReferenceEntriesForNode(node, program, sourceFilesToSearch, cancellationToken);
+    function getSemanticDocumentHighlights(position: number, node: Node, program: Program, cancellationToken: CancellationToken, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] {
+        const referenceEntries = FindAllReferences.getReferenceEntriesForNode(position, node, program, sourceFilesToSearch, cancellationToken);
         return referenceEntries && convertReferencedSymbols(referenceEntries);
     }
 

--- a/tests/cases/fourslash/findAllRefsForModule.ts
+++ b/tests/cases/fourslash/findAllRefsForModule.ts
@@ -12,12 +12,12 @@
 ////const a = require("[|../a|]");
 
 // @Filename: /d.ts
-//// /// <reference path="[|./a|]" />
+//// /// <reference path="[|./a.ts|]" />
 
 verify.noErrors();
 
 const ranges = test.ranges();
 const [r0, r1, r2] = ranges;
-verify.referenceGroups([r0, r1], [{ definition: 'module "/a"', ranges: [r0, r2, r1] }]);
-// TODO:GH#15736
-verify.referenceGroups(r2, undefined);
+verify.referenceGroups(ranges, [{ definition: 'module "/a"', ranges: [r0, r2, r1] }]);
+// Testing that it works with documentHighlights too
+verify.rangesAreDocumentHighlights();

--- a/tests/cases/fourslash/findAllRefsForModuleGlobal.ts
+++ b/tests/cases/fourslash/findAllRefsForModuleGlobal.ts
@@ -12,6 +12,4 @@ verify.noErrors();
 
 const ranges = test.ranges();
 const [r0, r1, r2] = ranges;
-verify.referenceGroups([r1, r2], [{ definition: 'module "/node_modules/foo/index"', ranges: [r0, r1, r2] }]);
-// TODO:GH#15736
-verify.referenceGroups(r0, undefined);
+verify.singleReferenceGroup('module "/node_modules/foo/index"');


### PR DESCRIPTION
Fixes #15736
