### PR TITLE
Accept corrected baseline

### DIFF
--- a/tests/baselines/reference/indexedAccessRetainsIndexSignature.types
+++ b/tests/baselines/reference/indexedAccessRetainsIndexSignature.types
@@ -14,7 +14,7 @@ type Diff<T extends string, U extends string> =
 >T : T
 
 type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>
->Omit : Pick<U, ({ [P in T]: P; } & { [P in U]: never; } & { [x: string]: never; })[keyof U]>
+>Omit : Pick<U, ({ [P in keyof U]: P; } & { [P in K]: never; } & { [x: string]: never; })[keyof U]>
 >U : U
 >K : K
 >U : U
@@ -25,7 +25,7 @@ type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>
 >K : K
 
 type Omit1<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
->Omit1 : Pick<U, ({ [P in T]: P; } & { [P in U]: never; } & { [x: string]: never; })[keyof U]>
+>Omit1 : Pick<U, ({ [P in keyof U]: P; } & { [P in K]: never; } & { [x: string]: never; })[keyof U]>
 >U : U
 >K : K
 >U : U
@@ -51,7 +51,7 @@ type Omit2<T, K extends keyof T> = {[P in Diff<keyof T, K>]: T[P]};
 
 type O = Omit<{ a: number, b: string }, 'a'>
 >O : Pick<{ a: number; b: string; }, "b">
->Omit : Pick<U, ({ [P in T]: P; } & { [P in U]: never; } & { [x: string]: never; })[keyof U]>
+>Omit : Pick<U, ({ [P in keyof U]: P; } & { [P in K]: never; } & { [x: string]: never; })[keyof U]>
 >a : number
 >b : string
 


### PR DESCRIPTION
#18860 merged, but in the time between its last update and merge a new test was added whose baseline emit for mapped types is corrected by the change (thus breaking the build). This accepts that baseline.
