### PR TITLE
AsteriskToken should always have length 1

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6491,7 +6491,7 @@ namespace ts {
                                 if (state === JSDocState.BeginningOfLine) {
                                     // leading asterisks start recording on the *next* (non-whitespace) token
                                     state = JSDocState.SawAsterisk;
-                                    indent += scanner.getTokenText().length;
+                                    indent += 1;
                                     break;
                                 }
                                 // record the * as a comment


### PR DESCRIPTION
Tested with `Debug.assert(scanner.getTokenText().length === 1);` just to be sure.