### PR TITLE
 Use unique symbol for wellknown symbols

### DIFF
--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -5,61 +5,61 @@ interface SymbolConstructor {
      * A method that determines if a constructor object recognizes an object as one of the
      * constructor’s instances. Called by the semantics of the instanceof operator.
      */
-    readonly hasInstance: symbol;
+    readonly hasInstance: unique symbol;
 
     /**
      * A Boolean value that if true indicates that an object should flatten to its array elements
      * by Array.prototype.concat.
      */
-    readonly isConcatSpreadable: symbol;
+    readonly isConcatSpreadable: unique symbol;
 
     /**
      * A regular expression method that matches the regular expression against a string. Called
      * by the String.prototype.match method.
      */
-    readonly match: symbol;
+    readonly match: unique symbol;
 
     /**
      * A regular expression method that replaces matched substrings of a string. Called by the
      * String.prototype.replace method.
      */
-    readonly replace: symbol;
+    readonly replace: unique symbol;
 
     /**
      * A regular expression method that returns the index within a string that matches the
      * regular expression. Called by the String.prototype.search method.
      */
-    readonly search: symbol;
+    readonly search: unique symbol;
 
     /**
      * A function valued property that is the constructor function that is used to create
      * derived objects.
      */
-    readonly species: symbol;
+    readonly species: unique symbol;
 
     /**
      * A regular expression method that splits a string at the indices that match the regular
      * expression. Called by the String.prototype.split method.
      */
-    readonly split: symbol;
+    readonly split: unique symbol;
 
     /**
      * A method that converts an object to a corresponding primitive value.
      * Called by the ToPrimitive abstract operation.
      */
-    readonly toPrimitive: symbol;
+    readonly toPrimitive: unique symbol;
 
     /**
      * A String value that is used in the creation of the default string description of an object.
      * Called by the built-in method Object.prototype.toString.
      */
-    readonly toStringTag: symbol;
+    readonly toStringTag: unique symbol;
 
     /**
      * An Object whose own property names are property names that are excluded from the 'with'
      * environment bindings of the associated objects.
      */
-    readonly unscopables: symbol;
+    readonly unscopables: unique symbol;
 }
 
 interface Symbol {

--- a/src/lib/esnext.asynciterable.d.ts
+++ b/src/lib/esnext.asynciterable.d.ts
@@ -6,7 +6,7 @@ interface SymbolConstructor {
      * A method that returns the default async iterator for an object. Called by the semantics of
      * the for-await-of statement.
      */
-    readonly asyncIterator: symbol;
+    readonly asyncIterator: unique symbol;
 }
 
 interface AsyncIterator<T> {

--- a/tests/baselines/reference/decoratorsOnComputedProperties.types
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.types
@@ -37,9 +37,9 @@ class A {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -57,18 +57,18 @@ class A {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -110,9 +110,9 @@ void class B {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -130,18 +130,18 @@ void class B {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -182,9 +182,9 @@ class C {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -202,18 +202,18 @@ class C {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -260,9 +260,9 @@ void class D {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -280,18 +280,18 @@ void class D {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -337,9 +337,9 @@ class E {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -357,18 +357,18 @@ class E {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -415,9 +415,9 @@ void class F {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -435,18 +435,18 @@ void class F {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -492,9 +492,9 @@ class G {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -512,18 +512,18 @@ class G {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -575,9 +575,9 @@ void class H {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -595,18 +595,18 @@ void class H {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -657,9 +657,9 @@ class I {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -677,18 +677,18 @@ class I {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;
@@ -741,9 +741,9 @@ void class J {
 
     @x [Symbol.toStringTag]: any;
 >x : (o: object, k: PropertyKey) => void
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     @x ["property2"]: any = 2;
 >x : (o: object, k: PropertyKey) => void
@@ -761,18 +761,18 @@ void class J {
 >"property3" : "property3"
 
     [Symbol.isConcatSpreadable]: any;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     ["property4"]: any = 2;
 >"property4" : "property4"
 >2 : 2
 
     [Symbol.match]: any = null;
->Symbol.match : symbol
+>Symbol.match : unique symbol
 >Symbol : SymbolConstructor
->match : symbol
+>match : unique symbol
 >null : null
 
     [foo()]: any;

--- a/tests/baselines/reference/intersectionTypeInference3.types
+++ b/tests/baselines/reference/intersectionTypeInference3.types
@@ -8,9 +8,9 @@ type Nominal<Kind extends string, Type> = Type & {
 >Type : Type
 
     [Symbol.species]: Kind;
->Symbol.species : symbol
+>Symbol.species : unique symbol
 >Symbol : SymbolConstructor
->species : symbol
+>species : unique symbol
 >Kind : Kind
 
 };

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.types
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.types
@@ -112,9 +112,9 @@ var o = {
 >2 : 2
 
     [Symbol.hasInstance](value: any) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >value : any
 
         return false;
@@ -126,9 +126,9 @@ o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
 >hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
 // Using ES6 promise
 async function out() {
@@ -219,9 +219,9 @@ const o1 = {
 >{    [Symbol.hasInstance](value: any) {        return false;    }} : { [Symbol.hasInstance](value: any): boolean; }
 
     [Symbol.hasInstance](value: any) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >value : any
 
         return false;

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.types
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.types
@@ -112,9 +112,9 @@ var o = {
 >2 : 2
 
     [Symbol.hasInstance](value: any) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >value : any
 
         return false;
@@ -126,9 +126,9 @@ o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
 >hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
 // Using ES6 promise
 async function out() {
@@ -219,9 +219,9 @@ const o1 = {
 >{    [Symbol.hasInstance](value: any) {        return false;    }} : { [Symbol.hasInstance](value: any): boolean; }
 
     [Symbol.hasInstance](value: any) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >value : any
 
         return false;

--- a/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.types
+++ b/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.types
@@ -112,9 +112,9 @@ var o = {
 >2 : 2
 
     [Symbol.hasInstance](value: any) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >value : any
 
         return false;
@@ -126,9 +126,9 @@ o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
 >hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
 // Using ES6 promise
 async function out() {
@@ -219,9 +219,9 @@ const o1 = {
 >{    [Symbol.hasInstance](value: any) {        return false;    }} : { [Symbol.hasInstance](value: any): boolean; }
 
     [Symbol.hasInstance](value: any) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >value : any
 
         return false;

--- a/tests/baselines/reference/modularizeLibrary_TargetES6UsingES6Lib.types
+++ b/tests/baselines/reference/modularizeLibrary_TargetES6UsingES6Lib.types
@@ -67,9 +67,9 @@ var o = {
 >2 : 2
 
     [Symbol.hasInstance](value: any) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >value : any
 
         return false;
@@ -81,9 +81,9 @@ o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty : { (v: string): boolean; (v: PropertyKey): boolean; }
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
 >hasOwnProperty : { (v: string): boolean; (v: PropertyKey): boolean; }
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
 // Using Es6 proxy
 var t = {}
@@ -142,9 +142,9 @@ const o1 = {
 >{    [Symbol.hasInstance](value: any) {        return false;    }} : { [Symbol.hasInstance](value: any): boolean; }
 
     [Symbol.hasInstance](value: any) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >value : any
 
         return false;

--- a/tests/baselines/reference/modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.types
+++ b/tests/baselines/reference/modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.types
@@ -30,8 +30,8 @@ a[Symbol.isConcatSpreadable] = false;
 >a[Symbol.isConcatSpreadable] = false : false
 >a[Symbol.isConcatSpreadable] : any
 >a : string[]
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >false : false
 

--- a/tests/baselines/reference/parserSymbolProperty2.types
+++ b/tests/baselines/reference/parserSymbolProperty2.types
@@ -3,7 +3,7 @@ interface I {
 >I : I
 
     [Symbol.unscopables](): string;
->Symbol.unscopables : symbol
+>Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
->unscopables : symbol
+>unscopables : unique symbol
 }

--- a/tests/baselines/reference/parserSymbolProperty3.types
+++ b/tests/baselines/reference/parserSymbolProperty3.types
@@ -3,7 +3,7 @@ declare class C {
 >C : C
 
     [Symbol.unscopables](): string;
->Symbol.unscopables : symbol
+>Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
->unscopables : symbol
+>unscopables : unique symbol
 }

--- a/tests/baselines/reference/parserSymbolProperty4.types
+++ b/tests/baselines/reference/parserSymbolProperty4.types
@@ -3,7 +3,7 @@ declare class C {
 >C : C
 
     [Symbol.toPrimitive]: string;
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }

--- a/tests/baselines/reference/parserSymbolProperty5.types
+++ b/tests/baselines/reference/parserSymbolProperty5.types
@@ -3,7 +3,7 @@ class C {
 >C : C
 
     [Symbol.toPrimitive]: string;
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }

--- a/tests/baselines/reference/parserSymbolProperty6.types
+++ b/tests/baselines/reference/parserSymbolProperty6.types
@@ -3,8 +3,8 @@ class C {
 >C : C
 
     [Symbol.toStringTag]: string = "";
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >"" : ""
 }

--- a/tests/baselines/reference/parserSymbolProperty7.types
+++ b/tests/baselines/reference/parserSymbolProperty7.types
@@ -3,7 +3,7 @@ class C {
 >C : C
 
     [Symbol.toStringTag](): void { }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 }

--- a/tests/baselines/reference/parserSymbolProperty8.types
+++ b/tests/baselines/reference/parserSymbolProperty8.types
@@ -3,7 +3,7 @@ var x: {
 >x : { [Symbol.toPrimitive](): string; }
 
     [Symbol.toPrimitive](): string
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }

--- a/tests/baselines/reference/parserSymbolProperty8.types
+++ b/tests/baselines/reference/parserSymbolProperty8.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts ===
 var x: {
->x : { [Symbol.toPrimitive](): string; }
+>x : { [Symbol.toPrimitive](): string; [Symbol.toPrimitive](): string; }
 
     [Symbol.toPrimitive](): string
 >Symbol.toPrimitive : unique symbol

--- a/tests/baselines/reference/parserSymbolProperty9.types
+++ b/tests/baselines/reference/parserSymbolProperty9.types
@@ -3,7 +3,7 @@ var x: {
 >x : { [Symbol.toPrimitive]: string; }
 
     [Symbol.toPrimitive]: string
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }

--- a/tests/baselines/reference/parserSymbolProperty9.types
+++ b/tests/baselines/reference/parserSymbolProperty9.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty9.ts ===
 var x: {
->x : { [Symbol.toPrimitive]: string; }
+>x : { [Symbol.toPrimitive]: string; [Symbol.toPrimitive]: string; }
 
     [Symbol.toPrimitive]: string
 >Symbol.toPrimitive : unique symbol

--- a/tests/baselines/reference/superSymbolIndexedAccess2.types
+++ b/tests/baselines/reference/superSymbolIndexedAccess2.types
@@ -3,9 +3,9 @@ class Foo {
 >Foo : Foo
 
     [Symbol.isConcatSpreadable]() {
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
         return 0;
 >0 : 0
@@ -17,16 +17,16 @@ class Bar extends Foo {
 >Foo : Foo
 
     [Symbol.isConcatSpreadable]() {
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
         return super[Symbol.isConcatSpreadable]();
 >super[Symbol.isConcatSpreadable]() : number
 >super[Symbol.isConcatSpreadable] : () => number
 >super : Foo
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
     }
 }

--- a/tests/baselines/reference/symbolDeclarationEmit1.types
+++ b/tests/baselines/reference/symbolDeclarationEmit1.types
@@ -3,7 +3,7 @@ class C {
 >C : C
 
     [Symbol.toPrimitive]: number;
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }

--- a/tests/baselines/reference/symbolDeclarationEmit10.types
+++ b/tests/baselines/reference/symbolDeclarationEmit10.types
@@ -4,14 +4,14 @@ var obj = {
 >{    get [Symbol.isConcatSpreadable]() { return '' },    set [Symbol.isConcatSpreadable](x) { }} : { [Symbol.isConcatSpreadable]: string; }
 
     get [Symbol.isConcatSpreadable]() { return '' },
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >'' : ""
 
     set [Symbol.isConcatSpreadable](x) { }
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >x : string
 }

--- a/tests/baselines/reference/symbolDeclarationEmit11.types
+++ b/tests/baselines/reference/symbolDeclarationEmit11.types
@@ -9,19 +9,19 @@ class C {
 >0 : 0
 
     static [Symbol.isConcatSpreadable]() { }
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     static get [Symbol.toPrimitive]() { return ""; }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >"" : ""
 
     static set [Symbol.toPrimitive](x) { }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >x : string
 }

--- a/tests/baselines/reference/symbolDeclarationEmit12.errors.txt
+++ b/tests/baselines/reference/symbolDeclarationEmit12.errors.txt
@@ -1,13 +1,16 @@
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(4,28): error TS4031: Public property '[Symbol.iterator]' of exported class has or is using private name 'I'.
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(5,9): error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
+tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(5,9): error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(5,33): error TS4073: Parameter 'x' of public method from exported class has or is using private name 'I'.
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(6,40): error TS4055: Return type of public method from exported class has or is using private name 'I'.
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(9,13): error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
+tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(9,13): error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,13): error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
+tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,13): error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
 tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,37): error TS4037: Parameter type of public setter '[Symbol.toPrimitive]' from exported class has or is using private name 'I'.
 
 
-==== tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts (7 errors) ====
+==== tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts (10 errors) ====
     module M {
         interface I { }
         export class C {
@@ -17,6 +20,8 @@ tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,37): error TS4
             [Symbol.toPrimitive](x: I) { }
             ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
                                     ~
 !!! error TS4073: Parameter 'x' of public method from exported class has or is using private name 'I'.
             [Symbol.isConcatSpreadable](): I {
@@ -27,9 +32,13 @@ tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts(10,37): error TS4
             get [Symbol.toPrimitive]() { return undefined; }
                 ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
+                ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
             set [Symbol.toPrimitive](x: I) { }
                 ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
+                ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
                                         ~
 !!! error TS4037: Parameter type of public setter '[Symbol.toPrimitive]' from exported class has or is using private name 'I'.
         }

--- a/tests/baselines/reference/symbolDeclarationEmit12.types
+++ b/tests/baselines/reference/symbolDeclarationEmit12.types
@@ -15,31 +15,31 @@ module M {
 >I : I
 
         [Symbol.toPrimitive](x: I) { }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >x : I
 >I : I
 
         [Symbol.isConcatSpreadable](): I {
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >I : I
 
             return undefined
 >undefined : undefined
         }
         get [Symbol.toPrimitive]() { return undefined; }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >undefined : undefined
 
         set [Symbol.toPrimitive](x: I) { }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >x : I
 >I : I
     }

--- a/tests/baselines/reference/symbolDeclarationEmit13.types
+++ b/tests/baselines/reference/symbolDeclarationEmit13.types
@@ -3,14 +3,14 @@ class C {
 >C : C
 
     get [Symbol.toPrimitive]() { return ""; }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >"" : ""
 
     set [Symbol.toStringTag](x) { }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >x : any
 }

--- a/tests/baselines/reference/symbolDeclarationEmit14.types
+++ b/tests/baselines/reference/symbolDeclarationEmit14.types
@@ -3,14 +3,14 @@ class C {
 >C : C
 
     get [Symbol.toPrimitive]() { return ""; }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >"" : ""
 
     get [Symbol.toStringTag]() { return ""; }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >"" : ""
 }

--- a/tests/baselines/reference/symbolDeclarationEmit2.types
+++ b/tests/baselines/reference/symbolDeclarationEmit2.types
@@ -3,8 +3,8 @@ class C {
 >C : C
 
     [Symbol.toPrimitive] = "";
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >"" : ""
 }

--- a/tests/baselines/reference/symbolDeclarationEmit3.types
+++ b/tests/baselines/reference/symbolDeclarationEmit3.types
@@ -3,20 +3,20 @@ class C {
 >C : C
 
     [Symbol.toPrimitive](x: number);
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >x : number
 
     [Symbol.toPrimitive](x: string);
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >x : string
 
     [Symbol.toPrimitive](x: any) { }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >x : any
 }

--- a/tests/baselines/reference/symbolDeclarationEmit4.errors.txt
+++ b/tests/baselines/reference/symbolDeclarationEmit4.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/conformance/es6/Symbols/symbolDeclarationEmit4.ts(2,9): error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
+tests/cases/conformance/es6/Symbols/symbolDeclarationEmit4.ts(3,9): error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
+
+
+==== tests/cases/conformance/es6/Symbols/symbolDeclarationEmit4.ts (2 errors) ====
+    class C {
+        get [Symbol.toPrimitive]() { return ""; }
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
+        set [Symbol.toPrimitive](x) { }
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.toPrimitive]'.
+    }

--- a/tests/baselines/reference/symbolDeclarationEmit4.types
+++ b/tests/baselines/reference/symbolDeclarationEmit4.types
@@ -3,14 +3,14 @@ class C {
 >C : C
 
     get [Symbol.toPrimitive]() { return ""; }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >"" : ""
 
     set [Symbol.toPrimitive](x) { }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >x : string
 }

--- a/tests/baselines/reference/symbolDeclarationEmit5.types
+++ b/tests/baselines/reference/symbolDeclarationEmit5.types
@@ -3,7 +3,7 @@ interface I {
 >I : I
 
     [Symbol.isConcatSpreadable](): string;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 }

--- a/tests/baselines/reference/symbolDeclarationEmit6.types
+++ b/tests/baselines/reference/symbolDeclarationEmit6.types
@@ -3,7 +3,7 @@ interface I {
 >I : I
 
     [Symbol.isConcatSpreadable]: string;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 }

--- a/tests/baselines/reference/symbolDeclarationEmit7.types
+++ b/tests/baselines/reference/symbolDeclarationEmit7.types
@@ -3,7 +3,7 @@ var obj: {
 >obj : { [Symbol.isConcatSpreadable]: string; }
 
     [Symbol.isConcatSpreadable]: string;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 }

--- a/tests/baselines/reference/symbolDeclarationEmit7.types
+++ b/tests/baselines/reference/symbolDeclarationEmit7.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/Symbols/symbolDeclarationEmit7.ts ===
 var obj: {
->obj : { [Symbol.isConcatSpreadable]: string; }
+>obj : { [Symbol.isConcatSpreadable]: string; [Symbol.isConcatSpreadable]: string; }
 
     [Symbol.isConcatSpreadable]: string;
 >Symbol.isConcatSpreadable : unique symbol

--- a/tests/baselines/reference/symbolDeclarationEmit8.errors.txt
+++ b/tests/baselines/reference/symbolDeclarationEmit8.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/es6/Symbols/symbolDeclarationEmit8.ts(2,6): error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+
+
+==== tests/cases/conformance/es6/Symbols/symbolDeclarationEmit8.ts (1 errors) ====
+    var obj = {
+        [Symbol.isConcatSpreadable]: 0
+         ~~~~~~
+!!! error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+    }

--- a/tests/baselines/reference/symbolDeclarationEmit8.types
+++ b/tests/baselines/reference/symbolDeclarationEmit8.types
@@ -4,8 +4,8 @@ var obj = {
 >{    [Symbol.isConcatSpreadable]: 0} : { [Symbol.isConcatSpreadable]: number; }
 
     [Symbol.isConcatSpreadable]: 0
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >0 : 0
 }

--- a/tests/baselines/reference/symbolDeclarationEmit9.errors.txt
+++ b/tests/baselines/reference/symbolDeclarationEmit9.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/es6/Symbols/symbolDeclarationEmit9.ts(2,6): error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+
+
+==== tests/cases/conformance/es6/Symbols/symbolDeclarationEmit9.ts (1 errors) ====
+    var obj = {
+        [Symbol.isConcatSpreadable]() { }
+         ~~~~~~
+!!! error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+    }

--- a/tests/baselines/reference/symbolDeclarationEmit9.types
+++ b/tests/baselines/reference/symbolDeclarationEmit9.types
@@ -4,7 +4,7 @@ var obj = {
 >{    [Symbol.isConcatSpreadable]() { }} : { [Symbol.isConcatSpreadable](): void; }
 
     [Symbol.isConcatSpreadable]() { }
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 }

--- a/tests/baselines/reference/symbolProperty18.types
+++ b/tests/baselines/reference/symbolProperty18.types
@@ -41,7 +41,7 @@ var str = i[Symbol.toStringTag]();
 
 i[Symbol.toPrimitive] = false;
 >i[Symbol.toPrimitive] = false : false
->i[Symbol.toPrimitive] : boolean
+>i[Symbol.toPrimitive] : any
 >i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; [Symbol.toPrimitive]: boolean; }
 >Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor

--- a/tests/baselines/reference/symbolProperty18.types
+++ b/tests/baselines/reference/symbolProperty18.types
@@ -10,15 +10,15 @@ var i = {
 >0 : 0
 
     [Symbol.toStringTag]() { return "" },
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >"" : ""
 
     set [Symbol.toPrimitive](p: boolean) { }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >p : boolean
 }
 
@@ -35,16 +35,16 @@ var str = i[Symbol.toStringTag]();
 >i[Symbol.toStringTag]() : string
 >i[Symbol.toStringTag] : () => string
 >i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; [Symbol.toPrimitive]: boolean; }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
 i[Symbol.toPrimitive] = false;
 >i[Symbol.toPrimitive] = false : false
 >i[Symbol.toPrimitive] : boolean
 >i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; [Symbol.toPrimitive]: boolean; }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >false : false
 

--- a/tests/baselines/reference/symbolProperty19.types
+++ b/tests/baselines/reference/symbolProperty19.types
@@ -12,9 +12,9 @@ var i = {
 >null : null
 
     [Symbol.toStringTag]() { return { p: undefined }; }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >{ p: undefined } : { p: undefined; }
 >p : undefined
 >undefined : undefined
@@ -33,7 +33,7 @@ var str = i[Symbol.toStringTag]();
 >i[Symbol.toStringTag]() : { p: any; }
 >i[Symbol.toStringTag] : () => { p: any; }
 >i : { [Symbol.iterator]: { p: any; }; [Symbol.toStringTag](): { p: any; }; }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 

--- a/tests/baselines/reference/symbolProperty20.errors.txt
+++ b/tests/baselines/reference/symbolProperty20.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/conformance/es6/Symbols/symbolProperty20.ts(6,5): error TS2322: Type '{ [Symbol.iterator]: (s: string) => string; [Symbol.toStringTag](n: number): number; }' is not assignable to type 'I'.
+  Property '[Symbol.toStringTag]' is missing in type '{ [Symbol.iterator]: (s: string) => string; [Symbol.toStringTag](n: number): number; }'.
+tests/cases/conformance/es6/Symbols/symbolProperty20.ts(8,6): error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+
+
+==== tests/cases/conformance/es6/Symbols/symbolProperty20.ts (2 errors) ====
+    interface I {
+        [Symbol.iterator]: (s: string) => string;
+        [Symbol.toStringTag](s: number): number;
+    }
+    
+    var i: I = {
+        ~
+!!! error TS2322: Type '{ [Symbol.iterator]: (s: string) => string; [Symbol.toStringTag](n: number): number; }' is not assignable to type 'I'.
+!!! error TS2322:   Property '[Symbol.toStringTag]' is missing in type '{ [Symbol.iterator]: (s: string) => string; [Symbol.toStringTag](n: number): number; }'.
+        [Symbol.iterator]: s => s,
+        [Symbol.toStringTag](n) { return n; }
+         ~~~~~~
+!!! error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+    }

--- a/tests/baselines/reference/symbolProperty20.types
+++ b/tests/baselines/reference/symbolProperty20.types
@@ -9,9 +9,9 @@ interface I {
 >s : string
 
     [Symbol.toStringTag](s: number): number;
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >s : number
 }
 
@@ -29,9 +29,9 @@ var i: I = {
 >s : string
 
     [Symbol.toStringTag](n) { return n; }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >n : number
 >n : number
 }

--- a/tests/baselines/reference/symbolProperty21.errors.txt
+++ b/tests/baselines/reference/symbolProperty21.errors.txt
@@ -1,8 +1,11 @@
-tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
-  Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(9,6): error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<{}, {}>'.
+  Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<{}, {}>'.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,6): error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(11,6): error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
 
 
-==== tests/cases/conformance/es6/Symbols/symbolProperty21.ts (1 errors) ====
+==== tests/cases/conformance/es6/Symbols/symbolProperty21.ts (4 errors) ====
     interface I<T, U> {
         [Symbol.unscopables]: T;
         [Symbol.isConcatSpreadable]: U;
@@ -12,9 +15,15 @@ tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Arg
     
     foo({
         [Symbol.isConcatSpreadable]: "",
+         ~~~~~~
+!!! error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
         [Symbol.toPrimitive]: 0,
         ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
-!!! error TS2345:   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
+!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<{}, {}>'.
+!!! error TS2345:   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<{}, {}>'.
+         ~~~~~~
+!!! error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
         [Symbol.unscopables]: true
+         ~~~~~~
+!!! error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
     });

--- a/tests/baselines/reference/symbolProperty21.types
+++ b/tests/baselines/reference/symbolProperty21.types
@@ -5,15 +5,15 @@ interface I<T, U> {
 >U : U
 
     [Symbol.unscopables]: T;
->Symbol.unscopables : symbol
+>Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
->unscopables : symbol
+>unscopables : unique symbol
 >T : T
 
     [Symbol.isConcatSpreadable]: U;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >U : U
 }
 
@@ -36,21 +36,21 @@ foo({
 >{    [Symbol.isConcatSpreadable]: "",    [Symbol.toPrimitive]: 0,    [Symbol.unscopables]: true} : { [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }
 
     [Symbol.isConcatSpreadable]: "",
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >"" : ""
 
     [Symbol.toPrimitive]: 0,
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 >0 : 0
 
     [Symbol.unscopables]: true
->Symbol.unscopables : symbol
+>Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
->unscopables : symbol
+>unscopables : unique symbol
 >true : true
 
 });

--- a/tests/baselines/reference/symbolProperty22.errors.txt
+++ b/tests/baselines/reference/symbolProperty22.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/conformance/es6/Symbols/symbolProperty22.ts(7,9): error TS2345: Argument of type '{ [Symbol.unscopables]: (s: string) => number; }' is not assignable to parameter of type 'I<string, {}>'.
+  Property '[Symbol.unscopables]' is missing in type '{ [Symbol.unscopables]: (s: string) => number; }'.
+tests/cases/conformance/es6/Symbols/symbolProperty22.ts(7,12): error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.
+
+
+==== tests/cases/conformance/es6/Symbols/symbolProperty22.ts (2 errors) ====
+    interface I<T, U> {
+        [Symbol.unscopables](x: T): U;
+    }
+    
+    declare function foo<T, U>(p1: T, p2: I<T, U>): U;
+    
+    foo("", { [Symbol.unscopables]: s => s.length });
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ [Symbol.unscopables]: (s: string) => number; }' is not assignable to parameter of type 'I<string, {}>'.
+!!! error TS2345:   Property '[Symbol.unscopables]' is missing in type '{ [Symbol.unscopables]: (s: string) => number; }'.
+               ~~~~~~
+!!! error TS2702: 'Symbol' only refers to a type, but is being used as a namespace here.

--- a/tests/baselines/reference/symbolProperty22.types
+++ b/tests/baselines/reference/symbolProperty22.types
@@ -5,9 +5,9 @@ interface I<T, U> {
 >U : U
 
     [Symbol.unscopables](x: T): U;
->Symbol.unscopables : symbol
+>Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
->unscopables : symbol
+>unscopables : unique symbol
 >x : T
 >T : T
 >U : U
@@ -30,9 +30,9 @@ foo("", { [Symbol.unscopables]: s => s.length });
 >foo : <T, U>(p1: T, p2: I<T, U>) => U
 >"" : ""
 >{ [Symbol.unscopables]: s => s.length } : { [Symbol.unscopables]: (s: string) => number; }
->Symbol.unscopables : symbol
+>Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
->unscopables : symbol
+>unscopables : unique symbol
 >s => s.length : (s: string) => number
 >s : string
 >s.length : number

--- a/tests/baselines/reference/symbolProperty22.types
+++ b/tests/baselines/reference/symbolProperty22.types
@@ -26,7 +26,7 @@ declare function foo<T, U>(p1: T, p2: I<T, U>): U;
 >U : U
 
 foo("", { [Symbol.unscopables]: s => s.length });
->foo("", { [Symbol.unscopables]: s => s.length }) : number
+>foo("", { [Symbol.unscopables]: s => s.length }) : any
 >foo : <T, U>(p1: T, p2: I<T, U>) => U
 >"" : ""
 >{ [Symbol.unscopables]: s => s.length } : { [Symbol.unscopables]: (s: string) => number; }

--- a/tests/baselines/reference/symbolProperty23.types
+++ b/tests/baselines/reference/symbolProperty23.types
@@ -3,9 +3,9 @@ interface I {
 >I : I
 
     [Symbol.toPrimitive]: () => boolean;
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }
 
 class C implements I {
@@ -13,9 +13,9 @@ class C implements I {
 >I : I
 
     [Symbol.toPrimitive]() {
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 
         return true;
 >true : true

--- a/tests/baselines/reference/symbolProperty24.types
+++ b/tests/baselines/reference/symbolProperty24.types
@@ -3,9 +3,9 @@ interface I {
 >I : I
 
     [Symbol.toPrimitive]: () => boolean;
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }
 
 class C implements I {
@@ -13,9 +13,9 @@ class C implements I {
 >I : I
 
     [Symbol.toPrimitive]() {
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 
         return "";
 >"" : ""

--- a/tests/baselines/reference/symbolProperty25.types
+++ b/tests/baselines/reference/symbolProperty25.types
@@ -3,9 +3,9 @@ interface I {
 >I : I
 
     [Symbol.toPrimitive]: () => boolean;
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }
 
 class C implements I {
@@ -13,9 +13,9 @@ class C implements I {
 >I : I
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return "";
 >"" : ""

--- a/tests/baselines/reference/symbolProperty26.types
+++ b/tests/baselines/reference/symbolProperty26.types
@@ -3,9 +3,9 @@ class C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return "";
 >"" : ""
@@ -17,9 +17,9 @@ class C2 extends C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return "";
 >"" : ""

--- a/tests/baselines/reference/symbolProperty27.types
+++ b/tests/baselines/reference/symbolProperty27.types
@@ -3,9 +3,9 @@ class C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return {};
 >{} : {}
@@ -17,9 +17,9 @@ class C2 extends C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return "";
 >"" : ""

--- a/tests/baselines/reference/symbolProperty28.types
+++ b/tests/baselines/reference/symbolProperty28.types
@@ -3,9 +3,9 @@ class C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return { x: "" };
 >{ x: "" } : { x: string; }
@@ -28,8 +28,8 @@ var obj = c[Symbol.toStringTag]().x;
 >c[Symbol.toStringTag]() : { x: string; }
 >c[Symbol.toStringTag] : () => { x: string; }
 >c : C2
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >x : string
 

--- a/tests/baselines/reference/symbolProperty29.types
+++ b/tests/baselines/reference/symbolProperty29.types
@@ -3,9 +3,9 @@ class C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return { x: "" };
 >{ x: "" } : { x: string; }

--- a/tests/baselines/reference/symbolProperty30.types
+++ b/tests/baselines/reference/symbolProperty30.types
@@ -3,9 +3,9 @@ class C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return { x: "" };
 >{ x: "" } : { x: string; }

--- a/tests/baselines/reference/symbolProperty31.types
+++ b/tests/baselines/reference/symbolProperty31.types
@@ -3,9 +3,9 @@ class C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return { x: "" };
 >{ x: "" } : { x: string; }

--- a/tests/baselines/reference/symbolProperty32.types
+++ b/tests/baselines/reference/symbolProperty32.types
@@ -3,9 +3,9 @@ class C1 {
 >C1 : C1
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return { x: "" };
 >{ x: "" } : { x: string; }

--- a/tests/baselines/reference/symbolProperty33.types
+++ b/tests/baselines/reference/symbolProperty33.types
@@ -4,9 +4,9 @@ class C1 extends C2 {
 >C2 : C2
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return { x: "" };
 >{ x: "" } : { x: string; }

--- a/tests/baselines/reference/symbolProperty34.types
+++ b/tests/baselines/reference/symbolProperty34.types
@@ -4,9 +4,9 @@ class C1 extends C2 {
 >C2 : C2
 
     [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return { x: "" };
 >{ x: "" } : { x: string; }

--- a/tests/baselines/reference/symbolProperty35.types
+++ b/tests/baselines/reference/symbolProperty35.types
@@ -3,18 +3,18 @@ interface I1 {
 >I1 : I1
 
     [Symbol.toStringTag](): { x: string }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >x : string
 }
 interface I2 {
 >I2 : I2
 
     [Symbol.toStringTag](): { x: number }
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 >x : number
 }
 

--- a/tests/baselines/reference/symbolProperty36.types
+++ b/tests/baselines/reference/symbolProperty36.types
@@ -4,14 +4,14 @@ var x = {
 >{    [Symbol.isConcatSpreadable]: 0,    [Symbol.isConcatSpreadable]: 1} : { [Symbol.isConcatSpreadable]: number; }
 
     [Symbol.isConcatSpreadable]: 0,
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >0 : 0
 
     [Symbol.isConcatSpreadable]: 1
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >1 : 1
 }

--- a/tests/baselines/reference/symbolProperty37.types
+++ b/tests/baselines/reference/symbolProperty37.types
@@ -3,12 +3,12 @@ interface I {
 >I : I
 
     [Symbol.isConcatSpreadable]: string;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 
     [Symbol.isConcatSpreadable]: string;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 }

--- a/tests/baselines/reference/symbolProperty38.types
+++ b/tests/baselines/reference/symbolProperty38.types
@@ -3,15 +3,15 @@ interface I {
 >I : I
 
     [Symbol.isConcatSpreadable]: string;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 }
 interface I {
 >I : I
 
     [Symbol.isConcatSpreadable]: string;
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 }

--- a/tests/baselines/reference/symbolProperty44.errors.txt
+++ b/tests/baselines/reference/symbolProperty44.errors.txt
@@ -1,17 +1,23 @@
 tests/cases/conformance/es6/Symbols/symbolProperty44.ts(2,9): error TS2300: Duplicate identifier '[Symbol.hasInstance]'.
+tests/cases/conformance/es6/Symbols/symbolProperty44.ts(2,9): error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
 tests/cases/conformance/es6/Symbols/symbolProperty44.ts(5,9): error TS2300: Duplicate identifier '[Symbol.hasInstance]'.
+tests/cases/conformance/es6/Symbols/symbolProperty44.ts(5,9): error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
 
 
-==== tests/cases/conformance/es6/Symbols/symbolProperty44.ts (2 errors) ====
+==== tests/cases/conformance/es6/Symbols/symbolProperty44.ts (4 errors) ====
     class C {
         get [Symbol.hasInstance]() {
             ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2300: Duplicate identifier '[Symbol.hasInstance]'.
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
             return "";
         }
         get [Symbol.hasInstance]() {
             ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2300: Duplicate identifier '[Symbol.hasInstance]'.
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
             return "";
         }
     }

--- a/tests/baselines/reference/symbolProperty44.types
+++ b/tests/baselines/reference/symbolProperty44.types
@@ -3,17 +3,17 @@ class C {
 >C : C
 
     get [Symbol.hasInstance]() {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
         return "";
 >"" : ""
     }
     get [Symbol.hasInstance]() {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
         return "";
 >"" : ""

--- a/tests/baselines/reference/symbolProperty45.types
+++ b/tests/baselines/reference/symbolProperty45.types
@@ -3,17 +3,17 @@ class C {
 >C : C
 
     get [Symbol.hasInstance]() {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
         return "";
 >"" : ""
     }
     get [Symbol.toPrimitive]() {
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 
         return "";
 >"" : ""

--- a/tests/baselines/reference/symbolProperty46.errors.txt
+++ b/tests/baselines/reference/symbolProperty46.errors.txt
@@ -1,13 +1,19 @@
+tests/cases/conformance/es6/Symbols/symbolProperty46.ts(2,9): error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
+tests/cases/conformance/es6/Symbols/symbolProperty46.ts(6,9): error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
 tests/cases/conformance/es6/Symbols/symbolProperty46.ts(10,1): error TS2322: Type '0' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/es6/Symbols/symbolProperty46.ts (1 errors) ====
+==== tests/cases/conformance/es6/Symbols/symbolProperty46.ts (3 errors) ====
     class C {
         get [Symbol.hasInstance]() {
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
             return "";
         }
         // Should take a string
         set [Symbol.hasInstance](x) {
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
         }
     }
     

--- a/tests/baselines/reference/symbolProperty46.types
+++ b/tests/baselines/reference/symbolProperty46.types
@@ -3,18 +3,18 @@ class C {
 >C : C
 
     get [Symbol.hasInstance]() {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
         return "";
 >"" : ""
     }
     // Should take a string
     set [Symbol.hasInstance](x) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >x : string
     }
 }
@@ -25,9 +25,9 @@ class C {
 >(new C) : C
 >new C : C
 >C : typeof C
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >0 : 0
 
 (new C)[Symbol.hasInstance] = "";
@@ -36,8 +36,8 @@ class C {
 >(new C) : C
 >new C : C
 >C : typeof C
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >"" : ""
 

--- a/tests/baselines/reference/symbolProperty47.errors.txt
+++ b/tests/baselines/reference/symbolProperty47.errors.txt
@@ -1,20 +1,26 @@
+tests/cases/conformance/es6/Symbols/symbolProperty47.ts(2,9): error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
 tests/cases/conformance/es6/Symbols/symbolProperty47.ts(3,9): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/conformance/es6/Symbols/symbolProperty47.ts(11,1): error TS2322: Type '""' is not assignable to type 'number'.
+tests/cases/conformance/es6/Symbols/symbolProperty47.ts(6,9): error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
+tests/cases/conformance/es6/Symbols/symbolProperty47.ts(10,1): error TS2322: Type '0' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/es6/Symbols/symbolProperty47.ts (2 errors) ====
+==== tests/cases/conformance/es6/Symbols/symbolProperty47.ts (4 errors) ====
     class C {
         get [Symbol.hasInstance]() {
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
             return "";
             ~~~~~~~~~~
 !!! error TS2322: Type '""' is not assignable to type 'number'.
         }
         // Should take a string
         set [Symbol.hasInstance](x: number) {
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2718: Duplicate declaration '[Symbol.hasInstance]'.
         }
     }
     
     (new C)[Symbol.hasInstance] = 0;
-    (new C)[Symbol.hasInstance] = "";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '""' is not assignable to type 'number'.
+!!! error TS2322: Type '0' is not assignable to type 'string'.
+    (new C)[Symbol.hasInstance] = "";

--- a/tests/baselines/reference/symbolProperty47.types
+++ b/tests/baselines/reference/symbolProperty47.types
@@ -3,18 +3,18 @@ class C {
 >C : C
 
     get [Symbol.hasInstance]() {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 
         return "";
 >"" : ""
     }
     // Should take a string
     set [Symbol.hasInstance](x: number) {
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >x : number
     }
 }
@@ -25,9 +25,9 @@ class C {
 >(new C) : C
 >new C : C
 >C : typeof C
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >0 : 0
 
 (new C)[Symbol.hasInstance] = "";
@@ -36,8 +36,8 @@ class C {
 >(new C) : C
 >new C : C
 >C : typeof C
->Symbol.hasInstance : symbol
+>Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
->hasInstance : symbol
+>hasInstance : unique symbol
 >"" : ""
 

--- a/tests/baselines/reference/symbolProperty47.types
+++ b/tests/baselines/reference/symbolProperty47.types
@@ -21,7 +21,7 @@ class C {
 
 (new C)[Symbol.hasInstance] = 0;
 >(new C)[Symbol.hasInstance] = 0 : 0
->(new C)[Symbol.hasInstance] : number
+>(new C)[Symbol.hasInstance] : string
 >(new C) : C
 >new C : C
 >C : typeof C
@@ -32,7 +32,7 @@ class C {
 
 (new C)[Symbol.hasInstance] = "";
 >(new C)[Symbol.hasInstance] = "" : ""
->(new C)[Symbol.hasInstance] : number
+>(new C)[Symbol.hasInstance] : string
 >(new C) : C
 >new C : C
 >C : typeof C

--- a/tests/baselines/reference/symbolProperty5.types
+++ b/tests/baselines/reference/symbolProperty5.types
@@ -10,14 +10,14 @@ var x = {
 >0 : 0
 
     [Symbol.toPrimitive]() { },
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 
     get [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return 0;
 >0 : 0

--- a/tests/baselines/reference/symbolProperty6.types
+++ b/tests/baselines/reference/symbolProperty6.types
@@ -9,19 +9,19 @@ class C {
 >0 : 0
 
     [Symbol.unscopables]: number;
->Symbol.unscopables : symbol
+>Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
->unscopables : symbol
+>unscopables : unique symbol
 
     [Symbol.toPrimitive]() { }
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 
     get [Symbol.toStringTag]() {
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
         return 0;
 >0 : 0

--- a/tests/baselines/reference/symbolProperty60.types
+++ b/tests/baselines/reference/symbolProperty60.types
@@ -4,9 +4,9 @@ interface I1 {
 >I1 : I1
 
     [Symbol.toStringTag]: string;
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     [key: string]: number;
 >key : string
@@ -16,9 +16,9 @@ interface I2 {
 >I2 : I2
 
     [Symbol.toStringTag]: string;
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
     [key: number]: boolean;
 >key : number

--- a/tests/baselines/reference/symbolProperty8.types
+++ b/tests/baselines/reference/symbolProperty8.types
@@ -3,12 +3,12 @@ interface I {
 >I : I
 
     [Symbol.unscopables]: number;
->Symbol.unscopables : symbol
+>Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
->unscopables : symbol
+>unscopables : unique symbol
 
     [Symbol.toPrimitive]();
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 }

--- a/tests/baselines/reference/symbolType2.types
+++ b/tests/baselines/reference/symbolType2.types
@@ -1,15 +1,15 @@
 === tests/cases/conformance/es6/Symbols/symbolType2.ts ===
 Symbol.isConcatSpreadable in {};
 >Symbol.isConcatSpreadable in {} : boolean
->Symbol.isConcatSpreadable : symbol
+>Symbol.isConcatSpreadable : unique symbol
 >Symbol : SymbolConstructor
->isConcatSpreadable : symbol
+>isConcatSpreadable : unique symbol
 >{} : {}
 
 "" in Symbol.toPrimitive;
 >"" in Symbol.toPrimitive : boolean
 >"" : ""
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 

--- a/tests/baselines/reference/symbolType3.types
+++ b/tests/baselines/reference/symbolType3.types
@@ -12,15 +12,15 @@ delete Symbol.iterator;
 
 void Symbol.toPrimitive;
 >void Symbol.toPrimitive : undefined
->Symbol.toPrimitive : symbol
+>Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
->toPrimitive : symbol
+>toPrimitive : unique symbol
 
 typeof Symbol.toStringTag;
 >typeof Symbol.toStringTag : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
 ++s;
 >++s : number

--- a/tests/baselines/reference/useSharedArrayBuffer4.types
+++ b/tests/baselines/reference/useSharedArrayBuffer4.types
@@ -18,17 +18,17 @@ var species = foge[Symbol.species];
 >species : SharedArrayBuffer
 >foge[Symbol.species] : SharedArrayBuffer
 >foge : SharedArrayBuffer
->Symbol.species : symbol
+>Symbol.species : unique symbol
 >Symbol : SymbolConstructor
->species : symbol
+>species : unique symbol
 
 var stringTag = foge[Symbol.toStringTag];
 >stringTag : "SharedArrayBuffer"
 >foge[Symbol.toStringTag] : "SharedArrayBuffer"
 >foge : SharedArrayBuffer
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 
 var len = foge.byteLength;
 >len : number

--- a/tests/baselines/reference/useSharedArrayBuffer5.types
+++ b/tests/baselines/reference/useSharedArrayBuffer5.types
@@ -9,15 +9,15 @@ var species = foge[Symbol.species];
 >species : SharedArrayBuffer
 >foge[Symbol.species] : SharedArrayBuffer
 >foge : SharedArrayBuffer
->Symbol.species : symbol
+>Symbol.species : unique symbol
 >Symbol : SymbolConstructor
->species : symbol
+>species : unique symbol
 
 var stringTag = foge[Symbol.toStringTag];
 >stringTag : "SharedArrayBuffer"
 >foge[Symbol.toStringTag] : "SharedArrayBuffer"
 >foge : SharedArrayBuffer
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 

--- a/tests/baselines/reference/useSharedArrayBuffer6.types
+++ b/tests/baselines/reference/useSharedArrayBuffer6.types
@@ -9,15 +9,15 @@ var species = foge[Symbol.species];
 >species : SharedArrayBuffer
 >foge[Symbol.species] : SharedArrayBuffer
 >foge : SharedArrayBuffer
->Symbol.species : symbol
+>Symbol.species : unique symbol
 >Symbol : SymbolConstructor
->species : symbol
+>species : unique symbol
 
 var stringTag = foge[Symbol.toStringTag];
 >stringTag : "SharedArrayBuffer"
 >foge[Symbol.toStringTag] : "SharedArrayBuffer"
 >foge : SharedArrayBuffer
->Symbol.toStringTag : symbol
+>Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
->toStringTag : symbol
+>toStringTag : unique symbol
 


### PR DESCRIPTION
Fixes #21603

As @rbuckton said at https://github.com/Microsoft/TypeScript/pull/15473#discussion_r149260368, we can't update `Symbol.iterator` because of @\types/node for now.

From https://github.com/Microsoft/TypeScript/commit/af73ca009369b21f2031042268ba3ccfdebdc876, unique symbol seems to have some bugs. @rbuckton Can you take a look?