### PR TITLE
Apply 'align' lint rule

### DIFF
--- a/scripts/tslint/rules/align2Rule.ts
+++ b/scripts/tslint/rules/align2Rule.ts
@@ -1,0 +1,97 @@
+// Based on https://github.com/palantir/tslint/blob/master/src/rules/alignRule.ts
+// Has code to count a comment at the beginning of a line as the start of that line
+
+import * as ts from "typescript";
+
+import * as Lint from "tslint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new AlignWalker(sourceFile, this.ruleName, undefined));
+    }
+}
+
+class AlignWalker extends Lint.AbstractWalker<void> {
+    public walk(sourceFile: ts.SourceFile) {
+        const cb = (node: ts.Node): void => {
+            switch (node.kind) {
+                case ts.SyntaxKind.SourceFile:
+                case ts.SyntaxKind.ModuleBlock:
+                case ts.SyntaxKind.Block:
+                case ts.SyntaxKind.CaseClause:
+                case ts.SyntaxKind.DefaultClause:
+                    this.checkAlignment((node as ts.SourceFile | ts.ModuleBlock | ts.Block | ts.CaseClause | ts.DefaultClause).statements.filter((s) => s.kind !== ts.SyntaxKind.EmptyStatement));
+                    break;
+                case ts.SyntaxKind.ArrayLiteralExpression:
+                case ts.SyntaxKind.ArrayBindingPattern:
+                    this.checkAlignment((node as ts.ArrayBindingOrAssignmentPattern).elements);
+                    break;
+                case ts.SyntaxKind.TupleType:
+                    this.checkAlignment((node as ts.TupleTypeNode).elementTypes);
+                    break;
+                case ts.SyntaxKind.ObjectLiteralExpression:
+                    this.checkAlignment((node as ts.ObjectLiteralExpression).properties);
+                    break;
+                case ts.SyntaxKind.ObjectBindingPattern:
+                    this.checkAlignment((node as ts.ObjectBindingPattern).elements);
+                    break;
+                case ts.SyntaxKind.ClassDeclaration:
+                case ts.SyntaxKind.ClassExpression:
+                    this.checkAlignment((node as ts.ClassLikeDeclaration).members.filter((m) => m.kind !== ts.SyntaxKind.SemicolonClassElement));
+                    break;
+                case ts.SyntaxKind.InterfaceDeclaration:
+                case ts.SyntaxKind.TypeLiteral:
+                    this.checkAlignment((node as ts.InterfaceDeclaration | ts.TypeLiteralNode).members);
+            }
+            return ts.forEachChild(node, cb);
+        };
+        return cb(sourceFile);
+    }
+
+    private checkAlignment(nodes: ReadonlyArray<ts.Node>) {
+        if (nodes.length <= 1) {
+            return;
+        }
+        const sourceFile = this.sourceFile;
+
+        let pos = this.getStart(nodes[0]).lineAndChar;
+        const alignToColumn = pos.character;
+        let line = pos.line;
+
+        // skip first node in list
+        for (let i = 1; i < nodes.length; ++i) {
+            const node = nodes[i];
+            const { pos: start, lineAndChar } = this.getStart(node);
+            pos = lineAndChar;
+            if (line !== pos.line && pos.character !== alignToColumn) {
+                const diff = alignToColumn - pos.character;
+                let fix: Lint.Fix | undefined;
+                if (diff >= 0) {
+                    fix = Lint.Replacement.appendText(start, " ".repeat(diff));
+                }
+                else if (node.pos <= start + diff && /^\s+$/.test(sourceFile.text.substring(start + diff, start))) {
+                    // only delete text if there is only whitespace
+                    fix = Lint.Replacement.deleteText(start + diff, -diff);
+                }
+                this.addFailure(start, Math.max(node.end, start), "Lines are not aligned.", fix);
+            }
+            line = pos.line;
+        }
+    }
+
+    private getStart(node: ts.Node): { pos: number, lineAndChar: ts.LineAndCharacter } {
+        const start = node.getStart(this.sourceFile);
+        const lineAndChar = ts.getLineAndCharacterOfPosition(this.sourceFile, start);
+        const ranges = ts.getLeadingCommentRanges(this.sourceFile.text, node.pos);
+        if (ranges) {
+            const last = ranges[ranges.length - 1];
+            if (last.kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+                const commentLc = ts.getLineAndCharacterOfPosition(this.sourceFile, last.pos);
+                if (commentLc.line === lineAndChar.line) {
+                    return { pos: last.pos, lineAndChar: commentLc };
+                }
+            }
+        }
+        return { pos: start, lineAndChar };
+    }
+}

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -19,7 +19,7 @@ namespace ts {
         cancellationToken?: CancellationToken, customTransformers?: CustomTransformers): EmitOutput {
         const outputFiles: OutputFile[] = [];
         const emitResult = program.emit(sourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
-            return { outputFiles, emitSkipped: emitResult.emitSkipped };
+        return { outputFiles, emitSkipped: emitResult.emitSkipped };
 
         function writeFile(fileName: string, text: string, writeByteOrderMark: boolean) {
             outputFiles.push({ name: fileName, writeByteOrderMark, text });

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15744,7 +15744,7 @@ namespace ts {
             if (flags & ModifierFlags.Static) {
                 return true;
             }
-             if (type.flags & TypeFlags.TypeParameter) {
+            if (type.flags & TypeFlags.TypeParameter) {
                 // get the original type -- represented as the type constraint of the 'this' type
                 type = (type as TypeParameter).isThisType ? getConstraintOfTypeParameter(<TypeParameter>type) : getBaseConstraintOfType(<TypeParameter>type);
             }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -398,9 +398,9 @@ namespace ts {
             ch === CharacterCodes.mathematicalSpace ||
             ch === CharacterCodes.ideographicSpace ||
             ch === CharacterCodes.byteOrderMark;
-      }
+    }
 
-      export function isLineBreak(ch: number): boolean {
+    export function isLineBreak(ch: number): boolean {
           // ES5 7.3:
           // The ECMAScript line terminator characters are listed in Table 3.
           //     Table 3: Line Terminator Characters
@@ -416,124 +416,124 @@ namespace ts {
               ch === CharacterCodes.carriageReturn ||
               ch === CharacterCodes.lineSeparator ||
               ch === CharacterCodes.paragraphSeparator;
-      }
+    }
 
-      function isDigit(ch: number): boolean {
-          return ch >= CharacterCodes._0 && ch <= CharacterCodes._9;
-      }
+    function isDigit(ch: number): boolean {
+        return ch >= CharacterCodes._0 && ch <= CharacterCodes._9;
+    }
 
-      /* @internal */
-      export function isOctalDigit(ch: number): boolean {
-          return ch >= CharacterCodes._0 && ch <= CharacterCodes._7;
-      }
+    /* @internal */
+    export function isOctalDigit(ch: number): boolean {
+        return ch >= CharacterCodes._0 && ch <= CharacterCodes._7;
+    }
 
-      export function couldStartTrivia(text: string, pos: number): boolean {
-          // Keep in sync with skipTrivia
-          const ch = text.charCodeAt(pos);
-          switch (ch) {
-              case CharacterCodes.carriageReturn:
-              case CharacterCodes.lineFeed:
-              case CharacterCodes.tab:
-              case CharacterCodes.verticalTab:
-              case CharacterCodes.formFeed:
-              case CharacterCodes.space:
-              case CharacterCodes.slash:
-                  // starts of normal trivia
-              case CharacterCodes.lessThan:
-              case CharacterCodes.bar:
-              case CharacterCodes.equals:
-              case CharacterCodes.greaterThan:
-                  // Starts of conflict marker trivia
-                  return true;
-              case CharacterCodes.hash:
-                  // Only if its the beginning can we have #! trivia
-                  return pos === 0;
-              default:
-                  return ch > CharacterCodes.maxAsciiCharacter;
-          }
-      }
+    export function couldStartTrivia(text: string, pos: number): boolean {
+        // Keep in sync with skipTrivia
+        const ch = text.charCodeAt(pos);
+        switch (ch) {
+            case CharacterCodes.carriageReturn:
+            case CharacterCodes.lineFeed:
+            case CharacterCodes.tab:
+            case CharacterCodes.verticalTab:
+            case CharacterCodes.formFeed:
+            case CharacterCodes.space:
+            case CharacterCodes.slash:
+                // starts of normal trivia
+            case CharacterCodes.lessThan:
+            case CharacterCodes.bar:
+            case CharacterCodes.equals:
+            case CharacterCodes.greaterThan:
+                // Starts of conflict marker trivia
+                return true;
+            case CharacterCodes.hash:
+                // Only if its the beginning can we have #! trivia
+                return pos === 0;
+            default:
+                return ch > CharacterCodes.maxAsciiCharacter;
+        }
+    }
 
-      /* @internal */
-      export function skipTrivia(text: string, pos: number, stopAfterLineBreak?: boolean, stopAtComments = false): number {
-          if (positionIsSynthesized(pos)) {
-              return pos;
-          }
+    /* @internal */
+    export function skipTrivia(text: string, pos: number, stopAfterLineBreak?: boolean, stopAtComments = false): number {
+        if (positionIsSynthesized(pos)) {
+            return pos;
+        }
 
-          // Keep in sync with couldStartTrivia
-          while (true) {
-              const ch = text.charCodeAt(pos);
-              switch (ch) {
-                  case CharacterCodes.carriageReturn:
-                      if (text.charCodeAt(pos + 1) === CharacterCodes.lineFeed) {
-                          pos++;
-                      }
-                      // falls through
-                  case CharacterCodes.lineFeed:
-                      pos++;
-                      if (stopAfterLineBreak) {
-                          return pos;
-                      }
-                      continue;
-                  case CharacterCodes.tab:
-                  case CharacterCodes.verticalTab:
-                  case CharacterCodes.formFeed:
-                  case CharacterCodes.space:
-                      pos++;
-                      continue;
-                  case CharacterCodes.slash:
-                      if (stopAtComments) {
-                          break;
-                      }
-                      if (text.charCodeAt(pos + 1) === CharacterCodes.slash) {
-                          pos += 2;
-                          while (pos < text.length) {
-                              if (isLineBreak(text.charCodeAt(pos))) {
-                                  break;
-                              }
-                              pos++;
-                          }
-                          continue;
-                      }
-                      if (text.charCodeAt(pos + 1) === CharacterCodes.asterisk) {
-                          pos += 2;
-                          while (pos < text.length) {
-                              if (text.charCodeAt(pos) === CharacterCodes.asterisk && text.charCodeAt(pos + 1) === CharacterCodes.slash) {
-                                  pos += 2;
-                                  break;
-                              }
-                              pos++;
-                          }
-                          continue;
-                      }
-                      break;
+        // Keep in sync with couldStartTrivia
+        while (true) {
+            const ch = text.charCodeAt(pos);
+            switch (ch) {
+                case CharacterCodes.carriageReturn:
+                    if (text.charCodeAt(pos + 1) === CharacterCodes.lineFeed) {
+                        pos++;
+                    }
+                    // falls through
+                case CharacterCodes.lineFeed:
+                    pos++;
+                    if (stopAfterLineBreak) {
+                        return pos;
+                    }
+                    continue;
+                case CharacterCodes.tab:
+                case CharacterCodes.verticalTab:
+                case CharacterCodes.formFeed:
+                case CharacterCodes.space:
+                    pos++;
+                    continue;
+                case CharacterCodes.slash:
+                    if (stopAtComments) {
+                        break;
+                    }
+                    if (text.charCodeAt(pos + 1) === CharacterCodes.slash) {
+                        pos += 2;
+                        while (pos < text.length) {
+                            if (isLineBreak(text.charCodeAt(pos))) {
+                                break;
+                            }
+                            pos++;
+                        }
+                        continue;
+                    }
+                    if (text.charCodeAt(pos + 1) === CharacterCodes.asterisk) {
+                        pos += 2;
+                        while (pos < text.length) {
+                            if (text.charCodeAt(pos) === CharacterCodes.asterisk && text.charCodeAt(pos + 1) === CharacterCodes.slash) {
+                                pos += 2;
+                                break;
+                            }
+                            pos++;
+                        }
+                        continue;
+                    }
+                    break;
 
-                  case CharacterCodes.lessThan:
-                  case CharacterCodes.bar:
-                  case CharacterCodes.equals:
-                  case CharacterCodes.greaterThan:
-                      if (isConflictMarkerTrivia(text, pos)) {
-                          pos = scanConflictMarkerTrivia(text, pos);
-                          continue;
-                      }
-                      break;
+                case CharacterCodes.lessThan:
+                case CharacterCodes.bar:
+                case CharacterCodes.equals:
+                case CharacterCodes.greaterThan:
+                    if (isConflictMarkerTrivia(text, pos)) {
+                        pos = scanConflictMarkerTrivia(text, pos);
+                        continue;
+                    }
+                    break;
 
-                  case CharacterCodes.hash:
-                      if (pos === 0 && isShebangTrivia(text, pos)) {
-                          pos = scanShebangTrivia(text, pos);
-                          continue;
-                      }
-                      break;
+                case CharacterCodes.hash:
+                    if (pos === 0 && isShebangTrivia(text, pos)) {
+                        pos = scanShebangTrivia(text, pos);
+                        continue;
+                    }
+                    break;
 
-                  default:
-                      if (ch > CharacterCodes.maxAsciiCharacter && (isWhiteSpaceLike(ch))) {
-                          pos++;
-                          continue;
-                      }
-                      break;
-              }
-              return pos;
-          }
-      }
+                default:
+                    if (ch > CharacterCodes.maxAsciiCharacter && (isWhiteSpaceLike(ch))) {
+                        pos++;
+                        continue;
+                    }
+                    break;
+            }
+            return pos;
+        }
+    }
 
       // All conflict markers consist of the same character repeated seven times.  If it is
       // a <<<<<<< or >>>>>>> marker then it is also followed by a space.

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1174,7 +1174,7 @@ namespace ts {
             && (<PropertyAccessExpression | ElementAccessExpression>node).expression.kind === SyntaxKind.ThisKeyword;
     }
 
-   export function getEntityNameFromTypeNode(node: TypeNode): EntityNameOrEntityNameExpression {
+    export function getEntityNameFromTypeNode(node: TypeNode): EntityNameOrEntityNameExpression {
         switch (node.kind) {
             case SyntaxKind.TypeReference:
                 return (<TypeReferenceNode>node).typeName;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -3777,7 +3777,7 @@ namespace FourSlashInterface {
 
         public eachMarker(markers: ReadonlyArray<string>, action: (marker: FourSlash.Marker, index: number) => void): void;
         public eachMarker(action: (marker: FourSlash.Marker, index: number) => void): void;
-        public eachMarker(a: ReadonlyArray<string> | ((marker: FourSlash.Marker, index: number) => void), b?: (marker: FourSlash.Marker, index: number) => void): void  {
+        public eachMarker(a: ReadonlyArray<string> | ((marker: FourSlash.Marker, index: number) => void), b?: (marker: FourSlash.Marker, index: number) => void): void {
             const markers = typeof a === "function" ? this.state.getMarkers() : a.map(m => this.state.getMarkerByName(m));
             this.state.goToEachMarker(markers, typeof a === "function" ? a : b);
         }

--- a/src/harness/fourslashRunner.ts
+++ b/src/harness/fourslashRunner.ts
@@ -51,7 +51,7 @@ class FourSlashRunner extends RunnerBase {
         describe(this.testSuiteName + " tests", () => {
             this.tests.forEach((fn: string) => {
                  describe(fn, () => {
-                       fn = ts.normalizeSlashes(fn);
+                        fn = ts.normalizeSlashes(fn);
                         const justName = fn.replace(/^.*[\\\/]/, "");
 
                         // Convert to relative path

--- a/src/harness/unittests/commandLineParsing.ts
+++ b/src/harness/unittests/commandLineParsing.ts
@@ -78,15 +78,17 @@ namespace ts {
             // 0.ts --jsx
             assertParseResult(["0.ts", "--jsx"],
                 {
-                    errors: [{
-                        messageText: "Compiler option 'jsx' expects an argument.",
-                        category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
-                        code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
+                    errors: [
+                        {
+                            messageText: "Compiler option 'jsx' expects an argument.",
+                            category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
+                            code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
 
-                        file: undefined,
-                        start: undefined,
-                        length: undefined,
-                    }, {
+                            file: undefined,
+                            start: undefined,
+                            length: undefined,
+                        },
+                        {
                             messageText: "Argument for '--jsx' option must be: 'preserve', 'react-native', 'react'.",
                             category: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.category,
                             code: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.code,
@@ -94,7 +96,8 @@ namespace ts {
                             file: undefined,
                             start: undefined,
                             length: undefined,
-                        }],
+                        },
+                    ],
                     fileNames: ["0.ts"],
                     options: {}
                 });
@@ -104,15 +107,17 @@ namespace ts {
             // 0.ts --
             assertParseResult(["0.ts", "--module"],
                 {
-                    errors: [{
-                        messageText: "Compiler option 'module' expects an argument.",
-                        category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
-                        code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
+                    errors: [
+                        {
+                            messageText: "Compiler option 'module' expects an argument.",
+                            category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
+                            code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
 
-                        file: undefined,
-                        start: undefined,
-                        length: undefined,
-                    }, {
+                            file: undefined,
+                            start: undefined,
+                            length: undefined,
+                        },
+                        {
                             messageText: "Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.",
                             category: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.category,
                             code: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.code,
@@ -120,7 +125,8 @@ namespace ts {
                             file: undefined,
                             start: undefined,
                             length: undefined,
-                        }],
+                        },
+                    ],
                     fileNames: ["0.ts"],
                     options: {}
                 });
@@ -130,15 +136,17 @@ namespace ts {
             // 0.ts --newLine
             assertParseResult(["0.ts", "--newLine"],
                 {
-                    errors: [{
-                        messageText: "Compiler option 'newLine' expects an argument.",
-                        category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
-                        code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
+                    errors: [
+                        {
+                            messageText: "Compiler option 'newLine' expects an argument.",
+                            category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
+                            code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
 
-                        file: undefined,
-                        start: undefined,
-                        length: undefined,
-                    }, {
+                            file: undefined,
+                            start: undefined,
+                            length: undefined,
+                        },
+                        {
                             messageText: "Argument for '--newLine' option must be: 'crlf', 'lf'.",
                             category: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.category,
                             code: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.code,
@@ -146,7 +154,8 @@ namespace ts {
                             file: undefined,
                             start: undefined,
                             length: undefined,
-                        }],
+                        },
+                    ],
                     fileNames: ["0.ts"],
                     options: {}
                 });
@@ -156,15 +165,17 @@ namespace ts {
             // 0.ts --target
             assertParseResult(["0.ts", "--target"],
                 {
-                    errors: [{
-                        messageText: "Compiler option 'target' expects an argument.",
-                        category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
-                        code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
+                    errors: [
+                        {
+                            messageText: "Compiler option 'target' expects an argument.",
+                            category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
+                            code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
 
-                        file: undefined,
-                        start: undefined,
-                        length: undefined,
-                    }, {
+                            file: undefined,
+                            start: undefined,
+                            length: undefined,
+                        },
+                        {
                             messageText: "Argument for '--target' option must be: 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'esnext'.",
                             category: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.category,
                             code: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.code,
@@ -172,7 +183,8 @@ namespace ts {
                             file: undefined,
                             start: undefined,
                             length: undefined,
-                        }],
+                        },
+                    ],
                     fileNames: ["0.ts"],
                     options: {}
                 });
@@ -182,15 +194,17 @@ namespace ts {
             // 0.ts --moduleResolution
             assertParseResult(["0.ts", "--moduleResolution"],
                 {
-                    errors: [{
-                        messageText: "Compiler option 'moduleResolution' expects an argument.",
-                        category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
-                        code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
+                    errors: [
+                        {
+                            messageText: "Compiler option 'moduleResolution' expects an argument.",
+                            category: ts.Diagnostics.Compiler_option_0_expects_an_argument.category,
+                            code: ts.Diagnostics.Compiler_option_0_expects_an_argument.code,
 
-                        file: undefined,
-                        start: undefined,
-                        length: undefined,
-                    }, {
+                            file: undefined,
+                            start: undefined,
+                            length: undefined,
+                        },
+                        {
                             messageText: "Argument for '--moduleResolution' option must be: 'node', 'classic'.",
                             category: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.category,
                             code: ts.Diagnostics.Argument_for_0_option_must_be_Colon_1.code,
@@ -198,7 +212,8 @@ namespace ts {
                             file: undefined,
                             start: undefined,
                             length: undefined,
-                        }],
+                        },
+                    ],
                     fileNames: ["0.ts"],
                     options: {}
                 });

--- a/src/harness/unittests/services/preProcessFile.ts
+++ b/src/harness/unittests/services/preProcessFile.ts
@@ -37,8 +37,12 @@ describe("PreProcessFile:", () => {
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
-                    referencedFiles: [{ fileName: "refFile1.ts", pos: 22, end: 33 }, { fileName: "refFile2.ts", pos: 59, end: 70 },
-                        { fileName: "refFile3.ts", pos: 94, end: 105 }, { fileName: "..\\refFile4d.ts", pos: 131, end: 146 }],
+                    referencedFiles: [
+                        { fileName: "refFile1.ts", pos: 22, end: 33 },
+                        { fileName: "refFile2.ts", pos: 59, end: 70 },
+                        { fileName: "refFile3.ts", pos: 94, end: 105 },
+                        { fileName: "..\\refFile4d.ts", pos: 131, end: 146 },
+                    ],
                     importedFiles: <ts.FileReference[]>[],
                     typeReferenceDirectives: [],
                     ambientExternalModules: undefined,
@@ -66,8 +70,13 @@ describe("PreProcessFile:", () => {
                 {
                     referencedFiles: <ts.FileReference[]>[],
                     typeReferenceDirectives: [],
-                    importedFiles: [{ fileName: "r1.ts", pos: 20, end: 25 }, { fileName: "r2.ts", pos: 49, end: 54 }, { fileName: "r3.ts", pos: 78, end: 83 },
-                        { fileName: "r4.ts", pos: 106, end: 111 }, { fileName: "r5.ts", pos: 138, end: 143 }],
+                    importedFiles: [
+                        { fileName: "r1.ts", pos: 20, end: 25 },
+                        { fileName: "r2.ts", pos: 49, end: 54 },
+                        { fileName: "r3.ts", pos: 78, end: 83 },
+                        { fileName: "r4.ts", pos: 106, end: 111 },
+                        { fileName: "r5.ts", pos: 138, end: 143 },
+                    ],
                     ambientExternalModules: undefined,
                     isLibFile: false
                 });

--- a/src/harness/unittests/tsconfigParsing.ts
+++ b/src/harness/unittests/tsconfigParsing.ts
@@ -109,7 +109,7 @@ namespace ts {
                         "xx//file.d.ts"
                     ]
                 }`, { config: { exclude: ["xx//file.d.ts"] } });
-         assertParseResult(
+            assertParseResult(
                 `{
                     "exclude": [
                         "xx/*file.d.ts*/"

--- a/src/services/codefixes/disableJsDiagnostics.ts
+++ b/src/services/codefixes/disableJsDiagnostics.ts
@@ -15,23 +15,25 @@ namespace ts.codefix {
                 return undefined;
             }
 
-            return [{
-                description: getLocaleSpecificMessage(Diagnostics.Ignore_this_error_message),
-                changes: [createFileTextChanges(sourceFile.fileName, [getIgnoreCommentLocationForLocation(sourceFile, span.start, newLineCharacter)])],
-                fixId,
-            },
-            {
-                description: getLocaleSpecificMessage(Diagnostics.Disable_checking_for_this_file),
-                changes: [createFileTextChanges(sourceFile.fileName, [{
-                    span: {
-                        start: sourceFile.checkJsDirective ? sourceFile.checkJsDirective.pos : 0,
-                        length: sourceFile.checkJsDirective ? sourceFile.checkJsDirective.end - sourceFile.checkJsDirective.pos : 0
-                    },
-                    newText: `// @ts-nocheck${newLineCharacter}`
-                }])],
-                // fixId unnecessary because adding `// @ts-nocheck` even once will ignore every error in the file.
-                fixId: undefined,
-            }];
+            return [
+                {
+                    description: getLocaleSpecificMessage(Diagnostics.Ignore_this_error_message),
+                    changes: [createFileTextChanges(sourceFile.fileName, [getIgnoreCommentLocationForLocation(sourceFile, span.start, newLineCharacter)])],
+                    fixId,
+                },
+                {
+                    description: getLocaleSpecificMessage(Diagnostics.Disable_checking_for_this_file),
+                    changes: [createFileTextChanges(sourceFile.fileName, [{
+                        span: {
+                            start: sourceFile.checkJsDirective ? sourceFile.checkJsDirective.pos : 0,
+                            length: sourceFile.checkJsDirective ? sourceFile.checkJsDirective.end - sourceFile.checkJsDirective.pos : 0
+                        },
+                        newText: `// @ts-nocheck${newLineCharacter}`
+                    }])],
+                    // fixId unnecessary because adding `// @ts-nocheck` even once will ignore every error in the file.
+                    fixId: undefined,
+                },
+            ];
         },
         fixIds: [fixId], // No point applying as a group, doing it once will fix all errors
         getAllCodeActions: context => codeFixAllWithTextChanges(context, errorCodes, (changes, err) => {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -60,13 +60,17 @@ namespace ts.Completions {
             //     var x = <div> </ /*1*/>
             // The completion list at "1" will contain "div" with type any
             const tagName = (<JsxElement>location.parent.parent).openingElement.tagName;
-            return { isGlobalCompletion: false, isMemberCompletion: true, isNewIdentifierLocation: false,
+            return {
+                isGlobalCompletion: false,
+                isMemberCompletion: true,
+                isNewIdentifierLocation: false,
                 entries: [{
                     name: (<JsxTagNameExpression>tagName).getFullText(),
                     kind: ScriptElementKind.classElement,
                     kindModifiers: undefined,
                     sortText: "0",
-                }]};
+                }],
+            };
         }
 
         if (request) {

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -482,7 +482,7 @@ namespace ts {
         public useCaseSensitiveFileNames: boolean;
 
         constructor(private shimHost: CoreServicesShimHost) {
-        this.useCaseSensitiveFileNames = this.shimHost.useCaseSensitiveFileNames ? this.shimHost.useCaseSensitiveFileNames() : false;
+            this.useCaseSensitiveFileNames = this.shimHost.useCaseSensitiveFileNames ? this.shimHost.useCaseSensitiveFileNames() : false;
             if ("directoryExists" in this.shimHost) {
                 this.directoryExists = directoryName => this.shimHost.directoryExists(directoryName);
             }

--- a/tslint.json
+++ b/tslint.json
@@ -88,6 +88,9 @@
         "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
 
         // TODO
+        "align2": true,
+        //"align": [true, "statements", "members", "elements"],
+        "align": false,
         "arrow-parens": false, // [true, "ban-single-arg-parens"]
         "arrow-return-shorthand": false,
         "ban-types": false,
@@ -109,7 +112,6 @@
         "trailing-comma": false,
 
         // These should be done automatically by a formatter. https://github.com/Microsoft/TypeScript/issues/18340
-        "align": false,
         "eofline": false,
         "max-line-length": false,
         "no-consecutive-blank-lines": false,


### PR DESCRIPTION
Better solution to #21043
Had to modify the rule implementation to support comments like `/* @internal */` at the beginning of a line. This could be done as a PR to tslint later.