### PR TITLE
fix: `matchedText` module resolution incorrect length

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2985,8 +2985,7 @@ namespace ts {
      */
     export function matchedText(pattern: Pattern, candidate: string): string {
         Debug.assert(isPatternMatch(pattern, candidate));
-        const matchLength = candidate.length - pattern.suffix.length - pattern.prefix.length;
-        return candidate.substr(pattern.prefix.length, matchLength);
+        return candidate.substring(pattern.prefix.length, candidate.length - pattern.suffix.length);
     }
 
     /** Return the object corresponding to the best pattern to match `candidate`. */

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2985,7 +2985,8 @@ namespace ts {
      */
     export function matchedText(pattern: Pattern, candidate: string): string {
         Debug.assert(isPatternMatch(pattern, candidate));
-        return candidate.substr(pattern.prefix.length, candidate.length - pattern.suffix.length);
+        const matchLength = candidate.length - pattern.suffix.length - pattern.prefix.length;
+        return candidate.substr(pattern.prefix.length, matchLength);
     }
 
     /** Return the object corresponding to the best pattern to match `candidate`. */

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.js
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.js
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts] ////
+
+//// [index.ts]
+import {x} from "@speedy/folder1/testing"
+declare function use(a: any): void;
+use(x.toExponential());
+
+//// [index.ts]
+export const x = 1 + 2;
+
+
+//// [index.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    exports.x = 1 + 2;
+});
+//// [index.js]
+define(["require", "exports", "@speedy/folder1/testing"], function (require, exports, testing_1) {
+    "use strict";
+    exports.__esModule = true;
+    use(testing_1.x.toExponential());
+});

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.js
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.js
@@ -2,8 +2,6 @@
 
 //// [index.ts]
 import {x} from "@speedy/folder1/testing"
-declare function use(a: any): void;
-use(x.toExponential());
 
 //// [index.ts]
 export const x = 1 + 2;
@@ -16,8 +14,7 @@ define(["require", "exports"], function (require, exports) {
     exports.x = 1 + 2;
 });
 //// [index.js]
-define(["require", "exports", "@speedy/folder1/testing"], function (require, exports, testing_1) {
+define(["require", "exports"], function (require, exports) {
     "use strict";
     exports.__esModule = true;
-    use(testing_1.x.toExponential());
 });

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.symbols
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.symbols
@@ -2,16 +2,6 @@
 import {x} from "@speedy/folder1/testing"
 >x : Symbol(x, Decl(index.ts, 0, 8))
 
-declare function use(a: any): void;
->use : Symbol(use, Decl(index.ts, 0, 41))
->a : Symbol(a, Decl(index.ts, 1, 21))
-
-use(x.toExponential());
->use : Symbol(use, Decl(index.ts, 0, 41))
->x.toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
->x : Symbol(x, Decl(index.ts, 0, 8))
->toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
-
 === c:/root/folder1/dist/index.ts ===
 export const x = 1 + 2;
 >x : Symbol(x, Decl(index.ts, 0, 12))

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.symbols
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.symbols
@@ -1,0 +1,18 @@
+=== c:/root/index.ts ===
+import {x} from "@speedy/folder1/testing"
+>x : Symbol(x, Decl(index.ts, 0, 8))
+
+declare function use(a: any): void;
+>use : Symbol(use, Decl(index.ts, 0, 41))
+>a : Symbol(a, Decl(index.ts, 1, 21))
+
+use(x.toExponential());
+>use : Symbol(use, Decl(index.ts, 0, 41))
+>x.toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(index.ts, 0, 8))
+>toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+
+=== c:/root/folder1/dist/index.ts ===
+export const x = 1 + 2;
+>x : Symbol(x, Decl(index.ts, 0, 12))
+

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.trace.json
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.trace.json
@@ -1,0 +1,10 @@
+[
+    "======== Resolving module '@speedy/folder1/testing' from 'c:/root/index.ts'. ========",
+    "Explicitly specified module resolution kind: 'Classic'.",
+    "'baseUrl' option is set to 'c:/root', using this value to resolve non-relative module name '@speedy/folder1/testing'.",
+    "'paths' option is specified, looking for a pattern to match module name '@speedy/folder1/testing'.",
+    "Module name '@speedy/folder1/testing', matched pattern '@speedy/*/testing'.",
+    "Trying substitution '*/dist/index.ts', candidate module location: 'folder1/dist/index.ts'.",
+    "File 'c:/root/folder1/dist/index.ts' exist - use it as a name resolution result.",
+    "======== Module name '@speedy/folder1/testing' was successfully resolved to 'c:/root/folder1/dist/index.ts'. ========"
+]

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.types
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.types
@@ -1,0 +1,23 @@
+=== c:/root/index.ts ===
+import {x} from "@speedy/folder1/testing"
+>x : number
+
+declare function use(a: any): void;
+>use : (a: any) => void
+>a : any
+
+use(x.toExponential());
+>use(x.toExponential()) : void
+>use : (a: any) => void
+>x.toExponential() : string
+>x.toExponential : (fractionDigits?: number) => string
+>x : number
+>toExponential : (fractionDigits?: number) => string
+
+=== c:/root/folder1/dist/index.ts ===
+export const x = 1 + 2;
+>x : number
+>1 + 2 : number
+>1 : 1
+>2 : 2
+

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.types
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_classic.types
@@ -2,18 +2,6 @@
 import {x} from "@speedy/folder1/testing"
 >x : number
 
-declare function use(a: any): void;
->use : (a: any) => void
->a : any
-
-use(x.toExponential());
->use(x.toExponential()) : void
->use : (a: any) => void
->x.toExponential() : string
->x.toExponential : (fractionDigits?: number) => string
->x : number
->toExponential : (fractionDigits?: number) => string
-
 === c:/root/folder1/dist/index.ts ===
 export const x = 1 + 2;
 >x : number

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_node.js
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_node.js
@@ -2,8 +2,6 @@
 
 //// [index.ts]
 import {x} from "@speedy/folder1/testing"
-declare function use(a: any): void;
-use(x.toExponential());
 
 //// [index.ts]
 export const x = 1 + 2;
@@ -16,5 +14,3 @@ exports.x = 1 + 2;
 //// [index.js]
 "use strict";
 exports.__esModule = true;
-var testing_1 = require("@speedy/folder1/testing");
-use(testing_1.x.toExponential());

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_node.js
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_node.js
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/pathMappingBasedModuleResolution8_node.ts] ////
+
+//// [index.ts]
+import {x} from "@speedy/folder1/testing"
+declare function use(a: any): void;
+use(x.toExponential());
+
+//// [index.ts]
+export const x = 1 + 2;
+
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.x = 1 + 2;
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var testing_1 = require("@speedy/folder1/testing");
+use(testing_1.x.toExponential());

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_node.symbols
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_node.symbols
@@ -2,16 +2,6 @@
 import {x} from "@speedy/folder1/testing"
 >x : Symbol(x, Decl(index.ts, 0, 8))
 
-declare function use(a: any): void;
->use : Symbol(use, Decl(index.ts, 0, 41))
->a : Symbol(a, Decl(index.ts, 1, 21))
-
-use(x.toExponential());
->use : Symbol(use, Decl(index.ts, 0, 41))
->x.toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
->x : Symbol(x, Decl(index.ts, 0, 8))
->toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
-
 === c:/root/folder1/dist/index.ts ===
 export const x = 1 + 2;
 >x : Symbol(x, Decl(index.ts, 0, 12))

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_node.symbols
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_node.symbols
@@ -1,0 +1,18 @@
+=== c:/root/index.ts ===
+import {x} from "@speedy/folder1/testing"
+>x : Symbol(x, Decl(index.ts, 0, 8))
+
+declare function use(a: any): void;
+>use : Symbol(use, Decl(index.ts, 0, 41))
+>a : Symbol(a, Decl(index.ts, 1, 21))
+
+use(x.toExponential());
+>use : Symbol(use, Decl(index.ts, 0, 41))
+>x.toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(index.ts, 0, 8))
+>toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+
+=== c:/root/folder1/dist/index.ts ===
+export const x = 1 + 2;
+>x : Symbol(x, Decl(index.ts, 0, 12))
+

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_node.trace.json
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_node.trace.json
@@ -1,0 +1,10 @@
+[
+    "======== Resolving module '@speedy/folder1/testing' from 'c:/root/index.ts'. ========",
+    "Explicitly specified module resolution kind: 'NodeJs'.",
+    "'baseUrl' option is set to 'c:/root', using this value to resolve non-relative module name '@speedy/folder1/testing'.",
+    "'paths' option is specified, looking for a pattern to match module name '@speedy/folder1/testing'.",
+    "Module name '@speedy/folder1/testing', matched pattern '@speedy/*/testing'.",
+    "Trying substitution '*/dist/index.ts', candidate module location: 'folder1/dist/index.ts'.",
+    "File 'c:/root/folder1/dist/index.ts' exist - use it as a name resolution result.",
+    "======== Module name '@speedy/folder1/testing' was successfully resolved to 'c:/root/folder1/dist/index.ts'. ========"
+]

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_node.types
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_node.types
@@ -1,0 +1,23 @@
+=== c:/root/index.ts ===
+import {x} from "@speedy/folder1/testing"
+>x : number
+
+declare function use(a: any): void;
+>use : (a: any) => void
+>a : any
+
+use(x.toExponential());
+>use(x.toExponential()) : void
+>use : (a: any) => void
+>x.toExponential() : string
+>x.toExponential : (fractionDigits?: number) => string
+>x : number
+>toExponential : (fractionDigits?: number) => string
+
+=== c:/root/folder1/dist/index.ts ===
+export const x = 1 + 2;
+>x : number
+>1 + 2 : number
+>1 : 1
+>2 : 2
+

--- a/tests/baselines/reference/pathMappingBasedModuleResolution8_node.types
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution8_node.types
@@ -2,18 +2,6 @@
 import {x} from "@speedy/folder1/testing"
 >x : number
 
-declare function use(a: any): void;
->use : (a: any) => void
->a : any
-
-use(x.toExponential());
->use(x.toExponential()) : void
->use : (a: any) => void
->x.toExponential() : string
->x.toExponential : (fractionDigits?: number) => string
->x : number
->toExponential : (fractionDigits?: number) => string
-
 === c:/root/folder1/dist/index.ts ===
 export const x = 1 + 2;
 >x : number

--- a/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
+++ b/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
@@ -1,0 +1,23 @@
+// @moduleResolution: classic
+// @module: amd
+// @traceResolution: true
+
+// @filename: c:/root/tsconfig.json
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@speedy/*/testing": [
+               "*/dist/index.ts"
+            ]
+        }
+    }
+}
+
+// @filename: c:/root/index.ts
+import {x} from "@speedy/folder1/testing"
+declare function use(a: any): void;
+use(x.toExponential());
+
+// @filename: c:/root/folder1/dist/index.ts
+export const x = 1 + 2;

--- a/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
+++ b/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
@@ -16,8 +16,6 @@
 
 // @filename: c:/root/index.ts
 import {x} from "@speedy/folder1/testing"
-declare function use(a: any): void;
-use(x.toExponential());
 
 // @filename: c:/root/folder1/dist/index.ts
 export const x = 1 + 2;

--- a/tests/cases/compiler/pathMappingBasedModuleResolution8_node.ts
+++ b/tests/cases/compiler/pathMappingBasedModuleResolution8_node.ts
@@ -1,0 +1,23 @@
+// @moduleResolution: node
+// @module: commonjs
+// @traceResolution: true
+
+// @filename: c:/root/tsconfig.json
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@speedy/*/testing": [
+               "*/dist/index.ts"
+            ]
+        }
+    }
+}
+
+// @filename: c:/root/index.ts
+import {x} from "@speedy/folder1/testing"
+declare function use(a: any): void;
+use(x.toExponential());
+
+// @filename: c:/root/folder1/dist/index.ts
+export const x = 1 + 2;

--- a/tests/cases/compiler/pathMappingBasedModuleResolution8_node.ts
+++ b/tests/cases/compiler/pathMappingBasedModuleResolution8_node.ts
@@ -16,8 +16,6 @@
 
 // @filename: c:/root/index.ts
 import {x} from "@speedy/folder1/testing"
-declare function use(a: any): void;
-use(x.toExponential());
 
 // @filename: c:/root/folder1/dist/index.ts
 export const x = 1 + 2;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

`matchedText` was not properly extract the correct parts from the candidate.

Fixes #21636
