### PR TITLE
add fixAwaitInSyncFunction code fix

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3845,7 +3845,7 @@
     },
     "Convert to async": {
         "category": "Message",
-        "code": 90028
+        "code": 90029
     },
     "Convert function to an ES2015 class": {
         "category": "Message",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3843,6 +3843,10 @@
         "category": "Message",
         "code": 90028
     },
+    "Convert to async": {
+        "category": "Message",
+        "code": 90028
+    },
     "Convert function to an ES2015 class": {
         "category": "Message",
         "code": 95001

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3843,7 +3843,7 @@
         "category": "Message",
         "code": 90028
     },
-    "Convert to async": {
+    "Add async modifier to containing function": {
         "category": "Message",
         "code": 90029
     },

--- a/src/services/codefixes/fixAwaitInSyncFunction.ts
+++ b/src/services/codefixes/fixAwaitInSyncFunction.ts
@@ -1,0 +1,52 @@
+/* @internal */
+namespace ts.codefix {
+    const fixId = "fixAwaitInSyncFunction";
+    const errorCodes = [
+        Diagnostics.await_expression_is_only_allowed_within_an_async_function.code,
+        Diagnostics.A_for_await_of_statement_is_only_allowed_within_an_async_function_or_async_generator.code,
+    ];
+    registerCodeFix({
+        errorCodes,
+        getCodeActions(context) {
+            const { sourceFile, span } = context;
+            const node = getNode(sourceFile, span.start);
+            if (!node) return undefined;
+            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, node));
+            return [{ description: getLocaleSpecificMessage(Diagnostics.Convert_to_async), changes, fixId }];
+        },
+        fixIds: [fixId],
+        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) =>
+            doChange(changes, context.sourceFile, getNode(diag.file, diag.start!))),
+    });
+
+    function getNode(sourceFile: SourceFile, pos: number): FunctionLikeDeclaration {
+        const token = getTokenAtPosition(sourceFile, pos, /*includeJsDocComment*/ false);
+        const containingFunction = getContainingFunction(token);
+        if (!isFunctionLikeDeclaration(containingFunction) ||
+            isConstructorDeclaration(containingFunction) ||
+            isGetAccessorDeclaration(containingFunction) ||
+            isSetAccessorDeclaration(containingFunction)) return;
+        return containingFunction;
+    }
+
+    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, decl: FunctionLikeDeclaration) {
+        const asyncToken = createToken(SyntaxKind.AsyncKeyword);
+        const modifiers = decl.modifiers ? decl.modifiers.concat(asyncToken) : createNodeArray([asyncToken]);
+        let changed;
+        switch (decl.kind) {
+            case SyntaxKind.MethodDeclaration:
+                changed = createMethod(decl.decorators, modifiers, decl.asteriskToken, decl.name, decl.questionToken, decl.typeParameters, decl.parameters, decl.type, decl.body);
+                break;
+            case SyntaxKind.FunctionExpression:
+                changed = createFunctionExpression(modifiers, decl.asteriskToken, decl.name, decl.typeParameters, decl.parameters, decl.type, decl.body);
+                break;
+            case SyntaxKind.FunctionDeclaration:
+                changed = createFunctionDeclaration(decl.decorators, modifiers, decl.asteriskToken, decl.name, decl.typeParameters, decl.parameters, decl.type, decl.body);
+                break;
+            case SyntaxKind.ArrowFunction:
+                changed = createArrowFunction(modifiers, decl.typeParameters, decl.parameters, decl.type, decl.equalsGreaterThanToken, decl.body);
+                break;
+        }
+        changes.replaceNode(sourceFile, decl, changed);
+    }
+}

--- a/src/services/codefixes/fixAwaitInSyncFunction.ts
+++ b/src/services/codefixes/fixAwaitInSyncFunction.ts
@@ -12,7 +12,7 @@ namespace ts.codefix {
             const nodes = getNodes(sourceFile, span.start);
             if (!nodes) return undefined;
             const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, nodes));
-            return [{ description: getLocaleSpecificMessage(Diagnostics.Convert_to_async), changes, fixId }];
+            return [{ description: getLocaleSpecificMessage(Diagnostics.Add_async_modifier_to_containing_function), changes, fixId }];
         },
         fixIds: [fixId],
         getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {

--- a/src/services/codefixes/fixAwaitInSyncFunction.ts
+++ b/src/services/codefixes/fixAwaitInSyncFunction.ts
@@ -9,19 +9,42 @@ namespace ts.codefix {
         errorCodes,
         getCodeActions(context) {
             const { sourceFile, span } = context;
-            const node = getNodeToInsertBefore(sourceFile, span.start);
-            if (!node) return undefined;
-            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, node));
+            const token = getTokenAtPosition(sourceFile, span.start, /*includeJsDocComment*/ false);
+            const containingFunction = getContainingFunction(token);
+            const insertBefore = getNodeToInsertBefore(sourceFile, containingFunction);
+            const returnType = getReturnTypeNode(containingFunction);
+            if (!insertBefore) return undefined;
+            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, insertBefore, returnType));
             return [{ description: getLocaleSpecificMessage(Diagnostics.Convert_to_async), changes, fixId }];
         },
         fixIds: [fixId],
-        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) =>
-            doChange(changes, context.sourceFile, getNodeToInsertBefore(diag.file, diag.start!))),
+        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {
+            const token = getTokenAtPosition(diag.file, diag.start!, /*includeJsDocComment*/ false);
+            const containingFunction = getContainingFunction(token);
+            const insertBefore = getNodeToInsertBefore(diag.file, containingFunction);
+            const returnType = getReturnTypeNode(containingFunction);
+            if (insertBefore) {
+                doChange(changes, context.sourceFile, insertBefore, returnType);
+            }
+        }),
     });
 
-    function getNodeToInsertBefore(sourceFile: SourceFile, pos: number): Node | undefined {
-        const token = getTokenAtPosition(sourceFile, pos, /*includeJsDocComment*/ false);
-        const containingFunction = getContainingFunction(token);
+    function getReturnTypeNode(containingFunction: FunctionLike): TypeNode | undefined {
+        switch (containingFunction.kind) {
+            case SyntaxKind.MethodDeclaration:
+            case SyntaxKind.FunctionDeclaration:
+                return containingFunction.type;
+            case SyntaxKind.FunctionExpression:
+            case SyntaxKind.ArrowFunction:
+                if (isVariableDeclaration(containingFunction.parent) &&
+                    containingFunction.parent.type &&
+                    isFunctionTypeNode(containingFunction.parent.type)) {
+                    return containingFunction.parent.type.type;
+                }
+        }
+    }
+
+    function getNodeToInsertBefore(sourceFile: SourceFile, containingFunction: FunctionLike): Node | undefined {
         switch (containingFunction.kind) {
             case SyntaxKind.MethodDeclaration:
                 return containingFunction.name;
@@ -35,7 +58,13 @@ namespace ts.codefix {
         }
     }
 
-    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, insertBefore: Node): void {
+    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, insertBefore: Node, returnType: TypeNode | undefined): void {
+        if (returnType) {
+            const entityName = getEntityNameFromTypeNode(returnType);
+            if (!entityName || entityName.getText() !== "Promise") {
+                changes.replaceNode(sourceFile, returnType, createTypeReferenceNode("Promise", createNodeArray([returnType])));
+            }
+        }
         changes.insertModifierBefore(sourceFile, SyntaxKind.AsyncKeyword, insertBefore);
     }
 }

--- a/src/services/codefixes/fixAwaitInSyncFunction.ts
+++ b/src/services/codefixes/fixAwaitInSyncFunction.ts
@@ -19,7 +19,7 @@ namespace ts.codefix {
             doChange(changes, context.sourceFile, getNodeToInsertBefore(diag.file, diag.start!))),
     });
 
-    function getNodeToInsertBefore(sourceFile: SourceFile, pos: number): Node | undefined {//name
+    function getNodeToInsertBefore(sourceFile: SourceFile, pos: number): Node | undefined {
         const token = getTokenAtPosition(sourceFile, pos, /*includeJsDocComment*/ false);
         const containingFunction = getContainingFunction(token);
         switch (containingFunction.kind) {

--- a/src/services/codefixes/fixes.ts
+++ b/src/services/codefixes/fixes.ts
@@ -11,6 +11,7 @@
 /// <reference path="fixForgottenThisPropertyAccess.ts" />
 /// <reference path='fixUnusedIdentifier.ts' />
 /// <reference path='fixJSDocTypes.ts' />
+/// <reference path='fixAwaitInSyncFunction.ts' />
 /// <reference path='importFixes.ts' />
 /// <reference path='disableJsDiagnostics.ts' />
 /// <reference path='helpers.ts' />

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -345,6 +345,11 @@ namespace ts.textChanges {
             return this.replaceWithSingle(sourceFile, startPosition, startPosition, newNode, this.getOptionsForInsertNodeBefore(before, blankLineBetween));
         }
 
+        public insertModifierBefore(sourceFile: SourceFile, modifier: SyntaxKind, before: Node): void {
+            const pos = before.getStart(sourceFile);
+            this.replaceWithSingle(sourceFile, pos, pos, createToken(modifier), { suffix: " " });
+        }
+
         public changeIdentifierToPropertyAccess(sourceFile: SourceFile, prefix: string, node: Identifier): void {
             const startPosition = getAdjustedStartPosition(sourceFile, node, {}, Position.Start);
             this.replaceWithSingle(sourceFile, startPosition, startPosition, createPropertyAccess(createIdentifier(prefix), ""), {});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction1.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction1.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+////function f() {
+////    await Promise.resolve();
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    index: 0,
+    newFileContent:
+`async function f() {\r
+    await Promise.resolve();\r
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction1.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction1.ts
@@ -6,9 +6,8 @@
 
 verify.codeFix({
     description: "Convert to async",
-    index: 0,
     newFileContent:
-`async function f() {\r
-    await Promise.resolve();\r
+`async function f() {
+    await Promise.resolve();
 }`,
 });

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction1.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction1.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `async function f() {
     await Promise.resolve();

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction10.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction10.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f: () => Promise<number | string> = async () => {
     await Promise.resolve('foo');

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction10.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction10.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////const f: () => number | string = () => {
+////    await Promise.resolve('foo');
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`const f: () => Promise<number | string> = async () => {
+    await Promise.resolve('foo');
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction11.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction11.ts
@@ -6,7 +6,7 @@
 
 // should not change type if it's incorrectly set
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f: string = async () => {
     await Promise.resolve('foo');

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction11.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction11.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+////const f: string = () => {
+////    await Promise.resolve('foo');
+////}
+
+// should not change type if it's incorrectly set
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`const f: string = async () => {
+    await Promise.resolve('foo');
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction12.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction12.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////const f: () => Array<number | string> = function() {
+////    await Promise.resolve([]);
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`const f: () => Promise<Array<number | string>> = async function() {
+    await Promise.resolve([]);
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction12.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction12.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f: () => Promise<Array<number | string>> = async function() {
     await Promise.resolve([]);

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction13.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction13.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f: () => Promise<number | string> = async () => {
     await Promise.resolve('foo');

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction13.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction13.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////const f: () => Promise<number | string> = () => {
+////    await Promise.resolve('foo');
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`const f: () => Promise<number | string> = async () => {
+    await Promise.resolve('foo');
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction14.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction14.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////const f = function(): number {
+////    await Promise.resolve(1);
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`const f = async function(): Promise<number> {
+    await Promise.resolve(1);
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction14.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction14.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f = async function(): Promise<number> {
     await Promise.resolve(1);

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction15.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction15.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f = async (): Promise<number[]> => {
     await Promise.resolve([1]);

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction15.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction15.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////const f = (): number[] => {
+////    await Promise.resolve([1]);
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`const f = async (): Promise<number[]> => {
+    await Promise.resolve([1]);
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction2.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction2.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+////const f = function() {
+////    await Promise.resolve();
+////    await Promise.resolve();
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    index: 0,
+    newFileContent:
+`const f = async function() {\r
+    await Promise.resolve();\r
+    await Promise.resolve();\r
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction2.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction2.ts
@@ -7,10 +7,9 @@
 
 verify.codeFix({
     description: "Convert to async",
-    index: 0,
     newFileContent:
-`const f = async function() {\r
-    await Promise.resolve();\r
-    await Promise.resolve();\r
+`const f = async function() {
+    await Promise.resolve();
+    await Promise.resolve();
 }`,
 });

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction2.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction2.ts
@@ -2,14 +2,12 @@
 
 ////const f = function() {
 ////    await Promise.resolve();
-////    await Promise.resolve();
 ////}
 
 verify.codeFix({
     description: "Convert to async",
     newFileContent:
 `const f = async function() {
-    await Promise.resolve();
     await Promise.resolve();
 }`,
 });

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction2.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction2.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f = async function() {
     await Promise.resolve();

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction3.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction3.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts' />
+
+////const f = {
+////    get a() {
+////        return await Promise.resolve();
+////    },
+////    get a() {
+////        await Promise.resolve();
+////    },
+////}
+
+verify.not.codeFixAvailable();

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction4.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction4.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+////class Foo {
+////    constructor {
+////        await Promise.resolve();
+////    }
+////}
+
+verify.not.codeFixAvailable();

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction5.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction5.ts
@@ -8,10 +8,10 @@
 
 verify.codeFix({
     description: "Convert to async",
-    index: 0,
     newFileContent:
 `class Foo {
-    async bar() {\r
-        await Promise.resolve();\r
-    }}`,
+    async bar() {
+        await Promise.resolve();
+    }
+}`,
 });

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction5.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction5.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+////class Foo {
+////    bar() {
+////        await Promise.resolve();
+////    }
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    index: 0,
+    newFileContent:
+`class Foo {
+    async bar() {\r
+        await Promise.resolve();\r
+    }}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction5.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction5.ts
@@ -7,7 +7,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `class Foo {
     async bar() {

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction6.5.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction6.5.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////const f = promise => {
+////    await promise;
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`const f = async promise => {
+    await promise;
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction6.5.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction6.5.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f = async promise => {
     await promise;

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction6.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction6.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+////const f = (promise) => {
+////    await promise;
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    index: 0,
+    newFileContent:
+`const f = async (promise) => {\r
+    await promise;\r
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction6.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction6.ts
@@ -6,9 +6,8 @@
 
 verify.codeFix({
     description: "Convert to async",
-    index: 0,
     newFileContent:
-`const f = async (promise) => {\r
-    await promise;\r
+`const f = async (promise) => {
+    await promise;
 }`,
 });

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction6.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction6.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `const f = async (promise) => {
     await promise;

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction7.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction7.ts
@@ -8,11 +8,10 @@
 
 verify.codeFix({
     description: "Convert to async",
-    index: 0,
     newFileContent:
-`function f() => {\r
-    for await (const x of g()) {\r
-        console.log(x);\r
-    }\r
+`async function f() {
+    for await (const x of g()) {
+        console.log(x);
+    }
 }`,
 });

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction7.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction7.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+////function f() {
+////    for await (const x of g()) {
+////        console.log(x);
+////    }
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    index: 0,
+    newFileContent:
+`function f() => {\r
+    for await (const x of g()) {\r
+        console.log(x);\r
+    }\r
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction7.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction7.ts
@@ -7,7 +7,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `async function f() {
     for await (const x of g()) {

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction8.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction8.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////function f(): number | string {
+////    await Promise.resolve(8);
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`async function f(): Promise<number | string> {
+    await Promise.resolve(8);
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction8.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction8.ts
@@ -5,7 +5,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `async function f(): Promise<number | string> {
     await Promise.resolve(8);

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction9.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction9.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+////class Foo {
+////    bar(): string {
+////        await Promise.resolve('baz');
+////    }
+////}
+
+verify.codeFix({
+    description: "Convert to async",
+    newFileContent:
+`class Foo {
+    async bar(): Promise<string> {
+        await Promise.resolve('baz');
+    }
+}`,
+});

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction9.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction9.ts
@@ -7,7 +7,7 @@
 ////}
 
 verify.codeFix({
-    description: "Convert to async",
+    description: "Add async modifier to containing function",
     newFileContent:
 `class Foo {
     async bar(): Promise<string> {

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction_all.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction_all.ts
@@ -11,10 +11,11 @@
 verify.codeFixAll({
     fixId: "fixAwaitInSyncFunction",
     newFileContent:
-`async function f() {\r
-    await Promise.resolve();\r
+`async function f() {
+    await Promise.resolve();
 }
-const g = async () => {\r
-    await f();\r
+
+const g = async () => {
+    await f();
 }`,
 });

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction_all.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction_all.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////function f() {
+////    await Promise.resolve();
+////}
+////
+////const g = () => {
+////    await f();
+////}
+
+verify.codeFixAll({
+    fixId: "fixAwaitInSyncFunction",
+    newFileContent:
+`async function f() {\r
+    await Promise.resolve();\r
+}
+const g = async () => {\r
+    await f();\r
+}`,
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #21034

This is pretty straightforward, replacing function expressions/declarations, method declarations and arrow functions with corresponding ones with the async modifier. 

There are 2 issues that I need some help with:

**1.** Replacing the entire node seems to omit the line break at the end of the replaced node. So that this:

```
class Foo {
    bar() {
        await Promise.resolve();
    }
}
```
Becomes:
```
class Foo {
    async bar() {
        await Promise.resolve();
    }}
```

This happens both in the unit tests, and in manual e2e testing with vscode.

**2.** `codeFixAwaitInSyncFunction7`, the test case of an `for-await-of` loop, fails - 

```
  tests/cases/fourslash/codeFixAwaitInSyncFunction7.ts
         fourslash test codeFixAwaitInSyncFunction7.ts runs correctly:
     Error: Debug Failure. False expression: Token end is child end
      at processChildNode (src\services\formatting\formatting.ts:704:27)
      at src\services\formatting\formatting.ts:629:21
      at visitNode (src\compiler\parser.ts:38:24)
      at Object.forEachChild (src\compiler\parser.ts:285:24)
      at processNode (src\services\formatting\formatting.ts:626:13)
      at processChildNode (src\services\formatting\formatting.ts:712:17)
      at processChildNodes (src\services\formatting\formatting.ts:767:44)
      at src\services\formatting\formatting.ts:632:21
      at visitNodes (src\compiler\parser.ts:44:24)
      at Object.forEachChild (src\compiler\parser.ts:253:24)
      at processNode (src\services\formatting\formatting.ts:626:13)
      at processChildNode (src\services\formatting\formatting.ts:712:17)
      at src\services\formatting\formatting.ts:629:21
      at visitNode (src\compiler\parser.ts:38:24)
      at Object.forEachChild (src\compiler\parser.ts:160:21)
      at processNode (src\services\formatting\formatting.ts:626:13)
      at formatSpanWorker (src\services\formatting\formatting.ts:416:13)
      at src\services\formatting\formatting.ts:346:108
      at Object.getFormattingScanner (src\services\formatting\formattingScanner.ts:41:21)
```

I tried to debug this for a while, but nothing conclusive. This does not happen when I use the compiled tsserver.js in vscode to test the code fix.
  