### PR TITLE
Check syntax kind in isDeclarationNameOrImportPropertyName

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26580,7 +26580,7 @@ namespace ts {
         switch (name.parent.kind) {
             case SyntaxKind.ImportSpecifier:
             case SyntaxKind.ExportSpecifier:
-                return true;
+                return isIdentifier(name);
             default:
                 return isDeclarationName(name);
         }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2876,6 +2876,15 @@ Actual: ${stringify(fullActual)}`);
             }
         }
 
+        public verifyNoDocumentHighlights(startRange: Range) {
+            this.goToRangeStart(startRange);
+            const documentHighlights = this.getDocumentHighlightsAtCurrentPosition([this.activeFile.fileName]);
+            const numHighlights = ts.length(documentHighlights);
+            if (numHighlights > 0) {
+                this.raiseError(`verifyNoDocumentHighlights failed - unexpectedly got ${numHighlights} highlights`);
+            }
+        }
+
         private verifyDocumentHighlights(expectedRanges: Range[], fileNames: string[] = [this.activeFile.fileName]) {
             const documentHighlights = this.getDocumentHighlightsAtCurrentPosition(fileNames) || [];
 
@@ -4282,6 +4291,10 @@ namespace FourSlashInterface {
 
         public documentHighlightsOf(startRange: FourSlash.Range, ranges: FourSlash.Range[]) {
             this.state.verifyDocumentHighlightsOf(startRange, ranges);
+        }
+
+        public noDocumentHighlights(startRange: FourSlash.Range) {
+            this.state.verifyNoDocumentHighlights(startRange);
         }
 
         public completionEntryDetailIs(entryName: string, text: string, documentation?: string, kind?: string, tags?: ts.JSDocTagInfo[]) {

--- a/tests/cases/fourslash/documentHighlightInExport1.ts
+++ b/tests/cases/fourslash/documentHighlightInExport1.ts
@@ -1,6 +1,5 @@
 ﻿/// <reference path='fourslash.ts'/>
 
-// @Filename: file1.ts
 //// class [|C|] {}
 //// [|export|] { [|C|] [|as|] [|D|] };
 

--- a/tests/cases/fourslash/documentHighlightInExport1.ts
+++ b/tests/cases/fourslash/documentHighlightInExport1.ts
@@ -1,0 +1,11 @@
+﻿/// <reference path='fourslash.ts'/>
+
+// @Filename: file1.ts
+//// class [|C|] {}
+//// [|export|] { [|C|] [|as|] [|D|] };
+
+const [classRange, exportKeywordRange, propertyNameRange, asKeywordRange, nameRange] = test.ranges();
+verify.noDocumentHighlights(exportKeywordRange);
+verify.documentHighlightsOf(propertyNameRange, [classRange, propertyNameRange, nameRange]);
+verify.noDocumentHighlights(asKeywordRange);
+verify.documentHighlightsOf(nameRange, [nameRange]);

--- a/tests/cases/fourslash/findAllRefsInExport1.ts
+++ b/tests/cases/fourslash/findAllRefsInExport1.ts
@@ -1,0 +1,10 @@
+﻿/// <reference path='fourslash.ts'/>
+
+//// class C {}
+//// /*1*/export { C /*2*/as D };
+
+goTo.marker("1");
+verify.noReferences();
+
+goTo.marker("2");
+verify.noReferences();


### PR DESCRIPTION
Otherwise, keywords are accepted. Assert was

```
fail (e:\ts_gh\src\compiler\core.ts:2867)
assert (e:\ts_gh\src\compiler\core.ts:2837)
isExportSpecifierAlias (e:\ts_gh\src\services\findAllReferences.ts:931)
getLocalSymbolForExportSpecifier
(e:\ts_gh\src\services\findAllReferences.ts:926)
skipPastExportOrImportSpecifierOrUnion
(e:\ts_gh\src\services\findAllReferences.ts:411)
getReferencedSymbolsForSymbol
(e:\ts_gh\src\services\findAllReferences.ts:359)
getReferencedSymbolsForNode
(e:\ts_gh\src\services\findAllReferences.ts:271)
getReferenceEntriesForNode
(e:\ts_gh\src\services\findAllReferences.ts:91)
getSemanticDocumentHighlights
(e:\ts_gh\src\services\documentHighlights.ts:25)
getDocumentHighlights (e:\ts_gh\src\services\documentHighlights.ts:13)
getDocumentHighlights (e:\ts_gh\src\services\services.ts:1584)
getOccurrencesAtPositionCore (e:\ts_gh\src\services\services.ts:1588)
getOccurrencesAtPosition (e:\ts_gh\src\services\services.ts:1567)
Session.getOccurrences (e:\ts_gh\src\server\session.ts:718)
Session.handlers.ts.createMapFromTemplate._a.(anonymous function)
(e:\ts_gh\src\server\session.ts:1999)
(anonymous function) (e:\ts_gh\src\server\session.ts:2079)
Session.executeWithRequestId (e:\ts_gh\src\server\session.ts:2069)
Session.executeCommand (e:\ts_gh\src\server\session.ts:2079)
Session.onMessage (e:\ts_gh\src\server\session.ts:2101)
(anonymous function) (e:\ts_gh\src\server\server.ts:593)
```
