### PR TITLE
Do not trigger resolution cache invalidation if watch is triggered by program file emit

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -18,8 +18,8 @@ namespace ts {
      *   If an array, the full list of source files to emit.
      *   Else, calls `getSourceFilesToEmit` with the (optional) target source file to determine the list of source files to emit.
      */
-    export function forEachEmittedFile(
-        host: EmitHost, action: (emitFileNames: EmitFileNames, sourceFileOrBundle: SourceFile | Bundle, emitOnlyDtsFiles: boolean) => void,
+    export function forEachEmittedFile<T>(
+        host: EmitHost, action: (emitFileNames: EmitFileNames, sourceFileOrBundle: SourceFile | Bundle, emitOnlyDtsFiles: boolean) => T,
         sourceFilesOrTargetSourceFile?: SourceFile[] | SourceFile,
         emitOnlyDtsFiles?: boolean) {
 
@@ -30,7 +30,10 @@ namespace ts {
                 const jsFilePath = options.outFile || options.out;
                 const sourceMapFilePath = getSourceMapFilePath(jsFilePath, options);
                 const declarationFilePath = options.declaration ? removeFileExtension(jsFilePath) + Extension.Dts : "";
-                action({ jsFilePath, sourceMapFilePath, declarationFilePath }, createBundle(sourceFiles), emitOnlyDtsFiles);
+                const result = action({ jsFilePath, sourceMapFilePath, declarationFilePath }, createBundle(sourceFiles), emitOnlyDtsFiles);
+                if (result) {
+                    return result;
+                }
             }
         }
         else {
@@ -38,7 +41,10 @@ namespace ts {
                 const jsFilePath = getOwnEmitOutputFilePath(sourceFile, host, getOutputExtension(sourceFile, options));
                 const sourceMapFilePath = getSourceMapFilePath(jsFilePath, options);
                 const declarationFilePath = !isSourceFileJavaScript(sourceFile) && (emitOnlyDtsFiles || options.declaration) ? getDeclarationEmitOutputFilePath(sourceFile, host) : undefined;
-                action({ jsFilePath, sourceMapFilePath, declarationFilePath }, sourceFile, emitOnlyDtsFiles);
+                const result = action({ jsFilePath, sourceMapFilePath, declarationFilePath }, sourceFile, emitOnlyDtsFiles);
+                if (result) {
+                    return result;
+                }
             }
         }
     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -667,7 +667,8 @@ namespace ts {
             dropDiagnosticsProducingTypeChecker,
             getSourceFileFromReference,
             sourceFileToPackageName,
-            redirectTargetsSet
+            redirectTargetsSet,
+            isEmittedFile
         };
 
         verifyCompilerOptions();
@@ -2342,6 +2343,20 @@ namespace ts {
         function blockEmittingOfFile(emitFileName: string, diag: Diagnostic) {
             hasEmitBlockingDiagnostics.set(toPath(emitFileName), true);
             programDiagnostics.add(diag);
+        }
+
+        function isEmittedFile(file: string) {
+            if (options.noEmit) {
+                return false;
+            }
+
+            return forEachEmittedFile(getEmitHost(), ({ jsFilePath, declarationFilePath }) =>
+                isSameFile(jsFilePath, file) ||
+                (declarationFilePath && isSameFile(declarationFilePath, file)));
+        }
+
+        function isSameFile(file1: string, file2: string) {
+            return comparePaths(file1, file2, currentDirectory, !host.useCaseSensitiveFileNames()) === Comparison.EqualTo;
         }
     }
 

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -52,6 +52,7 @@ namespace ts {
         getGlobalCache?(): string | undefined;
         writeLog(s: string): void;
         maxNumberOfFilesToIterateForInvalidation?: number;
+        getCurrentProgram(): Program;
     }
 
     interface DirectoryWatchesOfFailedLookup {
@@ -470,6 +471,11 @@ namespace ts {
                 if (resolutionHost.getCachedDirectoryStructureHost) {
                     // Since the file existance changed, update the sourceFiles cache
                     resolutionHost.getCachedDirectoryStructureHost().addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
+                }
+
+                // Ignore emits from the program
+                if (isEmittedFileOfProgram(resolutionHost.getCurrentProgram(), fileOrDirectory)) {
+                    return;
                 }
 
                 // If the files are added to project root or node_modules directory, always run through the invalidation process

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2659,6 +2659,8 @@ namespace ts {
         /* @internal */ sourceFileToPackageName: Map<string>;
         /** Set of all source files that some other source file redirects to. */
         /* @internal */ redirectTargetsSet: Map<true>;
+        /** Is the file emitted file */
+        /* @internal */ isEmittedFile(file: string): boolean;
     }
 
     /* @internal */

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -305,6 +305,7 @@ namespace ts {
                 scheduleProgramUpdate();
             },
             maxNumberOfFilesToIterateForInvalidation: watchingHost.maxNumberOfFilesToIterateForInvalidation,
+            getCurrentProgram,
             writeLog
         };
         // Cache for the module resolution
@@ -322,7 +323,11 @@ namespace ts {
         // Update the wild card directory watch
         watchConfigFileWildCardDirectories();
 
-        return () => program;
+        return getCurrentProgram;
+
+        function getCurrentProgram() {
+            return program;
+        }
 
         function synchronizeProgram() {
             writeLog(`Synchronizing program`);

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -20,6 +20,9 @@ namespace ts {
         // Callbacks to do custom action before creating program and after creating program
         beforeCompile(compilerOptions: CompilerOptions): void;
         afterCompile(host: DirectoryStructureHost, program: Program, builder: Builder): void;
+
+        // Only for testing
+        maxNumberOfFilesToIterateForInvalidation?: number;
     }
 
     const defaultFormatDiagnosticsHost: FormatDiagnosticsHost = sys ? {
@@ -301,6 +304,7 @@ namespace ts {
                 hasChangedAutomaticTypeDirectiveNames = true;
                 scheduleProgramUpdate();
             },
+            maxNumberOfFilesToIterateForInvalidation: watchingHost.maxNumberOfFilesToIterateForInvalidation,
             writeLog
         };
         // Cache for the module resolution

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -82,6 +82,14 @@ namespace ts {
         }
     }
 
+    export function isEmittedFileOfProgram(program: Program | undefined, file: string) {
+        if (!program) {
+            return false;
+        }
+
+        return program.isEmittedFile(file);
+    }
+
     export function addFileWatcher(host: System, file: string, cb: FileWatcherCallback): FileWatcher {
         return host.watchFile(file, cb);
     }

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -1096,7 +1096,7 @@ namespace ts.tscWatch {
             assert.isTrue(host.fileExists("build/src/file2.js"));
 
             // This should be 0
-            host.checkTimeoutQueueLengthAndRun(1);
+            host.checkTimeoutQueueLengthAndRun(0);
         });
     });
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -830,7 +830,10 @@ namespace ts.server {
             return !hasChanges;
         }
 
-
+        /* @internal */
+        getCurrentProgram() {
+            return this.program;
+        }
 
         protected removeExistingTypings(include: string[]): string[] {
             const existing = ts.getAutomaticTypeDirectiveNames(this.getCompilerOptions(), this.directoryStructureHost);


### PR DESCRIPTION
If the number of source files in the resolution cache are more than maxNumberOfFilesToIterateForInvalidation (which is 256) then any file addition/removal triggers the new program creation to optimize for having to iterate through lot more resolutions.
This ensures that if file added/removed is from program emit, we ignore those and do not recompile the program
Fixes #20934
