### PR TITLE
remove GeneratorFunction global from lib.d.ts

### DIFF
--- a/src/lib/es2015.generator.d.ts
+++ b/src/lib/es2015.generator.d.ts
@@ -49,4 +49,3 @@ interface GeneratorFunctionConstructor {
      */
     readonly prototype: GeneratorFunction;
 }
-declare var GeneratorFunction: GeneratorFunctionConstructor;


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction):

> Note that GeneratorFunction is not a global object.

I found the bug when reading https://github.com/Microsoft/TypeScript/issues/21527.

This [code](https://www.typescriptlang.org/play/#src=%0AGeneratorFunction.name%20) compiles in playground but throws a runtime error.