### PR TITLE
Fix Windows-style absolute paths in triple-slash directives

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1909,7 +1909,7 @@ namespace ts {
             return p2 + 1;
         }
         if (path.charCodeAt(1) === CharacterCodes.colon) {
-            if (path.charCodeAt(2) === CharacterCodes.slash) return 3;
+            if (path.charCodeAt(2) === CharacterCodes.slash || path.charCodeAt(2) === CharacterCodes.backslash) return 3;
         }
         // Per RFC 1738 'file' URI schema has the shape file://<host>/<path>
         // if <host> is omitted then it is assumed that host value is 'localhost',

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -15,7 +15,8 @@ namespace ts {
 
     export function resolveTripleslashReference(moduleName: string, containingFile: string): string {
         const basePath = getDirectoryPath(containingFile);
-        const referencedFileName = isRootedDiskPath(moduleName) ? moduleName : combinePaths(basePath, moduleName);
+        const normalizedModuleName = normalizePath(moduleName);
+        const referencedFileName = isRootedDiskPath(normalizedModuleName) ? normalizedModuleName : combinePaths(basePath, normalizedModuleName);
         return normalizePath(referencedFileName);
     }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -15,8 +15,7 @@ namespace ts {
 
     export function resolveTripleslashReference(moduleName: string, containingFile: string): string {
         const basePath = getDirectoryPath(containingFile);
-        const normalizedModuleName = normalizePath(moduleName);
-        const referencedFileName = isRootedDiskPath(normalizedModuleName) ? normalizedModuleName : combinePaths(basePath, normalizedModuleName);
+        const referencedFileName = isRootedDiskPath(moduleName) ? moduleName : combinePaths(basePath, moduleName);
         return normalizePath(referencedFileName);
     }
 

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2821,6 +2821,31 @@ namespace ts.projectSystem {
             checkWatchedDirectories(host, watchedRecursiveDirectories, /*recursive*/ true);
         });
 
+        it("Properly handle Windows-style outDir", () => {
+            const configFile: FileOrFolder = {
+                path: "C:\\a\\tsconfig.json",
+                content: JSON.stringify({
+                    compilerOptions: {
+                        outDir: `C:\\a\\b`
+                    },
+                    include: ["*.ts"]
+                })
+            };
+            const file1: FileOrFolder = {
+                path: "C:\\a\\f1.ts",
+                content: "let x = 1;"
+            };
+
+            const host = createServerHost([file1, configFile], { useWindowsStylePaths: true });
+            const projectService = createProjectService(host);
+
+            projectService.openClientFile(file1.path);
+            checkNumberOfProjects(projectService, { configuredProjects: 1 });
+            const project = configuredProjectAt(projectService, 0);
+            checkProjectActualFiles(project, [normalizePath(file1.path), normalizePath(configFile.path)]);
+            const options = project.getCompilerOptions();
+            assert.equal(options.outDir, "C:/a/b", "");
+        });
     });
 
     describe("tsserverProjectSystem Proper errors", () => {

--- a/tests/baselines/reference/tripleSlashReferenceAbsoluteWindowsPath.js
+++ b/tests/baselines/reference/tripleSlashReferenceAbsoluteWindowsPath.js
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/tripleSlashReferenceAbsoluteWindowsPath.ts] ////
+
+//// [c.ts]
+const x = 5;
+
+//// [d.ts]
+/// <reference path="C:\a\b\c.ts" />
+const y = x + 3;
+
+//// [c.js]
+var x = 5;
+//// [d.js]
+/// <reference path="C:\a\b\c.ts" />
+var y = x + 3;

--- a/tests/baselines/reference/tripleSlashReferenceAbsoluteWindowsPath.symbols
+++ b/tests/baselines/reference/tripleSlashReferenceAbsoluteWindowsPath.symbols
@@ -1,0 +1,10 @@
+=== C:/a/b/d.ts ===
+/// <reference path="C:\a\b\c.ts" />
+const y = x + 3;
+>y : Symbol(y, Decl(d.ts, 1, 5))
+>x : Symbol(x, Decl(c.ts, 0, 5))
+
+=== C:/a/b/c.ts ===
+const x = 5;
+>x : Symbol(x, Decl(c.ts, 0, 5))
+

--- a/tests/baselines/reference/tripleSlashReferenceAbsoluteWindowsPath.types
+++ b/tests/baselines/reference/tripleSlashReferenceAbsoluteWindowsPath.types
@@ -1,0 +1,13 @@
+=== C:/a/b/d.ts ===
+/// <reference path="C:\a\b\c.ts" />
+const y = x + 3;
+>y : number
+>x + 3 : number
+>x : 5
+>3 : 3
+
+=== C:/a/b/c.ts ===
+const x = 5;
+>x : 5
+>5 : 5
+

--- a/tests/cases/compiler/tripleSlashReferenceAbsoluteWindowsPath.ts
+++ b/tests/cases/compiler/tripleSlashReferenceAbsoluteWindowsPath.ts
@@ -1,0 +1,6 @@
+//@Filename: C:\a\b\c.ts
+const x = 5;
+
+//@Filename: C:\a\b\d.ts
+/// <reference path="C:\a\b\c.ts" />
+const y = x + 3;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

PR #19702 caused Windows-style absolute paths to be no longer understood as absolute paths.
This change appropriately normalizes paths in triple-slash directives so that they can be recognized correctly.

EDIT: This change now checks for backslashes in file paths to determine if a path is rooted. This was updated to cover more cases than just triple-slash directives.