### PR TITLE
Handle different default export forms the same way in import code fixes

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -789,9 +789,7 @@ namespace ts.codefix {
             }
 
             function getEscapedNameForExportDefault(symbol: Symbol): __String | undefined {
-                const declarations = symbol.declarations;
-                if (length(declarations) > 0) {
-                    const declaration = declarations[0];
+                return firstDefined(symbol.declarations, declaration => {
                     if (isExportAssignment(declaration)) {
                         if (isIdentifier(declaration.expression)) {
                             return declaration.expression.escapedText;
@@ -803,7 +801,7 @@ namespace ts.codefix {
                             return declaration.propertyName.escapedText;
                         }
                     }
-                }
+                });
             }
         });
 

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -798,6 +798,7 @@ namespace ts.codefix {
                         }
                     }
                     else if (isExportSpecifier(declaration)) {
+                        Debug.assert(declaration.name.escapedText === InternalSymbolName.Default);
                         if (declaration.propertyName) {
                             return declaration.propertyName.escapedText;
                         }

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -511,7 +511,8 @@ namespace ts.FindAllReferences.Core {
         createSearch(location: Node, symbol: Symbol, comingFrom: ImportExport | undefined, searchOptions: { text?: string, allSearchSymbols?: Symbol[] } = {}): Search {
             // Note: if this is an external module symbol, the name doesn't include quotes.
             // Note: getLocalSymbolForExportDefault handles `export default class C {}`, but not `export default C` or `export { C as default }`.
-            // The other two forms seem to be handled downstream (i.e. special-casing the first form here appears to be intentional).
+            // The other two forms seem to be handled downstream (e.g. in `skipPastExportOrImportSpecifier`), so special-casing the first form
+            // here appears to be intentional).
             const {
                 text = stripQuotes(unescapeLeadingUnderscores((getLocalSymbolForExportDefault(symbol) || symbol).escapedName)),
                 allSearchSymbols = undefined,

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -510,6 +510,8 @@ namespace ts.FindAllReferences.Core {
         /** @param allSearchSymbols set of additinal symbols for use by `includes`. */
         createSearch(location: Node, symbol: Symbol, comingFrom: ImportExport | undefined, searchOptions: { text?: string, allSearchSymbols?: Symbol[] } = {}): Search {
             // Note: if this is an external module symbol, the name doesn't include quotes.
+            // Note: getLocalSymbolForExportDefault handles `export default class C {}`, but not `export default C` or `export { C as default }`.
+            // The other two forms seem to be handled downstream (i.e. special-casing the first form here appears to be intentional).
             const {
                 text = stripQuotes(unescapeLeadingUnderscores((getLocalSymbolForExportDefault(symbol) || symbol).escapedName)),
                 allSearchSymbols = undefined,

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -38,9 +38,17 @@ namespace ts.Rename {
                     return undefined;
                 }
 
-                const displayName = stripQuotes(getDeclaredName(typeChecker, symbol, node));
                 const kind = SymbolDisplay.getSymbolKind(typeChecker, symbol, node);
-                return kind ? getRenameInfoSuccess(displayName, typeChecker.getFullyQualifiedName(symbol), kind, SymbolDisplay.getSymbolModifiers(symbol), node, sourceFile) : undefined;
+                if (!kind) {
+                    return undefined;
+                }
+
+                const specifierName = (isImportOrExportSpecifierName(node) || isStringOrNumericLiteral(node) && node.parent.kind === SyntaxKind.ComputedPropertyName)
+                    ? stripQuotes(getTextOfIdentifierOrLiteral(node))
+                    : undefined;
+                const displayName = specifierName || typeChecker.symbolToString(symbol);
+                const fullDisplayName = specifierName || typeChecker.getFullyQualifiedName(symbol);
+                return getRenameInfoSuccess(displayName, fullDisplayName, kind, SymbolDisplay.getSymbolModifiers(symbol), node, sourceFile);
             }
         }
         else if (node.kind === SyntaxKind.StringLiteral) {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1278,19 +1278,6 @@ namespace ts {
         });
     }
 
-    export function getDeclaredName(typeChecker: TypeChecker, symbol: Symbol, location: Node): string {
-        // If this is an export or import specifier it could have been renamed using the 'as' syntax.
-        // If so we want to search for whatever is under the cursor.
-        if (isImportOrExportSpecifierName(location) || isStringOrNumericLiteral(location) && location.parent.kind === SyntaxKind.ComputedPropertyName) {
-            return getTextOfIdentifierOrLiteral(location);
-        }
-
-        // Try to get the local symbol if we're dealing with an 'export default'
-        // since that symbol has the "true" name.
-        const localExportDefaultSymbol = getLocalSymbolForExportDefault(symbol);
-        return typeChecker.symbolToString(localExportDefaultSymbol || symbol);
-    }
-
     export function isImportOrExportSpecifierName(location: Node): location is Identifier {
         return location.parent &&
             (location.parent.kind === SyntaxKind.ImportSpecifier || location.parent.kind === SyntaxKind.ExportSpecifier) &&

--- a/tests/cases/fourslash/importNameCodeFixDefaultExport2.ts
+++ b/tests/cases/fourslash/importNameCodeFixDefaultExport2.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /lib.js
+////class Base { }
+////export default Base;
+
+// @Filename: /test.js
+////[|class Derived extends Base { }|]
+
+goTo.file("/test.js");
+verify.importFixAtPosition([
+`// @ts-ignore
+class Derived extends Base { }`,
+`// @ts-nocheck
+class Derived extends Base { }`,
+`import Base from "./lib";
+
+class Derived extends Base { }`,]);

--- a/tests/cases/fourslash/importNameCodeFixDefaultExport2.ts
+++ b/tests/cases/fourslash/importNameCodeFixDefaultExport2.ts
@@ -1,21 +1,14 @@
 /// <reference path="fourslash.ts" />
 
-// @allowJs: true
-// @checkJs: true
-
-// @Filename: /lib.js
+// @Filename: /lib.ts
 ////class Base { }
 ////export default Base;
 
-// @Filename: /test.js
+// @Filename: /test.ts
 ////[|class Derived extends Base { }|]
 
-goTo.file("/test.js");
+goTo.file("/test.ts");
 verify.importFixAtPosition([
-`// @ts-ignore
-class Derived extends Base { }`,
-`// @ts-nocheck
-class Derived extends Base { }`,
 `import Base from "./lib";
 
 class Derived extends Base { }`,]);

--- a/tests/cases/fourslash/importNameCodeFixDefaultExport3.ts
+++ b/tests/cases/fourslash/importNameCodeFixDefaultExport3.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /lib.js
+////class Base { }
+////export { Base as default };
+
+// @Filename: /test.js
+////[|class Derived extends Base { }|]
+
+goTo.file("/test.js");
+verify.importFixAtPosition([
+`// @ts-ignore
+class Derived extends Base { }`,
+`// @ts-nocheck
+class Derived extends Base { }`,
+`import Base from "./lib";
+
+class Derived extends Base { }`,]);

--- a/tests/cases/fourslash/renameForAliasingExport01.ts
+++ b/tests/cases/fourslash/renameForAliasingExport01.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: foo.ts
+////let x = 1;
+////
+////export { /**/[|x|] as y };
+
+goTo.marker();
+verify.renameInfoSucceeded(/*displayName*/"x", /*fullDisplayName*/"x");

--- a/tests/cases/fourslash/renameForAliasingExport02.ts
+++ b/tests/cases/fourslash/renameForAliasingExport02.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: foo.ts
+////let x = 1;
+////
+////export { x as /**/[|y|] };
+
+goTo.marker();
+verify.renameInfoSucceeded(/*displayName*/"y", /*fullDisplayName*/'"/tests/cases/fourslash/foo".y');


### PR DESCRIPTION
`export default C` and `export { C as default }` should be handled the same as `export default class C { }`.

Fixes #19115