### PR TITLE
Offer per-member diagnostics for incorrectly implemented inherited members

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22804,7 +22804,7 @@ namespace ts {
         }
 
         function issueMemberSpecificError(node: ClassLikeDeclaration, typeWithThis: Type, baseWithThis: Type, broadDiag: DiagnosticMessage) {
-            // iterate over all implemented properties and issue errors on each one which isn't compatible, ratehr than the class as a whole, if possible
+            // iterate over all implemented properties and issue errors on each one which isn't compatible, rather than the class as a whole, if possible
             let issuedMemberError = false;
             for (const member of node.members) {
                 if (hasStaticModifier(member)) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1396,6 +1396,10 @@
         "category": "Error",
         "code": 2415
     },
+    "Class member of type '{0}' is not assignable to base class member of type '{1}'.": {
+        "category": "Error",
+        "code": 2416
+    },
     "Class static side '{0}' incorrectly extends base class static side '{1}'.": {
         "category": "Error",
         "code": 2417
@@ -1403,6 +1407,10 @@
     "Class '{0}' incorrectly implements interface '{1}'.": {
         "category": "Error",
         "code": 2420
+    },
+    "Class member of type '{0}' is not assignable to implementing interface member of type '{1}'.": {
+        "category": "Error",
+        "code": 2421
     },
     "A class may only implement another class or interface.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1396,7 +1396,7 @@
         "category": "Error",
         "code": 2415
     },
-    "Class member of type '{0}' is not assignable to base class member of type '{1}'.": {
+    "Property '{0}' in type '{1}' is not assignable to the same property in base type '{2}'.": {
         "category": "Error",
         "code": 2416
     },
@@ -1407,10 +1407,6 @@
     "Class '{0}' incorrectly implements interface '{1}'.": {
         "category": "Error",
         "code": 2420
-    },
-    "Class member of type '{0}' is not assignable to implementing interface member of type '{1}'.": {
-        "category": "Error",
-        "code": 2421
     },
     "A class may only implement another class or interface.": {
         "category": "Error",

--- a/tests/baselines/reference/abstractPropertyNegative.errors.txt
+++ b/tests/baselines/reference/abstractPropertyNegative.errors.txt
@@ -7,15 +7,9 @@ tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstra
 tests/cases/compiler/abstractPropertyNegative.ts(15,5): error TS1244: Abstract methods can only appear within an abstract class.
 tests/cases/compiler/abstractPropertyNegative.ts(16,37): error TS1005: '{' expected.
 tests/cases/compiler/abstractPropertyNegative.ts(19,3): error TS2540: Cannot assign to 'ro' because it is a constant or a read-only property.
-tests/cases/compiler/abstractPropertyNegative.ts(24,7): error TS2415: Class 'WrongTypePropertyImpl' incorrectly extends base class 'WrongTypeProperty'.
-  Types of property 'num' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/abstractPropertyNegative.ts(30,7): error TS2415: Class 'WrongTypeAccessorImpl' incorrectly extends base class 'WrongTypeAccessor'.
-  Types of property 'num' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/abstractPropertyNegative.ts(33,7): error TS2415: Class 'WrongTypeAccessorImpl2' incorrectly extends base class 'WrongTypeAccessor'.
-  Types of property 'num' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(25,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(31,9): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(34,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
 tests/cases/compiler/abstractPropertyNegative.ts(38,18): error TS2676: Accessors must both be abstract or non-abstract.
 tests/cases/compiler/abstractPropertyNegative.ts(39,9): error TS2676: Accessors must both be abstract or non-abstract.
 tests/cases/compiler/abstractPropertyNegative.ts(40,9): error TS2676: Accessors must both be abstract or non-abstract.
@@ -65,28 +59,22 @@ tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors
         abstract num: number;
     }
     class WrongTypePropertyImpl extends WrongTypeProperty {
-          ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2415: Class 'WrongTypePropertyImpl' incorrectly extends base class 'WrongTypeProperty'.
-!!! error TS2415:   Types of property 'num' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'number'.
         num = "nope, wrong";
+        ~~~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
     }
     abstract class WrongTypeAccessor {
         abstract get num(): number;
     }
     class WrongTypeAccessorImpl extends WrongTypeAccessor {
-          ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2415: Class 'WrongTypeAccessorImpl' incorrectly extends base class 'WrongTypeAccessor'.
-!!! error TS2415:   Types of property 'num' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'number'.
         get num() { return "nope, wrong"; }
+            ~~~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
     }
     class WrongTypeAccessorImpl2 extends WrongTypeAccessor {
-          ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2415: Class 'WrongTypeAccessorImpl2' incorrectly extends base class 'WrongTypeAccessor'.
-!!! error TS2415:   Types of property 'num' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'number'.
         num = "nope, wrong";
+        ~~~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
     }
     
     abstract class AbstractAccessorMismatch {

--- a/tests/baselines/reference/abstractPropertyNegative.errors.txt
+++ b/tests/baselines/reference/abstractPropertyNegative.errors.txt
@@ -7,9 +7,12 @@ tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstra
 tests/cases/compiler/abstractPropertyNegative.ts(15,5): error TS1244: Abstract methods can only appear within an abstract class.
 tests/cases/compiler/abstractPropertyNegative.ts(16,37): error TS1005: '{' expected.
 tests/cases/compiler/abstractPropertyNegative.ts(19,3): error TS2540: Cannot assign to 'ro' because it is a constant or a read-only property.
-tests/cases/compiler/abstractPropertyNegative.ts(25,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
-tests/cases/compiler/abstractPropertyNegative.ts(31,9): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
-tests/cases/compiler/abstractPropertyNegative.ts(34,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(25,5): error TS2416: Property 'num' in type 'WrongTypePropertyImpl' is not assignable to the same property in base type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(31,9): error TS2416: Property 'num' in type 'WrongTypeAccessorImpl' is not assignable to the same property in base type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(34,5): error TS2416: Property 'num' in type 'WrongTypeAccessorImpl2' is not assignable to the same property in base type 'number'.
+  Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/abstractPropertyNegative.ts(38,18): error TS2676: Accessors must both be abstract or non-abstract.
 tests/cases/compiler/abstractPropertyNegative.ts(39,9): error TS2676: Accessors must both be abstract or non-abstract.
 tests/cases/compiler/abstractPropertyNegative.ts(40,9): error TS2676: Accessors must both be abstract or non-abstract.
@@ -61,7 +64,8 @@ tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors
     class WrongTypePropertyImpl extends WrongTypeProperty {
         num = "nope, wrong";
         ~~~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+!!! error TS2416: Property 'num' in type 'WrongTypePropertyImpl' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
     }
     abstract class WrongTypeAccessor {
         abstract get num(): number;
@@ -69,12 +73,14 @@ tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors
     class WrongTypeAccessorImpl extends WrongTypeAccessor {
         get num() { return "nope, wrong"; }
             ~~~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+!!! error TS2416: Property 'num' in type 'WrongTypeAccessorImpl' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
     }
     class WrongTypeAccessorImpl2 extends WrongTypeAccessor {
         num = "nope, wrong";
         ~~~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+!!! error TS2416: Property 'num' in type 'WrongTypeAccessorImpl2' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
     }
     
     abstract class AbstractAccessorMismatch {

--- a/tests/baselines/reference/apparentTypeSubtyping.errors.txt
+++ b/tests/baselines/reference/apparentTypeSubtyping.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts(9,7): error TS2415: Class 'Derived<U>' incorrectly extends base class 'Base<string>'.
-  Types of property 'x' are incompatible.
-    Type 'String' is not assignable to type 'string'.
-      'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts(10,5): error TS2416: Class member of type 'String' is not assignable to base class member of type 'string'.
+  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
 
 ==== tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts (1 errors) ====
@@ -14,12 +12,10 @@ tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtypi
     
     // is String (S) a subtype of U extends String (T)? Would only be true if we used the apparent type of U (T)
     class Derived<U> extends Base<string> { // error
-          ~~~~~~~
-!!! error TS2415: Class 'Derived<U>' incorrectly extends base class 'Base<string>'.
-!!! error TS2415:   Types of property 'x' are incompatible.
-!!! error TS2415:     Type 'String' is not assignable to type 'string'.
-!!! error TS2415:       'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
         x: String;
+        ~
+!!! error TS2416: Class member of type 'String' is not assignable to base class member of type 'string'.
+!!! error TS2416:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
     }
     
     class Base2 {

--- a/tests/baselines/reference/apparentTypeSubtyping.errors.txt
+++ b/tests/baselines/reference/apparentTypeSubtyping.errors.txt
@@ -1,5 +1,6 @@
-tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts(10,5): error TS2416: Class member of type 'String' is not assignable to base class member of type 'string'.
-  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts(10,5): error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'string'.
+  Type 'String' is not assignable to type 'string'.
+    'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
 
 ==== tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts (1 errors) ====
@@ -14,8 +15,9 @@ tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtypi
     class Derived<U> extends Base<string> { // error
         x: String;
         ~
-!!! error TS2416: Class member of type 'String' is not assignable to base class member of type 'string'.
-!!! error TS2416:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+!!! error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type 'String' is not assignable to type 'string'.
+!!! error TS2416:     'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
     }
     
     class Base2 {

--- a/tests/baselines/reference/apparentTypeSupertype.errors.txt
+++ b/tests/baselines/reference/apparentTypeSupertype.errors.txt
@@ -1,6 +1,7 @@
-tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts(10,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'string'.
-  Type 'String' is not assignable to type 'string'.
-    'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts(10,5): error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'string'.
+  Type 'U' is not assignable to type 'string'.
+    Type 'String' is not assignable to type 'string'.
+      'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
 
 ==== tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts (1 errors) ====
@@ -15,7 +16,8 @@ tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSuperty
     class Derived<U extends String> extends Base { // error
         x: U;
         ~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'string'.
-!!! error TS2416:   Type 'String' is not assignable to type 'string'.
-!!! error TS2416:     'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+!!! error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type 'U' is not assignable to type 'string'.
+!!! error TS2416:     Type 'String' is not assignable to type 'string'.
+!!! error TS2416:       'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
     }

--- a/tests/baselines/reference/apparentTypeSupertype.errors.txt
+++ b/tests/baselines/reference/apparentTypeSupertype.errors.txt
@@ -1,8 +1,6 @@
-tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts(9,7): error TS2415: Class 'Derived<U>' incorrectly extends base class 'Base'.
-  Types of property 'x' are incompatible.
-    Type 'U' is not assignable to type 'string'.
-      Type 'String' is not assignable to type 'string'.
-        'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts(10,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'string'.
+  Type 'String' is not assignable to type 'string'.
+    'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
 
 ==== tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts (1 errors) ====
@@ -15,11 +13,9 @@ tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSuperty
     
     // is String (S) a subtype of U extends String (T)? Would only be true if we used the apparent type of U (T)
     class Derived<U extends String> extends Base { // error
-          ~~~~~~~
-!!! error TS2415: Class 'Derived<U>' incorrectly extends base class 'Base'.
-!!! error TS2415:   Types of property 'x' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'string'.
-!!! error TS2415:       Type 'String' is not assignable to type 'string'.
-!!! error TS2415:         'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
         x: U;
+        ~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'string'.
+!!! error TS2416:   Type 'String' is not assignable to type 'string'.
+!!! error TS2416:     'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
     }

--- a/tests/baselines/reference/baseClassImprovedMismatchErrors.errors.txt
+++ b/tests/baselines/reference/baseClassImprovedMismatchErrors.errors.txt
@@ -1,23 +1,27 @@
-tests/cases/compiler/baseClassImprovedMismatchErrors.ts(8,5): error TS2416: Class member of type 'string | Derived' is not assignable to base class member of type 'string | Base'.
-  Type 'Derived' is not assignable to type 'string | Base'.
-    Type 'Derived' is not assignable to type 'Base'.
-      Types of property 'n' are incompatible.
-        Type 'string | Derived' is not assignable to type 'string | Base'.
-          Type 'Derived' is not assignable to type 'string | Base'.
-            Type 'Derived' is not assignable to type 'Base'.
-tests/cases/compiler/baseClassImprovedMismatchErrors.ts(9,5): error TS2416: Class member of type '() => string | number' is not assignable to base class member of type '() => number'.
-  Type 'string | number' is not assignable to type 'number'.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/baseClassImprovedMismatchErrors.ts(14,5): error TS2421: Class member of type 'string | DerivedInterface' is not assignable to implementing interface member of type 'string | Base'.
-  Type 'DerivedInterface' is not assignable to type 'string | Base'.
-    Type 'DerivedInterface' is not assignable to type 'Base'.
-      Types of property 'n' are incompatible.
-        Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
-          Type 'DerivedInterface' is not assignable to type 'string | Base'.
-            Type 'DerivedInterface' is not assignable to type 'Base'.
-tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2421: Class member of type '() => string | number' is not assignable to implementing interface member of type '() => number'.
-  Type 'string | number' is not assignable to type 'number'.
-    Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(8,5): error TS2416: Property 'n' in type 'Derived' is not assignable to the same property in base type 'string | Base'.
+  Type 'string | Derived' is not assignable to type 'string | Base'.
+    Type 'Derived' is not assignable to type 'string | Base'.
+      Type 'Derived' is not assignable to type 'Base'.
+        Types of property 'n' are incompatible.
+          Type 'string | Derived' is not assignable to type 'string | Base'.
+            Type 'Derived' is not assignable to type 'string | Base'.
+              Type 'Derived' is not assignable to type 'Base'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(9,5): error TS2416: Property 'fn' in type 'Derived' is not assignable to the same property in base type '() => number'.
+  Type '() => string | number' is not assignable to type '() => number'.
+    Type 'string | number' is not assignable to type 'number'.
+      Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(14,5): error TS2416: Property 'n' in type 'DerivedInterface' is not assignable to the same property in base type 'string | Base'.
+  Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
+    Type 'DerivedInterface' is not assignable to type 'string | Base'.
+      Type 'DerivedInterface' is not assignable to type 'Base'.
+        Types of property 'n' are incompatible.
+          Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
+            Type 'DerivedInterface' is not assignable to type 'string | Base'.
+              Type 'DerivedInterface' is not assignable to type 'Base'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2416: Property 'fn' in type 'DerivedInterface' is not assignable to the same property in base type '() => number'.
+  Type '() => string | number' is not assignable to type '() => number'.
+    Type 'string | number' is not assignable to type 'number'.
+      Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/baseClassImprovedMismatchErrors.ts (4 errors) ====
@@ -30,36 +34,40 @@ tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2421: Cla
     class Derived extends Base {
         n: Derived | string;
         ~
-!!! error TS2416: Class member of type 'string | Derived' is not assignable to base class member of type 'string | Base'.
-!!! error TS2416:   Type 'Derived' is not assignable to type 'string | Base'.
-!!! error TS2416:     Type 'Derived' is not assignable to type 'Base'.
-!!! error TS2416:       Types of property 'n' are incompatible.
-!!! error TS2416:         Type 'string | Derived' is not assignable to type 'string | Base'.
-!!! error TS2416:           Type 'Derived' is not assignable to type 'string | Base'.
-!!! error TS2416:             Type 'Derived' is not assignable to type 'Base'.
+!!! error TS2416: Property 'n' in type 'Derived' is not assignable to the same property in base type 'string | Base'.
+!!! error TS2416:   Type 'string | Derived' is not assignable to type 'string | Base'.
+!!! error TS2416:     Type 'Derived' is not assignable to type 'string | Base'.
+!!! error TS2416:       Type 'Derived' is not assignable to type 'Base'.
+!!! error TS2416:         Types of property 'n' are incompatible.
+!!! error TS2416:           Type 'string | Derived' is not assignable to type 'string | Base'.
+!!! error TS2416:             Type 'Derived' is not assignable to type 'string | Base'.
+!!! error TS2416:               Type 'Derived' is not assignable to type 'Base'.
         fn() {
         ~~
-!!! error TS2416: Class member of type '() => string | number' is not assignable to base class member of type '() => number'.
-!!! error TS2416:   Type 'string | number' is not assignable to type 'number'.
-!!! error TS2416:     Type 'string' is not assignable to type 'number'.
+!!! error TS2416: Property 'fn' in type 'Derived' is not assignable to the same property in base type '() => number'.
+!!! error TS2416:   Type '() => string | number' is not assignable to type '() => number'.
+!!! error TS2416:     Type 'string | number' is not assignable to type 'number'.
+!!! error TS2416:       Type 'string' is not assignable to type 'number'.
             return 10 as number | string;
         }
     }
     class DerivedInterface implements Base {
         n: DerivedInterface | string;
         ~
-!!! error TS2421: Class member of type 'string | DerivedInterface' is not assignable to implementing interface member of type 'string | Base'.
-!!! error TS2421:   Type 'DerivedInterface' is not assignable to type 'string | Base'.
-!!! error TS2421:     Type 'DerivedInterface' is not assignable to type 'Base'.
-!!! error TS2421:       Types of property 'n' are incompatible.
-!!! error TS2421:         Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
-!!! error TS2421:           Type 'DerivedInterface' is not assignable to type 'string | Base'.
-!!! error TS2421:             Type 'DerivedInterface' is not assignable to type 'Base'.
+!!! error TS2416: Property 'n' in type 'DerivedInterface' is not assignable to the same property in base type 'string | Base'.
+!!! error TS2416:   Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
+!!! error TS2416:     Type 'DerivedInterface' is not assignable to type 'string | Base'.
+!!! error TS2416:       Type 'DerivedInterface' is not assignable to type 'Base'.
+!!! error TS2416:         Types of property 'n' are incompatible.
+!!! error TS2416:           Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
+!!! error TS2416:             Type 'DerivedInterface' is not assignable to type 'string | Base'.
+!!! error TS2416:               Type 'DerivedInterface' is not assignable to type 'Base'.
         fn() {
         ~~
-!!! error TS2421: Class member of type '() => string | number' is not assignable to implementing interface member of type '() => number'.
-!!! error TS2421:   Type 'string | number' is not assignable to type 'number'.
-!!! error TS2421:     Type 'string' is not assignable to type 'number'.
+!!! error TS2416: Property 'fn' in type 'DerivedInterface' is not assignable to the same property in base type '() => number'.
+!!! error TS2416:   Type '() => string | number' is not assignable to type '() => number'.
+!!! error TS2416:     Type 'string | number' is not assignable to type 'number'.
+!!! error TS2416:       Type 'string' is not assignable to type 'number'.
             return 10 as number | string;
         }
     }

--- a/tests/baselines/reference/baseClassImprovedMismatchErrors.errors.txt
+++ b/tests/baselines/reference/baseClassImprovedMismatchErrors.errors.txt
@@ -1,0 +1,65 @@
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(8,5): error TS2416: Class member of type 'string | Derived' is not assignable to base class member of type 'string | Base'.
+  Type 'Derived' is not assignable to type 'string | Base'.
+    Type 'Derived' is not assignable to type 'Base'.
+      Types of property 'n' are incompatible.
+        Type 'string | Derived' is not assignable to type 'string | Base'.
+          Type 'Derived' is not assignable to type 'string | Base'.
+            Type 'Derived' is not assignable to type 'Base'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(9,5): error TS2416: Class member of type '() => string | number' is not assignable to base class member of type '() => number'.
+  Type 'string | number' is not assignable to type 'number'.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(14,5): error TS2421: Class member of type 'string | DerivedInterface' is not assignable to implementing interface member of type 'string | Base'.
+  Type 'DerivedInterface' is not assignable to type 'string | Base'.
+    Type 'DerivedInterface' is not assignable to type 'Base'.
+      Types of property 'n' are incompatible.
+        Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
+          Type 'DerivedInterface' is not assignable to type 'string | Base'.
+            Type 'DerivedInterface' is not assignable to type 'Base'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2421: Class member of type '() => string | number' is not assignable to implementing interface member of type '() => number'.
+  Type 'string | number' is not assignable to type 'number'.
+    Type 'string' is not assignable to type 'number'.
+
+
+==== tests/cases/compiler/baseClassImprovedMismatchErrors.ts (4 errors) ====
+    class Base {
+        n: Base | string;
+        fn() {
+            return 10;
+        }
+    }
+    class Derived extends Base {
+        n: Derived | string;
+        ~
+!!! error TS2416: Class member of type 'string | Derived' is not assignable to base class member of type 'string | Base'.
+!!! error TS2416:   Type 'Derived' is not assignable to type 'string | Base'.
+!!! error TS2416:     Type 'Derived' is not assignable to type 'Base'.
+!!! error TS2416:       Types of property 'n' are incompatible.
+!!! error TS2416:         Type 'string | Derived' is not assignable to type 'string | Base'.
+!!! error TS2416:           Type 'Derived' is not assignable to type 'string | Base'.
+!!! error TS2416:             Type 'Derived' is not assignable to type 'Base'.
+        fn() {
+        ~~
+!!! error TS2416: Class member of type '() => string | number' is not assignable to base class member of type '() => number'.
+!!! error TS2416:   Type 'string | number' is not assignable to type 'number'.
+!!! error TS2416:     Type 'string' is not assignable to type 'number'.
+            return 10 as number | string;
+        }
+    }
+    class DerivedInterface implements Base {
+        n: DerivedInterface | string;
+        ~
+!!! error TS2421: Class member of type 'string | DerivedInterface' is not assignable to implementing interface member of type 'string | Base'.
+!!! error TS2421:   Type 'DerivedInterface' is not assignable to type 'string | Base'.
+!!! error TS2421:     Type 'DerivedInterface' is not assignable to type 'Base'.
+!!! error TS2421:       Types of property 'n' are incompatible.
+!!! error TS2421:         Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
+!!! error TS2421:           Type 'DerivedInterface' is not assignable to type 'string | Base'.
+!!! error TS2421:             Type 'DerivedInterface' is not assignable to type 'Base'.
+        fn() {
+        ~~
+!!! error TS2421: Class member of type '() => string | number' is not assignable to implementing interface member of type '() => number'.
+!!! error TS2421:   Type 'string | number' is not assignable to type 'number'.
+!!! error TS2421:     Type 'string' is not assignable to type 'number'.
+            return 10 as number | string;
+        }
+    }

--- a/tests/baselines/reference/baseClassImprovedMismatchErrors.js
+++ b/tests/baselines/reference/baseClassImprovedMismatchErrors.js
@@ -1,0 +1,57 @@
+//// [baseClassImprovedMismatchErrors.ts]
+class Base {
+    n: Base | string;
+    fn() {
+        return 10;
+    }
+}
+class Derived extends Base {
+    n: Derived | string;
+    fn() {
+        return 10 as number | string;
+    }
+}
+class DerivedInterface implements Base {
+    n: DerivedInterface | string;
+    fn() {
+        return 10 as number | string;
+    }
+}
+
+//// [baseClassImprovedMismatchErrors.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.fn = function () {
+        return 10;
+    };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.fn = function () {
+        return 10;
+    };
+    return Derived;
+}(Base));
+var DerivedInterface = /** @class */ (function () {
+    function DerivedInterface() {
+    }
+    DerivedInterface.prototype.fn = function () {
+        return 10;
+    };
+    return DerivedInterface;
+}());

--- a/tests/baselines/reference/baseClassImprovedMismatchErrors.symbols
+++ b/tests/baselines/reference/baseClassImprovedMismatchErrors.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/baseClassImprovedMismatchErrors.ts ===
+class Base {
+>Base : Symbol(Base, Decl(baseClassImprovedMismatchErrors.ts, 0, 0))
+
+    n: Base | string;
+>n : Symbol(Base.n, Decl(baseClassImprovedMismatchErrors.ts, 0, 12))
+>Base : Symbol(Base, Decl(baseClassImprovedMismatchErrors.ts, 0, 0))
+
+    fn() {
+>fn : Symbol(Base.fn, Decl(baseClassImprovedMismatchErrors.ts, 1, 21))
+
+        return 10;
+    }
+}
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(baseClassImprovedMismatchErrors.ts, 5, 1))
+>Base : Symbol(Base, Decl(baseClassImprovedMismatchErrors.ts, 0, 0))
+
+    n: Derived | string;
+>n : Symbol(Derived.n, Decl(baseClassImprovedMismatchErrors.ts, 6, 28))
+>Derived : Symbol(Derived, Decl(baseClassImprovedMismatchErrors.ts, 5, 1))
+
+    fn() {
+>fn : Symbol(Derived.fn, Decl(baseClassImprovedMismatchErrors.ts, 7, 24))
+
+        return 10 as number | string;
+    }
+}
+class DerivedInterface implements Base {
+>DerivedInterface : Symbol(DerivedInterface, Decl(baseClassImprovedMismatchErrors.ts, 11, 1))
+>Base : Symbol(Base, Decl(baseClassImprovedMismatchErrors.ts, 0, 0))
+
+    n: DerivedInterface | string;
+>n : Symbol(DerivedInterface.n, Decl(baseClassImprovedMismatchErrors.ts, 12, 40))
+>DerivedInterface : Symbol(DerivedInterface, Decl(baseClassImprovedMismatchErrors.ts, 11, 1))
+
+    fn() {
+>fn : Symbol(DerivedInterface.fn, Decl(baseClassImprovedMismatchErrors.ts, 13, 33))
+
+        return 10 as number | string;
+    }
+}

--- a/tests/baselines/reference/baseClassImprovedMismatchErrors.types
+++ b/tests/baselines/reference/baseClassImprovedMismatchErrors.types
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/baseClassImprovedMismatchErrors.ts ===
+class Base {
+>Base : Base
+
+    n: Base | string;
+>n : string | Base
+>Base : Base
+
+    fn() {
+>fn : () => number
+
+        return 10;
+>10 : 10
+    }
+}
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    n: Derived | string;
+>n : string | Derived
+>Derived : Derived
+
+    fn() {
+>fn : () => string | number
+
+        return 10 as number | string;
+>10 as number | string : string | number
+>10 : 10
+    }
+}
+class DerivedInterface implements Base {
+>DerivedInterface : DerivedInterface
+>Base : Base
+
+    n: DerivedInterface | string;
+>n : string | DerivedInterface
+>DerivedInterface : DerivedInterface
+
+    fn() {
+>fn : () => string | number
+
+        return 10 as number | string;
+>10 as number | string : string | number
+>10 : 10
+    }
+}

--- a/tests/baselines/reference/classIsSubtypeOfBaseType.errors.txt
+++ b/tests/baselines/reference/classIsSubtypeOfBaseType.errors.txt
@@ -1,5 +1,6 @@
-tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts(12,5): error TS2416: Class member of type '{ bar?: string; }' is not assignable to base class member of type '{ bar: string; }'.
-  Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
+tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts(12,5): error TS2416: Property 'foo' in type 'Derived2' is not assignable to the same property in base type '{ bar: string; }'.
+  Type '{ bar?: string; }' is not assignable to type '{ bar: string; }'.
+    Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
 
 
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts (1 errors) ====
@@ -16,8 +17,9 @@ tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/cla
     class Derived2 extends Base<{ bar: string; }> {
         foo: {
         ~~~
-!!! error TS2416: Class member of type '{ bar?: string; }' is not assignable to base class member of type '{ bar: string; }'.
-!!! error TS2416:   Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
+!!! error TS2416: Property 'foo' in type 'Derived2' is not assignable to the same property in base type '{ bar: string; }'.
+!!! error TS2416:   Type '{ bar?: string; }' is not assignable to type '{ bar: string; }'.
+!!! error TS2416:     Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
             bar?: string; // error
         }
     }

--- a/tests/baselines/reference/classIsSubtypeOfBaseType.errors.txt
+++ b/tests/baselines/reference/classIsSubtypeOfBaseType.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts(11,7): error TS2415: Class 'Derived2' incorrectly extends base class 'Base<{ bar: string; }>'.
-  Types of property 'foo' are incompatible.
-    Type '{ bar?: string; }' is not assignable to type '{ bar: string; }'.
-      Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
+tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts(12,5): error TS2416: Class member of type '{ bar?: string; }' is not assignable to base class member of type '{ bar: string; }'.
+  Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
 
 
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts (1 errors) ====
@@ -16,12 +14,10 @@ tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/cla
     }
     
     class Derived2 extends Base<{ bar: string; }> {
-          ~~~~~~~~
-!!! error TS2415: Class 'Derived2' incorrectly extends base class 'Base<{ bar: string; }>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type '{ bar?: string; }' is not assignable to type '{ bar: string; }'.
-!!! error TS2415:       Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
         foo: {
+        ~~~
+!!! error TS2416: Class member of type '{ bar?: string; }' is not assignable to base class member of type '{ bar: string; }'.
+!!! error TS2416:   Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
             bar?: string; // error
         }
     }

--- a/tests/baselines/reference/derivedClassFunctionOverridesBaseClassAccessor.errors.txt
+++ b/tests/baselines/reference/derivedClassFunctionOverridesBaseClassAccessor.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(2,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(5,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(11,5): error TS2416: Class member of type '() => number' is not assignable to base class member of type 'number'.
+tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(11,5): error TS2416: Property 'x' in type 'Derived' is not assignable to the same property in base type 'number'.
+  Type '() => number' is not assignable to type 'number'.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(11,5): error TS2426: Class 'Base' defines instance member accessor 'x', but extended class 'Derived' defines it as instance member function.
 
 
@@ -21,7 +22,8 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFun
     class Derived extends Base {
         x() {
         ~
-!!! error TS2416: Class member of type '() => number' is not assignable to base class member of type 'number'.
+!!! error TS2416: Property 'x' in type 'Derived' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type '() => number' is not assignable to type 'number'.
         ~
 !!! error TS2426: Class 'Base' defines instance member accessor 'x', but extended class 'Derived' defines it as instance member function.
             return 1;

--- a/tests/baselines/reference/derivedClassFunctionOverridesBaseClassAccessor.errors.txt
+++ b/tests/baselines/reference/derivedClassFunctionOverridesBaseClassAccessor.errors.txt
@@ -1,8 +1,6 @@
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(2,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(5,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(10,7): error TS2415: Class 'Derived' incorrectly extends base class 'Base'.
-  Types of property 'x' are incompatible.
-    Type '() => number' is not assignable to type 'number'.
+tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(11,5): error TS2416: Class member of type '() => number' is not assignable to base class member of type 'number'.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(11,5): error TS2426: Class 'Base' defines instance member accessor 'x', but extended class 'Derived' defines it as instance member function.
 
 
@@ -21,11 +19,9 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFun
     
     // error
     class Derived extends Base {
-          ~~~~~~~
-!!! error TS2415: Class 'Derived' incorrectly extends base class 'Base'.
-!!! error TS2415:   Types of property 'x' are incompatible.
-!!! error TS2415:     Type '() => number' is not assignable to type 'number'.
         x() {
+        ~
+!!! error TS2416: Class member of type '() => number' is not assignable to base class member of type 'number'.
         ~
 !!! error TS2426: Class 'Base' defines instance member accessor 'x', but extended class 'Derived' defines it as instance member function.
             return 1;

--- a/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
@@ -34,13 +34,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
       Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(46,13): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(47,13): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
-tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(55,7): error TS2420: Class 'C4' incorrectly implements interface 'F2'.
-  Types of property 'd4' are incompatible.
-    Type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
-      Types of parameters '__0' and '__0' are incompatible.
-        Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
-          Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(56,8): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(57,5): error TS2421: Class member of type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to implementing interface member of type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
+  Types of parameters '__0' and '__0' are incompatible.
+    Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
+      Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(65,18): error TS2300: Duplicate identifier 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(65,26): error TS2300: Duplicate identifier 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(65,34): error TS2300: Duplicate identifier 'number'.
@@ -155,17 +153,15 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
     }
     
     class C4 implements F2 {
-          ~~
-!!! error TS2420: Class 'C4' incorrectly implements interface 'F2'.
-!!! error TS2420:   Types of property 'd4' are incompatible.
-!!! error TS2420:     Type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
-!!! error TS2420:       Types of parameters '__0' and '__0' are incompatible.
-!!! error TS2420:         Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
-!!! error TS2420:           Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
         d3([a, b, c]?) { }  // Error, binding pattern can't be optional in implementation signature
            ~~~~~~~~~~
 !!! error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
         d4({x, y, c}) { }
+        ~~
+!!! error TS2421: Class member of type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to implementing interface member of type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
+!!! error TS2421:   Types of parameters '__0' and '__0' are incompatible.
+!!! error TS2421:     Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
+!!! error TS2421:       Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
         e0([a, b, q]) { }
     }
     

--- a/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
@@ -35,10 +35,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(46,13): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(47,13): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(56,8): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
-tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(57,5): error TS2421: Class member of type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to implementing interface member of type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
-  Types of parameters '__0' and '__0' are incompatible.
-    Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
-      Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(57,5): error TS2416: Property 'd4' in type 'C4' is not assignable to the same property in base type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
+  Type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
+    Types of parameters '__0' and '__0' are incompatible.
+      Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
+        Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(65,18): error TS2300: Duplicate identifier 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(65,26): error TS2300: Duplicate identifier 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(65,34): error TS2300: Duplicate identifier 'number'.
@@ -158,10 +159,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 !!! error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
         d4({x, y, c}) { }
         ~~
-!!! error TS2421: Class member of type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to implementing interface member of type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
-!!! error TS2421:   Types of parameters '__0' and '__0' are incompatible.
-!!! error TS2421:     Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
-!!! error TS2421:       Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
+!!! error TS2416: Property 'd4' in type 'C4' is not assignable to the same property in base type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
+!!! error TS2416:   Type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
+!!! error TS2416:     Types of parameters '__0' and '__0' are incompatible.
+!!! error TS2416:       Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
+!!! error TS2416:         Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
         e0([a, b, q]) { }
     }
     

--- a/tests/baselines/reference/elaboratedErrors.errors.txt
+++ b/tests/baselines/reference/elaboratedErrors.errors.txt
@@ -1,4 +1,5 @@
-tests/cases/compiler/elaboratedErrors.ts(11,3): error TS2421: Class member of type 'string' is not assignable to implementing interface member of type 'number'.
+tests/cases/compiler/elaboratedErrors.ts(11,3): error TS2416: Property 'read' in type 'WorkerFS' is not assignable to the same property in base type 'number'.
+  Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/elaboratedErrors.ts(20,1): error TS2322: Type 'Beta' is not assignable to type 'Alpha'.
   Property 'x' is missing in type 'Beta'.
 tests/cases/compiler/elaboratedErrors.ts(21,1): error TS2322: Type 'Beta' is not assignable to type 'Alpha'.
@@ -20,7 +21,8 @@ tests/cases/compiler/elaboratedErrors.ts(25,1): error TS2322: Type 'Alpha' is no
     class WorkerFS implements FileSystem {
       read: string;
       ~~~~
-!!! error TS2421: Class member of type 'string' is not assignable to implementing interface member of type 'number'.
+!!! error TS2416: Property 'read' in type 'WorkerFS' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
     }
     
     interface Alpha { x: string; }

--- a/tests/baselines/reference/elaboratedErrors.errors.txt
+++ b/tests/baselines/reference/elaboratedErrors.errors.txt
@@ -1,6 +1,4 @@
-tests/cases/compiler/elaboratedErrors.ts(10,7): error TS2420: Class 'WorkerFS' incorrectly implements interface 'FileSystem'.
-  Types of property 'read' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/elaboratedErrors.ts(11,3): error TS2421: Class member of type 'string' is not assignable to implementing interface member of type 'number'.
 tests/cases/compiler/elaboratedErrors.ts(20,1): error TS2322: Type 'Beta' is not assignable to type 'Alpha'.
   Property 'x' is missing in type 'Beta'.
 tests/cases/compiler/elaboratedErrors.ts(21,1): error TS2322: Type 'Beta' is not assignable to type 'Alpha'.
@@ -20,11 +18,9 @@ tests/cases/compiler/elaboratedErrors.ts(25,1): error TS2322: Type 'Alpha' is no
     
     // This should issue a large error, not a small one
     class WorkerFS implements FileSystem {
-          ~~~~~~~~
-!!! error TS2420: Class 'WorkerFS' incorrectly implements interface 'FileSystem'.
-!!! error TS2420:   Types of property 'read' are incompatible.
-!!! error TS2420:     Type 'string' is not assignable to type 'number'.
       read: string;
+      ~~~~
+!!! error TS2421: Class member of type 'string' is not assignable to implementing interface member of type 'number'.
     }
     
     interface Alpha { x: string; }

--- a/tests/baselines/reference/genericImplements.errors.txt
+++ b/tests/baselines/reference/genericImplements.errors.txt
@@ -1,5 +1,6 @@
-tests/cases/compiler/genericImplements.ts(9,5): error TS2421: Class member of type '<T extends B>() => T' is not assignable to implementing interface member of type '<T extends A>() => T'.
-  Type 'B' is not assignable to type 'T'.
+tests/cases/compiler/genericImplements.ts(9,5): error TS2416: Property 'f' in type 'X' is not assignable to the same property in base type '<T extends A>() => T'.
+  Type '<T extends B>() => T' is not assignable to type '<T extends A>() => T'.
+    Type 'B' is not assignable to type 'T'.
 
 
 ==== tests/cases/compiler/genericImplements.ts (1 errors) ====
@@ -13,8 +14,9 @@ tests/cases/compiler/genericImplements.ts(9,5): error TS2421: Class member of ty
     class X implements I {  
         f<T extends B>(): T { return undefined; }
         ~
-!!! error TS2421: Class member of type '<T extends B>() => T' is not assignable to implementing interface member of type '<T extends A>() => T'.
-!!! error TS2421:   Type 'B' is not assignable to type 'T'.
+!!! error TS2416: Property 'f' in type 'X' is not assignable to the same property in base type '<T extends A>() => T'.
+!!! error TS2416:   Type '<T extends B>() => T' is not assignable to type '<T extends A>() => T'.
+!!! error TS2416:     Type 'B' is not assignable to type 'T'.
     } // { f: () => { b; } }
     
     // OK

--- a/tests/baselines/reference/genericImplements.errors.txt
+++ b/tests/baselines/reference/genericImplements.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/compiler/genericImplements.ts(8,7): error TS2420: Class 'X' incorrectly implements interface 'I'.
-  Types of property 'f' are incompatible.
-    Type '<T extends B>() => T' is not assignable to type '<T extends A>() => T'.
-      Type 'B' is not assignable to type 'T'.
+tests/cases/compiler/genericImplements.ts(9,5): error TS2421: Class member of type '<T extends B>() => T' is not assignable to implementing interface member of type '<T extends A>() => T'.
+  Type 'B' is not assignable to type 'T'.
 
 
 ==== tests/cases/compiler/genericImplements.ts (1 errors) ====
@@ -13,12 +11,10 @@ tests/cases/compiler/genericImplements.ts(8,7): error TS2420: Class 'X' incorrec
     
     // OK
     class X implements I {  
-          ~
-!!! error TS2420: Class 'X' incorrectly implements interface 'I'.
-!!! error TS2420:   Types of property 'f' are incompatible.
-!!! error TS2420:     Type '<T extends B>() => T' is not assignable to type '<T extends A>() => T'.
-!!! error TS2420:       Type 'B' is not assignable to type 'T'.
         f<T extends B>(): T { return undefined; }
+        ~
+!!! error TS2421: Class member of type '<T extends B>() => T' is not assignable to implementing interface member of type '<T extends A>() => T'.
+!!! error TS2421:   Type 'B' is not assignable to type 'T'.
     } // { f: () => { b; } }
     
     // OK

--- a/tests/baselines/reference/genericSpecializations1.errors.txt
+++ b/tests/baselines/reference/genericSpecializations1.errors.txt
@@ -1,9 +1,11 @@
-tests/cases/compiler/genericSpecializations1.ts(6,5): error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-  Types of parameters 'x' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/genericSpecializations1.ts(10,5): error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-  Types of parameters 'x' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations1.ts(6,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '<T>(x: T) => T'.
+  Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
+    Types of parameters 'x' and 'x' are incompatible.
+      Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations1.ts(10,5): error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type '<T>(x: T) => T'.
+  Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
+    Types of parameters 'x' and 'x' are incompatible.
+      Type 'T' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/genericSpecializations1.ts (2 errors) ====
@@ -14,17 +16,19 @@ tests/cases/compiler/genericSpecializations1.ts(10,5): error TS2421: Class membe
     class IntFooBad implements IFoo<number> {
         foo(x: string): string { return null; }
         ~~~
-!!! error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2421:     Type 'T' is not assignable to type 'string'.
+!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416:   Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2416:       Type 'T' is not assignable to type 'string'.
     }
     
     class StringFoo2 implements IFoo<string> {
         foo(x: string): string { return null; }
         ~~~
-!!! error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2421:     Type 'T' is not assignable to type 'string'.
+!!! error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416:   Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2416:       Type 'T' is not assignable to type 'string'.
     }
     
     class StringFoo3 implements IFoo<string> {

--- a/tests/baselines/reference/genericSpecializations1.errors.txt
+++ b/tests/baselines/reference/genericSpecializations1.errors.txt
@@ -1,13 +1,9 @@
-tests/cases/compiler/genericSpecializations1.ts(5,7): error TS2420: Class 'IntFooBad' incorrectly implements interface 'IFoo<number>'.
-  Types of property 'foo' are incompatible.
-    Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/genericSpecializations1.ts(9,7): error TS2420: Class 'StringFoo2' incorrectly implements interface 'IFoo<string>'.
-  Types of property 'foo' are incompatible.
-    Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations1.ts(6,5): error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations1.ts(10,5): error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'T' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/genericSpecializations1.ts (2 errors) ====
@@ -16,23 +12,19 @@ tests/cases/compiler/genericSpecializations1.ts(9,7): error TS2420: Class 'Strin
     }
     
     class IntFooBad implements IFoo<number> {
-          ~~~~~~~~~
-!!! error TS2420: Class 'IntFooBad' incorrectly implements interface 'IFoo<number>'.
-!!! error TS2420:   Types of property 'foo' are incompatible.
-!!! error TS2420:     Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
-!!! error TS2420:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2420:         Type 'T' is not assignable to type 'string'.
         foo(x: string): string { return null; }
+        ~~~
+!!! error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2421:     Type 'T' is not assignable to type 'string'.
     }
     
     class StringFoo2 implements IFoo<string> {
-          ~~~~~~~~~~
-!!! error TS2420: Class 'StringFoo2' incorrectly implements interface 'IFoo<string>'.
-!!! error TS2420:   Types of property 'foo' are incompatible.
-!!! error TS2420:     Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
-!!! error TS2420:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2420:         Type 'T' is not assignable to type 'string'.
         foo(x: string): string { return null; }
+        ~~~
+!!! error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2421:     Type 'T' is not assignable to type 'string'.
     }
     
     class StringFoo3 implements IFoo<string> {

--- a/tests/baselines/reference/genericSpecializations2.errors.txt
+++ b/tests/baselines/reference/genericSpecializations2.errors.txt
@@ -1,10 +1,12 @@
-tests/cases/compiler/genericSpecializations2.ts(8,5): error TS2421: Class member of type '<string>(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-  Types of parameters 'x' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations2.ts(8,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '<T>(x: T) => T'.
+  Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
+    Types of parameters 'x' and 'x' are incompatible.
+      Type 'T' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations2.ts(8,9): error TS2368: Type parameter name cannot be 'string'.
-tests/cases/compiler/genericSpecializations2.ts(12,5): error TS2421: Class member of type '<string>(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-  Types of parameters 'x' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations2.ts(12,5): error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type '<T>(x: T) => T'.
+  Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
+    Types of parameters 'x' and 'x' are incompatible.
+      Type 'T' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations2.ts(12,9): error TS2368: Type parameter name cannot be 'string'.
 
 
@@ -18,9 +20,10 @@ tests/cases/compiler/genericSpecializations2.ts(12,9): error TS2368: Type parame
     class IntFooBad implements IFoo<number> {
         foo<string>(x: string): string { return null; }
         ~~~
-!!! error TS2421: Class member of type '<string>(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2421:     Type 'T' is not assignable to type 'string'.
+!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416:   Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2416:       Type 'T' is not assignable to type 'string'.
             ~~~~~~
 !!! error TS2368: Type parameter name cannot be 'string'.
     }
@@ -28,9 +31,10 @@ tests/cases/compiler/genericSpecializations2.ts(12,9): error TS2368: Type parame
     class StringFoo2 implements IFoo<string> {
         foo<string>(x: string): string { return null; }
         ~~~
-!!! error TS2421: Class member of type '<string>(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2421:     Type 'T' is not assignable to type 'string'.
+!!! error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416:   Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2416:       Type 'T' is not assignable to type 'string'.
             ~~~~~~
 !!! error TS2368: Type parameter name cannot be 'string'.
     }

--- a/tests/baselines/reference/genericSpecializations2.errors.txt
+++ b/tests/baselines/reference/genericSpecializations2.errors.txt
@@ -1,14 +1,10 @@
-tests/cases/compiler/genericSpecializations2.ts(7,7): error TS2720: Class 'IntFooBad' incorrectly implements class 'IFoo<number>'. Did you mean to extend 'IFoo<number>' and inherit its members as a subclass?
-  Types of property 'foo' are incompatible.
-    Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations2.ts(8,5): error TS2421: Class member of type '<string>(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'T' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations2.ts(8,9): error TS2368: Type parameter name cannot be 'string'.
-tests/cases/compiler/genericSpecializations2.ts(11,7): error TS2720: Class 'StringFoo2' incorrectly implements class 'IFoo<string>'. Did you mean to extend 'IFoo<string>' and inherit its members as a subclass?
-  Types of property 'foo' are incompatible.
-    Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations2.ts(12,5): error TS2421: Class member of type '<string>(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'T' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations2.ts(12,9): error TS2368: Type parameter name cannot be 'string'.
 
 
@@ -20,25 +16,21 @@ tests/cases/compiler/genericSpecializations2.ts(12,9): error TS2368: Type parame
     }
     
     class IntFooBad implements IFoo<number> {
-          ~~~~~~~~~
-!!! error TS2720: Class 'IntFooBad' incorrectly implements class 'IFoo<number>'. Did you mean to extend 'IFoo<number>' and inherit its members as a subclass?
-!!! error TS2720:   Types of property 'foo' are incompatible.
-!!! error TS2720:     Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
-!!! error TS2720:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2720:         Type 'T' is not assignable to type 'string'.
         foo<string>(x: string): string { return null; }
+        ~~~
+!!! error TS2421: Class member of type '<string>(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2421:     Type 'T' is not assignable to type 'string'.
             ~~~~~~
 !!! error TS2368: Type parameter name cannot be 'string'.
     }
     
     class StringFoo2 implements IFoo<string> {
-          ~~~~~~~~~~
-!!! error TS2720: Class 'StringFoo2' incorrectly implements class 'IFoo<string>'. Did you mean to extend 'IFoo<string>' and inherit its members as a subclass?
-!!! error TS2720:   Types of property 'foo' are incompatible.
-!!! error TS2720:     Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
-!!! error TS2720:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2720:         Type 'T' is not assignable to type 'string'.
         foo<string>(x: string): string { return null; }
+        ~~~
+!!! error TS2421: Class member of type '<string>(x: string) => string' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2421:     Type 'T' is not assignable to type 'string'.
             ~~~~~~
 !!! error TS2368: Type parameter name cannot be 'string'.
     }

--- a/tests/baselines/reference/genericSpecializations3.errors.txt
+++ b/tests/baselines/reference/genericSpecializations3.errors.txt
@@ -1,8 +1,6 @@
-tests/cases/compiler/genericSpecializations3.ts(8,7): error TS2420: Class 'IntFooBad' incorrectly implements interface 'IFoo<number>'.
-  Types of property 'foo' are incompatible.
-    Type '(x: string) => string' is not assignable to type '(x: number) => number'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations3.ts(9,5): error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '(x: number) => number'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations3.ts(28,1): error TS2322: Type 'StringFoo2' is not assignable to type 'IntFoo'.
   Types of property 'foo' are incompatible.
     Type '(x: string) => string' is not assignable to type '(x: number) => number'.
@@ -24,13 +22,11 @@ tests/cases/compiler/genericSpecializations3.ts(29,1): error TS2322: Type 'IntFo
     iFoo.foo(1);
     
     class IntFooBad implements IFoo<number> { // error
-          ~~~~~~~~~
-!!! error TS2420: Class 'IntFooBad' incorrectly implements interface 'IFoo<number>'.
-!!! error TS2420:   Types of property 'foo' are incompatible.
-!!! error TS2420:     Type '(x: string) => string' is not assignable to type '(x: number) => number'.
-!!! error TS2420:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2420:         Type 'number' is not assignable to type 'string'.
         foo(x: string): string { return null; }
+        ~~~
+!!! error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '(x: number) => number'.
+!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2421:     Type 'number' is not assignable to type 'string'.
     }
     
     var intFooBad: IntFooBad;

--- a/tests/baselines/reference/genericSpecializations3.errors.txt
+++ b/tests/baselines/reference/genericSpecializations3.errors.txt
@@ -1,6 +1,7 @@
-tests/cases/compiler/genericSpecializations3.ts(9,5): error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '(x: number) => number'.
-  Types of parameters 'x' and 'x' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/genericSpecializations3.ts(9,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '(x: number) => number'.
+  Type '(x: string) => string' is not assignable to type '(x: number) => number'.
+    Types of parameters 'x' and 'x' are incompatible.
+      Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations3.ts(28,1): error TS2322: Type 'StringFoo2' is not assignable to type 'IntFoo'.
   Types of property 'foo' are incompatible.
     Type '(x: string) => string' is not assignable to type '(x: number) => number'.
@@ -24,9 +25,10 @@ tests/cases/compiler/genericSpecializations3.ts(29,1): error TS2322: Type 'IntFo
     class IntFooBad implements IFoo<number> { // error
         foo(x: string): string { return null; }
         ~~~
-!!! error TS2421: Class member of type '(x: string) => string' is not assignable to implementing interface member of type '(x: number) => number'.
-!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2421:     Type 'number' is not assignable to type 'string'.
+!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '(x: number) => number'.
+!!! error TS2416:   Type '(x: string) => string' is not assignable to type '(x: number) => number'.
+!!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2416:       Type 'number' is not assignable to type 'string'.
     }
     
     var intFooBad: IntFooBad;

--- a/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
+++ b/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
@@ -1,8 +1,6 @@
-tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(4,7): error TS2420: Class 'X<T>' incorrectly implements interface 'I'.
-  Types of property 'f' are incompatible.
-    Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
-      Types of parameters 'a' and 'a' are incompatible.
-        Type '{ a: number; }' is not assignable to type 'T'.
+tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(5,2): error TS2421: Class member of type '(a: T) => void' is not assignable to implementing interface member of type '(a: { a: number; }) => void'.
+  Types of parameters 'a' and 'a' are incompatible.
+    Type '{ a: number; }' is not assignable to type 'T'.
 tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322: Type 'X<{ a: string; }>' is not assignable to type 'I'.
   Types of property 'f' are incompatible.
     Type '(a: { a: string; }) => void' is not assignable to type '(a: { a: number; }) => void'.
@@ -17,13 +15,11 @@ tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322
     	f: (a: { a: number }) => void
     }
     class X<T extends { a: string }> implements I {
-          ~
-!!! error TS2420: Class 'X<T>' incorrectly implements interface 'I'.
-!!! error TS2420:   Types of property 'f' are incompatible.
-!!! error TS2420:     Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
-!!! error TS2420:       Types of parameters 'a' and 'a' are incompatible.
-!!! error TS2420:         Type '{ a: number; }' is not assignable to type 'T'.
     	f(a: T): void { }
+    	~
+!!! error TS2421: Class member of type '(a: T) => void' is not assignable to implementing interface member of type '(a: { a: number; }) => void'.
+!!! error TS2421:   Types of parameters 'a' and 'a' are incompatible.
+!!! error TS2421:     Type '{ a: number; }' is not assignable to type 'T'.
     }
     var x = new X<{ a: string }>();
     var i: I = x; // Should not be allowed -- type of 'f' is incompatible with 'I'

--- a/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
+++ b/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
@@ -1,6 +1,7 @@
-tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(5,2): error TS2421: Class member of type '(a: T) => void' is not assignable to implementing interface member of type '(a: { a: number; }) => void'.
-  Types of parameters 'a' and 'a' are incompatible.
-    Type '{ a: number; }' is not assignable to type 'T'.
+tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(5,2): error TS2416: Property 'f' in type 'X<T>' is not assignable to the same property in base type '(a: { a: number; }) => void'.
+  Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
+    Types of parameters 'a' and 'a' are incompatible.
+      Type '{ a: number; }' is not assignable to type 'T'.
 tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322: Type 'X<{ a: string; }>' is not assignable to type 'I'.
   Types of property 'f' are incompatible.
     Type '(a: { a: string; }) => void' is not assignable to type '(a: { a: number; }) => void'.
@@ -17,9 +18,10 @@ tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322
     class X<T extends { a: string }> implements I {
     	f(a: T): void { }
     	~
-!!! error TS2421: Class member of type '(a: T) => void' is not assignable to implementing interface member of type '(a: { a: number; }) => void'.
-!!! error TS2421:   Types of parameters 'a' and 'a' are incompatible.
-!!! error TS2421:     Type '{ a: number; }' is not assignable to type 'T'.
+!!! error TS2416: Property 'f' in type 'X<T>' is not assignable to the same property in base type '(a: { a: number; }) => void'.
+!!! error TS2416:   Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
+!!! error TS2416:     Types of parameters 'a' and 'a' are incompatible.
+!!! error TS2416:       Type '{ a: number; }' is not assignable to type 'T'.
     }
     var x = new X<{ a: string }>();
     var i: I = x; // Should not be allowed -- type of 'f' is incompatible with 'I'

--- a/tests/baselines/reference/implementGenericWithMismatchedTypes.errors.txt
+++ b/tests/baselines/reference/implementGenericWithMismatchedTypes.errors.txt
@@ -1,8 +1,10 @@
-tests/cases/compiler/implementGenericWithMismatchedTypes.ts(8,5): error TS2421: Class member of type '(x: string) => number' is not assignable to implementing interface member of type '(x: T) => T'.
-  Types of parameters 'x' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2421: Class member of type '<Tstring>(x: Tstring) => number' is not assignable to implementing interface member of type '(x: T) => T'.
-  Type 'number' is not assignable to type 'T'.
+tests/cases/compiler/implementGenericWithMismatchedTypes.ts(8,5): error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type '(x: T) => T'.
+  Type '(x: string) => number' is not assignable to type '(x: T) => T'.
+    Types of parameters 'x' and 'x' are incompatible.
+      Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type '(x: T) => T'.
+  Type '<Tstring>(x: Tstring) => number' is not assignable to type '(x: T) => T'.
+    Type 'number' is not assignable to type 'T'.
 
 
 ==== tests/cases/compiler/implementGenericWithMismatchedTypes.ts (2 errors) ====
@@ -15,9 +17,10 @@ tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2421:
     class C<T> implements IFoo<T> { // error
         foo(x: string): number {
         ~~~
-!!! error TS2421: Class member of type '(x: string) => number' is not assignable to implementing interface member of type '(x: T) => T'.
-!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2421:     Type 'T' is not assignable to type 'string'.
+!!! error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type '(x: T) => T'.
+!!! error TS2416:   Type '(x: string) => number' is not assignable to type '(x: T) => T'.
+!!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2416:       Type 'T' is not assignable to type 'string'.
             return null;
         }
     }
@@ -28,8 +31,9 @@ tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2421:
     class C2<T> implements IFoo2<T> { // error
         foo<Tstring>(x: Tstring): number {
         ~~~
-!!! error TS2421: Class member of type '<Tstring>(x: Tstring) => number' is not assignable to implementing interface member of type '(x: T) => T'.
-!!! error TS2421:   Type 'number' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type '(x: T) => T'.
+!!! error TS2416:   Type '<Tstring>(x: Tstring) => number' is not assignable to type '(x: T) => T'.
+!!! error TS2416:     Type 'number' is not assignable to type 'T'.
             return null;
         }
     }

--- a/tests/baselines/reference/implementGenericWithMismatchedTypes.errors.txt
+++ b/tests/baselines/reference/implementGenericWithMismatchedTypes.errors.txt
@@ -1,12 +1,8 @@
-tests/cases/compiler/implementGenericWithMismatchedTypes.ts(7,7): error TS2420: Class 'C<T>' incorrectly implements interface 'IFoo<T>'.
-  Types of property 'foo' are incompatible.
-    Type '(x: string) => number' is not assignable to type '(x: T) => T'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/implementGenericWithMismatchedTypes.ts(16,7): error TS2420: Class 'C2<T>' incorrectly implements interface 'IFoo2<T>'.
-  Types of property 'foo' are incompatible.
-    Type '<Tstring>(x: Tstring) => number' is not assignable to type '(x: T) => T'.
-      Type 'number' is not assignable to type 'T'.
+tests/cases/compiler/implementGenericWithMismatchedTypes.ts(8,5): error TS2421: Class member of type '(x: string) => number' is not assignable to implementing interface member of type '(x: T) => T'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2421: Class member of type '<Tstring>(x: Tstring) => number' is not assignable to implementing interface member of type '(x: T) => T'.
+  Type 'number' is not assignable to type 'T'.
 
 
 ==== tests/cases/compiler/implementGenericWithMismatchedTypes.ts (2 errors) ====
@@ -17,13 +13,11 @@ tests/cases/compiler/implementGenericWithMismatchedTypes.ts(16,7): error TS2420:
         foo(x: T): T;
     }
     class C<T> implements IFoo<T> { // error
-          ~
-!!! error TS2420: Class 'C<T>' incorrectly implements interface 'IFoo<T>'.
-!!! error TS2420:   Types of property 'foo' are incompatible.
-!!! error TS2420:     Type '(x: string) => number' is not assignable to type '(x: T) => T'.
-!!! error TS2420:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2420:         Type 'T' is not assignable to type 'string'.
         foo(x: string): number {
+        ~~~
+!!! error TS2421: Class member of type '(x: string) => number' is not assignable to implementing interface member of type '(x: T) => T'.
+!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2421:     Type 'T' is not assignable to type 'string'.
             return null;
         }
     }
@@ -32,12 +26,10 @@ tests/cases/compiler/implementGenericWithMismatchedTypes.ts(16,7): error TS2420:
         foo(x: T): T;
     }
     class C2<T> implements IFoo2<T> { // error
-          ~~
-!!! error TS2420: Class 'C2<T>' incorrectly implements interface 'IFoo2<T>'.
-!!! error TS2420:   Types of property 'foo' are incompatible.
-!!! error TS2420:     Type '<Tstring>(x: Tstring) => number' is not assignable to type '(x: T) => T'.
-!!! error TS2420:       Type 'number' is not assignable to type 'T'.
         foo<Tstring>(x: Tstring): number {
+        ~~~
+!!! error TS2421: Class member of type '<Tstring>(x: Tstring) => number' is not assignable to implementing interface member of type '(x: T) => T'.
+!!! error TS2421:   Type 'number' is not assignable to type 'T'.
             return null;
         }
     }

--- a/tests/baselines/reference/implementsIncorrectlyNoAssertion.errors.txt
+++ b/tests/baselines/reference/implementsIncorrectlyNoAssertion.errors.txt
@@ -1,7 +1,4 @@
-tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(8,7): error TS2420: Class 'Baz' incorrectly implements interface 'Foo & Bar'.
-  Type 'Baz' is not assignable to type 'Foo'.
-    Types of property 'x' are incompatible.
-      Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(9,5): error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
 
 
 ==== tests/cases/compiler/implementsIncorrectlyNoAssertion.ts (1 errors) ====
@@ -13,12 +10,9 @@ tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(8,7): error TS2420: Cla
     }
     type Wrapper = Foo & Bar;
     class Baz implements Wrapper {
-          ~~~
-!!! error TS2420: Class 'Baz' incorrectly implements interface 'Foo & Bar'.
-!!! error TS2420:   Type 'Baz' is not assignable to type 'Foo'.
-!!! error TS2420:     Types of property 'x' are incompatible.
-!!! error TS2420:       Type 'number' is not assignable to type 'string'.
         x: number;
+        ~
+!!! error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
         y: string;
     }
     

--- a/tests/baselines/reference/implementsIncorrectlyNoAssertion.errors.txt
+++ b/tests/baselines/reference/implementsIncorrectlyNoAssertion.errors.txt
@@ -1,4 +1,5 @@
-tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(9,5): error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
+tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(9,5): error TS2416: Property 'x' in type 'Baz' is not assignable to the same property in base type 'string'.
+  Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/implementsIncorrectlyNoAssertion.ts (1 errors) ====
@@ -12,7 +13,8 @@ tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(9,5): error TS2421: Cla
     class Baz implements Wrapper {
         x: number;
         ~
-!!! error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
+!!! error TS2416: Property 'x' in type 'Baz' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type 'number' is not assignable to type 'string'.
         y: string;
     }
     

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -1,11 +1,15 @@
-tests/cases/compiler/incompatibleTypes.ts(6,12): error TS2421: Class member of type '() => string' is not assignable to implementing interface member of type '() => number'.
-  Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(16,12): error TS2421: Class member of type '(n: number) => number' is not assignable to implementing interface member of type '(s: string) => number'.
-  Types of parameters 'n' and 's' are incompatible.
+tests/cases/compiler/incompatibleTypes.ts(6,12): error TS2416: Property 'p1' in type 'C1' is not assignable to the same property in base type '() => number'.
+  Type '() => string' is not assignable to type '() => number'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(26,12): error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
-tests/cases/compiler/incompatibleTypes.ts(34,12): error TS2421: Class member of type '{ c: { b: string; }; d: string; }' is not assignable to implementing interface member of type '{ a: { a: string; }; b: string; }'.
-  Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
+tests/cases/compiler/incompatibleTypes.ts(16,12): error TS2416: Property 'p1' in type 'C2' is not assignable to the same property in base type '(s: string) => number'.
+  Type '(n: number) => number' is not assignable to type '(s: string) => number'.
+    Types of parameters 'n' and 's' are incompatible.
+      Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/incompatibleTypes.ts(26,12): error TS2416: Property 'p1' in type 'C3' is not assignable to the same property in base type 'string'.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/incompatibleTypes.ts(34,12): error TS2416: Property 'p1' in type 'C4' is not assignable to the same property in base type '{ a: { a: string; }; b: string; }'.
+  Type '{ c: { b: string; }; d: string; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
+    Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2345: Argument of type 'C1' is not assignable to parameter of type 'IFoo2'.
   Types of property 'p1' are incompatible.
     Type '() => string' is not assignable to type '(s: string) => number'.
@@ -26,8 +30,9 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     class C1 implements IFoo1 { // incompatible on the return type
         public p1() {
                ~~
-!!! error TS2421: Class member of type '() => string' is not assignable to implementing interface member of type '() => number'.
-!!! error TS2421:   Type 'string' is not assignable to type 'number'.
+!!! error TS2416: Property 'p1' in type 'C1' is not assignable to the same property in base type '() => number'.
+!!! error TS2416:   Type '() => string' is not assignable to type '() => number'.
+!!! error TS2416:     Type 'string' is not assignable to type 'number'.
             return "s";
         }
     }
@@ -39,9 +44,10 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     class C2 implements IFoo2 { // incompatible on the param type
         public p1(n:number) {
                ~~
-!!! error TS2421: Class member of type '(n: number) => number' is not assignable to implementing interface member of type '(s: string) => number'.
-!!! error TS2421:   Types of parameters 'n' and 's' are incompatible.
-!!! error TS2421:     Type 'string' is not assignable to type 'number'.
+!!! error TS2416: Property 'p1' in type 'C2' is not assignable to the same property in base type '(s: string) => number'.
+!!! error TS2416:   Type '(n: number) => number' is not assignable to type '(s: string) => number'.
+!!! error TS2416:     Types of parameters 'n' and 's' are incompatible.
+!!! error TS2416:       Type 'string' is not assignable to type 'number'.
             return 0;
         }
     }
@@ -53,7 +59,8 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     class C3 implements IFoo3 { // incompatible on the property type
         public p1: number;
                ~~
-!!! error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
+!!! error TS2416: Property 'p1' in type 'C3' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type 'number' is not assignable to type 'string'.
     }
     
     interface IFoo4 {
@@ -63,8 +70,9 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     class C4 implements IFoo4 { // incompatible on the property type
         public p1: { c: { b: string; }; d: string; };
                ~~
-!!! error TS2421: Class member of type '{ c: { b: string; }; d: string; }' is not assignable to implementing interface member of type '{ a: { a: string; }; b: string; }'.
-!!! error TS2421:   Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
+!!! error TS2416: Property 'p1' in type 'C4' is not assignable to the same property in base type '{ a: { a: string; }; b: string; }'.
+!!! error TS2416:   Type '{ c: { b: string; }; d: string; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
+!!! error TS2416:     Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
     }
     
     function if1(i: IFoo1): void;

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -1,19 +1,11 @@
-tests/cases/compiler/incompatibleTypes.ts(5,7): error TS2420: Class 'C1' incorrectly implements interface 'IFoo1'.
-  Types of property 'p1' are incompatible.
-    Type '() => string' is not assignable to type '() => number'.
-      Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(15,7): error TS2420: Class 'C2' incorrectly implements interface 'IFoo2'.
-  Types of property 'p1' are incompatible.
-    Type '(n: number) => number' is not assignable to type '(s: string) => number'.
-      Types of parameters 'n' and 's' are incompatible.
-        Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(25,7): error TS2420: Class 'C3' incorrectly implements interface 'IFoo3'.
-  Types of property 'p1' are incompatible.
-    Type 'number' is not assignable to type 'string'.
-tests/cases/compiler/incompatibleTypes.ts(33,7): error TS2420: Class 'C4' incorrectly implements interface 'IFoo4'.
-  Types of property 'p1' are incompatible.
-    Type '{ c: { b: string; }; d: string; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
-      Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
+tests/cases/compiler/incompatibleTypes.ts(6,12): error TS2421: Class member of type '() => string' is not assignable to implementing interface member of type '() => number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/incompatibleTypes.ts(16,12): error TS2421: Class member of type '(n: number) => number' is not assignable to implementing interface member of type '(s: string) => number'.
+  Types of parameters 'n' and 's' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/incompatibleTypes.ts(26,12): error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
+tests/cases/compiler/incompatibleTypes.ts(34,12): error TS2421: Class member of type '{ c: { b: string; }; d: string; }' is not assignable to implementing interface member of type '{ a: { a: string; }; b: string; }'.
+  Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2345: Argument of type 'C1' is not assignable to parameter of type 'IFoo2'.
   Types of property 'p1' are incompatible.
     Type '() => string' is not assignable to type '(s: string) => number'.
@@ -32,12 +24,10 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     }
     
     class C1 implements IFoo1 { // incompatible on the return type
-          ~~
-!!! error TS2420: Class 'C1' incorrectly implements interface 'IFoo1'.
-!!! error TS2420:   Types of property 'p1' are incompatible.
-!!! error TS2420:     Type '() => string' is not assignable to type '() => number'.
-!!! error TS2420:       Type 'string' is not assignable to type 'number'.
         public p1() {
+               ~~
+!!! error TS2421: Class member of type '() => string' is not assignable to implementing interface member of type '() => number'.
+!!! error TS2421:   Type 'string' is not assignable to type 'number'.
             return "s";
         }
     }
@@ -47,13 +37,11 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     }
     
     class C2 implements IFoo2 { // incompatible on the param type
-          ~~
-!!! error TS2420: Class 'C2' incorrectly implements interface 'IFoo2'.
-!!! error TS2420:   Types of property 'p1' are incompatible.
-!!! error TS2420:     Type '(n: number) => number' is not assignable to type '(s: string) => number'.
-!!! error TS2420:       Types of parameters 'n' and 's' are incompatible.
-!!! error TS2420:         Type 'string' is not assignable to type 'number'.
         public p1(n:number) {
+               ~~
+!!! error TS2421: Class member of type '(n: number) => number' is not assignable to implementing interface member of type '(s: string) => number'.
+!!! error TS2421:   Types of parameters 'n' and 's' are incompatible.
+!!! error TS2421:     Type 'string' is not assignable to type 'number'.
             return 0;
         }
     }
@@ -63,11 +51,9 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     }
     
     class C3 implements IFoo3 { // incompatible on the property type
-          ~~
-!!! error TS2420: Class 'C3' incorrectly implements interface 'IFoo3'.
-!!! error TS2420:   Types of property 'p1' are incompatible.
-!!! error TS2420:     Type 'number' is not assignable to type 'string'.
         public p1: number;
+               ~~
+!!! error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
     }
     
     interface IFoo4 {
@@ -75,12 +61,10 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     }
     
     class C4 implements IFoo4 { // incompatible on the property type
-          ~~
-!!! error TS2420: Class 'C4' incorrectly implements interface 'IFoo4'.
-!!! error TS2420:   Types of property 'p1' are incompatible.
-!!! error TS2420:     Type '{ c: { b: string; }; d: string; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
-!!! error TS2420:       Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
         public p1: { c: { b: string; }; d: string; };
+               ~~
+!!! error TS2421: Class member of type '{ c: { b: string; }; d: string; }' is not assignable to implementing interface member of type '{ a: { a: string; }; b: string; }'.
+!!! error TS2421:   Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
     }
     
     function if1(i: IFoo1): void;

--- a/tests/baselines/reference/inheritance.errors.txt
+++ b/tests/baselines/reference/inheritance.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/inheritance.ts(31,12): error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
-tests/cases/compiler/inheritance.ts(32,12): error TS2416: Class member of type '(n: number) => number' is not assignable to base class member of type '() => number'.
+tests/cases/compiler/inheritance.ts(32,12): error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type '() => number'.
+  Type '(n: number) => number' is not assignable to type '() => number'.
 
 
 ==== tests/cases/compiler/inheritance.ts (2 errors) ====
@@ -38,6 +39,7 @@ tests/cases/compiler/inheritance.ts(32,12): error TS2416: Class member of type '
 !!! error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
         public g(n: number) { return 0; }
                ~
-!!! error TS2416: Class member of type '(n: number) => number' is not assignable to base class member of type '() => number'.
+!!! error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type '() => number'.
+!!! error TS2416:   Type '(n: number) => number' is not assignable to type '() => number'.
     }
     

--- a/tests/baselines/reference/inheritance.errors.txt
+++ b/tests/baselines/reference/inheritance.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/compiler/inheritance.ts(30,7): error TS2415: Class 'Baad' incorrectly extends base class 'Good'.
-  Types of property 'g' are incompatible.
-    Type '(n: number) => number' is not assignable to type '() => number'.
 tests/cases/compiler/inheritance.ts(31,12): error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
+tests/cases/compiler/inheritance.ts(32,12): error TS2416: Class member of type '(n: number) => number' is not assignable to base class member of type '() => number'.
 
 
 ==== tests/cases/compiler/inheritance.ts (2 errors) ====
@@ -35,13 +33,11 @@ tests/cases/compiler/inheritance.ts(31,12): error TS2425: Class 'Good' defines i
     }
     
     class Baad extends Good {
-          ~~~~
-!!! error TS2415: Class 'Baad' incorrectly extends base class 'Good'.
-!!! error TS2415:   Types of property 'g' are incompatible.
-!!! error TS2415:     Type '(n: number) => number' is not assignable to type '() => number'.
         public f(): number { return 0; }
                ~
 !!! error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
         public g(n: number) { return 0; }
+               ~
+!!! error TS2416: Class member of type '(n: number) => number' is not assignable to base class member of type '() => number'.
     }
     

--- a/tests/baselines/reference/inheritanceMemberAccessorOverridingMethod.errors.txt
+++ b/tests/baselines/reference/inheritanceMemberAccessorOverridingMethod.errors.txt
@@ -1,12 +1,11 @@
-tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(7,7): error TS2415: Class 'b' incorrectly extends base class 'a'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type '() => string'.
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
+tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS2416: Class member of type 'string' is not assignable to base class member of type '() => string'.
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS2423: Class 'a' defines instance member function 'x', but extended class 'b' defines it as instance member accessor.
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
+tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error TS2416: Class member of type 'string' is not assignable to base class member of type '() => string'.
 
 
-==== tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts (4 errors) ====
+==== tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts (5 errors) ====
     class a {
         x() {
             return "20";
@@ -14,13 +13,11 @@ tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error T
     }
     
     class b extends a {
-          ~
-!!! error TS2415: Class 'b' incorrectly extends base class 'a'.
-!!! error TS2415:   Types of property 'x' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type '() => string'.
         get x() {
             ~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
+            ~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type '() => string'.
             ~
 !!! error TS2423: Class 'a' defines instance member function 'x', but extended class 'b' defines it as instance member accessor.
             return "20";
@@ -28,6 +25,8 @@ tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error T
         set x(aValue: string) {
             ~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
+            ~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type '() => string'.
     
         }
     }

--- a/tests/baselines/reference/inheritanceMemberAccessorOverridingMethod.errors.txt
+++ b/tests/baselines/reference/inheritanceMemberAccessorOverridingMethod.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS2416: Class member of type 'string' is not assignable to base class member of type '() => string'.
+tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type '() => string'.
+  Type 'string' is not assignable to type '() => string'.
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS2423: Class 'a' defines instance member function 'x', but extended class 'b' defines it as instance member accessor.
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error TS2416: Class member of type 'string' is not assignable to base class member of type '() => string'.
+tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type '() => string'.
+  Type 'string' is not assignable to type '() => string'.
 
 
 ==== tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts (5 errors) ====
@@ -17,7 +19,8 @@ tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error T
             ~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             ~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type '() => string'.
+!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type '() => string'.
+!!! error TS2416:   Type 'string' is not assignable to type '() => string'.
             ~
 !!! error TS2423: Class 'a' defines instance member function 'x', but extended class 'b' defines it as instance member accessor.
             return "20";
@@ -26,7 +29,8 @@ tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error T
             ~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             ~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type '() => string'.
+!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type '() => string'.
+!!! error TS2416:   Type 'string' is not assignable to type '() => string'.
     
         }
     }

--- a/tests/baselines/reference/inheritanceMemberFuncOverridingAccessor.errors.txt
+++ b/tests/baselines/reference/inheritanceMemberFuncOverridingAccessor.errors.txt
@@ -1,8 +1,6 @@
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(2,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(5,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(10,7): error TS2415: Class 'b' incorrectly extends base class 'a'.
-  Types of property 'x' are incompatible.
-    Type '() => string' is not assignable to type 'string'.
+tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2416: Class member of type '() => string' is not assignable to base class member of type 'string'.
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2426: Class 'a' defines instance member accessor 'x', but extended class 'b' defines it as instance member function.
 
 
@@ -21,11 +19,9 @@ tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2
     }
     
     class b extends a {
-          ~
-!!! error TS2415: Class 'b' incorrectly extends base class 'a'.
-!!! error TS2415:   Types of property 'x' are incompatible.
-!!! error TS2415:     Type '() => string' is not assignable to type 'string'.
         x() {
+        ~
+!!! error TS2416: Class member of type '() => string' is not assignable to base class member of type 'string'.
         ~
 !!! error TS2426: Class 'a' defines instance member accessor 'x', but extended class 'b' defines it as instance member function.
             return "20";

--- a/tests/baselines/reference/inheritanceMemberFuncOverridingAccessor.errors.txt
+++ b/tests/baselines/reference/inheritanceMemberFuncOverridingAccessor.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(2,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(5,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2416: Class member of type '() => string' is not assignable to base class member of type 'string'.
+tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'string'.
+  Type '() => string' is not assignable to type 'string'.
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2426: Class 'a' defines instance member accessor 'x', but extended class 'b' defines it as instance member function.
 
 
@@ -21,7 +22,8 @@ tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2
     class b extends a {
         x() {
         ~
-!!! error TS2416: Class member of type '() => string' is not assignable to base class member of type 'string'.
+!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type '() => string' is not assignable to type 'string'.
         ~
 !!! error TS2426: Class 'a' defines instance member accessor 'x', but extended class 'b' defines it as instance member function.
             return "20";

--- a/tests/baselines/reference/instanceSubtypeCheck2.errors.txt
+++ b/tests/baselines/reference/instanceSubtypeCheck2.errors.txt
@@ -1,6 +1,4 @@
-tests/cases/compiler/instanceSubtypeCheck2.ts(5,7): error TS2415: Class 'C2<T>' incorrectly extends base class 'C1<T>'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'C2<T>'.
+tests/cases/compiler/instanceSubtypeCheck2.ts(6,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'C2<T>'.
 
 
 ==== tests/cases/compiler/instanceSubtypeCheck2.ts (1 errors) ====
@@ -9,9 +7,7 @@ tests/cases/compiler/instanceSubtypeCheck2.ts(5,7): error TS2415: Class 'C2<T>' 
     }
     
     class C2<T> extends C1<T> {
-          ~~
-!!! error TS2415: Class 'C2<T>' incorrectly extends base class 'C1<T>'.
-!!! error TS2415:   Types of property 'x' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'C2<T>'.
         x: string
+        ~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'C2<T>'.
     }

--- a/tests/baselines/reference/instanceSubtypeCheck2.errors.txt
+++ b/tests/baselines/reference/instanceSubtypeCheck2.errors.txt
@@ -1,4 +1,5 @@
-tests/cases/compiler/instanceSubtypeCheck2.ts(6,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'C2<T>'.
+tests/cases/compiler/instanceSubtypeCheck2.ts(6,5): error TS2416: Property 'x' in type 'C2<T>' is not assignable to the same property in base type 'C2<T>'.
+  Type 'string' is not assignable to type 'C2<T>'.
 
 
 ==== tests/cases/compiler/instanceSubtypeCheck2.ts (1 errors) ====
@@ -9,5 +10,6 @@ tests/cases/compiler/instanceSubtypeCheck2.ts(6,5): error TS2416: Class member o
     class C2<T> extends C1<T> {
         x: string
         ~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'C2<T>'.
+!!! error TS2416: Property 'x' in type 'C2<T>' is not assignable to the same property in base type 'C2<T>'.
+!!! error TS2416:   Type 'string' is not assignable to type 'C2<T>'.
     }

--- a/tests/baselines/reference/interfaceDeclaration3.errors.txt
+++ b/tests/baselines/reference/interfaceDeclaration3.errors.txt
@@ -1,5 +1,7 @@
-tests/cases/compiler/interfaceDeclaration3.ts(7,16): error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
-tests/cases/compiler/interfaceDeclaration3.ts(32,16): error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
+tests/cases/compiler/interfaceDeclaration3.ts(7,16): error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'string'.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/interfaceDeclaration3.ts(32,16): error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'string'.
+  Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I2' incorrectly extends interface 'I1'.
   Types of property 'item' are incompatible.
     Type 'string' is not assignable to type 'number'.
@@ -14,7 +16,8 @@ tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I
         class C1 implements I1 {
             public item:number;
                    ~~~~
-!!! error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
+!!! error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type 'number' is not assignable to type 'string'.
         }
         class C2 implements I1 {
             public item:string;
@@ -41,7 +44,8 @@ tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I
         class C1 implements I1 {
             public item:number;    
                    ~~~~
-!!! error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
+!!! error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type 'number' is not assignable to type 'string'.
         }
         class C2 implements I1 {
             public item:string;    

--- a/tests/baselines/reference/interfaceDeclaration3.errors.txt
+++ b/tests/baselines/reference/interfaceDeclaration3.errors.txt
@@ -1,9 +1,5 @@
-tests/cases/compiler/interfaceDeclaration3.ts(6,11): error TS2420: Class 'C1' incorrectly implements interface 'I1'.
-  Types of property 'item' are incompatible.
-    Type 'number' is not assignable to type 'string'.
-tests/cases/compiler/interfaceDeclaration3.ts(31,11): error TS2420: Class 'C1' incorrectly implements interface 'I1'.
-  Types of property 'item' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/interfaceDeclaration3.ts(7,16): error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
+tests/cases/compiler/interfaceDeclaration3.ts(32,16): error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
 tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I2' incorrectly extends interface 'I1'.
   Types of property 'item' are incompatible.
     Type 'string' is not assignable to type 'number'.
@@ -16,11 +12,9 @@ tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I
         interface I1 { item:string; }  
         interface I2 { item:number; }   
         class C1 implements I1 {
-              ~~
-!!! error TS2420: Class 'C1' incorrectly implements interface 'I1'.
-!!! error TS2420:   Types of property 'item' are incompatible.
-!!! error TS2420:     Type 'number' is not assignable to type 'string'.
             public item:number;
+                   ~~~~
+!!! error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
         }
         class C2 implements I1 {
             public item:string;
@@ -45,11 +39,9 @@ tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I
             export interface I1 { item:string; }
         }
         class C1 implements I1 {
-              ~~
-!!! error TS2420: Class 'C1' incorrectly implements interface 'I1'.
-!!! error TS2420:   Types of property 'item' are incompatible.
-!!! error TS2420:     Type 'number' is not assignable to type 'string'.
             public item:number;    
+                   ~~~~
+!!! error TS2421: Class member of type 'number' is not assignable to implementing interface member of type 'string'.
         }
         class C2 implements I1 {
             public item:string;    

--- a/tests/baselines/reference/interfaceExtendsClassWithPrivate2.errors.txt
+++ b/tests/baselines/reference/interfaceExtendsClassWithPrivate2.errors.txt
@@ -2,10 +2,8 @@ tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(10,7): error TS2415: C
   Types have separate declarations of a private property 'x'.
 tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(10,7): error TS2420: Class 'D' incorrectly implements interface 'I'.
   Types have separate declarations of a private property 'x'.
-tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(18,7): error TS2415: Class 'D2' incorrectly extends base class 'C'.
-  Types have separate declarations of a private property 'x'.
-tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(18,7): error TS2420: Class 'D2' incorrectly implements interface 'I'.
-  Types have separate declarations of a private property 'x'.
+tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2421: Class member of type 'string' is not assignable to implementing interface member of type 'number'.
 
 
 ==== tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts (4 errors) ====
@@ -33,14 +31,12 @@ tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(18,7): error TS2420: C
     } 
     
     class D2 extends C implements I { // error
-          ~~
-!!! error TS2415: Class 'D2' incorrectly extends base class 'C'.
-!!! error TS2415:   Types have separate declarations of a private property 'x'.
-          ~~
-!!! error TS2420: Class 'D2' incorrectly implements interface 'I'.
-!!! error TS2420:   Types have separate declarations of a private property 'x'.
         public foo(x: any) { return x; }
         private x = "";
+                ~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+                ~
+!!! error TS2421: Class member of type 'string' is not assignable to implementing interface member of type 'number'.
         other(x: any) { return x; }
         bar() { }
     } 

--- a/tests/baselines/reference/interfaceExtendsClassWithPrivate2.errors.txt
+++ b/tests/baselines/reference/interfaceExtendsClassWithPrivate2.errors.txt
@@ -2,11 +2,11 @@ tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(10,7): error TS2415: C
   Types have separate declarations of a private property 'x'.
 tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(10,7): error TS2420: Class 'D' incorrectly implements interface 'I'.
   Types have separate declarations of a private property 'x'.
-tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
-tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2421: Class member of type 'string' is not assignable to implementing interface member of type 'number'.
+tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2416: Property 'x' in type 'D2' is not assignable to the same property in base type 'number'.
+  Type 'string' is not assignable to type 'number'.
 
 
-==== tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts (4 errors) ====
+==== tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts (3 errors) ====
     class C {
         public foo(x: any) { return x; }
         private x = 1;
@@ -34,9 +34,8 @@ tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2421: 
         public foo(x: any) { return x; }
         private x = "";
                 ~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
-                ~
-!!! error TS2421: Class member of type 'string' is not assignable to implementing interface member of type 'number'.
+!!! error TS2416: Property 'x' in type 'D2' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
         other(x: any) { return x; }
         bar() { }
     } 

--- a/tests/baselines/reference/interfaceExtendsObjectIntersectionErrors.errors.txt
+++ b/tests/baselines/reference/interfaceExtendsObjectIntersectionErrors.errors.txt
@@ -14,11 +14,16 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(11,11): error TS2430: Interface 'I5' incorrectly extends interface 'T5'.
   Types of property 'c' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(16,38): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(17,38): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(18,38): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(19,38): error TS2416: Class member of type 'number' is not assignable to base class member of type 'string'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(20,38): error TS2416: Class member of type 'number' is not assignable to base class member of type 'string'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(16,38): error TS2416: Property 'a' in type 'C1' is not assignable to the same property in base type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(17,38): error TS2416: Property 'b' in type 'C2' is not assignable to the same property in base type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(18,38): error TS2416: Property 'length' in type 'C3' is not assignable to the same property in base type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(19,38): error TS2416: Property '0' in type 'C4' is not assignable to the same property in base type 'string'.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(20,38): error TS2416: Property 'c' in type 'C5' is not assignable to the same property in base type 'string'.
+  Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(30,11): error TS2430: Interface 'I10' incorrectly extends interface 'typeof CX'.
   Types of property 'a' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -89,19 +94,24 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
     
     class C1 extends Constructor<T1>() { a: string }
                                          ~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+!!! error TS2416: Property 'a' in type 'C1' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
     class C2 extends Constructor<T2>() { b: string }
                                          ~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+!!! error TS2416: Property 'b' in type 'C2' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
     class C3 extends Constructor<T3>() { length: string }
                                          ~~~~~~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+!!! error TS2416: Property 'length' in type 'C3' is not assignable to the same property in base type 'number'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
     class C4 extends Constructor<T4>() { 0: number }
                                          ~
-!!! error TS2416: Class member of type 'number' is not assignable to base class member of type 'string'.
+!!! error TS2416: Property '0' in type 'C4' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type 'number' is not assignable to type 'string'.
     class C5 extends Constructor<T5>() { c: number }
                                          ~
-!!! error TS2416: Class member of type 'number' is not assignable to base class member of type 'string'.
+!!! error TS2416: Property 'c' in type 'C5' is not assignable to the same property in base type 'string'.
+!!! error TS2416:   Type 'number' is not assignable to type 'string'.
     
     declare class CX { static a: string }
     declare enum EX { A, B, C }

--- a/tests/baselines/reference/interfaceExtendsObjectIntersectionErrors.errors.txt
+++ b/tests/baselines/reference/interfaceExtendsObjectIntersectionErrors.errors.txt
@@ -14,22 +14,11 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(11,11): error TS2430: Interface 'I5' incorrectly extends interface 'T5'.
   Types of property 'c' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(16,7): error TS2415: Class 'C1' incorrectly extends base class 'T1'.
-  Types of property 'a' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(17,7): error TS2415: Class 'C2' incorrectly extends base class 'T2'.
-  Type 'C2' is not assignable to type '{ b: number; }'.
-    Types of property 'b' are incompatible.
-      Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(18,7): error TS2415: Class 'C3' incorrectly extends base class 'number[]'.
-  Types of property 'length' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(19,7): error TS2415: Class 'C4' incorrectly extends base class '[string, number]'.
-  Types of property '0' are incompatible.
-    Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(20,7): error TS2415: Class 'C5' incorrectly extends base class 'T5'.
-  Types of property 'c' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(16,38): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(17,38): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(18,38): error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(19,38): error TS2416: Class member of type 'number' is not assignable to base class member of type 'string'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(20,38): error TS2416: Class member of type 'number' is not assignable to base class member of type 'string'.
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(30,11): error TS2430: Interface 'I10' incorrectly extends interface 'typeof CX'.
   Types of property 'a' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -99,31 +88,20 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
     declare function Constructor<T>(): Constructor<T>;
     
     class C1 extends Constructor<T1>() { a: string }
-          ~~
-!!! error TS2415: Class 'C1' incorrectly extends base class 'T1'.
-!!! error TS2415:   Types of property 'a' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'number'.
+                                         ~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
     class C2 extends Constructor<T2>() { b: string }
-          ~~
-!!! error TS2415: Class 'C2' incorrectly extends base class 'T2'.
-!!! error TS2415:   Type 'C2' is not assignable to type '{ b: number; }'.
-!!! error TS2415:     Types of property 'b' are incompatible.
-!!! error TS2415:       Type 'string' is not assignable to type 'number'.
+                                         ~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
     class C3 extends Constructor<T3>() { length: string }
-          ~~
-!!! error TS2415: Class 'C3' incorrectly extends base class 'number[]'.
-!!! error TS2415:   Types of property 'length' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'number'.
+                                         ~~~~~~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'number'.
     class C4 extends Constructor<T4>() { 0: number }
-          ~~
-!!! error TS2415: Class 'C4' incorrectly extends base class '[string, number]'.
-!!! error TS2415:   Types of property '0' are incompatible.
-!!! error TS2415:     Type 'number' is not assignable to type 'string'.
+                                         ~
+!!! error TS2416: Class member of type 'number' is not assignable to base class member of type 'string'.
     class C5 extends Constructor<T5>() { c: number }
-          ~~
-!!! error TS2415: Class 'C5' incorrectly extends base class 'T5'.
-!!! error TS2415:   Types of property 'c' are incompatible.
-!!! error TS2415:     Type 'number' is not assignable to type 'string'.
+                                         ~
+!!! error TS2416: Class member of type 'number' is not assignable to base class member of type 'string'.
     
     declare class CX { static a: string }
     declare enum EX { A, B, C }

--- a/tests/baselines/reference/interfaceImplementation7.errors.txt
+++ b/tests/baselines/reference/interfaceImplementation7.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/compiler/interfaceImplementation7.ts(4,11): error TS2320: Interface 'i3' cannot simultaneously extend types 'i1' and 'i2'.
   Named property 'name' of types 'i1' and 'i2' are not identical.
-tests/cases/compiler/interfaceImplementation7.ts(8,12): error TS2421: Class member of type '() => string' is not assignable to implementing interface member of type '() => { s: string; n: number; }'.
-  Type 'string' is not assignable to type '{ s: string; n: number; }'.
+tests/cases/compiler/interfaceImplementation7.ts(8,12): error TS2416: Property 'name' in type 'C1' is not assignable to the same property in base type '() => { s: string; n: number; }'.
+  Type '() => string' is not assignable to type '() => { s: string; n: number; }'.
+    Type 'string' is not assignable to type '{ s: string; n: number; }'.
 
 
 ==== tests/cases/compiler/interfaceImplementation7.ts (2 errors) ====
@@ -17,7 +18,8 @@ tests/cases/compiler/interfaceImplementation7.ts(8,12): error TS2421: Class memb
     class C1 implements i4 {
         public name(): string { return ""; }
                ~~~~
-!!! error TS2421: Class member of type '() => string' is not assignable to implementing interface member of type '() => { s: string; n: number; }'.
-!!! error TS2421:   Type 'string' is not assignable to type '{ s: string; n: number; }'.
+!!! error TS2416: Property 'name' in type 'C1' is not assignable to the same property in base type '() => { s: string; n: number; }'.
+!!! error TS2416:   Type '() => string' is not assignable to type '() => { s: string; n: number; }'.
+!!! error TS2416:     Type 'string' is not assignable to type '{ s: string; n: number; }'.
     }
     

--- a/tests/baselines/reference/interfaceImplementation7.errors.txt
+++ b/tests/baselines/reference/interfaceImplementation7.errors.txt
@@ -1,9 +1,7 @@
 tests/cases/compiler/interfaceImplementation7.ts(4,11): error TS2320: Interface 'i3' cannot simultaneously extend types 'i1' and 'i2'.
   Named property 'name' of types 'i1' and 'i2' are not identical.
-tests/cases/compiler/interfaceImplementation7.ts(7,7): error TS2420: Class 'C1' incorrectly implements interface 'i4'.
-  Types of property 'name' are incompatible.
-    Type '() => string' is not assignable to type '() => { s: string; n: number; }'.
-      Type 'string' is not assignable to type '{ s: string; n: number; }'.
+tests/cases/compiler/interfaceImplementation7.ts(8,12): error TS2421: Class member of type '() => string' is not assignable to implementing interface member of type '() => { s: string; n: number; }'.
+  Type 'string' is not assignable to type '{ s: string; n: number; }'.
 
 
 ==== tests/cases/compiler/interfaceImplementation7.ts (2 errors) ====
@@ -17,11 +15,9 @@ tests/cases/compiler/interfaceImplementation7.ts(7,7): error TS2420: Class 'C1' 
     interface i4 extends i1, i2 { name(): { s: string; n: number; }; }
     
     class C1 implements i4 {
-          ~~
-!!! error TS2420: Class 'C1' incorrectly implements interface 'i4'.
-!!! error TS2420:   Types of property 'name' are incompatible.
-!!! error TS2420:     Type '() => string' is not assignable to type '() => { s: string; n: number; }'.
-!!! error TS2420:       Type 'string' is not assignable to type '{ s: string; n: number; }'.
         public name(): string { return ""; }
+               ~~~~
+!!! error TS2421: Class member of type '() => string' is not assignable to implementing interface member of type '() => { s: string; n: number; }'.
+!!! error TS2421:   Type 'string' is not assignable to type '{ s: string; n: number; }'.
     }
     

--- a/tests/baselines/reference/mismatchedGenericArguments1.errors.txt
+++ b/tests/baselines/reference/mismatchedGenericArguments1.errors.txt
@@ -1,9 +1,11 @@
-tests/cases/compiler/mismatchedGenericArguments1.ts(5,4): error TS2421: Class member of type '(x: string) => number' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-  Types of parameters 'x' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2421: Class member of type '<U>(x: string) => number' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-  Types of parameters 'x' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/mismatchedGenericArguments1.ts(5,4): error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type '<T>(x: T) => T'.
+  Type '(x: string) => number' is not assignable to type '<T>(x: T) => T'.
+    Types of parameters 'x' and 'x' are incompatible.
+      Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type '<T>(x: T) => T'.
+  Type '<U>(x: string) => number' is not assignable to type '<T>(x: T) => T'.
+    Types of parameters 'x' and 'x' are incompatible.
+      Type 'T' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/mismatchedGenericArguments1.ts (2 errors) ====
@@ -13,9 +15,10 @@ tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2421: Class m
     class C<T> implements IFoo<T> {
        foo(x: string): number {
        ~~~
-!!! error TS2421: Class member of type '(x: string) => number' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2421:     Type 'T' is not assignable to type 'string'.
+!!! error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416:   Type '(x: string) => number' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2416:       Type 'T' is not assignable to type 'string'.
          return null;
        }
     }
@@ -23,9 +26,10 @@ tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2421: Class m
     class C2<T> implements IFoo<T> {
        foo<U>(x: string): number {
        ~~~
-!!! error TS2421: Class member of type '<U>(x: string) => number' is not assignable to implementing interface member of type '<T>(x: T) => T'.
-!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2421:     Type 'T' is not assignable to type 'string'.
+!!! error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416:   Type '<U>(x: string) => number' is not assignable to type '<T>(x: T) => T'.
+!!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2416:       Type 'T' is not assignable to type 'string'.
          return null;
        }
     }

--- a/tests/baselines/reference/mismatchedGenericArguments1.errors.txt
+++ b/tests/baselines/reference/mismatchedGenericArguments1.errors.txt
@@ -1,13 +1,9 @@
-tests/cases/compiler/mismatchedGenericArguments1.ts(4,7): error TS2420: Class 'C<T>' incorrectly implements interface 'IFoo<T>'.
-  Types of property 'foo' are incompatible.
-    Type '(x: string) => number' is not assignable to type '<T>(x: T) => T'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/mismatchedGenericArguments1.ts(10,7): error TS2420: Class 'C2<T>' incorrectly implements interface 'IFoo<T>'.
-  Types of property 'foo' are incompatible.
-    Type '<U>(x: string) => number' is not assignable to type '<T>(x: T) => T'.
-      Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/mismatchedGenericArguments1.ts(5,4): error TS2421: Class member of type '(x: string) => number' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'T' is not assignable to type 'string'.
+tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2421: Class member of type '<U>(x: string) => number' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type 'T' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/mismatchedGenericArguments1.ts (2 errors) ====
@@ -15,25 +11,21 @@ tests/cases/compiler/mismatchedGenericArguments1.ts(10,7): error TS2420: Class '
        foo<T>(x: T): T;
     }
     class C<T> implements IFoo<T> {
-          ~
-!!! error TS2420: Class 'C<T>' incorrectly implements interface 'IFoo<T>'.
-!!! error TS2420:   Types of property 'foo' are incompatible.
-!!! error TS2420:     Type '(x: string) => number' is not assignable to type '<T>(x: T) => T'.
-!!! error TS2420:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2420:         Type 'T' is not assignable to type 'string'.
        foo(x: string): number {
+       ~~~
+!!! error TS2421: Class member of type '(x: string) => number' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2421:     Type 'T' is not assignable to type 'string'.
          return null;
        }
     }
     
     class C2<T> implements IFoo<T> {
-          ~~
-!!! error TS2420: Class 'C2<T>' incorrectly implements interface 'IFoo<T>'.
-!!! error TS2420:   Types of property 'foo' are incompatible.
-!!! error TS2420:     Type '<U>(x: string) => number' is not assignable to type '<T>(x: T) => T'.
-!!! error TS2420:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2420:         Type 'T' is not assignable to type 'string'.
        foo<U>(x: string): number {
+       ~~~
+!!! error TS2421: Class member of type '<U>(x: string) => number' is not assignable to implementing interface member of type '<T>(x: T) => T'.
+!!! error TS2421:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2421:     Type 'T' is not assignable to type 'string'.
          return null;
        }
     }

--- a/tests/baselines/reference/multipleInheritance.errors.txt
+++ b/tests/baselines/reference/multipleInheritance.errors.txt
@@ -1,9 +1,7 @@
 tests/cases/compiler/multipleInheritance.ts(9,21): error TS1174: Classes can only extend a single class.
 tests/cases/compiler/multipleInheritance.ts(18,21): error TS1174: Classes can only extend a single class.
-tests/cases/compiler/multipleInheritance.ts(34,7): error TS2415: Class 'Baad' incorrectly extends base class 'Good'.
-  Types of property 'g' are incompatible.
-    Type '(n: number) => number' is not assignable to type '() => number'.
 tests/cases/compiler/multipleInheritance.ts(35,12): error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
+tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Class member of type '(n: number) => number' is not assignable to base class member of type '() => number'.
 
 
 ==== tests/cases/compiler/multipleInheritance.ts (4 errors) ====
@@ -45,13 +43,11 @@ tests/cases/compiler/multipleInheritance.ts(35,12): error TS2425: Class 'Good' d
     }
     
     class Baad extends Good {
-          ~~~~
-!!! error TS2415: Class 'Baad' incorrectly extends base class 'Good'.
-!!! error TS2415:   Types of property 'g' are incompatible.
-!!! error TS2415:     Type '(n: number) => number' is not assignable to type '() => number'.
         public f(): number { return 0; }
                ~
 !!! error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
         public g(n:number) { return 0; }
+               ~
+!!! error TS2416: Class member of type '(n: number) => number' is not assignable to base class member of type '() => number'.
     }
     

--- a/tests/baselines/reference/multipleInheritance.errors.txt
+++ b/tests/baselines/reference/multipleInheritance.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/compiler/multipleInheritance.ts(9,21): error TS1174: Classes can only extend a single class.
 tests/cases/compiler/multipleInheritance.ts(18,21): error TS1174: Classes can only extend a single class.
 tests/cases/compiler/multipleInheritance.ts(35,12): error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
-tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Class member of type '(n: number) => number' is not assignable to base class member of type '() => number'.
+tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type '() => number'.
+  Type '(n: number) => number' is not assignable to type '() => number'.
 
 
 ==== tests/cases/compiler/multipleInheritance.ts (4 errors) ====
@@ -48,6 +49,7 @@ tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Class member o
 !!! error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
         public g(n:number) { return 0; }
                ~
-!!! error TS2416: Class member of type '(n: number) => number' is not assignable to base class member of type '() => number'.
+!!! error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type '() => number'.
+!!! error TS2416:   Type '(n: number) => number' is not assignable to type '() => number'.
     }
     

--- a/tests/baselines/reference/requiredInitializedParameter2.errors.txt
+++ b/tests/baselines/reference/requiredInitializedParameter2.errors.txt
@@ -1,6 +1,4 @@
-tests/cases/compiler/requiredInitializedParameter2.ts(5,7): error TS2420: Class 'C1' incorrectly implements interface 'I1'.
-  Types of property 'method' are incompatible.
-    Type '(a: number, b: any) => void' is not assignable to type '() => any'.
+tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2421: Class member of type '(a: number, b: any) => void' is not assignable to implementing interface member of type '() => any'.
 
 
 ==== tests/cases/compiler/requiredInitializedParameter2.ts (1 errors) ====
@@ -9,9 +7,7 @@ tests/cases/compiler/requiredInitializedParameter2.ts(5,7): error TS2420: Class 
     }
     
     class C1 implements I1 {
-          ~~
-!!! error TS2420: Class 'C1' incorrectly implements interface 'I1'.
-!!! error TS2420:   Types of property 'method' are incompatible.
-!!! error TS2420:     Type '(a: number, b: any) => void' is not assignable to type '() => any'.
         method(a = 0, b) { }
+        ~~~~~~
+!!! error TS2421: Class member of type '(a: number, b: any) => void' is not assignable to implementing interface member of type '() => any'.
     }

--- a/tests/baselines/reference/requiredInitializedParameter2.errors.txt
+++ b/tests/baselines/reference/requiredInitializedParameter2.errors.txt
@@ -1,4 +1,5 @@
-tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2421: Class member of type '(a: number, b: any) => void' is not assignable to implementing interface member of type '() => any'.
+tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2416: Property 'method' in type 'C1' is not assignable to the same property in base type '() => any'.
+  Type '(a: number, b: any) => void' is not assignable to type '() => any'.
 
 
 ==== tests/cases/compiler/requiredInitializedParameter2.ts (1 errors) ====
@@ -9,5 +10,6 @@ tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2421: Class 
     class C1 implements I1 {
         method(a = 0, b) { }
         ~~~~~~
-!!! error TS2421: Class member of type '(a: number, b: any) => void' is not assignable to implementing interface member of type '() => any'.
+!!! error TS2416: Property 'method' in type 'C1' is not assignable to the same property in base type '() => any'.
+!!! error TS2416:   Type '(a: number, b: any) => void' is not assignable to type '() => any'.
     }

--- a/tests/baselines/reference/subtypesOfTypeParameter.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameter.errors.txt
@@ -1,4 +1,5 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts(8,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts(8,5): error TS2416: Property 'foo' in type 'D1<T, U>' is not assignable to the same property in base type 'T'.
+  Type 'U' is not assignable to type 'T'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts (1 errors) ====
@@ -11,7 +12,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     class D1<T, U> extends C3<T> {
         foo: U; // error
         ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+!!! error TS2416: Property 'foo' in type 'D1<T, U>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'U' is not assignable to type 'T'.
     }
     
     function f1<T, U>(x: T, y: U) {

--- a/tests/baselines/reference/subtypesOfTypeParameter.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameter.errors.txt
@@ -1,6 +1,4 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts(7,7): error TS2415: Class 'D1<T, U>' incorrectly extends base class 'C3<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'U' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts(8,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts (1 errors) ====
@@ -11,11 +9,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     }
     
     class D1<T, U> extends C3<T> {
-          ~~
-!!! error TS2415: Class 'D1<T, U>' incorrectly extends base class 'C3<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'T'.
         foo: U; // error
+        ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
     }
     
     function f1<T, U>(x: T, y: U) {

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
@@ -1,47 +1,27 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(17,7): error TS2415: Class 'D3<T, U>' incorrectly extends base class 'C3<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'U' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(19,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(19,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(48,7): error TS2415: Class 'D8<T, U, V>' incorrectly extends base class 'C3<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'U' is not assignable to type 'T'.
-      Type 'V' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(50,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+  Type 'V' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(50,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(65,7): error TS2415: Class 'D11<T, U, V>' incorrectly extends base class 'C3<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(67,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(67,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(70,7): error TS2415: Class 'D12<T, U, V>' incorrectly extends base class 'C3<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(72,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(72,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(110,7): error TS2415: Class 'D19<T, U, V>' incorrectly extends base class 'C3<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'U' is not assignable to type 'T'.
-      Type 'V' is not assignable to type 'T'.
-        Type 'Date' is not assignable to type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(132,7): error TS2415: Class 'D23<T, U, V>' incorrectly extends base class 'C3<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'T'.
-      Type 'Date' is not assignable to type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(137,7): error TS2415: Class 'D24<T, U, V>' incorrectly extends base class 'C3<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'U'.
-      Type 'Date' is not assignable to type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(154,7): error TS2415: Class 'D27<T, U, V>' incorrectly extends base class 'C3<T>'.
-  Types of property 'foo' are incompatible.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+  Type 'V' is not assignable to type 'T'.
     Type 'Date' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
+  Type 'Date' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
+  Type 'Date' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2416: Class member of type 'Date' is not assignable to base class member of type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(159,7): error TS2415: Class 'D28<T, U, V>' incorrectly extends base class 'C3<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'Date' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(161,5): error TS2416: Class member of type 'Date' is not assignable to base class member of type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(161,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(164,7): error TS2415: Class 'D29<T, U, V>' incorrectly extends base class 'C3<V>'.
-  Types of property 'foo' are incompatible.
-    Type 'Date' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(166,5): error TS2416: Class member of type 'Date' is not assignable to base class member of type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(166,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'V'.
 
 
@@ -63,12 +43,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     }
     
     class D3<T extends U, U> extends C3<T> {
-          ~~
-!!! error TS2415: Class 'D3<T, U>' incorrectly extends base class 'C3<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'T'.
         [x: string]: T;
         foo: U; // error
+        ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
     }
@@ -100,13 +78,11 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     // test if U is a subtype of T, U, V
     // only a subtype of V and itself
     class D8<T extends U, U extends V, V> extends C3<T> {
-          ~~
-!!! error TS2415: Class 'D8<T, U, V>' incorrectly extends base class 'C3<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'T'.
-!!! error TS2415:       Type 'V' is not assignable to type 'T'.
         [x: string]: T;
         foo: U; // error
+        ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+!!! error TS2416:   Type 'V' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
     }
@@ -124,23 +100,19 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     // test if V is a subtype of T, U, V
     // only a subtype of itself
     class D11<T extends U, U extends V, V> extends C3<T> {
-          ~~~
-!!! error TS2415: Class 'D11<T, U, V>' incorrectly extends base class 'C3<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'T'.
         [x: string]: T;
         foo: V; // error
+        ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
     }
     
     class D12<T extends U, U extends V, V> extends C3<U> {
-          ~~~
-!!! error TS2415: Class 'D12<T, U, V>' incorrectly extends base class 'C3<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'U'.
         [x: string]: U;
         foo: V; // error
+        ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
     }
@@ -181,14 +153,12 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     }
     
     class D19<T extends U, U extends V, V extends Date> extends C3<T> {
-          ~~~
-!!! error TS2415: Class 'D19<T, U, V>' incorrectly extends base class 'C3<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'T'.
-!!! error TS2415:       Type 'V' is not assignable to type 'T'.
-!!! error TS2415:         Type 'Date' is not assignable to type 'T'.
         [x: string]: T;
         foo: U; // error
+        ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+!!! error TS2416:   Type 'V' is not assignable to type 'T'.
+!!! error TS2416:     Type 'Date' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
     }
@@ -211,25 +181,21 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     }
     
     class D23<T extends U, U extends V, V extends Date> extends C3<T> {
-          ~~~
-!!! error TS2415: Class 'D23<T, U, V>' incorrectly extends base class 'C3<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'T'.
-!!! error TS2415:       Type 'Date' is not assignable to type 'T'.
         [x: string]: T;
         foo: V; // error
+        ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
+!!! error TS2416:   Type 'Date' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
     }
     
     class D24<T extends U, U extends V, V extends Date> extends C3<U> {
-          ~~~
-!!! error TS2415: Class 'D24<T, U, V>' incorrectly extends base class 'C3<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'U'.
-!!! error TS2415:       Type 'Date' is not assignable to type 'U'.
         [x: string]: U;
         foo: V; // error
+        ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
+!!! error TS2416:   Type 'Date' is not assignable to type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
     }
@@ -247,34 +213,28 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     }
     
     class D27<T extends U, U extends V, V extends Date> extends C3<T> {
-          ~~~
-!!! error TS2415: Class 'D27<T, U, V>' incorrectly extends base class 'C3<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'Date' is not assignable to type 'T'.
         [x: string]: T;
         foo: Date; // error
+        ~~~
+!!! error TS2416: Class member of type 'Date' is not assignable to base class member of type 'T'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'T'.
     }
     
     class D28<T extends U, U extends V, V extends Date> extends C3<U> {
-          ~~~
-!!! error TS2415: Class 'D28<T, U, V>' incorrectly extends base class 'C3<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'Date' is not assignable to type 'U'.
         [x: string]: U;
         foo: Date; // error
+        ~~~
+!!! error TS2416: Class member of type 'Date' is not assignable to base class member of type 'U'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'U'.
     }
     
     class D29<T extends U, U extends V, V extends Date> extends C3<V> {
-          ~~~
-!!! error TS2415: Class 'D29<T, U, V>' incorrectly extends base class 'C3<V>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'Date' is not assignable to type 'V'.
         [x: string]: V;
         foo: Date; // error
+        ~~~
+!!! error TS2416: Class member of type 'Date' is not assignable to base class member of type 'V'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'V'.
     }

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
@@ -1,27 +1,37 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(19,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(19,5): error TS2416: Property 'foo' in type 'D3<T, U>' is not assignable to the same property in base type 'T'.
+  Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(19,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(50,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
-  Type 'V' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(50,5): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'T'.
+  Type 'U' is not assignable to type 'T'.
+    Type 'V' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(50,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(67,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(67,5): error TS2416: Property 'foo' in type 'D11<T, U, V>' is not assignable to the same property in base type 'T'.
+  Type 'V' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(67,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(72,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(72,5): error TS2416: Property 'foo' in type 'D12<T, U, V>' is not assignable to the same property in base type 'U'.
+  Type 'V' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(72,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2416: Property 'foo' in type 'D19<T, U, V>' is not assignable to the same property in base type 'T'.
+  Type 'U' is not assignable to type 'T'.
+    Type 'V' is not assignable to type 'T'.
+      Type 'Date' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2416: Property 'foo' in type 'D23<T, U, V>' is not assignable to the same property in base type 'T'.
   Type 'V' is not assignable to type 'T'.
     Type 'Date' is not assignable to type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
-  Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
-  Type 'Date' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2416: Property 'foo' in type 'D24<T, U, V>' is not assignable to the same property in base type 'U'.
+  Type 'V' is not assignable to type 'U'.
+    Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2416: Class member of type 'Date' is not assignable to base class member of type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2416: Property 'foo' in type 'D27<T, U, V>' is not assignable to the same property in base type 'T'.
+  Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(161,5): error TS2416: Class member of type 'Date' is not assignable to base class member of type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(161,5): error TS2416: Property 'foo' in type 'D28<T, U, V>' is not assignable to the same property in base type 'U'.
+  Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(161,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(166,5): error TS2416: Class member of type 'Date' is not assignable to base class member of type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(166,5): error TS2416: Property 'foo' in type 'D29<T, U, V>' is not assignable to the same property in base type 'V'.
+  Type 'Date' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(166,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'V'.
 
 
@@ -46,7 +56,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: U; // error
         ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+!!! error TS2416: Property 'foo' in type 'D3<T, U>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'U' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
     }
@@ -81,8 +92,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: U; // error
         ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
-!!! error TS2416:   Type 'V' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'U' is not assignable to type 'T'.
+!!! error TS2416:     Type 'V' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
     }
@@ -103,7 +115,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: V; // error
         ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
+!!! error TS2416: Property 'foo' in type 'D11<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'V' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
     }
@@ -112,7 +125,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: V; // error
         ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
+!!! error TS2416: Property 'foo' in type 'D12<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416:   Type 'V' is not assignable to type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
     }
@@ -156,9 +170,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: U; // error
         ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
-!!! error TS2416:   Type 'V' is not assignable to type 'T'.
-!!! error TS2416:     Type 'Date' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'D19<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'U' is not assignable to type 'T'.
+!!! error TS2416:     Type 'V' is not assignable to type 'T'.
+!!! error TS2416:       Type 'Date' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
     }
@@ -184,8 +199,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: V; // error
         ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
-!!! error TS2416:   Type 'Date' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'D23<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'V' is not assignable to type 'T'.
+!!! error TS2416:     Type 'Date' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
     }
@@ -194,8 +210,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: V; // error
         ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
-!!! error TS2416:   Type 'Date' is not assignable to type 'U'.
+!!! error TS2416: Property 'foo' in type 'D24<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416:   Type 'V' is not assignable to type 'U'.
+!!! error TS2416:     Type 'Date' is not assignable to type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
     }
@@ -216,7 +233,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: Date; // error
         ~~~
-!!! error TS2416: Class member of type 'Date' is not assignable to base class member of type 'T'.
+!!! error TS2416: Property 'foo' in type 'D27<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'Date' is not assignable to type 'T'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'T'.
     }
@@ -225,7 +243,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: Date; // error
         ~~~
-!!! error TS2416: Class member of type 'Date' is not assignable to base class member of type 'U'.
+!!! error TS2416: Property 'foo' in type 'D28<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416:   Type 'Date' is not assignable to type 'U'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'U'.
     }
@@ -234,7 +253,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: V;
         foo: Date; // error
         ~~~
-!!! error TS2416: Class member of type 'Date' is not assignable to base class member of type 'V'.
+!!! error TS2416: Property 'foo' in type 'D29<T, U, V>' is not assignable to the same property in base type 'V'.
+!!! error TS2416:   Type 'Date' is not assignable to type 'V'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'V'.
     }

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
@@ -1,24 +1,14 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(45,7): error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'B1<Foo>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'Foo'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'Foo'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(55,7): error TS2415: Class 'D5<T, U, V>' incorrectly extends base class 'B1<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'U' is not assignable to type 'T'.
-      Type 'Foo' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+  Type 'Foo' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(60,7): error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'B1<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(65,7): error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'B1<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'T' is not assignable to type 'U'.
-      Type 'Foo' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2416: Class member of type 'T' is not assignable to base class member of type 'U'.
+  Type 'Foo' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(75,7): error TS2415: Class 'D9<T, U, V>' incorrectly extends base class 'B1<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
 
 
@@ -68,12 +58,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     }
     
     class D3<T extends Foo, U extends Foo, V> extends B1<Foo> {
-          ~~
-!!! error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'B1<Foo>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'Foo'.
         [x: string]: Foo;
         foo: V; // error
+        ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'Foo'.
     }
@@ -84,36 +72,30 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     }
     
     class D5<T extends Foo, U extends Foo, V> extends B1<T> {
-          ~~
-!!! error TS2415: Class 'D5<T, U, V>' incorrectly extends base class 'B1<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'T'.
-!!! error TS2415:       Type 'Foo' is not assignable to type 'T'.
         [x: string]: T;
         foo: U; // error
+        ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+!!! error TS2416:   Type 'Foo' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
     }
     
     class D6<T extends Foo, U extends Foo, V> extends B1<T> {
-          ~~
-!!! error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'B1<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'T'.
         [x: string]: T;
         foo: V; // error
+        ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
     }
     
     class D7<T extends Foo, U extends Foo, V> extends B1<U> {
-          ~~
-!!! error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'B1<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'T' is not assignable to type 'U'.
-!!! error TS2415:       Type 'Foo' is not assignable to type 'U'.
         [x: string]: U;
         foo: T; // error
+        ~~~
+!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'U'.
+!!! error TS2416:   Type 'Foo' is not assignable to type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
     }
@@ -124,12 +106,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     }
     
     class D9<T extends Foo, U extends Foo, V> extends B1<U> {
-          ~~
-!!! error TS2415: Class 'D9<T, U, V>' incorrectly extends base class 'B1<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'U'.
         [x: string]: U;
         foo: V; // error
+        ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
     }

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
@@ -1,14 +1,19 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Foo'.
+  Type 'V' is not assignable to type 'Foo'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'Foo'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
-  Type 'Foo' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'T'.
+  Type 'U' is not assignable to type 'T'.
+    Type 'Foo' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'T'.
+  Type 'V' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2416: Class member of type 'T' is not assignable to base class member of type 'U'.
-  Type 'Foo' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'U'.
+  Type 'T' is not assignable to type 'U'.
+    Type 'Foo' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2416: Property 'foo' in type 'D9<T, U, V>' is not assignable to the same property in base type 'U'.
+  Type 'V' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
 
 
@@ -61,7 +66,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: Foo;
         foo: V; // error
         ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo'.
+!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Foo'.
+!!! error TS2416:   Type 'V' is not assignable to type 'Foo'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'Foo'.
     }
@@ -75,8 +81,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: U; // error
         ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
-!!! error TS2416:   Type 'Foo' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'U' is not assignable to type 'T'.
+!!! error TS2416:     Type 'Foo' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
     }
@@ -85,7 +92,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: V; // error
         ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
+!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'V' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
     }
@@ -94,8 +102,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: T; // error
         ~~~
-!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'U'.
-!!! error TS2416:   Type 'Foo' is not assignable to type 'U'.
+!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416:   Type 'T' is not assignable to type 'U'.
+!!! error TS2416:     Type 'Foo' is not assignable to type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
     }
@@ -109,7 +118,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: V; // error
         ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
+!!! error TS2416: Property 'foo' in type 'D9<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416:   Type 'V' is not assignable to type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
     }

--- a/tests/baselines/reference/subtypesOfTypeParameterWithRecursiveConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithRecursiveConstraints.errors.txt
@@ -1,74 +1,50 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(66,11): error TS2415: Class 'D2<T, U, V>' incorrectly extends base class 'Base<T>'.
-  Types of property 'foo' are incompatible.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+  Type 'Foo<T>' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
+  Type 'Foo<V>' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2416: Class member of type 'T' is not assignable to base class member of type 'U'.
+  Type 'Foo<U>' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
+  Type 'Foo<V>' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2416: Class member of type 'T' is not assignable to base class member of type 'V'.
+  Type 'Foo<U>' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2416: Class member of type 'U' is not assignable to base class member of type 'V'.
+  Type 'Foo<T>' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(115,9): error TS2416: Class member of type 'T' is not assignable to base class member of type 'Foo<T>'.
+  Type 'Foo<U>' is not assignable to type 'Foo<T>'.
     Type 'U' is not assignable to type 'T'.
       Type 'Foo<T>' is not assignable to type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(71,11): error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'Base<T>'.
-  Types of property 'foo' are incompatible.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(120,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(125,9): error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo<T>'.
+  Type 'Foo<V>' is not assignable to type 'Foo<T>'.
     Type 'V' is not assignable to type 'T'.
       Type 'Foo<V>' is not assignable to type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(76,11): error TS2415: Class 'D4<T, U, V>' incorrectly extends base class 'Base<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'T' is not assignable to type 'U'.
-      Type 'Foo<U>' is not assignable to type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(86,11): error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'Base<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'U'.
-      Type 'Foo<V>' is not assignable to type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(91,11): error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'Base<V>'.
-  Types of property 'foo' are incompatible.
-    Type 'T' is not assignable to type 'V'.
-      Type 'Foo<U>' is not assignable to type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(96,11): error TS2415: Class 'D8<T, U, V>' incorrectly extends base class 'Base<V>'.
-  Types of property 'foo' are incompatible.
-    Type 'U' is not assignable to type 'V'.
-      Type 'Foo<T>' is not assignable to type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(113,11): error TS2415: Class 'D1<T, U, V>' incorrectly extends base class 'Base2<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'T' is not assignable to type 'Foo<T>'.
-      Type 'Foo<U>' is not assignable to type 'Foo<T>'.
-        Type 'U' is not assignable to type 'T'.
-          Type 'Foo<T>' is not assignable to type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(120,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(123,11): error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'Base2<T>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'Foo<T>'.
-      Type 'Foo<V>' is not assignable to type 'Foo<T>'.
-        Type 'V' is not assignable to type 'T'.
-          Type 'Foo<V>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(125,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(130,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(133,11): error TS2415: Class 'D5<T, U, V>' incorrectly extends base class 'Base2<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'U' is not assignable to type 'Foo<U>'.
-      Type 'Foo<T>' is not assignable to type 'Foo<U>'.
-        Type 'T' is not assignable to type 'U'.
-          Type 'Foo<U>' is not assignable to type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(138,11): error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'Base2<U>'.
-  Types of property 'foo' are incompatible.
-    Type 'V' is not assignable to type 'Foo<U>'.
-      Type 'Foo<V>' is not assignable to type 'Foo<U>'.
-        Type 'V' is not assignable to type 'U'.
-          Type 'Foo<V>' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(135,9): error TS2416: Class member of type 'U' is not assignable to base class member of type 'Foo<U>'.
+  Type 'Foo<T>' is not assignable to type 'Foo<U>'.
+    Type 'T' is not assignable to type 'U'.
+      Type 'Foo<U>' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(140,9): error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo<U>'.
+  Type 'Foo<V>' is not assignable to type 'Foo<U>'.
+    Type 'V' is not assignable to type 'U'.
+      Type 'Foo<V>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(140,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(143,11): error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'Base2<V>'.
-  Types of property 'foo' are incompatible.
-    Type 'T' is not assignable to type 'Foo<V>'.
-      Type 'Foo<U>' is not assignable to type 'Foo<V>'.
-        Type 'U' is not assignable to type 'V'.
-          Type 'Foo<T>' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(145,9): error TS2416: Class member of type 'T' is not assignable to base class member of type 'Foo<V>'.
+  Type 'Foo<U>' is not assignable to type 'Foo<V>'.
+    Type 'U' is not assignable to type 'V'.
+      Type 'Foo<T>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(145,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(148,11): error TS2415: Class 'D8<T, U, V>' incorrectly extends base class 'Base2<V>'.
-  Types of property 'foo' are incompatible.
-    Type 'U' is not assignable to type 'Foo<V>'.
-      Type 'Foo<T>' is not assignable to type 'Foo<V>'.
-        Type 'T' is not assignable to type 'V'.
-          Type 'Foo<U>' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(150,9): error TS2416: Class member of type 'U' is not assignable to base class member of type 'Foo<V>'.
+  Type 'Foo<T>' is not assignable to type 'Foo<V>'.
+    Type 'T' is not assignable to type 'V'.
+      Type 'Foo<U>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(150,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
 
 
@@ -139,37 +115,31 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         }
     
         class D2<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base<T> {
-              ~~
-!!! error TS2415: Class 'D2<T, U, V>' incorrectly extends base class 'Base<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'T'.
-!!! error TS2415:       Type 'Foo<T>' is not assignable to type 'T'.
             [x: string]: T;
             foo: U
+            ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
+!!! error TS2416:   Type 'Foo<T>' is not assignable to type 'T'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
         }
     
         class D3<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base<T> {
-              ~~
-!!! error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'Base<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'T'.
-!!! error TS2415:       Type 'Foo<V>' is not assignable to type 'T'.
             [x: string]: T;
             foo: V
+            ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
+!!! error TS2416:   Type 'Foo<V>' is not assignable to type 'T'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
         }
     
         class D4<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base<U> {
-              ~~
-!!! error TS2415: Class 'D4<T, U, V>' incorrectly extends base class 'Base<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'T' is not assignable to type 'U'.
-!!! error TS2415:       Type 'Foo<U>' is not assignable to type 'U'.
             [x: string]: U;
             foo: T
+            ~~~
+!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'U'.
+!!! error TS2416:   Type 'Foo<U>' is not assignable to type 'U'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
         }
@@ -180,37 +150,31 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         }
     
         class D6<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base<U> {
-              ~~
-!!! error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'Base<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'U'.
-!!! error TS2415:       Type 'Foo<V>' is not assignable to type 'U'.
             [x: string]: U;
             foo: V
+            ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
+!!! error TS2416:   Type 'Foo<V>' is not assignable to type 'U'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
         }
     
         class D7<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base<V> {
-              ~~
-!!! error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'Base<V>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'T' is not assignable to type 'V'.
-!!! error TS2415:       Type 'Foo<U>' is not assignable to type 'V'.
             [x: string]: V;
             foo: T
+            ~~~
+!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'V'.
+!!! error TS2416:   Type 'Foo<U>' is not assignable to type 'V'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
         }
     
         class D8<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base<V> {
-              ~~
-!!! error TS2415: Class 'D8<T, U, V>' incorrectly extends base class 'Base<V>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'V'.
-!!! error TS2415:       Type 'Foo<T>' is not assignable to type 'V'.
             [x: string]: V;
             foo: U
+            ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'V'.
+!!! error TS2416:   Type 'Foo<T>' is not assignable to type 'V'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
         }
@@ -228,15 +192,13 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         }
     
         class D1<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<T> {
-              ~~
-!!! error TS2415: Class 'D1<T, U, V>' incorrectly extends base class 'Base2<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'T' is not assignable to type 'Foo<T>'.
-!!! error TS2415:       Type 'Foo<U>' is not assignable to type 'Foo<T>'.
-!!! error TS2415:         Type 'U' is not assignable to type 'T'.
-!!! error TS2415:           Type 'Foo<T>' is not assignable to type 'T'.
             [x: string]: T;
             foo: T
+            ~~~
+!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'Foo<T>'.
+!!! error TS2416:   Type 'Foo<U>' is not assignable to type 'Foo<T>'.
+!!! error TS2416:     Type 'U' is not assignable to type 'T'.
+!!! error TS2416:       Type 'Foo<T>' is not assignable to type 'T'.
         }
     
         class D2<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<T> {
@@ -247,15 +209,13 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         }
     
         class D3<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<T> {
-              ~~
-!!! error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'Base2<T>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'Foo<T>'.
-!!! error TS2415:       Type 'Foo<V>' is not assignable to type 'Foo<T>'.
-!!! error TS2415:         Type 'V' is not assignable to type 'T'.
-!!! error TS2415:           Type 'Foo<V>' is not assignable to type 'T'.
             [x: string]: T;
             foo: V
+            ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo<T>'.
+!!! error TS2416:   Type 'Foo<V>' is not assignable to type 'Foo<T>'.
+!!! error TS2416:     Type 'V' is not assignable to type 'T'.
+!!! error TS2416:       Type 'Foo<V>' is not assignable to type 'T'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
         }
@@ -268,55 +228,47 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         }
     
         class D5<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<U> {
-              ~~
-!!! error TS2415: Class 'D5<T, U, V>' incorrectly extends base class 'Base2<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'Foo<U>'.
-!!! error TS2415:       Type 'Foo<T>' is not assignable to type 'Foo<U>'.
-!!! error TS2415:         Type 'T' is not assignable to type 'U'.
-!!! error TS2415:           Type 'Foo<U>' is not assignable to type 'U'.
             [x: string]: U;
             foo: U
+            ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'Foo<U>'.
+!!! error TS2416:   Type 'Foo<T>' is not assignable to type 'Foo<U>'.
+!!! error TS2416:     Type 'T' is not assignable to type 'U'.
+!!! error TS2416:       Type 'Foo<U>' is not assignable to type 'U'.
         }
     
         class D6<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<U> {
-              ~~
-!!! error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'Base2<U>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'V' is not assignable to type 'Foo<U>'.
-!!! error TS2415:       Type 'Foo<V>' is not assignable to type 'Foo<U>'.
-!!! error TS2415:         Type 'V' is not assignable to type 'U'.
-!!! error TS2415:           Type 'Foo<V>' is not assignable to type 'U'.
             [x: string]: U;
             foo: V
+            ~~~
+!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo<U>'.
+!!! error TS2416:   Type 'Foo<V>' is not assignable to type 'Foo<U>'.
+!!! error TS2416:     Type 'V' is not assignable to type 'U'.
+!!! error TS2416:       Type 'Foo<V>' is not assignable to type 'U'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
         }
     
         class D7<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<V> {
-              ~~
-!!! error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'Base2<V>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'T' is not assignable to type 'Foo<V>'.
-!!! error TS2415:       Type 'Foo<U>' is not assignable to type 'Foo<V>'.
-!!! error TS2415:         Type 'U' is not assignable to type 'V'.
-!!! error TS2415:           Type 'Foo<T>' is not assignable to type 'V'.
             [x: string]: V;
             foo: T
+            ~~~
+!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'Foo<V>'.
+!!! error TS2416:   Type 'Foo<U>' is not assignable to type 'Foo<V>'.
+!!! error TS2416:     Type 'U' is not assignable to type 'V'.
+!!! error TS2416:       Type 'Foo<T>' is not assignable to type 'V'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
         }
     
         class D8<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<V> {
-              ~~
-!!! error TS2415: Class 'D8<T, U, V>' incorrectly extends base class 'Base2<V>'.
-!!! error TS2415:   Types of property 'foo' are incompatible.
-!!! error TS2415:     Type 'U' is not assignable to type 'Foo<V>'.
-!!! error TS2415:       Type 'Foo<T>' is not assignable to type 'Foo<V>'.
-!!! error TS2415:         Type 'T' is not assignable to type 'V'.
-!!! error TS2415:           Type 'Foo<U>' is not assignable to type 'V'.
             [x: string]: V;
             foo: U
+            ~~~
+!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'Foo<V>'.
+!!! error TS2416:   Type 'Foo<T>' is not assignable to type 'Foo<V>'.
+!!! error TS2416:     Type 'T' is not assignable to type 'V'.
+!!! error TS2416:       Type 'Foo<U>' is not assignable to type 'V'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
         }

--- a/tests/baselines/reference/subtypesOfTypeParameterWithRecursiveConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithRecursiveConstraints.errors.txt
@@ -1,50 +1,62 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
-  Type 'Foo<T>' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2416: Property 'foo' in type 'D2<T, U, V>' is not assignable to the same property in base type 'T'.
+  Type 'U' is not assignable to type 'T'.
+    Type 'Foo<T>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
-  Type 'Foo<V>' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'T'.
+  Type 'V' is not assignable to type 'T'.
+    Type 'Foo<V>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2416: Class member of type 'T' is not assignable to base class member of type 'U'.
-  Type 'Foo<U>' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2416: Property 'foo' in type 'D4<T, U, V>' is not assignable to the same property in base type 'U'.
+  Type 'T' is not assignable to type 'U'.
+    Type 'Foo<U>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
-  Type 'Foo<V>' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'U'.
+  Type 'V' is not assignable to type 'U'.
+    Type 'Foo<V>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2416: Class member of type 'T' is not assignable to base class member of type 'V'.
-  Type 'Foo<U>' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'V'.
+  Type 'T' is not assignable to type 'V'.
+    Type 'Foo<U>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2416: Class member of type 'U' is not assignable to base class member of type 'V'.
-  Type 'Foo<T>' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'V'.
+  Type 'U' is not assignable to type 'V'.
+    Type 'Foo<T>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(115,9): error TS2416: Class member of type 'T' is not assignable to base class member of type 'Foo<T>'.
-  Type 'Foo<U>' is not assignable to type 'Foo<T>'.
-    Type 'U' is not assignable to type 'T'.
-      Type 'Foo<T>' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(115,9): error TS2416: Property 'foo' in type 'D1<T, U, V>' is not assignable to the same property in base type 'Foo<T>'.
+  Type 'T' is not assignable to type 'Foo<T>'.
+    Type 'Foo<U>' is not assignable to type 'Foo<T>'.
+      Type 'U' is not assignable to type 'T'.
+        Type 'Foo<T>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(120,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(125,9): error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo<T>'.
-  Type 'Foo<V>' is not assignable to type 'Foo<T>'.
-    Type 'V' is not assignable to type 'T'.
-      Type 'Foo<V>' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(125,9): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Foo<T>'.
+  Type 'V' is not assignable to type 'Foo<T>'.
+    Type 'Foo<V>' is not assignable to type 'Foo<T>'.
+      Type 'V' is not assignable to type 'T'.
+        Type 'Foo<V>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(125,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(130,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(135,9): error TS2416: Class member of type 'U' is not assignable to base class member of type 'Foo<U>'.
-  Type 'Foo<T>' is not assignable to type 'Foo<U>'.
-    Type 'T' is not assignable to type 'U'.
-      Type 'Foo<U>' is not assignable to type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(140,9): error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo<U>'.
-  Type 'Foo<V>' is not assignable to type 'Foo<U>'.
-    Type 'V' is not assignable to type 'U'.
-      Type 'Foo<V>' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(135,9): error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'Foo<U>'.
+  Type 'U' is not assignable to type 'Foo<U>'.
+    Type 'Foo<T>' is not assignable to type 'Foo<U>'.
+      Type 'T' is not assignable to type 'U'.
+        Type 'Foo<U>' is not assignable to type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(140,9): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'Foo<U>'.
+  Type 'V' is not assignable to type 'Foo<U>'.
+    Type 'Foo<V>' is not assignable to type 'Foo<U>'.
+      Type 'V' is not assignable to type 'U'.
+        Type 'Foo<V>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(140,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(145,9): error TS2416: Class member of type 'T' is not assignable to base class member of type 'Foo<V>'.
-  Type 'Foo<U>' is not assignable to type 'Foo<V>'.
-    Type 'U' is not assignable to type 'V'.
-      Type 'Foo<T>' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(145,9): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'Foo<V>'.
+  Type 'T' is not assignable to type 'Foo<V>'.
+    Type 'Foo<U>' is not assignable to type 'Foo<V>'.
+      Type 'U' is not assignable to type 'V'.
+        Type 'Foo<T>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(145,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(150,9): error TS2416: Class member of type 'U' is not assignable to base class member of type 'Foo<V>'.
-  Type 'Foo<T>' is not assignable to type 'Foo<V>'.
-    Type 'T' is not assignable to type 'V'.
-      Type 'Foo<U>' is not assignable to type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(150,9): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'Foo<V>'.
+  Type 'U' is not assignable to type 'Foo<V>'.
+    Type 'Foo<T>' is not assignable to type 'Foo<V>'.
+      Type 'T' is not assignable to type 'V'.
+        Type 'Foo<U>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(150,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
 
 
@@ -118,8 +130,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: T;
             foo: U
             ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'T'.
-!!! error TS2416:   Type 'Foo<T>' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'D2<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'U' is not assignable to type 'T'.
+!!! error TS2416:     Type 'Foo<T>' is not assignable to type 'T'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
         }
@@ -128,8 +141,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: T;
             foo: V
             ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'T'.
-!!! error TS2416:   Type 'Foo<V>' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416:   Type 'V' is not assignable to type 'T'.
+!!! error TS2416:     Type 'Foo<V>' is not assignable to type 'T'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
         }
@@ -138,8 +152,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: U;
             foo: T
             ~~~
-!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'U'.
-!!! error TS2416:   Type 'Foo<U>' is not assignable to type 'U'.
+!!! error TS2416: Property 'foo' in type 'D4<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416:   Type 'T' is not assignable to type 'U'.
+!!! error TS2416:     Type 'Foo<U>' is not assignable to type 'U'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
         }
@@ -153,8 +168,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: U;
             foo: V
             ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'U'.
-!!! error TS2416:   Type 'Foo<V>' is not assignable to type 'U'.
+!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416:   Type 'V' is not assignable to type 'U'.
+!!! error TS2416:     Type 'Foo<V>' is not assignable to type 'U'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
         }
@@ -163,8 +179,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: V;
             foo: T
             ~~~
-!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'V'.
-!!! error TS2416:   Type 'Foo<U>' is not assignable to type 'V'.
+!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'V'.
+!!! error TS2416:   Type 'T' is not assignable to type 'V'.
+!!! error TS2416:     Type 'Foo<U>' is not assignable to type 'V'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
         }
@@ -173,8 +190,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: V;
             foo: U
             ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'V'.
-!!! error TS2416:   Type 'Foo<T>' is not assignable to type 'V'.
+!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'V'.
+!!! error TS2416:   Type 'U' is not assignable to type 'V'.
+!!! error TS2416:     Type 'Foo<T>' is not assignable to type 'V'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
         }
@@ -195,10 +213,11 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: T;
             foo: T
             ~~~
-!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'Foo<T>'.
-!!! error TS2416:   Type 'Foo<U>' is not assignable to type 'Foo<T>'.
-!!! error TS2416:     Type 'U' is not assignable to type 'T'.
-!!! error TS2416:       Type 'Foo<T>' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'D1<T, U, V>' is not assignable to the same property in base type 'Foo<T>'.
+!!! error TS2416:   Type 'T' is not assignable to type 'Foo<T>'.
+!!! error TS2416:     Type 'Foo<U>' is not assignable to type 'Foo<T>'.
+!!! error TS2416:       Type 'U' is not assignable to type 'T'.
+!!! error TS2416:         Type 'Foo<T>' is not assignable to type 'T'.
         }
     
         class D2<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<T> {
@@ -212,10 +231,11 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: T;
             foo: V
             ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo<T>'.
-!!! error TS2416:   Type 'Foo<V>' is not assignable to type 'Foo<T>'.
-!!! error TS2416:     Type 'V' is not assignable to type 'T'.
-!!! error TS2416:       Type 'Foo<V>' is not assignable to type 'T'.
+!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Foo<T>'.
+!!! error TS2416:   Type 'V' is not assignable to type 'Foo<T>'.
+!!! error TS2416:     Type 'Foo<V>' is not assignable to type 'Foo<T>'.
+!!! error TS2416:       Type 'V' is not assignable to type 'T'.
+!!! error TS2416:         Type 'Foo<V>' is not assignable to type 'T'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
         }
@@ -231,20 +251,22 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: U;
             foo: U
             ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'Foo<U>'.
-!!! error TS2416:   Type 'Foo<T>' is not assignable to type 'Foo<U>'.
-!!! error TS2416:     Type 'T' is not assignable to type 'U'.
-!!! error TS2416:       Type 'Foo<U>' is not assignable to type 'U'.
+!!! error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'Foo<U>'.
+!!! error TS2416:   Type 'U' is not assignable to type 'Foo<U>'.
+!!! error TS2416:     Type 'Foo<T>' is not assignable to type 'Foo<U>'.
+!!! error TS2416:       Type 'T' is not assignable to type 'U'.
+!!! error TS2416:         Type 'Foo<U>' is not assignable to type 'U'.
         }
     
         class D6<T extends Foo<U>, U extends Foo<T>, V extends Foo<V>> extends Base2<U> {
             [x: string]: U;
             foo: V
             ~~~
-!!! error TS2416: Class member of type 'V' is not assignable to base class member of type 'Foo<U>'.
-!!! error TS2416:   Type 'Foo<V>' is not assignable to type 'Foo<U>'.
-!!! error TS2416:     Type 'V' is not assignable to type 'U'.
-!!! error TS2416:       Type 'Foo<V>' is not assignable to type 'U'.
+!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'Foo<U>'.
+!!! error TS2416:   Type 'V' is not assignable to type 'Foo<U>'.
+!!! error TS2416:     Type 'Foo<V>' is not assignable to type 'Foo<U>'.
+!!! error TS2416:       Type 'V' is not assignable to type 'U'.
+!!! error TS2416:         Type 'Foo<V>' is not assignable to type 'U'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
         }
@@ -253,10 +275,11 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: V;
             foo: T
             ~~~
-!!! error TS2416: Class member of type 'T' is not assignable to base class member of type 'Foo<V>'.
-!!! error TS2416:   Type 'Foo<U>' is not assignable to type 'Foo<V>'.
-!!! error TS2416:     Type 'U' is not assignable to type 'V'.
-!!! error TS2416:       Type 'Foo<T>' is not assignable to type 'V'.
+!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'Foo<V>'.
+!!! error TS2416:   Type 'T' is not assignable to type 'Foo<V>'.
+!!! error TS2416:     Type 'Foo<U>' is not assignable to type 'Foo<V>'.
+!!! error TS2416:       Type 'U' is not assignable to type 'V'.
+!!! error TS2416:         Type 'Foo<T>' is not assignable to type 'V'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
         }
@@ -265,10 +288,11 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: V;
             foo: U
             ~~~
-!!! error TS2416: Class member of type 'U' is not assignable to base class member of type 'Foo<V>'.
-!!! error TS2416:   Type 'Foo<T>' is not assignable to type 'Foo<V>'.
-!!! error TS2416:     Type 'T' is not assignable to type 'V'.
-!!! error TS2416:       Type 'Foo<U>' is not assignable to type 'V'.
+!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'Foo<V>'.
+!!! error TS2416:   Type 'U' is not assignable to type 'Foo<V>'.
+!!! error TS2416:     Type 'Foo<T>' is not assignable to type 'Foo<V>'.
+!!! error TS2416:       Type 'T' is not assignable to type 'V'.
+!!! error TS2416:         Type 'Foo<U>' is not assignable to type 'V'.
             ~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
         }

--- a/tests/baselines/reference/subtypingWithObjectMembers.errors.txt
+++ b/tests/baselines/reference/subtypingWithObjectMembers.errors.txt
@@ -1,9 +1,15 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(14,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(24,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(34,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(45,9): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(55,9): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(65,9): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(14,5): error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'Base'.
+  Type 'string' is not assignable to type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(24,5): error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'Base'.
+  Type 'string' is not assignable to type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(34,5): error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'Base'.
+  Type 'string' is not assignable to type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(45,9): error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'Base'.
+  Type 'string' is not assignable to type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(55,9): error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'Base'.
+  Type 'string' is not assignable to type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(65,9): error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'Base'.
+  Type 'string' is not assignable to type 'Base'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts (6 errors) ====
@@ -22,7 +28,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         foo: Derived; // ok
         bar: string; // error
         ~~~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+!!! error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type 'string' is not assignable to type 'Base'.
     }
     
     class A2 {
@@ -34,7 +41,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         1: Derived; // ok
         2: string; // error
         ~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+!!! error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type 'string' is not assignable to type 'Base'.
     }
     
     class A3 {
@@ -46,7 +54,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         '1': Derived; // ok
         '2.0': string; // error
         ~~~~~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+!!! error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type 'string' is not assignable to type 'Base'.
     }
     
     module TwoLevels {
@@ -59,7 +68,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
             foo: Derived2; // ok
             bar: string; // error
             ~~~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+!!! error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type 'string' is not assignable to type 'Base'.
         }
     
         class A2 {
@@ -71,7 +81,8 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
             1: Derived2; // ok
             2: string; // error
             ~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+!!! error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type 'string' is not assignable to type 'Base'.
         }
     
         class A3 {
@@ -83,6 +94,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
             '1': Derived2; // ok
             '2.0': string; // error
             ~~~~~
-!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+!!! error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type 'string' is not assignable to type 'Base'.
         }
     }

--- a/tests/baselines/reference/subtypingWithObjectMembers.errors.txt
+++ b/tests/baselines/reference/subtypingWithObjectMembers.errors.txt
@@ -1,21 +1,9 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(12,7): error TS2415: Class 'B' incorrectly extends base class 'A'.
-  Types of property 'bar' are incompatible.
-    Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(22,7): error TS2415: Class 'B2' incorrectly extends base class 'A2'.
-  Types of property '2.0' are incompatible.
-    Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(32,7): error TS2415: Class 'B3' incorrectly extends base class 'A3'.
-  Types of property ''2.0'' are incompatible.
-    Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(43,11): error TS2415: Class 'B' incorrectly extends base class 'A'.
-  Types of property 'bar' are incompatible.
-    Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(53,11): error TS2415: Class 'B2' incorrectly extends base class 'A2'.
-  Types of property '2.0' are incompatible.
-    Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(63,11): error TS2415: Class 'B3' incorrectly extends base class 'A3'.
-  Types of property ''2.0'' are incompatible.
-    Type 'string' is not assignable to type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(14,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(24,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(34,5): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(45,9): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(55,9): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(65,9): error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts (6 errors) ====
@@ -31,12 +19,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
     }
     
     class B extends A {
-          ~
-!!! error TS2415: Class 'B' incorrectly extends base class 'A'.
-!!! error TS2415:   Types of property 'bar' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'Base'.
         foo: Derived; // ok
         bar: string; // error
+        ~~~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
     }
     
     class A2 {
@@ -45,12 +31,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
     }
     
     class B2 extends A2 {
-          ~~
-!!! error TS2415: Class 'B2' incorrectly extends base class 'A2'.
-!!! error TS2415:   Types of property '2.0' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'Base'.
         1: Derived; // ok
         2: string; // error
+        ~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
     }
     
     class A3 {
@@ -59,12 +43,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
     }
     
     class B3 extends A3 {
-          ~~
-!!! error TS2415: Class 'B3' incorrectly extends base class 'A3'.
-!!! error TS2415:   Types of property ''2.0'' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'Base'.
         '1': Derived; // ok
         '2.0': string; // error
+        ~~~~~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
     }
     
     module TwoLevels {
@@ -74,12 +56,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         }
     
         class B extends A {
-              ~
-!!! error TS2415: Class 'B' incorrectly extends base class 'A'.
-!!! error TS2415:   Types of property 'bar' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'Base'.
             foo: Derived2; // ok
             bar: string; // error
+            ~~~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
         }
     
         class A2 {
@@ -88,12 +68,10 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         }
     
         class B2 extends A2 {
-              ~~
-!!! error TS2415: Class 'B2' incorrectly extends base class 'A2'.
-!!! error TS2415:   Types of property '2.0' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'Base'.
             1: Derived2; // ok
             2: string; // error
+            ~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
         }
     
         class A3 {
@@ -102,11 +80,9 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         }
     
         class B3 extends A3 {
-              ~~
-!!! error TS2415: Class 'B3' incorrectly extends base class 'A3'.
-!!! error TS2415:   Types of property ''2.0'' are incompatible.
-!!! error TS2415:     Type 'string' is not assignable to type 'Base'.
             '1': Derived2; // ok
             '2.0': string; // error
+            ~~~~~
+!!! error TS2416: Class member of type 'string' is not assignable to base class member of type 'Base'.
         }
     }

--- a/tests/cases/compiler/baseClassImprovedMismatchErrors.ts
+++ b/tests/cases/compiler/baseClassImprovedMismatchErrors.ts
@@ -1,0 +1,18 @@
+class Base {
+    n: Base | string;
+    fn() {
+        return 10;
+    }
+}
+class Derived extends Base {
+    n: Derived | string;
+    fn() {
+        return 10 as number | string;
+    }
+}
+class DerivedInterface implements Base {
+    n: DerivedInterface | string;
+    fn() {
+        return 10 as number | string;
+    }
+}

--- a/tests/cases/fourslash/incompatibleOverride.ts
+++ b/tests/cases/fourslash/incompatibleOverride.ts
@@ -3,8 +3,8 @@
 // Squiggle for implementing a derived class with an incompatible override is too large
 
 //// class Foo { xyz: string; }
-//// class /*1*/Bar/*2*/ extends Foo { xyz: number; }
-//// class /*3*/Baz/*4*/ extends Foo { public xyz: number; }
+//// class Bar extends Foo { /*1*/xyz/*2*/: number; }
+//// class Baz extends Foo { public /*3*/xyz/*4*/: number; }
 //// class /*5*/Baf/*6*/ extends Foo {
 ////    constructor(public xyz: number) {
 ////       super();

--- a/tests/cases/fourslash/squiggleIllegalSubclassOverride.ts
+++ b/tests/cases/fourslash/squiggleIllegalSubclassOverride.ts
@@ -4,8 +4,8 @@
 ////    public x: number;
 ////}
 ////
-////class /*1*/Bar/*2*/ extends Foo {
-////    public x: string;
+////class Bar extends Foo {
+////    public /*1*/x/*2*/: string;
 ////}
 
 verify.errorExistsBetweenMarkers("1", "2");


### PR DESCRIPTION
If possible, this causes us to issue a diagnostic on each property which is not compatible with the base type, rather than just the class name. This should assist with identifying and correcting problem properties, since the reason for each property's mismatch will now be listed (if there are multiple which do not match).

Fixes #20980.
