### PR TITLE
Assert `exportingModuleSymbol` is defined

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2872,6 +2872,11 @@ namespace ts {
             throw e;
         }
 
+        export function assertDefined<T>(value: T | null | undefined): T {
+            assert(value !== undefined && value !== null);
+            return value;
+        }
+
         export function assertNever(member: never, message?: string, stackCrawlMark?: AnyFunction): never {
             return fail(message || `Illegal value: ${member}`, stackCrawlMark || assertNever);
         }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2872,8 +2872,8 @@ namespace ts {
             throw e;
         }
 
-        export function assertDefined<T>(value: T | null | undefined): T {
-            assert(value !== undefined && value !== null);
+        export function assertDefined<T>(value: T | null | undefined, message?: string): T {
+            assert(value !== undefined && value !== null, message);
             return value;
         }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -366,7 +366,7 @@ namespace ts.FindAllReferences.Core {
 
         if (node.kind === SyntaxKind.DefaultKeyword) {
             addReference(node, symbol, node, state);
-            searchForImportsOfExport(node, symbol, { exportingModuleSymbol: Debug.assertDefined(symbol.parent), exportKind: ExportKind.Default }, state);
+            searchForImportsOfExport(node, symbol, { exportingModuleSymbol: Debug.assertDefined(symbol.parent, "Expected export symbol to have a parent"), exportKind: ExportKind.Default }, state);
         }
         else {
             const search = state.createSearch(node, symbol, /*comingFrom*/ undefined, { allSearchSymbols: populateSearchSymbolSet(symbol, node, checker, options.implementations) });

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -366,7 +366,7 @@ namespace ts.FindAllReferences.Core {
 
         if (node.kind === SyntaxKind.DefaultKeyword) {
             addReference(node, symbol, node, state);
-            searchForImportsOfExport(node, symbol, { exportingModuleSymbol: symbol.parent, exportKind: ExportKind.Default }, state);
+            searchForImportsOfExport(node, symbol, { exportingModuleSymbol: Debug.assertDefined(symbol.parent), exportKind: ExportKind.Default }, state);
         }
         else {
             const search = state.createSearch(node, symbol, /*comingFrom*/ undefined, { allSearchSymbols: populateSearchSymbolSet(symbol, node, checker, options.implementations) });

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -491,8 +491,7 @@ namespace ts.FindAllReferences {
 
             function getExportAssignmentExport(ex: ExportAssignment): ExportedSymbol {
                 // Get the symbol for the `export =` node; its parent is the module it's the export of.
-                const exportingModuleSymbol = ex.symbol.parent;
-                Debug.assert(!!exportingModuleSymbol);
+                const exportingModuleSymbol = Debug.assertDefined(ex.symbol.parent);
                 const exportKind = ex.isExportEquals ? ExportKind.ExportEquals : ExportKind.Default;
                 return { kind: ImportExport.Export, symbol, exportInfo: { exportingModuleSymbol, exportKind } };
             }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -491,7 +491,7 @@ namespace ts.FindAllReferences {
 
             function getExportAssignmentExport(ex: ExportAssignment): ExportedSymbol {
                 // Get the symbol for the `export =` node; its parent is the module it's the export of.
-                const exportingModuleSymbol = Debug.assertDefined(ex.symbol.parent);
+                const exportingModuleSymbol = Debug.assertDefined(ex.symbol.parent, "Expected export symbol to have a parent");
                 const exportKind = ex.isExportEquals ? ExportKind.ExportEquals : ExportKind.Default;
                 return { kind: ImportExport.Export, symbol, exportInfo: { exportingModuleSymbol, exportKind } };
             }


### PR DESCRIPTION
First stab at #20793
At each definition of `exportingModuleSymbol`, asserts that it's defined.
Uses a helper function from #21339.