### PR TITLE
Fix conflict between formatting rules

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -80,7 +80,7 @@ namespace ts.formatting {
             rule("SpaceAfterSubtractWhenFollowedByUnaryMinus", SyntaxKind.MinusToken, SyntaxKind.MinusToken, [isNonJsxSameLineTokenContext, isBinaryOpContext], RuleAction.Space),
             rule("SpaceAfterSubtractWhenFollowedByPredecrement", SyntaxKind.MinusToken, SyntaxKind.MinusMinusToken, [isNonJsxSameLineTokenContext, isBinaryOpContext], RuleAction.Space),
 
-            rule("NoSpaceAfterCloseBrace", SyntaxKind.CloseBraceToken, [SyntaxKind.CloseBracketToken, SyntaxKind.CommaToken, SyntaxKind.SemicolonToken], [isNonJsxSameLineTokenContext], RuleAction.Delete),
+            rule("NoSpaceAfterCloseBrace", SyntaxKind.CloseBraceToken, [SyntaxKind.CommaToken, SyntaxKind.SemicolonToken], [isNonJsxSameLineTokenContext], RuleAction.Delete),
             // For functions and control block place } on a new line [multi-line rule]
             rule("NewLineBeforeCloseBraceInBlockContext", anyTokenIncludingMultilineComments, SyntaxKind.CloseBraceToken, [isMultilineBlockContext], RuleAction.NewLine),
 

--- a/tests/cases/fourslash/formatInsertSpaceAfterCloseBraceBeforeCloseBracket.ts
+++ b/tests/cases/fourslash/formatInsertSpaceAfterCloseBraceBeforeCloseBracket.ts
@@ -1,0 +1,7 @@
+///<reference path="fourslash.ts"/>
+
+////[{}]
+
+format.setOption("insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets", true);
+format.document();
+verify.currentFileContentIs("[ {} ]");


### PR DESCRIPTION
Fixes #20456
"NoSpaceAfterCloseBrace" was applying unconditional preceding a `CloseBracketToken`, overriding the `insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets` option.