### PR TITLE
Fix incorrect parenthesization logic for conditional expression branches

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -3954,7 +3954,9 @@ namespace ts {
         // per ES grammar both 'whenTrue' and 'whenFalse' parts of conditional expression are assignment expressions
         // so in case when comma expression is introduced as a part of previous transformations
         // if should be wrapped in parens since comma operator has the lowest precedence
-        return e.kind === SyntaxKind.BinaryExpression && (<BinaryExpression>e).operatorToken.kind === SyntaxKind.CommaToken
+        const emittedExpression = skipPartiallyEmittedExpressions(e);
+        return emittedExpression.kind === SyntaxKind.BinaryExpression && (<BinaryExpression>emittedExpression).operatorToken.kind === SyntaxKind.CommaToken ||
+            emittedExpression.kind === SyntaxKind.CommaListExpression
             ? createParen(e)
             : e;
     }

--- a/tests/baselines/reference/transformParenthesizesConditionalSubexpression.js
+++ b/tests/baselines/reference/transformParenthesizesConditionalSubexpression.js
@@ -1,0 +1,10 @@
+//// [transformParenthesizesConditionalSubexpression.ts]
+var K = 'k'
+var a = { p  : (true ? { [K] : 'v'}        : null) }
+var b = { p  : (true ? { [K] : 'v'} as any : null) }
+
+//// [transformParenthesizesConditionalSubexpression.js]
+var K = 'k';
+var a = { p: (true ? (_a = {}, _a[K] = 'v', _a) : null) };
+var b = { p: (true ? (_b = {}, _b[K] = 'v', _b) : null) };
+var _a, _b;

--- a/tests/baselines/reference/transformParenthesizesConditionalSubexpression.symbols
+++ b/tests/baselines/reference/transformParenthesizesConditionalSubexpression.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/transformParenthesizesConditionalSubexpression.ts ===
+var K = 'k'
+>K : Symbol(K, Decl(transformParenthesizesConditionalSubexpression.ts, 0, 3))
+
+var a = { p  : (true ? { [K] : 'v'}        : null) }
+>a : Symbol(a, Decl(transformParenthesizesConditionalSubexpression.ts, 1, 3))
+>p : Symbol(p, Decl(transformParenthesizesConditionalSubexpression.ts, 1, 9))
+>K : Symbol(K, Decl(transformParenthesizesConditionalSubexpression.ts, 0, 3))
+
+var b = { p  : (true ? { [K] : 'v'} as any : null) }
+>b : Symbol(b, Decl(transformParenthesizesConditionalSubexpression.ts, 2, 3))
+>p : Symbol(p, Decl(transformParenthesizesConditionalSubexpression.ts, 2, 9))
+>K : Symbol(K, Decl(transformParenthesizesConditionalSubexpression.ts, 0, 3))
+

--- a/tests/baselines/reference/transformParenthesizesConditionalSubexpression.types
+++ b/tests/baselines/reference/transformParenthesizesConditionalSubexpression.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/transformParenthesizesConditionalSubexpression.ts ===
+var K = 'k'
+>K : string
+>'k' : "k"
+
+var a = { p  : (true ? { [K] : 'v'}        : null) }
+>a : { p: { [x: string]: string; }; }
+>{ p  : (true ? { [K] : 'v'}        : null) } : { p: { [x: string]: string; }; }
+>p : { [x: string]: string; }
+>(true ? { [K] : 'v'}        : null) : { [x: string]: string; }
+>true ? { [K] : 'v'}        : null : { [x: string]: string; }
+>true : true
+>{ [K] : 'v'} : { [x: string]: string; }
+>K : string
+>'v' : "v"
+>null : null
+
+var b = { p  : (true ? { [K] : 'v'} as any : null) }
+>b : { p: any; }
+>{ p  : (true ? { [K] : 'v'} as any : null) } : { p: any; }
+>p : any
+>(true ? { [K] : 'v'} as any : null) : any
+>true ? { [K] : 'v'} as any : null : any
+>true : true
+>{ [K] : 'v'} as any : any
+>{ [K] : 'v'} : { [x: string]: string; }
+>K : string
+>'v' : "v"
+>null : null
+

--- a/tests/cases/compiler/transformParenthesizesConditionalSubexpression.ts
+++ b/tests/cases/compiler/transformParenthesizesConditionalSubexpression.ts
@@ -1,0 +1,4 @@
+// @target: es5
+var K = 'k'
+var a = { p  : (true ? { [K] : 'v'}        : null) }
+var b = { p  : (true ? { [K] : 'v'} as any : null) }


### PR DESCRIPTION
When determining whether we should parenthesize a conditional branch, we were only looking at the conditional branch node even when it might be wrapped in `PartiallyEmittedExpression` nodes.

Fixes #19103
