### PR TITLE
Fixes var declaration shadowing in async functions

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1341,7 +1341,8 @@ namespace ts {
 
     export function cloneMap(map: SymbolTable): SymbolTable;
     export function cloneMap<T>(map: ReadonlyMap<T>): Map<T>;
-    export function cloneMap<T>(map: ReadonlyMap<T> | SymbolTable): Map<T> | SymbolTable {
+    export function cloneMap<T>(map: ReadonlyUnderscoreEscapedMap<T>): UnderscoreEscapedMap<T>;
+    export function cloneMap<T>(map: ReadonlyMap<T> | ReadonlyUnderscoreEscapedMap<T> | SymbolTable): Map<T> | UnderscoreEscapedMap<T> | SymbolTable {
         const clone = createMap<T>();
         copyEntries(map as Map<T>, clone);
         return clone;

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -86,31 +86,34 @@ namespace ts {
         }
 
         function asyncBodyVisitor(node: Node): VisitResult<Node> {
-            switch (node.kind) {
-                case SyntaxKind.VariableStatement:
-                    return visitVariableStatementInAsyncBody(<VariableStatement>node);
-                case SyntaxKind.ForStatement:
-                    return visitForStatementInAsyncBody(<ForStatement>node);
-                case SyntaxKind.ForInStatement:
-                    return visitForInStatementInAsyncBody(<ForInStatement>node);
-                case SyntaxKind.ForOfStatement:
-                    return visitForOfStatementInAsyncBody(<ForOfStatement>node);
-                case SyntaxKind.CatchClause:
-                    return visitCatchClauseInAsyncBody(<CatchClause>node);
-                case SyntaxKind.Block:
-                case SyntaxKind.SwitchStatement:
-                case SyntaxKind.CaseBlock:
-                case SyntaxKind.CaseClause:
-                case SyntaxKind.DefaultClause:
-                case SyntaxKind.TryStatement:
-                case SyntaxKind.DoStatement:
-                case SyntaxKind.WhileStatement:
-                case SyntaxKind.IfStatement:
-                case SyntaxKind.WithStatement:
-                case SyntaxKind.LabeledStatement:
-                    return visitEachChild(node, asyncBodyVisitor, context);
+            if (isNodeWithPossibleHoistedDeclaration(node)) {
+                switch (node.kind) {
+                    case SyntaxKind.VariableStatement:
+                        return visitVariableStatementInAsyncBody(node);
+                    case SyntaxKind.ForStatement:
+                        return visitForStatementInAsyncBody(node);
+                    case SyntaxKind.ForInStatement:
+                        return visitForInStatementInAsyncBody(node);
+                    case SyntaxKind.ForOfStatement:
+                        return visitForOfStatementInAsyncBody(node);
+                    case SyntaxKind.CatchClause:
+                        return visitCatchClauseInAsyncBody(node);
+                    case SyntaxKind.Block:
+                    case SyntaxKind.SwitchStatement:
+                    case SyntaxKind.CaseBlock:
+                    case SyntaxKind.CaseClause:
+                    case SyntaxKind.DefaultClause:
+                    case SyntaxKind.TryStatement:
+                    case SyntaxKind.DoStatement:
+                    case SyntaxKind.WhileStatement:
+                    case SyntaxKind.IfStatement:
+                    case SyntaxKind.WithStatement:
+                    case SyntaxKind.LabeledStatement:
+                        return visitEachChild(node, asyncBodyVisitor, context);
+                    default:
+                        return Debug.assertNever(node, "Unhandled node.");
+                }
             }
-            Debug.assert(!isNodeWithPossibleVarDeclaration(node), "Unhandled node.");
             return visitor(node);
         }
 

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -12,9 +12,9 @@ namespace ts {
 
     export function transformES2017(context: TransformationContext) {
         const {
-            startLexicalEnvironment,
             resumeLexicalEnvironment,
-            endLexicalEnvironment
+            endLexicalEnvironment,
+            hoistVariableDeclaration
         } = context;
 
         const resolver = context.getEmitResolver();
@@ -32,6 +32,8 @@ namespace ts {
          * just-in-time substitution for `super` expressions inside of async methods.
          */
         let enclosingSuperContainerFlags: NodeCheckFlags = 0;
+
+        let enclosingFunctionParameterNames: UnderscoreEscapedMap<true>;
 
         // Save the previous transformation hooks.
         const previousOnEmitNode = context.onEmitNode;
@@ -81,6 +83,103 @@ namespace ts {
                 default:
                     return visitEachChild(node, visitor, context);
             }
+        }
+
+        function asyncBodyVisitor(node: Node): VisitResult<Node> {
+            switch (node.kind) {
+                case SyntaxKind.VariableStatement:
+                    return visitVariableStatementInAsyncBody(<VariableStatement>node);
+                case SyntaxKind.ForStatement:
+                    return visitForStatementInAsyncBody(<ForStatement>node);
+                case SyntaxKind.ForInStatement:
+                    return visitForInStatementInAsyncBody(<ForInStatement>node);
+                case SyntaxKind.ForOfStatement:
+                    return visitForOfStatementInAsyncBody(<ForOfStatement>node);
+                case SyntaxKind.Block:
+                case SyntaxKind.SwitchStatement:
+                case SyntaxKind.CaseBlock:
+                case SyntaxKind.CaseClause:
+                case SyntaxKind.DefaultClause:
+                case SyntaxKind.TryStatement:
+                case SyntaxKind.DoStatement:
+                case SyntaxKind.WhileStatement:
+                case SyntaxKind.IfStatement:
+                case SyntaxKind.WithStatement:
+                    return visitEachChild(node, asyncBodyVisitor, context);
+                case SyntaxKind.CatchClause:
+                    return visitCatchClauseInAsyncBody(<CatchClause>node);
+            }
+            return visitor(node);
+        }
+
+        function visitCatchClauseInAsyncBody(node: CatchClause) {
+            const catchClauseNames = createUnderscoreEscapedMap<true>();
+            recordDeclarationName(node.variableDeclaration, catchClauseNames);
+
+            // names declared in a catch variable are block scoped
+            let catchClauseUnshadowedNames: UnderscoreEscapedMap<true>;
+            catchClauseNames.forEach((_, escapedName) => {
+                if (enclosingFunctionParameterNames.has(escapedName)) {
+                    if (!catchClauseUnshadowedNames) {
+                        catchClauseUnshadowedNames = cloneMap(enclosingFunctionParameterNames);
+                    }
+                    catchClauseUnshadowedNames.delete(escapedName);
+                }
+            });
+
+            if (catchClauseUnshadowedNames) {
+                const savedEnclosingFunctionParameterNames = enclosingFunctionParameterNames;
+                enclosingFunctionParameterNames = catchClauseUnshadowedNames;
+                const result = visitEachChild(node, asyncBodyVisitor, context);
+                enclosingFunctionParameterNames = savedEnclosingFunctionParameterNames;
+                return result;
+            }
+            else {
+                return visitEachChild(node, asyncBodyVisitor, context);
+            }
+        }
+
+        function visitVariableStatementInAsyncBody(node: VariableStatement) {
+            if (isVariableDeclarationListWithCollidingName(node.declarationList)) {
+                const expression = visitVariableDeclarationListWithCollidingNames(node.declarationList, /*hasReceiver*/ false);
+                return expression ? createStatement(expression) : undefined;
+            }
+            return visitEachChild(node, visitor, context);
+        }
+
+        function visitForInStatementInAsyncBody(node: ForInStatement) {
+            return updateForIn(
+                node,
+                isVariableDeclarationListWithCollidingName(node.initializer)
+                    ? visitVariableDeclarationListWithCollidingNames(node.initializer, /*hasReceiver*/ true)
+                    : visitNode(node.initializer, visitor, isForInitializer),
+                visitNode(node.expression, visitor, isExpression),
+                visitNode(node.statement, asyncBodyVisitor, isStatement, liftToBlock)
+            );
+        }
+
+        function visitForOfStatementInAsyncBody(node: ForOfStatement) {
+            return updateForOf(
+                node,
+                visitNode(node.awaitModifier, visitor, isToken),
+                isVariableDeclarationListWithCollidingName(node.initializer)
+                    ? visitVariableDeclarationListWithCollidingNames(node.initializer, /*hasReceiver*/ true)
+                    : visitNode(node.initializer, visitor, isForInitializer),
+                visitNode(node.expression, visitor, isExpression),
+                visitNode(node.statement, asyncBodyVisitor, isStatement, liftToBlock)
+            );
+        }
+
+        function visitForStatementInAsyncBody(node: ForStatement) {
+            return updateFor(
+                node,
+                isVariableDeclarationListWithCollidingName(node.initializer)
+                    ? visitVariableDeclarationListWithCollidingNames(node.initializer, /*hasReceiver*/ false)
+                    : visitNode(node.initializer, visitor, isForInitializer),
+                visitNode(node.condition, visitor, isExpression),
+                visitNode(node.incrementor, visitor, isExpression),
+                visitNode((<ForStatement>node).statement, asyncBodyVisitor, isStatement, liftToBlock)
+            );
         }
 
         /**
@@ -197,6 +296,149 @@ namespace ts {
             );
         }
 
+        function recordDeclarationName({ name }: ParameterDeclaration | VariableDeclaration | BindingElement, names: UnderscoreEscapedMap<true>) {
+            if (isIdentifier(name)) {
+                names.set(name.escapedText, true);
+            }
+            else {
+                for (const element of name.elements) {
+                    if (!isOmittedExpression(element)) {
+                        recordDeclarationName(element, names);
+                    }
+                }
+            }
+        }
+
+        function isVariableDeclarationListWithCollidingName(node: ForInitializer): node is VariableDeclarationList {
+            return node
+                && isVariableDeclarationList(node)
+                && !(node.flags & NodeFlags.BlockScoped)
+                && forEach(node.declarations, collidesWithParameterName);
+        }
+
+        function visitVariableDeclarationListWithCollidingNames(node: VariableDeclarationList, hasReceiver: boolean) {
+            hoistVariableDeclarationList(node);
+
+            const variables = getInitializedVariables(node);
+            if (variables.length === 0) {
+                if (hasReceiver) {
+                    return convertBindingNameToAssignmentTarget(node.declarations[0].name);
+                }
+                return undefined;
+            }
+
+            return inlineExpressions(map(variables, transformInitializedVariable));
+        }
+
+        function hoistVariableDeclarationList(node: VariableDeclarationList) {
+            forEach(node.declarations, hoistVariable);
+        }
+
+        function hoistVariable({ name }: VariableDeclaration | BindingElement) {
+            if (isIdentifier(name)) {
+                hoistVariableDeclaration(name);
+            }
+            else {
+                for (const element of name.elements) {
+                    if (!isOmittedExpression(element)) {
+                        hoistVariable(element);
+                    }
+                }
+            }
+        }
+
+        function transformInitializedVariable(node: VariableDeclaration) {
+            return setSourceMapRange(
+                createAssignment(
+                    convertBindingNameToAssignmentTarget(node.name),
+                    visitNode(node.initializer, visitor, isExpression)
+                ),
+                node
+            );
+        }
+
+        function convertBindingNameToAssignmentTarget(node: BindingName): Identifier | AssignmentPattern {
+            return isObjectBindingPattern(node) ? convertObjectBindingPatternToObjectAssignmentPattern(node) :
+                isArrayBindingPattern(node) ? convertArrayBindingPatternToArrayAssignmentPattern(node) :
+                setSourceMapRange(<Identifier>getSynthesizedClone(node), node);
+        }
+
+        function convertObjectBindingPatternToObjectAssignmentPattern(node: ObjectBindingPattern): ObjectLiteralExpression {
+            return createObjectLiteral(
+                map(node.elements, convertObjectBindingElementToObjectAssignmentElement)
+            );
+        }
+
+        function convertObjectBindingElementToObjectAssignmentElement(node: BindingElement): ObjectLiteralElementLike {
+            if (node.propertyName) {
+                let expression: Expression = convertBindingNameToAssignmentTarget(node.name);
+                if (node.initializer) {
+                    expression = createAssignment(expression, visitNode(node.initializer, visitor, isExpression));
+                }
+                return setSourceMapRange(
+                    createPropertyAssignment(
+                        visitNode(node.propertyName, visitor, isPropertyName),
+                        expression
+                    ),
+                    node
+                );
+            }
+            else if (node.dotDotDotToken) {
+                return setSourceMapRange(
+                    createSpreadAssignment(
+                        visitNode(cast(node.name, isIdentifier), visitor, isIdentifier)
+                    ),
+                    node
+                );
+            }
+            else {
+                return setSourceMapRange(
+                    createShorthandPropertyAssignment(
+                        visitNode(cast(node.name, isIdentifier), visitor, isIdentifier),
+                        visitNode(node.initializer, visitor, isExpression)
+                    ),
+                    node
+                );
+            }
+        }
+
+        function convertArrayBindingPatternToArrayAssignmentPattern(node: ArrayBindingPattern): ArrayLiteralExpression {
+            return setSourceMapRange(
+                createArrayLiteral(
+                    map(node.elements, convertArrayBindingElementToArrayAssignmentElement)
+                ),
+                node
+            );
+        }
+
+        function convertArrayBindingElementToArrayAssignmentElement(node: ArrayBindingElement): Expression {
+            if (isOmittedExpression(node)) return node;
+            let expression: Expression = convertBindingNameToAssignmentTarget(node.name);
+            if (node.initializer) {
+                expression = createAssignment(expression, visitNode(node.initializer, visitor, isExpression));
+                setSourceMapRange(expression, node);
+            }
+            else if (node.dotDotDotToken) {
+                expression = createSpread(expression);
+                setSourceMapRange(expression, node);
+            }
+            return expression;
+        }
+
+        function collidesWithParameterName({ name }: VariableDeclaration | BindingElement): boolean {
+            if (isIdentifier(name)) {
+                return enclosingFunctionParameterNames.has(name.escapedText);
+            }
+            else {
+                for (const element of name.elements) {
+                    if (!isOmittedExpression(element) && collidesWithParameterName(element)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         function transformAsyncFunctionBody(node: MethodDeclaration | AccessorDeclaration | FunctionDeclaration | FunctionExpression): FunctionBody;
         function transformAsyncFunctionBody(node: ArrowFunction): ConciseBody;
         function transformAsyncFunctionBody(node: FunctionLikeDeclaration): ConciseBody {
@@ -214,6 +456,13 @@ namespace ts {
             // passed to `__awaiter` is executed inside of the callback to the
             // promise constructor.
 
+            const savedEnclosingFunctionParameterNames = enclosingFunctionParameterNames;
+            enclosingFunctionParameterNames = createUnderscoreEscapedMap<true>();
+            for (const parameter of node.parameters) {
+                recordDeclarationName(parameter, enclosingFunctionParameterNames);
+            }
+
+            let result: ConciseBody;
             if (!isArrowFunction) {
                 const statements: Statement[] = [];
                 const statementOffset = addPrologue(statements, (<Block>node.body).statements, /*ensureUseStrict*/ false, visitor);
@@ -223,7 +472,7 @@ namespace ts {
                             context,
                             hasLexicalArguments,
                             promiseConstructor,
-                            transformFunctionBodyWorker(<Block>node.body, statementOffset)
+                            transformAsyncFunctionBodyWorker(<Block>node.body, statementOffset)
                         )
                     )
                 );
@@ -246,35 +495,36 @@ namespace ts {
                     }
                 }
 
-                return block;
+                result = block;
             }
             else {
                 const expression = createAwaiterHelper(
                     context,
                     hasLexicalArguments,
                     promiseConstructor,
-                    transformFunctionBodyWorker(node.body)
+                    transformAsyncFunctionBodyWorker(node.body)
                 );
 
                 const declarations = endLexicalEnvironment();
                 if (some(declarations)) {
                     const block = convertToFunctionBody(expression);
-                    return updateBlock(block, setTextRange(createNodeArray(concatenate(block.statements, declarations)), block.statements));
+                    result = updateBlock(block, setTextRange(createNodeArray(concatenate(block.statements, declarations)), block.statements));
                 }
-
-                return expression;
+                else {
+                    result = expression;
+                }
             }
+
+            enclosingFunctionParameterNames = savedEnclosingFunctionParameterNames;
+            return result;
         }
 
-        function transformFunctionBodyWorker(body: ConciseBody, start?: number) {
+        function transformAsyncFunctionBodyWorker(body: ConciseBody, start?: number) {
             if (isBlock(body)) {
-                return updateBlock(body, visitLexicalEnvironment(body.statements, visitor, context, start));
+                return updateBlock(body, visitNodes(body.statements, asyncBodyVisitor, isStatement, start));
             }
             else {
-                startLexicalEnvironment();
-                const visited = convertToFunctionBody(visitNode(body, visitor, isConciseBody));
-                const declarations = endLexicalEnvironment();
-                return updateBlock(visited, setTextRange(createNodeArray(concatenate(visited.statements, declarations)), visited.statements));
+                return convertToFunctionBody(visitNode(body, asyncBodyVisitor, isConciseBody));
             }
         }
 

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -95,6 +95,8 @@ namespace ts {
                     return visitForInStatementInAsyncBody(<ForInStatement>node);
                 case SyntaxKind.ForOfStatement:
                     return visitForOfStatementInAsyncBody(<ForOfStatement>node);
+                case SyntaxKind.CatchClause:
+                    return visitCatchClauseInAsyncBody(<CatchClause>node);
                 case SyntaxKind.Block:
                 case SyntaxKind.SwitchStatement:
                 case SyntaxKind.CaseBlock:
@@ -105,10 +107,10 @@ namespace ts {
                 case SyntaxKind.WhileStatement:
                 case SyntaxKind.IfStatement:
                 case SyntaxKind.WithStatement:
+                case SyntaxKind.LabeledStatement:
                     return visitEachChild(node, asyncBodyVisitor, context);
-                case SyntaxKind.CatchClause:
-                    return visitCatchClauseInAsyncBody(<CatchClause>node);
             }
+            Debug.assert(!isNodeWithPossibleVarDeclaration(node), "Unhandled node.");
             return visitor(node);
         }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1783,8 +1783,6 @@ namespace ts {
             case SyntaxKind.WhileStatement:
             case SyntaxKind.TryStatement:
             case SyntaxKind.CatchClause:
-            case SyntaxKind.ModuleDeclaration:
-            case SyntaxKind.ModuleBlock:
                 return true;
         }
         return false;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1761,6 +1761,35 @@ namespace ts {
         return getAssignmentTargetKind(node) !== AssignmentKind.None;
     }
 
+    /**
+     * Indicates whether a node could contain embedded statements that share the same `var`
+     * declaration scope as its parent.
+     */
+    export function isNodeWithPossibleVarDeclaration(node: Node) {
+        switch (node.kind) {
+            case SyntaxKind.SourceFile:
+            case SyntaxKind.Block:
+            case SyntaxKind.WithStatement:
+            case SyntaxKind.IfStatement:
+            case SyntaxKind.SwitchStatement:
+            case SyntaxKind.CaseBlock:
+            case SyntaxKind.CaseClause:
+            case SyntaxKind.DefaultClause:
+            case SyntaxKind.LabeledStatement:
+            case SyntaxKind.ForStatement:
+            case SyntaxKind.ForInStatement:
+            case SyntaxKind.ForOfStatement:
+            case SyntaxKind.DoStatement:
+            case SyntaxKind.WhileStatement:
+            case SyntaxKind.TryStatement:
+            case SyntaxKind.CatchClause:
+            case SyntaxKind.ModuleDeclaration:
+            case SyntaxKind.ModuleBlock:
+                return true;
+        }
+        return false;
+    }
+
     function walkUp(node: Node, kind: SyntaxKind) {
         while (node && node.kind === kind) {
             node = node.parent;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1761,14 +1761,32 @@ namespace ts {
         return getAssignmentTargetKind(node) !== AssignmentKind.None;
     }
 
+    export type NodeWithPossibleHoistedDeclaration =
+        | Block
+        | VariableStatement
+        | WithStatement
+        | IfStatement
+        | SwitchStatement
+        | CaseBlock
+        | CaseClause
+        | DefaultClause
+        | LabeledStatement
+        | ForStatement
+        | ForInStatement
+        | ForOfStatement
+        | DoStatement
+        | WhileStatement
+        | TryStatement
+        | CatchClause;
+
     /**
-     * Indicates whether a node could contain embedded statements that share the same `var`
-     * declaration scope as its parent.
+     * Indicates whether a node could contain a `var` VariableDeclarationList that contributes to
+     * the same `var` declaration scope as the node's parent.
      */
-    export function isNodeWithPossibleVarDeclaration(node: Node) {
+    export function isNodeWithPossibleHoistedDeclaration(node: Node): node is NodeWithPossibleHoistedDeclaration {
         switch (node.kind) {
-            case SyntaxKind.SourceFile:
             case SyntaxKind.Block:
+            case SyntaxKind.VariableStatement:
             case SyntaxKind.WithStatement:
             case SyntaxKind.IfStatement:
             case SyntaxKind.SwitchStatement:

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.js
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.js
@@ -1,0 +1,463 @@
+//// [asyncWithVarShadowing_es6.ts]
+// https://github.com/Microsoft/TypeScript/issues/20461
+declare const y: any;
+
+async function fn1(x) {
+    var x;
+}
+
+async function fn2(x) {
+    var x, z;
+}
+
+async function fn3(x) {
+    var z;
+}
+
+async function fn4(x) {
+    var x = y;
+}
+
+async function fn5(x) {
+    var { x } = y;
+}
+
+async function fn6(x) {
+    var { x, z } = y;
+}
+
+async function fn7(x) {
+    var { x = y } = y;
+}
+
+async function fn8(x) {
+    var { z: x } = y;
+}
+
+async function fn9(x) {
+    var { z: { x } } = y;
+}
+
+async function fn10(x) {
+    var { z: { x } = y } = y;
+}
+
+async function fn11(x) {
+    var { ...x } = y;
+}
+
+async function fn12(x) {
+    var [x] = y;
+}
+
+async function fn13(x) {
+    var [x = y] = y;
+}
+
+async function fn14(x) {
+    var [, x] = y;
+}
+
+async function fn15(x) {
+    var [...x] = y;
+}
+
+async function fn16(x) {
+    var [[x]] = y;
+}
+
+async function fn17(x) {
+    var [[x] = y] = y;
+}
+
+async function fn18({ x }) {
+    var x;
+}
+
+async function fn19([x]) {
+    var x;
+}
+
+async function fn20(x) {
+    {
+        var x;
+    }
+}
+
+async function fn21(x) {
+    if (y) {
+        var x;
+    }
+}
+
+async function fn22(x) {
+    if (y) {
+    }
+    else {
+        var x;
+    }
+}
+
+async function fn23(x) {
+    try {
+        var x;
+    }
+    catch (e) {
+    }
+}
+
+async function fn24(x) {
+    try {
+
+    }
+    catch (e) {
+        var x;
+    }
+}
+
+async function fn25(x) {
+    try {
+
+    }
+    catch (x) {
+        var x;
+    }
+}
+
+async function fn26(x) {
+    try {
+
+    }
+    catch ({ x }) {
+        var x;
+    }
+}
+
+async function fn27(x) {
+    try {
+    }
+    finally {
+        var x;
+    }
+}
+
+async function fn28(x) {
+    while (y) {
+        var x;
+    }
+}
+
+async function fn29(x) {
+    do {
+        var x;
+    }
+    while (y);
+}
+
+async function fn30(x) {
+    for (var x = y;;) {
+
+    }
+}
+
+async function fn31(x) {
+    for (var { x } = y;;) {
+    }
+}
+
+async function fn32(x) {
+    for (;;) {
+        var x;
+    }
+}
+
+async function fn33(x: string) {
+    for (var x in y) {
+    }
+}
+
+async function fn34(x) {
+    for (var z in y) {
+        var x;
+    }
+}
+
+async function fn35(x) {
+    for (var x of y) {
+    }
+}
+
+async function fn36(x) {
+    for (var { x } of y) {
+    }
+}
+
+async function fn37(x) {
+    for (var z of y) {
+        var x;
+    }
+}
+
+async function fn38(x) {
+    switch (y) {
+        case y:
+            var x;
+    }
+}
+
+//// [asyncWithVarShadowing_es6.js]
+function fn1(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+    });
+    var x;
+}
+function fn2(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+    });
+    var x, z;
+}
+function fn3(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var z;
+    });
+}
+function fn4(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        x = y;
+    });
+    var x;
+}
+function fn5(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        ({ x } = y);
+    });
+    var x;
+}
+function fn6(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        ({ x, z } = y);
+    });
+    var x, z;
+}
+function fn7(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        ({ x = y } = y);
+    });
+    var x;
+}
+function fn8(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        ({ z: x } = y);
+    });
+    var x;
+}
+function fn9(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        ({ z: { x } } = y);
+    });
+    var x;
+}
+function fn10(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        ({ z: { x } = y } = y);
+    });
+    var x;
+}
+function fn11(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        x = __rest(y, []);
+    });
+    var x;
+}
+function fn12(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        [x] = y;
+    });
+    var x;
+}
+function fn13(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        [x = y] = y;
+    });
+    var x;
+}
+function fn14(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        [, x] = y;
+    });
+    var x;
+}
+function fn15(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        [...x] = y;
+    });
+    var x;
+}
+function fn16(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        [[x]] = y;
+    });
+    var x;
+}
+function fn17(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        [[x] = y] = y;
+    });
+    var x;
+}
+function fn18({ x }) {
+    return __awaiter(this, void 0, void 0, function* () {
+    });
+    var x;
+}
+function fn19([x]) {
+    return __awaiter(this, void 0, void 0, function* () {
+    });
+    var x;
+}
+function fn20(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        {
+        }
+    });
+    var x;
+}
+function fn21(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (y) {
+        }
+    });
+    var x;
+}
+function fn22(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (y) {
+        }
+        else {
+        }
+    });
+    var x;
+}
+function fn23(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+        }
+        catch (e) {
+        }
+    });
+    var x;
+}
+function fn24(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+        }
+        catch (e) {
+        }
+    });
+    var x;
+}
+function fn25(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+        }
+        catch (x) {
+            var x;
+        }
+    });
+}
+function fn26(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+        }
+        catch ({ x }) {
+            var x;
+        }
+    });
+}
+function fn27(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+        }
+        finally {
+        }
+    });
+    var x;
+}
+function fn28(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        while (y) {
+        }
+    });
+    var x;
+}
+function fn29(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        do {
+        } while (y);
+    });
+    var x;
+}
+function fn30(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        for (x = y;;) {
+        }
+    });
+    var x;
+}
+function fn31(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        for ({ x } = y;;) {
+        }
+    });
+    var x;
+}
+function fn32(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        for (;;) {
+        }
+    });
+    var x;
+}
+function fn33(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        for (x in y) {
+        }
+    });
+    var x;
+}
+function fn34(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        for (var z in y) {
+        }
+    });
+    var x;
+}
+function fn35(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        for (x of y) {
+        }
+    });
+    var x;
+}
+function fn36(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        for ({ x } of y) {
+        }
+    });
+    var x;
+}
+function fn37(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        for (var z of y) {
+        }
+    });
+    var x;
+}
+function fn38(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        switch (y) {
+            case y:
+        }
+    });
+    var x;
+}

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.js
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.js
@@ -212,6 +212,16 @@ async function fn39(x) {
     }
 }
 
+async function fn40(x) {
+    try {
+
+    }
+    catch {
+        var x;
+    }
+}
+
+
 //// [asyncWithVarShadowing_es6.js]
 function fn1(x) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -472,6 +482,15 @@ function fn39(x) {
     return __awaiter(this, void 0, void 0, function* () {
         foo: {
             break foo;
+        }
+    });
+    var x;
+}
+function fn40(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+        }
+        catch (_a) {
         }
     });
     var x;

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.js
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.js
@@ -205,6 +205,13 @@ async function fn38(x) {
     }
 }
 
+async function fn39(x) {
+    foo: {
+        var x;
+        break foo;
+    }
+}
+
 //// [asyncWithVarShadowing_es6.js]
 function fn1(x) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -457,6 +464,14 @@ function fn38(x) {
     return __awaiter(this, void 0, void 0, function* () {
         switch (y) {
             case y:
+        }
+    });
+    var x;
+}
+function fn39(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        foo: {
+            break foo;
         }
     });
     var x;

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.symbols
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.symbols
@@ -404,3 +404,15 @@ async function fn38(x) {
 >x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 199, 20), Decl(asyncWithVarShadowing_es6.ts, 202, 15))
     }
 }
+
+async function fn39(x) {
+>fn39 : Symbol(fn39, Decl(asyncWithVarShadowing_es6.ts, 204, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 206, 20), Decl(asyncWithVarShadowing_es6.ts, 208, 11))
+
+    foo: {
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 206, 20), Decl(asyncWithVarShadowing_es6.ts, 208, 11))
+
+        break foo;
+    }
+}

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.symbols
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.symbols
@@ -416,3 +416,17 @@ async function fn39(x) {
         break foo;
     }
 }
+
+async function fn40(x) {
+>fn40 : Symbol(fn40, Decl(asyncWithVarShadowing_es6.ts, 211, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 213, 20), Decl(asyncWithVarShadowing_es6.ts, 218, 11))
+
+    try {
+
+    }
+    catch {
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 213, 20), Decl(asyncWithVarShadowing_es6.ts, 218, 11))
+    }
+}
+

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.symbols
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.symbols
@@ -1,0 +1,406 @@
+=== tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/20461
+declare const y: any;
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+
+async function fn1(x) {
+>fn1 : Symbol(fn1, Decl(asyncWithVarShadowing_es6.ts, 1, 21))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 3, 19), Decl(asyncWithVarShadowing_es6.ts, 4, 7))
+
+    var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 3, 19), Decl(asyncWithVarShadowing_es6.ts, 4, 7))
+}
+
+async function fn2(x) {
+>fn2 : Symbol(fn2, Decl(asyncWithVarShadowing_es6.ts, 5, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 7, 19), Decl(asyncWithVarShadowing_es6.ts, 8, 7))
+
+    var x, z;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 7, 19), Decl(asyncWithVarShadowing_es6.ts, 8, 7))
+>z : Symbol(z, Decl(asyncWithVarShadowing_es6.ts, 8, 10))
+}
+
+async function fn3(x) {
+>fn3 : Symbol(fn3, Decl(asyncWithVarShadowing_es6.ts, 9, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 11, 19))
+
+    var z;
+>z : Symbol(z, Decl(asyncWithVarShadowing_es6.ts, 12, 7))
+}
+
+async function fn4(x) {
+>fn4 : Symbol(fn4, Decl(asyncWithVarShadowing_es6.ts, 13, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 15, 19), Decl(asyncWithVarShadowing_es6.ts, 16, 7))
+
+    var x = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 15, 19), Decl(asyncWithVarShadowing_es6.ts, 16, 7))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn5(x) {
+>fn5 : Symbol(fn5, Decl(asyncWithVarShadowing_es6.ts, 17, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 19, 19), Decl(asyncWithVarShadowing_es6.ts, 20, 9))
+
+    var { x } = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 19, 19), Decl(asyncWithVarShadowing_es6.ts, 20, 9))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn6(x) {
+>fn6 : Symbol(fn6, Decl(asyncWithVarShadowing_es6.ts, 21, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 23, 19), Decl(asyncWithVarShadowing_es6.ts, 24, 9))
+
+    var { x, z } = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 23, 19), Decl(asyncWithVarShadowing_es6.ts, 24, 9))
+>z : Symbol(z, Decl(asyncWithVarShadowing_es6.ts, 24, 12))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn7(x) {
+>fn7 : Symbol(fn7, Decl(asyncWithVarShadowing_es6.ts, 25, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 27, 19), Decl(asyncWithVarShadowing_es6.ts, 28, 9))
+
+    var { x = y } = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 27, 19), Decl(asyncWithVarShadowing_es6.ts, 28, 9))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn8(x) {
+>fn8 : Symbol(fn8, Decl(asyncWithVarShadowing_es6.ts, 29, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 31, 19), Decl(asyncWithVarShadowing_es6.ts, 32, 9))
+
+    var { z: x } = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 31, 19), Decl(asyncWithVarShadowing_es6.ts, 32, 9))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn9(x) {
+>fn9 : Symbol(fn9, Decl(asyncWithVarShadowing_es6.ts, 33, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 35, 19), Decl(asyncWithVarShadowing_es6.ts, 36, 14))
+
+    var { z: { x } } = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 35, 19), Decl(asyncWithVarShadowing_es6.ts, 36, 14))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn10(x) {
+>fn10 : Symbol(fn10, Decl(asyncWithVarShadowing_es6.ts, 37, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 39, 20), Decl(asyncWithVarShadowing_es6.ts, 40, 14))
+
+    var { z: { x } = y } = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 39, 20), Decl(asyncWithVarShadowing_es6.ts, 40, 14))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn11(x) {
+>fn11 : Symbol(fn11, Decl(asyncWithVarShadowing_es6.ts, 41, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 43, 20), Decl(asyncWithVarShadowing_es6.ts, 44, 9))
+
+    var { ...x } = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 43, 20), Decl(asyncWithVarShadowing_es6.ts, 44, 9))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn12(x) {
+>fn12 : Symbol(fn12, Decl(asyncWithVarShadowing_es6.ts, 45, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 47, 20), Decl(asyncWithVarShadowing_es6.ts, 48, 9))
+
+    var [x] = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 47, 20), Decl(asyncWithVarShadowing_es6.ts, 48, 9))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn13(x) {
+>fn13 : Symbol(fn13, Decl(asyncWithVarShadowing_es6.ts, 49, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 51, 20), Decl(asyncWithVarShadowing_es6.ts, 52, 9))
+
+    var [x = y] = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 51, 20), Decl(asyncWithVarShadowing_es6.ts, 52, 9))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn14(x) {
+>fn14 : Symbol(fn14, Decl(asyncWithVarShadowing_es6.ts, 53, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 55, 20), Decl(asyncWithVarShadowing_es6.ts, 56, 10))
+
+    var [, x] = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 55, 20), Decl(asyncWithVarShadowing_es6.ts, 56, 10))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn15(x) {
+>fn15 : Symbol(fn15, Decl(asyncWithVarShadowing_es6.ts, 57, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 59, 20), Decl(asyncWithVarShadowing_es6.ts, 60, 9))
+
+    var [...x] = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 59, 20), Decl(asyncWithVarShadowing_es6.ts, 60, 9))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn16(x) {
+>fn16 : Symbol(fn16, Decl(asyncWithVarShadowing_es6.ts, 61, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 63, 20), Decl(asyncWithVarShadowing_es6.ts, 64, 10))
+
+    var [[x]] = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 63, 20), Decl(asyncWithVarShadowing_es6.ts, 64, 10))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn17(x) {
+>fn17 : Symbol(fn17, Decl(asyncWithVarShadowing_es6.ts, 65, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 67, 20), Decl(asyncWithVarShadowing_es6.ts, 68, 10))
+
+    var [[x] = y] = y;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 67, 20), Decl(asyncWithVarShadowing_es6.ts, 68, 10))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn18({ x }) {
+>fn18 : Symbol(fn18, Decl(asyncWithVarShadowing_es6.ts, 69, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 71, 21), Decl(asyncWithVarShadowing_es6.ts, 72, 7))
+
+    var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 71, 21), Decl(asyncWithVarShadowing_es6.ts, 72, 7))
+}
+
+async function fn19([x]) {
+>fn19 : Symbol(fn19, Decl(asyncWithVarShadowing_es6.ts, 73, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 75, 21), Decl(asyncWithVarShadowing_es6.ts, 76, 7))
+
+    var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 75, 21), Decl(asyncWithVarShadowing_es6.ts, 76, 7))
+}
+
+async function fn20(x) {
+>fn20 : Symbol(fn20, Decl(asyncWithVarShadowing_es6.ts, 77, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 79, 20), Decl(asyncWithVarShadowing_es6.ts, 81, 11))
+    {
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 79, 20), Decl(asyncWithVarShadowing_es6.ts, 81, 11))
+    }
+}
+
+async function fn21(x) {
+>fn21 : Symbol(fn21, Decl(asyncWithVarShadowing_es6.ts, 83, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 85, 20), Decl(asyncWithVarShadowing_es6.ts, 87, 11))
+
+    if (y) {
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 85, 20), Decl(asyncWithVarShadowing_es6.ts, 87, 11))
+    }
+}
+
+async function fn22(x) {
+>fn22 : Symbol(fn22, Decl(asyncWithVarShadowing_es6.ts, 89, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 91, 20), Decl(asyncWithVarShadowing_es6.ts, 95, 11))
+
+    if (y) {
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+    }
+    else {
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 91, 20), Decl(asyncWithVarShadowing_es6.ts, 95, 11))
+    }
+}
+
+async function fn23(x) {
+>fn23 : Symbol(fn23, Decl(asyncWithVarShadowing_es6.ts, 97, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 99, 20), Decl(asyncWithVarShadowing_es6.ts, 101, 11))
+
+    try {
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 99, 20), Decl(asyncWithVarShadowing_es6.ts, 101, 11))
+    }
+    catch (e) {
+>e : Symbol(e, Decl(asyncWithVarShadowing_es6.ts, 103, 11))
+    }
+}
+
+async function fn24(x) {
+>fn24 : Symbol(fn24, Decl(asyncWithVarShadowing_es6.ts, 105, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 107, 20), Decl(asyncWithVarShadowing_es6.ts, 112, 11))
+
+    try {
+
+    }
+    catch (e) {
+>e : Symbol(e, Decl(asyncWithVarShadowing_es6.ts, 111, 11))
+
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 107, 20), Decl(asyncWithVarShadowing_es6.ts, 112, 11))
+    }
+}
+
+async function fn25(x) {
+>fn25 : Symbol(fn25, Decl(asyncWithVarShadowing_es6.ts, 114, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 116, 20), Decl(asyncWithVarShadowing_es6.ts, 121, 11))
+
+    try {
+
+    }
+    catch (x) {
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 120, 11))
+
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 116, 20), Decl(asyncWithVarShadowing_es6.ts, 121, 11))
+    }
+}
+
+async function fn26(x) {
+>fn26 : Symbol(fn26, Decl(asyncWithVarShadowing_es6.ts, 123, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 125, 20), Decl(asyncWithVarShadowing_es6.ts, 130, 11))
+
+    try {
+
+    }
+    catch ({ x }) {
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 129, 12))
+
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 125, 20), Decl(asyncWithVarShadowing_es6.ts, 130, 11))
+    }
+}
+
+async function fn27(x) {
+>fn27 : Symbol(fn27, Decl(asyncWithVarShadowing_es6.ts, 132, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 134, 20), Decl(asyncWithVarShadowing_es6.ts, 138, 11))
+
+    try {
+    }
+    finally {
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 134, 20), Decl(asyncWithVarShadowing_es6.ts, 138, 11))
+    }
+}
+
+async function fn28(x) {
+>fn28 : Symbol(fn28, Decl(asyncWithVarShadowing_es6.ts, 140, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 142, 20), Decl(asyncWithVarShadowing_es6.ts, 144, 11))
+
+    while (y) {
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 142, 20), Decl(asyncWithVarShadowing_es6.ts, 144, 11))
+    }
+}
+
+async function fn29(x) {
+>fn29 : Symbol(fn29, Decl(asyncWithVarShadowing_es6.ts, 146, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 148, 20), Decl(asyncWithVarShadowing_es6.ts, 150, 11))
+
+    do {
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 148, 20), Decl(asyncWithVarShadowing_es6.ts, 150, 11))
+    }
+    while (y);
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+}
+
+async function fn30(x) {
+>fn30 : Symbol(fn30, Decl(asyncWithVarShadowing_es6.ts, 153, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 155, 20), Decl(asyncWithVarShadowing_es6.ts, 156, 12))
+
+    for (var x = y;;) {
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 155, 20), Decl(asyncWithVarShadowing_es6.ts, 156, 12))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+
+    }
+}
+
+async function fn31(x) {
+>fn31 : Symbol(fn31, Decl(asyncWithVarShadowing_es6.ts, 159, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 161, 20), Decl(asyncWithVarShadowing_es6.ts, 162, 14))
+
+    for (var { x } = y;;) {
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 161, 20), Decl(asyncWithVarShadowing_es6.ts, 162, 14))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+    }
+}
+
+async function fn32(x) {
+>fn32 : Symbol(fn32, Decl(asyncWithVarShadowing_es6.ts, 164, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 166, 20), Decl(asyncWithVarShadowing_es6.ts, 168, 11))
+
+    for (;;) {
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 166, 20), Decl(asyncWithVarShadowing_es6.ts, 168, 11))
+    }
+}
+
+async function fn33(x: string) {
+>fn33 : Symbol(fn33, Decl(asyncWithVarShadowing_es6.ts, 170, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 172, 20), Decl(asyncWithVarShadowing_es6.ts, 173, 12))
+
+    for (var x in y) {
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 172, 20), Decl(asyncWithVarShadowing_es6.ts, 173, 12))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+    }
+}
+
+async function fn34(x) {
+>fn34 : Symbol(fn34, Decl(asyncWithVarShadowing_es6.ts, 175, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 177, 20), Decl(asyncWithVarShadowing_es6.ts, 179, 11))
+
+    for (var z in y) {
+>z : Symbol(z, Decl(asyncWithVarShadowing_es6.ts, 178, 12))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 177, 20), Decl(asyncWithVarShadowing_es6.ts, 179, 11))
+    }
+}
+
+async function fn35(x) {
+>fn35 : Symbol(fn35, Decl(asyncWithVarShadowing_es6.ts, 181, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 183, 20), Decl(asyncWithVarShadowing_es6.ts, 184, 12))
+
+    for (var x of y) {
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 183, 20), Decl(asyncWithVarShadowing_es6.ts, 184, 12))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+    }
+}
+
+async function fn36(x) {
+>fn36 : Symbol(fn36, Decl(asyncWithVarShadowing_es6.ts, 186, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 188, 20), Decl(asyncWithVarShadowing_es6.ts, 189, 14))
+
+    for (var { x } of y) {
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 188, 20), Decl(asyncWithVarShadowing_es6.ts, 189, 14))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+    }
+}
+
+async function fn37(x) {
+>fn37 : Symbol(fn37, Decl(asyncWithVarShadowing_es6.ts, 191, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 193, 20), Decl(asyncWithVarShadowing_es6.ts, 195, 11))
+
+    for (var z of y) {
+>z : Symbol(z, Decl(asyncWithVarShadowing_es6.ts, 194, 12))
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+
+        var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 193, 20), Decl(asyncWithVarShadowing_es6.ts, 195, 11))
+    }
+}
+
+async function fn38(x) {
+>fn38 : Symbol(fn38, Decl(asyncWithVarShadowing_es6.ts, 197, 1))
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 199, 20), Decl(asyncWithVarShadowing_es6.ts, 202, 15))
+
+    switch (y) {
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+
+        case y:
+>y : Symbol(y, Decl(asyncWithVarShadowing_es6.ts, 1, 13))
+
+            var x;
+>x : Symbol(x, Decl(asyncWithVarShadowing_es6.ts, 199, 20), Decl(asyncWithVarShadowing_es6.ts, 202, 15))
+    }
+}

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.types
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.types
@@ -1,0 +1,410 @@
+=== tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/20461
+declare const y: any;
+>y : any
+
+async function fn1(x) {
+>fn1 : (x: any) => Promise<void>
+>x : any
+
+    var x;
+>x : any
+}
+
+async function fn2(x) {
+>fn2 : (x: any) => Promise<void>
+>x : any
+
+    var x, z;
+>x : any
+>z : any
+}
+
+async function fn3(x) {
+>fn3 : (x: any) => Promise<void>
+>x : any
+
+    var z;
+>z : any
+}
+
+async function fn4(x) {
+>fn4 : (x: any) => Promise<void>
+>x : any
+
+    var x = y;
+>x : any
+>y : any
+}
+
+async function fn5(x) {
+>fn5 : (x: any) => Promise<void>
+>x : any
+
+    var { x } = y;
+>x : any
+>y : any
+}
+
+async function fn6(x) {
+>fn6 : (x: any) => Promise<void>
+>x : any
+
+    var { x, z } = y;
+>x : any
+>z : any
+>y : any
+}
+
+async function fn7(x) {
+>fn7 : (x: any) => Promise<void>
+>x : any
+
+    var { x = y } = y;
+>x : any
+>y : any
+>y : any
+}
+
+async function fn8(x) {
+>fn8 : (x: any) => Promise<void>
+>x : any
+
+    var { z: x } = y;
+>z : any
+>x : any
+>y : any
+}
+
+async function fn9(x) {
+>fn9 : (x: any) => Promise<void>
+>x : any
+
+    var { z: { x } } = y;
+>z : any
+>x : any
+>y : any
+}
+
+async function fn10(x) {
+>fn10 : (x: any) => Promise<void>
+>x : any
+
+    var { z: { x } = y } = y;
+>z : any
+>x : any
+>y : any
+>y : any
+}
+
+async function fn11(x) {
+>fn11 : (x: any) => Promise<void>
+>x : any
+
+    var { ...x } = y;
+>x : any
+>y : any
+}
+
+async function fn12(x) {
+>fn12 : (x: any) => Promise<void>
+>x : any
+
+    var [x] = y;
+>x : any
+>y : any
+}
+
+async function fn13(x) {
+>fn13 : (x: any) => Promise<void>
+>x : any
+
+    var [x = y] = y;
+>x : any
+>y : any
+>y : any
+}
+
+async function fn14(x) {
+>fn14 : (x: any) => Promise<void>
+>x : any
+
+    var [, x] = y;
+> : undefined
+>x : any
+>y : any
+}
+
+async function fn15(x) {
+>fn15 : (x: any) => Promise<void>
+>x : any
+
+    var [...x] = y;
+>x : any
+>y : any
+}
+
+async function fn16(x) {
+>fn16 : (x: any) => Promise<void>
+>x : any
+
+    var [[x]] = y;
+>x : any
+>y : any
+}
+
+async function fn17(x) {
+>fn17 : (x: any) => Promise<void>
+>x : any
+
+    var [[x] = y] = y;
+>x : any
+>y : any
+>y : any
+}
+
+async function fn18({ x }) {
+>fn18 : ({ x }: { x: any; }) => Promise<void>
+>x : any
+
+    var x;
+>x : any
+}
+
+async function fn19([x]) {
+>fn19 : ([x]: [any]) => Promise<void>
+>x : any
+
+    var x;
+>x : any
+}
+
+async function fn20(x) {
+>fn20 : (x: any) => Promise<void>
+>x : any
+    {
+        var x;
+>x : any
+    }
+}
+
+async function fn21(x) {
+>fn21 : (x: any) => Promise<void>
+>x : any
+
+    if (y) {
+>y : any
+
+        var x;
+>x : any
+    }
+}
+
+async function fn22(x) {
+>fn22 : (x: any) => Promise<void>
+>x : any
+
+    if (y) {
+>y : any
+    }
+    else {
+        var x;
+>x : any
+    }
+}
+
+async function fn23(x) {
+>fn23 : (x: any) => Promise<void>
+>x : any
+
+    try {
+        var x;
+>x : any
+    }
+    catch (e) {
+>e : any
+    }
+}
+
+async function fn24(x) {
+>fn24 : (x: any) => Promise<void>
+>x : any
+
+    try {
+
+    }
+    catch (e) {
+>e : any
+
+        var x;
+>x : any
+    }
+}
+
+async function fn25(x) {
+>fn25 : (x: any) => Promise<void>
+>x : any
+
+    try {
+
+    }
+    catch (x) {
+>x : any
+
+        var x;
+>x : any
+    }
+}
+
+async function fn26(x) {
+>fn26 : (x: any) => Promise<void>
+>x : any
+
+    try {
+
+    }
+    catch ({ x }) {
+>x : any
+
+        var x;
+>x : any
+    }
+}
+
+async function fn27(x) {
+>fn27 : (x: any) => Promise<void>
+>x : any
+
+    try {
+    }
+    finally {
+        var x;
+>x : any
+    }
+}
+
+async function fn28(x) {
+>fn28 : (x: any) => Promise<void>
+>x : any
+
+    while (y) {
+>y : any
+
+        var x;
+>x : any
+    }
+}
+
+async function fn29(x) {
+>fn29 : (x: any) => Promise<void>
+>x : any
+
+    do {
+        var x;
+>x : any
+    }
+    while (y);
+>y : any
+}
+
+async function fn30(x) {
+>fn30 : (x: any) => Promise<void>
+>x : any
+
+    for (var x = y;;) {
+>x : any
+>y : any
+
+    }
+}
+
+async function fn31(x) {
+>fn31 : (x: any) => Promise<void>
+>x : any
+
+    for (var { x } = y;;) {
+>x : any
+>y : any
+    }
+}
+
+async function fn32(x) {
+>fn32 : (x: any) => Promise<void>
+>x : any
+
+    for (;;) {
+        var x;
+>x : any
+    }
+}
+
+async function fn33(x: string) {
+>fn33 : (x: string) => Promise<void>
+>x : string
+
+    for (var x in y) {
+>x : string
+>y : any
+    }
+}
+
+async function fn34(x) {
+>fn34 : (x: any) => Promise<void>
+>x : any
+
+    for (var z in y) {
+>z : string
+>y : any
+
+        var x;
+>x : any
+    }
+}
+
+async function fn35(x) {
+>fn35 : (x: any) => Promise<void>
+>x : any
+
+    for (var x of y) {
+>x : any
+>y : any
+    }
+}
+
+async function fn36(x) {
+>fn36 : (x: any) => Promise<void>
+>x : any
+
+    for (var { x } of y) {
+>x : any
+>y : any
+    }
+}
+
+async function fn37(x) {
+>fn37 : (x: any) => Promise<void>
+>x : any
+
+    for (var z of y) {
+>z : any
+>y : any
+
+        var x;
+>x : any
+    }
+}
+
+async function fn38(x) {
+>fn38 : (x: any) => Promise<void>
+>x : any
+
+    switch (y) {
+>y : any
+
+        case y:
+>y : any
+
+            var x;
+>x : any
+    }
+}

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.types
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.types
@@ -423,3 +423,17 @@ async function fn39(x) {
 >foo : any
     }
 }
+
+async function fn40(x) {
+>fn40 : (x: any) => Promise<void>
+>x : any
+
+    try {
+
+    }
+    catch {
+        var x;
+>x : any
+    }
+}
+

--- a/tests/baselines/reference/asyncWithVarShadowing_es6.types
+++ b/tests/baselines/reference/asyncWithVarShadowing_es6.types
@@ -408,3 +408,18 @@ async function fn38(x) {
 >x : any
     }
 }
+
+async function fn39(x) {
+>fn39 : (x: any) => Promise<void>
+>x : any
+
+    foo: {
+>foo : any
+
+        var x;
+>x : any
+
+        break foo;
+>foo : any
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
@@ -205,3 +205,10 @@ async function fn38(x) {
             var x;
     }
 }
+
+async function fn39(x) {
+    foo: {
+        var x;
+        break foo;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
@@ -1,0 +1,207 @@
+// @target: es2015
+// @noEmitHelpers: true
+// https://github.com/Microsoft/TypeScript/issues/20461
+declare const y: any;
+
+async function fn1(x) {
+    var x;
+}
+
+async function fn2(x) {
+    var x, z;
+}
+
+async function fn3(x) {
+    var z;
+}
+
+async function fn4(x) {
+    var x = y;
+}
+
+async function fn5(x) {
+    var { x } = y;
+}
+
+async function fn6(x) {
+    var { x, z } = y;
+}
+
+async function fn7(x) {
+    var { x = y } = y;
+}
+
+async function fn8(x) {
+    var { z: x } = y;
+}
+
+async function fn9(x) {
+    var { z: { x } } = y;
+}
+
+async function fn10(x) {
+    var { z: { x } = y } = y;
+}
+
+async function fn11(x) {
+    var { ...x } = y;
+}
+
+async function fn12(x) {
+    var [x] = y;
+}
+
+async function fn13(x) {
+    var [x = y] = y;
+}
+
+async function fn14(x) {
+    var [, x] = y;
+}
+
+async function fn15(x) {
+    var [...x] = y;
+}
+
+async function fn16(x) {
+    var [[x]] = y;
+}
+
+async function fn17(x) {
+    var [[x] = y] = y;
+}
+
+async function fn18({ x }) {
+    var x;
+}
+
+async function fn19([x]) {
+    var x;
+}
+
+async function fn20(x) {
+    {
+        var x;
+    }
+}
+
+async function fn21(x) {
+    if (y) {
+        var x;
+    }
+}
+
+async function fn22(x) {
+    if (y) {
+    }
+    else {
+        var x;
+    }
+}
+
+async function fn23(x) {
+    try {
+        var x;
+    }
+    catch (e) {
+    }
+}
+
+async function fn24(x) {
+    try {
+
+    }
+    catch (e) {
+        var x;
+    }
+}
+
+async function fn25(x) {
+    try {
+
+    }
+    catch (x) {
+        var x;
+    }
+}
+
+async function fn26(x) {
+    try {
+
+    }
+    catch ({ x }) {
+        var x;
+    }
+}
+
+async function fn27(x) {
+    try {
+    }
+    finally {
+        var x;
+    }
+}
+
+async function fn28(x) {
+    while (y) {
+        var x;
+    }
+}
+
+async function fn29(x) {
+    do {
+        var x;
+    }
+    while (y);
+}
+
+async function fn30(x) {
+    for (var x = y;;) {
+
+    }
+}
+
+async function fn31(x) {
+    for (var { x } = y;;) {
+    }
+}
+
+async function fn32(x) {
+    for (;;) {
+        var x;
+    }
+}
+
+async function fn33(x: string) {
+    for (var x in y) {
+    }
+}
+
+async function fn34(x) {
+    for (var z in y) {
+        var x;
+    }
+}
+
+async function fn35(x) {
+    for (var x of y) {
+    }
+}
+
+async function fn36(x) {
+    for (var { x } of y) {
+    }
+}
+
+async function fn37(x) {
+    for (var z of y) {
+        var x;
+    }
+}
+
+async function fn38(x) {
+    switch (y) {
+        case y:
+            var x;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
@@ -212,3 +212,12 @@ async function fn39(x) {
         break foo;
     }
 }
+
+async function fn40(x) {
+    try {
+
+    }
+    catch {
+        var x;
+    }
+}


### PR DESCRIPTION
This fixes an issue where the downlevel emit for async functions to ES2015 can result in incorrect runtime semantics when the async function body contains a `var` declaration that shadows a parameter name.

Fixes #20461
