### PR TITLE
fixInvalidImportSyntax: Preserve comment

### DIFF
--- a/tests/cases/fourslash/codeFixCalledES2015Import11.ts
+++ b/tests/cases/fourslash/codeFixCalledES2015Import11.ts
@@ -6,13 +6,15 @@
 ////export = foo;
 
 // @Filename: index.ts
+////// Comment
 ////import * as foo from "./foo";
 ////[|foo()|];
 
 goTo.file(1);
 verify.codeFix({
     description: `Replace import with 'import foo from "./foo";'.`,
-    newFileContent: `import foo from "./foo";
+    newFileContent: `// Comment
+import foo from "./foo";
 foo();`,
     index: 0,
 });


### PR DESCRIPTION
Fixes #21652
Another `replaceNode` that didn't work -- see #21246