### PR TITLE
Detect and prevent creation of bad Identifier

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5891,7 +5891,7 @@ namespace ts {
 
     /** True if node is of a kind that may contain comment text. */
     export function isJSDocCommentContainingNode(node: Node): boolean {
-        return node.kind === SyntaxKind.JSDocComment || isJSDocTag(node);
+        return node.kind === SyntaxKind.JSDocComment || isJSDocTag(node) || isJSDocTypeLiteral(node);
     }
 
     // TODO: determine what this does before making it public.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -114,12 +114,15 @@ namespace ts {
             return sourceFile.text.substring(this.getStart(sourceFile), this.getEnd());
         }
 
-        private addSyntheticNodes(nodes: Node[], pos: number, end: number): number {
+        private addSyntheticNodes(nodes: Push<Node>, pos: number, end: number): number {
             scanner.setTextPos(pos);
             while (pos < end) {
                 const token = scanner.scan();
                 const textPos = scanner.getTextPos();
                 if (textPos <= end) {
+                    if (token === SyntaxKind.Identifier) {
+                        Debug.fail(`Did not expect ${(ts as any).SyntaxKind[this.kind]} to have an Identifier in its trivia`);
+                    }
                     nodes.push(createNode(token, pos, textPos, this));
                 }
                 pos = textPos;

--- a/tests/cases/fourslash/findAllReferencesJsDocTypeLiteral.ts
+++ b/tests/cases/fourslash/findAllReferencesJsDocTypeLiteral.ts
@@ -14,9 +14,3 @@
 //// function f(o) { return o.nested.[|great|]; }
 
 verify.rangesReferenceEachOther();
-
-///**
-// * @param {object} [|o|] - very important!
-// * @param {string} o.x - a thing, its ok
-// */
-// function f([|o|]) { return [|o|].x; }


### PR DESCRIPTION
Fixes #20792
In `Node.getChildren()` we create synthetic nodes for all of the tokens that weren't parsed. This can cause a problem if we scan an `Identifier` because we don't give it any text here (and besides, an Identifier shouldn't be trivia). After adding an assertion and running all tests, I found that there was one kind of jsdoc node which we weren't avoiding scanning trivia for -- we need to avoid scanning trivia for these because arbitrary tokens could appear in a comment.
