### PR TITLE
Inference of string literals to keyof creates an object with props of type `any`, not `{}`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10965,7 +10965,7 @@ namespace ts {
             return type === typeParameter || type.flags & TypeFlags.UnionOrIntersection && forEach((<UnionOrIntersectionType>type).types, t => isTypeParameterAtTopLevel(t, typeParameter));
         }
 
-        /** Create an object with properties named in the string literal type. Every property has type `{}` */
+        /** Create an object with properties named in the string literal type. Every property has type `any` */
         function createEmptyObjectTypeFromStringLiteral(type: Type) {
             const members = createSymbolTable();
             forEachType(type, t => {
@@ -10974,7 +10974,7 @@ namespace ts {
                 }
                 const name = escapeLeadingUnderscores((t as StringLiteralType).value);
                 const literalProp = createSymbol(SymbolFlags.Property, name);
-                literalProp.type = emptyObjectType;
+                literalProp.type = anyType;
                 if (t.symbol) {
                     literalProp.declarations = t.symbol.declarations;
                     literalProp.valueDeclaration = t.symbol.valueDeclaration;

--- a/tests/baselines/reference/inferObjectTypeFromStringLiteralToKeyof.js
+++ b/tests/baselines/reference/inferObjectTypeFromStringLiteralToKeyof.js
@@ -1,8 +1,11 @@
 //// [inferObjectTypeFromStringLiteralToKeyof.ts]
-declare function inference<T>(target: T, name: keyof T): void;
+declare function inference1<T>(name: keyof T): T;
+declare function inference2<T>(target: T, name: keyof T): T;
 declare var two: "a" | "d";
-inference({ a: 1, b: 2, c: 3, d(n) { return n } }, two);
+const x = inference1(two);
+const y = inference2({ a: 1, b: 2, c: 3, d(n) { return n } }, two);
 
 
 //// [inferObjectTypeFromStringLiteralToKeyof.js]
-inference({ a: 1, b: 2, c: 3, d: function (n) { return n; } }, two);
+var x = inference1(two);
+var y = inference2({ a: 1, b: 2, c: 3, d: function (n) { return n; } }, two);

--- a/tests/baselines/reference/inferObjectTypeFromStringLiteralToKeyof.symbols
+++ b/tests/baselines/reference/inferObjectTypeFromStringLiteralToKeyof.symbols
@@ -1,22 +1,36 @@
 === tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts ===
-declare function inference<T>(target: T, name: keyof T): void;
->inference : Symbol(inference, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 0))
->T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 27))
->target : Symbol(target, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 30))
->T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 27))
->name : Symbol(name, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 40))
->T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 27))
+declare function inference1<T>(name: keyof T): T;
+>inference1 : Symbol(inference1, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 0))
+>T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 28))
+>name : Symbol(name, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 31))
+>T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 28))
+>T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 28))
+
+declare function inference2<T>(target: T, name: keyof T): T;
+>inference2 : Symbol(inference2, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 49))
+>T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 1, 28))
+>target : Symbol(target, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 1, 31))
+>T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 1, 28))
+>name : Symbol(name, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 1, 41))
+>T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 1, 28))
+>T : Symbol(T, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 1, 28))
 
 declare var two: "a" | "d";
->two : Symbol(two, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 1, 11))
+>two : Symbol(two, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 11))
 
-inference({ a: 1, b: 2, c: 3, d(n) { return n } }, two);
->inference : Symbol(inference, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 0))
->a : Symbol(a, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 11))
->b : Symbol(b, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 17))
->c : Symbol(c, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 23))
->d : Symbol(d, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 29))
->n : Symbol(n, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 32))
->n : Symbol(n, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 32))
->two : Symbol(two, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 1, 11))
+const x = inference1(two);
+>x : Symbol(x, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 3, 5))
+>inference1 : Symbol(inference1, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 0))
+>two : Symbol(two, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 11))
+
+const y = inference2({ a: 1, b: 2, c: 3, d(n) { return n } }, two);
+>y : Symbol(y, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 4, 5))
+>inference2 : Symbol(inference2, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 0, 49))
+>a : Symbol(a, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 4, 22))
+>b : Symbol(b, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 4, 28))
+>c : Symbol(c, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 4, 34))
+>d : Symbol(d, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 4, 40))
+>n : Symbol(n, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 4, 43))
+>n : Symbol(n, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 4, 43))
+>two : Symbol(two, Decl(inferObjectTypeFromStringLiteralToKeyof.ts, 2, 11))
 

--- a/tests/baselines/reference/inferObjectTypeFromStringLiteralToKeyof.types
+++ b/tests/baselines/reference/inferObjectTypeFromStringLiteralToKeyof.types
@@ -1,18 +1,33 @@
 === tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts ===
-declare function inference<T>(target: T, name: keyof T): void;
->inference : <T>(target: T, name: keyof T) => void
+declare function inference1<T>(name: keyof T): T;
+>inference1 : <T>(name: keyof T) => T
+>T : T
+>name : keyof T
+>T : T
+>T : T
+
+declare function inference2<T>(target: T, name: keyof T): T;
+>inference2 : <T>(target: T, name: keyof T) => T
 >T : T
 >target : T
 >T : T
 >name : keyof T
 >T : T
+>T : T
 
 declare var two: "a" | "d";
 >two : "a" | "d"
 
-inference({ a: 1, b: 2, c: 3, d(n) { return n } }, two);
->inference({ a: 1, b: 2, c: 3, d(n) { return n } }, two) : void
->inference : <T>(target: T, name: keyof T) => void
+const x = inference1(two);
+>x : { a: any; d: any; }
+>inference1(two) : { a: any; d: any; }
+>inference1 : <T>(name: keyof T) => T
+>two : "a" | "d"
+
+const y = inference2({ a: 1, b: 2, c: 3, d(n) { return n } }, two);
+>y : { a: number; b: number; c: number; d(n: any): any; }
+>inference2({ a: 1, b: 2, c: 3, d(n) { return n } }, two) : { a: number; b: number; c: number; d(n: any): any; }
+>inference2 : <T>(target: T, name: keyof T) => T
 >{ a: 1, b: 2, c: 3, d(n) { return n } } : { a: number; b: number; c: number; d(n: any): any; }
 >a : number
 >1 : 1

--- a/tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts
+++ b/tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts
@@ -1,3 +1,5 @@
-declare function inference<T>(target: T, name: keyof T): void;
+declare function inference1<T>(name: keyof T): T;
+declare function inference2<T>(target: T, name: keyof T): T;
 declare var two: "a" | "d";
-inference({ a: 1, b: 2, c: 3, d(n) { return n } }, two);
+const x = inference1(two);
+const y = inference2({ a: 1, b: 2, c: 3, d(n) { return n } }, two);


### PR DESCRIPTION
I forgot to change it to `any` before merging #19227. Thanks to @HerringtonDarkholme for noticing this before it went out this way in the official 2.7 release.