### PR TITLE
Fix initializer assignability for unique symbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8249,7 +8249,7 @@ namespace ts {
             if (isValidESSymbolDeclaration(node)) {
                 const symbol = getSymbolOfNode(node);
                 const links = getSymbolLinks(symbol);
-                return links.type || (links.type = createUniqueESSymbolType(symbol));
+                return links.uniqueESSymbolType || (links.uniqueESSymbolType = createUniqueESSymbolType(symbol));
             }
             return esSymbolType;
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3294,6 +3294,7 @@ namespace ts {
         immediateTarget?: Symbol;           // Immediate target of an alias. May be another alias. Do not access directly, use `checker.getImmediateAliasedSymbol` instead.
         target?: Symbol;                    // Resolved (non-alias) target of an alias
         type?: Type;                        // Type of value symbol
+        uniqueESSymbolType?: Type;          // UniqueESSymbol type for a symbol
         declaredType?: Type;                // Type of class, interface, enum, type alias, or type parameter
         typeParameters?: TypeParameter[];   // Type parameters of type alias (undefined if non-generic)
         inferredClassType?: Type;           // Type of an inferred ES5 class

--- a/tests/baselines/reference/uniqueSymbolsErrors.errors.txt
+++ b/tests/baselines/reference/uniqueSymbolsErrors.errors.txt
@@ -58,9 +58,10 @@ tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(82,29): error 
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(82,45): error TS1335: 'unique symbol' types are not allowed here.
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(83,36): error TS1335: 'unique symbol' types are not allowed here.
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(83,52): error TS1335: 'unique symbol' types are not allowed here.
+tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(87,7): error TS2322: Type 'unique symbol' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts (60 errors) ====
+==== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts (61 errors) ====
     // declarations
     declare const invalidUniqueType: unique number;
                                             ~~~~~~
@@ -265,5 +266,8 @@ tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(83,52): error 
                                                        ~~~~~~~~~~~~~
 !!! error TS1335: 'unique symbol' types are not allowed here.
     
-    
-    
+    // initializer assignability
+    // https://github.com/Microsoft/TypeScript/issues/21584
+    const shouldNotBeAssignable: string = Symbol();
+          ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'unique symbol' is not assignable to type 'string'.

--- a/tests/baselines/reference/uniqueSymbolsErrors.js
+++ b/tests/baselines/reference/uniqueSymbolsErrors.js
@@ -83,8 +83,9 @@ declare const invalidMappedType: { [P in string]: unique symbol };
 declare const invalidUnion: unique symbol | unique symbol;
 declare const invalidIntersection: unique symbol | unique symbol;
 
-
-
+// initializer assignability
+// https://github.com/Microsoft/TypeScript/issues/21584
+const shouldNotBeAssignable: string = Symbol();
 
 //// [uniqueSymbolsErrors.js]
 // classes
@@ -109,3 +110,6 @@ class InvalidClass {
     static get invalidStaticGetter() { return; }
     static set invalidStaticSetter(arg) { return; }
 }
+// initializer assignability
+// https://github.com/Microsoft/TypeScript/issues/21584
+const shouldNotBeAssignable = Symbol();

--- a/tests/baselines/reference/uniqueSymbolsErrors.symbols
+++ b/tests/baselines/reference/uniqueSymbolsErrors.symbols
@@ -234,5 +234,9 @@ declare const invalidUnion: unique symbol | unique symbol;
 declare const invalidIntersection: unique symbol | unique symbol;
 >invalidIntersection : Symbol(invalidIntersection, Decl(uniqueSymbolsErrors.ts, 82, 13))
 
-
+// initializer assignability
+// https://github.com/Microsoft/TypeScript/issues/21584
+const shouldNotBeAssignable: string = Symbol();
+>shouldNotBeAssignable : Symbol(shouldNotBeAssignable, Decl(uniqueSymbolsErrors.ts, 86, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 

--- a/tests/baselines/reference/uniqueSymbolsErrors.types
+++ b/tests/baselines/reference/uniqueSymbolsErrors.types
@@ -234,5 +234,10 @@ declare const invalidUnion: unique symbol | unique symbol;
 declare const invalidIntersection: unique symbol | unique symbol;
 >invalidIntersection : symbol
 
-
+// initializer assignability
+// https://github.com/Microsoft/TypeScript/issues/21584
+const shouldNotBeAssignable: string = Symbol();
+>shouldNotBeAssignable : string
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
 

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts
@@ -84,4 +84,6 @@ declare const invalidMappedType: { [P in string]: unique symbol };
 declare const invalidUnion: unique symbol | unique symbol;
 declare const invalidIntersection: unique symbol | unique symbol;
 
-
+// initializer assignability
+// https://github.com/Microsoft/TypeScript/issues/21584
+const shouldNotBeAssignable: string = Symbol();


### PR DESCRIPTION
Uses a separate property on `SymbolLinks` to hold the unique symbol type of a node so as not to collide with a type annotation on the node.

Fixes #21584
