### PR TITLE
Make fixCannotFindModule return an empty array if there is no code action

### DIFF
--- a/src/services/codefixes/fixCannotFindModule.ts
+++ b/src/services/codefixes/fixCannotFindModule.ts
@@ -4,8 +4,10 @@ namespace ts.codefix {
     const errorCodes = [Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type.code];
     registerCodeFix({
         errorCodes,
-        getCodeActions: context => (codeAction => codeAction && [{ fixId, ...codeAction }])(
-            tryGetCodeActionForInstallPackageTypes(context.host, context.sourceFile.fileName, getModuleName(context.sourceFile, context.span.start))),
+        getCodeActions: context => {
+            const codeAction = tryGetCodeActionForInstallPackageTypes(context.host, context.sourceFile.fileName, getModuleName(context.sourceFile, context.span.start));
+            return codeAction && [{ fixId, ...codeAction }];
+        },
         fixIds: [fixId],
         getAllCodeActions: context => codeFixAll(context, errorCodes, (_, diag, commands) => {
             const pkg = getTypesPackageNameToInstall(context.host, getModuleName(diag.file, diag.start));

--- a/src/services/codefixes/fixCannotFindModule.ts
+++ b/src/services/codefixes/fixCannotFindModule.ts
@@ -4,9 +4,8 @@ namespace ts.codefix {
     const errorCodes = [Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type.code];
     registerCodeFix({
         errorCodes,
-        getCodeActions: context => [
-            { fixId, ...tryGetCodeActionForInstallPackageTypes(context.host, context.sourceFile.fileName, getModuleName(context.sourceFile, context.span.start)) }
-        ],
+        getCodeActions: context => (codeAction => codeAction ? [ { fixId, ...codeAction } ] : [])(
+            tryGetCodeActionForInstallPackageTypes(context.host, context.sourceFile.fileName, getModuleName(context.sourceFile, context.span.start))),
         fixIds: [fixId],
         getAllCodeActions: context => codeFixAll(context, errorCodes, (_, diag, commands) => {
             const pkg = getTypesPackageNameToInstall(context.host, getModuleName(diag.file, diag.start));

--- a/src/services/codefixes/fixCannotFindModule.ts
+++ b/src/services/codefixes/fixCannotFindModule.ts
@@ -4,7 +4,7 @@ namespace ts.codefix {
     const errorCodes = [Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type.code];
     registerCodeFix({
         errorCodes,
-        getCodeActions: context => (codeAction => codeAction ? [ { fixId, ...codeAction } ] : [])(
+        getCodeActions: context => (codeAction => codeAction && [{ fixId, ...codeAction }])(
             tryGetCodeActionForInstallPackageTypes(context.host, context.sourceFile.fileName, getModuleName(context.sourceFile, context.span.start))),
         fixIds: [fixId],
         getAllCodeActions: context => codeFixAll(context, errorCodes, (_, diag, commands) => {


### PR DESCRIPTION
Don't send a code action containing just a `fixId`.  Among other things, VS crashes if there's no description.