### PR TITLE
In formatter, get lineAction directly from applyRuleEdits

### DIFF
--- a/tests/cases/fourslash/formatObjectBindingPattern.ts
+++ b/tests/cases/fourslash/formatObjectBindingPattern.ts
@@ -1,0 +1,14 @@
+///<reference path="fourslash.ts"/>
+
+////const {
+////x,
+////y,
+////} = 0;
+
+format.document();
+verify.currentFileContentIs(
+`const {
+    x,
+    y,
+} = 0;`
+);


### PR DESCRIPTION
Fixes #20508

`processPair` was trying to calculate `lineAction` based only on `rule.action`.
But only `applyRuleEdits` knows whether a line was actually added/deleted; in this case there was a `RuleAction.Space` rule that happened to do nothing, but `processPair` was assuming that it had removed a line, which meant that we didn't try to correct the indentation for the line with `x,`.