### PR TITLE
URLSearchParams constructor: add overload to support iterables

### DIFF
--- a/lib/lib.dom.iterable.d.ts
+++ b/lib/lib.dom.iterable.d.ts
@@ -133,3 +133,10 @@ interface URLSearchParams {
      */
     [Symbol.iterator](): IterableIterator<[string, string]>;
 }
+
+declare var URLSearchParams: {
+  /**
+   * Constructor returning a URLSearchParams object.
+   */
+  new (init?: string | URLSearchParams | Iterable<[string, string]>): URLSearchParams;
+};


### PR DESCRIPTION
Partially fixes https://github.com/Microsoft/TypeScript/issues/19806

/cc @mhegazy

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
