### PR TITLE
remove stack message limit

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -11,8 +11,8 @@ namespace ts {
      */
     /* @internal */
     export function setStackTraceLimit() {
-        if ((Error as any).stackTraceLimit < 100) { // Also tests that we won't set the property if it doesn't exist.
-            (Error as any).stackTraceLimit = 100;
+        if ((Error as any).stackTraceLimit < Infinity) { // Also tests that we won't set the property if it doesn't exist.
+            (Error as any).stackTraceLimit = Infinity;
         }
     }
 


### PR DESCRIPTION
As part of handling `Source: Telemetry` tagged issues, increasing the limit on the number of stack lines was requested (https://github.com/Microsoft/TypeScript/issues/20477). https://github.com/Microsoft/TypeScript/issues/20808 is an issue for a second stack overflow that is difficult to make progress on without more information.

I've changed the limit on the number of lines in a stack trace to `Infinity` in this PR, but I'm open to a discussion of what a correct limit would be.

Note that the default maximum stack depth in node is 496kb -- this in unchanged with this PR. I wrote a simple recursive function that blows out the stack in a refactor request, and found that with no limit, the stack trace is 0.78mb in size, and has 10431 lines. Note that since the function I wrote had no local variables, its likely that a stack trace from a real stack overflow would be shorter and smaller.

With such long stacks triggering on every refactoring requests, performance in the editor was noticeably slowed. I would guesstimate each character after refactor requests were fired took ~70ms to get a response (slow, annoying, but not unusable).

*EDIT*: clarified distinction between stack size and stack trace size.

# TODO
Check what the limits are on the size of telemetry properties in VS and vscode.
