### PR TITLE
Avoid an expression getting a contextual type from its own inferred type

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1433,4 +1433,13 @@ namespace ts {
             }
         }
     }
+
+    export function getContextualType(node: Expression, checker: TypeChecker) {
+        const type = checker.getContextualType(node);
+        // It's possible that we'll get a contextual type that comes from the current object itself.
+        // For example: `function id<T>(a: T): void; a({ x: 0 })`.
+        // The contextual type of `{ x: 0 }` would come from the inferred type argument, which comes from the type of the object.
+        const declarations = type && type.symbol && type.symbol.declarations;
+        return length(declarations) === 1 && first(declarations!) === <Declaration | Expression>node ? undefined : type;
+    }
 }

--- a/tests/cases/fourslash/completionsObjectWithSelfAsContextualType.ts
+++ b/tests/cases/fourslash/completionsObjectWithSelfAsContextualType.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+// Test that we don't use the contexual type `{ x: any }` from the inferred type argument to `id`,
+// since that comes from the object itself.
+
+////declare function id<T>(a: T): void;
+////id({ x/**/ });
+
+goTo.marker("");
+verify.completionListIsEmpty();


### PR DESCRIPTION
Fixes #21580
Currently a services-only change. Would have liked to change this in `getContextualTypeForArgument`, but that affects some types baselines based on this situation:
```ts
declare function id<T>(a: T): T;
const x = () => false; // () => boolean
const y = id(() => false); // () => false
```
Something with a contextual type will not have literal types widened -- even if the contextual type is itself. If we avoided the contextual type in this case it would be a breaking change, although I think we only recently started doing this in the first place. CC @weswigham