### PR TITLE
Fix bug: get merged symbol of symbol.parent before checking against module symbol

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1200,7 +1200,7 @@ namespace ts.Completions {
                     // Don't add a completion for a re-export, only for the original.
                     // If `symbol.parent !== ...`, this comes from an `export * from "foo"` re-export. Those don't create new symbols.
                     // If `some(...)`, this comes from an `export { foo } from "foo"` re-export, which creates a new symbol (thus isn't caught by the first check).
-                    if (symbol.parent !== typeChecker.resolveExternalModuleSymbol(moduleSymbol)
+                    if (typeChecker.getMergedSymbol(symbol.parent) !== typeChecker.resolveExternalModuleSymbol(moduleSymbol)
                         || some(symbol.declarations, d => isExportSpecifier(d) && !!d.parent.parent.moduleSpecifier)) {
                         continue;
                     }

--- a/tests/cases/fourslash/completionsImport_named_exportEqualsNamespace_merged.ts
+++ b/tests/cases/fourslash/completionsImport_named_exportEqualsNamespace_merged.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /b.d.ts
+////declare namespace N {
+////    export const foo: number;
+////}
+////declare module "n" {
+////    export = N;
+////}
+
+// @Filename: /c.d.ts
+////declare namespace N {}
+
+// @Filename: /a.ts
+////fo/**/
+
+goTo.marker("");
+verify.completionListContains({ name: "foo", source: "n" }, "const N.foo: number", "", "const", undefined, /*hasAction*/ true, {
+    includeExternalModuleExports: true,
+    sourceDisplay: "n",
+});


### PR DESCRIPTION
Fixes #21143
Sequel to #20989