### PR TITLE
Add semicolon to unused class member list

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21028,6 +21028,7 @@ namespace ts {
                             }
                             break;
                         case SyntaxKind.IndexSignature:
+                        case SyntaxKind.SemicolonClassElement:
                             // Can't be private
                             break;
                         default:

--- a/tests/baselines/reference/unusedSemicolonsInClasses.js
+++ b/tests/baselines/reference/unusedSemicolonsInClasses.js
@@ -1,0 +1,13 @@
+//// [unusedSemicolonsInClasses.ts]
+class Unused {
+    ;
+}
+
+
+//// [unusedSemicolonsInClasses.js]
+var Unused = /** @class */ (function () {
+    function Unused() {
+    }
+    ;
+    return Unused;
+}());

--- a/tests/baselines/reference/unusedSemicolonsInClasses.symbols
+++ b/tests/baselines/reference/unusedSemicolonsInClasses.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/unusedSemicolonsInClasses.ts ===
+class Unused {
+>Unused : Symbol(Unused, Decl(unusedSemicolonsInClasses.ts, 0, 0))
+
+    ;
+}
+

--- a/tests/baselines/reference/unusedSemicolonsInClasses.types
+++ b/tests/baselines/reference/unusedSemicolonsInClasses.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/unusedSemicolonsInClasses.ts ===
+class Unused {
+>Unused : Unused
+
+    ;
+}
+

--- a/tests/cases/compiler/unusedSemicolonsInClasses.ts
+++ b/tests/cases/compiler/unusedSemicolonsInClasses.ts
@@ -1,0 +1,4 @@
+// @noUnusedLocals: true
+class Unused {
+    ;
+}


### PR DESCRIPTION
Turns out SemicolonClassElement is a specific kind for semicolons inside a class. Having one of them with --noUnusedLocals on would crash the compiler after the assert added in #21013.