### PR TITLE
Rework how default vs local name selection is done for default symbols to be more correct

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -358,7 +358,7 @@ namespace ts {
             }
             else {
                 errorNameNode = declaration.name;
-                const format = TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback | TypeFormatFlags.WriteDefaultSymbolWithoutName |
+                const format = TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback |
                     TypeFormatFlags.WriteClassExpressionAsTypeLiteral |
                     (shouldUseResolverType ? TypeFormatFlags.AddUndefined : 0);
                 resolver.writeTypeOfDeclaration(declaration, enclosingDeclaration, format, writer);
@@ -378,7 +378,7 @@ namespace ts {
                 resolver.writeReturnTypeOfSignatureDeclaration(
                     signature,
                     enclosingDeclaration,
-                    TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback | TypeFormatFlags.WriteClassExpressionAsTypeLiteral | TypeFormatFlags.WriteDefaultSymbolWithoutName,
+                    TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback | TypeFormatFlags.WriteClassExpressionAsTypeLiteral,
                     writer);
                 errorNameNode = undefined;
             }
@@ -643,7 +643,7 @@ namespace ts {
             resolver.writeTypeOfExpression(
                 expr,
                 enclosingDeclaration,
-                TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback | TypeFormatFlags.WriteClassExpressionAsTypeLiteral | TypeFormatFlags.WriteDefaultSymbolWithoutName,
+                TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.UseStructuralFallback | TypeFormatFlags.WriteClassExpressionAsTypeLiteral,
                 writer);
             write(";");
             writeLine();

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2937,7 +2937,7 @@ namespace ts {
         // Options
         NoTruncation                            = 1 << 0,   // Don't truncate result
         WriteArrayAsGenericType                 = 1 << 1,   // Write Array<T> instead T[]
-        WriteDefaultSymbolWithoutName           = 1 << 2,   // Write `default`-named symbols as `default` instead of how they were written
+        // empty space
         UseStructuralFallback                   = 1 << 3,   // When an alias cannot be named by its symbol, rather than report an error, fallback to a structural printout if possible
         // empty space
         WriteTypeArgumentsOfSignature           = 1 << 5,   // Write the type arguments instead of type parameters of the signature
@@ -2965,6 +2965,7 @@ namespace ts {
         // State
         InObjectTypeLiteral                     = 1 << 22,
         InTypeAlias                             = 1 << 23,    // Writing type in type alias declaration
+        InInitialEntityName                     = 1 << 24,    // Set when writing the LHS of an entity name or entity name expression
     }
 
     // Ensure the shared flags between this and `NodeBuilderFlags` stay in alignment
@@ -2972,7 +2973,7 @@ namespace ts {
         None                                    = 0,
         NoTruncation                            = 1 << 0,  // Don't truncate typeToString result
         WriteArrayAsGenericType                 = 1 << 1,  // Write Array<T> instead T[]
-        WriteDefaultSymbolWithoutName           = 1 << 2,  // Write all `defaut`-named symbols as `default` instead of their written name
+        // hole because there's a hole in node builder flags
         UseStructuralFallback                   = 1 << 3,   // When an alias cannot be named by its symbol, rather than report an error, fallback to a structural printout if possible
         // hole because there's a hole in node builder flags
         WriteTypeArgumentsOfSignature           = 1 << 5,  // Write the type arguments instead of type parameters of the signature
@@ -3003,7 +3004,7 @@ namespace ts {
         /** @deprecated */ WriteOwnNameForAnyLike  = 0,  // Does nothing
 
         NodeBuilderFlagsMask =
-            NoTruncation | WriteArrayAsGenericType | WriteDefaultSymbolWithoutName | UseStructuralFallback | WriteTypeArgumentsOfSignature |
+            NoTruncation | WriteArrayAsGenericType | UseStructuralFallback | WriteTypeArgumentsOfSignature |
             UseFullyQualifiedType | SuppressAnyReturnType | MultilineObjectLiterals | WriteClassExpressionAsTypeLiteral |
             UseTypeOfFunction | OmitParameterModifiers | UseAliasDefinedOutsideCurrentScope | AllowUniqueESSymbolType | InTypeAlias,
     }
@@ -3024,6 +3025,9 @@ namespace ts {
 
         // Build symbol name using any nodes needed, instead of just components of an entity name
         AllowAnyNodeKind = 0x00000004,
+
+        // Prefer aliases which are not directly visible
+        UseAliasDefinedOutsideCurrentScope = 0x00000008,
     }
 
     /* @internal */

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -353,6 +353,7 @@ namespace ts.SignatureHelp {
         return children[indexOfOpenerToken + 1];
     }
 
+    const signatureHelpNodeBuilderFlags = NodeBuilderFlags.OmitParameterModifiers | NodeBuilderFlags.IgnoreErrors;
     function createSignatureHelpItems(candidates: Signature[], resolvedSignature: Signature, argumentListInfo: ArgumentListInfo, typeChecker: TypeChecker): SignatureHelpItems {
         const { argumentCount, argumentsSpan: applicableSpan, invocation, argumentIndex } = argumentListInfo;
         const isTypeParameterList = argumentListInfo.kind === ArgumentListKind.TypeArguments;
@@ -378,9 +379,8 @@ namespace ts.SignatureHelp {
                 signatureHelpParameters = typeParameters && typeParameters.length > 0 ? map(typeParameters, createSignatureHelpParameterForTypeParameter) : emptyArray;
                 suffixDisplayParts.push(punctuationPart(SyntaxKind.GreaterThanToken));
                 const parameterParts = mapToDisplayParts(writer => {
-                    const flags = NodeBuilderFlags.OmitParameterModifiers | NodeBuilderFlags.IgnoreErrors;
-                    const thisParameter = candidateSignature.thisParameter ? [typeChecker.symbolToParameterDeclaration(candidateSignature.thisParameter, invocation, flags)] : [];
-                    const params = createNodeArray([...thisParameter, ...map(candidateSignature.parameters, param => typeChecker.symbolToParameterDeclaration(param, invocation, flags))]);
+                    const thisParameter = candidateSignature.thisParameter ? [typeChecker.symbolToParameterDeclaration(candidateSignature.thisParameter, invocation, signatureHelpNodeBuilderFlags)] : [];
+                    const params = createNodeArray([...thisParameter, ...map(candidateSignature.parameters, param => typeChecker.symbolToParameterDeclaration(param, invocation, signatureHelpNodeBuilderFlags))]);
                     printer.writeList(ListFormat.CallExpressionArguments, params, getSourceFileOfNode(getParseTreeNode(invocation)), writer);
                 });
                 addRange(suffixDisplayParts, parameterParts);
@@ -435,7 +435,7 @@ namespace ts.SignatureHelp {
 
         function createSignatureHelpParameterForParameter(parameter: Symbol): SignatureHelpParameter {
             const displayParts = mapToDisplayParts(writer => {
-                const param = typeChecker.symbolToParameterDeclaration(parameter, invocation, NodeBuilderFlags.OmitParameterModifiers | NodeBuilderFlags.IgnoreErrors);
+                const param = typeChecker.symbolToParameterDeclaration(parameter, invocation, signatureHelpNodeBuilderFlags);
                 printer.writeNode(EmitHint.Unspecified, param, getSourceFileOfNode(getParseTreeNode(invocation)), writer);
             });
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1300,7 +1300,7 @@ namespace ts {
 
     export function symbolToDisplayParts(typeChecker: TypeChecker, symbol: Symbol, enclosingDeclaration?: Node, meaning?: SymbolFlags, flags?: SymbolFormatFlags): SymbolDisplayPart[] {
         return mapToDisplayParts(writer => {
-            typeChecker.writeSymbol(symbol, enclosingDeclaration, meaning, flags, writer);
+            typeChecker.writeSymbol(symbol, enclosingDeclaration, meaning, flags | SymbolFormatFlags.UseAliasDefinedOutsideCurrentScope, writer);
         });
     }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1799,7 +1799,6 @@ declare namespace ts {
         None = 0,
         NoTruncation = 1,
         WriteArrayAsGenericType = 2,
-        WriteDefaultSymbolWithoutName = 4,
         UseStructuralFallback = 8,
         WriteTypeArgumentsOfSignature = 32,
         UseFullyQualifiedType = 64,
@@ -1821,12 +1820,12 @@ declare namespace ts {
         IgnoreErrors = 3112960,
         InObjectTypeLiteral = 4194304,
         InTypeAlias = 8388608,
+        InInitialEntityName = 16777216,
     }
     enum TypeFormatFlags {
         None = 0,
         NoTruncation = 1,
         WriteArrayAsGenericType = 2,
-        WriteDefaultSymbolWithoutName = 4,
         UseStructuralFallback = 8,
         WriteTypeArgumentsOfSignature = 32,
         UseFullyQualifiedType = 64,
@@ -1844,13 +1843,14 @@ declare namespace ts {
         InFirstTypeArgument = 4194304,
         InTypeAlias = 8388608,
         /** @deprecated */ WriteOwnNameForAnyLike = 0,
-        NodeBuilderFlagsMask = 9469295,
+        NodeBuilderFlagsMask = 9469291,
     }
     enum SymbolFormatFlags {
         None = 0,
         WriteTypeParametersOrArguments = 1,
         UseOnlyExternalAliasing = 2,
         AllowAnyNodeKind = 4,
+        UseAliasDefinedOutsideCurrentScope = 8,
     }
     /**
      * @deprecated

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1799,7 +1799,6 @@ declare namespace ts {
         None = 0,
         NoTruncation = 1,
         WriteArrayAsGenericType = 2,
-        WriteDefaultSymbolWithoutName = 4,
         UseStructuralFallback = 8,
         WriteTypeArgumentsOfSignature = 32,
         UseFullyQualifiedType = 64,
@@ -1821,12 +1820,12 @@ declare namespace ts {
         IgnoreErrors = 3112960,
         InObjectTypeLiteral = 4194304,
         InTypeAlias = 8388608,
+        InInitialEntityName = 16777216,
     }
     enum TypeFormatFlags {
         None = 0,
         NoTruncation = 1,
         WriteArrayAsGenericType = 2,
-        WriteDefaultSymbolWithoutName = 4,
         UseStructuralFallback = 8,
         WriteTypeArgumentsOfSignature = 32,
         UseFullyQualifiedType = 64,
@@ -1844,13 +1843,14 @@ declare namespace ts {
         InFirstTypeArgument = 4194304,
         InTypeAlias = 8388608,
         /** @deprecated */ WriteOwnNameForAnyLike = 0,
-        NodeBuilderFlagsMask = 9469295,
+        NodeBuilderFlagsMask = 9469291,
     }
     enum SymbolFormatFlags {
         None = 0,
         WriteTypeParametersOrArguments = 1,
         UseOnlyExternalAliasing = 2,
         AllowAnyNodeKind = 4,
+        UseAliasDefinedOutsideCurrentScope = 8,
     }
     /**
      * @deprecated

--- a/tests/baselines/reference/declarationEmitTypeofDefaultExport.symbols
+++ b/tests/baselines/reference/declarationEmitTypeofDefaultExport.symbols
@@ -7,7 +7,7 @@ import * as a from "./a";
 >a : Symbol(a, Decl(b.ts, 0, 6))
 
 export default a.default;
->a.default : Symbol(a.C, Decl(a.ts, 0, 0))
+>a.default : Symbol(a.default, Decl(a.ts, 0, 0))
 >a : Symbol(a, Decl(b.ts, 0, 6))
->default : Symbol(a.C, Decl(a.ts, 0, 0))
+>default : Symbol(a.default, Decl(a.ts, 0, 0))
 

--- a/tests/baselines/reference/declarationEmitTypeofDefaultExport.types
+++ b/tests/baselines/reference/declarationEmitTypeofDefaultExport.types
@@ -7,7 +7,7 @@ import * as a from "./a";
 >a : typeof a
 
 export default a.default;
->a.default : typeof a.C
+>a.default : typeof a.default
 >a : typeof a
->default : typeof a.C
+>default : typeof a.default
 

--- a/tests/baselines/reference/defaultDeclarationEmitDefaultImport.js
+++ b/tests/baselines/reference/defaultDeclarationEmitDefaultImport.js
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts] ////
+
+//// [root.ts]
+export function getSomething(): Something { return null as any }
+export default class Something {}
+//// [main.ts]
+import Thing, { getSomething } from "./root";
+export const instance = getSomething();
+
+
+//// [root.js]
+"use strict";
+exports.__esModule = true;
+function getSomething() { return null; }
+exports.getSomething = getSomething;
+var Something = /** @class */ (function () {
+    function Something() {
+    }
+    return Something;
+}());
+exports["default"] = Something;
+//// [main.js]
+"use strict";
+exports.__esModule = true;
+var root_1 = require("./root");
+exports.instance = root_1.getSomething();
+
+
+//// [root.d.ts]
+export declare function getSomething(): Something;
+export default class Something {
+}
+//// [main.d.ts]
+import Thing from "./root";
+export declare const instance: Thing;

--- a/tests/baselines/reference/defaultDeclarationEmitDefaultImport.symbols
+++ b/tests/baselines/reference/defaultDeclarationEmitDefaultImport.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/root.ts ===
+export function getSomething(): Something { return null as any }
+>getSomething : Symbol(getSomething, Decl(root.ts, 0, 0))
+>Something : Symbol(Something, Decl(root.ts, 0, 64))
+
+export default class Something {}
+>Something : Symbol(Something, Decl(root.ts, 0, 64))
+
+=== tests/cases/compiler/main.ts ===
+import Thing, { getSomething } from "./root";
+>Thing : Symbol(Thing, Decl(main.ts, 0, 6))
+>getSomething : Symbol(getSomething, Decl(main.ts, 0, 15))
+
+export const instance = getSomething();
+>instance : Symbol(instance, Decl(main.ts, 1, 12))
+>getSomething : Symbol(getSomething, Decl(main.ts, 0, 15))
+

--- a/tests/baselines/reference/defaultDeclarationEmitDefaultImport.types
+++ b/tests/baselines/reference/defaultDeclarationEmitDefaultImport.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/root.ts ===
+export function getSomething(): Something { return null as any }
+>getSomething : () => Something
+>Something : Something
+>null as any : any
+>null : null
+
+export default class Something {}
+>Something : Something
+
+=== tests/cases/compiler/main.ts ===
+import Thing, { getSomething } from "./root";
+>Thing : typeof Thing
+>getSomething : () => Thing
+
+export const instance = getSomething();
+>instance : Thing
+>getSomething() : Thing
+>getSomething : () => Thing
+

--- a/tests/baselines/reference/defaultDeclarationEmitNamedCorrectly.js
+++ b/tests/baselines/reference/defaultDeclarationEmitNamedCorrectly.js
@@ -1,0 +1,49 @@
+//// [defaultDeclarationEmitNamedCorrectly.ts]
+export interface Things<P, T> {
+    p: P;
+    t: T;
+}
+export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
+    return null as any;
+}
+
+export interface Props {
+}
+
+export default class MyComponent {
+    props: Props;
+    static create = make(MyComponent);
+}
+
+//// [defaultDeclarationEmitNamedCorrectly.js]
+"use strict";
+exports.__esModule = true;
+function make(x) {
+    return null;
+}
+exports.make = make;
+var MyComponent = /** @class */ (function () {
+    function MyComponent() {
+    }
+    MyComponent.create = make(MyComponent);
+    return MyComponent;
+}());
+exports["default"] = MyComponent;
+
+
+//// [defaultDeclarationEmitNamedCorrectly.d.ts]
+export interface Things<P, T> {
+    p: P;
+    t: T;
+}
+export declare function make<P, CTor>(x: {
+    new (): CTor & {
+        props: P;
+    };
+}): Things<P, CTor>;
+export interface Props {
+}
+export default class MyComponent {
+    props: Props;
+    static create: Things<Props, MyComponent>;
+}

--- a/tests/baselines/reference/defaultDeclarationEmitNamedCorrectly.symbols
+++ b/tests/baselines/reference/defaultDeclarationEmitNamedCorrectly.symbols
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts ===
+export interface Things<P, T> {
+>Things : Symbol(Things, Decl(defaultDeclarationEmitNamedCorrectly.ts, 0, 0))
+>P : Symbol(P, Decl(defaultDeclarationEmitNamedCorrectly.ts, 0, 24))
+>T : Symbol(T, Decl(defaultDeclarationEmitNamedCorrectly.ts, 0, 26))
+
+    p: P;
+>p : Symbol(Things.p, Decl(defaultDeclarationEmitNamedCorrectly.ts, 0, 31))
+>P : Symbol(P, Decl(defaultDeclarationEmitNamedCorrectly.ts, 0, 24))
+
+    t: T;
+>t : Symbol(Things.t, Decl(defaultDeclarationEmitNamedCorrectly.ts, 1, 9))
+>T : Symbol(T, Decl(defaultDeclarationEmitNamedCorrectly.ts, 0, 26))
+}
+export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
+>make : Symbol(make, Decl(defaultDeclarationEmitNamedCorrectly.ts, 3, 1))
+>P : Symbol(P, Decl(defaultDeclarationEmitNamedCorrectly.ts, 4, 21))
+>CTor : Symbol(CTor, Decl(defaultDeclarationEmitNamedCorrectly.ts, 4, 23))
+>x : Symbol(x, Decl(defaultDeclarationEmitNamedCorrectly.ts, 4, 30))
+>CTor : Symbol(CTor, Decl(defaultDeclarationEmitNamedCorrectly.ts, 4, 23))
+>props : Symbol(props, Decl(defaultDeclarationEmitNamedCorrectly.ts, 4, 51))
+>P : Symbol(P, Decl(defaultDeclarationEmitNamedCorrectly.ts, 4, 21))
+>Things : Symbol(Things, Decl(defaultDeclarationEmitNamedCorrectly.ts, 0, 0))
+>P : Symbol(P, Decl(defaultDeclarationEmitNamedCorrectly.ts, 4, 21))
+>CTor : Symbol(CTor, Decl(defaultDeclarationEmitNamedCorrectly.ts, 4, 23))
+
+    return null as any;
+}
+
+export interface Props {
+>Props : Symbol(Props, Decl(defaultDeclarationEmitNamedCorrectly.ts, 6, 1))
+}
+
+export default class MyComponent {
+>MyComponent : Symbol(MyComponent, Decl(defaultDeclarationEmitNamedCorrectly.ts, 9, 1))
+
+    props: Props;
+>props : Symbol(MyComponent.props, Decl(defaultDeclarationEmitNamedCorrectly.ts, 11, 34))
+>Props : Symbol(Props, Decl(defaultDeclarationEmitNamedCorrectly.ts, 6, 1))
+
+    static create = make(MyComponent);
+>create : Symbol(MyComponent.create, Decl(defaultDeclarationEmitNamedCorrectly.ts, 12, 17))
+>make : Symbol(make, Decl(defaultDeclarationEmitNamedCorrectly.ts, 3, 1))
+>MyComponent : Symbol(MyComponent, Decl(defaultDeclarationEmitNamedCorrectly.ts, 9, 1))
+}

--- a/tests/baselines/reference/defaultDeclarationEmitNamedCorrectly.types
+++ b/tests/baselines/reference/defaultDeclarationEmitNamedCorrectly.types
@@ -1,0 +1,48 @@
+=== tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts ===
+export interface Things<P, T> {
+>Things : Things<P, T>
+>P : P
+>T : T
+
+    p: P;
+>p : P
+>P : P
+
+    t: T;
+>t : T
+>T : T
+}
+export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
+>make : <P, CTor>(x: new () => CTor & { props: P; }) => Things<P, CTor>
+>P : P
+>CTor : CTor
+>x : new () => CTor & { props: P; }
+>CTor : CTor
+>props : P
+>P : P
+>Things : Things<P, T>
+>P : P
+>CTor : CTor
+
+    return null as any;
+>null as any : any
+>null : null
+}
+
+export interface Props {
+>Props : Props
+}
+
+export default class MyComponent {
+>MyComponent : MyComponent
+
+    props: Props;
+>props : Props
+>Props : Props
+
+    static create = make(MyComponent);
+>create : Things<Props, MyComponent>
+>make(MyComponent) : Things<Props, MyComponent>
+>make : <P, CTor>(x: new () => CTor & { props: P; }) => Things<P, CTor>
+>MyComponent : typeof MyComponent
+}

--- a/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.js
+++ b/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.js
@@ -1,0 +1,61 @@
+//// [this.ts]
+import * as me from "./this";
+export interface Things<P, T> {
+    p: P;
+    t: T;
+}
+export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
+    return null as any;
+}
+
+export interface Props {
+}
+
+export default class MyComponent {
+    props: Props;
+}
+export namespace Something {
+    let MyComponent = 2; // Shadow declaration, so symbol is only usable via the self-import
+    export const create = make(me.default);
+}
+
+//// [this.js]
+"use strict";
+exports.__esModule = true;
+var me = require("./this");
+function make(x) {
+    return null;
+}
+exports.make = make;
+var MyComponent = /** @class */ (function () {
+    function MyComponent() {
+    }
+    return MyComponent;
+}());
+exports["default"] = MyComponent;
+var Something;
+(function (Something) {
+    var MyComponent = 2; // Shadow declaration, so symbol is only usable via the self-import
+    Something.create = make(me["default"]);
+})(Something = exports.Something || (exports.Something = {}));
+
+
+//// [this.d.ts]
+import * as me from "./this";
+export interface Things<P, T> {
+    p: P;
+    t: T;
+}
+export declare function make<P, CTor>(x: {
+    new (): CTor & {
+        props: P;
+    };
+}): Things<P, CTor>;
+export interface Props {
+}
+export default class MyComponent {
+    props: Props;
+}
+export declare namespace Something {
+    const create: me.Things<me.Props, me.default>;
+}

--- a/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.symbols
+++ b/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.symbols
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/this.ts ===
+import * as me from "./this";
+>me : Symbol(me, Decl(this.ts, 0, 6))
+
+export interface Things<P, T> {
+>Things : Symbol(me.Things, Decl(this.ts, 0, 29))
+>P : Symbol(P, Decl(this.ts, 1, 24))
+>T : Symbol(T, Decl(this.ts, 1, 26))
+
+    p: P;
+>p : Symbol(me.Things.p, Decl(this.ts, 1, 31))
+>P : Symbol(P, Decl(this.ts, 1, 24))
+
+    t: T;
+>t : Symbol(me.Things.t, Decl(this.ts, 2, 9))
+>T : Symbol(T, Decl(this.ts, 1, 26))
+}
+export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
+>make : Symbol(me.make, Decl(this.ts, 4, 1))
+>P : Symbol(P, Decl(this.ts, 5, 21))
+>CTor : Symbol(CTor, Decl(this.ts, 5, 23))
+>x : Symbol(x, Decl(this.ts, 5, 30))
+>CTor : Symbol(CTor, Decl(this.ts, 5, 23))
+>props : Symbol(props, Decl(this.ts, 5, 51))
+>P : Symbol(P, Decl(this.ts, 5, 21))
+>Things : Symbol(me.Things, Decl(this.ts, 0, 29))
+>P : Symbol(P, Decl(this.ts, 5, 21))
+>CTor : Symbol(CTor, Decl(this.ts, 5, 23))
+
+    return null as any;
+}
+
+export interface Props {
+>Props : Symbol(me.Props, Decl(this.ts, 7, 1))
+}
+
+export default class MyComponent {
+>MyComponent : Symbol(me.default, Decl(this.ts, 10, 1))
+
+    props: Props;
+>props : Symbol(me.default.props, Decl(this.ts, 12, 34))
+>Props : Symbol(me.Props, Decl(this.ts, 7, 1))
+}
+export namespace Something {
+>Something : Symbol(me.Something, Decl(this.ts, 14, 1))
+
+    let MyComponent = 2; // Shadow declaration, so symbol is only usable via the self-import
+>MyComponent : Symbol(MyComponent, Decl(this.ts, 16, 7))
+
+    export const create = make(me.default);
+>create : Symbol(create, Decl(this.ts, 17, 16))
+>make : Symbol(me.make, Decl(this.ts, 4, 1))
+>me.default : Symbol(me.default, Decl(this.ts, 10, 1))
+>me : Symbol(me, Decl(this.ts, 0, 6))
+>default : Symbol(me.default, Decl(this.ts, 10, 1))
+}

--- a/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.types
+++ b/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.types
@@ -1,0 +1,60 @@
+=== tests/cases/compiler/this.ts ===
+import * as me from "./this";
+>me : typeof me
+
+export interface Things<P, T> {
+>Things : me.Things<P, T>
+>P : P
+>T : T
+
+    p: P;
+>p : P
+>P : P
+
+    t: T;
+>t : T
+>T : T
+}
+export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
+>make : <P, CTor>(x: new () => CTor & { props: P; }) => me.Things<P, CTor>
+>P : P
+>CTor : CTor
+>x : new () => CTor & { props: P; }
+>CTor : CTor
+>props : P
+>P : P
+>Things : me.Things<P, T>
+>P : P
+>CTor : CTor
+
+    return null as any;
+>null as any : any
+>null : null
+}
+
+export interface Props {
+>Props : me.Props
+}
+
+export default class MyComponent {
+>MyComponent : me.default
+
+    props: Props;
+>props : me.Props
+>Props : me.Props
+}
+export namespace Something {
+>Something : typeof me.Something
+
+    let MyComponent = 2; // Shadow declaration, so symbol is only usable via the self-import
+>MyComponent : number
+>2 : 2
+
+    export const create = make(me.default);
+>create : me.Things<me.Props, me.default>
+>make(me.default) : me.Things<me.Props, me.default>
+>make : <P, CTor>(x: new () => CTor & { props: P; }) => me.Things<P, CTor>
+>me.default : typeof me.default
+>me : typeof me
+>default : typeof me.default
+}

--- a/tests/baselines/reference/duplicatePackage.types
+++ b/tests/baselines/reference/duplicatePackage.types
@@ -1,22 +1,22 @@
 === /src/a.ts ===
 import { a } from "a";
->a : (x: X) => void
+>a : (x: default) => void
 
 import { b } from "b";
->b : X
+>b : default
 
 import { c } from "c";
->c : X
+>c : default
 
 a(b); // Works
 >a(b) : void
->a : (x: X) => void
->b : X
+>a : (x: default) => void
+>b : default
 
 a(c); // Error, these are from different versions of the library.
 >a(c) : void
->a : (x: X) => void
->c : X
+>a : (x: default) => void
+>c : default
 
 === /node_modules/a/index.d.ts ===
 import X from "x";

--- a/tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts
+++ b/tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts
@@ -1,0 +1,7 @@
+// @declaration: true
+// @filename: root.ts
+export function getSomething(): Something { return null as any }
+export default class Something {}
+// @filename: main.ts
+import Thing, { getSomething } from "./root";
+export const instance = getSomething();

--- a/tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts
+++ b/tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts
@@ -1,0 +1,16 @@
+// @declaration: true
+export interface Things<P, T> {
+    p: P;
+    t: T;
+}
+export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
+    return null as any;
+}
+
+export interface Props {
+}
+
+export default class MyComponent {
+    props: Props;
+    static create = make(MyComponent);
+}

--- a/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
+++ b/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
@@ -1,0 +1,21 @@
+// @declaration: true
+// @filename: this.ts
+import * as me from "./this";
+export interface Things<P, T> {
+    p: P;
+    t: T;
+}
+export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
+    return null as any;
+}
+
+export interface Props {
+}
+
+export default class MyComponent {
+    props: Props;
+}
+export namespace Something {
+    let MyComponent = 2; // Shadow declaration, so symbol is only usable via the self-import
+    export const create = make(me.default);
+}


### PR DESCRIPTION
Fixes #21520

In merging the symbol display builder and node builder, I had to add a flag to control how `default` was printed in order to shim some behavior that the services layer expected; however the way I did so was somewhat incomplete, as it turns out (it was missing many conditions required for correct emit for the declaration emitter - though it was correct for signature help). Now, rather than a single flag, we check those conditions, and reuse another flag already in-use within the services layer to indicate that we want a non-visible name for the symbol. This causes some minor changes to two of our type/symbol baselines which seem to actually be more correct than the old output.