### PR TITLE
Add `-dev` to version patch number in master

### DIFF
--- a/scripts/configurePrerelease.ts
+++ b/scripts/configurePrerelease.ts
@@ -55,7 +55,7 @@ function updateTsFile(tsFilePath: string, tsFileContents: string, majorMinor: st
     const parsedMajorMinor = majorMinorMatch[1];
     ts.Debug.assert(parsedMajorMinor === majorMinor, "versionMajorMinor does not match.", () => `${tsFilePath}: '${parsedMajorMinor}'; package.json: '${majorMinor}'`);
 
-    const versionRgx = /export const version = `\$\{versionMajorMinor\}\.(\d)`;/;
+    const versionRgx = /export const version = `\$\{versionMajorMinor\}\.(\d)(-dev)?`;/;
     const patchMatch = versionRgx.exec(tsFileContents);
     ts.Debug.assert(patchMatch !== null, "The file seems to no longer have a string matching", () => versionRgx.toString());
     const parsedPatch = patchMatch[1];

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -6,7 +6,7 @@ namespace ts {
     // If changing the text in this section, be sure to test `configureNightly` too.
     export const versionMajorMinor = "2.8";
     /** The version of the TypeScript compiler release */
-    export const version = `${versionMajorMinor}.0`;
+    export const version = `${versionMajorMinor}.0-dev`;
 }
 
 namespace ts {


### PR DESCRIPTION
Version number is reported in the [telemetry exception reports](https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22Source%3A+Telemetry%22+) from VSCode. we would like to filter out ppl working on master branch and testing locally. This change adds `-dev` to the version in master. the version will be replaced when we publish a release.