### PR TITLE
Print the correct type in the top level chain as the message indicates

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23005,7 +23005,7 @@ namespace ts {
                             Diagnostics.Property_0_in_type_1_is_not_assignable_to_the_same_property_in_base_type_2,
                             unescapeLeadingUnderscores(declaredProp.escapedName),
                             typeToString(typeWithThis),
-                            typeToString(getTypeOfSymbol(baseProp))
+                            typeToString(baseWithThis)
                         );
                         if (!checkTypeAssignableTo(getTypeOfSymbol(prop), getTypeOfSymbol(baseProp), member.name || member, /*message*/ undefined, rootChain)) {
                             issuedMemberError = true;

--- a/tests/baselines/reference/abstractPropertyNegative.errors.txt
+++ b/tests/baselines/reference/abstractPropertyNegative.errors.txt
@@ -7,11 +7,11 @@ tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstra
 tests/cases/compiler/abstractPropertyNegative.ts(15,5): error TS1244: Abstract methods can only appear within an abstract class.
 tests/cases/compiler/abstractPropertyNegative.ts(16,37): error TS1005: '{' expected.
 tests/cases/compiler/abstractPropertyNegative.ts(19,3): error TS2540: Cannot assign to 'ro' because it is a constant or a read-only property.
-tests/cases/compiler/abstractPropertyNegative.ts(25,5): error TS2416: Property 'num' in type 'WrongTypePropertyImpl' is not assignable to the same property in base type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(25,5): error TS2416: Property 'num' in type 'WrongTypePropertyImpl' is not assignable to the same property in base type 'WrongTypeProperty'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/abstractPropertyNegative.ts(31,9): error TS2416: Property 'num' in type 'WrongTypeAccessorImpl' is not assignable to the same property in base type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(31,9): error TS2416: Property 'num' in type 'WrongTypeAccessorImpl' is not assignable to the same property in base type 'WrongTypeAccessor'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/abstractPropertyNegative.ts(34,5): error TS2416: Property 'num' in type 'WrongTypeAccessorImpl2' is not assignable to the same property in base type 'number'.
+tests/cases/compiler/abstractPropertyNegative.ts(34,5): error TS2416: Property 'num' in type 'WrongTypeAccessorImpl2' is not assignable to the same property in base type 'WrongTypeAccessor'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/abstractPropertyNegative.ts(38,18): error TS2676: Accessors must both be abstract or non-abstract.
 tests/cases/compiler/abstractPropertyNegative.ts(39,9): error TS2676: Accessors must both be abstract or non-abstract.
@@ -64,7 +64,7 @@ tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors
     class WrongTypePropertyImpl extends WrongTypeProperty {
         num = "nope, wrong";
         ~~~
-!!! error TS2416: Property 'num' in type 'WrongTypePropertyImpl' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'num' in type 'WrongTypePropertyImpl' is not assignable to the same property in base type 'WrongTypeProperty'.
 !!! error TS2416:   Type 'string' is not assignable to type 'number'.
     }
     abstract class WrongTypeAccessor {
@@ -73,13 +73,13 @@ tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors
     class WrongTypeAccessorImpl extends WrongTypeAccessor {
         get num() { return "nope, wrong"; }
             ~~~
-!!! error TS2416: Property 'num' in type 'WrongTypeAccessorImpl' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'num' in type 'WrongTypeAccessorImpl' is not assignable to the same property in base type 'WrongTypeAccessor'.
 !!! error TS2416:   Type 'string' is not assignable to type 'number'.
     }
     class WrongTypeAccessorImpl2 extends WrongTypeAccessor {
         num = "nope, wrong";
         ~~~
-!!! error TS2416: Property 'num' in type 'WrongTypeAccessorImpl2' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'num' in type 'WrongTypeAccessorImpl2' is not assignable to the same property in base type 'WrongTypeAccessor'.
 !!! error TS2416:   Type 'string' is not assignable to type 'number'.
     }
     

--- a/tests/baselines/reference/apparentTypeSubtyping.errors.txt
+++ b/tests/baselines/reference/apparentTypeSubtyping.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts(10,5): error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'string'.
+tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts(10,5): error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'Base<string>'.
   Type 'String' is not assignable to type 'string'.
     'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
@@ -15,7 +15,7 @@ tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtypi
     class Derived<U> extends Base<string> { // error
         x: String;
         ~
-!!! error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'Base<string>'.
 !!! error TS2416:   Type 'String' is not assignable to type 'string'.
 !!! error TS2416:     'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
     }

--- a/tests/baselines/reference/apparentTypeSupertype.errors.txt
+++ b/tests/baselines/reference/apparentTypeSupertype.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts(10,5): error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'string'.
+tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts(10,5): error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'Base'.
   Type 'U' is not assignable to type 'string'.
     Type 'String' is not assignable to type 'string'.
       'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
@@ -16,7 +16,7 @@ tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSuperty
     class Derived<U extends String> extends Base { // error
         x: U;
         ~
-!!! error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'Base'.
 !!! error TS2416:   Type 'U' is not assignable to type 'string'.
 !!! error TS2416:     Type 'String' is not assignable to type 'string'.
 !!! error TS2416:       'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.

--- a/tests/baselines/reference/baseClassImprovedMismatchErrors.errors.txt
+++ b/tests/baselines/reference/baseClassImprovedMismatchErrors.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/baseClassImprovedMismatchErrors.ts(8,5): error TS2416: Property 'n' in type 'Derived' is not assignable to the same property in base type 'string | Base'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(8,5): error TS2416: Property 'n' in type 'Derived' is not assignable to the same property in base type 'Base'.
   Type 'string | Derived' is not assignable to type 'string | Base'.
     Type 'Derived' is not assignable to type 'string | Base'.
       Type 'Derived' is not assignable to type 'Base'.
@@ -6,11 +6,11 @@ tests/cases/compiler/baseClassImprovedMismatchErrors.ts(8,5): error TS2416: Prop
           Type 'string | Derived' is not assignable to type 'string | Base'.
             Type 'Derived' is not assignable to type 'string | Base'.
               Type 'Derived' is not assignable to type 'Base'.
-tests/cases/compiler/baseClassImprovedMismatchErrors.ts(9,5): error TS2416: Property 'fn' in type 'Derived' is not assignable to the same property in base type '() => number'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(9,5): error TS2416: Property 'fn' in type 'Derived' is not assignable to the same property in base type 'Base'.
   Type '() => string | number' is not assignable to type '() => number'.
     Type 'string | number' is not assignable to type 'number'.
       Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/baseClassImprovedMismatchErrors.ts(14,5): error TS2416: Property 'n' in type 'DerivedInterface' is not assignable to the same property in base type 'string | Base'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(14,5): error TS2416: Property 'n' in type 'DerivedInterface' is not assignable to the same property in base type 'Base'.
   Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
     Type 'DerivedInterface' is not assignable to type 'string | Base'.
       Type 'DerivedInterface' is not assignable to type 'Base'.
@@ -18,7 +18,7 @@ tests/cases/compiler/baseClassImprovedMismatchErrors.ts(14,5): error TS2416: Pro
           Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
             Type 'DerivedInterface' is not assignable to type 'string | Base'.
               Type 'DerivedInterface' is not assignable to type 'Base'.
-tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2416: Property 'fn' in type 'DerivedInterface' is not assignable to the same property in base type '() => number'.
+tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2416: Property 'fn' in type 'DerivedInterface' is not assignable to the same property in base type 'Base'.
   Type '() => string | number' is not assignable to type '() => number'.
     Type 'string | number' is not assignable to type 'number'.
       Type 'string' is not assignable to type 'number'.
@@ -34,7 +34,7 @@ tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2416: Pro
     class Derived extends Base {
         n: Derived | string;
         ~
-!!! error TS2416: Property 'n' in type 'Derived' is not assignable to the same property in base type 'string | Base'.
+!!! error TS2416: Property 'n' in type 'Derived' is not assignable to the same property in base type 'Base'.
 !!! error TS2416:   Type 'string | Derived' is not assignable to type 'string | Base'.
 !!! error TS2416:     Type 'Derived' is not assignable to type 'string | Base'.
 !!! error TS2416:       Type 'Derived' is not assignable to type 'Base'.
@@ -44,7 +44,7 @@ tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2416: Pro
 !!! error TS2416:               Type 'Derived' is not assignable to type 'Base'.
         fn() {
         ~~
-!!! error TS2416: Property 'fn' in type 'Derived' is not assignable to the same property in base type '() => number'.
+!!! error TS2416: Property 'fn' in type 'Derived' is not assignable to the same property in base type 'Base'.
 !!! error TS2416:   Type '() => string | number' is not assignable to type '() => number'.
 !!! error TS2416:     Type 'string | number' is not assignable to type 'number'.
 !!! error TS2416:       Type 'string' is not assignable to type 'number'.
@@ -54,7 +54,7 @@ tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2416: Pro
     class DerivedInterface implements Base {
         n: DerivedInterface | string;
         ~
-!!! error TS2416: Property 'n' in type 'DerivedInterface' is not assignable to the same property in base type 'string | Base'.
+!!! error TS2416: Property 'n' in type 'DerivedInterface' is not assignable to the same property in base type 'Base'.
 !!! error TS2416:   Type 'string | DerivedInterface' is not assignable to type 'string | Base'.
 !!! error TS2416:     Type 'DerivedInterface' is not assignable to type 'string | Base'.
 !!! error TS2416:       Type 'DerivedInterface' is not assignable to type 'Base'.
@@ -64,7 +64,7 @@ tests/cases/compiler/baseClassImprovedMismatchErrors.ts(15,5): error TS2416: Pro
 !!! error TS2416:               Type 'DerivedInterface' is not assignable to type 'Base'.
         fn() {
         ~~
-!!! error TS2416: Property 'fn' in type 'DerivedInterface' is not assignable to the same property in base type '() => number'.
+!!! error TS2416: Property 'fn' in type 'DerivedInterface' is not assignable to the same property in base type 'Base'.
 !!! error TS2416:   Type '() => string | number' is not assignable to type '() => number'.
 !!! error TS2416:     Type 'string | number' is not assignable to type 'number'.
 !!! error TS2416:       Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/classIsSubtypeOfBaseType.errors.txt
+++ b/tests/baselines/reference/classIsSubtypeOfBaseType.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts(12,5): error TS2416: Property 'foo' in type 'Derived2' is not assignable to the same property in base type '{ bar: string; }'.
+tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts(12,5): error TS2416: Property 'foo' in type 'Derived2' is not assignable to the same property in base type 'Base<{ bar: string; }>'.
   Type '{ bar?: string; }' is not assignable to type '{ bar: string; }'.
     Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
 
@@ -17,7 +17,7 @@ tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/cla
     class Derived2 extends Base<{ bar: string; }> {
         foo: {
         ~~~
-!!! error TS2416: Property 'foo' in type 'Derived2' is not assignable to the same property in base type '{ bar: string; }'.
+!!! error TS2416: Property 'foo' in type 'Derived2' is not assignable to the same property in base type 'Base<{ bar: string; }>'.
 !!! error TS2416:   Type '{ bar?: string; }' is not assignable to type '{ bar: string; }'.
 !!! error TS2416:     Property 'bar' is optional in type '{ bar?: string; }' but required in type '{ bar: string; }'.
             bar?: string; // error

--- a/tests/baselines/reference/derivedClassFunctionOverridesBaseClassAccessor.errors.txt
+++ b/tests/baselines/reference/derivedClassFunctionOverridesBaseClassAccessor.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(2,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(5,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(11,5): error TS2416: Property 'x' in type 'Derived' is not assignable to the same property in base type 'number'.
+tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(11,5): error TS2416: Property 'x' in type 'Derived' is not assignable to the same property in base type 'Base'.
   Type '() => number' is not assignable to type 'number'.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts(11,5): error TS2426: Class 'Base' defines instance member accessor 'x', but extended class 'Derived' defines it as instance member function.
 
@@ -22,7 +22,7 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFun
     class Derived extends Base {
         x() {
         ~
-!!! error TS2416: Property 'x' in type 'Derived' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'x' in type 'Derived' is not assignable to the same property in base type 'Base'.
 !!! error TS2416:   Type '() => number' is not assignable to type 'number'.
         ~
 !!! error TS2426: Class 'Base' defines instance member accessor 'x', but extended class 'Derived' defines it as instance member function.

--- a/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
@@ -35,7 +35,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(46,13): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(47,13): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(56,8): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
-tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(57,5): error TS2416: Property 'd4' in type 'C4' is not assignable to the same property in base type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(57,5): error TS2416: Property 'd4' in type 'C4' is not assignable to the same property in base type 'F2'.
   Type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
     Types of parameters '__0' and '__0' are incompatible.
       Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
@@ -159,7 +159,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 !!! error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
         d4({x, y, c}) { }
         ~~
-!!! error TS2416: Property 'd4' in type 'C4' is not assignable to the same property in base type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
+!!! error TS2416: Property 'd4' in type 'C4' is not assignable to the same property in base type 'F2'.
 !!! error TS2416:   Type '({ x, y, c }: { x: any; y: any; c: any; }) => void' is not assignable to type '({ x, y, z }?: { x: any; y: any; z: any; }) => any'.
 !!! error TS2416:     Types of parameters '__0' and '__0' are incompatible.
 !!! error TS2416:       Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.

--- a/tests/baselines/reference/elaboratedErrors.errors.txt
+++ b/tests/baselines/reference/elaboratedErrors.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/elaboratedErrors.ts(11,3): error TS2416: Property 'read' in type 'WorkerFS' is not assignable to the same property in base type 'number'.
+tests/cases/compiler/elaboratedErrors.ts(11,3): error TS2416: Property 'read' in type 'WorkerFS' is not assignable to the same property in base type 'FileSystem'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/elaboratedErrors.ts(20,1): error TS2322: Type 'Beta' is not assignable to type 'Alpha'.
   Property 'x' is missing in type 'Beta'.
@@ -21,7 +21,7 @@ tests/cases/compiler/elaboratedErrors.ts(25,1): error TS2322: Type 'Alpha' is no
     class WorkerFS implements FileSystem {
       read: string;
       ~~~~
-!!! error TS2416: Property 'read' in type 'WorkerFS' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'read' in type 'WorkerFS' is not assignable to the same property in base type 'FileSystem'.
 !!! error TS2416:   Type 'string' is not assignable to type 'number'.
     }
     

--- a/tests/baselines/reference/genericImplements.errors.txt
+++ b/tests/baselines/reference/genericImplements.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/genericImplements.ts(9,5): error TS2416: Property 'f' in type 'X' is not assignable to the same property in base type '<T extends A>() => T'.
+tests/cases/compiler/genericImplements.ts(9,5): error TS2416: Property 'f' in type 'X' is not assignable to the same property in base type 'I'.
   Type '<T extends B>() => T' is not assignable to type '<T extends A>() => T'.
     Type 'B' is not assignable to type 'T'.
 
@@ -14,7 +14,7 @@ tests/cases/compiler/genericImplements.ts(9,5): error TS2416: Property 'f' in ty
     class X implements I {  
         f<T extends B>(): T { return undefined; }
         ~
-!!! error TS2416: Property 'f' in type 'X' is not assignable to the same property in base type '<T extends A>() => T'.
+!!! error TS2416: Property 'f' in type 'X' is not assignable to the same property in base type 'I'.
 !!! error TS2416:   Type '<T extends B>() => T' is not assignable to type '<T extends A>() => T'.
 !!! error TS2416:     Type 'B' is not assignable to type 'T'.
     } // { f: () => { b; } }

--- a/tests/baselines/reference/genericSpecializations1.errors.txt
+++ b/tests/baselines/reference/genericSpecializations1.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/genericSpecializations1.ts(6,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '<T>(x: T) => T'.
+tests/cases/compiler/genericSpecializations1.ts(6,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type 'IFoo<number>'.
   Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
     Types of parameters 'x' and 'x' are incompatible.
       Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/genericSpecializations1.ts(10,5): error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type '<T>(x: T) => T'.
+tests/cases/compiler/genericSpecializations1.ts(10,5): error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type 'IFoo<string>'.
   Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
     Types of parameters 'x' and 'x' are incompatible.
       Type 'T' is not assignable to type 'string'.
@@ -16,7 +16,7 @@ tests/cases/compiler/genericSpecializations1.ts(10,5): error TS2416: Property 'f
     class IntFooBad implements IFoo<number> {
         foo(x: string): string { return null; }
         ~~~
-!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type 'IFoo<number>'.
 !!! error TS2416:   Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
 !!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2416:       Type 'T' is not assignable to type 'string'.
@@ -25,7 +25,7 @@ tests/cases/compiler/genericSpecializations1.ts(10,5): error TS2416: Property 'f
     class StringFoo2 implements IFoo<string> {
         foo(x: string): string { return null; }
         ~~~
-!!! error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type 'IFoo<string>'.
 !!! error TS2416:   Type '(x: string) => string' is not assignable to type '<T>(x: T) => T'.
 !!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2416:       Type 'T' is not assignable to type 'string'.

--- a/tests/baselines/reference/genericSpecializations2.errors.txt
+++ b/tests/baselines/reference/genericSpecializations2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/genericSpecializations2.ts(8,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '<T>(x: T) => T'.
+tests/cases/compiler/genericSpecializations2.ts(8,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type 'IFoo<number>'.
   Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
     Types of parameters 'x' and 'x' are incompatible.
       Type 'T' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations2.ts(8,9): error TS2368: Type parameter name cannot be 'string'.
-tests/cases/compiler/genericSpecializations2.ts(12,5): error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type '<T>(x: T) => T'.
+tests/cases/compiler/genericSpecializations2.ts(12,5): error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type 'IFoo<string>'.
   Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
     Types of parameters 'x' and 'x' are incompatible.
       Type 'T' is not assignable to type 'string'.
@@ -20,7 +20,7 @@ tests/cases/compiler/genericSpecializations2.ts(12,9): error TS2368: Type parame
     class IntFooBad implements IFoo<number> {
         foo<string>(x: string): string { return null; }
         ~~~
-!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type 'IFoo<number>'.
 !!! error TS2416:   Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
 !!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2416:       Type 'T' is not assignable to type 'string'.
@@ -31,7 +31,7 @@ tests/cases/compiler/genericSpecializations2.ts(12,9): error TS2368: Type parame
     class StringFoo2 implements IFoo<string> {
         foo<string>(x: string): string { return null; }
         ~~~
-!!! error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416: Property 'foo' in type 'StringFoo2' is not assignable to the same property in base type 'IFoo<string>'.
 !!! error TS2416:   Type '<string>(x: string) => string' is not assignable to type '<T>(x: T) => T'.
 !!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2416:       Type 'T' is not assignable to type 'string'.

--- a/tests/baselines/reference/genericSpecializations3.errors.txt
+++ b/tests/baselines/reference/genericSpecializations3.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/genericSpecializations3.ts(9,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '(x: number) => number'.
+tests/cases/compiler/genericSpecializations3.ts(9,5): error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type 'IFoo<number>'.
   Type '(x: string) => string' is not assignable to type '(x: number) => number'.
     Types of parameters 'x' and 'x' are incompatible.
       Type 'number' is not assignable to type 'string'.
@@ -25,7 +25,7 @@ tests/cases/compiler/genericSpecializations3.ts(29,1): error TS2322: Type 'IntFo
     class IntFooBad implements IFoo<number> { // error
         foo(x: string): string { return null; }
         ~~~
-!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type '(x: number) => number'.
+!!! error TS2416: Property 'foo' in type 'IntFooBad' is not assignable to the same property in base type 'IFoo<number>'.
 !!! error TS2416:   Type '(x: string) => string' is not assignable to type '(x: number) => number'.
 !!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2416:       Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
+++ b/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(5,2): error TS2416: Property 'f' in type 'X<T>' is not assignable to the same property in base type '(a: { a: number; }) => void'.
+tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(5,2): error TS2416: Property 'f' in type 'X<T>' is not assignable to the same property in base type 'I'.
   Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
     Types of parameters 'a' and 'a' are incompatible.
       Type '{ a: number; }' is not assignable to type 'T'.
@@ -18,7 +18,7 @@ tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322
     class X<T extends { a: string }> implements I {
     	f(a: T): void { }
     	~
-!!! error TS2416: Property 'f' in type 'X<T>' is not assignable to the same property in base type '(a: { a: number; }) => void'.
+!!! error TS2416: Property 'f' in type 'X<T>' is not assignable to the same property in base type 'I'.
 !!! error TS2416:   Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
 !!! error TS2416:     Types of parameters 'a' and 'a' are incompatible.
 !!! error TS2416:       Type '{ a: number; }' is not assignable to type 'T'.

--- a/tests/baselines/reference/implementGenericWithMismatchedTypes.errors.txt
+++ b/tests/baselines/reference/implementGenericWithMismatchedTypes.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/implementGenericWithMismatchedTypes.ts(8,5): error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type '(x: T) => T'.
+tests/cases/compiler/implementGenericWithMismatchedTypes.ts(8,5): error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type 'IFoo<T>'.
   Type '(x: string) => number' is not assignable to type '(x: T) => T'.
     Types of parameters 'x' and 'x' are incompatible.
       Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type '(x: T) => T'.
+tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type 'IFoo2<T>'.
   Type '<Tstring>(x: Tstring) => number' is not assignable to type '(x: T) => T'.
     Type 'number' is not assignable to type 'T'.
 
@@ -17,7 +17,7 @@ tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2416:
     class C<T> implements IFoo<T> { // error
         foo(x: string): number {
         ~~~
-!!! error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type '(x: T) => T'.
+!!! error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type 'IFoo<T>'.
 !!! error TS2416:   Type '(x: string) => number' is not assignable to type '(x: T) => T'.
 !!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2416:       Type 'T' is not assignable to type 'string'.
@@ -31,7 +31,7 @@ tests/cases/compiler/implementGenericWithMismatchedTypes.ts(17,5): error TS2416:
     class C2<T> implements IFoo2<T> { // error
         foo<Tstring>(x: Tstring): number {
         ~~~
-!!! error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type '(x: T) => T'.
+!!! error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type 'IFoo2<T>'.
 !!! error TS2416:   Type '<Tstring>(x: Tstring) => number' is not assignable to type '(x: T) => T'.
 !!! error TS2416:     Type 'number' is not assignable to type 'T'.
             return null;

--- a/tests/baselines/reference/implementsIncorrectlyNoAssertion.errors.txt
+++ b/tests/baselines/reference/implementsIncorrectlyNoAssertion.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(9,5): error TS2416: Property 'x' in type 'Baz' is not assignable to the same property in base type 'string'.
+tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(9,5): error TS2416: Property 'x' in type 'Baz' is not assignable to the same property in base type 'Foo & Bar'.
   Type 'number' is not assignable to type 'string'.
 
 
@@ -13,7 +13,7 @@ tests/cases/compiler/implementsIncorrectlyNoAssertion.ts(9,5): error TS2416: Pro
     class Baz implements Wrapper {
         x: number;
         ~
-!!! error TS2416: Property 'x' in type 'Baz' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property 'x' in type 'Baz' is not assignable to the same property in base type 'Foo & Bar'.
 !!! error TS2416:   Type 'number' is not assignable to type 'string'.
         y: string;
     }

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/compiler/incompatibleTypes.ts(6,12): error TS2416: Property 'p1' in type 'C1' is not assignable to the same property in base type '() => number'.
+tests/cases/compiler/incompatibleTypes.ts(6,12): error TS2416: Property 'p1' in type 'C1' is not assignable to the same property in base type 'IFoo1'.
   Type '() => string' is not assignable to type '() => number'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(16,12): error TS2416: Property 'p1' in type 'C2' is not assignable to the same property in base type '(s: string) => number'.
+tests/cases/compiler/incompatibleTypes.ts(16,12): error TS2416: Property 'p1' in type 'C2' is not assignable to the same property in base type 'IFoo2'.
   Type '(n: number) => number' is not assignable to type '(s: string) => number'.
     Types of parameters 'n' and 's' are incompatible.
       Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(26,12): error TS2416: Property 'p1' in type 'C3' is not assignable to the same property in base type 'string'.
+tests/cases/compiler/incompatibleTypes.ts(26,12): error TS2416: Property 'p1' in type 'C3' is not assignable to the same property in base type 'IFoo3'.
   Type 'number' is not assignable to type 'string'.
-tests/cases/compiler/incompatibleTypes.ts(34,12): error TS2416: Property 'p1' in type 'C4' is not assignable to the same property in base type '{ a: { a: string; }; b: string; }'.
+tests/cases/compiler/incompatibleTypes.ts(34,12): error TS2416: Property 'p1' in type 'C4' is not assignable to the same property in base type 'IFoo4'.
   Type '{ c: { b: string; }; d: string; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
     Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2345: Argument of type 'C1' is not assignable to parameter of type 'IFoo2'.
@@ -30,7 +30,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     class C1 implements IFoo1 { // incompatible on the return type
         public p1() {
                ~~
-!!! error TS2416: Property 'p1' in type 'C1' is not assignable to the same property in base type '() => number'.
+!!! error TS2416: Property 'p1' in type 'C1' is not assignable to the same property in base type 'IFoo1'.
 !!! error TS2416:   Type '() => string' is not assignable to type '() => number'.
 !!! error TS2416:     Type 'string' is not assignable to type 'number'.
             return "s";
@@ -44,7 +44,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     class C2 implements IFoo2 { // incompatible on the param type
         public p1(n:number) {
                ~~
-!!! error TS2416: Property 'p1' in type 'C2' is not assignable to the same property in base type '(s: string) => number'.
+!!! error TS2416: Property 'p1' in type 'C2' is not assignable to the same property in base type 'IFoo2'.
 !!! error TS2416:   Type '(n: number) => number' is not assignable to type '(s: string) => number'.
 !!! error TS2416:     Types of parameters 'n' and 's' are incompatible.
 !!! error TS2416:       Type 'string' is not assignable to type 'number'.
@@ -59,7 +59,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     class C3 implements IFoo3 { // incompatible on the property type
         public p1: number;
                ~~
-!!! error TS2416: Property 'p1' in type 'C3' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property 'p1' in type 'C3' is not assignable to the same property in base type 'IFoo3'.
 !!! error TS2416:   Type 'number' is not assignable to type 'string'.
     }
     
@@ -70,7 +70,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     class C4 implements IFoo4 { // incompatible on the property type
         public p1: { c: { b: string; }; d: string; };
                ~~
-!!! error TS2416: Property 'p1' in type 'C4' is not assignable to the same property in base type '{ a: { a: string; }; b: string; }'.
+!!! error TS2416: Property 'p1' in type 'C4' is not assignable to the same property in base type 'IFoo4'.
 !!! error TS2416:   Type '{ c: { b: string; }; d: string; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
 !!! error TS2416:     Property 'a' is missing in type '{ c: { b: string; }; d: string; }'.
     }

--- a/tests/baselines/reference/inheritance.errors.txt
+++ b/tests/baselines/reference/inheritance.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/inheritance.ts(31,12): error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
-tests/cases/compiler/inheritance.ts(32,12): error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type '() => number'.
+tests/cases/compiler/inheritance.ts(32,12): error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type 'Good'.
   Type '(n: number) => number' is not assignable to type '() => number'.
 
 
@@ -39,7 +39,7 @@ tests/cases/compiler/inheritance.ts(32,12): error TS2416: Property 'g' in type '
 !!! error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
         public g(n: number) { return 0; }
                ~
-!!! error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type '() => number'.
+!!! error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type 'Good'.
 !!! error TS2416:   Type '(n: number) => number' is not assignable to type '() => number'.
     }
     

--- a/tests/baselines/reference/inheritanceMemberAccessorOverridingMethod.errors.txt
+++ b/tests/baselines/reference/inheritanceMemberAccessorOverridingMethod.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type '() => string'.
+tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'a'.
   Type 'string' is not assignable to type '() => string'.
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(8,9): error TS2423: Class 'a' defines instance member function 'x', but extended class 'b' defines it as instance member accessor.
 tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type '() => string'.
+tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'a'.
   Type 'string' is not assignable to type '() => string'.
 
 
@@ -19,7 +19,7 @@ tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error T
             ~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             ~
-!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type '() => string'.
+!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'a'.
 !!! error TS2416:   Type 'string' is not assignable to type '() => string'.
             ~
 !!! error TS2423: Class 'a' defines instance member function 'x', but extended class 'b' defines it as instance member accessor.
@@ -29,7 +29,7 @@ tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts(11,9): error T
             ~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             ~
-!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type '() => string'.
+!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'a'.
 !!! error TS2416:   Type 'string' is not assignable to type '() => string'.
     
         }

--- a/tests/baselines/reference/inheritanceMemberFuncOverridingAccessor.errors.txt
+++ b/tests/baselines/reference/inheritanceMemberFuncOverridingAccessor.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(2,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(5,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'string'.
+tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'a'.
   Type '() => string' is not assignable to type 'string'.
 tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2426: Class 'a' defines instance member accessor 'x', but extended class 'b' defines it as instance member function.
 
@@ -22,7 +22,7 @@ tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts(11,5): error TS2
     class b extends a {
         x() {
         ~
-!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property 'x' in type 'b' is not assignable to the same property in base type 'a'.
 !!! error TS2416:   Type '() => string' is not assignable to type 'string'.
         ~
 !!! error TS2426: Class 'a' defines instance member accessor 'x', but extended class 'b' defines it as instance member function.

--- a/tests/baselines/reference/instanceSubtypeCheck2.errors.txt
+++ b/tests/baselines/reference/instanceSubtypeCheck2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/instanceSubtypeCheck2.ts(6,5): error TS2416: Property 'x' in type 'C2<T>' is not assignable to the same property in base type 'C2<T>'.
+tests/cases/compiler/instanceSubtypeCheck2.ts(6,5): error TS2416: Property 'x' in type 'C2<T>' is not assignable to the same property in base type 'C1<T>'.
   Type 'string' is not assignable to type 'C2<T>'.
 
 
@@ -10,6 +10,6 @@ tests/cases/compiler/instanceSubtypeCheck2.ts(6,5): error TS2416: Property 'x' i
     class C2<T> extends C1<T> {
         x: string
         ~
-!!! error TS2416: Property 'x' in type 'C2<T>' is not assignable to the same property in base type 'C2<T>'.
+!!! error TS2416: Property 'x' in type 'C2<T>' is not assignable to the same property in base type 'C1<T>'.
 !!! error TS2416:   Type 'string' is not assignable to type 'C2<T>'.
     }

--- a/tests/baselines/reference/interfaceDeclaration3.errors.txt
+++ b/tests/baselines/reference/interfaceDeclaration3.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/interfaceDeclaration3.ts(7,16): error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'string'.
+tests/cases/compiler/interfaceDeclaration3.ts(7,16): error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'I1'.
   Type 'number' is not assignable to type 'string'.
-tests/cases/compiler/interfaceDeclaration3.ts(32,16): error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'string'.
+tests/cases/compiler/interfaceDeclaration3.ts(32,16): error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'I1'.
   Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I2' incorrectly extends interface 'I1'.
   Types of property 'item' are incompatible.
@@ -16,7 +16,7 @@ tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I
         class C1 implements I1 {
             public item:number;
                    ~~~~
-!!! error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'I1'.
 !!! error TS2416:   Type 'number' is not assignable to type 'string'.
         }
         class C2 implements I1 {
@@ -44,7 +44,7 @@ tests/cases/compiler/interfaceDeclaration3.ts(54,11): error TS2430: Interface 'I
         class C1 implements I1 {
             public item:number;    
                    ~~~~
-!!! error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property 'item' in type 'C1' is not assignable to the same property in base type 'I1'.
 !!! error TS2416:   Type 'number' is not assignable to type 'string'.
         }
         class C2 implements I1 {

--- a/tests/baselines/reference/interfaceExtendsClassWithPrivate2.errors.txt
+++ b/tests/baselines/reference/interfaceExtendsClassWithPrivate2.errors.txt
@@ -2,11 +2,13 @@ tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(10,7): error TS2415: C
   Types have separate declarations of a private property 'x'.
 tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(10,7): error TS2420: Class 'D' incorrectly implements interface 'I'.
   Types have separate declarations of a private property 'x'.
-tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2416: Property 'x' in type 'D2' is not assignable to the same property in base type 'number'.
+tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2416: Property 'x' in type 'D2' is not assignable to the same property in base type 'C'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2416: Property 'x' in type 'D2' is not assignable to the same property in base type 'I'.
   Type 'string' is not assignable to type 'number'.
 
 
-==== tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts (3 errors) ====
+==== tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts (4 errors) ====
     class C {
         public foo(x: any) { return x; }
         private x = 1;
@@ -34,7 +36,10 @@ tests/cases/compiler/interfaceExtendsClassWithPrivate2.ts(20,13): error TS2416: 
         public foo(x: any) { return x; }
         private x = "";
                 ~
-!!! error TS2416: Property 'x' in type 'D2' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'x' in type 'D2' is not assignable to the same property in base type 'C'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
+                ~
+!!! error TS2416: Property 'x' in type 'D2' is not assignable to the same property in base type 'I'.
 !!! error TS2416:   Type 'string' is not assignable to type 'number'.
         other(x: any) { return x; }
         bar() { }

--- a/tests/baselines/reference/interfaceExtendsObjectIntersectionErrors.errors.txt
+++ b/tests/baselines/reference/interfaceExtendsObjectIntersectionErrors.errors.txt
@@ -14,15 +14,15 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(11,11): error TS2430: Interface 'I5' incorrectly extends interface 'T5'.
   Types of property 'c' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(16,38): error TS2416: Property 'a' in type 'C1' is not assignable to the same property in base type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(16,38): error TS2416: Property 'a' in type 'C1' is not assignable to the same property in base type 'T1'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(17,38): error TS2416: Property 'b' in type 'C2' is not assignable to the same property in base type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(17,38): error TS2416: Property 'b' in type 'C2' is not assignable to the same property in base type 'T2'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(18,38): error TS2416: Property 'length' in type 'C3' is not assignable to the same property in base type 'number'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(18,38): error TS2416: Property 'length' in type 'C3' is not assignable to the same property in base type 'number[]'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(19,38): error TS2416: Property '0' in type 'C4' is not assignable to the same property in base type 'string'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(19,38): error TS2416: Property '0' in type 'C4' is not assignable to the same property in base type '[string, number]'.
   Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(20,38): error TS2416: Property 'c' in type 'C5' is not assignable to the same property in base type 'string'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(20,38): error TS2416: Property 'c' in type 'C5' is not assignable to the same property in base type 'T5'.
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts(30,11): error TS2430: Interface 'I10' incorrectly extends interface 'typeof CX'.
   Types of property 'a' are incompatible.
@@ -94,23 +94,23 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectI
     
     class C1 extends Constructor<T1>() { a: string }
                                          ~
-!!! error TS2416: Property 'a' in type 'C1' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'a' in type 'C1' is not assignable to the same property in base type 'T1'.
 !!! error TS2416:   Type 'string' is not assignable to type 'number'.
     class C2 extends Constructor<T2>() { b: string }
                                          ~
-!!! error TS2416: Property 'b' in type 'C2' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'b' in type 'C2' is not assignable to the same property in base type 'T2'.
 !!! error TS2416:   Type 'string' is not assignable to type 'number'.
     class C3 extends Constructor<T3>() { length: string }
                                          ~~~~~~
-!!! error TS2416: Property 'length' in type 'C3' is not assignable to the same property in base type 'number'.
+!!! error TS2416: Property 'length' in type 'C3' is not assignable to the same property in base type 'number[]'.
 !!! error TS2416:   Type 'string' is not assignable to type 'number'.
     class C4 extends Constructor<T4>() { 0: number }
                                          ~
-!!! error TS2416: Property '0' in type 'C4' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property '0' in type 'C4' is not assignable to the same property in base type '[string, number]'.
 !!! error TS2416:   Type 'number' is not assignable to type 'string'.
     class C5 extends Constructor<T5>() { c: number }
                                          ~
-!!! error TS2416: Property 'c' in type 'C5' is not assignable to the same property in base type 'string'.
+!!! error TS2416: Property 'c' in type 'C5' is not assignable to the same property in base type 'T5'.
 !!! error TS2416:   Type 'number' is not assignable to type 'string'.
     
     declare class CX { static a: string }

--- a/tests/baselines/reference/interfaceImplementation7.errors.txt
+++ b/tests/baselines/reference/interfaceImplementation7.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/interfaceImplementation7.ts(4,11): error TS2320: Interface 'i3' cannot simultaneously extend types 'i1' and 'i2'.
   Named property 'name' of types 'i1' and 'i2' are not identical.
-tests/cases/compiler/interfaceImplementation7.ts(8,12): error TS2416: Property 'name' in type 'C1' is not assignable to the same property in base type '() => { s: string; n: number; }'.
+tests/cases/compiler/interfaceImplementation7.ts(8,12): error TS2416: Property 'name' in type 'C1' is not assignable to the same property in base type 'i4'.
   Type '() => string' is not assignable to type '() => { s: string; n: number; }'.
     Type 'string' is not assignable to type '{ s: string; n: number; }'.
 
@@ -18,7 +18,7 @@ tests/cases/compiler/interfaceImplementation7.ts(8,12): error TS2416: Property '
     class C1 implements i4 {
         public name(): string { return ""; }
                ~~~~
-!!! error TS2416: Property 'name' in type 'C1' is not assignable to the same property in base type '() => { s: string; n: number; }'.
+!!! error TS2416: Property 'name' in type 'C1' is not assignable to the same property in base type 'i4'.
 !!! error TS2416:   Type '() => string' is not assignable to type '() => { s: string; n: number; }'.
 !!! error TS2416:     Type 'string' is not assignable to type '{ s: string; n: number; }'.
     }

--- a/tests/baselines/reference/mismatchedGenericArguments1.errors.txt
+++ b/tests/baselines/reference/mismatchedGenericArguments1.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/mismatchedGenericArguments1.ts(5,4): error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type '<T>(x: T) => T'.
+tests/cases/compiler/mismatchedGenericArguments1.ts(5,4): error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type 'IFoo<T>'.
   Type '(x: string) => number' is not assignable to type '<T>(x: T) => T'.
     Types of parameters 'x' and 'x' are incompatible.
       Type 'T' is not assignable to type 'string'.
-tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type '<T>(x: T) => T'.
+tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type 'IFoo<T>'.
   Type '<U>(x: string) => number' is not assignable to type '<T>(x: T) => T'.
     Types of parameters 'x' and 'x' are incompatible.
       Type 'T' is not assignable to type 'string'.
@@ -15,7 +15,7 @@ tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2416: Propert
     class C<T> implements IFoo<T> {
        foo(x: string): number {
        ~~~
-!!! error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416: Property 'foo' in type 'C<T>' is not assignable to the same property in base type 'IFoo<T>'.
 !!! error TS2416:   Type '(x: string) => number' is not assignable to type '<T>(x: T) => T'.
 !!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2416:       Type 'T' is not assignable to type 'string'.
@@ -26,7 +26,7 @@ tests/cases/compiler/mismatchedGenericArguments1.ts(11,4): error TS2416: Propert
     class C2<T> implements IFoo<T> {
        foo<U>(x: string): number {
        ~~~
-!!! error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type '<T>(x: T) => T'.
+!!! error TS2416: Property 'foo' in type 'C2<T>' is not assignable to the same property in base type 'IFoo<T>'.
 !!! error TS2416:   Type '<U>(x: string) => number' is not assignable to type '<T>(x: T) => T'.
 !!! error TS2416:     Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2416:       Type 'T' is not assignable to type 'string'.

--- a/tests/baselines/reference/multipleInheritance.errors.txt
+++ b/tests/baselines/reference/multipleInheritance.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/multipleInheritance.ts(9,21): error TS1174: Classes can only extend a single class.
 tests/cases/compiler/multipleInheritance.ts(18,21): error TS1174: Classes can only extend a single class.
 tests/cases/compiler/multipleInheritance.ts(35,12): error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
-tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type '() => number'.
+tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type 'Good'.
   Type '(n: number) => number' is not assignable to type '() => number'.
 
 
@@ -49,7 +49,7 @@ tests/cases/compiler/multipleInheritance.ts(36,12): error TS2416: Property 'g' i
 !!! error TS2425: Class 'Good' defines instance member property 'f', but extended class 'Baad' defines it as instance member function.
         public g(n:number) { return 0; }
                ~
-!!! error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type '() => number'.
+!!! error TS2416: Property 'g' in type 'Baad' is not assignable to the same property in base type 'Good'.
 !!! error TS2416:   Type '(n: number) => number' is not assignable to type '() => number'.
     }
     

--- a/tests/baselines/reference/requiredInitializedParameter2.errors.txt
+++ b/tests/baselines/reference/requiredInitializedParameter2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2416: Property 'method' in type 'C1' is not assignable to the same property in base type '() => any'.
+tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2416: Property 'method' in type 'C1' is not assignable to the same property in base type 'I1'.
   Type '(a: number, b: any) => void' is not assignable to type '() => any'.
 
 
@@ -10,6 +10,6 @@ tests/cases/compiler/requiredInitializedParameter2.ts(6,5): error TS2416: Proper
     class C1 implements I1 {
         method(a = 0, b) { }
         ~~~~~~
-!!! error TS2416: Property 'method' in type 'C1' is not assignable to the same property in base type '() => any'.
+!!! error TS2416: Property 'method' in type 'C1' is not assignable to the same property in base type 'I1'.
 !!! error TS2416:   Type '(a: number, b: any) => void' is not assignable to type '() => any'.
     }

--- a/tests/baselines/reference/subtypesOfTypeParameter.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameter.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts(8,5): error TS2416: Property 'foo' in type 'D1<T, U>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameter.ts(8,5): error TS2416: Property 'foo' in type 'D1<T, U>' is not assignable to the same property in base type 'C3<T>'.
   Type 'U' is not assignable to type 'T'.
 
 
@@ -12,7 +12,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
     class D1<T, U> extends C3<T> {
         foo: U; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D1<T, U>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D1<T, U>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'T'.
     }
     

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
@@ -1,36 +1,36 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(19,5): error TS2416: Property 'foo' in type 'D3<T, U>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(19,5): error TS2416: Property 'foo' in type 'D3<T, U>' is not assignable to the same property in base type 'C3<T>'.
   Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(19,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(50,5): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(50,5): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
   Type 'U' is not assignable to type 'T'.
     Type 'V' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(50,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(67,5): error TS2416: Property 'foo' in type 'D11<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(67,5): error TS2416: Property 'foo' in type 'D11<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
   Type 'V' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(67,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(72,5): error TS2416: Property 'foo' in type 'D12<T, U, V>' is not assignable to the same property in base type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(72,5): error TS2416: Property 'foo' in type 'D12<T, U, V>' is not assignable to the same property in base type 'C3<U>'.
   Type 'V' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(72,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2416: Property 'foo' in type 'D19<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2416: Property 'foo' in type 'D19<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
   Type 'U' is not assignable to type 'T'.
     Type 'V' is not assignable to type 'T'.
       Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2416: Property 'foo' in type 'D23<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2416: Property 'foo' in type 'D23<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
   Type 'V' is not assignable to type 'T'.
     Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2416: Property 'foo' in type 'D24<T, U, V>' is not assignable to the same property in base type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2416: Property 'foo' in type 'D24<T, U, V>' is not assignable to the same property in base type 'C3<U>'.
   Type 'V' is not assignable to type 'U'.
     Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2416: Property 'foo' in type 'D27<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2416: Property 'foo' in type 'D27<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
   Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(161,5): error TS2416: Property 'foo' in type 'D28<T, U, V>' is not assignable to the same property in base type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(161,5): error TS2416: Property 'foo' in type 'D28<T, U, V>' is not assignable to the same property in base type 'C3<U>'.
   Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(161,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(166,5): error TS2416: Property 'foo' in type 'D29<T, U, V>' is not assignable to the same property in base type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(166,5): error TS2416: Property 'foo' in type 'D29<T, U, V>' is not assignable to the same property in base type 'C3<V>'.
   Type 'Date' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(166,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'V'.
 
@@ -56,7 +56,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: U; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D3<T, U>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D3<T, U>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
@@ -92,7 +92,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: U; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'T'.
 !!! error TS2416:     Type 'V' is not assignable to type 'T'.
         ~~~~~~~
@@ -115,7 +115,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: V; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D11<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D11<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
@@ -125,7 +125,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: V; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D12<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416: Property 'foo' in type 'D12<T, U, V>' is not assignable to the same property in base type 'C3<U>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
@@ -170,7 +170,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: U; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D19<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D19<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'T'.
 !!! error TS2416:     Type 'V' is not assignable to type 'T'.
 !!! error TS2416:       Type 'Date' is not assignable to type 'T'.
@@ -199,7 +199,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: V; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D23<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D23<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'T'.
 !!! error TS2416:     Type 'Date' is not assignable to type 'T'.
         ~~~~~~~
@@ -210,7 +210,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: V; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D24<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416: Property 'foo' in type 'D24<T, U, V>' is not assignable to the same property in base type 'C3<U>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'U'.
 !!! error TS2416:     Type 'Date' is not assignable to type 'U'.
         ~~~~~~~
@@ -233,7 +233,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: Date; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D27<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D27<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'Date' is not assignable to type 'T'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'T'.
@@ -243,7 +243,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: Date; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D28<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416: Property 'foo' in type 'D28<T, U, V>' is not assignable to the same property in base type 'C3<U>'.
 !!! error TS2416:   Type 'Date' is not assignable to type 'U'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'U'.
@@ -253,7 +253,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: V;
         foo: Date; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D29<T, U, V>' is not assignable to the same property in base type 'V'.
+!!! error TS2416: Property 'foo' in type 'D29<T, U, V>' is not assignable to the same property in base type 'C3<V>'.
 !!! error TS2416:   Type 'Date' is not assignable to type 'V'.
         ~~~~~~~~~~
 !!! error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'V'.

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
@@ -1,18 +1,18 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Foo'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'B1<Foo>'.
   Type 'V' is not assignable to type 'Foo'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'Foo'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'B1<T>'.
   Type 'U' is not assignable to type 'T'.
     Type 'Foo' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'B1<T>'.
   Type 'V' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'B1<U>'.
   Type 'T' is not assignable to type 'U'.
     Type 'Foo' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2416: Property 'foo' in type 'D9<T, U, V>' is not assignable to the same property in base type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2416: Property 'foo' in type 'D9<T, U, V>' is not assignable to the same property in base type 'B1<U>'.
   Type 'V' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
 
@@ -66,7 +66,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: Foo;
         foo: V; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Foo'.
+!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'B1<Foo>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'Foo'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'Foo'.
@@ -81,7 +81,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: U; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'B1<T>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'T'.
 !!! error TS2416:     Type 'Foo' is not assignable to type 'T'.
         ~~~~~~~
@@ -92,7 +92,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: T;
         foo: V; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'B1<T>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'T'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
@@ -102,7 +102,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: T; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'B1<U>'.
 !!! error TS2416:   Type 'T' is not assignable to type 'U'.
 !!! error TS2416:     Type 'Foo' is not assignable to type 'U'.
         ~~~~~~~
@@ -118,7 +118,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
         [x: string]: U;
         foo: V; // error
         ~~~
-!!! error TS2416: Property 'foo' in type 'D9<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416: Property 'foo' in type 'D9<T, U, V>' is not assignable to the same property in base type 'B1<U>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'U'.
         ~~~~~~~
 !!! error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.

--- a/tests/baselines/reference/subtypesOfTypeParameterWithRecursiveConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithRecursiveConstraints.errors.txt
@@ -1,58 +1,58 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2416: Property 'foo' in type 'D2<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2416: Property 'foo' in type 'D2<T, U, V>' is not assignable to the same property in base type 'Base<T>'.
   Type 'U' is not assignable to type 'T'.
     Type 'Foo<T>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(68,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'T'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Base<T>'.
   Type 'V' is not assignable to type 'T'.
     Type 'Foo<V>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(73,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2416: Property 'foo' in type 'D4<T, U, V>' is not assignable to the same property in base type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2416: Property 'foo' in type 'D4<T, U, V>' is not assignable to the same property in base type 'Base<U>'.
   Type 'T' is not assignable to type 'U'.
     Type 'Foo<U>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(78,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'U'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'Base<U>'.
   Type 'V' is not assignable to type 'U'.
     Type 'Foo<V>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(88,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'Base<V>'.
   Type 'T' is not assignable to type 'V'.
     Type 'Foo<U>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(93,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'V'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'Base<V>'.
   Type 'U' is not assignable to type 'V'.
     Type 'Foo<T>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(98,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(115,9): error TS2416: Property 'foo' in type 'D1<T, U, V>' is not assignable to the same property in base type 'Foo<T>'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(115,9): error TS2416: Property 'foo' in type 'D1<T, U, V>' is not assignable to the same property in base type 'Base2<T>'.
   Type 'T' is not assignable to type 'Foo<T>'.
     Type 'Foo<U>' is not assignable to type 'Foo<T>'.
       Type 'U' is not assignable to type 'T'.
         Type 'Foo<T>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(120,9): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(125,9): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Foo<T>'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(125,9): error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Base2<T>'.
   Type 'V' is not assignable to type 'Foo<T>'.
     Type 'Foo<V>' is not assignable to type 'Foo<T>'.
       Type 'V' is not assignable to type 'T'.
         Type 'Foo<V>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(125,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(130,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(135,9): error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'Foo<U>'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(135,9): error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'Base2<U>'.
   Type 'U' is not assignable to type 'Foo<U>'.
     Type 'Foo<T>' is not assignable to type 'Foo<U>'.
       Type 'T' is not assignable to type 'U'.
         Type 'Foo<U>' is not assignable to type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(140,9): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'Foo<U>'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(140,9): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'Base2<U>'.
   Type 'V' is not assignable to type 'Foo<U>'.
     Type 'Foo<V>' is not assignable to type 'Foo<U>'.
       Type 'V' is not assignable to type 'U'.
         Type 'Foo<V>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(140,9): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(145,9): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'Foo<V>'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(145,9): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'Base2<V>'.
   Type 'T' is not assignable to type 'Foo<V>'.
     Type 'Foo<U>' is not assignable to type 'Foo<V>'.
       Type 'U' is not assignable to type 'V'.
         Type 'Foo<T>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(145,9): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'V'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(150,9): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'Foo<V>'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(150,9): error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'Base2<V>'.
   Type 'U' is not assignable to type 'Foo<V>'.
     Type 'Foo<T>' is not assignable to type 'Foo<V>'.
       Type 'T' is not assignable to type 'V'.
@@ -130,7 +130,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: T;
             foo: U
             ~~~
-!!! error TS2416: Property 'foo' in type 'D2<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D2<T, U, V>' is not assignable to the same property in base type 'Base<T>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'T'.
 !!! error TS2416:     Type 'Foo<T>' is not assignable to type 'T'.
             ~~~~~~
@@ -141,7 +141,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: T;
             foo: V
             ~~~
-!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'T'.
+!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Base<T>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'T'.
 !!! error TS2416:     Type 'Foo<V>' is not assignable to type 'T'.
             ~~~~~~
@@ -152,7 +152,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: U;
             foo: T
             ~~~
-!!! error TS2416: Property 'foo' in type 'D4<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416: Property 'foo' in type 'D4<T, U, V>' is not assignable to the same property in base type 'Base<U>'.
 !!! error TS2416:   Type 'T' is not assignable to type 'U'.
 !!! error TS2416:     Type 'Foo<U>' is not assignable to type 'U'.
             ~~~~~~
@@ -168,7 +168,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: U;
             foo: V
             ~~~
-!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'U'.
+!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'Base<U>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'U'.
 !!! error TS2416:     Type 'Foo<V>' is not assignable to type 'U'.
             ~~~~~~
@@ -179,7 +179,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: V;
             foo: T
             ~~~
-!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'V'.
+!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'Base<V>'.
 !!! error TS2416:   Type 'T' is not assignable to type 'V'.
 !!! error TS2416:     Type 'Foo<U>' is not assignable to type 'V'.
             ~~~~~~
@@ -190,7 +190,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: V;
             foo: U
             ~~~
-!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'V'.
+!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'Base<V>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'V'.
 !!! error TS2416:     Type 'Foo<T>' is not assignable to type 'V'.
             ~~~~~~
@@ -213,7 +213,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: T;
             foo: T
             ~~~
-!!! error TS2416: Property 'foo' in type 'D1<T, U, V>' is not assignable to the same property in base type 'Foo<T>'.
+!!! error TS2416: Property 'foo' in type 'D1<T, U, V>' is not assignable to the same property in base type 'Base2<T>'.
 !!! error TS2416:   Type 'T' is not assignable to type 'Foo<T>'.
 !!! error TS2416:     Type 'Foo<U>' is not assignable to type 'Foo<T>'.
 !!! error TS2416:       Type 'U' is not assignable to type 'T'.
@@ -231,7 +231,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: T;
             foo: V
             ~~~
-!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Foo<T>'.
+!!! error TS2416: Property 'foo' in type 'D3<T, U, V>' is not assignable to the same property in base type 'Base2<T>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'Foo<T>'.
 !!! error TS2416:     Type 'Foo<V>' is not assignable to type 'Foo<T>'.
 !!! error TS2416:       Type 'V' is not assignable to type 'T'.
@@ -251,7 +251,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: U;
             foo: U
             ~~~
-!!! error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'Foo<U>'.
+!!! error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'Base2<U>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'Foo<U>'.
 !!! error TS2416:     Type 'Foo<T>' is not assignable to type 'Foo<U>'.
 !!! error TS2416:       Type 'T' is not assignable to type 'U'.
@@ -262,7 +262,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: U;
             foo: V
             ~~~
-!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'Foo<U>'.
+!!! error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'Base2<U>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'Foo<U>'.
 !!! error TS2416:     Type 'Foo<V>' is not assignable to type 'Foo<U>'.
 !!! error TS2416:       Type 'V' is not assignable to type 'U'.
@@ -275,7 +275,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: V;
             foo: T
             ~~~
-!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'Foo<V>'.
+!!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'Base2<V>'.
 !!! error TS2416:   Type 'T' is not assignable to type 'Foo<V>'.
 !!! error TS2416:     Type 'Foo<U>' is not assignable to type 'Foo<V>'.
 !!! error TS2416:       Type 'U' is not assignable to type 'V'.
@@ -288,7 +288,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
             [x: string]: V;
             foo: U
             ~~~
-!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'Foo<V>'.
+!!! error TS2416: Property 'foo' in type 'D8<T, U, V>' is not assignable to the same property in base type 'Base2<V>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'Foo<V>'.
 !!! error TS2416:     Type 'Foo<T>' is not assignable to type 'Foo<V>'.
 !!! error TS2416:       Type 'T' is not assignable to type 'V'.

--- a/tests/baselines/reference/subtypingWithObjectMembers.errors.txt
+++ b/tests/baselines/reference/subtypingWithObjectMembers.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(14,5): error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(14,5): error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'A'.
   Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(24,5): error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(24,5): error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'A2'.
   Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(34,5): error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(34,5): error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'A3'.
   Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(45,9): error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(45,9): error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'A'.
   Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(55,9): error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(55,9): error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'A2'.
   Type 'string' is not assignable to type 'Base'.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(65,9): error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'Base'.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers.ts(65,9): error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'A3'.
   Type 'string' is not assignable to type 'Base'.
 
 
@@ -28,7 +28,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         foo: Derived; // ok
         bar: string; // error
         ~~~
-!!! error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'Base'.
+!!! error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'A'.
 !!! error TS2416:   Type 'string' is not assignable to type 'Base'.
     }
     
@@ -41,7 +41,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         1: Derived; // ok
         2: string; // error
         ~
-!!! error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'Base'.
+!!! error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'A2'.
 !!! error TS2416:   Type 'string' is not assignable to type 'Base'.
     }
     
@@ -54,7 +54,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
         '1': Derived; // ok
         '2.0': string; // error
         ~~~~~
-!!! error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'Base'.
+!!! error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'A3'.
 !!! error TS2416:   Type 'string' is not assignable to type 'Base'.
     }
     
@@ -68,7 +68,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
             foo: Derived2; // ok
             bar: string; // error
             ~~~
-!!! error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'Base'.
+!!! error TS2416: Property 'bar' in type 'B' is not assignable to the same property in base type 'A'.
 !!! error TS2416:   Type 'string' is not assignable to type 'Base'.
         }
     
@@ -81,7 +81,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
             1: Derived2; // ok
             2: string; // error
             ~
-!!! error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'Base'.
+!!! error TS2416: Property '2' in type 'B2' is not assignable to the same property in base type 'A2'.
 !!! error TS2416:   Type 'string' is not assignable to type 'Base'.
         }
     
@@ -94,7 +94,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
             '1': Derived2; // ok
             '2.0': string; // error
             ~~~~~
-!!! error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'Base'.
+!!! error TS2416: Property '2.0' in type 'B3' is not assignable to the same property in base type 'A3'.
 !!! error TS2416:   Type 'string' is not assignable to type 'Base'.
         }
     }


### PR DESCRIPTION
The new class error was printing the incorrect type in its second type position on the first line (as the format of the message had been changed), and I didn't notice it before merging (since so many of the tests affected in our unittest suite have similar types as member types and base types in those positions). I went to go accept the RWC baselines for the new errors and noticed my error. 😨 