### PR TITLE
In getSpecialPropertyExport, add debug failure when symbol parent is not a module

### DIFF
--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -510,9 +510,29 @@ namespace ts.FindAllReferences {
                         return undefined;
                 }
 
-                const sym = useLhsSymbol ? checker.getSymbolAtLocation((node.left as ts.PropertyAccessExpression).name) : symbol;
+                const sym = useLhsSymbol ? checker.getSymbolAtLocation(cast(node.left, isPropertyAccessExpression).name) : symbol;
+                // Better detection for GH#20803
+                if (sym && !(checker.getMergedSymbol(sym.parent).flags & SymbolFlags.Module)) {
+                    Debug.fail(`Special property assignment kind does not have a module as its parent. Assignment is ${showSymbol(sym)}, parent is ${showSymbol(sym.parent)}`);
+                }
                 return sym && exportInfo(sym, kind);
             }
+        }
+
+        function showSymbol(s: Symbol): string {
+            const decls = s.declarations.map(d => (ts as any).SyntaxKind[d.kind]).join(",");
+            const flags = showFlags(s.flags, (ts as any).SymbolFlags);
+            return `{ declarations: ${decls}, flags: ${flags} }`;
+        }
+
+        function showFlags(f: number, flags: any) {
+            const out = [];
+            for (let pow = 0; pow <= 30; pow++) {
+                const n = 1 << pow;
+                if (f & n)
+                    out.push(flags[n]);
+            }
+            return out.join("|");
         }
 
         function getImport(): ImportedSymbol | undefined {

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -529,8 +529,9 @@ namespace ts.FindAllReferences {
             const out = [];
             for (let pow = 0; pow <= 30; pow++) {
                 const n = 1 << pow;
-                if (f & n)
+                if (f & n) {
                     out.push(flags[n]);
+                }
             }
             return out.join("|");
         }


### PR DESCRIPTION
Should give us a better debug failure for #20803