### PR TITLE
Don't treat class name contextToken as a completion list blocker if it is not the previousToken

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1921,7 +1921,8 @@ namespace ts.Completions {
             return isDeclarationName(contextToken)
                 && !isJsxAttribute(contextToken.parent)
                 // Don't block completions if we're in `class C /**/`, because we're *past* the end of the identifier and might want to complete `extends`.
-                && !(isClassLike(contextToken.parent) && position > previousToken.end);
+                // If `contextToken !== previousToken`, this is `class C ex/**/`.
+                && !(isClassLike(contextToken.parent) && (contextToken !== previousToken || position > previousToken.end));
         }
 
         function isFunctionLikeButNotConstructor(kind: SyntaxKind) {

--- a/tests/cases/fourslash/completionsKeywordsExtends.ts
+++ b/tests/cases/fourslash/completionsKeywordsExtends.ts
@@ -1,6 +1,7 @@
 /// <reference path="fourslash.ts" />
 
 ////class C/*a*/ /*b*/ { }
+////class C e/*c*/ {}
 
 // Tests that `isCompletionListBlocker` is true *at* the class name, but false *after* it.
 
@@ -8,4 +9,7 @@ goTo.marker("a");
 verify.completionListIsEmpty();
 
 goTo.marker("b");
+verify.completionListContains("extends");
+
+goTo.marker("c");
 verify.completionListContains("extends");


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/20758#issuecomment-362276881
Sequel to #20762