### PR TITLE
Fix the invalid file/directory location when getting file system entries for caching the results

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -20,6 +20,7 @@ namespace ts {
 
 /* @internal */
 namespace ts {
+    export const emptyArray: never[] = [] as never[];
     /** Create a MapLike with good performance. */
     function createDictionaryObject<T>(): MapLike<T> {
         const map = Object.create(/*prototype*/ null); // tslint:disable-line:no-null-keyword
@@ -3069,6 +3070,10 @@ namespace ts {
         readonly directories: string[];
     }
 
+    export const emptyFileSystemEntries: FileSystemEntries = {
+        files: emptyArray,
+        directories: emptyArray
+    };
     export function createCachedDirectoryStructureHost(host: DirectoryStructureHost): CachedDirectoryStructureHost {
         const cachedReadDirectoryResult = createMap<MutableFileSystemEntries>();
         const getCurrentDirectory = memoize(() => host.getCurrentDirectory());
@@ -3210,7 +3215,7 @@ namespace ts {
                 if (path === rootDirPath) {
                     return result;
                 }
-                return getCachedFileSystemEntries(path) || createCachedFileSystemEntries(dir, path);
+                return tryReadDirectory(dir, path) || emptyFileSystemEntries;
             }
         }
 

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -398,7 +398,7 @@ namespace ts {
                     return { files, directories };
                 }
                 catch (e) {
-                    return { files: [], directories: [] };
+                    return emptyFileSystemEntries;
                 }
             }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2,7 +2,6 @@
 
 /* @internal */
 namespace ts {
-    export const emptyArray: never[] = [] as never[];
     export const resolvingEmptyArray: never[] = [] as never[];
     export const emptyMap: ReadonlyMap<never> = createMap<never>();
     export const emptyUnderscoreEscapedMap: ReadonlyUnderscoreEscapedMap<never> = emptyMap as ReadonlyUnderscoreEscapedMap<never>;

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -4168,6 +4168,32 @@ namespace ts.projectSystem {
             // Since no file from the configured project is open, it would be closed immediately
             projectService.checkNumberOfProjects({ configuredProjects: 0, inferredProjects: 1 });
         });
+
+        it("should tolerate invalid include files that start in subDirectory", () => {
+            const projectFolder = "/user/username/projects/myproject";
+            const f = {
+                path: `${projectFolder}/src/server/index.ts`,
+                content: "let x = 1"
+            };
+            const config = {
+                path: `${projectFolder}/src/server/tsconfig.json`,
+                content: JSON.stringify({
+                    compiler: {
+                        module: "commonjs",
+                        outDir: "../../build"
+                    },
+                    include: [
+                        "../src/**/*.ts"
+                    ]
+                })
+            };
+            const host = createServerHost([f, config, libFile], { useCaseSensitiveFileNames: true });
+            const projectService = createProjectService(host);
+
+            projectService.openClientFile(f.path);
+            // Since no file from the configured project is open, it would be closed immediately
+            projectService.checkNumberOfProjects({ configuredProjects: 0, inferredProjects: 1 });
+        });
     });
 
     describe("tsserverProjectSystem reload", () => {


### PR DESCRIPTION
With invalid include path, the read directory in the matchFiles might not be subdirectory to the rootDir and hence we need to catch the exceptions when return file system entry results
Fixes #20607 