### PR TITLE
Symbol-named properties do not need to align with string indexer type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22298,7 +22298,8 @@ namespace ts {
                 indexType: Type,
                 indexKind: IndexKind): void {
 
-                if (!indexType) {
+                // ESSymbol properties apply to neither string nor numeric indexers.
+                if (!indexType || isKnownSymbol(prop)) {
                     return;
                 }
 

--- a/tests/baselines/reference/symbolProperty60.js
+++ b/tests/baselines/reference/symbolProperty60.js
@@ -1,0 +1,25 @@
+//// [symbolProperty60.ts]
+// https://github.com/Microsoft/TypeScript/issues/20146
+interface I1 {
+    [Symbol.toStringTag]: string;
+    [key: string]: number;
+}
+
+interface I2 {
+    [Symbol.toStringTag]: string;
+    [key: number]: boolean;
+}
+
+declare const mySymbol: unique symbol;
+
+interface I3 {
+    [mySymbol]: string;
+    [key: string]: number;
+}
+
+interface I4 {
+    [mySymbol]: string;
+    [key: number]: boolean;
+}
+
+//// [symbolProperty60.js]

--- a/tests/baselines/reference/symbolProperty60.symbols
+++ b/tests/baselines/reference/symbolProperty60.symbols
@@ -1,0 +1,48 @@
+=== tests/cases/conformance/es6/Symbols/symbolProperty60.ts ===
+// https://github.com/Microsoft/TypeScript/issues/20146
+interface I1 {
+>I1 : Symbol(I1, Decl(symbolProperty60.ts, 0, 0))
+
+    [Symbol.toStringTag]: string;
+>Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    [key: string]: number;
+>key : Symbol(key, Decl(symbolProperty60.ts, 3, 5))
+}
+
+interface I2 {
+>I2 : Symbol(I2, Decl(symbolProperty60.ts, 4, 1))
+
+    [Symbol.toStringTag]: string;
+>Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    [key: number]: boolean;
+>key : Symbol(key, Decl(symbolProperty60.ts, 8, 5))
+}
+
+declare const mySymbol: unique symbol;
+>mySymbol : Symbol(mySymbol, Decl(symbolProperty60.ts, 11, 13))
+
+interface I3 {
+>I3 : Symbol(I3, Decl(symbolProperty60.ts, 11, 38))
+
+    [mySymbol]: string;
+>mySymbol : Symbol(mySymbol, Decl(symbolProperty60.ts, 11, 13))
+
+    [key: string]: number;
+>key : Symbol(key, Decl(symbolProperty60.ts, 15, 5))
+}
+
+interface I4 {
+>I4 : Symbol(I4, Decl(symbolProperty60.ts, 16, 1))
+
+    [mySymbol]: string;
+>mySymbol : Symbol(mySymbol, Decl(symbolProperty60.ts, 11, 13))
+
+    [key: number]: boolean;
+>key : Symbol(key, Decl(symbolProperty60.ts, 20, 5))
+}

--- a/tests/baselines/reference/symbolProperty60.types
+++ b/tests/baselines/reference/symbolProperty60.types
@@ -1,0 +1,48 @@
+=== tests/cases/conformance/es6/Symbols/symbolProperty60.ts ===
+// https://github.com/Microsoft/TypeScript/issues/20146
+interface I1 {
+>I1 : I1
+
+    [Symbol.toStringTag]: string;
+>Symbol.toStringTag : symbol
+>Symbol : SymbolConstructor
+>toStringTag : symbol
+
+    [key: string]: number;
+>key : string
+}
+
+interface I2 {
+>I2 : I2
+
+    [Symbol.toStringTag]: string;
+>Symbol.toStringTag : symbol
+>Symbol : SymbolConstructor
+>toStringTag : symbol
+
+    [key: number]: boolean;
+>key : number
+}
+
+declare const mySymbol: unique symbol;
+>mySymbol : unique symbol
+
+interface I3 {
+>I3 : I3
+
+    [mySymbol]: string;
+>mySymbol : unique symbol
+
+    [key: string]: number;
+>key : string
+}
+
+interface I4 {
+>I4 : I4
+
+    [mySymbol]: string;
+>mySymbol : unique symbol
+
+    [key: number]: boolean;
+>key : number
+}

--- a/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
+++ b/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
@@ -1,0 +1,23 @@
+// @target: es2015
+// https://github.com/Microsoft/TypeScript/issues/20146
+interface I1 {
+    [Symbol.toStringTag]: string;
+    [key: string]: number;
+}
+
+interface I2 {
+    [Symbol.toStringTag]: string;
+    [key: number]: boolean;
+}
+
+declare const mySymbol: unique symbol;
+
+interface I3 {
+    [mySymbol]: string;
+    [key: string]: number;
+}
+
+interface I4 {
+    [mySymbol]: string;
+    [key: number]: boolean;
+}


### PR DESCRIPTION
This fixes errors when declaring a type with a symbol-named property that also specifies a string indexer, as symbol-named properties do not collide with string indexers.

Fixes #20146
