### PR TITLE
Fix harness getDirectores implementation to not include directory as prefix

### DIFF
--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -189,10 +189,7 @@ namespace Harness.LanguageService {
         getCancellationToken() { return this.cancellationToken; }
         getDirectories(path: string): string[] {
             const dir = this.virtualFileSystem.traversePath(path);
-            if (dir && dir.isDirectory()) {
-                return ts.map((<Utils.VirtualDirectory>dir).getDirectories(), (d) => ts.combinePaths(path, d.name));
-            }
-            return [];
+            return dir && dir.isDirectory() ? dir.getDirectories().map(d => d.name) : [];
         }
         getCurrentDirectory(): string { return virtualFileSystemRoot; }
         getDefaultLibFileName(): string { return Harness.Compiler.defaultLibFileName; }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -359,7 +359,7 @@ namespace ts.Completions {
                 //      import x = require("/*completion position*/");
                 //      var y = require("/*completion position*/");
                 //      export * from "/*completion position*/";
-                return pathCompletionsInfo(PathCompletions.getStringLiteralCompletionsFromModuleNames(sourceFile, node as StringLiteral, compilerOptions, host, typeChecker));
+                return pathCompletionsInfo(PathCompletions.getStringLiteralCompletionsFromModuleNames(sourceFile, node, compilerOptions, host, typeChecker));
 
             default:
                 return fromContextualType();

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -200,8 +200,8 @@ namespace ts {
         /* @internal */ hasChangedAutomaticTypeDirectiveNames?: boolean;
 
         /*
-         * getDirectories is also required for full import and type reference completions. Without it defined, certain
-         * completions will not be provided
+         * Required for full import and type reference completions.
+         * These should be unprefixed names. E.g. `getDirectories("/foo/bar")` should return `["a", "b"]`, not `["/foo/bar/a", "/foo/bar/b"]`.
          */
         getDirectories?(directoryName: string): string[];
 

--- a/tests/cases/fourslash/completionsPaths_pathMapping.ts
+++ b/tests/cases/fourslash/completionsPaths_pathMapping.ts
@@ -20,8 +20,4 @@
 ////}
 
 const [replacementSpan] = test.ranges();
-verify.completionsAt("", [
-    { name: "a", replacementSpan },
-    { name: "b", replacementSpan },
-    { name: "dir", replacementSpan },
-]);
+verify.completionsAt("", ["a", "b", "dir"].map(name => ({ name, replacementSpan })));


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/pull/21100#issuecomment-362913096

We already had fourslash tests for getting directories in path completions. But, the harness implementation of `getDirectories` differed from the original one, as it returned directories with the prefix present.
Now directory completions with paths should for real in addition to in fourslash tests. (See the linked comment for repro instructions.)