### PR TITLE
Add KeywordCompletionFilters.TypeKeywords

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1070,12 +1070,16 @@ namespace ts {
     export const typeKeywords: ReadonlyArray<SyntaxKind> = [
         SyntaxKind.AnyKeyword,
         SyntaxKind.BooleanKeyword,
+        SyntaxKind.KeyOfKeyword,
         SyntaxKind.NeverKeyword,
+        SyntaxKind.NullKeyword,
         SyntaxKind.NumberKeyword,
         SyntaxKind.ObjectKeyword,
         SyntaxKind.StringKeyword,
         SyntaxKind.SymbolKeyword,
         SyntaxKind.VoidKeyword,
+        SyntaxKind.UndefinedKeyword,
+        SyntaxKind.UniqueKeyword,
     ];
 
     export function isTypeKeyword(kind: SyntaxKind): boolean {

--- a/tests/cases/fourslash/completionsTypeKeywords.ts
+++ b/tests/cases/fourslash/completionsTypeKeywords.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////type T = /**/
+
+goTo.marker();
+verify.completionListContains("undefined", "undefined", undefined, "keyword");
+verify.not.completionListContains("await");


### PR DESCRIPTION
Fixes #21351

Back in ts2.6 we would be adding all value symbols at that type location, and `undefined` was just one of them.
Instead of adding `undefined` as a value symbol, we will add a keyword completion for `undefined` here.