### PR TITLE
Avoid an expression getting a contextual type from its own inferred type (2)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14076,7 +14076,10 @@ namespace ts {
                 // If we're already in the process of resolving the given signature, don't resolve again as
                 // that could cause infinite recursion. Instead, return anySignature.
                 const signature = getNodeLinks(callTarget).resolvedSignature === resolvingSignature ? resolvingSignature : getResolvedSignature(callTarget);
-                return getTypeAtPosition(signature, argIndex);
+                const type = getTypeAtPosition(signature, argIndex);
+                // Don't return a contextual type that is a type inferred from this argument itself.
+                const declarations = type.symbol && type.symbol.declarations;
+                return length(declarations) === 1 && first(declarations!) === <Declaration | Expression>arg ? undefined : type;
             }
             return undefined;
         }

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints4.types
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints4.types
@@ -104,11 +104,11 @@ var r8 = foo(() => { }, () => { });
 >() => { } : () => void
 
 var r9 = foo(() => { }, () => 1);
->r9 : (x: () => void) => () => 1
->foo(() => { }, () => 1) : (x: () => void) => () => 1
+>r9 : (x: () => void) => () => number
+>foo(() => { }, () => 1) : (x: () => void) => () => number
 >foo : <T, U extends T>(t: T, t2: U) => (x: T) => U
 >() => { } : () => void
->() => 1 : () => 1
+>() => 1 : () => number
 >1 : 1
 
 function other<T, U extends T>() {

--- a/tests/baselines/reference/isomorphicMappedTypeInference.types
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.types
@@ -245,8 +245,8 @@ function f3() {
 >assignBoxified(b, { c: false }) : void
 >assignBoxified : <T>(obj: Boxified<T>, values: T) => void
 >b : { a: Box<number>; b: Box<string>; c: Box<boolean>; }
->{ c: false } : { c: false; }
->c : false
+>{ c: false } : { c: boolean; }
+>c : boolean
 >false : false
 }
 

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -952,8 +952,8 @@ function f71(func: <T, U>(x: T, y: U) => Partial<T & U>) {
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 
     x.a;  // number | undefined
@@ -999,8 +999,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'a' : "a"
 
@@ -1013,8 +1013,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'b' : "b"
 
@@ -1027,8 +1027,8 @@ function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T &
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'c' : "c"
 }
@@ -1060,8 +1060,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'a' : "a"
 
@@ -1074,8 +1074,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'b' : "b"
 
@@ -1088,8 +1088,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ c: true } : { c: true; }
->c : true
+>{ c: true } : { c: boolean; }
+>c : boolean
 >true : true
 >'c' : "c"
 }
@@ -1121,10 +1121,10 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ a: 2, b: true } : { a: number; b: true; }
+>{ a: 2, b: true } : { a: number; b: boolean; }
 >a : number
 >2 : 2
->b : true
+>b : boolean
 >true : true
 >'a' : "a"
 
@@ -1137,10 +1137,10 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 >1 : 1
 >b : string
 >"hello" : "hello"
->{ a: 2, b: true } : { a: number; b: true; }
+>{ a: 2, b: true } : { a: number; b: boolean; }
 >a : number
 >2 : 2
->b : true
+>b : boolean
 >true : true
 >'b' : "b"
 }

--- a/tests/baselines/reference/objectFreeze.types
+++ b/tests/baselines/reference/objectFreeze.types
@@ -1,20 +1,20 @@
 === tests/cases/compiler/objectFreeze.ts ===
 const f = Object.freeze(function foo(a: number, b: string) { return false; });
->f : (a: number, b: string) => false
->Object.freeze(function foo(a: number, b: string) { return false; }) : (a: number, b: string) => false
+>f : (a: number, b: string) => boolean
+>Object.freeze(function foo(a: number, b: string) { return false; }) : (a: number, b: string) => boolean
 >Object.freeze : { <T>(a: T[]): ReadonlyArray<T>; <T extends Function>(f: T): T; <T>(o: T): Readonly<T>; }
 >Object : ObjectConstructor
 >freeze : { <T>(a: T[]): ReadonlyArray<T>; <T extends Function>(f: T): T; <T>(o: T): Readonly<T>; }
->function foo(a: number, b: string) { return false; } : (a: number, b: string) => false
->foo : (a: number, b: string) => false
+>function foo(a: number, b: string) { return false; } : (a: number, b: string) => boolean
+>foo : (a: number, b: string) => boolean
 >a : number
 >b : string
 >false : false
 
 f(1, "") === false;
 >f(1, "") === false : boolean
->f(1, "") : false
->f : (a: number, b: string) => false
+>f(1, "") : boolean
+>f : (a: number, b: string) => boolean
 >1 : 1
 >"" : ""
 >false : false

--- a/tests/baselines/reference/objectLiteralParameterResolution.types
+++ b/tests/baselines/reference/objectLiteralParameterResolution.types
@@ -29,7 +29,7 @@ var s = $.extend({
 >$.extend : { <T>(target: T, ...objs: any[]): T; <T>(deep: boolean, target: T, ...objs: any[]): T; }
 >$ : Foo
 >extend : { <T>(target: T, ...objs: any[]): T; <T>(deep: boolean, target: T, ...objs: any[]): T; }
->{    type: "GET" ,    data: "data" ,    success: wrapSuccessCallback(requestContext, callback) ,    error: wrapErrorCallback(requestContext, errorCallback) ,    dataType: "json" ,    converters: { "text json": "" },    traditional: true ,    timeout: 12,    } : { type: string; data: string; success: any; error: any; dataType: string; converters: { "text json": string; }; traditional: true; timeout: number; }
+>{    type: "GET" ,    data: "data" ,    success: wrapSuccessCallback(requestContext, callback) ,    error: wrapErrorCallback(requestContext, errorCallback) ,    dataType: "json" ,    converters: { "text json": "" },    traditional: true ,    timeout: 12,    } : { type: string; data: string; success: any; error: any; dataType: string; converters: { "text json": string; }; traditional: boolean; timeout: number; }
 
     type: "GET" ,
 >type : string
@@ -63,7 +63,7 @@ var s = $.extend({
 >"" : ""
 
     traditional: true ,
->traditional : true
+>traditional : boolean
 >true : true
 
     timeout: 12,

--- a/tests/baselines/reference/objectSpreadNegative.types
+++ b/tests/baselines/reference/objectSpreadNegative.types
@@ -278,10 +278,10 @@ let exclusive: { id: string, a: number, b: string, c: string, d: boolean } =
 >1 : 1
 >b : string
 >'yes' : "yes"
->{ c: 'no', d: false } : { c: string; d: false; }
+>{ c: 'no', d: false } : { c: string; d: boolean; }
 >c : string
 >'no' : "no"
->d : false
+>d : boolean
 >false : false
 
 let overlap: { id: string, a: number, b: string } =
@@ -327,10 +327,10 @@ let overwriteId: { id: string, a: number, c: number, d: string } =
     f({ a: 1, id: true }, { c: 1, d: 'no' })
 >f({ a: 1, id: true }, { c: 1, d: 'no' }) : any
 >f : <T, U>(t: T, u: U) => any
->{ a: 1, id: true } : { a: number; id: true; }
+>{ a: 1, id: true } : { a: number; id: boolean; }
 >a : number
 >1 : 1
->id : true
+>id : boolean
 >true : true
 >{ c: 1, d: 'no' } : { c: number; d: string; }
 >c : number

--- a/tests/baselines/reference/selfReference.types
+++ b/tests/baselines/reference/selfReference.types
@@ -7,8 +7,8 @@ declare function asFunction<T>(value: T): () => T;
 >T : T
 
 asFunction(() => { return 1; });
->asFunction(() => { return 1; }) : () => () => 1
+>asFunction(() => { return 1; }) : () => () => number
 >asFunction : <T>(value: T) => () => T
->() => { return 1; } : () => 1
+>() => { return 1; } : () => number
 >1 : 1
 

--- a/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively.types
+++ b/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively.types
@@ -62,12 +62,12 @@ foo({ x: 1 }, { x: 1, y: '' }, { x: 2, y: '', z: true });
 >1 : 1
 >y : string
 >'' : ""
->{ x: 2, y: '', z: true } : { x: number; y: string; z: true; }
+>{ x: 2, y: '', z: true } : { x: number; y: string; z: boolean; }
 >x : number
 >2 : 2
 >y : string
 >'' : ""
->z : true
+>z : boolean
 >true : true
 
 foo(a, b, c);
@@ -82,12 +82,12 @@ foo(a, b, { foo: 1, bar: '', hm: true });
 >foo : <T, U, V>(x: T, y: U, z: V) => V
 >a : A
 >b : B
->{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: true; }
+>{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: boolean; }
 >foo : number
 >1 : 1
 >bar : string
 >'' : ""
->hm : true
+>hm : boolean
 >true : true
 
 foo((x: number, y) => { }, (x) => { }, () => { });

--- a/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively2.types
+++ b/tests/baselines/reference/typeParameterAsTypeParameterConstraintTransitively2.types
@@ -62,12 +62,12 @@ foo({ x: 1 }, { x: 1, y: '' }, { x: 2, y: 2, z: true });
 >1 : 1
 >y : string
 >'' : ""
->{ x: 2, y: 2, z: true } : { x: number; y: number; z: true; }
+>{ x: 2, y: 2, z: true } : { x: number; y: number; z: boolean; }
 >x : number
 >2 : 2
 >y : number
 >2 : 2
->z : true
+>z : boolean
 >true : true
 
 foo(a, b, a);
@@ -81,12 +81,12 @@ foo(a, { foo: 1, bar: '', hm: true }, b);
 >foo(a, { foo: 1, bar: '', hm: true }, b) : B
 >foo : <T, U, V>(x: T, y: U, z: V) => V
 >a : A
->{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: true; }
+>{ foo: 1, bar: '', hm: true } : { foo: number; bar: string; hm: boolean; }
 >foo : number
 >1 : 1
 >bar : string
 >'' : ""
->hm : true
+>hm : boolean
 >true : true
 >b : B
 

--- a/tests/cases/fourslash/completionsObjectWithSelfAsContextualType.ts
+++ b/tests/cases/fourslash/completionsObjectWithSelfAsContextualType.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+// Test that we don't use the contexual type `{ x: any }` from the inferred type argument to `id`,
+// since that comes from the object itself.
+
+////declare function id<T>(a: T): void;
+////id({ x/**/ });
+
+goTo.marker("");
+verify.completionListIsEmpty();

--- a/tests/cases/fourslash/completionsObjectWithSelfAsContextualType.ts
+++ b/tests/cases/fourslash/completionsObjectWithSelfAsContextualType.ts
@@ -1,6 +1,6 @@
 /// <reference path="fourslash.ts" />
 
-// Test that we don't use the contexual type `{ x: any }` from the inferred type argument to `id`,
+// Test that we don't use the contextual type `{ x: any }` from the inferred type argument to `id`,
 // since that comes from the object itself.
 
 ////declare function id<T>(a: T): void;

--- a/tests/cases/fourslash/extract-method10.ts
+++ b/tests/cases/fourslash/extract-method10.ts
@@ -12,7 +12,7 @@ edit.applyRefactor({
 `export {}; // Make this a module
 (x => x)(/*RENAME*/newFunction())(1);
 
-function newFunction(): (x: any) => any {
+function newFunction() {
     return x => x;
 }
 `


### PR DESCRIPTION
Like #21583, but changes the implementation in `checker.ts`.