### PR TITLE
Allow functions to be printed structurally in declaration emit even when they have symbols

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2945,7 +2945,7 @@ namespace ts {
                         // Always use 'typeof T' for type of class, enum, and module objects
                         if (symbol.flags & SymbolFlags.Class && !getBaseTypeVariableOfClass(symbol) && !(symbol.valueDeclaration.kind === SyntaxKind.ClassExpression && context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral) ||
                             symbol.flags & (SymbolFlags.Enum | SymbolFlags.ValueModule) ||
-                            shouldWriteTypeOfFunctionSymbol()) {
+                            shouldWriteTypeOfFunctionSymbol() && !(context.flags & NodeBuilderFlags.UseStructuralFallback && isSymbolAccessible(symbol, context.enclosingDeclaration, SymbolFlags.Value, /*computeAliases*/ false).accessibility !== SymbolAccessibility.Accessible)) {
                             return createTypeQueryNodeFromSymbol(symbol, SymbolFlags.Value);
                         }
                         else if (contains(context.symbolStack, symbol)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2531,6 +2531,11 @@ namespace ts {
             return access.accessibility === SymbolAccessibility.Accessible;
         }
 
+        function isValueSymbolAccessible(typeSymbol: Symbol, enclosingDeclaration: Node): boolean {
+            const access = isSymbolAccessible(typeSymbol, enclosingDeclaration, SymbolFlags.Value, /*shouldComputeAliasesToMakeVisible*/ false);
+            return access.accessibility === SymbolAccessibility.Accessible;
+        }
+
         /**
          * Check if the given symbol in given enclosing declaration is accessible and mark all associated alias to be visible if requested
          *
@@ -2945,7 +2950,7 @@ namespace ts {
                         // Always use 'typeof T' for type of class, enum, and module objects
                         if (symbol.flags & SymbolFlags.Class && !getBaseTypeVariableOfClass(symbol) && !(symbol.valueDeclaration.kind === SyntaxKind.ClassExpression && context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral) ||
                             symbol.flags & (SymbolFlags.Enum | SymbolFlags.ValueModule) ||
-                            shouldWriteTypeOfFunctionSymbol() && !(context.flags & NodeBuilderFlags.UseStructuralFallback && isSymbolAccessible(symbol, context.enclosingDeclaration, SymbolFlags.Value, /*computeAliases*/ false).accessibility !== SymbolAccessibility.Accessible)) {
+                            shouldWriteTypeOfFunctionSymbol()) {
                             return createTypeQueryNodeFromSymbol(symbol, SymbolFlags.Value);
                         }
                         else if (contains(context.symbolStack, symbol)) {
@@ -2993,7 +2998,8 @@ namespace ts {
                                     declaration.parent.kind === SyntaxKind.SourceFile || declaration.parent.kind === SyntaxKind.ModuleBlock));
                         if (isStaticMethodSymbol || isNonLocalFunctionSymbol) {
                             // typeof is allowed only for static/non local functions
-                            return !!(context.flags & NodeBuilderFlags.UseTypeOfFunction) || contains(context.symbolStack, symbol); // it is type of the symbol uses itself recursively
+                            return (!!(context.flags & NodeBuilderFlags.UseTypeOfFunction) || contains(context.symbolStack, symbol)) && // it is type of the symbol uses itself recursively
+                                (!(context.flags & NodeBuilderFlags.UseStructuralFallback) || isValueSymbolAccessible(symbol, context.enclosingDeclaration)); // And the build is going to succeed without visibility error or there is no structural fallback allowed
                         }
                     }
                 }

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -358,7 +358,7 @@ namespace ts {
             }
             else {
                 errorNameNode = declaration.name;
-                const format = TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.WriteDefaultSymbolWithoutName |
+                const format = TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback | TypeFormatFlags.WriteDefaultSymbolWithoutName |
                     TypeFormatFlags.WriteClassExpressionAsTypeLiteral |
                     (shouldUseResolverType ? TypeFormatFlags.AddUndefined : 0);
                 resolver.writeTypeOfDeclaration(declaration, enclosingDeclaration, format, writer);
@@ -378,7 +378,7 @@ namespace ts {
                 resolver.writeReturnTypeOfSignatureDeclaration(
                     signature,
                     enclosingDeclaration,
-                    TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.WriteClassExpressionAsTypeLiteral | TypeFormatFlags.WriteDefaultSymbolWithoutName,
+                    TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback | TypeFormatFlags.WriteClassExpressionAsTypeLiteral | TypeFormatFlags.WriteDefaultSymbolWithoutName,
                     writer);
                 errorNameNode = undefined;
             }
@@ -643,7 +643,7 @@ namespace ts {
             resolver.writeTypeOfExpression(
                 expr,
                 enclosingDeclaration,
-                TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.WriteClassExpressionAsTypeLiteral | TypeFormatFlags.WriteDefaultSymbolWithoutName,
+                TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback | TypeFormatFlags.WriteClassExpressionAsTypeLiteral | TypeFormatFlags.WriteDefaultSymbolWithoutName,
                 writer);
             write(";");
             writeLine();

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2934,6 +2934,7 @@ namespace ts {
         NoTruncation                            = 1 << 0,   // Don't truncate result
         WriteArrayAsGenericType                 = 1 << 1,   // Write Array<T> instead T[]
         WriteDefaultSymbolWithoutName           = 1 << 2,   // Write `default`-named symbols as `default` instead of how they were written
+        UseStructuralFallback                   = 1 << 3,   // When an alias cannot be named by its symbol, rather than report an error, fallback to a structural printout if possible 
         // empty space
         WriteTypeArgumentsOfSignature           = 1 << 5,   // Write the type arguments instead of type parameters of the signature
         UseFullyQualifiedType                   = 1 << 6,   // Write out the fully qualified type name (eg. Module.Type, instead of Type)
@@ -2968,6 +2969,7 @@ namespace ts {
         NoTruncation                            = 1 << 0,  // Don't truncate typeToString result
         WriteArrayAsGenericType                 = 1 << 1,  // Write Array<T> instead T[]
         WriteDefaultSymbolWithoutName           = 1 << 2,  // Write all `defaut`-named symbols as `default` instead of their written name
+        UseStructuralFallback                   = 1 << 3,   // When an alias cannot be named by its symbol, rather than report an error, fallback to a structural printout if possible 
         // hole because there's a hole in node builder flags
         WriteTypeArgumentsOfSignature           = 1 << 5,  // Write the type arguments instead of type parameters of the signature
         UseFullyQualifiedType                   = 1 << 6,  // Write out the fully qualified type name (eg. Module.Type, instead of Type)
@@ -2997,7 +2999,7 @@ namespace ts {
         /** @deprecated */ WriteOwnNameForAnyLike  = 0,  // Does nothing
 
         NodeBuilderFlagsMask =
-            NoTruncation | WriteArrayAsGenericType | WriteDefaultSymbolWithoutName | WriteTypeArgumentsOfSignature |
+            NoTruncation | WriteArrayAsGenericType | WriteDefaultSymbolWithoutName | UseStructuralFallback | WriteTypeArgumentsOfSignature |
             UseFullyQualifiedType | SuppressAnyReturnType | MultilineObjectLiterals | WriteClassExpressionAsTypeLiteral |
             UseTypeOfFunction | OmitParameterModifiers | UseAliasDefinedOutsideCurrentScope | AllowUniqueESSymbolType | InTypeAlias,
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2934,7 +2934,7 @@ namespace ts {
         NoTruncation                            = 1 << 0,   // Don't truncate result
         WriteArrayAsGenericType                 = 1 << 1,   // Write Array<T> instead T[]
         WriteDefaultSymbolWithoutName           = 1 << 2,   // Write `default`-named symbols as `default` instead of how they were written
-        UseStructuralFallback                   = 1 << 3,   // When an alias cannot be named by its symbol, rather than report an error, fallback to a structural printout if possible 
+        UseStructuralFallback                   = 1 << 3,   // When an alias cannot be named by its symbol, rather than report an error, fallback to a structural printout if possible
         // empty space
         WriteTypeArgumentsOfSignature           = 1 << 5,   // Write the type arguments instead of type parameters of the signature
         UseFullyQualifiedType                   = 1 << 6,   // Write out the fully qualified type name (eg. Module.Type, instead of Type)
@@ -2969,7 +2969,7 @@ namespace ts {
         NoTruncation                            = 1 << 0,  // Don't truncate typeToString result
         WriteArrayAsGenericType                 = 1 << 1,  // Write Array<T> instead T[]
         WriteDefaultSymbolWithoutName           = 1 << 2,  // Write all `defaut`-named symbols as `default` instead of their written name
-        UseStructuralFallback                   = 1 << 3,   // When an alias cannot be named by its symbol, rather than report an error, fallback to a structural printout if possible 
+        UseStructuralFallback                   = 1 << 3,   // When an alias cannot be named by its symbol, rather than report an error, fallback to a structural printout if possible
         // hole because there's a hole in node builder flags
         WriteTypeArgumentsOfSignature           = 1 << 5,  // Write the type arguments instead of type parameters of the signature
         UseFullyQualifiedType                   = 1 << 6,  // Write out the fully qualified type name (eg. Module.Type, instead of Type)

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1800,6 +1800,7 @@ declare namespace ts {
         NoTruncation = 1,
         WriteArrayAsGenericType = 2,
         WriteDefaultSymbolWithoutName = 4,
+        UseStructuralFallback = 8,
         WriteTypeArgumentsOfSignature = 32,
         UseFullyQualifiedType = 64,
         UseOnlyExternalAliasing = 128,
@@ -1826,6 +1827,7 @@ declare namespace ts {
         NoTruncation = 1,
         WriteArrayAsGenericType = 2,
         WriteDefaultSymbolWithoutName = 4,
+        UseStructuralFallback = 8,
         WriteTypeArgumentsOfSignature = 32,
         UseFullyQualifiedType = 64,
         SuppressAnyReturnType = 256,
@@ -1842,7 +1844,7 @@ declare namespace ts {
         InFirstTypeArgument = 4194304,
         InTypeAlias = 8388608,
         /** @deprecated */ WriteOwnNameForAnyLike = 0,
-        NodeBuilderFlagsMask = 9469287,
+        NodeBuilderFlagsMask = 9469295,
     }
     enum SymbolFormatFlags {
         None = 0,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1800,6 +1800,7 @@ declare namespace ts {
         NoTruncation = 1,
         WriteArrayAsGenericType = 2,
         WriteDefaultSymbolWithoutName = 4,
+        UseStructuralFallback = 8,
         WriteTypeArgumentsOfSignature = 32,
         UseFullyQualifiedType = 64,
         UseOnlyExternalAliasing = 128,
@@ -1826,6 +1827,7 @@ declare namespace ts {
         NoTruncation = 1,
         WriteArrayAsGenericType = 2,
         WriteDefaultSymbolWithoutName = 4,
+        UseStructuralFallback = 8,
         WriteTypeArgumentsOfSignature = 32,
         UseFullyQualifiedType = 64,
         SuppressAnyReturnType = 256,
@@ -1842,7 +1844,7 @@ declare namespace ts {
         InFirstTypeArgument = 4194304,
         InTypeAlias = 8388608,
         /** @deprecated */ WriteOwnNameForAnyLike = 0,
-        NodeBuilderFlagsMask = 9469287,
+        NodeBuilderFlagsMask = 9469295,
     }
     enum SymbolFormatFlags {
         None = 0,

--- a/tests/baselines/reference/declarationFunctionTypeNonlocalShouldNotBeAnError.js
+++ b/tests/baselines/reference/declarationFunctionTypeNonlocalShouldNotBeAnError.js
@@ -1,0 +1,26 @@
+//// [declarationFunctionTypeNonlocalShouldNotBeAnError.ts]
+namespace foo {
+    function bar(): void {}
+
+    export const obj = {
+        bar
+    }
+}
+
+
+//// [declarationFunctionTypeNonlocalShouldNotBeAnError.js]
+var foo;
+(function (foo) {
+    function bar() { }
+    foo.obj = {
+        bar: bar
+    };
+})(foo || (foo = {}));
+
+
+//// [declarationFunctionTypeNonlocalShouldNotBeAnError.d.ts]
+declare namespace foo {
+    const obj: {
+        bar: () => void;
+    };
+}

--- a/tests/baselines/reference/declarationFunctionTypeNonlocalShouldNotBeAnError.symbols
+++ b/tests/baselines/reference/declarationFunctionTypeNonlocalShouldNotBeAnError.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts ===
+namespace foo {
+>foo : Symbol(foo, Decl(declarationFunctionTypeNonlocalShouldNotBeAnError.ts, 0, 0))
+
+    function bar(): void {}
+>bar : Symbol(bar, Decl(declarationFunctionTypeNonlocalShouldNotBeAnError.ts, 0, 15))
+
+    export const obj = {
+>obj : Symbol(obj, Decl(declarationFunctionTypeNonlocalShouldNotBeAnError.ts, 3, 16))
+
+        bar
+>bar : Symbol(bar, Decl(declarationFunctionTypeNonlocalShouldNotBeAnError.ts, 3, 24))
+    }
+}
+

--- a/tests/baselines/reference/declarationFunctionTypeNonlocalShouldNotBeAnError.types
+++ b/tests/baselines/reference/declarationFunctionTypeNonlocalShouldNotBeAnError.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts ===
+namespace foo {
+>foo : typeof foo
+
+    function bar(): void {}
+>bar : () => void
+
+    export const obj = {
+>obj : { bar: () => void; }
+>{        bar    } : { bar: () => void; }
+
+        bar
+>bar : () => void
+    }
+}
+

--- a/tests/baselines/reference/privacyCheckTypeOfFunction.errors.txt
+++ b/tests/baselines/reference/privacyCheckTypeOfFunction.errors.txt
@@ -1,14 +1,11 @@
 tests/cases/compiler/privacyCheckTypeOfFunction.ts(3,22): error TS4025: Exported variable 'x' has or is using private name 'foo'.
-tests/cases/compiler/privacyCheckTypeOfFunction.ts(4,12): error TS4025: Exported variable 'b' has or is using private name 'foo'.
 
 
-==== tests/cases/compiler/privacyCheckTypeOfFunction.ts (2 errors) ====
+==== tests/cases/compiler/privacyCheckTypeOfFunction.ts (1 errors) ====
     function foo() {
     }
     export var x: typeof foo;
                          ~~~
 !!! error TS4025: Exported variable 'x' has or is using private name 'foo'.
     export var b = foo;
-               ~
-!!! error TS4025: Exported variable 'b' has or is using private name 'foo'.
     

--- a/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
+++ b/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
@@ -1,0 +1,8 @@
+// @declaration: true
+namespace foo {
+    function bar(): void {}
+
+    export const obj = {
+        bar
+    }
+}


### PR DESCRIPTION
#18860 introduced a break in a few of our RWC tests (mobx, one more) when it swapped to aggressively using `typeof` for the reproduction of function types (in order to be more like the type baseline output), but never introduced a fallback to the structural version of the type if the type wasn't accessible for declaration emit. This adds that fallback (and a flag to control it).