### PR TITLE
Remove isGlobalCompletionScope

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1087,7 +1087,7 @@ namespace ts.Completions {
             }
 
             // Get all entities in the current scope.
-            completionKind = CompletionKind.None;
+            completionKind = CompletionKind.Global;
             isNewIdentifierLocation = isNewIdentifierDefinitionLocation(contextToken);
 
             if (previousToken !== contextToken) {
@@ -1123,9 +1123,6 @@ namespace ts.Completions {
                 position;
 
             const scopeNode = getScopeNode(contextToken, adjustedPosition, sourceFile) || sourceFile;
-            if (isGlobalCompletionScope(scopeNode)) {
-                completionKind = CompletionKind.Global;
-            }
 
             const symbolMeanings = SymbolFlags.Type | SymbolFlags.Value | SymbolFlags.Namespace | SymbolFlags.Alias;
 
@@ -1148,18 +1145,6 @@ namespace ts.Completions {
             filterGlobalCompletion(symbols);
 
             return true;
-        }
-
-        function isGlobalCompletionScope(scopeNode: Node): boolean {
-            switch (scopeNode.kind) {
-                case SyntaxKind.SourceFile:
-                case SyntaxKind.TemplateExpression:
-                case SyntaxKind.JsxExpression:
-                case SyntaxKind.Block:
-                    return true;
-                default:
-                    return isStatement(scopeNode);
-            }
         }
 
         function filterGlobalCompletion(symbols: Symbol[]): void {

--- a/tests/cases/fourslash/completionListIsGlobalCompletion.ts
+++ b/tests/cases/fourslash/completionListIsGlobalCompletion.ts
@@ -31,7 +31,7 @@
 ////}
 /////*11*/ // insert globals
 ////const y = <div /*12*/ />; // no globals in jsx attribute found
-////const z = <div =/*13*/ />; // no globals in jsx attribute with syntax error
+////const z = <div =/*13*/ />; // Syntax error makes it looks like an expression position, so globals
 ////const x = `/*14*/ ${/*15*/}`; // globals only in template expression
 ////var user = </*16*/User name=/*17*/{ /*18*/window.isLoggedIn ? window.name : '/*19*/'} />; // globals only in JSX expression (but not in JSX expression strings)
 goTo.marker("1");
@@ -59,7 +59,7 @@ verify.completionListIsGlobal(true);
 goTo.marker("12");
 verify.completionListIsGlobal(false);
 goTo.marker("13");
-verify.completionListIsGlobal(false);
+verify.completionListIsGlobal(true);
 goTo.marker("14");
 verify.completionListIsGlobal(false);
 goTo.marker("15");
@@ -67,7 +67,7 @@ verify.completionListIsGlobal(true);
 goTo.marker("16");
 verify.completionListIsGlobal(false);
 goTo.marker("17");
-verify.completionListIsGlobal(false);
+verify.completionListIsGlobal(true); // TODO: GH#21341
 goTo.marker("18");
 verify.completionListIsGlobal(true);
 goTo.marker("19");


### PR DESCRIPTION
Alternate fix for #21330
Now if we're providing global completions, we always set `isGlobalCompletion` to true, regardless of whether we're in a statement vs expression.
I believe the original motivation for this check was to avoid setting `isGlobalCompletion` to true inside of imports and such -- but we also don't want to  be searching for global symbols in that case, and we now don't. I don't think there's any situation where we do want to provide global symbols but don't want `isGlobalCompletion` to be true.
CC @jramsay who originally did #11338 and #11647 for potential review.
Discovered #21341 along the way.