### PR TITLE
In switch case, narrow base constraint of type 

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12666,6 +12666,7 @@ namespace ts {
                 if (!switchTypes.length) {
                     return type;
                 }
+                type = getBaseConstraintOfType(type) || type;
                 const clauseTypes = switchTypes.slice(clauseStart, clauseEnd);
                 const hasDefaultClause = clauseStart === clauseEnd || contains(clauseTypes, neverType);
                 const discriminantType = getUnionType(clauseTypes);

--- a/tests/baselines/reference/switchWithConstrainedTypeVariable.errors.txt
+++ b/tests/baselines/reference/switchWithConstrainedTypeVariable.errors.txt
@@ -1,0 +1,41 @@
+tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts(22,19): error TS2322: Type '"a"' is not assignable to type 'never'.
+tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts(23,19): error TS2322: Type '"b"' is not assignable to type 'never'.
+tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts(24,19): error TS2322: Type '"c"' is not assignable to type 'never'.
+
+
+==== tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts (3 errors) ====
+    // Repro from #20840
+    
+    function function1<T extends 'a' | 'b'>(key: T) {
+      switch (key) {
+        case 'a':
+          key.toLowerCase();
+          break;
+        default:
+          key.toLowerCase();
+          break;
+      }
+    }
+    
+    // #20375
+    
+    declare var n: never;
+    declare function never(never: never): never;
+    function f<T extends 'a' | 'b' | 'c'>(t: T): void {
+        switch (t) {
+            // in a/b/c branches, assignment should fail as t narrows to a/b/c
+            // in default branch, assignment should be fine
+            case 'a': n = t; break;
+                      ~
+!!! error TS2322: Type '"a"' is not assignable to type 'never'.
+            case 'b': n = t; break;
+                      ~
+!!! error TS2322: Type '"b"' is not assignable to type 'never'.
+            case 'c': n = t; break;
+                      ~
+!!! error TS2322: Type '"c"' is not assignable to type 'never'.
+            default: n = t; break;
+        }
+    }
+    
+    

--- a/tests/baselines/reference/switchWithConstrainedTypeVariable.js
+++ b/tests/baselines/reference/switchWithConstrainedTypeVariable.js
@@ -12,6 +12,22 @@ function function1<T extends 'a' | 'b'>(key: T) {
   }
 }
 
+// #20375
+
+declare var n: never;
+declare function never(never: never): never;
+function f<T extends 'a' | 'b' | 'c'>(t: T): void {
+    switch (t) {
+        // in a/b/c branches, assignment should fail as t narrows to a/b/c
+        // in default branch, assignment should be fine
+        case 'a': n = t; break;
+        case 'b': n = t; break;
+        case 'c': n = t; break;
+        default: n = t; break;
+    }
+}
+
+
 
 //// [switchWithConstrainedTypeVariable.js]
 "use strict";
@@ -23,6 +39,24 @@ function function1(key) {
             break;
         default:
             key.toLowerCase();
+            break;
+    }
+}
+function f(t) {
+    switch (t) {
+        // in a/b/c branches, assignment should fail as t narrows to a/b/c
+        // in default branch, assignment should be fine
+        case 'a':
+            n = t;
+            break;
+        case 'b':
+            n = t;
+            break;
+        case 'c':
+            n = t;
+            break;
+        default:
+            n = t;
             break;
     }
 }

--- a/tests/baselines/reference/switchWithConstrainedTypeVariable.symbols
+++ b/tests/baselines/reference/switchWithConstrainedTypeVariable.symbols
@@ -27,3 +27,42 @@ function function1<T extends 'a' | 'b'>(key: T) {
   }
 }
 
+// #20375
+
+declare var n: never;
+>n : Symbol(n, Decl(switchWithConstrainedTypeVariable.ts, 15, 11))
+
+declare function never(never: never): never;
+>never : Symbol(never, Decl(switchWithConstrainedTypeVariable.ts, 15, 21))
+>never : Symbol(never, Decl(switchWithConstrainedTypeVariable.ts, 16, 23))
+
+function f<T extends 'a' | 'b' | 'c'>(t: T): void {
+>f : Symbol(f, Decl(switchWithConstrainedTypeVariable.ts, 16, 44))
+>T : Symbol(T, Decl(switchWithConstrainedTypeVariable.ts, 17, 11))
+>t : Symbol(t, Decl(switchWithConstrainedTypeVariable.ts, 17, 38))
+>T : Symbol(T, Decl(switchWithConstrainedTypeVariable.ts, 17, 11))
+
+    switch (t) {
+>t : Symbol(t, Decl(switchWithConstrainedTypeVariable.ts, 17, 38))
+
+        // in a/b/c branches, assignment should fail as t narrows to a/b/c
+        // in default branch, assignment should be fine
+        case 'a': n = t; break;
+>n : Symbol(n, Decl(switchWithConstrainedTypeVariable.ts, 15, 11))
+>t : Symbol(t, Decl(switchWithConstrainedTypeVariable.ts, 17, 38))
+
+        case 'b': n = t; break;
+>n : Symbol(n, Decl(switchWithConstrainedTypeVariable.ts, 15, 11))
+>t : Symbol(t, Decl(switchWithConstrainedTypeVariable.ts, 17, 38))
+
+        case 'c': n = t; break;
+>n : Symbol(n, Decl(switchWithConstrainedTypeVariable.ts, 15, 11))
+>t : Symbol(t, Decl(switchWithConstrainedTypeVariable.ts, 17, 38))
+
+        default: n = t; break;
+>n : Symbol(n, Decl(switchWithConstrainedTypeVariable.ts, 15, 11))
+>t : Symbol(t, Decl(switchWithConstrainedTypeVariable.ts, 17, 38))
+    }
+}
+
+

--- a/tests/baselines/reference/switchWithConstrainedTypeVariable.types
+++ b/tests/baselines/reference/switchWithConstrainedTypeVariable.types
@@ -16,7 +16,7 @@ function function1<T extends 'a' | 'b'>(key: T) {
       key.toLowerCase();
 >key.toLowerCase() : string
 >key.toLowerCase : () => string
->key : T
+>key : "a"
 >toLowerCase : () => string
 
       break;
@@ -24,10 +24,56 @@ function function1<T extends 'a' | 'b'>(key: T) {
       key.toLowerCase();
 >key.toLowerCase() : string
 >key.toLowerCase : () => string
->key : T
+>key : "b"
 >toLowerCase : () => string
 
       break;
   }
 }
+
+// #20375
+
+declare var n: never;
+>n : never
+
+declare function never(never: never): never;
+>never : (never: never) => never
+>never : never
+
+function f<T extends 'a' | 'b' | 'c'>(t: T): void {
+>f : <T extends "a" | "b" | "c">(t: T) => void
+>T : T
+>t : T
+>T : T
+
+    switch (t) {
+>t : T
+
+        // in a/b/c branches, assignment should fail as t narrows to a/b/c
+        // in default branch, assignment should be fine
+        case 'a': n = t; break;
+>'a' : "a"
+>n = t : "a"
+>n : never
+>t : "a"
+
+        case 'b': n = t; break;
+>'b' : "b"
+>n = t : "b"
+>n : never
+>t : "b"
+
+        case 'c': n = t; break;
+>'c' : "c"
+>n = t : "c"
+>n : never
+>t : "c"
+
+        default: n = t; break;
+>n = t : never
+>n : never
+>t : never
+    }
+}
+
 

--- a/tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts
+++ b/tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts
@@ -12,3 +12,19 @@ function function1<T extends 'a' | 'b'>(key: T) {
       break;
   }
 }
+
+// #20375
+
+declare var n: never;
+declare function never(never: never): never;
+function f<T extends 'a' | 'b' | 'c'>(t: T): void {
+    switch (t) {
+        // in a/b/c branches, assignment should fail as t narrows to a/b/c
+        // in default branch, assignment should be fine
+        case 'a': n = t; break;
+        case 'b': n = t; break;
+        case 'c': n = t; break;
+        default: n = t; break;
+    }
+}
+


### PR DESCRIPTION
Fixes  #20375

Previously, the type itself was narrowed, which was not useful for `T extends 'a' | 'b' | 'c'` and other type parameters that extend literal unions. Note that the previous behaviour was technically correct: at the function declaration, you can't prove that all branches of the case will be used because the type parameter may be instantiated with a smaller union (like `T='a' | 'b'`, in the example above). But the unused cases don't hurt anything, and people expect narrowing to work here.

For example:
```ts
declare var n: never;
function f<T extends 'a' | 'b' | 'c'>(t: T): void {
    switch (t) {
        case 'a': n = t; break; // t should be 'a'
        case 'b': n = t; break; // should be 'b'
        case 'c': n = t; break; // should be 'c'
        default: n = t; break;  // should be never
    }
}
```

Narrowing is technically incorrect, by analogy with the non-type-parameter example:

```ts
declare var n: never;
function f(t: 'a' | 'b'): void {
    switch (t) {
        case 'a': n = t; break;
        case 'b': n = t; break;
        case 'c': n = t; break; // 'c' is unused; 'c' *might* be unused in the type parameter case
        default: n = t; break;
    }
}
```
