### PR TITLE
Fix assert when goToDefinition, from location that is new expression target but not a class symbol

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -217,6 +217,7 @@ namespace ts.GoToDefinition {
     function isSignatureDeclaration(node: Node): boolean {
         switch (node.kind) {
             case ts.SyntaxKind.Constructor:
+            case ts.SyntaxKind.ConstructSignature:
             case ts.SyntaxKind.FunctionDeclaration:
             case ts.SyntaxKind.MethodDeclaration:
             case ts.SyntaxKind.MethodSignature:

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -191,7 +191,7 @@ namespace ts.GoToDefinition {
         function getConstructSignatureDefinition(): DefinitionInfo[] | undefined {
             // Applicable only if we are in a new expression, or we are on a constructor declaration
             // and in either case the symbol has a construct signature definition, i.e. class
-            if (isNewExpressionTarget(node) || node.kind === SyntaxKind.ConstructorKeyword && symbol.flags & SymbolFlags.Class) {
+            if (symbol.flags & SymbolFlags.Class && (isNewExpressionTarget(node) || node.kind === SyntaxKind.ConstructorKeyword)) {
                 const cls = find(symbol.declarations, isClassLike) || Debug.fail("Expected declaration to have at least one class-like declaration");
                 return getSignatureDefinition(cls.members, /*selectConstructors*/ true);
             }

--- a/tests/cases/fourslash/goToDefinitionNewExpressionTargetNotClass.ts
+++ b/tests/cases/fourslash/goToDefinitionNewExpressionTargetNotClass.ts
@@ -5,6 +5,12 @@
 ////let I: {
 ////    /*constructSignature*/new(): C2;
 ////};
-////let C = new [|/*invokeExpression*/I|]();
+////new [|/*invokeExpression1*/I|]();
+////let /*symbolDeclaration*/I2: {
+////};
+////new [|/*invokeExpression2*/I2|]();
 
-verify.goToDefinition("invokeExpression", "constructSignature");
+verify.goToDefinition({
+    invokeExpression1: "constructSignature",
+    invokeExpression2: "symbolDeclaration"
+});

--- a/tests/cases/fourslash/goToDefinitionNewExpressionTargetNotClass.ts
+++ b/tests/cases/fourslash/goToDefinitionNewExpressionTargetNotClass.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+////class C2 {
+////}
+////let I: {
+////    /*constructSignature*/new(): C2;
+////};
+////let C = new [|/*invokeExpression*/I|]();
+
+verify.goToDefinition("invokeExpression", "constructSignature");


### PR DESCRIPTION
Fixes #21501
