### PR TITLE
Assert the result of `getTokenValue` is defined

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2872,6 +2872,11 @@ namespace ts {
             throw e;
         }
 
+        export function assertDefined<T>(value: T | null | undefined): T {
+            assert(value !== undefined && value !== null);
+            return value;
+        }
+
         export function assertNever(member: never, message?: string, stackCrawlMark?: AnyFunction): never {
             return fail(message || `Illegal value: ${member}`, stackCrawlMark || assertNever);
         }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -829,7 +829,7 @@ namespace ts {
             getToken: () => token,
             getTokenPos: () => tokenPos,
             getTokenText: () => text.substring(tokenPos, pos),
-            getTokenValue: () => tokenValue,
+            getTokenValue: () => Debug.assertDefined(tokenValue),
             hasExtendedUnicodeEscape: () => (tokenFlags & TokenFlags.ExtendedUnicodeEscape) !== 0,
             hasPrecedingLineBreak: () => (tokenFlags & TokenFlags.PrecedingLineBreak) !== 0,
             isIdentifier: () => token === SyntaxKind.Identifier || token > SyntaxKind.LastReservedWord,


### PR DESCRIPTION
First stab at #20792. In that issue an identifier has no `escapedText` set -- that eventually comes from here.