### PR TITLE
Ignore specified error in //@ts-ignore

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3,7 +3,7 @@
 /// <reference path="core.ts" />
 
 namespace ts {
-    const ignoreDiagnosticCommentRegEx = /(^\s*$)|(^\s*\/\/\/?\s*(@ts-ignore)?)/;
+    const ignoreDiagnosticCommentRegEx = /(^\s*$)|(^\s*\/\/\/?\s*(@ts-ignore)?(?:\s+((?:(?:TS\d+),\s*)*(?:TS\d+)?))?)/;
 
     export function findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean, configName = "tsconfig.json"): string | undefined {
         return forEachAncestorDirectory(searchPath, ancestor => {
@@ -1323,7 +1323,12 @@ namespace ts {
                     }
                     if (result[3]) {
                         // @ts-ignore
-                        return false;
+                        const ignoreOptions = result[4];
+                        if (ignoreOptions) {
+                            return ignoreOptions.indexOf('TS'+diagnostic.code) === -1;
+                        } else {
+                            return false;
+                        }
                     }
                     line--;
                 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3,7 +3,7 @@
 /// <reference path="core.ts" />
 
 namespace ts {
-    const ignoreDiagnosticCommentRegEx = /(^\s*$)|(^\s*\/\/\/?\s*(@ts-ignore)?(?:\s+((?:(?:TS\d+),\s*)*TS\d+))?)/;
+    const ignoreDiagnosticCommentRegEx = /(^\s*$)|(^\s*\/\/\/?\s*(@ts-ignore)?(?:\s+((?:(?:TS\d+)\s*,\s*)*TS\d+))?)/;
 
     export function findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean, configName = "tsconfig.json"): string | undefined {
         return forEachAncestorDirectory(searchPath, ancestor => {
@@ -1325,7 +1325,8 @@ namespace ts {
                         // @ts-ignore
                         const ignoreOptions = result[4];
                         if (ignoreOptions) {
-                            return ignoreOptions.indexOf("TS" + diagnostic.code) === -1;
+                            const errorCodes = ignoreOptions.split(/\s*,\s*/g);
+                            return errorCodes.indexOf("TS" + diagnostic.code) === -1;
                         }
                         return false;
                     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1110,7 +1110,7 @@ namespace ts {
             // otherwise, using options specified in '--lib' instead of '--target' default library file
             const equalityComparer = host.useCaseSensitiveFileNames() ? equateStringsCaseSensitive : equateStringsCaseInsensitive;
             if (!options.lib) {
-               return equalityComparer(file.fileName, getDefaultLibraryFileName());
+                return equalityComparer(file.fileName, getDefaultLibraryFileName());
             }
             else {
                 return forEach(options.lib, libFileName => equalityComparer(file.fileName, combinePaths(defaultLibraryPath, libFileName)));
@@ -1325,10 +1325,9 @@ namespace ts {
                         // @ts-ignore
                         const ignoreOptions = result[4];
                         if (ignoreOptions) {
-                            return ignoreOptions.indexOf('TS'+diagnostic.code) === -1;
-                        } else {
-                            return false;
+                            return ignoreOptions.indexOf("TS" + diagnostic.code) === -1;
                         }
+                        return false;
                     }
                     line--;
                 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3,7 +3,7 @@
 /// <reference path="core.ts" />
 
 namespace ts {
-    const ignoreDiagnosticCommentRegEx = /(^\s*$)|(^\s*\/\/\/?\s*(@ts-ignore)?(?:\s+((?:(?:TS\d+),\s*)*(?:TS\d+)?))?)/;
+    const ignoreDiagnosticCommentRegEx = /(^\s*$)|(^\s*\/\/\/?\s*(@ts-ignore)?(?:\s+((?:(?:TS\d+),\s*)*TS\d+))?)/;
 
     export function findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean, configName = "tsconfig.json"): string | undefined {
         return forEachAncestorDirectory(searchPath, ancestor => {

--- a/tests/baselines/reference/checkJsFiles_skipDiagnostics.errors.txt
+++ b/tests/baselines/reference/checkJsFiles_skipDiagnostics.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/a.js(37,1): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Number' has no compatible call signatures.
+tests/cases/compiler/a.js(43,1): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Number' has no compatible call signatures.
 
 
 ==== tests/cases/compiler/a.js (1 errors) ====
@@ -35,6 +35,12 @@ tests/cases/compiler/a.js(37,1): error TS2349: Cannot invoke an expression whose
     x();
     
     // @ts-ignore TS2349, TS2350
+    x();
+    
+    // @ts-ignore TS2349 , TS2350 // space before comma and additioanl comment
+    x();
+    
+    // @ts-ignore TS2349 , TS2350, // trailing comma
     x();
     
     // @ts-ignore TS2350 here should be error

--- a/tests/baselines/reference/checkJsFiles_skipDiagnostics.errors.txt
+++ b/tests/baselines/reference/checkJsFiles_skipDiagnostics.errors.txt
@@ -1,0 +1,43 @@
+tests/cases/compiler/a.js(37,1): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Number' has no compatible call signatures.
+
+
+==== tests/cases/compiler/a.js (1 errors) ====
+    var x = 0;
+    
+    
+    /// @ts-ignore
+    x();
+    
+    /// @ts-ignore
+    x();
+    
+    /// @ts-ignore
+    x(
+        2,
+        3);
+    
+    
+    
+    // @ts-ignore
+    // come comment
+    // some other comment
+    
+    // @anohter
+    
+    x();
+    
+    
+    
+    // @ts-ignore: no call signature
+    x();
+    
+    // @ts-ignore TS2349
+    x();
+    
+    // @ts-ignore TS2349, TS2350
+    x();
+    
+    // @ts-ignore TS2350 here should be error
+    x();
+    ~~~
+!!! error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Number' has no compatible call signatures.

--- a/tests/baselines/reference/checkJsFiles_skipDiagnostics.symbols
+++ b/tests/baselines/reference/checkJsFiles_skipDiagnostics.symbols
@@ -35,3 +35,15 @@ x();
 x();
 >x : Symbol(x, Decl(a.js, 0, 3))
 
+// @ts-ignore TS2349
+x();
+>x : Symbol(x, Decl(a.js, 0, 3))
+
+// @ts-ignore TS2349, TS2350
+x();
+>x : Symbol(x, Decl(a.js, 0, 3))
+
+// @ts-ignore TS2350 here should be error
+x();
+>x : Symbol(x, Decl(a.js, 0, 3))
+

--- a/tests/baselines/reference/checkJsFiles_skipDiagnostics.symbols
+++ b/tests/baselines/reference/checkJsFiles_skipDiagnostics.symbols
@@ -43,6 +43,14 @@ x();
 x();
 >x : Symbol(x, Decl(a.js, 0, 3))
 
+// @ts-ignore TS2349 , TS2350 // space before comma and additioanl comment
+x();
+>x : Symbol(x, Decl(a.js, 0, 3))
+
+// @ts-ignore TS2349 , TS2350, // trailing comma
+x();
+>x : Symbol(x, Decl(a.js, 0, 3))
+
 // @ts-ignore TS2350 here should be error
 x();
 >x : Symbol(x, Decl(a.js, 0, 3))

--- a/tests/baselines/reference/checkJsFiles_skipDiagnostics.types
+++ b/tests/baselines/reference/checkJsFiles_skipDiagnostics.types
@@ -54,6 +54,16 @@ x();
 >x() : any
 >x : number
 
+// @ts-ignore TS2349 , TS2350 // space before comma and additioanl comment
+x();
+>x() : any
+>x : number
+
+// @ts-ignore TS2349 , TS2350, // trailing comma
+x();
+>x() : any
+>x : number
+
 // @ts-ignore TS2350 here should be error
 x();
 >x() : any

--- a/tests/baselines/reference/checkJsFiles_skipDiagnostics.types
+++ b/tests/baselines/reference/checkJsFiles_skipDiagnostics.types
@@ -44,3 +44,18 @@ x();
 >x() : any
 >x : number
 
+// @ts-ignore TS2349
+x();
+>x() : any
+>x : number
+
+// @ts-ignore TS2349, TS2350
+x();
+>x() : any
+>x : number
+
+// @ts-ignore TS2350 here should be error
+x();
+>x() : any
+>x : number
+

--- a/tests/cases/compiler/checkJsFiles_skipDiagnostics.ts
+++ b/tests/cases/compiler/checkJsFiles_skipDiagnostics.ts
@@ -38,5 +38,11 @@ x();
 // @ts-ignore TS2349, TS2350
 x();
 
+// @ts-ignore TS2349 , TS2350 // space before comma and additioanl comment
+x();
+
+// @ts-ignore TS2349 , TS2350, // trailing comma
+x();
+
 // @ts-ignore TS2350 here should be error
 x();

--- a/tests/cases/compiler/checkJsFiles_skipDiagnostics.ts
+++ b/tests/cases/compiler/checkJsFiles_skipDiagnostics.ts
@@ -31,3 +31,12 @@ x();
 
 // @ts-ignore: no call signature
 x();
+
+// @ts-ignore TS2349
+x();
+
+// @ts-ignore TS2349, TS2350
+x();
+
+// @ts-ignore TS2350 here should be error
+x();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
Fixes #21197
Special syntax available now:
```
//@ts-ignore TS2349
```
to ignore only "Cannot invoke an expression whose type lacks a call signature." error.
Comma separated list supported, trailing comma is supported too:
```
//@ts-ignore TS2349, TS2552
```
If no error code specified, it ignores all errors.
