### PR TITLE
Unused type parameters should be checked by --noUnusedParameters, not --noUnusedLocals.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21389,7 +21389,7 @@ namespace ts {
                                 error(name, Diagnostics._0_is_declared_but_its_value_is_never_read, symbolName(local));
                             }
                         }
-                        else if (compilerOptions.noUnusedLocals) {
+                        else if (local.flags & SymbolFlags.TypeParameter ? compilerOptions.noUnusedParameters : compilerOptions.noUnusedLocals) {
                             forEach(local.declarations, d => errorUnusedLocal(d, symbolName(local)));
                         }
                     }
@@ -21463,7 +21463,7 @@ namespace ts {
         }
 
         function checkUnusedTypeParameters(node: ClassDeclaration | ClassExpression | FunctionDeclaration | MethodDeclaration | FunctionExpression | ArrowFunction | ConstructorDeclaration | SignatureDeclaration | InterfaceDeclaration | TypeAliasDeclaration) {
-            if (compilerOptions.noUnusedLocals && !(node.flags & NodeFlags.Ambient)) {
+            if (compilerOptions.noUnusedParameters && !(node.flags & NodeFlags.Ambient)) {
                 if (node.typeParameters) {
                     // Only report errors on the last declaration for the type parameter container;
                     // this ensures that all uses have been accounted for.

--- a/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.errors.txt
+++ b/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts(1,12): error TS6133: 'T' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts(3,8): error TS6133: 'T' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts(5,13): error TS6133: 'T' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts(7,9): error TS6133: 'T' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts(8,14): error TS6133: 'V' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts(11,10): error TS6133: 'T' is declared but its value is never read.
+
+
+==== tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts (6 errors) ====
+    function f<T>() { }
+               ~
+!!! error TS6133: 'T' is declared but its value is never read.
+    
+    type T<T> = { };
+           ~
+!!! error TS6133: 'T' is declared but its value is never read.
+    
+    interface I<T> { };
+                ~
+!!! error TS6133: 'T' is declared but its value is never read.
+    
+    class C<T> {
+            ~
+!!! error TS6133: 'T' is declared but its value is never read.
+        public m<V>() { }
+                 ~
+!!! error TS6133: 'V' is declared but its value is never read.
+    };
+    
+    let l = <T>() => { };
+             ~
+!!! error TS6133: 'T' is declared but its value is never read.
+    

--- a/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.js
+++ b/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.js
@@ -1,0 +1,25 @@
+//// [unusedTypeParametersCheckedByNoUnusedParameters.ts]
+function f<T>() { }
+
+type T<T> = { };
+
+interface I<T> { };
+
+class C<T> {
+    public m<V>() { }
+};
+
+let l = <T>() => { };
+
+
+//// [unusedTypeParametersCheckedByNoUnusedParameters.js]
+function f() { }
+;
+var C = /** @class */ (function () {
+    function C() {
+    }
+    C.prototype.m = function () { };
+    return C;
+}());
+;
+var l = function () { };

--- a/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.symbols
+++ b/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts ===
+function f<T>() { }
+>f : Symbol(f, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 0, 0))
+>T : Symbol(T, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 0, 11))
+
+type T<T> = { };
+>T : Symbol(T, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 0, 19))
+>T : Symbol(T, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 2, 7))
+
+interface I<T> { };
+>I : Symbol(I, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 2, 16))
+>T : Symbol(T, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 4, 12))
+
+class C<T> {
+>C : Symbol(C, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 4, 19))
+>T : Symbol(T, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 6, 8))
+
+    public m<V>() { }
+>m : Symbol(C.m, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 6, 12))
+>V : Symbol(V, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 7, 13))
+
+};
+
+let l = <T>() => { };
+>l : Symbol(l, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 10, 3))
+>T : Symbol(T, Decl(unusedTypeParametersCheckedByNoUnusedParameters.ts, 10, 9))
+

--- a/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.types
+++ b/tests/baselines/reference/unusedTypeParametersCheckedByNoUnusedParameters.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts ===
+function f<T>() { }
+>f : <T>() => void
+>T : T
+
+type T<T> = { };
+>T : {}
+>T : T
+
+interface I<T> { };
+>I : I<T>
+>T : T
+
+class C<T> {
+>C : C<T>
+>T : T
+
+    public m<V>() { }
+>m : <V>() => void
+>V : V
+
+};
+
+let l = <T>() => { };
+>l : <T>() => void
+><T>() => { } : <T>() => void
+>T : T
+

--- a/tests/baselines/reference/unusedTypeParametersNotCheckedByNoUnusedLocals.js
+++ b/tests/baselines/reference/unusedTypeParametersNotCheckedByNoUnusedLocals.js
@@ -1,0 +1,25 @@
+//// [unusedTypeParametersNotCheckedByNoUnusedLocals.ts]
+function f<T>() { }
+
+type T<T> = { };
+
+interface I<T> { };
+
+class C<T> {
+    public m<V>() { }
+};
+
+let l = <T>() => { };
+
+
+//// [unusedTypeParametersNotCheckedByNoUnusedLocals.js]
+function f() { }
+;
+var C = /** @class */ (function () {
+    function C() {
+    }
+    C.prototype.m = function () { };
+    return C;
+}());
+;
+var l = function () { };

--- a/tests/baselines/reference/unusedTypeParametersNotCheckedByNoUnusedLocals.symbols
+++ b/tests/baselines/reference/unusedTypeParametersNotCheckedByNoUnusedLocals.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/unusedTypeParametersNotCheckedByNoUnusedLocals.ts ===
+function f<T>() { }
+>f : Symbol(f, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 0, 0))
+>T : Symbol(T, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 0, 11))
+
+type T<T> = { };
+>T : Symbol(T, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 0, 19))
+>T : Symbol(T, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 2, 7))
+
+interface I<T> { };
+>I : Symbol(I, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 2, 16))
+>T : Symbol(T, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 4, 12))
+
+class C<T> {
+>C : Symbol(C, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 4, 19))
+>T : Symbol(T, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 6, 8))
+
+    public m<V>() { }
+>m : Symbol(C.m, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 6, 12))
+>V : Symbol(V, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 7, 13))
+
+};
+
+let l = <T>() => { };
+>l : Symbol(l, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 10, 3))
+>T : Symbol(T, Decl(unusedTypeParametersNotCheckedByNoUnusedLocals.ts, 10, 9))
+

--- a/tests/baselines/reference/unusedTypeParametersNotCheckedByNoUnusedLocals.types
+++ b/tests/baselines/reference/unusedTypeParametersNotCheckedByNoUnusedLocals.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/unusedTypeParametersNotCheckedByNoUnusedLocals.ts ===
+function f<T>() { }
+>f : <T>() => void
+>T : T
+
+type T<T> = { };
+>T : {}
+>T : T
+
+interface I<T> { };
+>I : I<T>
+>T : T
+
+class C<T> {
+>C : C<T>
+>T : T
+
+    public m<V>() { }
+>m : <V>() => void
+>V : V
+
+};
+
+let l = <T>() => { };
+>l : <T>() => void
+><T>() => { } : <T>() => void
+>T : T
+

--- a/tests/baselines/reference/unusedTypeParametersWithUnderscore.errors.txt
+++ b/tests/baselines/reference/unusedTypeParametersWithUnderscore.errors.txt
@@ -2,9 +2,11 @@ tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(1,16): error TS6133: 
 tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(3,12): error TS6133: 'U' is declared but its value is never read.
 tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(5,17): error TS6133: 'U' is declared but its value is never read.
 tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(7,13): error TS6133: 'U' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(8,18): error TS6133: 'W' is declared but its value is never read.
+tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(11,14): error TS6133: 'U' is declared but its value is never read.
 
 
-==== tests/cases/compiler/unusedTypeParametersWithUnderscore.ts (4 errors) ====
+==== tests/cases/compiler/unusedTypeParametersWithUnderscore.ts (6 errors) ====
     function f<_T, U>() { }
                    ~
 !!! error TS6133: 'U' is declared but its value is never read.
@@ -17,7 +19,15 @@ tests/cases/compiler/unusedTypeParametersWithUnderscore.ts(7,13): error TS6133: 
                     ~
 !!! error TS6133: 'U' is declared but its value is never read.
     
-    class C<_T, U> { };
+    class C<_T, U> {
                 ~
+!!! error TS6133: 'U' is declared but its value is never read.
+        public m<_V, W>() { }
+                     ~
+!!! error TS6133: 'W' is declared but its value is never read.
+    };
+    
+    let l = <_T, U>() => { };
+                 ~
 !!! error TS6133: 'U' is declared but its value is never read.
     

--- a/tests/baselines/reference/unusedTypeParametersWithUnderscore.js
+++ b/tests/baselines/reference/unusedTypeParametersWithUnderscore.js
@@ -5,7 +5,11 @@ type T<_T, U> = { };
 
 interface I<_T, U> { };
 
-class C<_T, U> { };
+class C<_T, U> {
+    public m<_V, W>() { }
+};
+
+let l = <_T, U>() => { };
 
 
 //// [unusedTypeParametersWithUnderscore.js]
@@ -14,6 +18,8 @@ function f() { }
 var C = /** @class */ (function () {
     function C() {
     }
+    C.prototype.m = function () { };
     return C;
 }());
 ;
+var l = function () { };

--- a/tests/baselines/reference/unusedTypeParametersWithUnderscore.symbols
+++ b/tests/baselines/reference/unusedTypeParametersWithUnderscore.symbols
@@ -14,8 +14,20 @@ interface I<_T, U> { };
 >_T : Symbol(_T, Decl(unusedTypeParametersWithUnderscore.ts, 4, 12))
 >U : Symbol(U, Decl(unusedTypeParametersWithUnderscore.ts, 4, 15))
 
-class C<_T, U> { };
+class C<_T, U> {
 >C : Symbol(C, Decl(unusedTypeParametersWithUnderscore.ts, 4, 23))
 >_T : Symbol(_T, Decl(unusedTypeParametersWithUnderscore.ts, 6, 8))
 >U : Symbol(U, Decl(unusedTypeParametersWithUnderscore.ts, 6, 11))
+
+    public m<_V, W>() { }
+>m : Symbol(C.m, Decl(unusedTypeParametersWithUnderscore.ts, 6, 16))
+>_V : Symbol(_V, Decl(unusedTypeParametersWithUnderscore.ts, 7, 13))
+>W : Symbol(W, Decl(unusedTypeParametersWithUnderscore.ts, 7, 16))
+
+};
+
+let l = <_T, U>() => { };
+>l : Symbol(l, Decl(unusedTypeParametersWithUnderscore.ts, 10, 3))
+>_T : Symbol(_T, Decl(unusedTypeParametersWithUnderscore.ts, 10, 9))
+>U : Symbol(U, Decl(unusedTypeParametersWithUnderscore.ts, 10, 12))
 

--- a/tests/baselines/reference/unusedTypeParametersWithUnderscore.types
+++ b/tests/baselines/reference/unusedTypeParametersWithUnderscore.types
@@ -14,8 +14,21 @@ interface I<_T, U> { };
 >_T : _T
 >U : U
 
-class C<_T, U> { };
+class C<_T, U> {
 >C : C<_T, U>
+>_T : _T
+>U : U
+
+    public m<_V, W>() { }
+>m : <_V, W>() => void
+>_V : _V
+>W : W
+
+};
+
+let l = <_T, U>() => { };
+>l : <_T, U>() => void
+><_T, U>() => { } : <_T, U>() => void
 >_T : _T
 >U : U
 

--- a/tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts
+++ b/tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts
@@ -1,0 +1,13 @@
+//@noUnusedParameters:true
+
+function f<T>() { }
+
+type T<T> = { };
+
+interface I<T> { };
+
+class C<T> {
+    public m<V>() { }
+};
+
+let l = <T>() => { };

--- a/tests/cases/compiler/unusedTypeParametersNotCheckedByNoUnusedLocals.ts
+++ b/tests/cases/compiler/unusedTypeParametersNotCheckedByNoUnusedLocals.ts
@@ -1,0 +1,13 @@
+//@noUnusedLocals:true
+
+function f<T>() { }
+
+type T<T> = { };
+
+interface I<T> { };
+
+class C<T> {
+    public m<V>() { }
+};
+
+let l = <T>() => { };

--- a/tests/cases/compiler/unusedTypeParametersWithUnderscore.ts
+++ b/tests/cases/compiler/unusedTypeParametersWithUnderscore.ts
@@ -1,4 +1,4 @@
-//@noUnusedLocals:true
+//@noUnusedParameters:true
 
 function f<_T, U>() { }
 
@@ -6,4 +6,8 @@ type T<_T, U> = { };
 
 interface I<_T, U> { };
 
-class C<_T, U> { };
+class C<_T, U> {
+    public m<_V, W>() { }
+};
+
+let l = <_T, U>() => { };

--- a/tests/cases/fourslash/unusedTypeParametersInClass1.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInClass1.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 ////[|class greeter<T> |] {
 ////}
 

--- a/tests/cases/fourslash/unusedTypeParametersInClass2.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInClass2.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 ////[|class greeter<X, Y> |] {
 ////    public a: X;
 ////}

--- a/tests/cases/fourslash/unusedTypeParametersInClass3.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInClass3.ts
@@ -1,7 +1,7 @@
 
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 ////[|class greeter<X, Y, Z> |] {
 ////    public a: X;
 ////    public b: Z;

--- a/tests/cases/fourslash/unusedTypeParametersInFunction1.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInFunction1.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 //// [|function f1<T>() {}|]
 
 verify.codeFix({

--- a/tests/cases/fourslash/unusedTypeParametersInFunction2.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInFunction2.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 //// [|function f1<X, Y>(a: X) {a}|]
 
 verify.codeFix({

--- a/tests/cases/fourslash/unusedTypeParametersInFunction3.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInFunction3.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 //// [|function f1<X, Y, Z>(a: X) {a;var b:Z;b}|]
 
 verify.codeFix({

--- a/tests/cases/fourslash/unusedTypeParametersInLambda4.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInLambda4.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 //// class A<T> {
 ////    public x: T;
 //// }

--- a/tests/cases/fourslash/unusedTypeParametersInMethod1.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInMethod1.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 //// class C1 {
 ////    [|f1<T extends number>()|] {}
 //// }

--- a/tests/cases/fourslash/unusedTypeParametersInMethod2.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInMethod2.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 //// class C1 {
 ////    [|f1<T extends number, U>(a: U)|] {a;}
 //// }

--- a/tests/cases/fourslash/unusedTypeParametersInMethods1.ts
+++ b/tests/cases/fourslash/unusedTypeParametersInMethods1.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-// @noUnusedLocals: true
+// @noUnusedParameters: true
 //// class A {
 ////     [|public f1<X, Y, Z>(a: X)|] { a; var b: Z; b }
 //// }


### PR DESCRIPTION
Fixes #20568.

Most of the existing test cases of unused type parameters passed both `--noUnusedParameters` and `--noUnusedLocals`.  A few test cases passed only `--noUnusedLocals` and failed after I changed the code; I changed them to pass only `--noUnusedParameters`.  I also added the two missing contexts of type parameters (method, lambda) to `tests/cases/compiler/unusedTypeParametersWithUnderscore.ts` and used this test case as the basis of new test cases testing specifically that unused type parameters are checked with `--noUnusedParameters` alone and not with `--noUnusedLocals` alone.