### PR TITLE
Enable substitution for object literal shorthand property assignments in the system transform

### DIFF
--- a/tests/baselines/reference/systemObjectShorthandRename.js
+++ b/tests/baselines/reference/systemObjectShorthandRename.js
@@ -1,0 +1,44 @@
+//// [tests/cases/compiler/systemObjectShorthandRename.ts] ////
+
+//// [x.ts]
+export const x = 'X'
+//// [index.ts]
+import {x} from './x.js'
+
+const x2 = {x}
+const a = {x2}
+
+const x3 = x
+const b = {x3}
+
+//// [x.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var x;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("x", x = 'X');
+        }
+    };
+});
+//// [index.js]
+System.register(["./x.js"], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var x_js_1, x2, a, x3, b;
+    return {
+        setters: [
+            function (x_js_1_1) {
+                x_js_1 = x_js_1_1;
+            }
+        ],
+        execute: function () {
+            x2 = { x: x_js_1.x };
+            a = { x2 };
+            x3 = x_js_1.x;
+            b = { x3 };
+        }
+    };
+});

--- a/tests/baselines/reference/systemObjectShorthandRename.symbols
+++ b/tests/baselines/reference/systemObjectShorthandRename.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/x.ts ===
+export const x = 'X'
+>x : Symbol(x, Decl(x.ts, 0, 12))
+
+=== tests/cases/compiler/index.ts ===
+import {x} from './x.js'
+>x : Symbol(x, Decl(index.ts, 0, 8))
+
+const x2 = {x}
+>x2 : Symbol(x2, Decl(index.ts, 2, 5))
+>x : Symbol(x, Decl(index.ts, 2, 12))
+
+const a = {x2}
+>a : Symbol(a, Decl(index.ts, 3, 5))
+>x2 : Symbol(x2, Decl(index.ts, 3, 11))
+
+const x3 = x
+>x3 : Symbol(x3, Decl(index.ts, 5, 5))
+>x : Symbol(x, Decl(index.ts, 0, 8))
+
+const b = {x3}
+>b : Symbol(b, Decl(index.ts, 6, 5))
+>x3 : Symbol(x3, Decl(index.ts, 6, 11))
+

--- a/tests/baselines/reference/systemObjectShorthandRename.types
+++ b/tests/baselines/reference/systemObjectShorthandRename.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/x.ts ===
+export const x = 'X'
+>x : "X"
+>'X' : "X"
+
+=== tests/cases/compiler/index.ts ===
+import {x} from './x.js'
+>x : "X"
+
+const x2 = {x}
+>x2 : { x: string; }
+>{x} : { x: string; }
+>x : string
+
+const a = {x2}
+>a : { x2: { x: string; }; }
+>{x2} : { x2: { x: string; }; }
+>x2 : { x: string; }
+
+const x3 = x
+>x3 : "X"
+>x : "X"
+
+const b = {x3}
+>b : { x3: string; }
+>{x3} : { x3: string; }
+>x3 : string
+

--- a/tests/cases/compiler/systemObjectShorthandRename.ts
+++ b/tests/cases/compiler/systemObjectShorthandRename.ts
@@ -1,0 +1,12 @@
+// @module: system
+// @target: es2015
+// @filename: x.ts
+export const x = 'X'
+// @filename: index.ts
+import {x} from './x.js'
+
+const x2 = {x}
+const a = {x2}
+
+const x3 = x
+const b = {x3}


### PR DESCRIPTION
They were already on in the `module` transform, so the bug was unique to the `system` target.

Fixes #21057
