### PR TITLE
Don't use `export function` for a function whose name differs from its exported name

### DIFF
--- a/src/services/refactors/convertToEs6Module.ts
+++ b/src/services/refactors/convertToEs6Module.ts
@@ -375,7 +375,14 @@ namespace ts.refactor {
     function convertExportsDotXEquals(name: string | undefined, exported: Expression): Statement {
         const modifiers = [createToken(SyntaxKind.ExportKeyword)];
         switch (exported.kind) {
-            case SyntaxKind.FunctionExpression:
+            case SyntaxKind.FunctionExpression: {
+                const { name: expressionName } = exported as FunctionExpression;
+                if (expressionName && expressionName.text !== name) {
+                    // `exports.f = function g() {}` -> `export const f = function g() {}`
+                    return exportConst();
+                }
+                // falls through
+            }
             case SyntaxKind.ArrowFunction:
                 // `exports.f = function() {}` --> `export function f() {}`
                 return functionExpressionToDeclaration(name, modifiers, exported as FunctionExpression | ArrowFunction);
@@ -383,8 +390,12 @@ namespace ts.refactor {
                 // `exports.C = class {}` --> `export class C {}`
                 return classExpressionToDeclaration(name, modifiers, exported as ClassExpression);
             default:
-                // `exports.x = 0;` --> `export const x = 0;`
-                return makeConst(modifiers, createIdentifier(name), exported);
+                return exportConst();
+        }
+
+        function exportConst() {
+            // `exports.x = 0;` --> `export const x = 0;`
+            return makeConst(modifiers, createIdentifier(name), exported);
         }
     }
 

--- a/src/services/refactors/convertToEs6Module.ts
+++ b/src/services/refactors/convertToEs6Module.ts
@@ -381,8 +381,8 @@ namespace ts.refactor {
                     // `exports.f = function g() {}` -> `export const f = function g() {}`
                     return exportConst();
                 }
-                // falls through
             }
+                // falls through
             case SyntaxKind.ArrowFunction:
                 // `exports.f = function() {}` --> `export function f() {}`
                 return functionExpressionToDeclaration(name, modifiers, exported as FunctionExpression | ArrowFunction);

--- a/tests/cases/fourslash/refactorConvertToEs6Module_export_namedFunctionExpression.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_export_namedFunctionExpression.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+
+// @Filename: /a.js
+/////*a*/exports/*b*/.f = function g() { g(); }
+////exports.h = function h() { h(); }
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert to ES6 module",
+    actionName: "Convert to ES6 module",
+    actionDescription: "Convert to ES6 module",
+    newContent:
+`export const f = function g() { g(); };
+export function h() { h(); }`
+});


### PR DESCRIPTION
Fixes #21449