### PR TITLE
Fix bug: Support `this.` completions even when isGlobalCompletion is false

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -179,7 +179,7 @@ namespace ts.Completions {
 
         let insertText: string | undefined;
         let replacementSpan: TextSpan | undefined;
-        if (kind === CompletionKind.Global && origin && origin.type === "this-type") {
+        if (origin && origin.type === "this-type") {
             insertText = needsConvertPropertyAccess ? `this["${name}"]` : `this.${name}`;
         }
         else if (needsConvertPropertyAccess) {
@@ -682,6 +682,7 @@ namespace ts.Completions {
 
     const enum CompletionKind {
         ObjectPropertyDeclaration,
+        /** Note that sometimes we access completions from global scope, but use "None" instead of this. See isGlobalCompletionScope. */
         Global,
         PropertyAccess,
         MemberLike,
@@ -2112,13 +2113,13 @@ namespace ts.Completions {
         const validIdentiferResult: CompletionEntryDisplayNameForSymbol = { name, needsConvertPropertyAccess: false };
         if (isIdentifierText(name, target)) return validIdentiferResult;
         switch (kind) {
-            case CompletionKind.None:
             case CompletionKind.MemberLike:
                 return undefined;
             case CompletionKind.ObjectPropertyDeclaration:
                 // TODO: GH#18169
                 return { name: JSON.stringify(name), needsConvertPropertyAccess: false };
             case CompletionKind.PropertyAccess:
+            case CompletionKind.None:
             case CompletionKind.Global:
                 // Don't add a completion for a name starting with a space. See https://github.com/Microsoft/TypeScript/pull/20547
                 return name.charCodeAt(0) === CharacterCodes.space ? undefined : { name, needsConvertPropertyAccess: true };

--- a/tests/cases/fourslash/completionsThisType.ts
+++ b/tests/cases/fourslash/completionsThisType.ts
@@ -3,7 +3,7 @@
 ////class C {
 ////    "foo bar": number;
 ////    xyz() {
-////        /**/
+////        return (/**/)
 ////    }
 ////}
 ////
@@ -11,7 +11,7 @@
 
 goTo.marker("");
 
-verify.completionListContains("xyz", "(method) C.xyz(): void", "", "method", undefined, undefined, {
+verify.completionListContains("xyz", "(method) C.xyz(): any", "", "method", undefined, undefined, {
     includeInsertTextCompletions: true,
     insertText: "this.xyz",
 });


### PR DESCRIPTION
Fixes #21320

Does anyone know why we return `isGlobalCompletion` as part of a `CompletionInfo` and why it is not true in an expression context?