### PR TITLE
Adds missing 'textTracks' property of SourceBuffer in lib.dom.d.ts

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -9802,6 +9802,7 @@ interface SourceBuffer extends EventTarget {
     timestampOffset: number;
     readonly updating: boolean;
     readonly videoTracks: VideoTrackList;
+    readonly textTracks: TextTrackList;
     abort(): void;
     appendBuffer(data: ArrayBuffer | ArrayBufferView): void;
     appendStream(stream: MSStream, maxSize?: number): void;


### PR DESCRIPTION
See https://github.com/Microsoft/TypeScript/issues/21256

Did not run `jake` because this is a change to /lib

Here's a checklist you might find useful.
[x ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x ] Code is up-to-date with the `master` branch
[x ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ x] There are new or updated unit tests validating the change

Fixes # 21256