### PR TITLE
Mark many more places as contextual, skip first jsx inference pass if not contextual

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18056,9 +18056,9 @@ namespace ts {
             }
         }
 
-        function assignContextualParameterTypes(signature: Signature, context: Signature) {
+        function assignContextualParameterTypes(node: ArrowFunction | FunctionExpression | MethodDeclaration, signature: Signature, context: Signature) {
             signature.typeParameters = context.typeParameters;
-            if (context.thisParameter) {
+            if (context.thisParameter && node.kind !== SyntaxKind.ArrowFunction) {
                 const parameter = signature.thisParameter;
                 if (!parameter || parameter.valueDeclaration && !(<ParameterDeclaration>parameter.valueDeclaration).type) {
                     if (!parameter) {
@@ -18422,7 +18422,7 @@ namespace ts {
                             }
                             const instantiatedContextualSignature = contextualMapper === identityMapper ?
                                 contextualSignature : instantiateSignature(contextualSignature, contextualMapper);
-                            assignContextualParameterTypes(signature, instantiatedContextualSignature);
+                            assignContextualParameterTypes(node, signature, instantiatedContextualSignature);
                         }
                         if (!getEffectiveReturnTypeNode(node) && !signature.resolvedReturnType) {
                             const returnType = getReturnTypeFromBody(node, checkMode);

--- a/tests/baselines/reference/extractConstant/extractConstant_ContextualType.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ContextualType.ts
@@ -6,5 +6,5 @@ let i: I = /*[#|*/{ a: 1 }/*|]*/;
 // ==SCOPE::Extract to constant in enclosing scope==
 
 interface I { a: 1 | 2 | 3 }
-const newLocal = { a: 1 };
+const newLocal: I = { a: 1 };
 let i: I = /*RENAME*/newLocal;

--- a/tests/baselines/reference/for-of39.types
+++ b/tests/baselines/reference/for-of39.types
@@ -3,7 +3,7 @@ var map = new Map([["", true], ["", 0]]);
 >map : any
 >new Map([["", true], ["", 0]]) : any
 >Map : MapConstructor
->[["", true], ["", 0]] : ((string | boolean)[] | (string | number)[])[]
+>[["", true], ["", 0]] : ((string | number)[] | (string | boolean)[])[]
 >["", true] : (string | boolean)[]
 >"" : ""
 >true : true

--- a/tests/baselines/reference/genericCallWithFunctionTypedArguments.errors.txt
+++ b/tests/baselines/reference/genericCallWithFunctionTypedArguments.errors.txt
@@ -6,7 +6,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFun
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments.ts(33,23): error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => string'.
   Types of parameters 'x' and 'a' are incompatible.
     Type '1' is not assignable to type 'T'.
-tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments.ts(34,24): error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => string'.
+tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments.ts(34,24): error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => 1'.
   Types of parameters 'x' and 'a' are incompatible.
     Type '1' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments.ts(35,23): error TS2345: Argument of type '(a: number) => string' is not assignable to parameter of type '(a: number) => 1'.
@@ -60,7 +60,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFun
 !!! error TS2345:     Type '1' is not assignable to type 'T'.
         var r11b = foo3(1, (x: T) => '', 1); // error
                            ~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => string'.
+!!! error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => 1'.
 !!! error TS2345:   Types of parameters 'x' and 'a' are incompatible.
 !!! error TS2345:     Type '1' is not assignable to type 'T'.
         var r12 = foo3(1, function (a) { return '' }, 1); // error

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints5.errors.txt
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints5.errors.txt
@@ -1,11 +1,9 @@
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints5.ts(18,17): error TS2345: Argument of type 'C' is not assignable to parameter of type 'D'.
   Property 'y' is missing in type 'C'.
-tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints5.ts(19,23): error TS2345: Argument of type '() => void' is not assignable to parameter of type '() => number'.
-  Type 'void' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints5.ts(22,24): error TS2345: Argument of type 'C' is not assignable to parameter of type 'T'.
 
 
-==== tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints5.ts (3 errors) ====
+==== tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints5.ts (2 errors) ====
     // Generic call with constraints infering type parameter from object member properties
     
     class C {
@@ -28,9 +26,6 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObj
 !!! error TS2345: Argument of type 'C' is not assignable to parameter of type 'D'.
 !!! error TS2345:   Property 'y' is missing in type 'C'.
     var r9 = foo(() => 1, () => { }); // the constraints are self-referencing, no downstream error
-                          ~~~~~~~~~
-!!! error TS2345: Argument of type '() => void' is not assignable to parameter of type '() => number'.
-!!! error TS2345:   Type 'void' is not assignable to type 'number'.
     
     function other<T, U extends T>() {
         var r5 = foo<T, U>(c, d); // error

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints5.types
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints5.types
@@ -51,8 +51,8 @@ var r2 = foo(d, c); // the constraints are self-referencing, no downstream error
 >c : C
 
 var r9 = foo(() => 1, () => { }); // the constraints are self-referencing, no downstream error
->r9 : any
->foo(() => 1, () => { }) : any
+>r9 : (x: {}) => () => void
+>foo(() => 1, () => { }) : (x: {}) => () => void
 >foo : <T, U extends T>(t: T, t2: U) => (x: T) => U
 >() => 1 : () => number
 >1 : 1

--- a/tests/baselines/reference/genericClassWithFunctionTypedMemberArguments.errors.txt
+++ b/tests/baselines/reference/genericClassWithFunctionTypedMemberArguments.errors.txt
@@ -4,7 +4,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFu
 tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments.ts(60,30): error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => string'.
   Types of parameters 'x' and 'a' are incompatible.
     Type '1' is not assignable to type 'T'.
-tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments.ts(61,31): error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => string'.
+tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments.ts(61,31): error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => 1'.
   Types of parameters 'x' and 'a' are incompatible.
     Type '1' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments.ts(62,30): error TS2345: Argument of type '(a: number) => string' is not assignable to parameter of type '(a: number) => 1'.
@@ -82,7 +82,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFu
 !!! error TS2345:     Type '1' is not assignable to type 'T'.
             var r11b = c3.foo3(1, (x: T) => '', 1); // error
                                   ~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => string'.
+!!! error TS2345: Argument of type '(x: T) => string' is not assignable to parameter of type '(a: 1) => 1'.
 !!! error TS2345:   Types of parameters 'x' and 'a' are incompatible.
 !!! error TS2345:     Type '1' is not assignable to type 'T'.
             var r12 = c3.foo3(1, function (a) { return '' }, 1); // error

--- a/tests/baselines/reference/inferenceFromParameterlessLambda.errors.txt
+++ b/tests/baselines/reference/inferenceFromParameterlessLambda.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/compiler/inferenceFromParameterlessLambda.ts(9,12): error TS2339: Property 'length' does not exist on type '{}'.
+
+
+==== tests/cases/compiler/inferenceFromParameterlessLambda.ts (1 errors) ====
+    function foo<T>(o: Take<T>, i: Make<T>) { }
+    interface Make<T> {
+        (): T;
+    }
+    interface Take<T> {
+        (n: T): void;
+    }
+    // Infer string from second argument because it isn't context sensitive
+    foo(n => n.length, () => 'hi');
+               ~~~~~~
+!!! error TS2339: Property 'length' does not exist on type '{}'.
+    

--- a/tests/baselines/reference/inferenceFromParameterlessLambda.symbols
+++ b/tests/baselines/reference/inferenceFromParameterlessLambda.symbols
@@ -28,7 +28,5 @@ interface Take<T> {
 foo(n => n.length, () => 'hi');
 >foo : Symbol(foo, Decl(inferenceFromParameterlessLambda.ts, 0, 0))
 >n : Symbol(n, Decl(inferenceFromParameterlessLambda.ts, 8, 4))
->n.length : Symbol(String.length, Decl(lib.d.ts, --, --))
 >n : Symbol(n, Decl(inferenceFromParameterlessLambda.ts, 8, 4))
->length : Symbol(String.length, Decl(lib.d.ts, --, --))
 

--- a/tests/baselines/reference/inferenceFromParameterlessLambda.types
+++ b/tests/baselines/reference/inferenceFromParameterlessLambda.types
@@ -28,11 +28,11 @@ interface Take<T> {
 foo(n => n.length, () => 'hi');
 >foo(n => n.length, () => 'hi') : void
 >foo : <T>(o: Take<T>, i: Make<T>) => void
->n => n.length : (n: string) => number
->n : string
->n.length : number
->n : string
->length : number
+>n => n.length : (n: {}) => any
+>n : {}
+>n.length : any
+>n : {}
+>length : any
 >() => 'hi' : () => string
 >'hi' : "hi"
 

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.errors.txt
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.errors.txt
@@ -1,26 +1,31 @@
-tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(20,22): error TS2322: Type '{ prop: "x"; children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,22): error TS2322: Type '{ prop: "x"; children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
   Type '{ prop: "x"; children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; }' is not assignable to type 'LitProps<"x">'.
     Types of property 'children' are incompatible.
       Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
         Type '"y"' is not assignable to type '"x"'.
-tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(21,27): error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
-  Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(23,23): error TS2322: Type '{ prop: "x"; children: () => "y"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+  Type '{ prop: "x"; children: () => "y"; }' is not assignable to type 'LitProps<"x">'.
     Types of property 'children' are incompatible.
-      Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x" | "y">) => "x" | "y"'.
-        Types of parameters 'p' and 'x' are incompatible.
-          Type 'LitProps<"x" | "y">' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
-            Type 'LitProps<"x" | "y">' is not assignable to type 'LitProps<"x">'.
-              Types of property 'prop' are incompatible.
-                Type '"x" | "y"' is not assignable to type '"x"'.
-                  Type '"y"' is not assignable to type '"x"'.
-tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,29): error TS2322: Type '{ children: () => number; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+      Type '() => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
+        Type '"y"' is not assignable to type '"x"'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(24,27): error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+  Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x">'.
+    Types of property 'children' are incompatible.
+      Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
+        Type '"y"' is not assignable to type '"x"'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(25,28): error TS2322: Type '{ children: () => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+  Type '{ children: () => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x">'.
+    Types of property 'children' are incompatible.
+      Type '() => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
+        Type '"y"' is not assignable to type '"x"'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(26,29): error TS2322: Type '{ children: () => number; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
   Type '{ children: () => number; prop: "x"; }' is not assignable to type 'LitProps<"x">'.
     Types of property 'children' are incompatible.
       Type '() => number' is not assignable to type '(x: LitProps<"x">) => "x"'.
         Type 'number' is not assignable to type '"x"'.
 
 
-==== tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx (3 errors) ====
+==== tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx (5 errors) ====
     namespace JSX {
         export interface Element {}
         export interface ElementAttributesProperty { props: {}; }
@@ -37,7 +42,9 @@ tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,29): error TS2322:
     const ElemLit = <T extends string>(p: LitProps<T>) => <div></div>;
     ElemLit({prop: "x", children: () => "x"});
     const j = <ElemLit prop="x" children={() => "x"} />
+    const j2 = <ElemLit prop="x" children={p => "x"} />
     const jj = <ElemLit prop="x">{() => "x"}</ElemLit>
+    const jj2 = <ElemLit prop="x">{p => "x"}</ElemLit>
     
     // Should error
     const arg = <ElemLit prop="x" children={p => "y"} />
@@ -47,18 +54,27 @@ tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,29): error TS2322:
 !!! error TS2322:     Types of property 'children' are incompatible.
 !!! error TS2322:       Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
 !!! error TS2322:         Type '"y"' is not assignable to type '"x"'.
+    const arg2 = <ElemLit prop="x" children={() => "y"} />
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ prop: "x"; children: () => "y"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+!!! error TS2322:   Type '{ prop: "x"; children: () => "y"; }' is not assignable to type 'LitProps<"x">'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '() => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
+!!! error TS2322:         Type '"y"' is not assignable to type '"x"'.
     const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
                               ~~~~~~~~
-!!! error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
-!!! error TS2322:   Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
+!!! error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+!!! error TS2322:   Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x">'.
 !!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x" | "y">) => "x" | "y"'.
-!!! error TS2322:         Types of parameters 'p' and 'x' are incompatible.
-!!! error TS2322:           Type 'LitProps<"x" | "y">' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
-!!! error TS2322:             Type 'LitProps<"x" | "y">' is not assignable to type 'LitProps<"x">'.
-!!! error TS2322:               Types of property 'prop' are incompatible.
-!!! error TS2322:                 Type '"x" | "y"' is not assignable to type '"x"'.
-!!! error TS2322:                   Type '"y"' is not assignable to type '"x"'.
+!!! error TS2322:       Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
+!!! error TS2322:         Type '"y"' is not assignable to type '"x"'.
+    const argchild2 = <ElemLit prop="x">{() => "y"}</ElemLit>
+                               ~~~~~~~~
+!!! error TS2322: Type '{ children: () => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+!!! error TS2322:   Type '{ children: () => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x">'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '() => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
+!!! error TS2322:         Type '"y"' is not assignable to type '"x"'.
     const mismatched = <ElemLit prop="x">{() => 12}</ElemLit>
                                 ~~~~~~~~
 !!! error TS2322: Type '{ children: () => number; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.js
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.js
@@ -15,11 +15,15 @@ interface LitProps<T> { prop: T, children: (x: this) => T }
 const ElemLit = <T extends string>(p: LitProps<T>) => <div></div>;
 ElemLit({prop: "x", children: () => "x"});
 const j = <ElemLit prop="x" children={() => "x"} />
+const j2 = <ElemLit prop="x" children={p => "x"} />
 const jj = <ElemLit prop="x">{() => "x"}</ElemLit>
+const jj2 = <ElemLit prop="x">{p => "x"}</ElemLit>
 
 // Should error
 const arg = <ElemLit prop="x" children={p => "y"} />
+const arg2 = <ElemLit prop="x" children={() => "y"} />
 const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
+const argchild2 = <ElemLit prop="x">{() => "y"}</ElemLit>
 const mismatched = <ElemLit prop="x">{() => 12}</ElemLit>
 
 //// [jsxChildrenGenericContextualTypes.jsx]
@@ -31,8 +35,12 @@ var qq = <Elem prop={{ a: "x" }}>{function (i) { return ({ a: "z" }); }}</Elem>;
 var ElemLit = function (p) { return <div></div>; };
 ElemLit({ prop: "x", children: function () { return "x"; } });
 var j = <ElemLit prop="x" children={function () { return "x"; }}/>;
+var j2 = <ElemLit prop="x" children={function (p) { return "x"; }}/>;
 var jj = <ElemLit prop="x">{function () { return "x"; }}</ElemLit>;
+var jj2 = <ElemLit prop="x">{function (p) { return "x"; }}</ElemLit>;
 // Should error
 var arg = <ElemLit prop="x" children={function (p) { return "y"; }}/>;
+var arg2 = <ElemLit prop="x" children={function () { return "y"; }}/>;
 var argchild = <ElemLit prop="x">{function (p) { return "y"; }}</ElemLit>;
+var argchild2 = <ElemLit prop="x">{function () { return "y"; }}</ElemLit>;
 var mismatched = <ElemLit prop="x">{function () { return 12; }}</ElemLit>;

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.symbols
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.symbols
@@ -90,30 +90,56 @@ const j = <ElemLit prop="x" children={() => "x"} />
 >prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 15, 18))
 >children : Symbol(children, Decl(jsxChildrenGenericContextualTypes.tsx, 15, 27))
 
-const jj = <ElemLit prop="x">{() => "x"}</ElemLit>
->jj : Symbol(jj, Decl(jsxChildrenGenericContextualTypes.tsx, 16, 5))
+const j2 = <ElemLit prop="x" children={p => "x"} />
+>j2 : Symbol(j2, Decl(jsxChildrenGenericContextualTypes.tsx, 16, 5))
 >ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
 >prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 16, 19))
+>children : Symbol(children, Decl(jsxChildrenGenericContextualTypes.tsx, 16, 28))
+>p : Symbol(p, Decl(jsxChildrenGenericContextualTypes.tsx, 16, 39))
+
+const jj = <ElemLit prop="x">{() => "x"}</ElemLit>
+>jj : Symbol(jj, Decl(jsxChildrenGenericContextualTypes.tsx, 17, 5))
+>ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
+>prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 17, 19))
+>ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
+
+const jj2 = <ElemLit prop="x">{p => "x"}</ElemLit>
+>jj2 : Symbol(jj2, Decl(jsxChildrenGenericContextualTypes.tsx, 18, 5))
+>ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
+>prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 18, 20))
+>p : Symbol(p, Decl(jsxChildrenGenericContextualTypes.tsx, 18, 31))
 >ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
 
 // Should error
 const arg = <ElemLit prop="x" children={p => "y"} />
->arg : Symbol(arg, Decl(jsxChildrenGenericContextualTypes.tsx, 19, 5))
+>arg : Symbol(arg, Decl(jsxChildrenGenericContextualTypes.tsx, 21, 5))
 >ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
->prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 19, 20))
->children : Symbol(children, Decl(jsxChildrenGenericContextualTypes.tsx, 19, 29))
->p : Symbol(p, Decl(jsxChildrenGenericContextualTypes.tsx, 19, 40))
+>prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 21, 20))
+>children : Symbol(children, Decl(jsxChildrenGenericContextualTypes.tsx, 21, 29))
+>p : Symbol(p, Decl(jsxChildrenGenericContextualTypes.tsx, 21, 40))
+
+const arg2 = <ElemLit prop="x" children={() => "y"} />
+>arg2 : Symbol(arg2, Decl(jsxChildrenGenericContextualTypes.tsx, 22, 5))
+>ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
+>prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 22, 21))
+>children : Symbol(children, Decl(jsxChildrenGenericContextualTypes.tsx, 22, 30))
 
 const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
->argchild : Symbol(argchild, Decl(jsxChildrenGenericContextualTypes.tsx, 20, 5))
+>argchild : Symbol(argchild, Decl(jsxChildrenGenericContextualTypes.tsx, 23, 5))
 >ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
->prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 20, 25))
->p : Symbol(p, Decl(jsxChildrenGenericContextualTypes.tsx, 20, 36))
+>prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 23, 25))
+>p : Symbol(p, Decl(jsxChildrenGenericContextualTypes.tsx, 23, 36))
+>ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
+
+const argchild2 = <ElemLit prop="x">{() => "y"}</ElemLit>
+>argchild2 : Symbol(argchild2, Decl(jsxChildrenGenericContextualTypes.tsx, 24, 5))
+>ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
+>prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 24, 26))
 >ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
 
 const mismatched = <ElemLit prop="x">{() => 12}</ElemLit>
->mismatched : Symbol(mismatched, Decl(jsxChildrenGenericContextualTypes.tsx, 21, 5))
+>mismatched : Symbol(mismatched, Decl(jsxChildrenGenericContextualTypes.tsx, 25, 5))
 >ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
->prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 21, 27))
+>prop : Symbol(prop, Decl(jsxChildrenGenericContextualTypes.tsx, 25, 27))
 >ElemLit : Symbol(ElemLit, Decl(jsxChildrenGenericContextualTypes.tsx, 13, 5))
 

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.types
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.types
@@ -124,12 +124,32 @@ const j = <ElemLit prop="x" children={() => "x"} />
 >() => "x" : () => "x"
 >"x" : "x"
 
+const j2 = <ElemLit prop="x" children={p => "x"} />
+>j2 : JSX.Element
+><ElemLit prop="x" children={p => "x"} /> : JSX.Element
+>ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
+>prop : "x"
+>children : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "x"
+>p => "x" : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "x"
+>p : JSX.IntrinsicAttributes & LitProps<"x">
+>"x" : "x"
+
 const jj = <ElemLit prop="x">{() => "x"}</ElemLit>
 >jj : JSX.Element
 ><ElemLit prop="x">{() => "x"}</ElemLit> : JSX.Element
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
 >prop : "x"
 >() => "x" : () => "x"
+>"x" : "x"
+>ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
+
+const jj2 = <ElemLit prop="x">{p => "x"}</ElemLit>
+>jj2 : JSX.Element
+><ElemLit prop="x">{p => "x"}</ElemLit> : JSX.Element
+>ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
+>prop : "x"
+>p => "x" : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "x"
+>p : JSX.IntrinsicAttributes & LitProps<"x">
 >"x" : "x"
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
 
@@ -144,6 +164,15 @@ const arg = <ElemLit prop="x" children={p => "y"} />
 >p : JSX.IntrinsicAttributes & LitProps<"x">
 >"y" : "y"
 
+const arg2 = <ElemLit prop="x" children={() => "y"} />
+>arg2 : JSX.Element
+><ElemLit prop="x" children={() => "y"} /> : JSX.Element
+>ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
+>prop : "x"
+>children : () => "y"
+>() => "y" : () => "y"
+>"y" : "y"
+
 const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
 >argchild : JSX.Element
 ><ElemLit prop="x">{p => "y"}</ElemLit> : JSX.Element
@@ -151,6 +180,15 @@ const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
 >prop : "x"
 >p => "y" : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "y"
 >p : JSX.IntrinsicAttributes & LitProps<"x">
+>"y" : "y"
+>ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
+
+const argchild2 = <ElemLit prop="x">{() => "y"}</ElemLit>
+>argchild2 : JSX.Element
+><ElemLit prop="x">{() => "y"}</ElemLit> : JSX.Element
+>ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
+>prop : "x"
+>() => "y" : () => "y"
 >"y" : "y"
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
 

--- a/tests/baselines/reference/thisTypeInFunctions.types
+++ b/tests/baselines/reference/thisTypeInFunctions.types
@@ -186,11 +186,11 @@ impl.explicitVoid1 = function () { return 12; };
 >12 : 12
 
 impl.explicitVoid2 = () => 12;
->impl.explicitVoid2 = () => 12 : (this: void) => number
+>impl.explicitVoid2 = () => 12 : () => number
 >impl.explicitVoid2 : (this: void) => number
 >impl : I
 >explicitVoid2 : (this: void) => number
->() => 12 : (this: void) => number
+>() => 12 : () => number
 >12 : 12
 
 impl.explicitStructural = function() { return this.a; };
@@ -214,19 +214,19 @@ impl.explicitInterface = function() { return this.a; };
 >a : number
 
 impl.explicitStructural = () => 12;
->impl.explicitStructural = () => 12 : (this: { a: number; }) => number
+>impl.explicitStructural = () => 12 : () => number
 >impl.explicitStructural : (this: { a: number; }) => number
 >impl : I
 >explicitStructural : (this: { a: number; }) => number
->() => 12 : (this: { a: number; }) => number
+>() => 12 : () => number
 >12 : 12
 
 impl.explicitInterface = () => 12;
->impl.explicitInterface = () => 12 : (this: I) => number
+>impl.explicitInterface = () => 12 : () => number
 >impl.explicitInterface : (this: I) => number
 >impl : I
 >explicitInterface : (this: I) => number
->() => 12 : (this: I) => number
+>() => 12 : () => number
 >12 : 12
 
 impl.explicitThis = function () { return this.a; };
@@ -433,7 +433,7 @@ let unboundToSpecified: (this: { y: number }, x: number) => number = x => x + th
 >this : { y: number; }
 >y : number
 >x : number
->x => x + this.y : (this: { y: number; }, x: number) => any
+>x => x + this.y : (x: number) => any
 >x : number
 >x + this.y : any
 >x : number
@@ -472,7 +472,7 @@ let specifiedLambda: (this: void, x: number) => number = x => x + 12;
 >specifiedLambda : (this: void, x: number) => number
 >this : void
 >x : number
->x => x + 12 : (this: void, x: number) => number
+>x => x + 12 : (x: number) => number
 >x : number
 >x + 12 : number
 >x : number
@@ -560,40 +560,40 @@ c.explicitProperty = reconstructed.explicitProperty;
 
 // lambdas are assignable to anything
 c.explicitC = m => m;
->c.explicitC = m => m : (this: C, m: number) => number
+>c.explicitC = m => m : (m: number) => number
 >c.explicitC : (this: C, m: number) => number
 >c : C
 >explicitC : (this: C, m: number) => number
->m => m : (this: C, m: number) => number
+>m => m : (m: number) => number
 >m : number
 >m : number
 
 c.explicitThis = m => m;
->c.explicitThis = m => m : (this: C, m: number) => number
+>c.explicitThis = m => m : (m: number) => number
 >c.explicitThis : (this: C, m: number) => number
 >c : C
 >explicitThis : (this: C, m: number) => number
->m => m : (this: C, m: number) => number
+>m => m : (m: number) => number
 >m : number
 >m : number
 
 c.explicitProperty = m => m;
->c.explicitProperty = m => m : (this: { n: number; }, m: number) => number
+>c.explicitProperty = m => m : (m: number) => number
 >c.explicitProperty : (this: { n: number; }, m: number) => number
 >c : C
 >explicitProperty : (this: { n: number; }, m: number) => number
->m => m : (this: { n: number; }, m: number) => number
+>m => m : (m: number) => number
 >m : number
 >m : number
 
 // this inside lambdas refer to outer scope
 // the outer-scoped lambda at top-level is still just `any`
 c.explicitC = m => m + this.n;
->c.explicitC = m => m + this.n : (this: C, m: number) => any
+>c.explicitC = m => m + this.n : (m: number) => any
 >c.explicitC : (this: C, m: number) => number
 >c : C
 >explicitC : (this: C, m: number) => number
->m => m + this.n : (this: C, m: number) => any
+>m => m + this.n : (m: number) => any
 >m : number
 >m + this.n : any
 >m : number
@@ -602,11 +602,11 @@ c.explicitC = m => m + this.n;
 >n : any
 
 c.explicitThis = m => m + this.n;
->c.explicitThis = m => m + this.n : (this: C, m: number) => any
+>c.explicitThis = m => m + this.n : (m: number) => any
 >c.explicitThis : (this: C, m: number) => number
 >c : C
 >explicitThis : (this: C, m: number) => number
->m => m + this.n : (this: C, m: number) => any
+>m => m + this.n : (m: number) => any
 >m : number
 >m + this.n : any
 >m : number
@@ -615,11 +615,11 @@ c.explicitThis = m => m + this.n;
 >n : any
 
 c.explicitProperty = m => m + this.n;
->c.explicitProperty = m => m + this.n : (this: { n: number; }, m: number) => any
+>c.explicitProperty = m => m + this.n : (m: number) => any
 >c.explicitProperty : (this: { n: number; }, m: number) => number
 >c : C
 >explicitProperty : (this: { n: number; }, m: number) => number
->m => m + this.n : (this: { n: number; }, m: number) => any
+>m => m + this.n : (m: number) => any
 >m : number
 >m + this.n : any
 >m : number
@@ -723,11 +723,11 @@ c.explicitC = function(this: B, m: number) { return this.n + m };
 
 // this:void compatibility
 c.explicitVoid = n => n;
->c.explicitVoid = n => n : (this: void, n: number) => number
+>c.explicitVoid = n => n : (n: number) => number
 >c.explicitVoid : (this: void, m: number) => number
 >c : C
 >explicitVoid : (this: void, m: number) => number
->n => n : (this: void, n: number) => number
+>n => n : (n: number) => number
 >n : number
 >n : number
 

--- a/tests/baselines/reference/thisTypeInFunctions.types
+++ b/tests/baselines/reference/thisTypeInFunctions.types
@@ -186,11 +186,11 @@ impl.explicitVoid1 = function () { return 12; };
 >12 : 12
 
 impl.explicitVoid2 = () => 12;
->impl.explicitVoid2 = () => 12 : () => number
+>impl.explicitVoid2 = () => 12 : (this: void) => number
 >impl.explicitVoid2 : (this: void) => number
 >impl : I
 >explicitVoid2 : (this: void) => number
->() => 12 : () => number
+>() => 12 : (this: void) => number
 >12 : 12
 
 impl.explicitStructural = function() { return this.a; };
@@ -214,19 +214,19 @@ impl.explicitInterface = function() { return this.a; };
 >a : number
 
 impl.explicitStructural = () => 12;
->impl.explicitStructural = () => 12 : () => number
+>impl.explicitStructural = () => 12 : (this: { a: number; }) => number
 >impl.explicitStructural : (this: { a: number; }) => number
 >impl : I
 >explicitStructural : (this: { a: number; }) => number
->() => 12 : () => number
+>() => 12 : (this: { a: number; }) => number
 >12 : 12
 
 impl.explicitInterface = () => 12;
->impl.explicitInterface = () => 12 : () => number
+>impl.explicitInterface = () => 12 : (this: I) => number
 >impl.explicitInterface : (this: I) => number
 >impl : I
 >explicitInterface : (this: I) => number
->() => 12 : () => number
+>() => 12 : (this: I) => number
 >12 : 12
 
 impl.explicitThis = function () { return this.a; };

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.types
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.types
@@ -130,7 +130,7 @@ interface I {
 let impl: I = {
 >impl : I
 >I : I
->{    a: 12,    explicitVoid1() {        return this.a; // error, no 'a' in 'void'    },    explicitVoid2: () => this.a, // ok, `this:any` because it refers to an outer object    explicitStructural: () => 12,    explicitInterface: () => 12,    explicitThis() {        return this.a;    },} : { a: number; explicitVoid1(this: void): any; explicitVoid2: () => any; explicitStructural: () => number; explicitInterface: () => number; explicitThis(this: I): number; }
+>{    a: 12,    explicitVoid1() {        return this.a; // error, no 'a' in 'void'    },    explicitVoid2: () => this.a, // ok, `this:any` because it refers to an outer object    explicitStructural: () => 12,    explicitInterface: () => 12,    explicitThis() {        return this.a;    },} : { a: number; explicitVoid1(this: void): any; explicitVoid2: () => any; explicitStructural: (this: { a: number; }) => number; explicitInterface: (this: I) => number; explicitThis(this: I): number; }
 
     a: 12,
 >a : number
@@ -153,13 +153,13 @@ let impl: I = {
 >a : any
 
     explicitStructural: () => 12,
->explicitStructural : () => number
->() => 12 : () => number
+>explicitStructural : (this: { a: number; }) => number
+>() => 12 : (this: { a: number; }) => number
 >12 : 12
 
     explicitInterface: () => 12,
->explicitInterface : () => number
->() => 12 : () => number
+>explicitInterface : (this: I) => number
+>() => 12 : (this: I) => number
 >12 : 12
 
     explicitThis() {

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.types
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.types
@@ -130,7 +130,7 @@ interface I {
 let impl: I = {
 >impl : I
 >I : I
->{    a: 12,    explicitVoid1() {        return this.a; // error, no 'a' in 'void'    },    explicitVoid2: () => this.a, // ok, `this:any` because it refers to an outer object    explicitStructural: () => 12,    explicitInterface: () => 12,    explicitThis() {        return this.a;    },} : { a: number; explicitVoid1(this: void): any; explicitVoid2: () => any; explicitStructural: (this: { a: number; }) => number; explicitInterface: (this: I) => number; explicitThis(this: I): number; }
+>{    a: 12,    explicitVoid1() {        return this.a; // error, no 'a' in 'void'    },    explicitVoid2: () => this.a, // ok, `this:any` because it refers to an outer object    explicitStructural: () => 12,    explicitInterface: () => 12,    explicitThis() {        return this.a;    },} : { a: number; explicitVoid1(this: void): any; explicitVoid2: () => any; explicitStructural: () => number; explicitInterface: () => number; explicitThis(this: I): number; }
 
     a: 12,
 >a : number
@@ -153,13 +153,13 @@ let impl: I = {
 >a : any
 
     explicitStructural: () => 12,
->explicitStructural : (this: { a: number; }) => number
->() => 12 : (this: { a: number; }) => number
+>explicitStructural : () => number
+>() => 12 : () => number
 >12 : 12
 
     explicitInterface: () => 12,
->explicitInterface : (this: I) => number
->() => 12 : (this: I) => number
+>explicitInterface : () => number
+>() => 12 : () => number
 >12 : 12
 
     explicitThis() {

--- a/tests/baselines/reference/thisTypeInTypePredicate.types
+++ b/tests/baselines/reference/thisTypeInTypePredicate.types
@@ -13,7 +13,7 @@ const numbers = filter<number>((x): x is number => 'number' == typeof x)
 >numbers : number[]
 >filter<number>((x): x is number => 'number' == typeof x) : number[]
 >filter : <S>(f: (this: void, x: any) => x is S) => S[]
->(x): x is number => 'number' == typeof x : (this: void, x: any) => x is number
+>(x): x is number => 'number' == typeof x : (x: any) => x is number
 >x : any
 >x : any
 >'number' == typeof x : boolean

--- a/tests/baselines/reference/typeArgumentInferenceWithObjectLiteral.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceWithObjectLiteral.errors.txt
@@ -30,11 +30,11 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithObjec
     
     var v1: number;
     var v1 = f1({ w: x => x, r: () => 0 }, 0);
-    var v1 = f1({ w: x => x, r: () => 0 }, E1.X);
     var v1 = f1({ w: x => x, r: () => E1.X }, 0);
     
     var v2: E1;
     var v2 = f1({ w: x => x, r: () => E1.X }, E1.X);
+    var v2 = f1({ w: x => x, r: () => 0 }, E1.X);
     
     var v3 = f1({ w: x => x, r: () => E1.X }, E2.X);  // Error
                                               ~~~~

--- a/tests/baselines/reference/typeArgumentInferenceWithObjectLiteral.js
+++ b/tests/baselines/reference/typeArgumentInferenceWithObjectLiteral.js
@@ -27,11 +27,11 @@ declare function f1<T, U>(a: { w: (x: T) => U; r: () => T; }, b: T): U;
 
 var v1: number;
 var v1 = f1({ w: x => x, r: () => 0 }, 0);
-var v1 = f1({ w: x => x, r: () => 0 }, E1.X);
 var v1 = f1({ w: x => x, r: () => E1.X }, 0);
 
 var v2: E1;
 var v2 = f1({ w: x => x, r: () => E1.X }, E1.X);
+var v2 = f1({ w: x => x, r: () => 0 }, E1.X);
 
 var v3 = f1({ w: x => x, r: () => E1.X }, E2.X);  // Error
 
@@ -58,8 +58,8 @@ var E2;
 })(E2 || (E2 = {}));
 var v1;
 var v1 = f1({ w: function (x) { return x; }, r: function () { return 0; } }, 0);
-var v1 = f1({ w: function (x) { return x; }, r: function () { return 0; } }, E1.X);
 var v1 = f1({ w: function (x) { return x; }, r: function () { return E1.X; } }, 0);
 var v2;
 var v2 = f1({ w: function (x) { return x; }, r: function () { return E1.X; } }, E1.X);
+var v2 = f1({ w: function (x) { return x; }, r: function () { return 0; } }, E1.X);
 var v3 = f1({ w: function (x) { return x; }, r: function () { return E1.X; } }, E2.X); // Error

--- a/tests/baselines/reference/typeArgumentInferenceWithObjectLiteral.symbols
+++ b/tests/baselines/reference/typeArgumentInferenceWithObjectLiteral.symbols
@@ -79,18 +79,18 @@ declare function f1<T, U>(a: { w: (x: T) => U; r: () => T; }, b: T): U;
 >U : Symbol(U, Decl(typeArgumentInferenceWithObjectLiteral.ts, 24, 22))
 
 var v1: number;
->v1 : Symbol(v1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 26, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 29, 3))
+>v1 : Symbol(v1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 26, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 3))
 
 var v1 = f1({ w: x => x, r: () => 0 }, 0);
->v1 : Symbol(v1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 26, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 29, 3))
+>v1 : Symbol(v1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 26, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 3))
 >f1 : Symbol(f1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 20, 13))
 >w : Symbol(w, Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 13))
 >x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 16))
 >x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 16))
 >r : Symbol(r, Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 24))
 
-var v1 = f1({ w: x => x, r: () => 0 }, E1.X);
->v1 : Symbol(v1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 26, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 29, 3))
+var v1 = f1({ w: x => x, r: () => E1.X }, 0);
+>v1 : Symbol(v1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 26, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 3))
 >f1 : Symbol(f1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 20, 13))
 >w : Symbol(w, Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 13))
 >x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 16))
@@ -100,31 +100,31 @@ var v1 = f1({ w: x => x, r: () => 0 }, E1.X);
 >E1 : Symbol(E1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 17, 3))
 >X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))
 
-var v1 = f1({ w: x => x, r: () => E1.X }, 0);
->v1 : Symbol(v1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 26, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 27, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 28, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 29, 3))
+var v2: E1;
+>v2 : Symbol(v2, Decl(typeArgumentInferenceWithObjectLiteral.ts, 30, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 3))
+>E1 : Symbol(E1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 17, 3))
+
+var v2 = f1({ w: x => x, r: () => E1.X }, E1.X);
+>v2 : Symbol(v2, Decl(typeArgumentInferenceWithObjectLiteral.ts, 30, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 3))
 >f1 : Symbol(f1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 20, 13))
->w : Symbol(w, Decl(typeArgumentInferenceWithObjectLiteral.ts, 29, 13))
->x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 29, 16))
->x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 29, 16))
->r : Symbol(r, Decl(typeArgumentInferenceWithObjectLiteral.ts, 29, 24))
+>w : Symbol(w, Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 13))
+>x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 16))
+>x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 16))
+>r : Symbol(r, Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 24))
+>E1.X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))
+>E1 : Symbol(E1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 17, 3))
+>X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))
 >E1.X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))
 >E1 : Symbol(E1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 17, 3))
 >X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))
 
-var v2: E1;
->v2 : Symbol(v2, Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 3))
->E1 : Symbol(E1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 17, 3))
-
-var v2 = f1({ w: x => x, r: () => E1.X }, E1.X);
->v2 : Symbol(v2, Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 3))
+var v2 = f1({ w: x => x, r: () => 0 }, E1.X);
+>v2 : Symbol(v2, Decl(typeArgumentInferenceWithObjectLiteral.ts, 30, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 31, 3), Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 3))
 >f1 : Symbol(f1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 20, 13))
 >w : Symbol(w, Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 13))
 >x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 16))
 >x : Symbol(x, Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 16))
 >r : Symbol(r, Decl(typeArgumentInferenceWithObjectLiteral.ts, 32, 24))
->E1.X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))
->E1 : Symbol(E1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 17, 3))
->X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))
 >E1.X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))
 >E1 : Symbol(E1, Decl(typeArgumentInferenceWithObjectLiteral.ts, 17, 3))
 >X : Symbol(E1.X, Decl(typeArgumentInferenceWithObjectLiteral.ts, 19, 9))

--- a/tests/baselines/reference/typeArgumentInferenceWithObjectLiteral.types
+++ b/tests/baselines/reference/typeArgumentInferenceWithObjectLiteral.types
@@ -105,22 +105,6 @@ var v1 = f1({ w: x => x, r: () => 0 }, 0);
 >0 : 0
 >0 : 0
 
-var v1 = f1({ w: x => x, r: () => 0 }, E1.X);
->v1 : number
->f1({ w: x => x, r: () => 0 }, E1.X) : number
->f1 : <T, U>(a: { w: (x: T) => U; r: () => T; }, b: T) => U
->{ w: x => x, r: () => 0 } : { w: (x: number) => number; r: () => number; }
->w : (x: number) => number
->x => x : (x: number) => number
->x : number
->x : number
->r : () => number
->() => 0 : () => number
->0 : 0
->E1.X : E1
->E1 : typeof E1
->X : E1
-
 var v1 = f1({ w: x => x, r: () => E1.X }, 0);
 >v1 : number
 >f1({ w: x => x, r: () => E1.X }, 0) : number
@@ -155,6 +139,22 @@ var v2 = f1({ w: x => x, r: () => E1.X }, E1.X);
 >E1.X : E1
 >E1 : typeof E1
 >X : E1
+>E1.X : E1
+>E1 : typeof E1
+>X : E1
+
+var v2 = f1({ w: x => x, r: () => 0 }, E1.X);
+>v2 : E1
+>f1({ w: x => x, r: () => 0 }, E1.X) : E1
+>f1 : <T, U>(a: { w: (x: T) => U; r: () => T; }, b: T) => U
+>{ w: x => x, r: () => 0 } : { w: (x: E1) => E1; r: () => number; }
+>w : (x: E1) => E1
+>x => x : (x: E1) => E1
+>x : E1
+>x : E1
+>r : () => number
+>() => 0 : () => number
+>0 : 0
 >E1.X : E1
 >E1 : typeof E1
 >X : E1

--- a/tests/baselines/reference/typeAssertionToGenericFunctionType.types
+++ b/tests/baselines/reference/typeAssertionToGenericFunctionType.types
@@ -10,8 +10,8 @@ var x = {
 >x : T
 >T : T
 >T : T
->((x: any) => 1) : (x: any) => number
->(x: any) => 1 : (x: any) => number
+>((x: any) => 1) : <T>(x: any) => number
+>(x: any) => 1 : <T>(x: any) => number
 >x : any
 >1 : 1
 

--- a/tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx
+++ b/tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx
@@ -16,9 +16,13 @@ interface LitProps<T> { prop: T, children: (x: this) => T }
 const ElemLit = <T extends string>(p: LitProps<T>) => <div></div>;
 ElemLit({prop: "x", children: () => "x"});
 const j = <ElemLit prop="x" children={() => "x"} />
+const j2 = <ElemLit prop="x" children={p => "x"} />
 const jj = <ElemLit prop="x">{() => "x"}</ElemLit>
+const jj2 = <ElemLit prop="x">{p => "x"}</ElemLit>
 
 // Should error
 const arg = <ElemLit prop="x" children={p => "y"} />
+const arg2 = <ElemLit prop="x" children={() => "y"} />
 const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
+const argchild2 = <ElemLit prop="x">{() => "y"}</ElemLit>
 const mismatched = <ElemLit prop="x">{() => 12}</ElemLit>

--- a/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithObjectLiteral.ts
+++ b/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithObjectLiteral.ts
@@ -26,10 +26,10 @@ declare function f1<T, U>(a: { w: (x: T) => U; r: () => T; }, b: T): U;
 
 var v1: number;
 var v1 = f1({ w: x => x, r: () => 0 }, 0);
-var v1 = f1({ w: x => x, r: () => 0 }, E1.X);
 var v1 = f1({ w: x => x, r: () => E1.X }, 0);
 
 var v2: E1;
 var v2 = f1({ w: x => x, r: () => E1.X }, E1.X);
+var v2 = f1({ w: x => x, r: () => 0 }, E1.X);
 
 var v3 = f1({ w: x => x, r: () => E1.X }, E2.X);  // Error


### PR DESCRIPTION
Fixes #20727, also fixes an issue in jsx inference where when a child lambda has no parameters, we would fail to generate a literal type for its' return, even if it should have one by it's contextual type (which is partially a variant on #20727 that also required updating `isContextSensitive` to support checking jsx children).

In #20727 @ahejlsberg states:
> The isContextSensitive function really has nothing to do with literal types. As the comment on the function states: "Returns true if the given expression contains (at any level of nesting) a function or arrow expression that is subject to contextual typing." It's basically a helper function that is used to determine if we should assign contextual types to parameters without type annotations.

Specifically, we use it to determine if we need to perform one pass or two(+) passes of inference for a given parameter (and then assign inferred types to it on the second if it was). That second inference pass is actually important even when only the return type is context sensitive (which matters in jsx under strict mode, as most type parameters are used such that they need to be comparable invariantly). Additionally, previously I had hardcoded jsx to always do both passes (which is acceptable, if wasteful). Now, it can use `isContextSensitive` (since it handles jsx attributes and children correctly) to avoid doing an unnecessary inference round.

Additionally, my comment in #20727 on the difficulties of doing this were derived from an experiment back in december where I tried this - however all that I noted at the time was that it caused a sizable number of test failures. Looking at those test changes now (and there seem to be fewer, if memory serves), I believe them most to be desirable to one degree or another -  with the exception of `inferenceFromParameterlessLambda`, many seem like improvements.

@sandersn @andy-ms could you weigh in before I try to bring this up to more folks? You've both worked with/around the context sensitive mechanics recently.