### PR TITLE
Make error span for wrong type arguments be just `<...>`,d not `f<...>(...)`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16717,7 +16717,7 @@ namespace ts {
             const isDecorator = node.kind === SyntaxKind.Decorator;
             const isJsxOpeningOrSelfClosingElement = isJsxOpeningLikeElement(node);
 
-            let typeArguments: ReadonlyArray<TypeNode>;
+            let typeArguments: NodeArray<TypeNode>;
 
             if (!isTaggedTemplate && !isDecorator && !isJsxOpeningOrSelfClosingElement) {
                 typeArguments = (<CallExpression>node).typeArguments;
@@ -16846,7 +16846,7 @@ namespace ts {
                     max = Math.max(max, length(sig.typeParameters));
                 }
                 const paramCount = min < max ? min + "-" + max : min;
-                diagnostics.add(createDiagnosticForNode(node, Diagnostics.Expected_0_type_arguments_but_got_1, paramCount, typeArguments.length));
+                diagnostics.add(createDiagnosticForNodeArray(getSourceFileOfNode(node), typeArguments, Diagnostics.Expected_0_type_arguments_but_got_1, paramCount, typeArguments.length));
             }
             else if (args) {
                 let min = Number.POSITIVE_INFINITY;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -599,6 +599,11 @@ namespace ts {
         return createDiagnosticForNodeInSourceFile(sourceFile, node, message, arg0, arg1, arg2, arg3);
     }
 
+    export function createDiagnosticForNodeArray(sourceFile: SourceFile, nodes: NodeArray<Node>, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number): Diagnostic {
+        const start = skipTrivia(sourceFile.text, nodes.pos);
+        return createFileDiagnostic(sourceFile, start, nodes.end - start, message, arg0, arg1, arg2, arg3);
+    }
+
     export function createDiagnosticForNodeInSourceFile(sourceFile: SourceFile, node: Node, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number): Diagnostic {
         const span = getErrorSpanForNode(sourceFile, node);
         return createFileDiagnostic(sourceFile, span.start, span.length, message, arg0, arg1, arg2, arg3);

--- a/tests/baselines/reference/assigningFromObjectToAnythingElse.errors.txt
+++ b/tests/baselines/reference/assigningFromObjectToAnythingElse.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/assigningFromObjectToAnythingElse.ts(3,1): error TS2322: Type 'Object' is not assignable to type 'RegExp'.
   The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     Property 'exec' is missing in type 'Object'.
-tests/cases/compiler/assigningFromObjectToAnythingElse.ts(5,17): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/compiler/assigningFromObjectToAnythingElse.ts(6,17): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/assigningFromObjectToAnythingElse.ts(5,31): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/assigningFromObjectToAnythingElse.ts(6,31): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/compiler/assigningFromObjectToAnythingElse.ts(8,5): error TS2322: Type 'Object' is not assignable to type 'Error'.
   The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     Property 'name' is missing in type 'Object'.
@@ -18,10 +18,10 @@ tests/cases/compiler/assigningFromObjectToAnythingElse.ts(8,5): error TS2322: Ty
 !!! error TS2322:     Property 'exec' is missing in type 'Object'.
     
     var a: String = Object.create<Object>("");
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~
+                                  ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     var c: String = Object.create<Number>(1);
-                    ~~~~~~~~~~~~~~~~~~~~~~~~
+                                  ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     var w: Error = new Object();

--- a/tests/baselines/reference/callGenericFunctionWithIncorrectNumberOfTypeArguments.errors.txt
+++ b/tests/baselines/reference/callGenericFunctionWithIncorrectNumberOfTypeArguments.errors.txt
@@ -1,17 +1,17 @@
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(5,10): error TS2558: Expected 2 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(6,11): error TS2558: Expected 2 type arguments, but got 3.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(9,10): error TS2558: Expected 2 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(10,11): error TS2558: Expected 2 type arguments, but got 3.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(13,10): error TS2558: Expected 2 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(14,11): error TS2558: Expected 2 type arguments, but got 3.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(21,10): error TS2558: Expected 2 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(22,11): error TS2558: Expected 2 type arguments, but got 3.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(28,10): error TS2558: Expected 2 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(29,11): error TS2558: Expected 2 type arguments, but got 3.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(36,10): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(37,11): error TS2558: Expected 0 type arguments, but got 3.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(43,10): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(44,11): error TS2558: Expected 0 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(5,12): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(6,13): error TS2558: Expected 2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(9,13): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(10,14): error TS2558: Expected 2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(13,13): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(14,14): error TS2558: Expected 2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(21,22): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(22,23): error TS2558: Expected 2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(28,14): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(29,15): error TS2558: Expected 2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(36,23): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(37,24): error TS2558: Expected 0 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(43,15): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts(44,16): error TS2558: Expected 0 type arguments, but got 3.
 
 
 ==== tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts (14 errors) ====
@@ -20,26 +20,26 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFuncti
     
     function f<T, U>(x: T, y: U): T { return null; }
     var r1 = f<number>(1, '');
-             ~~~~~~~~~~~~~~~~
+               ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.
     var r1b = f<number, string, number>(1, '');
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 3.
     
     var f2 = <T, U>(x: T, y: U): T => { return null; }
     var r2 = f2<number>(1, '');
-             ~~~~~~~~~~~~~~~~~
+                ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.
     var r2b = f2<number, string, number>(1, '');
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 3.
     
     var f3: { <T, U>(x: T, y: U): T; }
     var r3 = f3<number>(1, '');
-             ~~~~~~~~~~~~~~~~~
+                ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.
     var r3b = f3<number, string, number>(1, '');
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 3.
     
     class C {
@@ -48,10 +48,10 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFuncti
         }
     }
     var r4 = (new C()).f<number>(1, '');
-             ~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.
     var r4b = (new C()).f<number, string, number>(1, '');
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                          ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 3.
     
     interface I {
@@ -59,10 +59,10 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFuncti
     }
     var i: I;
     var r5 = i.f<number>(1, '');
-             ~~~~~~~~~~~~~~~~~~
+                 ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.
     var r5b = i.f<number, string, number>(1, '');
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 3.
     
     class C2<T, U> {
@@ -71,10 +71,10 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFuncti
         }
     }
     var r6 = (new C2()).f<number>(1, '');
-             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                          ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     var r6b = (new C2()).f<number, string, number>(1, '');
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                           ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 3.
     
     interface I2<T, U> {
@@ -82,8 +82,8 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFuncti
     }
     var i2: I2<number, string>;
     var r7 = i2.f<number>(1, '');
-             ~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     var r7b = i2.f<number, string, number>(1, '');
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                   ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 3.

--- a/tests/baselines/reference/callNonGenericFunctionWithTypeArguments.errors.txt
+++ b/tests/baselines/reference/callNonGenericFunctionWithTypeArguments.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(5,9): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(8,10): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(11,10): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(18,10): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(24,10): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(31,10): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(37,10): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(5,11): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(8,13): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(11,13): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(18,22): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(24,14): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(31,23): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(37,15): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(40,10): error TS2347: Untyped function calls may not accept type arguments.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(43,10): error TS2347: Untyped function calls may not accept type arguments.
 
@@ -15,17 +15,17 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFun
     
     function f(x: number) { return null; }
     var r = f<string>(1);
-            ~~~~~~~~~~~~
+              ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     var f2 = (x: number) => { return null; }
     var r2 = f2<string>(1);
-             ~~~~~~~~~~~~~
+                ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     var f3: { (x: number): any; }
     var r3 = f3<string>(1);
-             ~~~~~~~~~~~~~
+                ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     class C {
@@ -34,7 +34,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFun
         }
     }
     var r4 = (new C()).f<string>(1);
-             ~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     interface I {
@@ -42,7 +42,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFun
     }
     var i: I;
     var r5 = i.f<string>(1);
-             ~~~~~~~~~~~~~~
+                 ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     class C2 {
@@ -51,7 +51,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFun
         }
     }
     var r6 = (new C2()).f<string>(1);
-             ~~~~~~~~~~~~~~~~~~~~~~~
+                          ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     interface I2 {
@@ -59,7 +59,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFun
     }
     var i2: I2;
     var r7 = i2.f<string>(1);
-             ~~~~~~~~~~~~~~~
+                  ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     var a;

--- a/tests/baselines/reference/callWithWrongNumberOfTypeArguments.errors.txt
+++ b/tests/baselines/reference/callWithWrongNumberOfTypeArguments.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts(3,1): error TS2558: Expected 2 type arguments, but got 1.
-tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts(5,1): error TS2558: Expected 2 type arguments, but got 3.
+tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts(3,3): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts(5,3): error TS2558: Expected 2 type arguments, but got 3.
 
 
 ==== tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts (2 errors) ====
     function f<T, U>() { }
     
     f<number>();
-    ~~~~~~~~~~~
+      ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.
     f<number, string>();
     f<number, string, number>();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 3.

--- a/tests/baselines/reference/constructorInvocationWithTooFewTypeArgs.errors.txt
+++ b/tests/baselines/reference/constructorInvocationWithTooFewTypeArgs.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts(9,9): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts(9,15): error TS2558: Expected 2 type arguments, but got 1.
 
 
 ==== tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts (1 errors) ====
@@ -11,6 +11,6 @@ tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts(9,9): error TS25
     }
      
     var d = new D<number>();
-            ~~~~~~~~~~~~~~~
+                  ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.
     

--- a/tests/baselines/reference/emptyTypeArgumentList.errors.txt
+++ b/tests/baselines/reference/emptyTypeArgumentList.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/emptyTypeArgumentList.ts(2,1): error TS2558: Expected 1 type arguments, but got 0.
 tests/cases/compiler/emptyTypeArgumentList.ts(2,4): error TS1099: Type argument list cannot be empty.
+tests/cases/compiler/emptyTypeArgumentList.ts(2,5): error TS2558: Expected 1 type arguments, but got 0.
 
 
 ==== tests/cases/compiler/emptyTypeArgumentList.ts (2 errors) ====
     function foo<T>() { }
     foo<>();
-    ~~~~~~~
-!!! error TS2558: Expected 1 type arguments, but got 0.
        ~~
 !!! error TS1099: Type argument list cannot be empty.
+        
+!!! error TS2558: Expected 1 type arguments, but got 0.

--- a/tests/baselines/reference/emptyTypeArgumentListWithNew.errors.txt
+++ b/tests/baselines/reference/emptyTypeArgumentListWithNew.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/emptyTypeArgumentListWithNew.ts(2,1): error TS2558: Expected 1 type arguments, but got 0.
 tests/cases/compiler/emptyTypeArgumentListWithNew.ts(2,8): error TS1099: Type argument list cannot be empty.
+tests/cases/compiler/emptyTypeArgumentListWithNew.ts(2,9): error TS2558: Expected 1 type arguments, but got 0.
 
 
 ==== tests/cases/compiler/emptyTypeArgumentListWithNew.ts (2 errors) ====
     class foo<T> { }
     new foo<>();
-    ~~~~~~~~~~~
-!!! error TS2558: Expected 1 type arguments, but got 0.
            ~~
 !!! error TS1099: Type argument list cannot be empty.
+            
+!!! error TS2558: Expected 1 type arguments, but got 0.

--- a/tests/baselines/reference/genericCallbackInvokedInsideItsContainingFunction1.errors.txt
+++ b/tests/baselines/reference/genericCallbackInvokedInsideItsContainingFunction1.errors.txt
@@ -1,32 +1,32 @@
-tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(2,14): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(2,16): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(3,16): error TS2345: Argument of type '1' is not assignable to parameter of type 'T'.
-tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(4,14): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(8,15): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(9,15): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(4,16): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(8,17): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(9,17): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(12,17): error TS2345: Argument of type 'U' is not assignable to parameter of type 'T'.
-tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(13,15): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(14,15): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(13,17): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(14,17): error TS2558: Expected 0 type arguments, but got 1.
 
 
 ==== tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts (8 errors) ====
     function foo<T, U>(x:T, y:U, f: (v: T) => U) {
         var r1 = f<number>(1);
-                 ~~~~~~~~~~~~
+                   ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
         var r2 = f(1);
                    ~
 !!! error TS2345: Argument of type '1' is not assignable to parameter of type 'T'.
         var r3 = f<any>(null);
-                 ~~~~~~~~~~~~
+                   ~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
         var r4 = f(null);
     
         var r11 = f(x);
         var r21 = f<number>(x);
-                  ~~~~~~~~~~~~
+                    ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
         var r31 = f<any>(null);
-                  ~~~~~~~~~~~~
+                    ~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
         var r41 = f(null);
     
@@ -34,10 +34,10 @@ tests/cases/compiler/genericCallbackInvokedInsideItsContainingFunction1.ts(14,15
                     ~
 !!! error TS2345: Argument of type 'U' is not assignable to parameter of type 'T'.
         var r22 = f<number>(y);
-                  ~~~~~~~~~~~~
+                    ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
         var r32 = f<any>(null);
-                  ~~~~~~~~~~~~
+                    ~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
         var r42 = f(null);
     }

--- a/tests/baselines/reference/genericDefaultsErrors.errors.txt
+++ b/tests/baselines/reference/genericDefaultsErrors.errors.txt
@@ -3,8 +3,8 @@ tests/cases/compiler/genericDefaultsErrors.ts(4,59): error TS2344: Type 'T' does
   Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/genericDefaultsErrors.ts(5,44): error TS2344: Type 'T' does not satisfy the constraint 'number'.
 tests/cases/compiler/genericDefaultsErrors.ts(6,39): error TS2344: Type 'number' does not satisfy the constraint 'T'.
-tests/cases/compiler/genericDefaultsErrors.ts(10,1): error TS2558: Expected 2-3 type arguments, but got 1.
-tests/cases/compiler/genericDefaultsErrors.ts(13,1): error TS2558: Expected 2-3 type arguments, but got 4.
+tests/cases/compiler/genericDefaultsErrors.ts(10,5): error TS2558: Expected 2-3 type arguments, but got 1.
+tests/cases/compiler/genericDefaultsErrors.ts(13,5): error TS2558: Expected 2-3 type arguments, but got 4.
 tests/cases/compiler/genericDefaultsErrors.ts(17,13): error TS2345: Argument of type '"a"' is not assignable to parameter of type 'number'.
 tests/cases/compiler/genericDefaultsErrors.ts(19,11): error TS2428: All declarations of 'i00' must have identical type parameters.
 tests/cases/compiler/genericDefaultsErrors.ts(20,11): error TS2428: All declarations of 'i00' must have identical type parameters.
@@ -44,12 +44,12 @@ tests/cases/compiler/genericDefaultsErrors.ts(42,29): error TS2716: Type paramet
     declare function f11<T, U, V = number>(): void;
     f11(); // ok
     f11<1>(); // error
-    ~~~~~~~~
+        ~
 !!! error TS2558: Expected 2-3 type arguments, but got 1.
     f11<1, 2>(); // ok
     f11<1, 2, 3>(); // ok
     f11<1, 2, 3, 4>(); // error
-    ~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~
 !!! error TS2558: Expected 2-3 type arguments, but got 4.
     
     declare function f12<T, U = T>(a?: U): void;

--- a/tests/baselines/reference/genericWithOpenTypeParameters1.errors.txt
+++ b/tests/baselines/reference/genericWithOpenTypeParameters1.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/genericWithOpenTypeParameters1.ts(7,40): error TS2345: Argument of type '1' is not assignable to parameter of type 'T'.
-tests/cases/compiler/genericWithOpenTypeParameters1.ts(8,35): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/compiler/genericWithOpenTypeParameters1.ts(9,35): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/genericWithOpenTypeParameters1.ts(8,41): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/genericWithOpenTypeParameters1.ts(9,41): error TS2558: Expected 0 type arguments, but got 1.
 
 
 ==== tests/cases/compiler/genericWithOpenTypeParameters1.ts (3 errors) ====
@@ -14,10 +14,10 @@ tests/cases/compiler/genericWithOpenTypeParameters1.ts(9,35): error TS2558: Expe
                                            ~
 !!! error TS2345: Argument of type '1' is not assignable to parameter of type 'T'.
     var f2 = <T>(x: B<T>) => { return x.foo<T>(1); } // error
-                                      ~~~~~~~~~~~
+                                            ~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     var f3 = <T>(x: B<T>) => { return x.foo<number>(1); } // error
-                                      ~~~~~~~~~~~~~~~~
+                                            ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     var f4 = (x: B<number>) => { return x.foo(1); } // no error
     

--- a/tests/baselines/reference/instantiateGenericClassWithWrongNumberOfTypeArguments.errors.txt
+++ b/tests/baselines/reference/instantiateGenericClassWithWrongNumberOfTypeArguments.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithWrongNumberOfTypeArguments.ts(8,9): error TS2558: Expected 1 type arguments, but got 2.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithWrongNumberOfTypeArguments.ts(16,9): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithWrongNumberOfTypeArguments.ts(8,15): error TS2558: Expected 1 type arguments, but got 2.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithWrongNumberOfTypeArguments.ts(16,15): error TS2558: Expected 2 type arguments, but got 1.
 
 
 ==== tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGenericClassWithWrongNumberOfTypeArguments.ts (2 errors) ====
@@ -11,7 +11,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGeneri
     }
     
     var c = new C<number, number>();
-            ~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~
 !!! error TS2558: Expected 1 type arguments, but got 2.
     
     class D<T, U> {
@@ -21,5 +21,5 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateGeneri
     
     // BUG 794238
     var d = new D<number>();
-            ~~~~~~~~~~~~~~~
+                  ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.

--- a/tests/baselines/reference/instantiateNonGenericTypeWithTypeArguments.errors.txt
+++ b/tests/baselines/reference/instantiateNonGenericTypeWithTypeArguments.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(8,9): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(8,15): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(11,9): error TS2350: Only a void function can be called with the 'new' keyword.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(11,9): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(11,17): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(14,10): error TS2350: Only a void function can be called with the 'new' keyword.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(14,10): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(14,16): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(18,10): error TS2347: Untyped function calls may not accept type arguments.
 
 
@@ -15,21 +15,21 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGen
     }
     
     var c = new C<number>();
-            ~~~~~~~~~~~~~~~
+                  ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     function Foo(): void { }
     var r = new Foo<number>();
             ~~~~~~~~~~~~~~~~~
 !!! error TS2350: Only a void function can be called with the 'new' keyword.
-            ~~~~~~~~~~~~~~~~~
+                    ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     var f: { (): void };
     var r2 = new f<number>();
              ~~~~~~~~~~~~~~~
 !!! error TS2350: Only a void function can be called with the 'new' keyword.
-             ~~~~~~~~~~~~~~~
+                   ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     var a: any;

--- a/tests/baselines/reference/mismatchedExplicitTypeParameterAndArgumentType.errors.txt
+++ b/tests/baselines/reference/mismatchedExplicitTypeParameterAndArgumentType.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts(10,30): error TS2345: Argument of type '(string | number)[]' is not assignable to parameter of type 'number[]'.
   Type 'string | number' is not assignable to type 'number'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts(11,11): error TS2558: Expected 2 type arguments, but got 1.
+tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts(11,15): error TS2558: Expected 2 type arguments, but got 1.
 
 
 ==== tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts (2 errors) ====
@@ -20,6 +20,6 @@ tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts(11,11): e
 !!! error TS2345:   Type 'string | number' is not assignable to type 'number'.
 !!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var r7b = map<number>([1, ""], (x) => x.toString()); // error
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~
 !!! error TS2558: Expected 2 type arguments, but got 1.
     var r8 = map<any, string>([1, ""], (x) => x.toString());

--- a/tests/baselines/reference/overloadResolution.errors.txt
+++ b/tests/baselines/reference/overloadResolution.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(27,5): error TS2345: Argument of type '{}' is not assignable to parameter of type 'number'.
 tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(41,11): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(63,1): error TS2558: Expected 1-3 type arguments, but got 4.
+tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(63,5): error TS2558: Expected 1-3 type arguments, but got 4.
 tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(70,21): error TS2345: Argument of type '3' is not assignable to parameter of type 'string'.
 tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(71,21): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
 tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(81,5): error TS2344: Type 'boolean' does not satisfy the constraint 'number'.
@@ -78,7 +78,7 @@ tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(91,22): 
     
     // Generic overloads with differing arity called with type argument count that doesn't match any overload
     fn3<number, number, number, number>(); // Error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 1-3 type arguments, but got 4.
     
     // Generic overloads with constraints called with type arguments that satisfy the constraints

--- a/tests/baselines/reference/overloadResolutionClassConstructors.errors.txt
+++ b/tests/baselines/reference/overloadResolutionClassConstructors.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(27,9): error TS2345: Argument of type '{}' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(60,1): error TS2558: Expected 3 type arguments, but got 1.
-tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(61,1): error TS2558: Expected 3 type arguments, but got 2.
-tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(65,1): error TS2558: Expected 3 type arguments, but got 4.
+tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(60,9): error TS2558: Expected 3 type arguments, but got 1.
+tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(61,9): error TS2558: Expected 3 type arguments, but got 2.
+tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(65,9): error TS2558: Expected 3 type arguments, but got 4.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(73,25): error TS2345: Argument of type '3' is not assignable to parameter of type 'string'.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(74,9): error TS2344: Type 'number' does not satisfy the constraint 'string'.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(75,9): error TS2344: Type 'number' does not satisfy the constraint 'string'.
@@ -77,16 +77,16 @@ tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstru
     
     // Generic overloads with differing arity called with type arguments matching each overload type parameter count
     new fn3<number>(4); // Error
-    ~~~~~~~~~~~~~~~~~~
+            ~~~~~~
 !!! error TS2558: Expected 3 type arguments, but got 1.
     new fn3<string, string>('', '', '');  // Error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~
 !!! error TS2558: Expected 3 type arguments, but got 2.
     new fn3<number, string, string>('', '', 3);
     
     // Generic overloads with differing arity called with type argument count that doesn't match any overload
     new fn3<number, number, number, number>(); // Error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 3 type arguments, but got 4.
     
     // Generic overloads with constraints called with type arguments that satisfy the constraints

--- a/tests/baselines/reference/overloadResolutionConstructors.errors.txt
+++ b/tests/baselines/reference/overloadResolutionConstructors.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(27,9): error TS2345: Argument of type '{}' is not assignable to parameter of type 'number'.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(43,15): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(67,1): error TS2558: Expected 1-3 type arguments, but got 4.
+tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(67,9): error TS2558: Expected 1-3 type arguments, but got 4.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(77,25): error TS2345: Argument of type '3' is not assignable to parameter of type 'string'.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(78,25): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(88,9): error TS2344: Type 'boolean' does not satisfy the constraint 'number'.
@@ -82,7 +82,7 @@ tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors
     
     // Generic overloads with differing arity called with type argument count that doesn't match any overload
     new fn3<number, number, number, number>(); // Error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 1-3 type arguments, but got 4.
     
     // Generic overloads with constraints called with type arguments that satisfy the constraints

--- a/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.errors.txt
+++ b/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(5,1): error TS2558: Expected 0-2 type arguments, but got 3.
+tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(5,11): error TS2558: Expected 0-2 type arguments, but got 3.
 tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,1): error TS2350: Only a void function can be called with the 'new' keyword.
-tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,1): error TS2558: Expected 0-2 type arguments, but got 3.
+tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,15): error TS2558: Expected 0-2 type arguments, but got 3.
 
 
 ==== tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts (3 errors) ====
@@ -9,10 +9,10 @@ tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,1): error TS2558: 
     declare function Callbacks<T1, T2>(flags?: string): void;
     
     Callbacks<number, string, boolean>('s'); // wrong number of type arguments
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 0-2 type arguments, but got 3.
     new Callbacks<number, string, boolean>('s'); // wrong number of type arguments
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2350: Only a void function can be called with the 'new' keyword.
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 0-2 type arguments, but got 3.

--- a/tests/baselines/reference/parserConstructorAmbiguity3.errors.txt
+++ b/tests/baselines/reference/parserConstructorAmbiguity3.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts(1,1): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts(1,10): error TS2304: Cannot find name 'A'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts(1,10): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts(1,12): error TS1005: '(' expected.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts (3 errors) ====
     new Date<A>
-    ~~~~~~~~~~~
-!!! error TS2558: Expected 0 type arguments, but got 1.
              ~
 !!! error TS2304: Cannot find name 'A'.
+             ~
+!!! error TS2558: Expected 0 type arguments, but got 1.
                
 !!! error TS1005: '(' expected.

--- a/tests/baselines/reference/thisExpressionInCallExpressionWithTypeArguments.errors.txt
+++ b/tests/baselines/reference/thisExpressionInCallExpressionWithTypeArguments.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/compiler/thisExpressionInCallExpressionWithTypeArguments.ts(2,20): error TS2558: Expected 1 type arguments, but got 2.
+tests/cases/compiler/thisExpressionInCallExpressionWithTypeArguments.ts(2,32): error TS2558: Expected 1 type arguments, but got 2.
 
 
 ==== tests/cases/compiler/thisExpressionInCallExpressionWithTypeArguments.ts (1 errors) ====
     class C {
         public foo() { [1,2,3].map<any,any>((x) => { return this; })}
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                   ~~~~~~~
 !!! error TS2558: Expected 1 type arguments, but got 2.
     }
     

--- a/tests/baselines/reference/tooManyTypeParameters1.errors.txt
+++ b/tests/baselines/reference/tooManyTypeParameters1.errors.txt
@@ -1,23 +1,23 @@
-tests/cases/compiler/tooManyTypeParameters1.ts(2,1): error TS2558: Expected 1 type arguments, but got 2.
-tests/cases/compiler/tooManyTypeParameters1.ts(5,1): error TS2558: Expected 1 type arguments, but got 2.
-tests/cases/compiler/tooManyTypeParameters1.ts(8,9): error TS2558: Expected 1 type arguments, but got 2.
+tests/cases/compiler/tooManyTypeParameters1.ts(2,3): error TS2558: Expected 1 type arguments, but got 2.
+tests/cases/compiler/tooManyTypeParameters1.ts(5,3): error TS2558: Expected 1 type arguments, but got 2.
+tests/cases/compiler/tooManyTypeParameters1.ts(8,15): error TS2558: Expected 1 type arguments, but got 2.
 tests/cases/compiler/tooManyTypeParameters1.ts(11,8): error TS2314: Generic type 'I<T>' requires 1 type argument(s).
 
 
 ==== tests/cases/compiler/tooManyTypeParameters1.ts (4 errors) ====
     function f<T>() { }
     f<string, string>();
-    ~~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~~
 !!! error TS2558: Expected 1 type arguments, but got 2.
     
     var x = <T>() => {};
     x<number,number>();
-    ~~~~~~~~~~~~~~~~~~
+      ~~~~~~~~~~~~~
 !!! error TS2558: Expected 1 type arguments, but got 2.
     
     class C<T> {}
     var c = new C<Date,Date>();
-            ~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~
 !!! error TS2558: Expected 1 type arguments, but got 2.
     
     interface I<T> {}

--- a/tests/baselines/reference/typeArgumentsOnFunctionsWithNoTypeParameters.errors.txt
+++ b/tests/baselines/reference/typeArgumentsOnFunctionsWithNoTypeParameters.errors.txt
@@ -1,18 +1,18 @@
-tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts(2,13): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts(2,15): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts(3,15): error TS2345: Argument of type '1' is not assignable to parameter of type 'T'.
-tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts(4,13): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts(4,15): error TS2558: Expected 0 type arguments, but got 1.
 
 
 ==== tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts (3 errors) ====
     function foo<T, U>(f: (v: T) => U) {
        var r1 = f<number>(1);
-                ~~~~~~~~~~~~
+                  ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
        var r2 = f(1);
                   ~
 !!! error TS2345: Argument of type '1' is not assignable to parameter of type 'T'.
        var r3 = f<any>(null);
-                ~~~~~~~~~~~~
+                  ~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
        var r4 = f(null);
     }

--- a/tests/baselines/reference/typeAssertions.errors.txt
+++ b/tests/baselines/reference/typeAssertions.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(5,5): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(5,9): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(31,12): error TS2352: Type 'SomeOther' cannot be converted to type 'SomeBase'.
   Property 'p' is missing in type 'SomeOther'.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(35,15): error TS2352: Type 'SomeOther' cannot be converted to type 'SomeDerived'.
@@ -29,7 +29,7 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,50): err
     function fn2(t: any) { }
     
     fn1(fn2<string>(4)); // Error
-        ~~~~~~~~~~~~~~
+            ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     var a: any;

--- a/tests/baselines/reference/untypedFunctionCallsWithTypeParameters1.errors.txt
+++ b/tests/baselines/reference/untypedFunctionCallsWithTypeParameters1.errors.txt
@@ -1,20 +1,20 @@
-tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(3,10): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(3,12): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(5,10): error TS2347: Untyped function calls may not accept type arguments.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(8,10): error TS2347: Untyped function calls may not accept type arguments.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(10,7): error TS2420: Class 'C' incorrectly implements interface 'Function'.
   Property 'apply' is missing in type 'C'.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(18,10): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'C' has no compatible call signatures.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(22,10): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(28,10): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(35,1): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(41,1): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(28,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(35,4): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(41,4): error TS2558: Expected 0 type arguments, but got 1.
 
 
 ==== tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts (9 errors) ====
     // none of these function calls should be allowed
     var x = function () { return; };
     var r1 = x<number>();
-             ~~~~~~~~~~~
+               ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     var y: any = x;
     var r2 = y<string>();
@@ -52,7 +52,7 @@ tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(41,1): error TS2
     }
     var z: I;
     var r6 = z<string>(1); // error
-             ~~~~~~~~~~~~
+               ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     interface callable2<T> {
@@ -61,7 +61,7 @@ tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(41,1): error TS2
     
     var c4: callable2<number>;
     c4<number>(1);
-    ~~~~~~~~~~~~~
+       ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     interface callable3<T> {
         (a: T): T;
@@ -69,7 +69,7 @@ tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(41,1): error TS2
     
     var c5: callable3<number>;
     c5<string>(1); // error
-    ~~~~~~~~~~~~~
+       ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     


### PR DESCRIPTION
This would tighten the span used for the diagnostic to just the type arguments array instead of the entire call.