### PR TITLE
For `{ type: "a" } | { type: "b" }`, find references for the union property

### DIFF
--- a/tests/cases/fourslash/findAllRefsUnionProperty.ts
+++ b/tests/cases/fourslash/findAllRefsUnionProperty.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts'/>
+
+////type T =
+////    | { [|{| "isWriteAccess": true, "isDefinition": true |}type|]: "a" }
+////    | { [|{| "isWriteAccess": true, "isDefinition": true |}type|]: "b" };
+////declare const t: T;
+////if (t.[|type|] !== "failure") {
+////    t.[|type|];
+////}
+
+const ranges = test.ranges();
+const [r0, r1, r2, r3] = ranges;
+verify.referenceGroups(ranges, [
+    { definition: '(property) type: "a"', ranges: [r0, r2, r3] }, // TODO: this have type `"a" | "b"`
+    { definition: '(property) type: "b"', ranges: [r1] },
+]);


### PR DESCRIPTION
Fixes #21288
Discovered #21297

This will not fix the issue if it is written like:
```ts
interface ResultA { kind: "success", code: number }
interface ResultB { kind: "failure", message: string }
type Result = ResultA | ResultB;
```
That case is harder, because we would have to find all references to the containing type to find out if it is used as part of a union.