### PR TITLE
Handle file versioning little better in tsc --watch mode

### DIFF
--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -488,13 +488,13 @@ namespace ts {
         const watchFilePath = compilerOptions.extendedDiagnostics ? ts.addFilePathWatcherWithLogging : ts.addFilePathWatcher;
         const watchDirectoryWorker = compilerOptions.extendedDiagnostics ? ts.addDirectoryWatcherWithLogging : ts.addDirectoryWatcher;
 
+        const getCanonicalFileName = createGetCanonicalFileName(useCaseSensitiveFileNames);
+        let newLine = updateNewLine();
+
         writeLog(`Current directory: ${currentDirectory} CaseSensitiveFileNames: ${useCaseSensitiveFileNames}`);
         if (configFileName) {
             watchFile(host, configFileName, scheduleProgramReload, writeLog);
         }
-
-        const getCanonicalFileName = createGetCanonicalFileName(useCaseSensitiveFileNames);
-        let newLine = updateNewLine();
 
         const compilerHost: CompilerHost & ResolutionCacheHost = {
             // Members for CompilerHost
@@ -583,7 +583,9 @@ namespace ts {
 
             // Compile the program
             if (loggingEnabled) {
-                writeLog(`CreatingProgramWith::\n  roots: ${JSON.stringify(rootFileNames)}\n  options: ${JSON.stringify(compilerOptions)}`);
+                writeLog(`CreatingProgramWith::`);
+                writeLog(`  roots: ${JSON.stringify(rootFileNames)}`);
+                writeLog(`  options: ${JSON.stringify(compilerOptions)}`);
             }
 
             const needsUpdateInTypeRootWatch = hasChangedCompilerOptions || !program;

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -420,8 +420,7 @@ namespace ts {
         }
     }
 
-    const intialVersion = 1;
-    const intialVersionString = "1";
+    const initialVersion = 1;
 
     /**
      * Creates the watch from the host for root files and compiler options
@@ -437,7 +436,7 @@ namespace ts {
             sourceFile: SourceFile;
             fileWatcher: FileWatcher;
         }
-        type FileMissingOnHost = string;
+        type FileMissingOnHost = number;
         interface FilePresenceUnknownOnHost {
             version: number;
         }
@@ -637,7 +636,7 @@ namespace ts {
         }
 
         function isFileMissingOnHost(hostSourceFile: HostFileInfo): hostSourceFile is FileMissingOnHost {
-            return isString(hostSourceFile);
+            return typeof hostSourceFile === "number";
         }
 
         function isFilePresentOnHost(hostSourceFile: FileMayBePresentOnHost): hostSourceFile is FilePresentOnHost {
@@ -683,17 +682,17 @@ namespace ts {
                         if (isFilePresentOnHost(hostSourceFile)) {
                             hostSourceFile.fileWatcher.close();
                         }
-                        sourceFilesCache.set(path, hostSourceFile.version.toString());
+                        sourceFilesCache.set(path, hostSourceFile.version);
                     }
                 }
                 else {
                     if (sourceFile) {
-                        sourceFile.version = intialVersionString;
+                        sourceFile.version = initialVersion.toString();
                         const fileWatcher = watchFilePath(host, fileName, onSourceFileChange, path, writeLog);
-                        sourceFilesCache.set(path, { sourceFile, version: intialVersion, fileWatcher });
+                        sourceFilesCache.set(path, { sourceFile, version: initialVersion, fileWatcher });
                     }
                     else {
-                        sourceFilesCache.set(path, intialVersionString);
+                        sourceFilesCache.set(path, initialVersion);
                     }
                 }
                 return sourceFile;

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -1730,7 +1730,7 @@ namespace ts.tscWatch {
             const configFile: FileOrFolder = {
                 path: `${projectLocation}/tsconfig.json`,
                 content: JSON.stringify({
-                    "include": [
+                    include: [
                         "app/**/*.ts"
                     ]
                 })
@@ -1740,7 +1740,7 @@ namespace ts.tscWatch {
             createWatchOfConfigFile("tsconfig.json", host);
             verifyProgram();
 
-            file.content += "var b = 10;";
+            file.content += "\nvar b = 10;";
 
             host.reloadFS(files, { invokeFileDeleteCreateAsPartInsteadOfChange: true });
             host.runQueuedTimeoutCallbacks();

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -246,8 +246,12 @@ interface Array<T> {}`
     }
 
     export interface ReloadWatchInvokeOptions {
+        /** Invokes the directory watcher for the parent instead of the file changed */
         invokeDirectoryWatcherInsteadOfFileChanged: boolean;
+        /** When new file is created, do not invoke watches for it */
         ignoreWatchInvokedWithTriggerAsFileCreate: boolean;
+        /** Invoke the file delete, followed by create instead of file changed */
+        invokeFileDeleteCreateAsPartInsteadOfChange: boolean;
     }
 
     export class TestServerHost implements server.ServerHost, FormatDiagnosticsHost, ModuleResolutionHost {
@@ -315,12 +319,18 @@ interface Array<T> {}`
                         if (isString(fileOrDirectory.content)) {
                             // Update file
                             if (currentEntry.content !== fileOrDirectory.content) {
-                                currentEntry.content = fileOrDirectory.content;
-                                if (options && options.invokeDirectoryWatcherInsteadOfFileChanged) {
-                                    this.invokeDirectoryWatcher(getDirectoryPath(currentEntry.fullPath), currentEntry.fullPath);
+                                if (options && options.invokeFileDeleteCreateAsPartInsteadOfChange) {
+                                    this.removeFileOrFolder(currentEntry, returnFalse);
+                                    this.ensureFileOrFolder(fileOrDirectory);
                                 }
                                 else {
-                                    this.invokeFileWatcher(currentEntry.fullPath, FileWatcherEventKind.Changed);
+                                    currentEntry.content = fileOrDirectory.content;
+                                    if (options && options.invokeDirectoryWatcherInsteadOfFileChanged) {
+                                        this.invokeDirectoryWatcher(getDirectoryPath(currentEntry.fullPath), currentEntry.fullPath);
+                                    }
+                                    else {
+                                        this.invokeFileWatcher(currentEntry.fullPath, FileWatcherEventKind.Changed);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Root cause:
Earlier the source file cache use to either have { version, sourceFile, fileWatcher } or string.
string meant file is on present on the disk and we wont go ahead and create source file at all for these whenever asked for new source file.
During watch callback, especially during wild card directory callback, if the file wasnt present on the disk, we would just remove the entry from cache..  So in below sequence the file version didnt change even though the content had changed:
1. Watch created, file was on disk, so version is set to inital version = 1
2. File deleted, deleted from the cache
3. File get created
4. Updating the program structure, since file is on the disk, create source file and set the version as initial version (as the entry wasn't there in the cache) = 1
5. During emit since old program and new program had files with same version, they arent marked as changed and hence not emitted

Fix:
Now whenever the file callback is invoked, and cache has file as missing, instead of removing the entry, we would create a temp entry that represents that file may be on the disk = { version++ } 
This ensures that next time program is able to find the file on the disk and create new source file, it wont have initial version. Thus when creating new source file from oldProgram, if the file is changed, it would always have different version than the oldSourceFile from oldProgram.

Fixes #21444
