### PR TITLE
Ensure visitor visits the awaitModifier of a ForOfStatement

### DIFF
--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -622,7 +622,7 @@ namespace ts {
 
             case SyntaxKind.ForOfStatement:
                 return updateForOf(<ForOfStatement>node,
-                    (<ForOfStatement>node).awaitModifier,
+                    visitNode((<ForOfStatement>node).awaitModifier, visitor, isToken),
                     visitNode((<ForOfStatement>node).initializer, visitor, isForInitializer),
                     visitNode((<ForOfStatement>node).expression, visitor, isExpression),
                     visitNode((<ForOfStatement>node).statement, visitor, isStatement, liftToBlock));

--- a/tests/cases/fourslash/extractMethod_forAwait.ts
+++ b/tests/cases/fourslash/extractMethod_forAwait.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+////async function f(xs: AsyncIterable<number>) {
+////    /*a*/for await (const x of xs) {
+////        x * 2;
+////    }/*b*/
+////}
+
+goTo.select('a', 'b')
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "function_scope_1",
+    actionDescription: "Extract to function in global scope",
+    newContent:
+`async function f(xs: AsyncIterable<number>) {
+    /*RENAME*/newFunction(xs);
+}
+
+function newFunction(xs: any) {
+    for await (const x of xs) {
+        x * 2;
+    }
+}
+`
+});


### PR DESCRIPTION
Should fix the second issue from https://github.com/Microsoft/TypeScript/pull/21069#issue-286832176
When we don't visit the node, we don't create a new one, so it will still have the old position, which triggers an assertion in the formatter.