### PR TITLE
Fix crash by leveraging existing function for finding spread validity

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17603,7 +17603,7 @@ namespace ts {
                         const anonymousSymbol = createSymbol(SymbolFlags.TypeLiteral, InternalSymbolName.Type);
                         const defaultContainingObject = createAnonymousType(anonymousSymbol, memberTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
                         anonymousSymbol.type = defaultContainingObject;
-                        synthType.syntheticType = (type.flags & TypeFlags.StructuredType && type.symbol.flags & (SymbolFlags.Module | SymbolFlags.Variable)) ? getSpreadType(type, defaultContainingObject, anonymousSymbol, /*propegatedFlags*/ 0) : defaultContainingObject;
+                        synthType.syntheticType = isValidSpreadType(type) ? getSpreadType(type, defaultContainingObject, anonymousSymbol, /*propegatedFlags*/ 0) : defaultContainingObject;
                     }
                     else {
                         synthType.syntheticType = type;

--- a/tests/baselines/reference/esModuleIntersectionCrash.js
+++ b/tests/baselines/reference/esModuleIntersectionCrash.js
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/esModuleIntersectionCrash.ts] ////
+
+//// [mod.d.ts]
+export = modObj;
+declare const modObj: modObj.A & modObj.B;
+declare namespace modObj {
+    interface A { (): void; a: string; }
+    interface B { (x: string): void; b: string; }
+}
+//// [idx.ts]
+import * as mod from "./mod";
+mod.a;
+mod.b;
+
+//// [idx.js]
+"use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+}
+exports.__esModule = true;
+var mod = __importStar(require("./mod"));
+mod.a;
+mod.b;

--- a/tests/baselines/reference/esModuleIntersectionCrash.symbols
+++ b/tests/baselines/reference/esModuleIntersectionCrash.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/mod.d.ts ===
+export = modObj;
+>modObj : Symbol(modObj, Decl(mod.d.ts, 1, 13), Decl(mod.d.ts, 1, 42))
+
+declare const modObj: modObj.A & modObj.B;
+>modObj : Symbol(modObj, Decl(mod.d.ts, 1, 13), Decl(mod.d.ts, 1, 42))
+>modObj : Symbol(modObj, Decl(mod.d.ts, 1, 13), Decl(mod.d.ts, 1, 42))
+>A : Symbol(modObj.A, Decl(mod.d.ts, 2, 26))
+>modObj : Symbol(modObj, Decl(mod.d.ts, 1, 13), Decl(mod.d.ts, 1, 42))
+>B : Symbol(modObj.B, Decl(mod.d.ts, 3, 40))
+
+declare namespace modObj {
+>modObj : Symbol(modObj, Decl(mod.d.ts, 1, 13), Decl(mod.d.ts, 1, 42))
+
+    interface A { (): void; a: string; }
+>A : Symbol(A, Decl(mod.d.ts, 2, 26))
+>a : Symbol(A.a, Decl(mod.d.ts, 3, 27))
+
+    interface B { (x: string): void; b: string; }
+>B : Symbol(B, Decl(mod.d.ts, 3, 40))
+>x : Symbol(x, Decl(mod.d.ts, 4, 19))
+>b : Symbol(B.b, Decl(mod.d.ts, 4, 36))
+}
+=== tests/cases/compiler/idx.ts ===
+import * as mod from "./mod";
+>mod : Symbol(mod, Decl(idx.ts, 0, 6))
+
+mod.a;
+>mod.a : Symbol(mod.A.a, Decl(mod.d.ts, 3, 27))
+>mod : Symbol(mod, Decl(idx.ts, 0, 6))
+>a : Symbol(mod.A.a, Decl(mod.d.ts, 3, 27))
+
+mod.b;
+>mod.b : Symbol(mod.B.b, Decl(mod.d.ts, 4, 36))
+>mod : Symbol(mod, Decl(idx.ts, 0, 6))
+>b : Symbol(mod.B.b, Decl(mod.d.ts, 4, 36))
+

--- a/tests/baselines/reference/esModuleIntersectionCrash.types
+++ b/tests/baselines/reference/esModuleIntersectionCrash.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/mod.d.ts ===
+export = modObj;
+>modObj : modObj.A & modObj.B
+
+declare const modObj: modObj.A & modObj.B;
+>modObj : modObj.A & modObj.B
+>modObj : any
+>A : modObj.A
+>modObj : any
+>B : modObj.B
+
+declare namespace modObj {
+>modObj : A & B
+
+    interface A { (): void; a: string; }
+>A : A
+>a : string
+
+    interface B { (x: string): void; b: string; }
+>B : B
+>x : string
+>b : string
+}
+=== tests/cases/compiler/idx.ts ===
+import * as mod from "./mod";
+>mod : { default: mod.A & mod.B; a: string; b: string; }
+
+mod.a;
+>mod.a : string
+>mod : { default: mod.A & mod.B; a: string; b: string; }
+>a : string
+
+mod.b;
+>mod.b : string
+>mod : { default: mod.A & mod.B; a: string; b: string; }
+>b : string
+

--- a/tests/cases/compiler/esModuleIntersectionCrash.ts
+++ b/tests/cases/compiler/esModuleIntersectionCrash.ts
@@ -1,0 +1,12 @@
+// @esModuleInterop: true
+// @filename: mod.d.ts
+export = modObj;
+declare const modObj: modObj.A & modObj.B;
+declare namespace modObj {
+    interface A { (): void; a: string; }
+    interface B { (x: string): void; b: string; }
+}
+// @filename: idx.ts
+import * as mod from "./mod";
+mod.a;
+mod.b;


### PR DESCRIPTION
Fixes #21554

An intersection type with no alias has no symbol, which triggered the above bug. Now, this PR just leverages an existing function for checking the validity of a type in a spread, rather than attempting to infer from the type's symbol if it could be spread. This is potentially more work than is required (since module exports are all top level types, we know that many generic types can't exist, so don't need to bother checking), but is better because of the consolidation of functionality.