### PR TITLE
Fix recursive mapped type infinite recursion

### DIFF
--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.errors.txt
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts(2,32): error TS2322: Type 'T' is not assignable to type 'string'.
+  Type '{ [P in T]: number; }' is not assignable to type 'string'.
+
+
+==== tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts (1 errors) ====
+    // #17847
+    function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
+                                   ~
+!!! error TS2322: Type 'T' is not assignable to type 'string'.
+!!! error TS2322:   Type '{ [P in T]: number; }' is not assignable to type 'string'.
+        n += v[k];
+    }
+    

--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.errors.txt
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.errors.txt
@@ -1,13 +1,11 @@
-tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts(2,32): error TS2322: Type 'T' is not assignable to type 'string'.
-  Type '{ [P in T]: number; }' is not assignable to type 'string'.
+tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts(2,32): error TS2313: Type parameter 'P' has a circular constraint.
 
 
 ==== tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts (1 errors) ====
     // #17847
     function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
                                    ~
-!!! error TS2322: Type 'T' is not assignable to type 'string'.
-!!! error TS2322:   Type '{ [P in T]: number; }' is not assignable to type 'string'.
+!!! error TS2313: Type parameter 'P' has a circular constraint.
         n += v[k];
     }
     

--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.js
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.js
@@ -1,0 +1,12 @@
+//// [incorrectRecursiveMappedTypeConstraint.ts]
+// #17847
+function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
+    n += v[k];
+}
+
+
+//// [incorrectRecursiveMappedTypeConstraint.js]
+// #17847
+function sum(n, v, k) {
+    n += v[k];
+}

--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.symbols
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts ===
+// #17847
+function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
+>sum : Symbol(sum, Decl(incorrectRecursiveMappedTypeConstraint.ts, 0, 0))
+>T : Symbol(T, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 13))
+>P : Symbol(P, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 26))
+>T : Symbol(T, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 13))
+>K : Symbol(K, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 44))
+>T : Symbol(T, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 13))
+>n : Symbol(n, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 64))
+>v : Symbol(v, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 74))
+>T : Symbol(T, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 13))
+>k : Symbol(k, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 80))
+>K : Symbol(K, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 44))
+
+    n += v[k];
+>n : Symbol(n, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 64))
+>v : Symbol(v, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 74))
+>k : Symbol(k, Decl(incorrectRecursiveMappedTypeConstraint.ts, 1, 80))
+}
+

--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.types
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts ===
+// #17847
+function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
+>sum : <T extends { [P in T]: number; }, K extends keyof T>(n: number, v: T, k: K) => void
+>T : T
+>P : P
+>T : T
+>K : K
+>T : T
+>n : number
+>v : T
+>T : T
+>k : K
+>K : K
+
+    n += v[k];
+>n += v[k] : number
+>n : number
+>v[k] : T[K]
+>v : T
+>k : K
+}
+

--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.types
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts ===
 // #17847
 function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
->sum : <T extends { [P in T]: number; }, K extends keyof T>(n: number, v: T, k: K) => void
+>sum : <T extends { [x: string]: number; }, K extends keyof T>(n: number, v: T, k: K) => void
 >T : T
 >P : P
 >T : T

--- a/tests/baselines/reference/recursiveMappedTypes.errors.txt
+++ b/tests/baselines/reference/recursiveMappedTypes.errors.txt
@@ -1,25 +1,34 @@
 tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(3,6): error TS2456: Type alias 'Recurse' circularly references itself.
+tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(4,11): error TS2313: Type parameter 'K' has a circular constraint.
 tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(7,6): error TS2456: Type alias 'Recurse1' circularly references itself.
+tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(8,11): error TS2313: Type parameter 'K' has a circular constraint.
 tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(11,6): error TS2456: Type alias 'Recurse2' circularly references itself.
+tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(12,11): error TS2313: Type parameter 'K' has a circular constraint.
 
 
-==== tests/cases/conformance/types/mapped/recursiveMappedTypes.ts (3 errors) ====
+==== tests/cases/conformance/types/mapped/recursiveMappedTypes.ts (6 errors) ====
     // Recursive mapped types simply appear empty
     
     type Recurse = {
          ~~~~~~~
 !!! error TS2456: Type alias 'Recurse' circularly references itself.
         [K in keyof Recurse]: Recurse[K]
+              ~~~~~~~~~~~~~
+!!! error TS2313: Type parameter 'K' has a circular constraint.
     }
     
     type Recurse1 = {
          ~~~~~~~~
 !!! error TS2456: Type alias 'Recurse1' circularly references itself.
         [K in keyof Recurse2]: Recurse2[K]
+              ~~~~~~~~~~~~~~
+!!! error TS2313: Type parameter 'K' has a circular constraint.
     }
     
     type Recurse2 = {
          ~~~~~~~~
 !!! error TS2456: Type alias 'Recurse2' circularly references itself.
         [K in keyof Recurse1]: Recurse1[K]
+              ~~~~~~~~~~~~~~
+!!! error TS2313: Type parameter 'K' has a circular constraint.
     }

--- a/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts
+++ b/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts
@@ -1,0 +1,4 @@
+// #17847
+function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
+    n += v[k];
+}


### PR DESCRIPTION
Fixes #17847 

`isGenericMappedType` indirectly calls `getResolvedBaseConstraint`, but is called indirectly from inside `getResolvedBaseConstraint`. This avoids the circularity check in `getResolvedBaseConstraint`, which causes an infinite recursion for certain malformed types.

Interestingly, I found four approaches that fixed the bug:

1. Delete lines 6559-6561 (`if (isGenericMappedType(t)) { return emptyObjectType; }`)
2. Pass `typeStack` to `isGenericMappedType` and check it in `getConstraintOfTypeParameter` instead of calling `hasNonCircularBaseConstraint`.
3. Clone `isGenericMappedType` and its callees into `getResolvedBaseConstraint` (and check `typeStack`).
4. Clone `isGenericMappedType` and its callees into `getResolvedBaseConstraint`, and merge into a single function (that checks `typeStack`).

And @weswigham suggested a fifth,

5. Remove `typeStack` and use `push/popTypeResolution` instead.

Previously, I decided on (2) because it avoids forking the code paths, but (5) reuses code even better.