### PR TITLE
Allow boolean literals to be generated from contextual types again

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18980,13 +18980,9 @@ namespace ts {
 
         function isLiteralOfContextualType(candidateType: Type, contextualType: Type): boolean {
             if (contextualType) {
-                if (contextualType.flags & TypeFlags.UnionOrIntersection && !(contextualType.flags & TypeFlags.Boolean)) {
-                    // If the contextual type is a union containing both of the 'true' and 'false' types we
-                    // don't consider it a literal context for boolean literals.
+                if (contextualType.flags & TypeFlags.UnionOrIntersection) {
                     const types = (<UnionType>contextualType).types;
-                    return some(types, t =>
-                        !(t.flags & TypeFlags.BooleanLiteral && containsType(types, trueType) && containsType(types, falseType)) &&
-                        isLiteralOfContextualType(candidateType, t));
+                    return some(types, t => isLiteralOfContextualType(candidateType, t));
                 }
                 if (contextualType.flags & TypeFlags.TypeVariable) {
                     // If the contextual type is a type variable constrained to a primitive type, consider

--- a/tests/baselines/reference/argumentExpressionContextualTyping.types
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.types
@@ -51,14 +51,14 @@ var o1: { x: [string, number], y: { c: boolean, d: string, e: number } } = { x: 
 >c : boolean
 >d : string
 >e : number
->{ x: ["string", 1], y: { c: true, d: "world", e: 3 } } : { x: [string, number]; y: { c: boolean; d: string; e: number; }; }
+>{ x: ["string", 1], y: { c: true, d: "world", e: 3 } } : { x: [string, number]; y: { c: true; d: string; e: number; }; }
 >x : [string, number]
 >["string", 1] : [string, number]
 >"string" : "string"
 >1 : 1
->y : { c: boolean; d: string; e: number; }
->{ c: true, d: "world", e: 3 } : { c: boolean; d: string; e: number; }
->c : boolean
+>y : { c: true; d: string; e: number; }
+>{ c: true, d: "world", e: 3 } : { c: true; d: string; e: number; }
+>c : true
 >true : true
 >d : string
 >"world" : "world"
@@ -96,7 +96,7 @@ var array = ["string", 1, true];
 
 var tuple: [string, number, boolean] = ["string", 1, true];
 >tuple : [string, number, boolean]
->["string", 1, true] : [string, number, boolean]
+>["string", 1, true] : [string, number, true]
 >"string" : "string"
 >1 : 1
 >true : true
@@ -109,7 +109,7 @@ baz(tuple);
 baz(["string", 1, true]);
 >baz(["string", 1, true]) : void
 >baz : (x: [string, number, boolean]) => void
->["string", 1, true] : [string, number, boolean]
+>["string", 1, true] : [string, number, true]
 >"string" : "string"
 >1 : 1
 >true : true

--- a/tests/baselines/reference/arrayBestCommonTypes.types
+++ b/tests/baselines/reference/arrayBestCommonTypes.types
@@ -255,15 +255,15 @@ module EmptyTypes {
 >x : boolean
 >y : base
 >base : base
->[{ x: true, y: new derived() }, { x: false, y: new base() }] : { x: boolean; y: derived; }[]
->{ x: true, y: new derived() } : { x: boolean; y: derived; }
->x : boolean
+>[{ x: true, y: new derived() }, { x: false, y: new base() }] : ({ x: true; y: derived; } | { x: false; y: base; })[]
+>{ x: true, y: new derived() } : { x: true; y: derived; }
+>x : true
 >true : true
 >y : derived
 >new derived() : derived
 >derived : typeof derived
->{ x: false, y: new base() } : { x: boolean; y: base; }
->x : boolean
+>{ x: false, y: new base() } : { x: false; y: base; }
+>x : false
 >false : false
 >y : base
 >new base() : base
@@ -658,15 +658,15 @@ module NonEmptyTypes {
 >x : boolean
 >y : base
 >base : base
->[{ x: true, y: new derived() }, { x: false, y: new base() }] : { x: boolean; y: base; }[]
->{ x: true, y: new derived() } : { x: boolean; y: derived; }
->x : boolean
+>[{ x: true, y: new derived() }, { x: false, y: new base() }] : ({ x: true; y: derived; } | { x: false; y: base; })[]
+>{ x: true, y: new derived() } : { x: true; y: derived; }
+>x : true
 >true : true
 >y : derived
 >new derived() : derived
 >derived : typeof derived
->{ x: false, y: new base() } : { x: boolean; y: base; }
->x : boolean
+>{ x: false, y: new base() } : { x: false; y: base; }
+>x : false
 >false : false
 >y : base
 >new base() : base

--- a/tests/baselines/reference/assignToFn.types
+++ b/tests/baselines/reference/assignToFn.types
@@ -13,9 +13,9 @@ module M {
     var x:I={ f:function(n) { return true; } };
 >x : I
 >I : I
->{ f:function(n) { return true; } } : { f: (n: number) => boolean; }
->f : (n: number) => boolean
->function(n) { return true; } : (n: number) => boolean
+>{ f:function(n) { return true; } } : { f: (n: number) => true; }
+>f : (n: number) => true
+>function(n) { return true; } : (n: number) => true
 >n : number
 >true : true
 

--- a/tests/baselines/reference/assignmentTypeNarrowing.types
+++ b/tests/baselines/reference/assignmentTypeNarrowing.types
@@ -12,14 +12,14 @@ x; // string
 >x : string
 
 [x] = [true];
->[x] = [true] : [boolean]
+>[x] = [true] : [true]
 >[x] : [string | number | boolean | RegExp]
 >x : string | number | boolean | RegExp
->[true] : [boolean]
+>[true] : [true]
 >true : true
 
 x; // boolean
->x : boolean
+>x : true
 
 [x = ""] = [1];
 >[x = ""] = [1] : [number]
@@ -34,16 +34,16 @@ x; // string | number
 >x : string | number
 
 ({x} = {x: true});
->({x} = {x: true}) : { x: boolean; }
->{x} = {x: true} : { x: boolean; }
+>({x} = {x: true}) : { x: true; }
+>{x} = {x: true} : { x: true; }
 >{x} : { x: string | number | boolean | RegExp; }
 >x : string | number | boolean | RegExp
->{x: true} : { x: boolean; }
->x : boolean
+>{x: true} : { x: true; }
+>x : true
 >true : true
 
 x; // boolean
->x : boolean
+>x : true
 
 ({y: x} = {y: 1});
 >({y: x} = {y: 1}) : { y: number; }
@@ -59,16 +59,16 @@ x; // number
 >x : number
 
 ({x = ""} = {x: true});
->({x = ""} = {x: true}) : { x?: boolean; }
->{x = ""} = {x: true} : { x?: boolean; }
+>({x = ""} = {x: true}) : { x?: true; }
+>{x = ""} = {x: true} : { x?: true; }
 >{x = ""} : { x?: string | number | boolean | RegExp; }
 >x : string | number | boolean | RegExp
->{x: true} : { x?: boolean; }
->x : boolean
+>{x: true} : { x?: true; }
+>x : true
 >true : true
 
 x; // string | boolean
->x : string | boolean
+>x : string | true
 
 ({y: x = /a/} = {y: 1});
 >({y: x = /a/} = {y: 1}) : { y?: number; }

--- a/tests/baselines/reference/asyncFunctionReturnType.types
+++ b/tests/baselines/reference/asyncFunctionReturnType.types
@@ -15,7 +15,7 @@ async function fAsyncExplicit(): Promise<[number, boolean]> {
 
     // This is contextually typed as a tuple.
     return [1, true];
->[1, true] : [number, boolean]
+>[1, true] : [number, true]
 >1 : 1
 >true : true
 }

--- a/tests/baselines/reference/booleanLiteralsContextuallyTypedFromUnion.js
+++ b/tests/baselines/reference/booleanLiteralsContextuallyTypedFromUnion.js
@@ -1,0 +1,38 @@
+//// [booleanLiteralsContextuallyTypedFromUnion.tsx]
+interface A { isIt: true; text: string; }
+interface B { isIt: false; value: number; }
+type C = A | B;
+const isIt = Math.random() > 0.5;
+const c: C = isIt ? { isIt, text: 'hey' } : { isIt, value: 123 };
+const cc: C = isIt ? { isIt: isIt, text: 'hey' } : { isIt: isIt, value: 123 };
+
+type ComponentProps =
+    | {
+        optionalBool: true;
+        mandatoryFn: () => void;
+    }
+    | {
+        optionalBool: false;
+    };
+
+let Funk = (_props: ComponentProps) => <div>Hello</div>;
+
+let Fail1 = () => <Funk mandatoryFn={() => { }} optionalBool={true} />
+let Fail2 = () => <Funk mandatoryFn={() => { }} optionalBool={true as true} />
+let True = true as true;
+let Fail3 = () => <Funk mandatoryFn={() => { }} optionalBool={True} />
+let attrs2 = { optionalBool: true as true, mandatoryFn: () => { } }
+let Success = () => <Funk {...attrs2} />
+
+//// [booleanLiteralsContextuallyTypedFromUnion.jsx]
+"use strict";
+var isIt = Math.random() > 0.5;
+var c = isIt ? { isIt: isIt, text: 'hey' } : { isIt: isIt, value: 123 };
+var cc = isIt ? { isIt: isIt, text: 'hey' } : { isIt: isIt, value: 123 };
+var Funk = function (_props) { return <div>Hello</div>; };
+var Fail1 = function () { return <Funk mandatoryFn={function () { }} optionalBool={true}/>; };
+var Fail2 = function () { return <Funk mandatoryFn={function () { }} optionalBool={true}/>; };
+var True = true;
+var Fail3 = function () { return <Funk mandatoryFn={function () { }} optionalBool={True}/>; };
+var attrs2 = { optionalBool: true, mandatoryFn: function () { } };
+var Success = function () { return <Funk {...attrs2}/>; };

--- a/tests/baselines/reference/booleanLiteralsContextuallyTypedFromUnion.symbols
+++ b/tests/baselines/reference/booleanLiteralsContextuallyTypedFromUnion.symbols
@@ -1,0 +1,97 @@
+=== tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx ===
+interface A { isIt: true; text: string; }
+>A : Symbol(A, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 0, 0))
+>isIt : Symbol(A.isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 0, 13))
+>text : Symbol(A.text, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 0, 25))
+
+interface B { isIt: false; value: number; }
+>B : Symbol(B, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 0, 41))
+>isIt : Symbol(B.isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 1, 13))
+>value : Symbol(B.value, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 1, 26))
+
+type C = A | B;
+>C : Symbol(C, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 1, 43))
+>A : Symbol(A, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 0, 0))
+>B : Symbol(B, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 0, 41))
+
+const isIt = Math.random() > 0.5;
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 3, 5))
+>Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+
+const c: C = isIt ? { isIt, text: 'hey' } : { isIt, value: 123 };
+>c : Symbol(c, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 4, 5))
+>C : Symbol(C, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 1, 43))
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 3, 5))
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 4, 21))
+>text : Symbol(text, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 4, 27))
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 4, 45))
+>value : Symbol(value, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 4, 51))
+
+const cc: C = isIt ? { isIt: isIt, text: 'hey' } : { isIt: isIt, value: 123 };
+>cc : Symbol(cc, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 5, 5))
+>C : Symbol(C, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 1, 43))
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 3, 5))
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 5, 22))
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 3, 5))
+>text : Symbol(text, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 5, 34))
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 5, 52))
+>isIt : Symbol(isIt, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 3, 5))
+>value : Symbol(value, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 5, 64))
+
+type ComponentProps =
+>ComponentProps : Symbol(ComponentProps, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 5, 78))
+
+    | {
+        optionalBool: true;
+>optionalBool : Symbol(optionalBool, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 8, 7))
+
+        mandatoryFn: () => void;
+>mandatoryFn : Symbol(mandatoryFn, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 9, 27))
+    }
+    | {
+        optionalBool: false;
+>optionalBool : Symbol(optionalBool, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 12, 7))
+
+    };
+
+let Funk = (_props: ComponentProps) => <div>Hello</div>;
+>Funk : Symbol(Funk, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 16, 3))
+>_props : Symbol(_props, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 16, 12))
+>ComponentProps : Symbol(ComponentProps, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 5, 78))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+
+let Fail1 = () => <Funk mandatoryFn={() => { }} optionalBool={true} />
+>Fail1 : Symbol(Fail1, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 18, 3))
+>Funk : Symbol(Funk, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 16, 3))
+>mandatoryFn : Symbol(mandatoryFn, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 18, 23))
+>optionalBool : Symbol(optionalBool, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 18, 47))
+
+let Fail2 = () => <Funk mandatoryFn={() => { }} optionalBool={true as true} />
+>Fail2 : Symbol(Fail2, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 19, 3))
+>Funk : Symbol(Funk, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 16, 3))
+>mandatoryFn : Symbol(mandatoryFn, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 19, 23))
+>optionalBool : Symbol(optionalBool, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 19, 47))
+
+let True = true as true;
+>True : Symbol(True, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 20, 3))
+
+let Fail3 = () => <Funk mandatoryFn={() => { }} optionalBool={True} />
+>Fail3 : Symbol(Fail3, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 21, 3))
+>Funk : Symbol(Funk, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 16, 3))
+>mandatoryFn : Symbol(mandatoryFn, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 21, 23))
+>optionalBool : Symbol(optionalBool, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 21, 47))
+>True : Symbol(True, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 20, 3))
+
+let attrs2 = { optionalBool: true as true, mandatoryFn: () => { } }
+>attrs2 : Symbol(attrs2, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 22, 3))
+>optionalBool : Symbol(optionalBool, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 22, 14))
+>mandatoryFn : Symbol(mandatoryFn, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 22, 42))
+
+let Success = () => <Funk {...attrs2} />
+>Success : Symbol(Success, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 23, 3))
+>Funk : Symbol(Funk, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 16, 3))
+>attrs2 : Symbol(attrs2, Decl(booleanLiteralsContextuallyTypedFromUnion.tsx, 22, 3))
+

--- a/tests/baselines/reference/booleanLiteralsContextuallyTypedFromUnion.types
+++ b/tests/baselines/reference/booleanLiteralsContextuallyTypedFromUnion.types
@@ -1,0 +1,139 @@
+=== tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx ===
+interface A { isIt: true; text: string; }
+>A : A
+>isIt : true
+>true : true
+>text : string
+
+interface B { isIt: false; value: number; }
+>B : B
+>isIt : false
+>false : false
+>value : number
+
+type C = A | B;
+>C : C
+>A : A
+>B : B
+
+const isIt = Math.random() > 0.5;
+>isIt : boolean
+>Math.random() > 0.5 : boolean
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+>0.5 : 0.5
+
+const c: C = isIt ? { isIt, text: 'hey' } : { isIt, value: 123 };
+>c : C
+>C : C
+>isIt ? { isIt, text: 'hey' } : { isIt, value: 123 } : { isIt: true; text: string; } | { isIt: false; value: number; }
+>isIt : boolean
+>{ isIt, text: 'hey' } : { isIt: true; text: string; }
+>isIt : true
+>text : string
+>'hey' : "hey"
+>{ isIt, value: 123 } : { isIt: false; value: number; }
+>isIt : false
+>value : number
+>123 : 123
+
+const cc: C = isIt ? { isIt: isIt, text: 'hey' } : { isIt: isIt, value: 123 };
+>cc : C
+>C : C
+>isIt ? { isIt: isIt, text: 'hey' } : { isIt: isIt, value: 123 } : { isIt: true; text: string; } | { isIt: false; value: number; }
+>isIt : boolean
+>{ isIt: isIt, text: 'hey' } : { isIt: true; text: string; }
+>isIt : true
+>isIt : true
+>text : string
+>'hey' : "hey"
+>{ isIt: isIt, value: 123 } : { isIt: false; value: number; }
+>isIt : false
+>isIt : false
+>value : number
+>123 : 123
+
+type ComponentProps =
+>ComponentProps : ComponentProps
+
+    | {
+        optionalBool: true;
+>optionalBool : true
+>true : true
+
+        mandatoryFn: () => void;
+>mandatoryFn : () => void
+    }
+    | {
+        optionalBool: false;
+>optionalBool : false
+>false : false
+
+    };
+
+let Funk = (_props: ComponentProps) => <div>Hello</div>;
+>Funk : (_props: ComponentProps) => JSX.Element
+>(_props: ComponentProps) => <div>Hello</div> : (_props: ComponentProps) => JSX.Element
+>_props : ComponentProps
+>ComponentProps : ComponentProps
+><div>Hello</div> : JSX.Element
+>div : any
+>div : any
+
+let Fail1 = () => <Funk mandatoryFn={() => { }} optionalBool={true} />
+>Fail1 : () => JSX.Element
+>() => <Funk mandatoryFn={() => { }} optionalBool={true} /> : () => JSX.Element
+><Funk mandatoryFn={() => { }} optionalBool={true} /> : JSX.Element
+>Funk : (_props: ComponentProps) => JSX.Element
+>mandatoryFn : () => void
+>() => { } : () => void
+>optionalBool : true
+>true : true
+
+let Fail2 = () => <Funk mandatoryFn={() => { }} optionalBool={true as true} />
+>Fail2 : () => JSX.Element
+>() => <Funk mandatoryFn={() => { }} optionalBool={true as true} /> : () => JSX.Element
+><Funk mandatoryFn={() => { }} optionalBool={true as true} /> : JSX.Element
+>Funk : (_props: ComponentProps) => JSX.Element
+>mandatoryFn : () => void
+>() => { } : () => void
+>optionalBool : true
+>true as true : true
+>true : true
+>true : true
+
+let True = true as true;
+>True : true
+>true as true : true
+>true : true
+>true : true
+
+let Fail3 = () => <Funk mandatoryFn={() => { }} optionalBool={True} />
+>Fail3 : () => JSX.Element
+>() => <Funk mandatoryFn={() => { }} optionalBool={True} /> : () => JSX.Element
+><Funk mandatoryFn={() => { }} optionalBool={True} /> : JSX.Element
+>Funk : (_props: ComponentProps) => JSX.Element
+>mandatoryFn : () => void
+>() => { } : () => void
+>optionalBool : true
+>True : true
+
+let attrs2 = { optionalBool: true as true, mandatoryFn: () => { } }
+>attrs2 : { optionalBool: true; mandatoryFn: () => void; }
+>{ optionalBool: true as true, mandatoryFn: () => { } } : { optionalBool: true; mandatoryFn: () => void; }
+>optionalBool : true
+>true as true : true
+>true : true
+>true : true
+>mandatoryFn : () => void
+>() => { } : () => void
+
+let Success = () => <Funk {...attrs2} />
+>Success : () => JSX.Element
+>() => <Funk {...attrs2} /> : () => JSX.Element
+><Funk {...attrs2} /> : JSX.Element
+>Funk : (_props: ComponentProps) => JSX.Element
+>attrs2 : { optionalBool: true; mandatoryFn: () => void; }
+

--- a/tests/baselines/reference/computedPropertyNamesContextualType6_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType6_ES5.types
@@ -19,7 +19,7 @@ declare function foo<T>(obj: I<T>): T
 foo({
 >foo({    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | number | boolean | (() => void) | number[]
 >foo : <T>(obj: I<T>) => T
->{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | boolean | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
+>{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | true | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
 
     p: "",
 >p : string

--- a/tests/baselines/reference/computedPropertyNamesContextualType6_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType6_ES6.types
@@ -19,7 +19,7 @@ declare function foo<T>(obj: I<T>): T
 foo({
 >foo({    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | number | boolean | (() => void) | number[]
 >foo : <T>(obj: I<T>) => T
->{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | boolean | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
+>{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | number | true | (() => void) | number[]; [x: number]: number | (() => void) | number[]; p: string; 0: () => void; }
 
     p: "",
 >p : string

--- a/tests/baselines/reference/constEnumPropertyAccess1.types
+++ b/tests/baselines/reference/constEnumPropertyAccess1.types
@@ -34,7 +34,7 @@ var o: {
 >idx : number
 
 } = {
->{        1: true    } : { 1: boolean; }
+>{        1: true    } : { 1: true; }
 
         1: true
 >true : true

--- a/tests/baselines/reference/contextualTypeWithTuple.types
+++ b/tests/baselines/reference/contextualTypeWithTuple.types
@@ -15,7 +15,7 @@ var numStrTuple2: [number, string] = [5, "foo", true];
 
 var numStrBoolTuple: [number, string, boolean] = [5, "foo", true];
 >numStrBoolTuple : [number, string, boolean]
->[5, "foo", true] : [number, string, boolean]
+>[5, "foo", true] : [number, string, true]
 >5 : 5
 >"foo" : "foo"
 >true : true

--- a/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.types
+++ b/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.types
@@ -38,14 +38,14 @@ var [a2, [b2, { x12, y12: c2 }]=["abc", { x12: 10, y12: false }]] = [1, ["hello"
 >10 : 10
 >y12 : boolean
 >false : false
->[1, ["hello", { x12: 5, y12: true }]] : [number, [string, { x12: number; y12: boolean; }]]
+>[1, ["hello", { x12: 5, y12: true }]] : [number, [string, { x12: number; y12: true; }]]
 >1 : 1
->["hello", { x12: 5, y12: true }] : [string, { x12: number; y12: boolean; }]
+>["hello", { x12: 5, y12: true }] : [string, { x12: number; y12: true; }]
 >"hello" : "hello"
->{ x12: 5, y12: true } : { x12: number; y12: boolean; }
+>{ x12: 5, y12: true } : { x12: number; y12: true; }
 >x12 : number
 >5 : 5
->y12 : boolean
+>y12 : true
 >true : true
 
 var [x13, y13] = [1, "hello"];

--- a/tests/baselines/reference/declarationsAndAssignments.errors.txt
+++ b/tests/baselines/reference/declarationsAndAssignments.errors.txt
@@ -17,10 +17,10 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,11): 
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,14): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,11): error TS2459: Type 'undefined[]' has no property 'a' and no string index signature.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,14): error TS2459: Type 'undefined[]' has no property 'b' and no string index signature.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,5): error TS2345: Argument of type '[number, [string, { y: boolean; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
-  Type '[string, { y: boolean; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
-    Type '{ y: boolean; }' is not assignable to type '{ x: any; y?: boolean; }'.
-      Property 'x' is missing in type '{ y: boolean; }'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,5): error TS2345: Argument of type '[number, [string, { y: false; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
+  Type '[string, { y: false; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
+    Type '{ y: false; }' is not assignable to type '{ x: any; y?: boolean; }'.
+      Property 'x' is missing in type '{ y: false; }'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,6): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): error TS2322: Type 'number' is not assignable to type 'string'.
 
@@ -171,10 +171,10 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): 
     f14([2, ["abc", { x: 0 }]]);
     f14([2, ["abc", { y: false }]]);  // Error, no x
         ~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '[number, [string, { y: boolean; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
-!!! error TS2345:   Type '[string, { y: boolean; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
-!!! error TS2345:     Type '{ y: boolean; }' is not assignable to type '{ x: any; y?: boolean; }'.
-!!! error TS2345:       Property 'x' is missing in type '{ y: boolean; }'.
+!!! error TS2345: Argument of type '[number, [string, { y: false; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
+!!! error TS2345:   Type '[string, { y: false; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
+!!! error TS2345:     Type '{ y: false; }' is not assignable to type '{ x: any; y?: boolean; }'.
+!!! error TS2345:       Property 'x' is missing in type '{ y: false; }'.
     
     module M {
         export var [a, b] = [1, 2];

--- a/tests/baselines/reference/declarationsAndAssignments.types
+++ b/tests/baselines/reference/declarationsAndAssignments.types
@@ -363,14 +363,14 @@ function f12() {
 >10 : 10
 >y : boolean
 >false : false
->[1, ["hello", { x: 5, y: true }]] : [number, [string, { x: number; y: boolean; }]]
+>[1, ["hello", { x: 5, y: true }]] : [number, [string, { x: number; y: true; }]]
 >1 : 1
->["hello", { x: 5, y: true }] : [string, { x: number; y: boolean; }]
+>["hello", { x: 5, y: true }] : [string, { x: number; y: true; }]
 >"hello" : "hello"
->{ x: 5, y: true } : { x: number; y: boolean; }
+>{ x: 5, y: true } : { x: number; y: true; }
 >x : number
 >5 : 5
->y : boolean
+>y : true
 >true : true
 
     var a: number;
@@ -433,14 +433,14 @@ function f14([a = 1, [b = "hello", { x, y: c = false }]]) {
 f14([2, ["abc", { x: 0, y: true }]]);
 >f14([2, ["abc", { x: 0, y: true }]]) : void
 >f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
->[2, ["abc", { x: 0, y: true }]] : [number, [string, { x: number; y: boolean; }]]
+>[2, ["abc", { x: 0, y: true }]] : [number, [string, { x: number; y: true; }]]
 >2 : 2
->["abc", { x: 0, y: true }] : [string, { x: number; y: boolean; }]
+>["abc", { x: 0, y: true }] : [string, { x: number; y: true; }]
 >"abc" : "abc"
->{ x: 0, y: true } : { x: number; y: boolean; }
+>{ x: 0, y: true } : { x: number; y: true; }
 >x : number
 >0 : 0
->y : boolean
+>y : true
 >true : true
 
 f14([2, ["abc", { x: 0 }]]);
@@ -534,8 +534,8 @@ f17({ a: "hello" });
 f17({ c: true });
 >f17({ c: true }) : void
 >f17 : ({ a, b, c }: { a?: string; b?: number; c?: boolean; }) => void
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 
 f17(f15());
@@ -818,47 +818,47 @@ function f21() {
 >true : true
 
     [...a] = [1, "hello", true];
->[...a] = [1, "hello", true] : (string | number | boolean)[]
+>[...a] = [1, "hello", true] : (string | number | true)[]
 >[...a] : (string | number | boolean)[]
 >...a : string | number | boolean
 >a : (string | number | boolean)[]
->[1, "hello", true] : (string | number | boolean)[]
+>[1, "hello", true] : (string | number | true)[]
 >1 : 1
 >"hello" : "hello"
 >true : true
 
     [x, ...a] = [1, "hello", true];
->[x, ...a] = [1, "hello", true] : (string | number | boolean)[]
+>[x, ...a] = [1, "hello", true] : (string | number | true)[]
 >[x, ...a] : (string | number | boolean)[]
 >x : string | number | boolean
 >...a : string | number | boolean
 >a : (string | number | boolean)[]
->[1, "hello", true] : (string | number | boolean)[]
+>[1, "hello", true] : (string | number | true)[]
 >1 : 1
 >"hello" : "hello"
 >true : true
 
     [x, y, ...a] = [1, "hello", true];
->[x, y, ...a] = [1, "hello", true] : (string | number | boolean)[]
+>[x, y, ...a] = [1, "hello", true] : (string | number | true)[]
 >[x, y, ...a] : (string | number | boolean)[]
 >x : string | number | boolean
 >y : string | number | boolean
 >...a : string | number | boolean
 >a : (string | number | boolean)[]
->[1, "hello", true] : (string | number | boolean)[]
+>[1, "hello", true] : (string | number | true)[]
 >1 : 1
 >"hello" : "hello"
 >true : true
 
     [x, y, z, ...a] = [1, "hello", true];
->[x, y, z, ...a] = [1, "hello", true] : (string | number | boolean)[]
+>[x, y, z, ...a] = [1, "hello", true] : (string | number | true)[]
 >[x, y, z, ...a] : (string | number | boolean)[]
 >x : string | number | boolean
 >y : string | number | boolean
 >z : string | number | boolean
 >...a : string | number | boolean
 >a : (string | number | boolean)[]
->[1, "hello", true] : (string | number | boolean)[]
+>[1, "hello", true] : (string | number | true)[]
 >1 : 1
 >"hello" : "hello"
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], boolean]
+>[[1], true] : [[number], true]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES5iterable.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], boolean]
+>[[1], true] : [[number], true]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment1ES6.types
@@ -109,7 +109,7 @@ var [[[c3]], [[[[c4]]]]] = [[[]], [[[[]]]]]
 var [[c5], c6]: [[string|number], boolean] = [[1], true];
 >c5 : string | number
 >c6 : boolean
->[[1], true] : [[number], boolean]
+>[[1], true] : [[number], true]
 >[1] : [number]
 >1 : 1
 >true : true

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.types
@@ -86,7 +86,7 @@ function foo(idx: number): F {
 >F : F
 
     return {
->{        2: true    } : { 2: boolean; }
+>{        2: true    } : { 2: true; }
 
         2: true
 >true : true

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
@@ -69,7 +69,7 @@ function foo(): F {
 >F : F
 
     return {
->{        1: true    } : { 1: boolean; }
+>{        1: true    } : { 1: true; }
 
         1: true
 >true : true
@@ -82,7 +82,7 @@ function bar(): F {
 >F : F
 
     return {
->{        2: true    } : { 2: boolean; }
+>{        2: true    } : { 2: true; }
 
         2: true
 >true : true

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
@@ -69,7 +69,7 @@ function foo(): F {
 >F : F
 
     return {
->{        1: true    } : { 1: boolean; }
+>{        1: true    } : { 1: true; }
 
         1: true
 >true : true
@@ -82,7 +82,7 @@ function bar(): F {
 >F : F
 
     return {
->{        2: true    } : { 2: boolean; }
+>{        2: true    } : { 2: true; }
 
         2: true
 >true : true

--- a/tests/baselines/reference/destructuringParameterProperties1.types
+++ b/tests/baselines/reference/destructuringParameterProperties1.types
@@ -104,12 +104,12 @@ var c3 = new C3({x: 0, y: "", z: false});
 >c3 : C3
 >new C3({x: 0, y: "", z: false}) : C3
 >C3 : typeof C3
->{x: 0, y: "", z: false} : { x: number; y: string; z: boolean; }
+>{x: 0, y: "", z: false} : { x: number; y: string; z: false; }
 >x : number
 >0 : 0
 >y : string
 >"" : ""
->z : boolean
+>z : false
 >false : false
 
 c3 = new C3({x: 0, "y": "y", z: true});
@@ -117,11 +117,11 @@ c3 = new C3({x: 0, "y": "y", z: true});
 >c3 : C3
 >new C3({x: 0, "y": "y", z: true}) : C3
 >C3 : typeof C3
->{x: 0, "y": "y", z: true} : { x: number; "y": string; z: boolean; }
+>{x: 0, "y": "y", z: true} : { x: number; "y": string; z: true; }
 >x : number
 >0 : 0
 >"y" : "y"
->z : boolean
+>z : true
 >true : true
 
 var [c3_x, c3_y, c3_z] = [c3.x, c3.y, c3.z];

--- a/tests/baselines/reference/destructuringParameterProperties2.types
+++ b/tests/baselines/reference/destructuringParameterProperties2.types
@@ -103,7 +103,7 @@ var y = new C1(10, [0, "", true]);
 >new C1(10, [0, "", true]) : C1
 >C1 : typeof C1
 >10 : 10
->[0, "", true] : [number, string, boolean]
+>[0, "", true] : [number, string, true]
 >0 : 0
 >"" : ""
 >true : true

--- a/tests/baselines/reference/destructuringParameterProperties3.types
+++ b/tests/baselines/reference/destructuringParameterProperties3.types
@@ -82,7 +82,7 @@ var x = new C1(undefined, [0, true, ""]);
 >new C1(undefined, [0, true, ""]) : C1<number, boolean, string>
 >C1 : typeof C1
 >undefined : undefined
->[0, true, ""] : [number, boolean, string]
+>[0, true, ""] : [number, true, string]
 >0 : 0
 >true : true
 >"" : ""
@@ -110,7 +110,7 @@ var y = new C1(10, [0, true, true]);
 >new C1(10, [0, true, true]) : C1<number, boolean, boolean>
 >C1 : typeof C1
 >10 : 10
->[0, true, true] : [number, boolean, boolean]
+>[0, true, true] : [number, true, true]
 >0 : 0
 >true : true
 >true : true

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], boolean]
+>[1, [["hello"]], true] : [number, [[string]], true]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,11 +52,11 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
->t1 : boolean
+>{ t1: false, t2: "hello" } : { t1: false; t2: string; }
+>t1 : false
 >false : false
 >t2 : string
 >"hello" : "hello"

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES5iterable.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], boolean]
+>[1, [["hello"]], true] : [number, [[string]], true]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,11 +52,11 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
->t1 : boolean
+>{ t1: false, t2: "hello" } : { t1: false; t2: string; }
+>t1 : false
 >false : false
 >t2 : string
 >"hello" : "hello"

--- a/tests/baselines/reference/destructuringVariableDeclaration1ES6.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration1ES6.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [["hello"]], true];
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [["hello"]], true] : [number, [[string]], boolean]
+>[1, [["hello"]], true] : [number, [[string]], true]
 >1 : 1
 >[["hello"]] : [[string]]
 >["hello"] : [string]
@@ -52,11 +52,11 @@ var [b2 = 3, b3 = true, b4 = temp] = [3, false, { t1: false, t2: "hello" }];
 >true : true
 >b4 : { t1: boolean; t2: string; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: "hello" }] : [number, boolean, { t1: boolean; t2: string; }]
+>[3, false, { t1: false, t2: "hello" }] : [number, false, { t1: false; t2: string; }]
 >3 : 3
 >false : false
->{ t1: false, t2: "hello" } : { t1: boolean; t2: string; }
->t1 : boolean
+>{ t1: false, t2: "hello" } : { t1: false; t2: string; }
+>t1 : false
 >false : false
 >t2 : string
 >"hello" : "hello"

--- a/tests/baselines/reference/destructuringVariableDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringVariableDeclaration2.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(3,5): error TS2322: Type '{ a1: boolean; a2: number; }' is not assignable to type '{ a1: number; a2: string; }'.
   Types of property 'a1' are incompatible.
     Type 'boolean' is not assignable to type 'number'.
-tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(4,5): error TS2322: Type '[number, [[boolean]], boolean]' is not assignable to type '[number, [[string]], boolean]'.
+tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(4,5): error TS2322: Type '[number, [[boolean]], true]' is not assignable to type '[number, [[string]], boolean]'.
   Type '[[boolean]]' is not assignable to type '[[string]]'.
     Type '[boolean]' is not assignable to type '[string]'.
       Type 'boolean' is not assignable to type 'string'.
@@ -19,7 +19,7 @@ tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(1
 !!! error TS2322:     Type 'boolean' is not assignable to type 'number'.
     var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [[false]], true];  // Error
         ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '[number, [[boolean]], boolean]' is not assignable to type '[number, [[string]], boolean]'.
+!!! error TS2322: Type '[number, [[boolean]], true]' is not assignable to type '[number, [[string]], boolean]'.
 !!! error TS2322:   Type '[[boolean]]' is not assignable to type '[[string]]'.
 !!! error TS2322:     Type '[boolean]' is not assignable to type '[string]'.
 !!! error TS2322:       Type 'boolean' is not assignable to type 'string'.

--- a/tests/baselines/reference/destructuringVariableDeclaration2.types
+++ b/tests/baselines/reference/destructuringVariableDeclaration2.types
@@ -16,7 +16,7 @@ var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [[false]], true];  // 
 >a3 : number
 >a4 : string
 >a5 : boolean
->[1, [[false]], true] : [number, [[boolean]], boolean]
+>[1, [[false]], true] : [number, [[boolean]], true]
 >1 : 1
 >[[false]] : [[boolean]]
 >[false] : [boolean]
@@ -38,13 +38,13 @@ var [b0 = 3, b1 = true, b2 = temp] = [3, false, { t1: false, t2: 5}];  // Error
 >3 : 3
 >b1 : boolean
 >true : true
->b2 : { t1: boolean; t2: string; } | { t1: boolean; t2: number; }
+>b2 : { t1: boolean; t2: string; } | { t1: false; t2: number; }
 >temp : { t1: boolean; t2: string; }
->[3, false, { t1: false, t2: 5}] : [number, boolean, { t1: boolean; t2: number; }]
+>[3, false, { t1: false, t2: 5}] : [number, false, { t1: false; t2: number; }]
 >3 : 3
 >false : false
->{ t1: false, t2: 5} : { t1: boolean; t2: number; }
->t1 : boolean
+>{ t1: false, t2: 5} : { t1: false; t2: number; }
+>t1 : false
 >false : false
 >t2 : number
 >5 : 5

--- a/tests/baselines/reference/disallowLineTerminatorBeforeArrow.types
+++ b/tests/baselines/reference/disallowLineTerminatorBeforeArrow.types
@@ -150,7 +150,7 @@ function foo(func: () => boolean) { }
 foo(()
 >foo(()    => true) : void
 >foo : (func: () => boolean) => void
->()    => true : () => boolean
+>()    => true : () => true
 
     => true);
 >true : true
@@ -158,7 +158,7 @@ foo(()
 foo(()
 >foo(()    => { return false; }) : void
 >foo : (func: () => boolean) => void
->()    => { return false; } : () => boolean
+>()    => { return false; } : () => false
 
     => { return false; });
 >false : false

--- a/tests/baselines/reference/duplicateLocalVariable1.types
+++ b/tests/baselines/reference/duplicateLocalVariable1.types
@@ -230,7 +230,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Basic test", function () { return true; }) : TestCase
 >TestCase : typeof TestCase
 >"Basic test" : "Basic test"
->function () { return true; } : () => boolean
+>function () { return true; } : () => true
 >true : true
 
     testRunner.addTest(new TestCase("Test for any error", function () { throw new Error(); return false; }, ""));
@@ -241,7 +241,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Test for any error", function () { throw new Error(); return false; }, "") : TestCase
 >TestCase : typeof TestCase
 >"Test for any error" : "Test for any error"
->function () { throw new Error(); return false; } : () => boolean
+>function () { throw new Error(); return false; } : () => false
 >new Error() : Error
 >Error : ErrorConstructor
 >false : false
@@ -255,7 +255,7 @@ export var tests: TestRunner = (function () {
 >new TestCase("Test RegEx error message match", function () { throw new Error("Should also pass"); return false; }, "Should [also]+ pass") : TestCase
 >TestCase : typeof TestCase
 >"Test RegEx error message match" : "Test RegEx error message match"
->function () { throw new Error("Should also pass"); return false; } : () => boolean
+>function () { throw new Error("Should also pass"); return false; } : () => false
 >new Error("Should also pass") : Error
 >Error : ErrorConstructor
 >"Should also pass" : "Should also pass"
@@ -1104,7 +1104,7 @@ export var tests: TestRunner = (function () {
 >"Check saving a file" : "Check saving a file"
 
         function () {
->function () {            var filename = TestFileDir + "\\tmpUTF16LE.txt";            var fb = new FileManager.FileBuffer(14);            fb.writeUtf16leBom();            var chars = [0x0054, 0x00E8, 0x1D23, 0x2020, 0x000D, 0x000A];            chars.forEach(function (val) { fb.writeUtf16CodePoint(val, false); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf16le') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xFF, 0xFE, 0x54, 0x00, 0xE8, 0x00, 0x23, 0x1D, 0x20, 0x20, 0x0D, 0x00, 0x0A, 0x00]            savedFile.index = 0;            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\tmpUTF16LE.txt";            var fb = new FileManager.FileBuffer(14);            fb.writeUtf16leBom();            var chars = [0x0054, 0x00E8, 0x1D23, 0x2020, 0x000D, 0x000A];            chars.forEach(function (val) { fb.writeUtf16CodePoint(val, false); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf16le') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xFF, 0xFE, 0x54, 0x00, 0xE8, 0x00, 0x23, 0x1D, 0x20, 0x20, 0x0D, 0x00, 0x0A, 0x00]            savedFile.index = 0;            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => true
 
             var filename = TestFileDir + "\\tmpUTF16LE.txt";
 >filename : string
@@ -1243,7 +1243,7 @@ export var tests: TestRunner = (function () {
 >"Check reading past buffer asserts" : "Check reading past buffer asserts"
 
     function () {
->function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        var result = fb.readByte(200);        return true;    } : () => boolean
+>function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        var result = fb.readByte(200);        return true;    } : () => true
 
         var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");
 >fb : any
@@ -1279,7 +1279,7 @@ export var tests: TestRunner = (function () {
 >"Check writing past buffer asserts" : "Check writing past buffer asserts"
 
     function () {
->function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        fb.writeByte(5, 200);        return true;    } : () => boolean
+>function () {        var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");        fb.writeByte(5, 200);        return true;    } : () => true
 
         var fb = new FileManager.FileBuffer(TestFileDir + "\\UTF8BOM.txt");
 >fb : any
@@ -1473,7 +1473,7 @@ export var tests: TestRunner = (function () {
 >"Write non-BMP utf8 chars" : "Write non-BMP utf8 chars"
 
         function () {
->function () {            var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";            var fb = new FileManager.FileBuffer(15);            var chars = [0x10480, 0x10481, 0x10482, 0x54, 0x68, 0x69];            chars.forEach(function (val) { fb.writeUtf8CodePoint(val); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf8') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xF0, 0x90, 0x92, 0x80, 0xF0, 0x90, 0x92, 0x81, 0xF0, 0x90, 0x92, 0x82, 0x54, 0x68, 0x69];            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";            var fb = new FileManager.FileBuffer(15);            var chars = [0x10480, 0x10481, 0x10482, 0x54, 0x68, 0x69];            chars.forEach(function (val) { fb.writeUtf8CodePoint(val); });            fb.save(filename);            var savedFile = new FileManager.FileBuffer(filename);            if (savedFile.encoding !== 'utf8') {                throw Error("Incorrect encoding");            }            var expectedBytes = [0xF0, 0x90, 0x92, 0x80, 0xF0, 0x90, 0x92, 0x81, 0xF0, 0x90, 0x92, 0x82, 0x54, 0x68, 0x69];            expectedBytes.forEach(function (val) {                var byteVal = savedFile.readByte();                if (byteVal !== val) {                    throw Error("Incorrect byte value");                }            });            return true;        } : () => true
 
             var filename = TestFileDir + "\\tmpUTF8nonBmp.txt";
 >filename : string
@@ -1599,7 +1599,7 @@ export var tests: TestRunner = (function () {
 >"Test invalid lead UTF8 byte" : "Test invalid lead UTF8 byte"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf8BadLeadByte.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\utf8BadLeadByte.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
 
             var filename = TestFileDir + "\\utf8BadLeadByte.txt";
 >filename : string
@@ -1631,7 +1631,7 @@ export var tests: TestRunner = (function () {
 >"Test invalid tail UTF8 byte" : "Test invalid tail UTF8 byte"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf8InvalidTail.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\utf8InvalidTail.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
 
             var filename = TestFileDir + "\\utf8InvalidTail.txt";
 >filename : string
@@ -1663,7 +1663,7 @@ export var tests: TestRunner = (function () {
 >"Test ANSI fails validation" : "Test ANSI fails validation"
 
         function () {
->function () {            var filename = TestFileDir + "\\ansi.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\ansi.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
 
             var filename = TestFileDir + "\\ansi.txt";
 >filename : string
@@ -1695,7 +1695,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16LE with invalid surrogate trail fails" : "Test UTF-16LE with invalid surrogate trail fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
 
             var filename = TestFileDir + "\\utf16leInvalidSurrogate.txt";
 >filename : string
@@ -1727,7 +1727,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16BE with invalid surrogate head fails" : "Test UTF-16BE with invalid surrogate head fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
 
             var filename = TestFileDir + "\\UTF16BEInvalidSurrogate.txt";
 >filename : string
@@ -1759,7 +1759,7 @@ export var tests: TestRunner = (function () {
 >"Test UTF-16LE with missing trail surrogate fails" : "Test UTF-16LE with missing trail surrogate fails"
 
         function () {
->function () {            var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
 
             var filename = TestFileDir + "\\utf16leMissingTrailSurrogate.txt";
 >filename : string
@@ -1851,7 +1851,7 @@ export var tests: TestRunner = (function () {
 >"Test file with control character" : "Test file with control character"
 
         function () {
->function () {            var filename = TestFileDir + "\\controlChar.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => boolean
+>function () {            var filename = TestFileDir + "\\controlChar.txt";            var fb = new FileManager.FileBuffer(filename);            return true;        } : () => true
 
             var filename = TestFileDir + "\\controlChar.txt";
 >filename : string

--- a/tests/baselines/reference/emitArrowFunction.types
+++ b/tests/baselines/reference/emitArrowFunction.types
@@ -31,12 +31,12 @@ function foo(func: () => boolean) { }
 foo(() => true);
 >foo(() => true) : void
 >foo : (func: () => boolean) => void
->() => true : () => boolean
+>() => true : () => true
 >true : true
 
 foo(() => { return false; });
 >foo(() => { return false; }) : void
 >foo : (func: () => boolean) => void
->() => { return false; } : () => boolean
+>() => { return false; } : () => false
 >false : false
 

--- a/tests/baselines/reference/emitArrowFunctionES6.types
+++ b/tests/baselines/reference/emitArrowFunctionES6.types
@@ -31,13 +31,13 @@ function foo(func: () => boolean) { }
 foo(() => true);
 >foo(() => true) : void
 >foo : (func: () => boolean) => void
->() => true : () => boolean
+>() => true : () => true
 >true : true
 
 foo(() => { return false; });
 >foo(() => { return false; }) : void
 >foo : (func: () => boolean) => void
->() => { return false; } : () => boolean
+>() => { return false; } : () => false
 >false : false
 
 // Binding patterns in arrow functions

--- a/tests/baselines/reference/emitArrowFunctionThisCapturing.types
+++ b/tests/baselines/reference/emitArrowFunctionThisCapturing.types
@@ -32,7 +32,7 @@ function foo(func: () => boolean) { }
 foo(() => {
 >foo(() => {    this.age = 100;    return true;}) : void
 >foo : (func: () => boolean) => void
->() => {    this.age = 100;    return true;} : () => boolean
+>() => {    this.age = 100;    return true;} : () => true
 
     this.age = 100;
 >this.age = 100 : 100

--- a/tests/baselines/reference/emitArrowFunctionThisCapturingES6.types
+++ b/tests/baselines/reference/emitArrowFunctionThisCapturingES6.types
@@ -32,7 +32,7 @@ function foo(func: () => boolean){ }
 foo(() => {
 >foo(() => {    this.age = 100;    return true;}) : void
 >foo : (func: () => boolean) => void
->() => {    this.age = 100;    return true;} : () => boolean
+>() => {    this.age = 100;    return true;} : () => true
 
     this.age = 100;
 >this.age = 100 : 100

--- a/tests/baselines/reference/excessPropertyCheckWithUnions.errors.txt
+++ b/tests/baselines/reference/excessPropertyCheckWithUnions.errors.txt
@@ -13,8 +13,8 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(39,1): error TS2322: Type 
   Type '{ tag: "A"; }' is not assignable to type '{ tag: "C"; }'.
     Types of property 'tag' are incompatible.
       Type '"A"' is not assignable to type '"C"'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(40,1): error TS2322: Type '{ tag: "A"; z: boolean; }' is not assignable to type 'Ambiguous'.
-  Type '{ tag: "A"; z: boolean; }' is not assignable to type '{ tag: "C"; }'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(40,1): error TS2322: Type '{ tag: "A"; z: true; }' is not assignable to type 'Ambiguous'.
+  Type '{ tag: "A"; z: true; }' is not assignable to type '{ tag: "C"; }'.
     Types of property 'tag' are incompatible.
       Type '"A"' is not assignable to type '"C"'.
 tests/cases/compiler/excessPropertyCheckWithUnions.ts(49,35): error TS2322: Type '{ a: 1; b: 1; first: string; second: string; }' is not assignable to type 'Overlapping'.
@@ -91,8 +91,8 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(66,9): error TS2322: Type 
 !!! error TS2322:       Type '"A"' is not assignable to type '"C"'.
     amb = { tag: "A", z: true }
     ~~~
-!!! error TS2322: Type '{ tag: "A"; z: boolean; }' is not assignable to type 'Ambiguous'.
-!!! error TS2322:   Type '{ tag: "A"; z: boolean; }' is not assignable to type '{ tag: "C"; }'.
+!!! error TS2322: Type '{ tag: "A"; z: true; }' is not assignable to type 'Ambiguous'.
+!!! error TS2322:   Type '{ tag: "A"; z: true; }' is not assignable to type '{ tag: "C"; }'.
 !!! error TS2322:     Types of property 'tag' are incompatible.
 !!! error TS2322:       Type '"A"' is not assignable to type '"C"'.
     

--- a/tests/baselines/reference/excessPropertyCheckWithUnions.types
+++ b/tests/baselines/reference/excessPropertyCheckWithUnions.types
@@ -139,12 +139,12 @@ amb = { tag: "A" }
 >"A" : "A"
 
 amb = { tag: "A", z: true }
->amb = { tag: "A", z: true } : { tag: "A"; z: boolean; }
+>amb = { tag: "A", z: true } : { tag: "A"; z: true; }
 >amb : Ambiguous
->{ tag: "A", z: true } : { tag: "A"; z: boolean; }
+>{ tag: "A", z: true } : { tag: "A"; z: true; }
 >tag : "A"
 >"A" : "A"
->z : boolean
+>z : true
 >true : true
 
 type Overlapping =

--- a/tests/baselines/reference/for-of36.types
+++ b/tests/baselines/reference/for-of36.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of36.ts ===
 var tuple: [string, boolean] = ["", true];
 >tuple : [string, boolean]
->["", true] : [string, boolean]
+>["", true] : [string, true]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of37.types
+++ b/tests/baselines/reference/for-of37.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of38.types
+++ b/tests/baselines/reference/for-of38.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of39.errors.txt
+++ b/tests/baselines/reference/for-of39.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,19): error TS2345: Argument of type '([string, boolean] | [string, number])[]' is not assignable to parameter of type 'Iterable<[string, boolean]>'.
+tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,19): error TS2345: Argument of type '([string, number] | [string, true])[]' is not assignable to parameter of type 'Iterable<[string, boolean]>'.
   Types of property '[Symbol.iterator]' are incompatible.
-    Type '() => IterableIterator<[string, boolean] | [string, number]>' is not assignable to type '() => Iterator<[string, boolean]>'.
-      Type 'IterableIterator<[string, boolean] | [string, number]>' is not assignable to type 'Iterator<[string, boolean]>'.
+    Type '() => IterableIterator<[string, number] | [string, true]>' is not assignable to type '() => Iterator<[string, boolean]>'.
+      Type 'IterableIterator<[string, number] | [string, true]>' is not assignable to type 'Iterator<[string, boolean]>'.
         Types of property 'next' are incompatible.
-          Type '(value?: any) => IteratorResult<[string, boolean] | [string, number]>' is not assignable to type '(value?: any) => IteratorResult<[string, boolean]>'.
-            Type 'IteratorResult<[string, boolean] | [string, number]>' is not assignable to type 'IteratorResult<[string, boolean]>'.
-              Type '[string, boolean] | [string, number]' is not assignable to type '[string, boolean]'.
+          Type '(value?: any) => IteratorResult<[string, number] | [string, true]>' is not assignable to type '(value?: any) => IteratorResult<[string, boolean]>'.
+            Type 'IteratorResult<[string, number] | [string, true]>' is not assignable to type 'IteratorResult<[string, boolean]>'.
+              Type '[string, number] | [string, true]' is not assignable to type '[string, boolean]'.
                 Type '[string, number]' is not assignable to type '[string, boolean]'.
                   Type 'number' is not assignable to type 'boolean'.
 
@@ -13,14 +13,14 @@ tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,19): error TS2345: Ar
 ==== tests/cases/conformance/es6/for-ofStatements/for-of39.ts (1 errors) ====
     var map = new Map([["", true], ["", 0]]);
                       ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '([string, boolean] | [string, number])[]' is not assignable to parameter of type 'Iterable<[string, boolean]>'.
+!!! error TS2345: Argument of type '([string, number] | [string, true])[]' is not assignable to parameter of type 'Iterable<[string, boolean]>'.
 !!! error TS2345:   Types of property '[Symbol.iterator]' are incompatible.
-!!! error TS2345:     Type '() => IterableIterator<[string, boolean] | [string, number]>' is not assignable to type '() => Iterator<[string, boolean]>'.
-!!! error TS2345:       Type 'IterableIterator<[string, boolean] | [string, number]>' is not assignable to type 'Iterator<[string, boolean]>'.
+!!! error TS2345:     Type '() => IterableIterator<[string, number] | [string, true]>' is not assignable to type '() => Iterator<[string, boolean]>'.
+!!! error TS2345:       Type 'IterableIterator<[string, number] | [string, true]>' is not assignable to type 'Iterator<[string, boolean]>'.
 !!! error TS2345:         Types of property 'next' are incompatible.
-!!! error TS2345:           Type '(value?: any) => IteratorResult<[string, boolean] | [string, number]>' is not assignable to type '(value?: any) => IteratorResult<[string, boolean]>'.
-!!! error TS2345:             Type 'IteratorResult<[string, boolean] | [string, number]>' is not assignable to type 'IteratorResult<[string, boolean]>'.
-!!! error TS2345:               Type '[string, boolean] | [string, number]' is not assignable to type '[string, boolean]'.
+!!! error TS2345:           Type '(value?: any) => IteratorResult<[string, number] | [string, true]>' is not assignable to type '(value?: any) => IteratorResult<[string, boolean]>'.
+!!! error TS2345:             Type 'IteratorResult<[string, number] | [string, true]>' is not assignable to type 'IteratorResult<[string, boolean]>'.
+!!! error TS2345:               Type '[string, number] | [string, true]' is not assignable to type '[string, boolean]'.
 !!! error TS2345:                 Type '[string, number]' is not assignable to type '[string, boolean]'.
 !!! error TS2345:                   Type 'number' is not assignable to type 'boolean'.
     for (var [k, v] of map) {

--- a/tests/baselines/reference/for-of40.types
+++ b/tests/baselines/reference/for-of40.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of44.types
+++ b/tests/baselines/reference/for-of44.types
@@ -1,11 +1,11 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of44.ts ===
 var array: [number, string | boolean | symbol][] = [[0, ""], [0, true], [1, Symbol()]]
 >array : [number, string | boolean | symbol][]
->[[0, ""], [0, true], [1, Symbol()]] : ([number, string] | [number, boolean] | [number, symbol])[]
+>[[0, ""], [0, true], [1, Symbol()]] : ([number, string] | [number, true] | [number, symbol])[]
 >[0, ""] : [number, string]
 >0 : 0
 >"" : ""
->[0, true] : [number, boolean]
+>[0, true] : [number, true]
 >0 : 0
 >true : true
 >[1, Symbol()] : [number, symbol]

--- a/tests/baselines/reference/for-of45.types
+++ b/tests/baselines/reference/for-of45.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of46.types
+++ b/tests/baselines/reference/for-of46.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of49.types
+++ b/tests/baselines/reference/for-of49.types
@@ -7,8 +7,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/for-of50.types
+++ b/tests/baselines/reference/for-of50.types
@@ -3,8 +3,8 @@ var map = new Map([["", true]]);
 >map : Map<string, boolean>
 >new Map([["", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/functionOverloads39.types
+++ b/tests/baselines/reference/functionOverloads39.types
@@ -19,8 +19,8 @@ var x = foo([{a:true}]);
 >x : number
 >foo([{a:true}]) : number
 >foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
->[{a:true}] : { a: boolean; }[]
->{a:true} : { a: boolean; }
->a : boolean
+>[{a:true}] : { a: true; }[]
+>{a:true} : { a: true; }
+>a : true
 >true : true
 

--- a/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.types
+++ b/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.types
@@ -64,7 +64,7 @@ _.all([true], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
->[true] : boolean[]
+>[true] : true[]
 >true : true
 >_.identity : <T>(value: T) => T
 >_ : Underscore.Static

--- a/tests/baselines/reference/genericTypeArgumentInference1.types
+++ b/tests/baselines/reference/genericTypeArgumentInference1.types
@@ -62,7 +62,7 @@ var r2 = _.all([true], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
->[true] : boolean[]
+>[true] : true[]
 >true : true
 >_.identity : <T>(value: T) => T
 >_ : Underscore.Static

--- a/tests/baselines/reference/getAndSetAsMemberNames.types
+++ b/tests/baselines/reference/getAndSetAsMemberNames.types
@@ -40,7 +40,7 @@ class C5 {
 
     public set: () => boolean = function () { return true; };
 >set : () => boolean
->function () { return true; } : () => boolean
+>function () { return true; } : () => true
 >true : true
 
     get (): boolean { return true; }

--- a/tests/baselines/reference/getterSetterNonAccessor.types
+++ b/tests/baselines/reference/getterSetterNonAccessor.types
@@ -16,8 +16,8 @@ Object.defineProperty({}, "0", <PropertyDescriptor>({
 >"0" : "0"
 ><PropertyDescriptor>({          get: getFunc,          set: setFunc,          configurable: true      }) : PropertyDescriptor
 >PropertyDescriptor : PropertyDescriptor
->({          get: getFunc,          set: setFunc,          configurable: true      }) : { get: () => any; set: (v: any) => void; configurable: boolean; }
->{          get: getFunc,          set: setFunc,          configurable: true      } : { get: () => any; set: (v: any) => void; configurable: boolean; }
+>({          get: getFunc,          set: setFunc,          configurable: true      }) : { get: () => any; set: (v: any) => void; configurable: true; }
+>{          get: getFunc,          set: setFunc,          configurable: true      } : { get: () => any; set: (v: any) => void; configurable: true; }
 
           get: getFunc,
 >get : () => any
@@ -28,7 +28,7 @@ Object.defineProperty({}, "0", <PropertyDescriptor>({
 >setFunc : (v: any) => void
 
           configurable: true
->configurable : boolean
+>configurable : true
 >true : true
 
       }));

--- a/tests/baselines/reference/indexerWithTuple.types
+++ b/tests/baselines/reference/indexerWithTuple.types
@@ -21,7 +21,7 @@ var unionTuple1: [number, string| number] = [10, "foo"];
 
 var unionTuple2: [boolean, string| number] = [true, "foo"]; 
 >unionTuple2 : [boolean, string | number]
->[true, "foo"] : [boolean, string]
+>[true, "foo"] : [true, string]
 >true : true
 >"foo" : "foo"
 

--- a/tests/baselines/reference/interfaceContextualType.types
+++ b/tests/baselines/reference/interfaceContextualType.types
@@ -34,30 +34,30 @@ class Bug {
 >{} : {}
 
         this.values['comments'] = { italic: true };
->this.values['comments'] = { italic: true } : { italic: boolean; }
+>this.values['comments'] = { italic: true } : { italic: true; }
 >this.values['comments'] : IOptions
 >this.values : IMap
 >this : this
 >values : IMap
 >'comments' : "comments"
->{ italic: true } : { italic: boolean; }
->italic : boolean
+>{ italic: true } : { italic: true; }
+>italic : true
 >true : true
     }
     shouldBeOK() {
 >shouldBeOK : () => void
 
         this.values = {
->this.values = {            comments: { italic: true }        } : { comments: { italic: boolean; }; }
+>this.values = {            comments: { italic: true }        } : { comments: { italic: true; }; }
 >this.values : IMap
 >this : this
 >values : IMap
->{            comments: { italic: true }        } : { comments: { italic: boolean; }; }
+>{            comments: { italic: true }        } : { comments: { italic: true; }; }
 
             comments: { italic: true }
->comments : { italic: boolean; }
->{ italic: true } : { italic: boolean; }
->italic : boolean
+>comments : { italic: true; }
+>{ italic: true } : { italic: true; }
+>italic : true
 >true : true
 
         };

--- a/tests/baselines/reference/interfaceWithPropertyOfEveryType.types
+++ b/tests/baselines/reference/interfaceWithPropertyOfEveryType.types
@@ -80,7 +80,7 @@ interface Foo {
 var a: Foo = {
 >a : Foo
 >Foo : Foo
->{    a: 1,    b: '',    c: true,    d: {},    e: null ,    f: [1],    g: {},    h: (x: number) => 1,    i: <T>(x: T) => x,    j: <Foo>null,    k: new C(),    l: f1,    m: M,    n: {},    o: E.A} : { a: number; b: string; c: boolean; d: {}; e: null; f: number[]; g: {}; h: (x: number) => number; i: <T>(x: T) => T; j: Foo; k: C; l: () => void; m: typeof M; n: {}; o: E; }
+>{    a: 1,    b: '',    c: true,    d: {},    e: null ,    f: [1],    g: {},    h: (x: number) => 1,    i: <T>(x: T) => x,    j: <Foo>null,    k: new C(),    l: f1,    m: M,    n: {},    o: E.A} : { a: number; b: string; c: true; d: {}; e: null; f: number[]; g: {}; h: (x: number) => number; i: <T>(x: T) => T; j: Foo; k: C; l: () => void; m: typeof M; n: {}; o: E; }
 
     a: 1,
 >a : number
@@ -91,7 +91,7 @@ var a: Foo = {
 >'' : ""
 
     c: true,
->c : boolean
+>c : true
 >true : true
 
     d: {},

--- a/tests/baselines/reference/isomorphicMappedTypeInference.types
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.types
@@ -245,8 +245,8 @@ function f3() {
 >assignBoxified(b, { c: false }) : void
 >assignBoxified : <T>(obj: Boxified<T>, values: T) => void
 >b : { a: Box<number>; b: Box<string>; c: Box<boolean>; }
->{ c: false } : { c: boolean; }
->c : boolean
+>{ c: false } : { c: false; }
+>c : false
 >false : false
 }
 

--- a/tests/baselines/reference/iterableArrayPattern23.types
+++ b/tests/baselines/reference/iterableArrayPattern23.types
@@ -4,11 +4,11 @@ var a: string, b: boolean;
 >b : boolean
 
 [a, b] = { 0: "", 1: true };
->[a, b] = { 0: "", 1: true } : { 0: string; 1: boolean; }
+>[a, b] = { 0: "", 1: true } : { 0: string; 1: true; }
 >[a, b] : [string, boolean]
 >a : string
 >b : boolean
->{ 0: "", 1: true } : { 0: string; 1: boolean; }
+>{ 0: "", 1: true } : { 0: string; 1: true; }
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern24.types
+++ b/tests/baselines/reference/iterableArrayPattern24.types
@@ -4,12 +4,12 @@ var a: string, b: boolean[];
 >b : boolean[]
 
 [a, ...b] = { 0: "", 1: true };
->[a, ...b] = { 0: "", 1: true } : { 0: string; 1: boolean; }
+>[a, ...b] = { 0: "", 1: true } : { 0: string; 1: true; }
 >[a, ...b] : (string | boolean)[]
 >a : string
 >...b : boolean
 >b : boolean[]
->{ 0: "", 1: true } : { 0: string; 1: boolean; }
+>{ 0: "", 1: true } : { 0: string; 1: true; }
 >"" : ""
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern29.types
+++ b/tests/baselines/reference/iterableArrayPattern29.types
@@ -12,11 +12,11 @@ takeFirstTwoEntries(...new Map([["", true], ["hello", true]]));
 >...new Map([["", true], ["hello", true]]) : [string, boolean]
 >new Map([["", true], ["hello", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true], ["hello", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true], ["hello", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
->["hello", true] : [string, boolean]
+>["hello", true] : [string, true]
 >"hello" : "hello"
 >true : true
 

--- a/tests/baselines/reference/iterableArrayPattern30.types
+++ b/tests/baselines/reference/iterableArrayPattern30.types
@@ -6,11 +6,11 @@ const [[k1, v1], [k2, v2]] = new Map([["", true], ["hello", true]])
 >v2 : boolean
 >new Map([["", true], ["hello", true]]) : Map<string, boolean>
 >Map : MapConstructor
->[["", true], ["hello", true]] : [string, boolean][]
->["", true] : [string, boolean]
+>[["", true], ["hello", true]] : [string, true][]
+>["", true] : [string, true]
 >"" : ""
 >true : true
->["hello", true] : [string, boolean]
+>["hello", true] : [string, true]
 >"hello" : "hello"
 >true : true
 

--- a/tests/baselines/reference/jsdocParamTagTypeLiteral.types
+++ b/tests/baselines/reference/jsdocParamTagTypeLiteral.types
@@ -149,20 +149,20 @@ function foo5(opts5) {
 foo5([{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }]);
 >foo5([{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }]) : void
 >foo5 : (opts5: { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }[]) => void
->[{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }] : { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }[]
->{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 } : { help: string; what: { a: string; bad: { idea: string; oh: boolean; }[]; }; unnest: number; }
+>[{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 }] : { help: string; what: { a: string; bad: { idea: string; oh: false; }[]; }; unnest: number; }[]
+>{ help: "help", what: { a: 'a', bad: [{ idea: 'idea', oh: false }] }, unnest: 1 } : { help: string; what: { a: string; bad: { idea: string; oh: false; }[]; }; unnest: number; }
 >help : string
 >"help" : "help"
->what : { a: string; bad: { idea: string; oh: boolean; }[]; }
->{ a: 'a', bad: [{ idea: 'idea', oh: false }] } : { a: string; bad: { idea: string; oh: boolean; }[]; }
+>what : { a: string; bad: { idea: string; oh: false; }[]; }
+>{ a: 'a', bad: [{ idea: 'idea', oh: false }] } : { a: string; bad: { idea: string; oh: false; }[]; }
 >a : string
 >'a' : "a"
->bad : { idea: string; oh: boolean; }[]
->[{ idea: 'idea', oh: false }] : { idea: string; oh: boolean; }[]
->{ idea: 'idea', oh: false } : { idea: string; oh: boolean; }
+>bad : { idea: string; oh: false; }[]
+>[{ idea: 'idea', oh: false }] : { idea: string; oh: false; }[]
+>{ idea: 'idea', oh: false } : { idea: string; oh: false; }
 >idea : string
 >'idea' : "idea"
->oh : boolean
+>oh : false
 >false : false
 >unnest : number
 >1 : 1

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -572,14 +572,14 @@ function f31<K extends keyof Shape>(key: K) {
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
 >shape : Shape
 >Shape : Shape
->{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: boolean; }
+>{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: true; }
 >name : string
 >"foo" : "foo"
 >width : number
 >5 : 5
 >height : number
 >10 : 10
->visible : boolean
+>visible : true
 >true : true
 
     return shape[key];  // Shape[K]
@@ -597,14 +597,14 @@ function f32<K extends "width" | "height">(key: K) {
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
 >shape : Shape
 >Shape : Shape
->{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: boolean; }
+>{ name: "foo", width: 5, height: 10, visible: true } : { name: string; width: number; height: number; visible: true; }
 >name : string
 >"foo" : "foo"
 >width : number
 >5 : 5
 >height : number
 >10 : 10
->visible : boolean
+>visible : true
 >true : true
 
     return shape[key];  // Shape[K]
@@ -952,8 +952,8 @@ function f71(func: <T, U>(x: T, y: U) => Partial<T & U>) {
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 
     x.a;  // number | undefined
@@ -999,8 +999,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 >'a' : "a"
 
@@ -1013,8 +1013,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 >'b' : "b"
 
@@ -1027,8 +1027,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 >'c' : "c"
 }
@@ -1060,8 +1060,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 >'a' : "a"
 
@@ -1074,8 +1074,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 >'b' : "b"
 
@@ -1088,8 +1088,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 >'c' : "c"
 }
@@ -1121,10 +1121,10 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ a: 2, b: true } : { a: number; b: boolean; }
+>{ a: 2, b: true } : { a: number; b: true; }
 >a : number
 >2 : 2
->b : boolean
+>b : true
 >true : true
 >'a' : "a"
 
@@ -1137,10 +1137,10 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ a: 2, b: true } : { a: number; b: boolean; }
+>{ a: 2, b: true } : { a: number; b: true; }
 >a : number
 >2 : 2
->b : boolean
+>b : true
 >true : true
 >'b' : "b"
 }

--- a/tests/baselines/reference/literalTypes2.types
+++ b/tests/baselines/reference/literalTypes2.types
@@ -501,8 +501,8 @@ function f6() {
 >0 : 0
 >x3 : string
 >"foo" : "foo"
->{ x1: false, x2: 1, x3: "bar" } : { x1?: boolean; x2?: number; x3?: string; }
->x1 : boolean
+>{ x1: false, x2: 1, x3: "bar" } : { x1?: false; x2?: number; x3?: string; }
+>x1 : false
 >false : false
 >x2 : number
 >1 : 1

--- a/tests/baselines/reference/mappedTypeErrors.types
+++ b/tests/baselines/reference/mappedTypeErrors.types
@@ -613,10 +613,10 @@ type O = {x: number, y: boolean};
 let o: O = {x: 5, y: false};
 >o : O
 >O : O
->{x: 5, y: false} : { x: number; y: boolean; }
+>{x: 5, y: false} : { x: number; y: false; }
 >x : number
 >5 : 5
->y : boolean
+>y : false
 >false : false
 
 let f: Foo2<O, 'x'> = {

--- a/tests/baselines/reference/objectLiteralNormalization.errors.txt
+++ b/tests/baselines/reference/objectLiteralNormalization.errors.txt
@@ -4,9 +4,9 @@ tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(8,1): error TS2322: Type '{ b: string; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
   Type '{ b: string; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
     Property 'a' is missing in type '{ b: string; }'.
-tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(9,1): error TS2322: Type '{ c: boolean; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
-  Type '{ c: boolean; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
-    Property 'a' is missing in type '{ c: boolean; }'.
+tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(9,1): error TS2322: Type '{ c: true; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
+  Type '{ c: true; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
+    Property 'a' is missing in type '{ c: true; }'.
 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(17,1): error TS2322: Type '{ a: string; b: number; }' is not assignable to type '{ a: number; b: number; } | { a: string; b?: undefined; } | { a?: undefined; b?: undefined; }'.
   Type '{ a: string; b: number; }' is not assignable to type '{ a?: undefined; b?: undefined; }'.
     Types of property 'a' are incompatible.
@@ -36,9 +36,9 @@ tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
 !!! error TS2322:     Property 'a' is missing in type '{ b: string; }'.
     a1 = { c: true };  // Error
     ~~
-!!! error TS2322: Type '{ c: boolean; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
-!!! error TS2322:   Type '{ c: boolean; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
-!!! error TS2322:     Property 'a' is missing in type '{ c: boolean; }'.
+!!! error TS2322: Type '{ c: true; }' is not assignable to type '{ a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }'.
+!!! error TS2322:   Type '{ c: true; }' is not assignable to type '{ a: number; b: string; c: boolean; }'.
+!!! error TS2322:     Property 'a' is missing in type '{ c: true; }'.
     
     let a2 = [{ a: 1, b: 2 }, { a: "abc" }, {}][0];
     a2.a;  // string | number | undefined

--- a/tests/baselines/reference/objectLiteralNormalization.types
+++ b/tests/baselines/reference/objectLiteralNormalization.types
@@ -60,10 +60,10 @@ a1 = { b: "y" };  // Error
 >"y" : "y"
 
 a1 = { c: true };  // Error
->a1 = { c: true } : { c: boolean; }
+>a1 = { c: true } : { c: true; }
 >a1 : { a: number; b?: undefined; c?: undefined; } | { a: number; b: string; c?: undefined; } | { a: number; b: string; c: boolean; }
->{ c: true } : { c: boolean; }
->c : boolean
+>{ c: true } : { c: true; }
+>c : true
 >true : true
 
 let a2 = [{ a: 1, b: 2 }, { a: "abc" }, {}][0];

--- a/tests/baselines/reference/objectLiteralParameterResolution.types
+++ b/tests/baselines/reference/objectLiteralParameterResolution.types
@@ -29,7 +29,7 @@ var s = $.extend({
 >$.extend : { <T>(target: T, ...objs: any[]): T; <T>(deep: boolean, target: T, ...objs: any[]): T; }
 >$ : Foo
 >extend : { <T>(target: T, ...objs: any[]): T; <T>(deep: boolean, target: T, ...objs: any[]): T; }
->{    type: "GET" ,    data: "data" ,    success: wrapSuccessCallback(requestContext, callback) ,    error: wrapErrorCallback(requestContext, errorCallback) ,    dataType: "json" ,    converters: { "text json": "" },    traditional: true ,    timeout: 12,    } : { type: string; data: string; success: any; error: any; dataType: string; converters: { "text json": string; }; traditional: boolean; timeout: number; }
+>{    type: "GET" ,    data: "data" ,    success: wrapSuccessCallback(requestContext, callback) ,    error: wrapErrorCallback(requestContext, errorCallback) ,    dataType: "json" ,    converters: { "text json": "" },    traditional: true ,    timeout: 12,    } : { type: string; data: string; success: any; error: any; dataType: string; converters: { "text json": string; }; traditional: true; timeout: number; }
 
     type: "GET" ,
 >type : string
@@ -63,7 +63,7 @@ var s = $.extend({
 >"" : ""
 
     traditional: true ,
->traditional : boolean
+>traditional : true
 >true : true
 
     timeout: 12,

--- a/tests/baselines/reference/objectSpread.types
+++ b/tests/baselines/reference/objectSpread.types
@@ -31,9 +31,9 @@ let addAfter: { a: number, b: string, c: boolean } =
 >c : boolean
 
     { ...o, c: false }
->{ ...o, c: false } : { c: boolean; a: number; b: string; }
+>{ ...o, c: false } : { c: false; a: number; b: string; }
 >o : { a: number; b: string; }
->c : boolean
+>c : false
 >false : false
 
 let addBefore: { a: number, b: string, c: boolean } =
@@ -43,8 +43,8 @@ let addBefore: { a: number, b: string, c: boolean } =
 >c : boolean
 
     { c: false, ...o }
->{ c: false, ...o } : { a: number; b: string; c: boolean; }
->c : boolean
+>{ c: false, ...o } : { a: number; b: string; c: false; }
+>c : false
 >false : false
 >o : { a: number; b: string; }
 
@@ -78,12 +78,12 @@ let nested: { a: number, b: boolean, c: string } =
 >c : string
 
     { ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' }
->{ ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' } : { c: string; b: boolean; a: number; }
->{ a: 3, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
+>{ ...{ a: 3, ...{ b: false, c: 'overriden' } }, c: 'whatever' } : { c: string; b: false; a: number; }
+>{ a: 3, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
 >a : number
 >3 : 3
->{ b: false, c: 'overriden' } : { b: boolean; c: string; }
->b : boolean
+>{ b: false, c: 'overriden' } : { b: false; c: string; }
+>b : false
 >false : false
 >c : string
 >'overriden' : "overriden"
@@ -148,12 +148,12 @@ let combinedNested: { a: number, b: boolean, c: string, d: string } =
 >d : string
 
     { ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } }
->{ ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } } : { a: number; d: string; b: boolean; c: string; }
->{ a: 4, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
+>{ ...{ a: 4, ...{ b: false, c: 'overriden' } }, d: 'actually new', ...{ a: 5, d: 'maybe new' } } : { a: number; d: string; b: false; c: string; }
+>{ a: 4, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
 >a : number
 >4 : 4
->{ b: false, c: 'overriden' } : { b: boolean; c: string; }
->b : boolean
+>{ b: false, c: 'overriden' } : { b: false; c: string; }
+>b : false
 >false : false
 >c : string
 >'overriden' : "overriden"
@@ -172,12 +172,12 @@ let combinedNestedChangeType: { a: number, b: boolean, c: number } =
 >c : number
 
     { ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 }
->{ ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 } : { c: number; b: boolean; a: number; }
->{ a: 1, ...{ b: false, c: 'overriden' } } : { b: boolean; c: string; a: number; }
+>{ ...{ a: 1, ...{ b: false, c: 'overriden' } }, c: -1 } : { c: number; b: false; a: number; }
+>{ a: 1, ...{ b: false, c: 'overriden' } } : { b: false; c: string; a: number; }
 >a : number
 >1 : 1
->{ b: false, c: 'overriden' } : { b: boolean; c: string; }
->b : boolean
+>{ b: false, c: 'overriden' } : { b: false; c: string; }
+>b : false
 >false : false
 >c : string
 >'overriden' : "overriden"

--- a/tests/baselines/reference/objectSpreadNegative.types
+++ b/tests/baselines/reference/objectSpreadNegative.types
@@ -278,10 +278,10 @@ let exclusive: { id: string, a: number, b: string, c: string, d: boolean } =
 >1 : 1
 >b : string
 >'yes' : "yes"
->{ c: 'no', d: false } : { c: string; d: boolean; }
+>{ c: 'no', d: false } : { c: string; d: false; }
 >c : string
 >'no' : "no"
->d : boolean
+>d : false
 >false : false
 
 let overlap: { id: string, a: number, b: string } =
@@ -327,10 +327,10 @@ let overwriteId: { id: string, a: number, c: number, d: string } =
     f({ a: 1, id: true }, { c: 1, d: 'no' })
 >f({ a: 1, id: true }, { c: 1, d: 'no' }) : any
 >f : <T, U>(t: T, u: U) => any
->{ a: 1, id: true } : { a: number; id: boolean; }
+>{ a: 1, id: true } : { a: number; id: true; }
 >a : number
 >1 : 1
->id : boolean
+>id : true
 >true : true
 >{ c: 1, d: 'no' } : { c: number; d: string; }
 >c : number

--- a/tests/baselines/reference/optionalBindingParameters1.types
+++ b/tests/baselines/reference/optionalBindingParameters1.types
@@ -10,7 +10,7 @@ function foo([x,y,z]?: [string, number, boolean]) {
 foo(["", 0, false]);
 >foo(["", 0, false]) : void
 >foo : ([x, y, z]?: [string, number, boolean]) => void
->["", 0, false] : [string, number, boolean]
+>["", 0, false] : [string, number, false]
 >"" : ""
 >0 : 0
 >false : false

--- a/tests/baselines/reference/optionalBindingParameters2.types
+++ b/tests/baselines/reference/optionalBindingParameters2.types
@@ -13,12 +13,12 @@ function foo({ x, y, z }?: { x: string; y: number; z: boolean }) {
 foo({ x: "", y: 0, z: false });
 >foo({ x: "", y: 0, z: false }) : void
 >foo : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => void
->{ x: "", y: 0, z: false } : { x: string; y: number; z: boolean; }
+>{ x: "", y: 0, z: false } : { x: string; y: number; z: false; }
 >x : string
 >"" : ""
 >y : number
 >0 : 0
->z : boolean
+>z : false
 >false : false
 
 foo({ x: false, y: 0, z: "" });

--- a/tests/baselines/reference/optionalBindingParametersInOverloads1.types
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads1.types
@@ -14,7 +14,7 @@ function foo(...rest: any[]) {
 foo(["", 0, false]);
 >foo(["", 0, false]) : any
 >foo : ([x, y, z]?: [string, number, boolean]) => any
->["", 0, false] : [string, number, boolean]
+>["", 0, false] : [string, number, false]
 >"" : ""
 >0 : 0
 >false : false

--- a/tests/baselines/reference/optionalBindingParametersInOverloads2.types
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads2.types
@@ -17,12 +17,12 @@ function foo(...rest: any[]) {
 foo({ x: "", y: 0, z: false });
 >foo({ x: "", y: 0, z: false }) : any
 >foo : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => any
->{ x: "", y: 0, z: false } : { x: string; y: number; z: boolean; }
+>{ x: "", y: 0, z: false } : { x: string; y: number; z: false; }
 >x : string
 >"" : ""
 >y : number
 >0 : 0
->z : boolean
+>z : false
 >false : false
 
 foo({ x: false, y: 0, z: "" });

--- a/tests/baselines/reference/overloadResolutionTest1.types
+++ b/tests/baselines/reference/overloadResolutionTest1.types
@@ -19,9 +19,9 @@ var x1 = foo([{a:true}]); // works
 >x1 : number
 >foo([{a:true}]) : number
 >foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
->[{a:true}] : { a: boolean; }[]
->{a:true} : { a: boolean; }
->a : boolean
+>[{a:true}] : { a: true; }[]
+>{a:true} : { a: true; }
+>a : true
 >true : true
 
 var x11 = foo([{a:0}]); // works
@@ -81,8 +81,8 @@ var x3 = foo2({a:true}); // works
 >x3 : number
 >foo2({a:true}) : number
 >foo2 : { (bar: { a: number; }): string; (bar: { a: boolean; }): number; }
->{a:true} : { a: boolean; }
->a : boolean
+>{a:true} : { a: true; }
+>a : true
 >true : true
 
 var x4 = foo2({a:"s"}); // error

--- a/tests/baselines/reference/parserUsingConstructorAsIdentifier.types
+++ b/tests/baselines/reference/parserUsingConstructorAsIdentifier.types
@@ -97,14 +97,14 @@
 >constructor : any
 >prototype : any
 >"constructor" : "constructor"
->{ value: constructor, writable: true, configurable: true, enumerable: true } : { value: any; writable: boolean; configurable: boolean; enumerable: boolean; }
+>{ value: constructor, writable: true, configurable: true, enumerable: true } : { value: any; writable: true; configurable: true; enumerable: true; }
 >value : any
 >constructor : any
->writable : boolean
+>writable : true
 >true : true
->configurable : boolean
+>configurable : true
 >true : true
->enumerable : boolean
+>enumerable : true
 >true : true
 
                 if (instanceMembers) {

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -1581,14 +1581,14 @@ module Harness {
                     var metadata: IScenarioMetadata = { id: undefined, desc: this.description, pass: false, bugs: assert.bugIds };
 >metadata : IScenarioMetadata
 >IScenarioMetadata : IScenarioMetadata
->{ id: undefined, desc: this.description, pass: false, bugs: assert.bugIds } : { id: undefined; desc: any; pass: boolean; bugs: any; }
+>{ id: undefined, desc: this.description, pass: false, bugs: assert.bugIds } : { id: undefined; desc: any; pass: false; bugs: any; }
 >id : undefined
 >undefined : undefined
 >desc : any
 >this.description : any
 >this : any
 >description : any
->pass : boolean
+>pass : false
 >false : false
 >bugs : any
 >assert.bugIds : any

--- a/tests/baselines/reference/privacyCheckAnonymousFunctionParameter.types
+++ b/tests/baselines/reference/privacyCheckAnonymousFunctionParameter.types
@@ -31,7 +31,7 @@ module Query {
         return fromDoWhile(test => {
 >fromDoWhile(test => {            return true;        }) : Iterator<{}>
 >fromDoWhile : <T>(doWhile: (test: Iterator<T>) => boolean) => Iterator<T>
->test => {            return true;        } : (test: Iterator<{}>) => boolean
+>test => {            return true;        } : (test: Iterator<{}>) => true
 >test : Iterator<{}>
 
             return true;

--- a/tests/baselines/reference/symbolProperty21.errors.txt
+++ b/tests/baselines/reference/symbolProperty21.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
 
 
@@ -14,7 +14,7 @@ tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Arg
         [Symbol.isConcatSpreadable]: "",
         [Symbol.toPrimitive]: 0,
         ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
+!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
 !!! error TS2345:   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
         [Symbol.unscopables]: true
     });

--- a/tests/baselines/reference/targetTypeArgs.types
+++ b/tests/baselines/reference/targetTypeArgs.types
@@ -35,7 +35,7 @@ foo(function(x) { x });
 >["hello"] : string[]
 >"hello" : "hello"
 >every : (callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any) => boolean
->function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => boolean
+>function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => true
 >v : string
 >i : number
 >a : string[]
@@ -47,7 +47,7 @@ foo(function(x) { x });
 >[1] : number[]
 >1 : 1
 >every : (callbackfn: (value: number, index: number, array: number[]) => boolean, thisArg?: any) => boolean
->function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => boolean
+>function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => true
 >v : number
 >i : number
 >a : number[]
@@ -59,7 +59,7 @@ foo(function(x) { x });
 >[1] : number[]
 >1 : 1
 >every : (callbackfn: (value: number, index: number, array: number[]) => boolean, thisArg?: any) => boolean
->function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => boolean
+>function(v,i,a) {return true;} : (v: number, i: number, a: number[]) => true
 >v : number
 >i : number
 >a : number[]
@@ -71,7 +71,7 @@ foo(function(x) { x });
 >["s"] : string[]
 >"s" : "s"
 >every : (callbackfn: (value: string, index: number, array: string[]) => boolean, thisArg?: any) => boolean
->function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => boolean
+>function(v,i,a) {return true;} : (v: string, i: number, a: string[]) => true
 >v : string
 >i : number
 >a : string[]

--- a/tests/baselines/reference/tsxAttributeResolution6.types
+++ b/tests/baselines/reference/tsxAttributeResolution6.types
@@ -43,7 +43,7 @@ declare module JSX {
 <test1 n={false} />;
 ><test1 n={false} /> : JSX.Element
 >test1 : any
->n : boolean
+>n : false
 >false : false
 
 <test2 n />;

--- a/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ editable: boolean; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
-  Type '{ editable: boolean; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
-    Type '{ editable: boolean; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
-      Property 'onEdit' is missing in type '{ editable: boolean; }'.
+tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
+  Type '{ editable: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
+    Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
+      Property 'onEdit' is missing in type '{ editable: true; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,10 +19,10 @@ tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ editable: boo
     // Error
     let x = <TextComponent editable={true} />
                            ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ editable: boolean; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
-!!! error TS2322:   Type '{ editable: boolean; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
-!!! error TS2322:     Type '{ editable: boolean; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
-!!! error TS2322:       Property 'onEdit' is missing in type '{ editable: boolean; }'.
+!!! error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
+!!! error TS2322:   Type '{ editable: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
+!!! error TS2322:     Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
+!!! error TS2322:       Property 'onEdit' is missing in type '{ editable: true; }'.
     
     const textProps: TextProps = {
         editable: false

--- a/tests/baselines/reference/tsxSpreadAttributesResolution6.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution6.types
@@ -35,7 +35,7 @@ let x = <TextComponent editable={true} />
 >x : JSX.Element
 ><TextComponent editable={true} /> : JSX.Element
 >TextComponent : typeof TextComponent
->editable : boolean
+>editable : true
 >true : true
 
 const textProps: TextProps = {

--- a/tests/baselines/reference/typeAliases.types
+++ b/tests/baselines/reference/typeAliases.types
@@ -231,7 +231,7 @@ f16(x);
 var y: StringAndBoolean = ["1", false];
 >y : [string, boolean]
 >StringAndBoolean : [string, boolean]
->["1", false] : [string, boolean]
+>["1", false] : [string, false]
 >"1" : "1"
 >false : false
 

--- a/tests/baselines/reference/typeGuardsOnClassProperty.types
+++ b/tests/baselines/reference/typeGuardsOnClassProperty.types
@@ -67,14 +67,14 @@ var o: {
 >prop2 : string | boolean
 
 } = {
->{        prop1: "string" ,        prop2: true    } : { prop1: string; prop2: boolean; }
+>{        prop1: "string" ,        prop2: true    } : { prop1: string; prop2: true; }
 
         prop1: "string" ,
 >prop1 : string
 >"string" : "string"
 
         prop2: true
->prop2 : boolean
+>prop2 : true
 >true : true
     }
 

--- a/tests/baselines/reference/typeInferenceLiteralUnion.types
+++ b/tests/baselines/reference/typeInferenceLiteralUnion.types
@@ -79,7 +79,7 @@ extentMixed = extent([new NumCoercible(10), 13, '12', true]);
 >extentMixed : [undefined, undefined] | [string | number | boolean | Date | NumCoercible, string | number | boolean | Date | NumCoercible]
 >extent([new NumCoercible(10), 13, '12', true]) : [undefined, undefined] | [string | number | boolean | Date | NumCoercible, string | number | boolean | Date | NumCoercible]
 >extent : <T extends Numeric>(array: (string | number | boolean | Date | T)[]) => [string | number | boolean | Date | T, string | number | boolean | Date | T] | [undefined, undefined]
->[new NumCoercible(10), 13, '12', true] : (string | number | boolean | NumCoercible)[]
+>[new NumCoercible(10), 13, '12', true] : (string | number | true | NumCoercible)[]
 >new NumCoercible(10) : NumCoercible
 >NumCoercible : typeof NumCoercible
 >10 : 10

--- a/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively.types
+++ b/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively.types
@@ -62,12 +62,12 @@ foo({ x: 1 }, { x: 1, y: '' }, { x: 2, y: '', z: true });
 >1 : 1
 >y : string
 >'' : ""
->{ x: 2, y: '', z: true } : { x: number; y: string; z: boolean; }
+>{ x: 2, y: '', z: true } : { x: number; y: string; z: true; }
 >x : number
 >2 : 2
 >y : string
 >'' : ""
->z : boolean
+>z : true
 >true : true
 
 foo(a, b, c);
@@ -82,12 +82,12 @@ foo(a, b, { foo: 1, bar: '', hm: true });
 >foo : <T, U, V>(x: T, y: U, z: V) => V
 >a : A
 >b : B
->{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: boolean; }
+>{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: true; }
 >foo : number
 >1 : 1
 >bar : string
 >'' : ""
->hm : boolean
+>hm : true
 >true : true
 
 foo((x: number, y) => { }, (x) => { }, () => { });

--- a/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively2.types
+++ b/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively2.types
@@ -62,12 +62,12 @@ foo({ x: 1 }, { x: 1, y: '' }, { x: 2, y: 2, z: true });
 >1 : 1
 >y : string
 >'' : ""
->{ x: 2, y: 2, z: true } : { x: number; y: number; z: boolean; }
+>{ x: 2, y: 2, z: true } : { x: number; y: number; z: true; }
 >x : number
 >2 : 2
 >y : number
 >2 : 2
->z : boolean
+>z : true
 >true : true
 
 foo(a, b, a);
@@ -81,12 +81,12 @@ foo(a, { foo: 1, bar: '', hm: true }, b);
 >foo(a, { foo: 1, bar: '', hm: true }, b) : B
 >foo : <T, U, V>(x: T, y: U, z: V) => V
 >a : A
->{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: boolean; }
+>{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: true; }
 >foo : number
 >1 : 1
 >bar : string
 >'' : ""
->hm : boolean
+>hm : true
 >true : true
 >b : B
 

--- a/tests/baselines/reference/underscoreTest1.types
+++ b/tests/baselines/reference/underscoreTest1.types
@@ -249,7 +249,7 @@ _.any([null, 0, 'yes', false]);
 >_.any : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
 >_ : Underscore.Static
 >any : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
->[null, 0, 'yes', false] : (string | number | boolean)[]
+>[null, 0, 'yes', false] : (string | number | false)[]
 >null : null
 >0 : 0
 >'yes' : "yes"
@@ -512,7 +512,7 @@ _.compact([0, 1, false, 2, '', 3]);
 >_.compact : <T>(list: T[]) => T[]
 >_ : Underscore.Static
 >compact : <T>(list: T[]) => T[]
->[0, 1, false, 2, '', 3] : (string | number | boolean)[]
+>[0, 1, false, 2, '', 3] : (string | number | false)[]
 >0 : 0
 >1 : 1
 >false : false

--- a/tests/baselines/reference/unionTypeInference.types
+++ b/tests/baselines/reference/unionTypeInference.types
@@ -77,7 +77,7 @@ var b1 = g(["string", true]);
 >b1 : boolean
 >g(["string", true]) : boolean
 >g : <T>(value: [string, T]) => T
->["string", true] : [string, boolean]
+>["string", true] : [string, true]
 >"string" : "string"
 >true : true
 

--- a/tests/baselines/reference/useObjectValuesAndEntries1.types
+++ b/tests/baselines/reference/useObjectValuesAndEntries1.types
@@ -58,8 +58,8 @@ var entries2 = Object.entries({ a: true, b: 2 });   // [string, number|boolean][
 >Object.entries : { <T>(o: { [s: string]: T; } | ArrayLike<T>): [string, T][]; (o: {}): [string, any][]; }
 >Object : ObjectConstructor
 >entries : { <T>(o: { [s: string]: T; } | ArrayLike<T>): [string, T][]; (o: {}): [string, any][]; }
->{ a: true, b: 2 } : { a: boolean; b: number; }
->a : boolean
+>{ a: true, b: 2 } : { a: true; b: number; }
+>a : true
 >true : true
 >b : number
 >2 : 2
@@ -70,8 +70,8 @@ var values2 = Object.values({ a: true, b: 2 });     // (number|boolean)[]
 >Object.values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
 >Object : ObjectConstructor
 >values : { <T>(o: { [s: string]: T; } | ArrayLike<T>): T[]; (o: {}): any[]; }
->{ a: true, b: 2 } : { a: boolean; b: number; }
->a : boolean
+>{ a: true, b: 2 } : { a: true; b: number; }
+>a : true
 >true : true
 >b : number
 >2 : 2

--- a/tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx
+++ b/tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx
@@ -1,0 +1,28 @@
+// @strict: true
+// @jsx: preserve
+// @skipLibCheck: true
+// @libFiles: lib.d.ts,react.d.ts
+interface A { isIt: true; text: string; }
+interface B { isIt: false; value: number; }
+type C = A | B;
+const isIt = Math.random() > 0.5;
+const c: C = isIt ? { isIt, text: 'hey' } : { isIt, value: 123 };
+const cc: C = isIt ? { isIt: isIt, text: 'hey' } : { isIt: isIt, value: 123 };
+
+type ComponentProps =
+    | {
+        optionalBool: true;
+        mandatoryFn: () => void;
+    }
+    | {
+        optionalBool: false;
+    };
+
+let Funk = (_props: ComponentProps) => <div>Hello</div>;
+
+let Fail1 = () => <Funk mandatoryFn={() => { }} optionalBool={true} />
+let Fail2 = () => <Funk mandatoryFn={() => { }} optionalBool={true as true} />
+let True = true as true;
+let Fail3 = () => <Funk mandatoryFn={() => { }} optionalBool={True} />
+let attrs2 = { optionalBool: true as true, mandatoryFn: () => { } }
+let Success = () => <Funk {...attrs2} />

--- a/tests/cases/fourslash/findAllRefsForMappedType.ts
+++ b/tests/cases/fourslash/findAllRefsForMappedType.ts
@@ -15,5 +15,5 @@ verify.referenceGroups(r1, [
 ]);
 verify.referenceGroups(r2, [
     { definition: "(property) T.a: number", ranges: [r0, r1] },
-    { definition: "(property) a: boolean", ranges: [r2] }
+    { definition: "(property) a: true", ranges: [r2] }
 ]);


### PR DESCRIPTION
This removes the exception for `boolean` from the checks in `isLiteralOfContextualType`. This causes us to infer boolean literals in more places (as expected and sometimes necessary), but I don't see any tests broken by this change, so it seems fine.

Fixes #21436
Fixes #21427
