### PR TITLE
Clear jsDocCache for reused nodes

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1679,6 +1679,11 @@ namespace ts {
                 return undefined;
             }
 
+            if ((node as JSDocContainer).jsDocCache) {
+                // jsDocCache may include tags from parent nodes, which might have been modified.
+                (node as JSDocContainer).jsDocCache = undefined;
+            }
+
             return node;
         }
 

--- a/tests/cases/fourslash/editClearsJsDocCache.ts
+++ b/tests/cases/fourslash/editClearsJsDocCache.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts'/>
+
+// @allowJs: true
+
+// @Filename: /a.js
+/////** @type {/*type*/number} */
+////let /*x*/x;
+
+verify.quickInfoAt("x", "let x: number");
+
+goTo.marker("type");
+edit.replace(test.markers()[0].position, "number".length, "string");
+
+verify.quickInfoAt("x", "let x: string");


### PR DESCRIPTION
Fixes #21082
`jsDocCache` can depend on the `.jsDoc` of parent nodes, but those parent nodes' jsdoc comments may have changed.
  