### PR TITLE
class Project: implement `log` and `error` from `LanguageServiceHost`

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -428,6 +428,14 @@ namespace ts.server {
             this.projectService.logger.info(s);
         }
 
+        log(s: string) {
+            this.writeLog(s);
+        }
+
+        error(s: string) {
+            this.projectService.logger.msg(s, Msg.Err);
+        }
+
         private setInternalCompilerOptionsForEmittingJsFiles() {
             if (this.projectKind === ProjectKind.Inferred || this.projectKind === ProjectKind.External) {
                 this.compilerOptions.noEmitForJsFiles = true;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7498,6 +7498,8 @@ declare namespace ts.server {
         resolveTypeReferenceDirectives(typeDirectiveNames: string[], containingFile: string): ResolvedTypeReferenceDirective[];
         directoryExists(path: string): boolean;
         getDirectories(path: string): string[];
+        log(s: string): void;
+        error(s: string): void;
         private setInternalCompilerOptionsForEmittingJsFiles();
         /**
          * Get the errors that dont have any file name associated


### PR DESCRIPTION
Without this, we won't see any logs from e.g. completions.