### PR TITLE
Remove unused properties from interface Refactor

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3897,10 +3897,6 @@
         "category": "Message",
         "code": 95002
     },
-    "Extract symbol": {
-        "category": "Message",
-        "code": 95003
-    },
     "Extract to {0} in {1}": {
         "category": "Message",
         "code": 95004

--- a/src/services/refactorProvider.ts
+++ b/src/services/refactorProvider.ts
@@ -1,12 +1,6 @@
 /* @internal */
 namespace ts {
     export interface Refactor {
-        /** An unique code associated with each refactor */
-        name: string;
-
-        /** Description of the refactor to display in the UI of the editor */
-        description: string;
-
         /** Compute the associated code actions */
         getEditsForAction(context: RefactorContext, actionName: string): RefactorEditInfo | undefined;
 
@@ -28,8 +22,9 @@ namespace ts {
         // e.g.  nonSuggestableRefactors[refactorCode] -> the refactor you want
         const refactors: Map<Refactor> = createMap<Refactor>();
 
-        export function registerRefactor(refactor: Refactor) {
-            refactors.set(refactor.name, refactor);
+        /** @param name An unique code associated with each refactor. Does not have to be human-readable. */
+        export function registerRefactor(name: string, refactor: Refactor) {
+            refactors.set(name, refactor);
         }
 
         export function getApplicableRefactors(context: RefactorContext): ApplicableRefactorInfo[] {

--- a/src/services/refactors/annotateWithTypeFromJSDoc.ts
+++ b/src/services/refactors/annotateWithTypeFromJSDoc.ts
@@ -1,21 +1,16 @@
 /* @internal */
 namespace ts.refactor.annotateWithTypeFromJSDoc {
+    const refactorName = "Annotate with type from JSDoc";
     const actionName = "annotate";
+    const description = Diagnostics.Annotate_with_type_from_JSDoc.message;
+    registerRefactor(refactorName, { getEditsForAction, getAvailableActions });
 
-    const annotateTypeFromJSDoc: Refactor = {
-        name: "Annotate with type from JSDoc",
-        description: Diagnostics.Annotate_with_type_from_JSDoc.message,
-        getEditsForAction,
-        getAvailableActions
-    };
     type DeclarationWithType =
         | FunctionLikeDeclaration
         | VariableDeclaration
         | ParameterDeclaration
         | PropertySignature
         | PropertyDeclaration;
-
-    registerRefactor(annotateTypeFromJSDoc);
 
     function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
         if (isInJavaScriptFile(context.file)) {
@@ -25,11 +20,11 @@ namespace ts.refactor.annotateWithTypeFromJSDoc {
         const node = getTokenAtPosition(context.file, context.startPosition, /*includeJsDocComment*/ false);
         if (hasUsableJSDoc(findAncestor(node, isDeclarationWithType))) {
             return [{
-                name: annotateTypeFromJSDoc.name,
-                description: annotateTypeFromJSDoc.description,
+                name: refactorName,
+                description,
                 actions: [
                     {
-                        description: annotateTypeFromJSDoc.description,
+                        description,
                         name: actionName
                     }
                 ]

--- a/src/services/refactors/convertFunctionToEs6Class.ts
+++ b/src/services/refactors/convertFunctionToEs6Class.ts
@@ -1,16 +1,10 @@
 /* @internal */
 
 namespace ts.refactor.convertFunctionToES6Class {
+    const refactorName = "Convert to ES2015 class";
     const actionName = "convert";
-
-    const convertFunctionToES6Class: Refactor = {
-        name: "Convert to ES2015 class",
-        description: Diagnostics.Convert_function_to_an_ES2015_class.message,
-        getEditsForAction,
-        getAvailableActions
-    };
-
-    registerRefactor(convertFunctionToES6Class);
+    const description = Diagnostics.Convert_function_to_an_ES2015_class.message;
+    registerRefactor(refactorName, { getEditsForAction, getAvailableActions });
 
     function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
         if (!isInJavaScriptFile(context.file)) {
@@ -29,11 +23,11 @@ namespace ts.refactor.convertFunctionToES6Class {
         if ((symbol.flags & SymbolFlags.Function) && symbol.members && (symbol.members.size > 0)) {
             return [
                 {
-                    name: convertFunctionToES6Class.name,
-                    description: convertFunctionToES6Class.description,
+                    name: refactorName,
+                    description,
                     actions: [
                         {
-                            description: convertFunctionToES6Class.description,
+                            description,
                             name: actionName
                         }
                     ]

--- a/src/services/refactors/convertToEs6Module.ts
+++ b/src/services/refactors/convertToEs6Module.ts
@@ -1,15 +1,8 @@
 /* @internal */
 namespace ts.refactor {
     const actionName = "Convert to ES6 module";
-
-    const convertToEs6Module: Refactor = {
-        name: actionName,
-        description: getLocaleSpecificMessage(Diagnostics.Convert_to_ES6_module),
-        getEditsForAction,
-        getAvailableActions,
-    };
-
-    registerRefactor(convertToEs6Module);
+    const description = getLocaleSpecificMessage(Diagnostics.Convert_to_ES6_module);
+    registerRefactor(actionName, { getEditsForAction, getAvailableActions });
 
     function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
         const { file, startPosition } = context;
@@ -20,11 +13,11 @@ namespace ts.refactor {
         const node = getTokenAtPosition(file, startPosition, /*includeJsDocComment*/ false);
         return !isAtTriggerLocation(file, node) ? undefined : [
             {
-                name: convertToEs6Module.name,
-                description: convertToEs6Module.description,
+                name: actionName,
+                description,
                 actions: [
                     {
-                        description: convertToEs6Module.description,
+                        description,
                         name: actionName,
                     },
                 ],

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -3,14 +3,8 @@
 
 /* @internal */
 namespace ts.refactor.extractSymbol {
-    const extractSymbol: Refactor = {
-        name: "Extract Symbol",
-        description: getLocaleSpecificMessage(Diagnostics.Extract_symbol),
-        getAvailableActions,
-        getEditsForAction,
-    };
-
-    registerRefactor(extractSymbol);
+    const refactorName = "Extract Symbol";
+    registerRefactor(refactorName, { getAvailableActions, getEditsForAction });
 
     /**
      * Compute the associated code actions
@@ -77,7 +71,7 @@ namespace ts.refactor.extractSymbol {
 
         if (functionActions.length) {
             infos.push({
-                name: extractSymbol.name,
+                name: refactorName,
                 description: getLocaleSpecificMessage(Diagnostics.Extract_function),
                 actions: functionActions
             });
@@ -85,7 +79,7 @@ namespace ts.refactor.extractSymbol {
 
         if (constantActions.length) {
             infos.push({
-                name: extractSymbol.name,
+                name: refactorName,
                 description: getLocaleSpecificMessage(Diagnostics.Extract_constant),
                 actions: constantActions
             });

--- a/src/services/refactors/installTypesForPackage.ts
+++ b/src/services/refactors/installTypesForPackage.ts
@@ -1,15 +1,9 @@
 /* @internal */
 namespace ts.refactor.installTypesForPackage {
+    const refactorName = "Install missing types package";
     const actionName = "install";
-
-    const installTypesForPackage: Refactor = {
-        name: "Install missing types package",
-        description: "Install missing types package",
-        getEditsForAction,
-        getAvailableActions,
-    };
-
-    registerRefactor(installTypesForPackage);
+    const description = "Install missing types package";
+    registerRefactor(refactorName, { getEditsForAction, getAvailableActions });
 
     function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
         if (getStrictOptionValue(context.program.getCompilerOptions(), "noImplicitAny")) {
@@ -20,8 +14,8 @@ namespace ts.refactor.installTypesForPackage {
         const action = getAction(context);
         return action && [
             {
-                name: installTypesForPackage.name,
-                description: installTypesForPackage.description,
+                name: refactorName,
+                description,
                 actions: [
                     {
                         description: action.description,

--- a/src/services/refactors/useDefaultImport.ts
+++ b/src/services/refactors/useDefaultImport.ts
@@ -1,15 +1,8 @@
 /* @internal */
 namespace ts.refactor.installTypesForPackage {
     const actionName = "Convert to default import";
-
-    const useDefaultImport: Refactor = {
-        name: actionName,
-        description: getLocaleSpecificMessage(Diagnostics.Convert_to_default_import),
-        getEditsForAction,
-        getAvailableActions,
-    };
-
-    registerRefactor(useDefaultImport);
+    const description = getLocaleSpecificMessage(Diagnostics.Convert_to_default_import);
+    registerRefactor(actionName, { getEditsForAction, getAvailableActions });
 
     function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
         const { file, startPosition, program } = context;
@@ -31,11 +24,11 @@ namespace ts.refactor.installTypesForPackage {
 
         return [
             {
-                name: useDefaultImport.name,
-                description: useDefaultImport.description,
+                name: actionName,
+                description,
                 actions: [
                     {
-                        description: useDefaultImport.description,
+                        description,
                         name: actionName,
                     },
                 ],


### PR DESCRIPTION
`name` and `description` are never used after initialization. Noticed by @mhegazy at the vscode meeting.