### PR TITLE
Fix formatter crash for `const { ...a: b } = {};`: forEachChild and emitBindingElement should handle `...` before the propertyName

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1268,12 +1268,12 @@ namespace ts {
         }
 
         function emitBindingElement(node: BindingElement) {
+            emitIfPresent(node.dotDotDotToken);
             if (node.propertyName) {
                 emit(node.propertyName);
                 writePunctuation(":");
                 writeSpace();
             }
-            emitIfPresent(node.dotDotDotToken);
             emit(node.name);
             emitInitializer(node.initializer);
         }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -126,8 +126,8 @@ namespace ts {
             case SyntaxKind.BindingElement:
                 return visitNodes(cbNode, cbNodes, node.decorators) ||
                     visitNodes(cbNode, cbNodes, node.modifiers) ||
-                    visitNode(cbNode, (<BindingElement>node).propertyName) ||
                     visitNode(cbNode, (<BindingElement>node).dotDotDotToken) ||
+                    visitNode(cbNode, (<BindingElement>node).propertyName) ||
                     visitNode(cbNode, (<BindingElement>node).name) ||
                     visitNode(cbNode, (<BindingElement>node).initializer);
             case SyntaxKind.FunctionType:

--- a/tests/cases/fourslash/formatObjectBindingPattern_restElementWithPropertyName.ts
+++ b/tests/cases/fourslash/formatObjectBindingPattern_restElementWithPropertyName.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts' />
+
+////const { ...a: b } = {};
+
+format.document();
+verify.currentFileContentIs("const { ...a: b } = {};");


### PR DESCRIPTION
Fixes #21265