### PR TITLE
Move insertSorted from server to core, use for diagnostic collections

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -788,6 +788,18 @@ namespace ts {
         return deduplicated;
     }
 
+    export function insertSorted<T>(array: SortedArray<T>, insert: T, compare: Comparer<T>): void {
+        if (array.length === 0) {
+            array.push(insert);
+            return;
+        }
+
+        const insertIndex = binarySearch(array, insert, identity, compare);
+        if (insertIndex < 0) {
+            array.splice(~insertIndex, 0, insert);
+        }
+    }
+
     export function sortAndDeduplicate<T>(array: ReadonlyArray<T>, comparer: Comparer<T>, equalityComparer?: EqualityComparer<T>) {
         return deduplicateSorted(sort(array, comparer), equalityComparer || comparer);
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4948,6 +4948,10 @@ namespace ts {
         newLength: number;
     }
 
+    export interface SortedArray<T> extends Array<T> {
+        " __sortedArrayBrand": any;
+    }
+
     /* @internal */
     export interface DiagnosticCollection {
         // Adds a diagnostic to this diagnostic collection.

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2432,6 +2432,7 @@ namespace ts {
     export function createDiagnosticCollection(): DiagnosticCollection {
         let nonFileDiagnostics = [] as SortedArray<Diagnostic>;
         const fileDiagnostics = createMap<SortedArray<Diagnostic>>();
+        const allDiagnostics = [] as SortedArray<Diagnostic>;
 
         let hasReadNonFileDiagnostics = false;
         let modificationCount = 0;
@@ -2472,6 +2473,7 @@ namespace ts {
             }
 
             insertSorted(diagnostics, diagnostic, compareDiagnostics);
+            insertSorted(allDiagnostics, diagnostic, compareDiagnostics);
             modificationCount++;
         }
 
@@ -2485,18 +2487,7 @@ namespace ts {
                 return fileDiagnostics.get(fileName) || [];
             }
 
-            const allDiagnostics: Diagnostic[] = [];
-            function pushDiagnostic(d: Diagnostic) {
-                allDiagnostics.push(d);
-            }
-
-            forEach(nonFileDiagnostics, pushDiagnostic);
-
-            fileDiagnostics.forEach(diagnostics => {
-                forEach(diagnostics, pushDiagnostic);
-            });
-
-            return sortAndDeduplicateDiagnostics(allDiagnostics);
+            return allDiagnostics;
         }
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2486,7 +2486,12 @@ namespace ts {
                 return fileDiagnostics.get(fileName) || [];
             }
 
-            return [...nonFileDiagnostics, ...flatMap(filesWithDiagnostics, f => fileDiagnostics.get(f))];
+            const fileDiags = flatMap(filesWithDiagnostics, f => fileDiagnostics.get(f));
+            if (!nonFileDiagnostics.length) {
+                return fileDiags;
+            }
+            fileDiags.unshift(...nonFileDiagnostics);
+            return fileDiags;
         }
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2431,9 +2431,8 @@ namespace ts {
 
     export function createDiagnosticCollection(): DiagnosticCollection {
         let nonFileDiagnostics = [] as SortedArray<Diagnostic>;
+        const filesWithDiagnostics = [] as SortedArray<string>;
         const fileDiagnostics = createMap<SortedArray<Diagnostic>>();
-        const allDiagnostics = [] as SortedArray<Diagnostic>;
-
         let hasReadNonFileDiagnostics = false;
         let modificationCount = 0;
 
@@ -2460,6 +2459,7 @@ namespace ts {
                 if (!diagnostics) {
                     diagnostics = [] as SortedArray<Diagnostic>;
                     fileDiagnostics.set(diagnostic.file.fileName, diagnostics);
+                    insertSorted(filesWithDiagnostics, diagnostic.file.fileName, compareStringsCaseSensitive);
                 }
             }
             else {
@@ -2473,7 +2473,6 @@ namespace ts {
             }
 
             insertSorted(diagnostics, diagnostic, compareDiagnostics);
-            insertSorted(allDiagnostics, diagnostic, compareDiagnostics);
             modificationCount++;
         }
 
@@ -2487,7 +2486,7 @@ namespace ts {
                 return fileDiagnostics.get(fileName) || [];
             }
 
-            return allDiagnostics;
+            return [...nonFileDiagnostics, ...flatMap(filesWithDiagnostics, f => fileDiagnostics.get(f))];
         }
     }
 

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -170,7 +170,8 @@ namespace RWC {
             });
 
 
-            it("has the expected emitted code", () => {
+            it("has the expected emitted code", function(this: Mocha.ITestCallbackContext) {
+                this.timeout(10000); // Allow long timeouts for RWC js verification
                 Harness.Baseline.runMultifileBaseline(baseName, "", () => {
                     return Harness.Compiler.iterateOutputs(compilerResult.files);
                 }, baselineOpts, [".js", ".jsx"]);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -22,10 +22,6 @@ declare namespace ts.server {
         require?(initialPath: string, moduleName: string): RequireResult;
     }
 
-    export interface SortedArray<T> extends Array<T> {
-        " __sortedArrayBrand": any;
-    }
-
     export interface SortedReadonlyArray<T> extends ReadonlyArray<T> {
         " __sortedArrayBrand": any;
     }

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -232,18 +232,6 @@ namespace ts.server {
         return base === "tsconfig.json" || base === "jsconfig.json" ? base : undefined;
     }
 
-    export function insertSorted<T>(array: SortedArray<T>, insert: T, compare: Comparer<T>): void {
-        if (array.length === 0) {
-            array.push(insert);
-            return;
-        }
-
-        const insertIndex = binarySearch(array, insert, identity, compare);
-        if (insertIndex < 0) {
-            array.splice(~insertIndex, 0, insert);
-        }
-    }
-
     export function removeSorted<T>(array: SortedArray<T>, remove: T, compare: Comparer<T>): void {
         if (!array || array.length === 0) {
             return;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2738,6 +2738,9 @@ declare namespace ts {
         span: TextSpan;
         newLength: number;
     }
+    interface SortedArray<T> extends Array<T> {
+        " __sortedArrayBrand": any;
+    }
     interface SyntaxList extends Node {
         _children: Node[];
     }
@@ -4809,9 +4812,6 @@ declare namespace ts.server {
         gc?(): void;
         trace?(s: string): void;
         require?(initialPath: string, moduleName: string): RequireResult;
-    }
-    interface SortedArray<T> extends Array<T> {
-        " __sortedArrayBrand": any;
     }
     interface SortedReadonlyArray<T> extends ReadonlyArray<T> {
         " __sortedArrayBrand": any;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2738,6 +2738,9 @@ declare namespace ts {
         span: TextSpan;
         newLength: number;
     }
+    interface SortedArray<T> extends Array<T> {
+        " __sortedArrayBrand": any;
+    }
     interface SyntaxList extends Node {
         _children: Node[];
     }


### PR DESCRIPTION
This causes us to spend considerably less time sorting diagnostics in projects with many files where we alternate between getting the file's diagnostics and adding diagnostics (~10s, or 8% on a very large project). Additionally, I've upped the time rwc tests have to verify js output, because our newest RWC test takes 5s (!!!) just to textually compare its js emit, and mocha's default 2s timeout was causing it to timeout when I ran it via mocha directly (to profile it).
