### PR TITLE
Fix loop labels for for..await

### DIFF
--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -148,7 +148,7 @@ namespace ts {
         }
 
         function visitLabeledStatement(node: LabeledStatement) {
-            if (enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator) {
+            if (enclosingFunctionFlags & FunctionFlags.Async) {
                 const statement = unwrapInnermostStatementOfLabel(node);
                 if (statement.kind === SyntaxKind.ForOfStatement && (<ForOfStatement>statement).awaitModifier) {
                     return visitForOfStatement(<ForOfStatement>statement, node);

--- a/tests/baselines/reference/emitter.forAwait.es2015.js
+++ b/tests/baselines/reference/emitter.forAwait.es2015.js
@@ -24,6 +24,22 @@ async function* f4() {
     for await (x of y) {
     }
 }
+//// [file5.ts]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+//// [file6.ts]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
 
 //// [file1.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -149,6 +165,78 @@ function f4() {
         try {
             for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
                 x = yield __await(y_1_1.value);
+            }
+        }
+        catch (e_1_1) { e_1 = { error: e_1_1 }; }
+        finally {
+            try {
+                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+            }
+            finally { if (e_1) throw e_1.error; }
+        }
+        var e_1, _a;
+    });
+}
+//// [file5.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
+};
+// https://github.com/Microsoft/TypeScript/issues/21363
+function f5() {
+    return __awaiter(this, void 0, void 0, function* () {
+        let y;
+        try {
+            outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), !y_1_1.done;) {
+                const x = yield y_1_1.value;
+                continue outer;
+            }
+        }
+        catch (e_1_1) { e_1 = { error: e_1_1 }; }
+        finally {
+            try {
+                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield _a.call(y_1);
+            }
+            finally { if (e_1) throw e_1.error; }
+        }
+        var e_1, _a;
+    });
+}
+//// [file6.js]
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
+};
+var __await = (this && this.__await) || function (v) { return this instanceof __await ? (this.v = v, this) : new __await(v); }
+var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var g = generator.apply(thisArg, _arguments || []), i, q = [];
+    return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+    function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+    function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+    function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r);  }
+    function fulfill(value) { resume("next", value); }
+    function reject(value) { resume("throw", value); }
+    function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+};
+// https://github.com/Microsoft/TypeScript/issues/21363
+function f6() {
+    return __asyncGenerator(this, arguments, function* f6_1() {
+        let y;
+        try {
+            outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
+                const x = yield __await(y_1_1.value);
+                continue outer;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/emitter.forAwait.es2015.symbols
+++ b/tests/baselines/reference/emitter.forAwait.es2015.symbols
@@ -48,3 +48,33 @@ async function* f4() {
 >y : Symbol(y, Decl(file4.ts, 1, 15))
     }
 }
+=== tests/cases/conformance/emitter/es2015/forAwait/file5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+>f5 : Symbol(f5, Decl(file5.ts, 0, 0))
+
+    let y: any;
+>y : Symbol(y, Decl(file5.ts, 2, 7))
+
+    outer: for await (const x of y) {
+>x : Symbol(x, Decl(file5.ts, 3, 27))
+>y : Symbol(y, Decl(file5.ts, 2, 7))
+
+        continue outer;
+    }
+}
+=== tests/cases/conformance/emitter/es2015/forAwait/file6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+>f6 : Symbol(f6, Decl(file6.ts, 0, 0))
+
+    let y: any;
+>y : Symbol(y, Decl(file6.ts, 2, 7))
+
+    outer: for await (const x of y) {
+>x : Symbol(x, Decl(file6.ts, 3, 27))
+>y : Symbol(y, Decl(file6.ts, 2, 7))
+
+        continue outer;
+    }
+}

--- a/tests/baselines/reference/emitter.forAwait.es2015.types
+++ b/tests/baselines/reference/emitter.forAwait.es2015.types
@@ -48,3 +48,37 @@ async function* f4() {
 >y : any
     }
 }
+=== tests/cases/conformance/emitter/es2015/forAwait/file5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+>f5 : () => Promise<void>
+
+    let y: any;
+>y : any
+
+    outer: for await (const x of y) {
+>outer : any
+>x : any
+>y : any
+
+        continue outer;
+>outer : any
+    }
+}
+=== tests/cases/conformance/emitter/es2015/forAwait/file6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+>f6 : () => AsyncIterableIterator<any>
+
+    let y: any;
+>y : any
+
+    outer: for await (const x of y) {
+>outer : any
+>x : any
+>y : any
+
+        continue outer;
+>outer : any
+    }
+}

--- a/tests/baselines/reference/emitter.forAwait.es2017.js
+++ b/tests/baselines/reference/emitter.forAwait.es2017.js
@@ -24,6 +24,22 @@ async function* f4() {
     for await (x of y) {
     }
 }
+//// [file5.ts]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+//// [file6.ts]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
 
 //// [file1.js]
 var __asyncValues = (this && this.__asyncValues) || function (o) {
@@ -129,6 +145,68 @@ function f4() {
         try {
             for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
                 x = yield __await(y_1_1.value);
+            }
+        }
+        catch (e_1_1) { e_1 = { error: e_1_1 }; }
+        finally {
+            try {
+                if (y_1_1 && !y_1_1.done && (_a = y_1.return)) yield __await(_a.call(y_1));
+            }
+            finally { if (e_1) throw e_1.error; }
+        }
+        var e_1, _a;
+    });
+}
+//// [file5.js]
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
+};
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y;
+    try {
+        outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), !y_1_1.done;) {
+            const x = await y_1_1.value;
+            continue outer;
+        }
+    }
+    catch (e_1_1) { e_1 = { error: e_1_1 }; }
+    finally {
+        try {
+            if (y_1_1 && !y_1_1.done && (_a = y_1.return)) await _a.call(y_1);
+        }
+        finally { if (e_1) throw e_1.error; }
+    }
+    var e_1, _a;
+}
+//// [file6.js]
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
+};
+var __await = (this && this.__await) || function (v) { return this instanceof __await ? (this.v = v, this) : new __await(v); }
+var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var g = generator.apply(thisArg, _arguments || []), i, q = [];
+    return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+    function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+    function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+    function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r);  }
+    function fulfill(value) { resume("next", value); }
+    function reject(value) { resume("throw", value); }
+    function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+};
+// https://github.com/Microsoft/TypeScript/issues/21363
+function f6() {
+    return __asyncGenerator(this, arguments, function* f6_1() {
+        let y;
+        try {
+            outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), !y_1_1.done;) {
+                const x = yield __await(y_1_1.value);
+                continue outer;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/emitter.forAwait.es2017.symbols
+++ b/tests/baselines/reference/emitter.forAwait.es2017.symbols
@@ -48,3 +48,33 @@ async function* f4() {
 >y : Symbol(y, Decl(file4.ts, 1, 15))
     }
 }
+=== tests/cases/conformance/emitter/es2017/forAwait/file5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+>f5 : Symbol(f5, Decl(file5.ts, 0, 0))
+
+    let y: any;
+>y : Symbol(y, Decl(file5.ts, 2, 7))
+
+    outer: for await (const x of y) {
+>x : Symbol(x, Decl(file5.ts, 3, 27))
+>y : Symbol(y, Decl(file5.ts, 2, 7))
+
+        continue outer;
+    }
+}
+=== tests/cases/conformance/emitter/es2017/forAwait/file6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+>f6 : Symbol(f6, Decl(file6.ts, 0, 0))
+
+    let y: any;
+>y : Symbol(y, Decl(file6.ts, 2, 7))
+
+    outer: for await (const x of y) {
+>x : Symbol(x, Decl(file6.ts, 3, 27))
+>y : Symbol(y, Decl(file6.ts, 2, 7))
+
+        continue outer;
+    }
+}

--- a/tests/baselines/reference/emitter.forAwait.es2017.types
+++ b/tests/baselines/reference/emitter.forAwait.es2017.types
@@ -48,3 +48,37 @@ async function* f4() {
 >y : any
     }
 }
+=== tests/cases/conformance/emitter/es2017/forAwait/file5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+>f5 : () => Promise<void>
+
+    let y: any;
+>y : any
+
+    outer: for await (const x of y) {
+>outer : any
+>x : any
+>y : any
+
+        continue outer;
+>outer : any
+    }
+}
+=== tests/cases/conformance/emitter/es2017/forAwait/file6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+>f6 : () => AsyncIterableIterator<any>
+
+    let y: any;
+>y : any
+
+    outer: for await (const x of y) {
+>outer : any
+>x : any
+>y : any
+
+        continue outer;
+>outer : any
+    }
+}

--- a/tests/baselines/reference/emitter.forAwait.es5.js
+++ b/tests/baselines/reference/emitter.forAwait.es5.js
@@ -24,6 +24,22 @@ async function* f4() {
     for await (x of y) {
     }
 }
+//// [file5.ts]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+//// [file6.ts]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
 
 //// [file1.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -330,6 +346,172 @@ function f4() {
                 case 3:
                     x = _b.sent();
                     _b.label = 4;
+                case 4: return [3 /*break*/, 1];
+                case 5: return [3 /*break*/, 12];
+                case 6:
+                    e_1_1 = _b.sent();
+                    e_1 = { error: e_1_1 };
+                    return [3 /*break*/, 12];
+                case 7:
+                    _b.trys.push([7, , 10, 11]);
+                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 9];
+                    return [4 /*yield*/, __await(_a.call(y_1))];
+                case 8:
+                    _b.sent();
+                    _b.label = 9;
+                case 9: return [3 /*break*/, 11];
+                case 10:
+                    if (e_1) throw e_1.error;
+                    return [7 /*endfinally*/];
+                case 11: return [7 /*endfinally*/];
+                case 12: return [2 /*return*/];
+            }
+        });
+    });
+}
+//// [file5.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
+};
+// https://github.com/Microsoft/TypeScript/issues/21363
+function f5() {
+    return __awaiter(this, void 0, void 0, function () {
+        var y, y_1, y_1_1, x, e_1_1, e_1, _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    _b.trys.push([0, 6, 7, 12]);
+                    y_1 = __asyncValues(y);
+                    _b.label = 1;
+                case 1: return [4 /*yield*/, y_1.next()];
+                case 2:
+                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 5];
+                    return [4 /*yield*/, y_1_1.value];
+                case 3:
+                    x = _b.sent();
+                    return [3 /*break*/, 4];
+                case 4: return [3 /*break*/, 1];
+                case 5: return [3 /*break*/, 12];
+                case 6:
+                    e_1_1 = _b.sent();
+                    e_1 = { error: e_1_1 };
+                    return [3 /*break*/, 12];
+                case 7:
+                    _b.trys.push([7, , 10, 11]);
+                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 9];
+                    return [4 /*yield*/, _a.call(y_1)];
+                case 8:
+                    _b.sent();
+                    _b.label = 9;
+                case 9: return [3 /*break*/, 11];
+                case 10:
+                    if (e_1) throw e_1.error;
+                    return [7 /*endfinally*/];
+                case 11: return [7 /*endfinally*/];
+                case 12: return [2 /*return*/];
+            }
+        });
+    });
+}
+//// [file6.js]
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
+};
+var __await = (this && this.__await) || function (v) { return this instanceof __await ? (this.v = v, this) : new __await(v); }
+var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var g = generator.apply(thisArg, _arguments || []), i, q = [];
+    return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+    function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+    function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+    function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r);  }
+    function fulfill(value) { resume("next", value); }
+    function reject(value) { resume("throw", value); }
+    function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+};
+// https://github.com/Microsoft/TypeScript/issues/21363
+function f6() {
+    return __asyncGenerator(this, arguments, function f6_1() {
+        var y, y_1, y_1_1, x, e_1_1, e_1, _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    _b.trys.push([0, 6, 7, 12]);
+                    y_1 = __asyncValues(y);
+                    _b.label = 1;
+                case 1: return [4 /*yield*/, __await(y_1.next())];
+                case 2:
+                    if (!(y_1_1 = _b.sent(), !y_1_1.done)) return [3 /*break*/, 5];
+                    return [4 /*yield*/, __await(y_1_1.value)];
+                case 3:
+                    x = _b.sent();
+                    return [3 /*break*/, 4];
                 case 4: return [3 /*break*/, 1];
                 case 5: return [3 /*break*/, 12];
                 case 6:

--- a/tests/baselines/reference/emitter.forAwait.es5.symbols
+++ b/tests/baselines/reference/emitter.forAwait.es5.symbols
@@ -48,3 +48,33 @@ async function* f4() {
 >y : Symbol(y, Decl(file4.ts, 1, 15))
     }
 }
+=== tests/cases/conformance/emitter/es5/forAwait/file5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+>f5 : Symbol(f5, Decl(file5.ts, 0, 0))
+
+    let y: any;
+>y : Symbol(y, Decl(file5.ts, 2, 7))
+
+    outer: for await (const x of y) {
+>x : Symbol(x, Decl(file5.ts, 3, 27))
+>y : Symbol(y, Decl(file5.ts, 2, 7))
+
+        continue outer;
+    }
+}
+=== tests/cases/conformance/emitter/es5/forAwait/file6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+>f6 : Symbol(f6, Decl(file6.ts, 0, 0))
+
+    let y: any;
+>y : Symbol(y, Decl(file6.ts, 2, 7))
+
+    outer: for await (const x of y) {
+>x : Symbol(x, Decl(file6.ts, 3, 27))
+>y : Symbol(y, Decl(file6.ts, 2, 7))
+
+        continue outer;
+    }
+}

--- a/tests/baselines/reference/emitter.forAwait.es5.types
+++ b/tests/baselines/reference/emitter.forAwait.es5.types
@@ -48,3 +48,37 @@ async function* f4() {
 >y : any
     }
 }
+=== tests/cases/conformance/emitter/es5/forAwait/file5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+>f5 : () => Promise<void>
+
+    let y: any;
+>y : any
+
+    outer: for await (const x of y) {
+>outer : any
+>x : any
+>y : any
+
+        continue outer;
+>outer : any
+    }
+}
+=== tests/cases/conformance/emitter/es5/forAwait/file6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+>f6 : () => AsyncIterableIterator<any>
+
+    let y: any;
+>y : any
+
+    outer: for await (const x of y) {
+>outer : any
+>x : any
+>y : any
+
+        continue outer;
+>outer : any
+    }
+}

--- a/tests/baselines/reference/emitter.forAwait.esnext.js
+++ b/tests/baselines/reference/emitter.forAwait.esnext.js
@@ -24,6 +24,22 @@ async function* f4() {
     for await (x of y) {
     }
 }
+//// [file5.ts]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+//// [file6.ts]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
 
 //// [file1.js]
 async function f1() {
@@ -47,5 +63,21 @@ async function* f3() {
 async function* f4() {
     let x, y;
     for await (x of y) {
+    }
+}
+//// [file5.js]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+//// [file6.js]
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y;
+    outer: for await (const x of y) {
+        continue outer;
     }
 }

--- a/tests/baselines/reference/emitter.forAwait.esnext.symbols
+++ b/tests/baselines/reference/emitter.forAwait.esnext.symbols
@@ -48,3 +48,33 @@ async function* f4() {
 >y : Symbol(y, Decl(file4.ts, 1, 15))
     }
 }
+=== tests/cases/conformance/emitter/esnext/forAwait/file5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+>f5 : Symbol(f5, Decl(file5.ts, 0, 0))
+
+    let y: any;
+>y : Symbol(y, Decl(file5.ts, 2, 7))
+
+    outer: for await (const x of y) {
+>x : Symbol(x, Decl(file5.ts, 3, 27))
+>y : Symbol(y, Decl(file5.ts, 2, 7))
+
+        continue outer;
+    }
+}
+=== tests/cases/conformance/emitter/esnext/forAwait/file6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+>f6 : Symbol(f6, Decl(file6.ts, 0, 0))
+
+    let y: any;
+>y : Symbol(y, Decl(file6.ts, 2, 7))
+
+    outer: for await (const x of y) {
+>x : Symbol(x, Decl(file6.ts, 3, 27))
+>y : Symbol(y, Decl(file6.ts, 2, 7))
+
+        continue outer;
+    }
+}

--- a/tests/baselines/reference/emitter.forAwait.esnext.types
+++ b/tests/baselines/reference/emitter.forAwait.esnext.types
@@ -48,3 +48,37 @@ async function* f4() {
 >y : any
     }
 }
+=== tests/cases/conformance/emitter/esnext/forAwait/file5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+>f5 : () => Promise<void>
+
+    let y: any;
+>y : any
+
+    outer: for await (const x of y) {
+>outer : any
+>x : any
+>y : any
+
+        continue outer;
+>outer : any
+    }
+}
+=== tests/cases/conformance/emitter/esnext/forAwait/file6.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+>f6 : () => AsyncIterableIterator<any>
+
+    let y: any;
+>y : any
+
+    outer: for await (const x of y) {
+>outer : any
+>x : any
+>y : any
+
+        continue outer;
+>outer : any
+    }
+}

--- a/tests/cases/conformance/emitter/es2015/forAwait/emitter.forAwait.es2015.ts
+++ b/tests/cases/conformance/emitter/es2015/forAwait/emitter.forAwait.es2015.ts
@@ -24,3 +24,19 @@ async function* f4() {
     for await (x of y) {
     }
 }
+// @filename: file5.ts
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+// @filename: file6.ts
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}

--- a/tests/cases/conformance/emitter/es2017/forAwait/emitter.forAwait.es2017.ts
+++ b/tests/cases/conformance/emitter/es2017/forAwait/emitter.forAwait.es2017.ts
@@ -24,3 +24,19 @@ async function* f4() {
     for await (x of y) {
     }
 }
+// @filename: file5.ts
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+// @filename: file6.ts
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}

--- a/tests/cases/conformance/emitter/es5/forAwait/emitter.forAwait.es5.ts
+++ b/tests/cases/conformance/emitter/es5/forAwait/emitter.forAwait.es5.ts
@@ -24,3 +24,19 @@ async function* f4() {
     for await (x of y) {
     }
 }
+// @filename: file5.ts
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+// @filename: file6.ts
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}

--- a/tests/cases/conformance/emitter/esnext/forAwait/emitter.forAwait.esnext.ts
+++ b/tests/cases/conformance/emitter/esnext/forAwait/emitter.forAwait.esnext.ts
@@ -24,3 +24,19 @@ async function* f4() {
     for await (x of y) {
     }
 }
+// @filename: file5.ts
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function f5() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}
+// @filename: file6.ts
+// https://github.com/Microsoft/TypeScript/issues/21363
+async function* f6() {
+    let y: any;
+    outer: for await (const x of y) {
+        continue outer;
+    }
+}


### PR DESCRIPTION
This fixes an issue where the esnext transformer was only adjusting a labeled `for await` statement in an async generator but not in async functions.

Fixes #21363
