### PR TITLE
Fix bug in normalizeAndPreserveTrailingSlash: For "./", return "", not "/" (#21704)

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -865,7 +865,7 @@ namespace FourSlash {
             ts.zipWith(actual, expected, (completion, expectedCompletion, index) => {
                 const { name, insertText, replacementSpan } = typeof expectedCompletion === "string" ? { name: expectedCompletion, insertText: undefined, replacementSpan: undefined } : expectedCompletion;
                 if (completion.name !== name) {
-                    this.raiseError(`Expected completion at index ${index} to be ${expectedCompletion}, got ${completion.name}`);
+                    this.raiseError(`Expected completion at index ${index} to be ${name}, got ${completion.name}`);
                 }
                 if (completion.insertText !== insertText) {
                     this.raiseError(`Expected completion insert text at index ${index} to be ${insertText}, got ${completion.insertText}`);

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -455,7 +455,7 @@ namespace ts.Completions.PathCompletions {
     }
 
     function normalizeAndPreserveTrailingSlash(path: string) {
-        if (path === "./") {
+        if (path === "./" || path === ".\\") {
             // normalizePath turns "./" into "". "" + "/" would then be a rooted path instead of a relative one, so avoid this particular case.
             // There is no problem for adding "/" to a non-empty string -- it's only a problem at the beginning.
             return "";

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -455,7 +455,13 @@ namespace ts.Completions.PathCompletions {
     }
 
     function normalizeAndPreserveTrailingSlash(path: string) {
-        return hasTrailingDirectorySeparator(path) ? ensureTrailingDirectorySeparator(normalizePath(path)) : normalizePath(path);
+        if (path === "./") {
+            // normalizePath turns "./" into "". "" + "/" would then be a rooted path instead of a relative one, so avoid this particular case.
+            // There is no problem for adding "/" to a non-empty string -- it's only a problem at the beginning.
+            return "";
+        }
+        const norm = normalizePath(path);
+        return hasTrailingDirectorySeparator(path) ? ensureTrailingDirectorySeparator(norm) : norm;
     }
 
     /**

--- a/tests/cases/fourslash/completionsPaths_pathMapping_relativePath.ts
+++ b/tests/cases/fourslash/completionsPaths_pathMapping_relativePath.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /foo.ts
+////not read
+
+// @Filename: /x/b.ts
+////export const x = 0;
+
+// @Filename: /x/a.ts
+////import { } from "foo/[|/**/|]";
+
+// @Filename: /x/tsconfig.json
+////{
+////    "compilerOptions": {
+////        "baseUrl": ".",
+////        "paths": {
+////            "foo/*": ["./*"]
+////        }
+////    }
+////}
+
+const [replacementSpan] = test.ranges();
+verify.completionsAt("", ["a", "b"].map(name => ({ name, replacementSpan })));


### PR DESCRIPTION
Port of #21704