### PR TITLE
Add semicolon to unused class member list

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21030,6 +21030,7 @@ namespace ts {
                             }
                             break;
                         case SyntaxKind.IndexSignature:
+                        case SyntaxKind.SemicolonClassElement:
                             // Can't be private
                             break;
                         default:

--- a/tests/baselines/reference/unusedSemicolonInClass.js
+++ b/tests/baselines/reference/unusedSemicolonInClass.js
@@ -1,0 +1,13 @@
+//// [unusedSemicolonInClass.ts]
+class Unused {
+    ;
+}
+
+
+//// [unusedSemicolonInClass.js]
+var Unused = /** @class */ (function () {
+    function Unused() {
+    }
+    ;
+    return Unused;
+}());

--- a/tests/baselines/reference/unusedSemicolonInClass.symbols
+++ b/tests/baselines/reference/unusedSemicolonInClass.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/unusedSemicolonInClass.ts ===
+class Unused {
+>Unused : Symbol(Unused, Decl(unusedSemicolonInClass.ts, 0, 0))
+
+    ;
+}
+

--- a/tests/baselines/reference/unusedSemicolonInClass.types
+++ b/tests/baselines/reference/unusedSemicolonInClass.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/unusedSemicolonInClass.ts ===
+class Unused {
+>Unused : Unused
+
+    ;
+}
+

--- a/tests/cases/compiler/unusedSemicolonInClass.ts
+++ b/tests/cases/compiler/unusedSemicolonInClass.ts
@@ -1,0 +1,4 @@
+// @noUnusedLocals: true
+class Unused {
+    ;
+}


### PR DESCRIPTION
Turns out SemicolonClassElement is a specific kind for semicolons inside
a class. Having one of them with --noUnusedLocals on would crash the
compiler after the assert added in #21013.