### PR TITLE
Avoid crashing when attempting to merge a source file with another declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20273,6 +20273,8 @@ namespace ts {
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.EnumDeclaration:
                         return DeclarationSpaces.ExportType | DeclarationSpaces.ExportValue;
+                    case SyntaxKind.SourceFile:
+                        return DeclarationSpaces.ExportType | DeclarationSpaces.ExportValue | DeclarationSpaces.ExportNamespace;
                     // The below options all declare an Alias, which is allowed to merge with other values within the importing module
                     case SyntaxKind.ImportEqualsDeclaration:
                     case SyntaxKind.NamespaceImport:

--- a/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.errors.txt
+++ b/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/compiler/file1.ts(5,1): error TS2708: Cannot use namespace 'Library' as a value.
+tests/cases/compiler/file2.ts(1,8): error TS2440: Import declaration conflicts with local declaration of 'Lib'.
+tests/cases/compiler/file2.ts(6,12): error TS2694: Namespace 'Lib' has no exported member 'Bar'.
+
+
+==== tests/cases/compiler/file1.ts (1 errors) ====
+    export namespace Library {
+        export type Bar = { a: number };
+    }
+    var x: Library.Bar; // should work
+    Library.foo; // should be an error
+    ~~~~~~~
+!!! error TS2708: Cannot use namespace 'Library' as a value.
+==== tests/cases/compiler/file2.ts (2 errors) ====
+    import * as Lib from './file1';
+           ~~~~~~~~
+!!! error TS2440: Import declaration conflicts with local declaration of 'Lib'.
+    namespace Lib { // should fail to merge
+        export const foo: string = "";
+    }
+    Lib.foo; // should work
+    var x: Lib.Bar; // should be an error
+               ~~~
+!!! error TS2694: Namespace 'Lib' has no exported member 'Bar'.
+    export { Lib }

--- a/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.js
+++ b/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/namespaceMergedWithImportAliasNoCrash.ts] ////
+
+//// [file1.ts]
+export namespace Library {
+    export type Bar = { a: number };
+}
+var x: Library.Bar; // should work
+Library.foo; // should be an error
+//// [file2.ts]
+import * as Lib from './file1';
+namespace Lib { // should fail to merge
+    export const foo: string = "";
+}
+Lib.foo; // should work
+var x: Lib.Bar; // should be an error
+export { Lib }
+
+//// [file1.js]
+"use strict";
+exports.__esModule = true;
+var x; // should work
+Library.foo; // should be an error
+//// [file2.js]
+"use strict";
+exports.__esModule = true;
+var Lib;
+(function (Lib) {
+    Lib.foo = "";
+})(Lib || (Lib = {}));
+exports.Lib = Lib;
+Lib.foo; // should work
+var x; // should be an error

--- a/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.symbols
+++ b/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.symbols
@@ -1,0 +1,36 @@
+=== tests/cases/compiler/file1.ts ===
+export namespace Library {
+>Library : Symbol(Library, Decl(file1.ts, 0, 0))
+
+    export type Bar = { a: number };
+>Bar : Symbol(Bar, Decl(file1.ts, 0, 26))
+>a : Symbol(a, Decl(file1.ts, 1, 23))
+}
+var x: Library.Bar; // should work
+>x : Symbol(x, Decl(file1.ts, 3, 3))
+>Library : Symbol(Library, Decl(file1.ts, 0, 0))
+>Bar : Symbol(Library.Bar, Decl(file1.ts, 0, 26))
+
+Library.foo; // should be an error
+=== tests/cases/compiler/file2.ts ===
+import * as Lib from './file1';
+>Lib : Symbol(Lib, Decl(file2.ts, 0, 6), Decl(file2.ts, 0, 31))
+
+namespace Lib { // should fail to merge
+>Lib : Symbol(Lib, Decl(file2.ts, 0, 6), Decl(file2.ts, 0, 31))
+
+    export const foo: string = "";
+>foo : Symbol(foo, Decl(file2.ts, 2, 16))
+}
+Lib.foo; // should work
+>Lib.foo : Symbol(Lib.foo, Decl(file2.ts, 2, 16))
+>Lib : Symbol(Lib, Decl(file2.ts, 0, 6), Decl(file2.ts, 0, 31))
+>foo : Symbol(Lib.foo, Decl(file2.ts, 2, 16))
+
+var x: Lib.Bar; // should be an error
+>x : Symbol(x, Decl(file2.ts, 5, 3))
+>Lib : Symbol(Lib, Decl(file2.ts, 0, 6), Decl(file2.ts, 0, 31))
+
+export { Lib }
+>Lib : Symbol(Lib, Decl(file2.ts, 6, 8))
+

--- a/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.types
+++ b/tests/baselines/reference/namespaceMergedWithImportAliasNoCrash.types
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/file1.ts ===
+export namespace Library {
+>Library : any
+
+    export type Bar = { a: number };
+>Bar : Bar
+>a : number
+}
+var x: Library.Bar; // should work
+>x : Library.Bar
+>Library : any
+>Bar : Library.Bar
+
+Library.foo; // should be an error
+>Library.foo : any
+>Library : any
+>foo : any
+
+=== tests/cases/compiler/file2.ts ===
+import * as Lib from './file1';
+>Lib : typeof Lib
+
+namespace Lib { // should fail to merge
+>Lib : typeof Lib
+
+    export const foo: string = "";
+>foo : string
+>"" : ""
+}
+Lib.foo; // should work
+>Lib.foo : string
+>Lib : typeof Lib
+>foo : string
+
+var x: Lib.Bar; // should be an error
+>x : any
+>Lib : any
+>Bar : No type information available!
+
+export { Lib }
+>Lib : typeof Lib
+

--- a/tests/cases/compiler/namespaceMergedWithImportAliasNoCrash.ts
+++ b/tests/cases/compiler/namespaceMergedWithImportAliasNoCrash.ts
@@ -1,0 +1,14 @@
+// @filename: file1.ts
+export namespace Library {
+    export type Bar = { a: number };
+}
+var x: Library.Bar; // should work
+Library.foo; // should be an error
+// @filename: file2.ts
+import * as Lib from './file1';
+namespace Lib { // should fail to merge
+    export const foo: string = "";
+}
+Lib.foo; // should work
+var x: Lib.Bar; // should be an error
+export { Lib }


### PR DESCRIPTION
By making a source file always have all declaration spaces (meaning it will never successfully merge).

Fixes #20886
