### PR TITLE
Fix deletion of node_modules in DT test

### DIFF
--- a/src/harness/externalCompileRunner.ts
+++ b/src/harness/externalCompileRunner.ts
@@ -61,7 +61,7 @@ abstract class ExternalCompileRunnerBase extends RunnerBase {
                         fs.unlinkSync(path.join(cwd, "package-lock.json"));
                     }
                     if (fs.existsSync(path.join(cwd, "node_modules"))) {
-                        require("del").sync(path.join(cwd, "node_modules"));
+                        require("del").sync(path.join(cwd, "node_modules"), { force: true });
                     }
                     const install = cp.spawnSync(`npm`, ["i"], { cwd, timeout, shell: true, stdio });
                     if (install.status !== 0) throw new Error(`NPM Install for ${directoryName} failed: ${install.stderr.toString()}`);


### PR DESCRIPTION
del needs to have `{ force: true }` passed so that it can delete node_modules outside the working directory.
Fixes multiple runs of the DT tests.