### PR TITLE
Add a `getFullText()` helper method to `IScriptSnapshot`

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -170,11 +170,7 @@ namespace FourSlash {
     // This function creates IScriptSnapshot object for testing getPreProcessedFileInfo
     // Return object may lack some functionalities for other purposes.
     function createScriptSnapShot(sourceText: string): ts.IScriptSnapshot {
-        return {
-            getText: (start: number, end: number) => sourceText.substr(start, end - start),
-            getLength: () => sourceText.length,
-            getChangeRange: () => undefined
-        };
+        return ts.ScriptSnapshot.fromString(sourceText);
     }
 
     export class TestState {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -73,10 +73,6 @@ namespace Harness.LanguageService {
             return this.textSnapshot.substring(start, end);
         }
 
-        public getFullText(): string {
-            return this.textSnapshot;
-        }
-
         public getLength(): number {
             return this.textSnapshot.length;
         }
@@ -93,10 +89,6 @@ namespace Harness.LanguageService {
 
         public getText(start: number, end: number): string {
             return this.scriptSnapshot.getText(start, end);
-        }
-
-        public getFullText() {
-            return this.scriptSnapshot.getFullText();
         }
 
         public getLength(): number {
@@ -238,7 +230,7 @@ namespace Harness.LanguageService {
         }
         readFile(path: string): string | undefined {
             const target = this.symlinks.get(path);
-            return target !== undefined ? this.readFile(target) : this.getScriptSnapshot(path).getFullText();
+            return target !== undefined ? this.readFile(target) : ts.getSnapshotText(this.getScriptSnapshot(path));
         }
         addSymlink(from: string, target: string) { this.symlinks.set(from, target); }
         realpath(path: string): string {
@@ -347,7 +339,7 @@ namespace Harness.LanguageService {
         fileExists(fileName: string) { return this.getScriptInfo(fileName) !== undefined; }
         readFile(fileName: string) {
             const snapshot = this.nativeHost.getScriptSnapshot(fileName);
-            return snapshot && snapshot.getFullText();
+            return snapshot && ts.getSnapshotText(snapshot);
         }
         log(s: string): void { this.nativeHost.log(s); }
         trace(s: string): void { this.nativeHost.trace(s); }
@@ -651,7 +643,7 @@ namespace Harness.LanguageService {
             }
 
             const snapshot = this.host.getScriptSnapshot(fileName);
-            return snapshot && snapshot.getFullText();
+            return snapshot && ts.getSnapshotText(snapshot);
         }
 
         writeFile = ts.noop;

--- a/src/harness/unittests/hostNewLineSupport.ts
+++ b/src/harness/unittests/hostNewLineSupport.ts
@@ -4,27 +4,10 @@ namespace ts {
         function testLSWithFiles(settings: CompilerOptions, files: Harness.Compiler.TestFile[]) {
             function snapFor(path: string): IScriptSnapshot {
                 if (path === "lib.d.ts") {
-                    return {
-                        dispose: noop,
-                        getChangeRange() { return undefined; },
-                        getLength() { return 0; },
-                        getText() {
-                            return "";
-                        }
-                    };
+                    return ScriptSnapshot.fromString("");
                 }
-                const result = forEach(files, f => f.unitName === path ? f : undefined);
-                if (result) {
-                    return {
-                        dispose: noop,
-                        getChangeRange() { return undefined; },
-                        getLength() { return result.content.length; },
-                        getText(start, end) {
-                            return result.content.substring(start, end);
-                        }
-                    };
-                }
-                return undefined;
+                const result = find(files, f => f.unitName === path);
+                return result && ScriptSnapshot.fromString(result.content);
             }
             const lshost: LanguageServiceHost = {
                 getCompilationSettings: () => settings,

--- a/src/harness/unittests/incrementalParser.ts
+++ b/src/harness/unittests/incrementalParser.ts
@@ -5,7 +5,7 @@ namespace ts {
     ts.disableIncrementalParsing = false;
 
     function withChange(text: IScriptSnapshot, start: number, length: number, newText: string): { text: IScriptSnapshot; textChangeRange: TextChangeRange; } {
-        const contents = text.getFullText();
+        const contents = getSnapshotText(text);
         const newContents = contents.substr(0, start) + newText + contents.substring(start + length);
 
         return { text: ScriptSnapshot.fromString(newContents), textChangeRange: createTextChangeRange(createTextSpan(start, length), newText.length) };
@@ -105,7 +105,7 @@ namespace ts {
             const newTextAndChange = withDelete(oldText, index, 1);
             const newTree = compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, -1, oldTree).incrementalNewTree;
 
-            source = newTextAndChange.text.getFullText();
+            source = getSnapshotText(newTextAndChange.text);
             oldTree = newTree;
         }
     }
@@ -118,7 +118,7 @@ namespace ts {
             const newTextAndChange = withInsert(oldText, index + i, toInsert.charAt(i));
             const newTree = compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, -1, oldTree).incrementalNewTree;
 
-            source = newTextAndChange.text.getFullText();
+            source = getSnapshotText(newTextAndChange.text);
             oldTree = newTree;
         }
     }

--- a/src/harness/unittests/incrementalParser.ts
+++ b/src/harness/unittests/incrementalParser.ts
@@ -5,7 +5,7 @@ namespace ts {
     ts.disableIncrementalParsing = false;
 
     function withChange(text: IScriptSnapshot, start: number, length: number, newText: string): { text: IScriptSnapshot; textChangeRange: TextChangeRange; } {
-        const contents = text.getText(0, text.getLength());
+        const contents = text.getFullText();
         const newContents = contents.substr(0, start) + newText + contents.substring(start + length);
 
         return { text: ScriptSnapshot.fromString(newContents), textChangeRange: createTextChangeRange(createTextSpan(start, length), newText.length) };
@@ -105,7 +105,7 @@ namespace ts {
             const newTextAndChange = withDelete(oldText, index, 1);
             const newTree = compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, -1, oldTree).incrementalNewTree;
 
-            source = newTextAndChange.text.getText(0, newTextAndChange.text.getLength());
+            source = newTextAndChange.text.getFullText();
             oldTree = newTree;
         }
     }
@@ -118,7 +118,7 @@ namespace ts {
             const newTextAndChange = withInsert(oldText, index + i, toInsert.charAt(i));
             const newTree = compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, -1, oldTree).incrementalNewTree;
 
-            source = newTextAndChange.text.getText(0, newTextAndChange.text.getLength());
+            source = newTextAndChange.text.getFullText();
             oldTree = newTree;
         }
     }

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2116,7 +2116,7 @@ namespace ts.projectSystem {
 
             const scriptInfo = project.getScriptInfo(file1.path);
             const snap = scriptInfo.getSnapshot();
-            const actualText = snap.getText(0, snap.getLength());
+            const actualText = snap.getFullText();
             assert.equal(actualText, "", `expected content to be empty string, got "${actualText}"`);
 
             projectService.openClientFile(file1.path, `var x = 1;`);
@@ -2129,7 +2129,7 @@ namespace ts.projectSystem {
 
             const scriptInfo2 = project.getScriptInfo(file1.path);
             const snap2 = scriptInfo2.getSnapshot();
-            const actualText2 = snap2.getText(0, snap.getLength());
+            const actualText2 = snap2.getFullText();
             assert.equal(actualText2, "", `expected content to be empty string, got "${actualText2}"`);
         });
 
@@ -4178,7 +4178,7 @@ namespace ts.projectSystem {
             // verify content
             const projectServiice = session.getProjectService();
             const snap1 = projectServiice.getScriptInfo(f1.path).getSnapshot();
-            assert.equal(snap1.getText(0, snap1.getLength()), tmp.content, "content should be equal to the content of temp file");
+            assert.equal(snap1.getFullText(), tmp.content, "content should be equal to the content of temp file");
 
             // reload from original file file
             session.executeCommand(<server.protocol.ReloadRequest>{
@@ -4190,7 +4190,7 @@ namespace ts.projectSystem {
 
             // verify content
             const snap2 = projectServiice.getScriptInfo(f1.path).getSnapshot();
-            assert.equal(snap2.getText(0, snap2.getLength()), f1.content, "content should be equal to the content of original file");
+            assert.equal(snap2.getFullText(), f1.content, "content should be equal to the content of original file");
 
         });
 
@@ -4280,7 +4280,7 @@ namespace ts.projectSystem {
 
             function checkScriptInfoContents(contentsOfInfo: string, captionForContents: string) {
                 const snap = info.getSnapshot();
-                assert.equal(snap.getText(0, snap.getLength()), contentsOfInfo, "content should be equal to " + captionForContents);
+                assert.equal(snap.getFullText(), contentsOfInfo, "content should be equal to " + captionForContents);
             }
         });
     });

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2116,7 +2116,7 @@ namespace ts.projectSystem {
 
             const scriptInfo = project.getScriptInfo(file1.path);
             const snap = scriptInfo.getSnapshot();
-            const actualText = snap.getFullText();
+            const actualText = getSnapshotText(snap);
             assert.equal(actualText, "", `expected content to be empty string, got "${actualText}"`);
 
             projectService.openClientFile(file1.path, `var x = 1;`);
@@ -2128,8 +2128,7 @@ namespace ts.projectSystem {
             projectService.closeClientFile(file1.path);
 
             const scriptInfo2 = project.getScriptInfo(file1.path);
-            const snap2 = scriptInfo2.getSnapshot();
-            const actualText2 = snap2.getFullText();
+            const actualText2 = getSnapshotText(scriptInfo2.getSnapshot());
             assert.equal(actualText2, "", `expected content to be empty string, got "${actualText2}"`);
         });
 
@@ -4178,7 +4177,7 @@ namespace ts.projectSystem {
             // verify content
             const projectServiice = session.getProjectService();
             const snap1 = projectServiice.getScriptInfo(f1.path).getSnapshot();
-            assert.equal(snap1.getFullText(), tmp.content, "content should be equal to the content of temp file");
+            assert.equal(getSnapshotText(snap1), tmp.content, "content should be equal to the content of temp file");
 
             // reload from original file file
             session.executeCommand(<server.protocol.ReloadRequest>{
@@ -4190,7 +4189,7 @@ namespace ts.projectSystem {
 
             // verify content
             const snap2 = projectServiice.getScriptInfo(f1.path).getSnapshot();
-            assert.equal(snap2.getFullText(), f1.content, "content should be equal to the content of original file");
+            assert.equal(getSnapshotText(snap2), f1.content, "content should be equal to the content of original file");
 
         });
 
@@ -4280,7 +4279,7 @@ namespace ts.projectSystem {
 
             function checkScriptInfoContents(contentsOfInfo: string, captionForContents: string) {
                 const snap = info.getSnapshot();
-                assert.equal(snap.getFullText(), contentsOfInfo, "content should be equal to " + captionForContents);
+                assert.equal(getSnapshotText(snap), contentsOfInfo, "content should be equal to " + captionForContents);
             }
         });
     });

--- a/src/harness/unittests/versionCache.ts
+++ b/src/harness/unittests/versionCache.ts
@@ -284,9 +284,7 @@ and grew 1cm per day`;
                 svc.edit(ersa[i], elas[i], insertString);
                 checkText = editFlat(ersa[i], elas[i], insertString, checkText);
                 if (0 === (i % 4)) {
-                    const snap = svc.getSnapshot();
-                    const snapText = snap.getText(0, checkText.length);
-                    assert.equal(checkText, snapText);
+                    assert.equal(checkText, svc.getSnapshot().getFullText());
                 }
             }
         });

--- a/src/harness/unittests/versionCache.ts
+++ b/src/harness/unittests/versionCache.ts
@@ -284,7 +284,7 @@ and grew 1cm per day`;
                 svc.edit(ersa[i], elas[i], insertString);
                 checkText = editFlat(ersa[i], elas[i], insertString, checkText);
                 if (0 === (i % 4)) {
-                    assert.equal(checkText, svc.getSnapshot().getFullText());
+                    assert.equal(checkText, getSnapshotText(svc.getSnapshot()));
                 }
             }
         });

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -52,7 +52,7 @@ namespace ts.server {
         private getLineMap(fileName: string): number[] {
             let lineMap = this.lineMaps.get(fileName);
             if (!lineMap) {
-                lineMap = computeLineStarts(this.host.getScriptSnapshot(fileName).getFullText());
+                lineMap = computeLineStarts(getSnapshotText(this.host.getScriptSnapshot(fileName)));
                 this.lineMaps.set(fileName, lineMap);
             }
             return lineMap;

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -52,8 +52,7 @@ namespace ts.server {
         private getLineMap(fileName: string): number[] {
             let lineMap = this.lineMaps.get(fileName);
             if (!lineMap) {
-                const scriptSnapshot = this.host.getScriptSnapshot(fileName);
-                lineMap = computeLineStarts(scriptSnapshot.getText(0, scriptSnapshot.getLength()));
+                lineMap = computeLineStarts(this.host.getScriptSnapshot(fileName).getFullText());
                 this.lineMaps.set(fileName, lineMap);
             }
             return lineMap;

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -370,8 +370,7 @@ namespace ts.server {
         }
 
         saveTo(fileName: string) {
-            const snap = this.textStorage.getSnapshot();
-            this.host.writeFile(fileName, snap.getText(0, snap.getLength()));
+            this.host.writeFile(fileName, this.textStorage.getSnapshot().getFullText());
         }
 
         /*@internal*/

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -370,7 +370,7 @@ namespace ts.server {
         }
 
         saveTo(fileName: string) {
-            this.host.writeFile(fileName, this.textStorage.getSnapshot().getFullText());
+            this.host.writeFile(fileName, getSnapshotText(this.textStorage.getSnapshot()));
         }
 
         /*@internal*/

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -370,10 +370,6 @@ namespace ts.server {
             return this.index.getText(rangeStart, rangeEnd - rangeStart);
         }
 
-        getFullText(): string {
-            return this.getText(0, this.getLength());
-        }
-
         getLength() {
             return this.index.getLength();
         }

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -370,8 +370,12 @@ namespace ts.server {
             return this.index.getText(rangeStart, rangeEnd - rangeStart);
         }
 
+        getFullText(): string {
+            return this.getText(0, this.getLength());
+        }
+
         getLength() {
-            return this.index.root.charCount();
+            return this.index.getLength();
         }
 
         getChangeRange(oldSnapshot: IScriptSnapshot): TextChangeRange {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1534,7 +1534,7 @@ namespace ts.server {
                 let mappedRenameLocation: protocol.Location | undefined;
                 if (renameFilename !== undefined && renameLocation !== undefined) {
                     const renameScriptInfo = project.getScriptInfoForNormalizedPath(toNormalizedPath(renameFilename));
-                    mappedRenameLocation = getLocationInNewDocument(renameScriptInfo.getSnapshot().getFullText(), renameFilename, renameLocation, edits);
+                    mappedRenameLocation = getLocationInNewDocument(getSnapshotText(renameScriptInfo.getSnapshot()), renameFilename, renameLocation, edits);
                 }
                 return { renameLocation: mappedRenameLocation, renameFilename, edits: this.mapTextChangesToCodeEdits(project, edits) };
             }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1534,9 +1534,7 @@ namespace ts.server {
                 let mappedRenameLocation: protocol.Location | undefined;
                 if (renameFilename !== undefined && renameLocation !== undefined) {
                     const renameScriptInfo = project.getScriptInfoForNormalizedPath(toNormalizedPath(renameFilename));
-                    const snapshot = renameScriptInfo.getSnapshot();
-                    const oldText = snapshot.getText(0, snapshot.getLength());
-                    mappedRenameLocation = getLocationInNewDocument(oldText, renameFilename, renameLocation, edits);
+                    mappedRenameLocation = getLocationInNewDocument(renameScriptInfo.getSnapshot().getFullText(), renameFilename, renameLocation, edits);
                 }
                 return { renameLocation: mappedRenameLocation, renameFilename, edits: this.mapTextChangesToCodeEdits(project, edits) };
             }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1065,7 +1065,7 @@ namespace ts {
     }
 
     export function createLanguageServiceSourceFile(fileName: string, scriptSnapshot: IScriptSnapshot, scriptTarget: ScriptTarget, version: string, setNodeParents: boolean, scriptKind?: ScriptKind): SourceFile {
-        const sourceFile = createSourceFile(fileName, scriptSnapshot.getFullText(), scriptTarget, setNodeParents, scriptKind);
+        const sourceFile = createSourceFile(fileName, getSnapshotText(scriptSnapshot), scriptTarget, setNodeParents, scriptKind);
         setSourceFileFields(sourceFile, scriptSnapshot, version);
         return sourceFile;
     }
@@ -1264,7 +1264,7 @@ namespace ts {
                     const path = toPath(fileName, currentDirectory, getCanonicalFileName);
                     const entry = hostCache.getEntryByPath(path);
                     if (entry) {
-                        return isString(entry) ? undefined : entry.scriptSnapshot.getFullText();
+                        return isString(entry) ? undefined : getSnapshotText(entry.scriptSnapshot);
                     }
                     return host.readFile && host.readFile(fileName);
                 },

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1065,8 +1065,7 @@ namespace ts {
     }
 
     export function createLanguageServiceSourceFile(fileName: string, scriptSnapshot: IScriptSnapshot, scriptTarget: ScriptTarget, version: string, setNodeParents: boolean, scriptKind?: ScriptKind): SourceFile {
-        const text = scriptSnapshot.getText(0, scriptSnapshot.getLength());
-        const sourceFile = createSourceFile(fileName, text, scriptTarget, setNodeParents, scriptKind);
+        const sourceFile = createSourceFile(fileName, scriptSnapshot.getFullText(), scriptTarget, setNodeParents, scriptKind);
         setSourceFileFields(sourceFile, scriptSnapshot, version);
         return sourceFile;
     }
@@ -1265,7 +1264,7 @@ namespace ts {
                     const path = toPath(fileName, currentDirectory, getCanonicalFileName);
                     const entry = hostCache.getEntryByPath(path);
                     if (entry) {
-                        return isString(entry) ? undefined : entry.scriptSnapshot.getText(0, entry.scriptSnapshot.getLength());
+                        return isString(entry) ? undefined : entry.scriptSnapshot.getFullText();
                     }
                     return host.readFile && host.readFile(fileName);
                 },

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -28,8 +28,6 @@ namespace ts {
         /** Gets a portion of the script snapshot specified by [start, end). */
         getText(start: number, end: number): string;
 
-        getFullText(): string;
-
         /** Gets the length of this script snapshot. */
         getLength(): number;
 
@@ -292,10 +290,6 @@ namespace ts {
 
         public getText(start: number, end: number): string {
             return this.scriptSnapshotShim.getText(start, end);
-        }
-
-        public getFullText() {
-            return this.scriptSnapshotShim.getFullText();
         }
 
         public getLength(): number {
@@ -1089,7 +1083,7 @@ namespace ts {
                 `getPreProcessedFileInfo('${fileName}')`,
                 () => {
                     // for now treat files as JavaScript
-                    const result = preProcessFile(sourceTextSnapshot.getFullText(), /* readImportFiles */ true, /* detectJavaScriptImports */ true);
+                    const result = preProcessFile(getSnapshotText(sourceTextSnapshot), /* readImportFiles */ true, /* detectJavaScriptImports */ true);
                     return {
                         referencedFiles: this.convertFileReferences(result.referencedFiles),
                         importedFiles: this.convertFileReferences(result.importedFiles),
@@ -1129,7 +1123,7 @@ namespace ts {
             return this.forwardJSONCall(
                 `getTSConfigFileInfo('${fileName}')`,
                 () => {
-                    const result = parseJsonText(fileName, sourceTextSnapshot.getFullText());
+                    const result = parseJsonText(fileName, getSnapshotText(sourceTextSnapshot));
                     const normalizedFileName = normalizeSlashes(fileName);
                     const configFile = parseJsonSourceFileConfigFileContent(result, this.host, getDirectoryPath(normalizedFileName), /*existingOptions*/ {}, normalizedFileName);
 

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -28,6 +28,8 @@ namespace ts {
         /** Gets a portion of the script snapshot specified by [start, end). */
         getText(start: number, end: number): string;
 
+        getFullText(): string;
+
         /** Gets the length of this script snapshot. */
         getLength(): number;
 
@@ -290,6 +292,10 @@ namespace ts {
 
         public getText(start: number, end: number): string {
             return this.scriptSnapshotShim.getText(start, end);
+        }
+
+        public getFullText() {
+            return this.scriptSnapshotShim.getFullText();
         }
 
         public getLength(): number {
@@ -1083,7 +1089,7 @@ namespace ts {
                 `getPreProcessedFileInfo('${fileName}')`,
                 () => {
                     // for now treat files as JavaScript
-                    const result = preProcessFile(sourceTextSnapshot.getText(0, sourceTextSnapshot.getLength()), /* readImportFiles */ true, /* detectJavaScriptImports */ true);
+                    const result = preProcessFile(sourceTextSnapshot.getFullText(), /* readImportFiles */ true, /* detectJavaScriptImports */ true);
                     return {
                         referencedFiles: this.convertFileReferences(result.referencedFiles),
                         importedFiles: this.convertFileReferences(result.importedFiles),
@@ -1123,9 +1129,7 @@ namespace ts {
             return this.forwardJSONCall(
                 `getTSConfigFileInfo('${fileName}')`,
                 () => {
-                    const text = sourceTextSnapshot.getText(0, sourceTextSnapshot.getLength());
-
-                    const result = parseJsonText(fileName, text);
+                    const result = parseJsonText(fileName, sourceTextSnapshot.getFullText());
                     const normalizedFileName = normalizeSlashes(fileName);
                     const configFile = parseJsonSourceFileConfigFileContent(result, this.host, getDirectoryPath(normalizedFileName), /*existingOptions*/ {}, normalizedFileName);
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -95,6 +95,9 @@ namespace ts {
         /** Gets a portion of the script snapshot specified by [start, end). */
         getText(start: number, end: number): string;
 
+        /* @internal */
+        getFullText(): string;
+
         /** Gets the length of this script snapshot. */
         getLength(): number;
 
@@ -121,6 +124,10 @@ namespace ts {
                 return start === 0 && end === this.text.length
                     ? this.text
                     : this.text.substring(start, end);
+            }
+
+            public getFullText(): string {
+                return this.text;
             }
 
             public getLength(): number {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -95,9 +95,6 @@ namespace ts {
         /** Gets a portion of the script snapshot specified by [start, end). */
         getText(start: number, end: number): string;
 
-        /* @internal */
-        getFullText(): string;
-
         /** Gets the length of this script snapshot. */
         getLength(): number;
 
@@ -124,10 +121,6 @@ namespace ts {
                 return start === 0 && end === this.text.length
                     ? this.text
                     : this.text.substring(start, end);
-            }
-
-            public getFullText(): string {
-                return this.text;
             }
 
             public getLength(): number {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1107,6 +1107,10 @@ namespace ts {
         seen.set(key, true);
         return true;
     }
+
+    export function getSnapshotText(snap: IScriptSnapshot): string {
+        return snap.getText(0, snap.getLength());
+    }
 }
 
 // Display-part writer helpers


### PR DESCRIPTION
Most of our uses of `getText()` are of the form `snap.getText(0, snap.getLength())`. This would add a method to simplify these uses.