### PR TITLE
Unmangle scoped package names in import completions

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1097,11 +1097,16 @@ namespace ts {
     export function getPackageNameFromAtTypesDirectory(mangledName: string): string {
         const withoutAtTypePrefix = removePrefix(mangledName, "@types/");
         if (withoutAtTypePrefix !== mangledName) {
-            return stringContains(withoutAtTypePrefix, mangledScopedPackageSeparator) ?
-                "@" + withoutAtTypePrefix.replace(mangledScopedPackageSeparator, ts.directorySeparator) :
-                withoutAtTypePrefix;
+            return getPackageNameFromAtTypesDirectoryWithoutPrefix(withoutAtTypePrefix);
         }
         return mangledName;
+    }
+
+    /* @internal */
+    export function getPackageNameFromAtTypesDirectoryWithoutPrefix(withoutAtTypePrefix: string): string {
+        return stringContains(withoutAtTypePrefix, mangledScopedPackageSeparator) ?
+            "@" + withoutAtTypePrefix.replace(mangledScopedPackageSeparator, ts.directorySeparator) :
+            withoutAtTypePrefix;
     }
 
     function tryFindNonRelativeModuleNameInCache(cache: PerModuleNameCache | undefined, moduleName: string, containingDirectory: string, traceEnabled: boolean, host: ModuleResolutionHost): SearchResult<Resolved> {

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1097,16 +1097,16 @@ namespace ts {
     export function getPackageNameFromAtTypesDirectory(mangledName: string): string {
         const withoutAtTypePrefix = removePrefix(mangledName, "@types/");
         if (withoutAtTypePrefix !== mangledName) {
-            return getPackageNameFromAtTypesDirectoryWithoutPrefix(withoutAtTypePrefix);
+            return getUnmangledNameForScopedPackage(withoutAtTypePrefix);
         }
         return mangledName;
     }
 
     /* @internal */
-    export function getPackageNameFromAtTypesDirectoryWithoutPrefix(withoutAtTypePrefix: string): string {
-        return stringContains(withoutAtTypePrefix, mangledScopedPackageSeparator) ?
-            "@" + withoutAtTypePrefix.replace(mangledScopedPackageSeparator, ts.directorySeparator) :
-            withoutAtTypePrefix;
+    export function getUnmangledNameForScopedPackage(typesPackageName: string): string {
+        return stringContains(typesPackageName, mangledScopedPackageSeparator) ?
+            "@" + typesPackageName.replace(mangledScopedPackageSeparator, ts.directorySeparator) :
+            typesPackageName;
     }
 
     function tryFindNonRelativeModuleNameInCache(cache: PerModuleNameCache | undefined, moduleName: string, containingDirectory: string, traceEnabled: boolean, host: ModuleResolutionHost): SearchResult<Resolved> {

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -315,7 +315,7 @@ namespace ts.Completions.PathCompletions {
         const seen = createMap<true>();
         if (options.types) {
             for (const typesName of options.types) {
-                const moduleName = getPackageNameFromAtTypesDirectoryWithoutPrefix(typesName);
+                const moduleName = getUnmangledNameForScopedPackage(typesName);
                 pushResult(moduleName);
             }
         }
@@ -349,7 +349,7 @@ namespace ts.Completions.PathCompletions {
                     for (let typeDirectory of directories) {
                         typeDirectory = normalizePath(typeDirectory);
                         const directoryName = getBaseFileName(typeDirectory);
-                        const moduleName = getPackageNameFromAtTypesDirectoryWithoutPrefix(directoryName);
+                        const moduleName = getUnmangledNameForScopedPackage(directoryName);
                         pushResult(moduleName);
                     }
                 }

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -326,29 +326,28 @@ namespace ts.Completions.PathCompletions {
 
             if (typeRoots) {
                 for (const root of typeRoots) {
-                    getCompletionEntriesFromDirectories(host, root, span, result);
+                    getCompletionEntriesFromDirectories(root);
                 }
             }
-        }
 
-        if (host.getDirectories) {
             // Also get all @types typings installed in visible node_modules directories
             for (const packageJson of findPackageJsons(scriptPath, host)) {
                 const typesDir = combinePaths(getDirectoryPath(packageJson), "node_modules/@types");
-                getCompletionEntriesFromDirectories(host, typesDir, span, result);
+                getCompletionEntriesFromDirectories(typesDir);
             }
         }
 
         return result;
-    }
 
-    function getCompletionEntriesFromDirectories(host: LanguageServiceHost, directory: string, span: TextSpan, result: Push<CompletionEntry>) {
-        if (host.getDirectories && tryDirectoryExists(host, directory)) {
-            const directories = tryGetDirectories(host, directory);
-            if (directories) {
-                for (let typeDirectory of directories) {
-                    typeDirectory = normalizePath(typeDirectory);
-                    result.push(createCompletionEntryForModule(getBaseFileName(typeDirectory), ScriptElementKind.externalModuleName, span));
+        function getCompletionEntriesFromDirectories(directory: string) {
+            Debug.assert(!!host.getDirectories);
+            if (tryDirectoryExists(host, directory)) {
+                const directories = tryGetDirectories(host, directory);
+                if (directories) {
+                    for (let typeDirectory of directories) {
+                        typeDirectory = normalizePath(typeDirectory);
+                        result.push(createCompletionEntryForModule(getBaseFileName(typeDirectory), ScriptElementKind.externalModuleName, span));
+                    }
                 }
             }
         }

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -312,7 +312,7 @@ namespace ts.Completions.PathCompletions {
 
     function getCompletionEntriesFromTypings(host: LanguageServiceHost, options: CompilerOptions, scriptPath: string, span: TextSpan, result: CompletionEntry[] = []): CompletionEntry[] {
         // Check for typings specified in compiler options
-        let seen = createMap<true>();
+        const seen = createMap<true>();
         if (options.types) {
             for (const typesName of options.types) {
                 const moduleName = getPackageNameFromAtTypesDirectoryWithoutPrefix(typesName);

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -312,10 +312,11 @@ namespace ts.Completions.PathCompletions {
 
     function getCompletionEntriesFromTypings(host: LanguageServiceHost, options: CompilerOptions, scriptPath: string, span: TextSpan, result: CompletionEntry[] = []): CompletionEntry[] {
         // Check for typings specified in compiler options
+        let seen = createMap<true>();
         if (options.types) {
             for (const typesName of options.types) {
                 const moduleName = getPackageNameFromAtTypesDirectoryWithoutPrefix(typesName);
-                result.push(createCompletionEntryForModule(moduleName, ScriptElementKind.externalModuleName, span));
+                pushResult(moduleName);
             }
         }
         else if (host.getDirectories) {
@@ -349,9 +350,16 @@ namespace ts.Completions.PathCompletions {
                         typeDirectory = normalizePath(typeDirectory);
                         const directoryName = getBaseFileName(typeDirectory);
                         const moduleName = getPackageNameFromAtTypesDirectoryWithoutPrefix(directoryName);
-                        result.push(createCompletionEntryForModule(moduleName, ScriptElementKind.externalModuleName, span));
+                        pushResult(moduleName);
                     }
                 }
+            }
+        }
+
+        function pushResult(moduleName: string) {
+            if (!seen.has(moduleName)) {
+                result.push(createCompletionEntryForModule(moduleName, ScriptElementKind.externalModuleName, span));
+                seen.set(moduleName, true);
             }
         }
     }

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -313,7 +313,8 @@ namespace ts.Completions.PathCompletions {
     function getCompletionEntriesFromTypings(host: LanguageServiceHost, options: CompilerOptions, scriptPath: string, span: TextSpan, result: CompletionEntry[] = []): CompletionEntry[] {
         // Check for typings specified in compiler options
         if (options.types) {
-            for (const moduleName of options.types) {
+            for (const typesName of options.types) {
+                const moduleName = getPackageNameFromAtTypesDirectoryWithoutPrefix(typesName);
                 result.push(createCompletionEntryForModule(moduleName, ScriptElementKind.externalModuleName, span));
             }
         }
@@ -346,7 +347,9 @@ namespace ts.Completions.PathCompletions {
                 if (directories) {
                     for (let typeDirectory of directories) {
                         typeDirectory = normalizePath(typeDirectory);
-                        result.push(createCompletionEntryForModule(getBaseFileName(typeDirectory), ScriptElementKind.externalModuleName, span));
+                        const directoryName = getBaseFileName(typeDirectory);
+                        const moduleName = getPackageNameFromAtTypesDirectoryWithoutPrefix(directoryName);
+                        result.push(createCompletionEntryForModule(moduleName, ScriptElementKind.externalModuleName, span));
                     }
                 }
             }

--- a/tests/cases/fourslash/completionListInImportClause05.ts
+++ b/tests/cases/fourslash/completionListInImportClause05.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: app.ts
-//// import * as A from "[|/*1*/|]";
+////import * as A from "[|/*1*/|]";
 
 // @Filename: /node_modules/@types/a__b/index.d.ts
 ////declare module "@e/f" { function fun(): string; }
@@ -9,10 +9,8 @@
 // @Filename: /node_modules/@types/c__d/index.d.ts
 ////export declare let x: number;
 
-// NOTE: When performing completion, the "current directory" appears to be "/",
-// which is well above "." (i.e. the directory containing "app.ts").  This issue
-// is specific to the virtual file system, so just work around it by putting the
-// node modules folder in "/", rather than ".".
+// NOTE: The node_modules folder is in "/", rather than ".", because it requires
+// less scaffolding to mock.  In particular, "/" is where we look for type roots.
 
 const [replacementSpan] = test.ranges();
 verify.completionsAt("1", [

--- a/tests/cases/fourslash/completionListInImportClause05.ts
+++ b/tests/cases/fourslash/completionListInImportClause05.ts
@@ -9,6 +9,11 @@
 // @Filename: /node_modules/@types/c__d/index.d.ts
 ////export declare let x: number;
 
+// NOTE: When performing completion, the "current directory" appears to be "/",
+// which is well above "." (i.e. the directory containing "app.ts").  This issue
+// is specific to the virtual file system, so just work around it by putting the
+// node modules folder in "/", rather than ".".
+
 const [replacementSpan] = test.ranges();
 verify.completionsAt("1", [
     { name: "@a/b", replacementSpan },

--- a/tests/cases/fourslash/completionListInImportClause05.ts
+++ b/tests/cases/fourslash/completionListInImportClause05.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: app.ts
+//// import * as A from "[|/*1*/|]";
+
+// @Filename: /node_modules/@types/a__b/index.d.ts
+////declare module "@e/f" { function fun(): string; }
+
+// @Filename: /node_modules/@types/c__d/index.d.ts
+////export declare let x: number;
+
+const [replacementSpan] = test.ranges();
+verify.completionsAt("1", [
+    { name: "@a/b", replacementSpan },
+    { name: "@c/d", replacementSpan },
+    { name: "@e/f", replacementSpan },
+]);

--- a/tests/cases/fourslash/completionListInImportClause06.ts
+++ b/tests/cases/fourslash/completionListInImportClause06.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @typeRoots: T1,T2
+
+// @Filename: app.ts
+////import * as A from "[|/*1*/|]";
+
+// @Filename: T1/a__b/index.d.ts
+////export declare let x: number;
+
+// @Filename: T2/a__b/index.d.ts
+////export declare let x: number;
+
+// Confirm that entries are de-dup'd.
+verify.completionsAt("1", [
+    { name: "@a/b", replacementSpan: test.ranges()[0] },
+]);


### PR DESCRIPTION
"@" is only allowed at the start of a package name, so the types for package `@a/b` are put in `@types/a__b`.  We want completion to offer `@a/b`, rather than `a__b`.

Note that, in at least some cases, it is impossible to determine whether `@types/a__b` came from `@a/b` or `a__b`.  We don't try to distinguish - we always offer `@a/b`.  (Conceivably, we could switch to `a__b` if it resolves and `@a/b` does not but, at present, there are no typings for packages with "__" in the name.)

Fixes #15533
