### PR TITLE
fix #21252, add package-lock.json to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,4 @@ Jakefile.js
 .travis.yml
 .vscode/
 test.config
+package-lock.json


### PR DESCRIPTION
Curiously, https://docs.npmjs.com/files/package.json#files said:

> Conversely, some files are always ignored: 
> * packge-lock.json

It is strange why npm doesn't ignore lock. I have checked package.json and npmignore, and they didn't explicitly include lock.

It might be better to investigate publish script before makeshift pull-request is merged.