### PR TITLE
traversePath: Don't stop at an entry unless we're at the last path component

### DIFF
--- a/src/harness/virtualFileSystem.ts
+++ b/src/harness/virtualFileSystem.ts
@@ -142,17 +142,18 @@ namespace Utils {
 
         traversePath(path: string) {
             path = ts.normalizePath(path);
-            let directory: VirtualDirectory = this.root;
-            for (const component of ts.getNormalizedPathComponents(path, this.currentDirectory)) {
-                const entry = directory.getFileSystemEntry(component);
+            let directory = this.root;
+            const components = ts.getNormalizedPathComponents(path, this.currentDirectory);
+            for (let i = 0; i < components.length; i++) {
+                const entry = directory.getFileSystemEntry(components[i]);
                 if (entry === undefined) {
                     return undefined;
                 }
                 else if (entry.isDirectory()) {
-                    directory = <VirtualDirectory>entry;
+                    directory = entry;
                 }
                 else {
-                    return entry;
+                    return i === components.length - 1 ? entry : undefined;
                 }
             }
 


### PR DESCRIPTION
Avoids returning content of `/a.ts` when querying for `/a.ts/package.json`.
@rbuckton hope you have a similar fix in #20763.