### PR TITLE
findAllReferences: Make definition info independent of search location

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -8,7 +8,7 @@ namespace ts.FindAllReferences {
     }
 
     export type Definition =
-        | { type: "symbol"; symbol: Symbol; node: Node }
+        | { type: "symbol"; symbol: Symbol }
         | { type: "label"; node: Identifier }
         | { type: "keyword"; node: ts.Node }
         | { type: "this"; node: ts.Node }
@@ -42,11 +42,12 @@ namespace ts.FindAllReferences {
     }
 
     export function findReferencedSymbols(program: Program, cancellationToken: CancellationToken, sourceFiles: ReadonlyArray<SourceFile>, sourceFile: SourceFile, position: number): ReferencedSymbol[] | undefined {
-        const referencedSymbols = findAllReferencedSymbols(program, cancellationToken, sourceFiles, sourceFile, position);
+        const node = getTouchingPropertyName(sourceFile, position, /*includeJsDocComment*/ true);
+        const referencedSymbols = Core.getReferencedSymbolsForNode(position, node, program, sourceFiles, cancellationToken, /*options*/ {});
         const checker = program.getTypeChecker();
         return !referencedSymbols || !referencedSymbols.length ? undefined : mapDefined<SymbolAndEntries, ReferencedSymbol>(referencedSymbols, ({ definition, references }) =>
             // Only include referenced symbols that have a valid definition.
-            definition && { definition: definitionToReferencedSymbolDefinitionInfo(definition, checker), references: references.map(toReferenceEntry) });
+            definition && { definition: definitionToReferencedSymbolDefinitionInfo(definition, checker, node), references: references.map(toReferenceEntry) });
     }
 
     export function getImplementationsAtPosition(program: Program, cancellationToken: CancellationToken, sourceFiles: ReadonlyArray<SourceFile>, sourceFile: SourceFile, position: number): ImplementationLocation[] {
@@ -83,31 +84,26 @@ namespace ts.FindAllReferences {
     }
 
     export function findReferencedEntries(program: Program, cancellationToken: CancellationToken, sourceFiles: ReadonlyArray<SourceFile>, sourceFile: SourceFile, position: number, options?: Options): ReferenceEntry[] | undefined {
-        const x = flattenEntries(findAllReferencedSymbols(program, cancellationToken, sourceFiles, sourceFile, position, options));
-        return map(x, toReferenceEntry);
+        const node = getTouchingPropertyName(sourceFile, position, /*includeJsDocComment*/ true);
+        return map(flattenEntries(Core.getReferencedSymbolsForNode(position, node, program, sourceFiles, cancellationToken, options)), toReferenceEntry);
     }
 
     export function getReferenceEntriesForNode(position: number, node: Node, program: Program, sourceFiles: ReadonlyArray<SourceFile>, cancellationToken: CancellationToken, options: Options = {}): Entry[] | undefined {
         return flattenEntries(Core.getReferencedSymbolsForNode(position, node, program, sourceFiles, cancellationToken, options));
     }
 
-    function findAllReferencedSymbols(program: Program, cancellationToken: CancellationToken, sourceFiles: ReadonlyArray<SourceFile>, sourceFile: SourceFile, position: number, options?: Options): SymbolAndEntries[] | undefined {
-        const node = getTouchingPropertyName(sourceFile, position, /*includeJsDocComment*/ true);
-        return Core.getReferencedSymbolsForNode(position, node, program, sourceFiles, cancellationToken, options);
-    }
-
     function flattenEntries(referenceSymbols: SymbolAndEntries[]): Entry[] {
         return referenceSymbols && flatMap(referenceSymbols, r => r.references);
     }
 
-    function definitionToReferencedSymbolDefinitionInfo(def: Definition, checker: TypeChecker): ReferencedSymbolDefinitionInfo | undefined {
+    function definitionToReferencedSymbolDefinitionInfo(def: Definition, checker: TypeChecker, originalNode: Node): ReferencedSymbolDefinitionInfo | undefined {
         const info = (() => {
             switch (def.type) {
                 case "symbol": {
-                    const { symbol, node } = def;
-                    const { displayParts, kind } = getDefinitionKindAndDisplayParts(symbol, node, checker);
+                    const { symbol } = def;
+                    const { displayParts, kind } = getDefinitionKindAndDisplayParts(symbol, checker, originalNode);
                     const name = displayParts.map(p => p.text).join("");
-                    return { node, name, kind, displayParts };
+                    return { node: symbol.declarations ? getNameOfDeclaration(first(symbol.declarations)) || first(symbol.declarations) : originalNode, name, kind, displayParts };
                 }
                 case "label": {
                     const { node } = def;
@@ -129,12 +125,10 @@ namespace ts.FindAllReferences {
                     const { node } = def;
                     return { node, name: node.text, kind: ScriptElementKind.variableElement, displayParts: [displayPart(getTextOfNode(node), SymbolDisplayPartKind.stringLiteral)] };
                 }
+                default:
+                    return Debug.assertNever(def);
             }
         })();
-
-        if (!info) {
-            return undefined;
-        }
 
         const { node, name, kind, displayParts } = info;
         const sourceFile = node.getSourceFile();
@@ -149,9 +143,11 @@ namespace ts.FindAllReferences {
         };
     }
 
-    function getDefinitionKindAndDisplayParts(symbol: Symbol, node: Node, checker: TypeChecker): { displayParts: SymbolDisplayPart[], kind: ScriptElementKind } {
+    function getDefinitionKindAndDisplayParts(symbol: Symbol, checker: TypeChecker, node: Node): { displayParts: SymbolDisplayPart[], kind: ScriptElementKind } {
+        const meaning = Core.getIntersectingMeaningFromDeclarations(node, symbol);
+        const enclosingDeclaration = firstOrUndefined(symbol.declarations) || node;
         const { displayParts, symbolKind } =
-            SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(checker, symbol, node.getSourceFile(), getContainerNode(node), node);
+            SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(checker, symbol, enclosingDeclaration.getSourceFile(), enclosingDeclaration, enclosingDeclaration, meaning);
         return { displayParts, kind: symbolKind };
     }
 
@@ -186,7 +182,7 @@ namespace ts.FindAllReferences {
     function implementationKindDisplayParts(node: ts.Node, checker: ts.TypeChecker): { kind: ScriptElementKind, displayParts: SymbolDisplayPart[] } {
         const symbol = checker.getSymbolAtLocation(isDeclaration(node) && node.name ? node.name : node);
         if (symbol) {
-            return getDefinitionKindAndDisplayParts(symbol, node, checker);
+            return getDefinitionKindAndDisplayParts(symbol, checker, node);
         }
         else if (node.kind === SyntaxKind.ObjectLiteralExpression) {
             return {
@@ -317,10 +313,7 @@ namespace ts.FindAllReferences.Core {
             }
         }
 
-        return [{
-            definition: { type: "symbol", symbol, node: symbol.valueDeclaration },
-            references
-        }];
+        return [{ definition: { type: "symbol", symbol }, references }];
     }
 
     /** getReferencedSymbols for special node kinds. */
@@ -359,13 +352,13 @@ namespace ts.FindAllReferences.Core {
         symbol = skipPastExportOrImportSpecifierOrUnion(symbol, node, checker);
 
         // Compute the meaning from the location and the symbol it references
-        const searchMeaning = getIntersectingMeaningFromDeclarations(getMeaningFromLocation(node), symbol.declarations);
+        const searchMeaning = getIntersectingMeaningFromDeclarations(node, symbol);
 
         const result: SymbolAndEntries[] = [];
         const state = new State(sourceFiles, getSpecialSearchKind(node), checker, cancellationToken, searchMeaning, options, result);
 
         if (node.kind === SyntaxKind.DefaultKeyword) {
-            addReference(node, symbol, node, state);
+            addReference(node, symbol, state);
             searchForImportsOfExport(node, symbol, { exportingModuleSymbol: Debug.assertDefined(symbol.parent, "Expected export symbol to have a parent"), exportKind: ExportKind.Default }, state);
         }
         else {
@@ -430,7 +423,6 @@ namespace ts.FindAllReferences.Core {
         /** If coming from an export, we will not recursively search for the imported symbol (since that's where we came from). */
         readonly comingFrom?: ImportExport;
 
-        readonly location: Node;
         readonly symbol: Symbol;
         readonly text: string;
         readonly escapedText: __String;
@@ -510,7 +502,7 @@ namespace ts.FindAllReferences.Core {
             const escapedText = escapeLeadingUnderscores(text);
             const parents = this.options.implementations && getParentSymbolsOfPropertyAccess(location, symbol, this.checker);
             return {
-                location, symbol, comingFrom, text, escapedText, parents,
+                symbol, comingFrom, text, escapedText, parents,
                 includes: referenceSymbol => allSearchSymbols ? contains(allSearchSymbols, referenceSymbol) : referenceSymbol === symbol,
             };
         }
@@ -520,12 +512,12 @@ namespace ts.FindAllReferences.Core {
          * Callback to add references for a particular searched symbol.
          * This initializes a reference group, so only call this if you will add at least one reference.
          */
-        referenceAdder(searchSymbol: Symbol, searchLocation: Node): (node: Node) => void {
+        referenceAdder(searchSymbol: Symbol): (node: Node) => void {
             const symbolId = getSymbolId(searchSymbol);
             let references = this.symbolIdToReferences[symbolId];
             if (!references) {
                 references = this.symbolIdToReferences[symbolId] = [];
-                this.result.push({ definition: { type: "symbol", symbol: searchSymbol, node: searchLocation }, references });
+                this.result.push({ definition: { type: "symbol", symbol: searchSymbol }, references });
             }
             return node => references.push(nodeEntry(node));
         }
@@ -555,7 +547,7 @@ namespace ts.FindAllReferences.Core {
 
         // For `import { foo as bar }` just add the reference to `foo`, and don't otherwise search in the file.
         if (singleReferences.length) {
-            const addRef = state.referenceAdder(exportSymbol, exportLocation);
+            const addRef = state.referenceAdder(exportSymbol);
             for (const singleRef of singleReferences) {
                 addRef(singleRef);
             }
@@ -861,7 +853,7 @@ namespace ts.FindAllReferences.Core {
 
         switch (state.specialSearchKind) {
             case SpecialSearchKind.None:
-                addReference(referenceLocation, relatedSymbol, search.location, state);
+                addReference(referenceLocation, relatedSymbol, state);
                 break;
             case SpecialSearchKind.Constructor:
                 addConstructorReferences(referenceLocation, sourceFile, search, state);
@@ -895,7 +887,7 @@ namespace ts.FindAllReferences.Core {
             }
 
             if (!state.options.isForRename && state.markSeenReExportRHS(name)) {
-                addReference(name, referenceSymbol, name, state);
+                addReference(name, referenceSymbol, state);
             }
         }
         else {
@@ -918,7 +910,7 @@ namespace ts.FindAllReferences.Core {
         }
 
         function addRef() {
-            addReference(referenceLocation, localSymbol, search.location, state);
+            addReference(referenceLocation, localSymbol, state);
         }
     }
 
@@ -967,12 +959,12 @@ namespace ts.FindAllReferences.Core {
          * position of property accessing, the referenceEntry of such position will be handled in the first case.
          */
         if (!(flags & SymbolFlags.Transient) && search.includes(shorthandValueSymbol)) {
-            addReference(getNameOfDeclaration(valueDeclaration), shorthandValueSymbol, search.location, state);
+            addReference(getNameOfDeclaration(valueDeclaration), shorthandValueSymbol, state);
         }
     }
 
-    function addReference(referenceLocation: Node, relatedSymbol: Symbol, searchLocation: Node, state: State): void {
-        const addRef = state.referenceAdder(relatedSymbol, searchLocation);
+    function addReference(referenceLocation: Node, relatedSymbol: Symbol, state: State): void {
+        const addRef = state.referenceAdder(relatedSymbol);
         if (state.options.implementations) {
             addImplementationReferences(referenceLocation, addRef, state);
         }
@@ -984,10 +976,10 @@ namespace ts.FindAllReferences.Core {
     /** Adds references when a constructor is used with `new this()` in its own class and `super()` calls in subclasses.  */
     function addConstructorReferences(referenceLocation: Node, sourceFile: SourceFile, search: Search, state: State): void {
         if (isNewExpressionTarget(referenceLocation)) {
-            addReference(referenceLocation, search.symbol, search.location, state);
+            addReference(referenceLocation, search.symbol, state);
         }
 
-        const pusher = () => state.referenceAdder(search.symbol, search.location);
+        const pusher = () => state.referenceAdder(search.symbol);
 
         if (isClassLike(referenceLocation.parent)) {
             Debug.assert(referenceLocation.kind === SyntaxKind.DefaultKeyword || referenceLocation.parent.name === referenceLocation);
@@ -1004,11 +996,11 @@ namespace ts.FindAllReferences.Core {
     }
 
     function addClassStaticThisReferences(referenceLocation: Node, search: Search, state: State): void {
-        addReference(referenceLocation, search.symbol, search.location, state);
+        addReference(referenceLocation, search.symbol, state);
         if (isClassLike(referenceLocation.parent)) {
             Debug.assert(referenceLocation.parent.name === referenceLocation);
             // This is the class declaration.
-            addStaticThisReferences(referenceLocation.parent, state.referenceAdder(search.symbol, search.location));
+            addStaticThisReferences(referenceLocation.parent, state.referenceAdder(search.symbol));
         }
     }
 
@@ -1304,7 +1296,7 @@ namespace ts.FindAllReferences.Core {
             }
         }
 
-        return [{ definition: { type: "symbol", symbol: searchSpaceNode.symbol, node: superKeyword }, references }];
+        return [{ definition: { type: "symbol", symbol: searchSpaceNode.symbol }, references }];
     }
 
     function getReferencesForThisKeyword(thisOrSuperKeyword: Node, sourceFiles: ReadonlyArray<SourceFile>, cancellationToken: CancellationToken): SymbolAndEntries[] {
@@ -1667,7 +1659,9 @@ namespace ts.FindAllReferences.Core {
      * module, we want to keep the search limited to only types, as the two declarations (interface and uninstantiated module)
      * do not intersect in any of the three spaces.
      */
-    function getIntersectingMeaningFromDeclarations(meaning: SemanticMeaning, declarations: Declaration[]): SemanticMeaning {
+    export function getIntersectingMeaningFromDeclarations(node: Node, symbol: Symbol): SemanticMeaning {
+        let meaning = getMeaningFromLocation(node);
+        const { declarations } = symbol;
         if (declarations) {
             let lastIterationMeaning: SemanticMeaning;
             do {

--- a/tests/cases/fourslash/cancellationWhenfindingAllRefsOnDefinition.ts
+++ b/tests/cases/fourslash/cancellationWhenfindingAllRefsOnDefinition.ts
@@ -33,8 +33,5 @@ cancellation.resetCancelled();
 checkRefs();
 
 function checkRefs() {
-    const ranges = test.ranges();
-    const [r0, r1] = ranges;
-    verify.referenceGroups(r0, [{ definition: "(method) Test.start(): this", ranges }]);
-    verify.referenceGroups(r1, [{ definition: "(method) Second.Test.start(): Second.Test", ranges }]);
+    verify.singleReferenceGroup("(method) Test.start(): this");
 }

--- a/tests/cases/fourslash/findAllReferencesOfConstructor.ts
+++ b/tests/cases/fourslash/findAllReferencesOfConstructor.ts
@@ -42,8 +42,8 @@
 
 const ranges = test.ranges();
 const [a0, a1, a2, a3, a4, b0, c0, d0, d1] = ranges;
-verify.referenceGroups([a0, a2], defs("constructor C(n: number): C (+1 overload)"));
-verify.referenceGroups(a1, defs("constructor C(): C (+1 overload)"));
+verify.referenceGroups([a0, a2], defs("class C"));
+verify.referenceGroups(a1, defs("class C"));
 
 function defs(definition: string) {
     return [

--- a/tests/cases/fourslash/findAllReferencesOfConstructor_badOverload.ts
+++ b/tests/cases/fourslash/findAllReferencesOfConstructor_badOverload.ts
@@ -5,4 +5,4 @@
 ////    [|constructor|](){}
 ////}
 
-verify.singleReferenceGroup("constructor C(n: number): C");
+verify.singleReferenceGroup("class C");

--- a/tests/cases/fourslash/findAllRefsDefinition.ts
+++ b/tests/cases/fourslash/findAllRefsDefinition.ts
@@ -3,13 +3,10 @@
 ////const [|{| "isWriteAccess": true, "isDefinition": true |}x|] = 0;
 ////[|x|];
 
-// TODO: GH#21301
-
 const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r1, [
+verify.referenceGroups(ranges, [
     {
-        definition: { text: "const x: 0", range: r1 },
+        definition: { text: "const x: 0", range: ranges[0] },
         ranges,
     },
 ])

--- a/tests/cases/fourslash/findAllRefsExportDefaultClassConstructor.ts
+++ b/tests/cases/fourslash/findAllRefsExportDefaultClassConstructor.ts
@@ -2,4 +2,4 @@
 ////    [|constructor|]() {}
 ////}
 
-verify.singleReferenceGroup("constructor default(): default");
+verify.singleReferenceGroup("class default");

--- a/tests/cases/fourslash/findAllRefsForDefaultExport.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport.ts
@@ -16,7 +16,6 @@ verify.referenceGroups(r0, [
     { definition: "function f(): void", ranges: [r0] },
     { definition: "(alias) function g(): void\nimport g", ranges: [r1, r2] }
 ]);
-verify.referenceGroups(r1, [{ definition: "(alias) function g(): void\nimport g", ranges: [r1, r2] }]);
-verify.referenceGroups(r2, [{ definition: "(alias) g(): void\nimport g", ranges: [r1, r2] }]);
+verify.singleReferenceGroup("(alias) function g(): void\nimport g", [r1, r2]);
 
 verify.goToDefinition("ref", "def");

--- a/tests/cases/fourslash/findAllRefsForDefaultExport01.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport01.ts
@@ -7,7 +7,4 @@
 ////
 ////var y = new [|DefaultExportedClass|];
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups([r0, r1], [{ definition: "class DefaultExportedClass", ranges }]);
-verify.referenceGroups(r2, [{ definition: "constructor DefaultExportedClass(): DefaultExportedClass", ranges }]);
+verify.singleReferenceGroup("class DefaultExportedClass");

--- a/tests/cases/fourslash/findAllRefsForDefaultExport03.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport03.ts
@@ -14,7 +14,4 @@
 ////    var local = 100;
 ////}
 
-const ranges = test.ranges();
-const [r0, r1, r2, r3, r4] = ranges;
-verify.referenceGroups([r0, r3], [{ definition: "function f(): number\nnamespace f", ranges }]);
-verify.referenceGroups([r1, r2, r4], [{ definition: "namespace f\nfunction f(): number", ranges }]);
+verify.singleReferenceGroup("namespace f\nfunction f(): number");

--- a/tests/cases/fourslash/findAllRefsImportStarOfExportEquals.ts
+++ b/tests/cases/fourslash/findAllRefsImportStarOfExportEquals.ts
@@ -27,31 +27,18 @@ const aRanges = [a0, a1, a2];
 const bRanges = [b0, b1, b2];
 const cRanges = [c0, c1, c2];
 
-verify.referenceGroups(a0, [
-    { definition: "function a(): void\nnamespace a", ranges: aRanges },
-    { definition: "(alias) function b(): void\n(alias) namespace b\nimport b", ranges: bRanges },
-    { definition: "(alias) function a(): void\n(alias) namespace a\nimport a", ranges: cRanges }
-]);
-verify.referenceGroups([a1, a2], [
+verify.referenceGroups([a0, a1, a2], [
     { definition: "namespace a\nfunction a(): void", ranges: aRanges },
     { definition: "(alias) function b(): void\n(alias) namespace b\nimport b", ranges: bRanges },
     { definition: "(alias) function a(): void\n(alias) namespace a\nimport a", ranges: cRanges }
 ]);
 
-verify.referenceGroups([b0, b0], [
+verify.referenceGroups([b0, b1], [
     { definition: "(alias) function b(): void\n(alias) namespace b\nimport b", ranges: bRanges }
 ]);
-verify.referenceGroups(b1, [
-    { definition: "(alias) b(): void\nimport b", ranges: bRanges }
-]);
 
-verify.referenceGroups([c0, c2], [
+verify.referenceGroups([c0, c1, c2], [
     { definition: "(alias) function a(): void\n(alias) namespace a\nimport a", ranges: cRanges },
-    { definition: "namespace a\nfunction a(): void", ranges: aRanges },
-    { definition: "(alias) function b(): void\n(alias) namespace b\nimport b", ranges: bRanges }
-]);
-verify.referenceGroups(c1, [
-    { definition: "(alias) a(): void\nimport a", ranges: cRanges },
     { definition: "namespace a\nfunction a(): void", ranges: aRanges },
     { definition: "(alias) function b(): void\n(alias) namespace b\nimport b", ranges: bRanges }
 ]);

--- a/tests/cases/fourslash/findAllRefsOfConstructor_withModifier.ts
+++ b/tests/cases/fourslash/findAllRefsOfConstructor_withModifier.ts
@@ -6,4 +6,4 @@
 ////var x = new [|X|]();
 
 const ranges = test.ranges();
-verify.referenceGroups(ranges[0], [{ definition: "constructor X(): X", ranges }]);
+verify.referenceGroups(ranges[0], [{ definition: "class X", ranges }]);

--- a/tests/cases/fourslash/findAllRefsOnDefinition.ts
+++ b/tests/cases/fourslash/findAllRefsOnDefinition.ts
@@ -23,7 +23,4 @@
 ////second.[|start|]();
 ////second.stop();
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) Test.start(): this", ranges }]);
-verify.referenceGroups(r1, [{ definition: "(method) Second.Test.start(): Second.Test", ranges }]);
+verify.singleReferenceGroup("(method) Test.start(): this");

--- a/tests/cases/fourslash/findAllRefsOnDefinition2.ts
+++ b/tests/cases/fourslash/findAllRefsOnDefinition2.ts
@@ -14,7 +14,4 @@
 ////var start: Second.Test.[|start|];
 ////var stop: Second.Test.stop;
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "interface Test.start", ranges }]);
-verify.referenceGroups(r1, [{ definition: "interface Second.Test.start", ranges }]);
+verify.singleReferenceGroup("interface Test.start");

--- a/tests/cases/fourslash/findAllRefsOnImportAliases.ts
+++ b/tests/cases/fourslash/findAllRefsOnImportAliases.ts
@@ -18,9 +18,4 @@ const classes = { definition: "class Class", ranges: [r0] };
 const imports = { definition: "(alias) class Class\nimport Class", ranges: [r1, r2] };
 const reExports = { definition: "(alias) class Class\nimport Class", ranges: [r3] };
 verify.referenceGroups(r0, [classes, imports, reExports]);
-verify.referenceGroups(r1, [imports, classes, reExports]);
-verify.referenceGroups(r2, [
-    { definition: "(alias) new Class(): Class\nimport Class", ranges: [r1, r2] },
-    classes,
-    reExports
-]);
+verify.referenceGroups([r1, r2], [imports, classes, reExports]);

--- a/tests/cases/fourslash/findAllRefsOnImportAliases2.ts
+++ b/tests/cases/fourslash/findAllRefsOnImportAliases2.ts
@@ -22,8 +22,7 @@ const c3s = { definition: "(alias) class C3\nimport C3", ranges: c3Ranges };
 
 verify.referenceGroups(classRanges, [classes, c2s, c3s]);
 
-verify.referenceGroups(c2_0, [c2s])
-verify.referenceGroups(c2_1, [{ definition: "(alias) new C2(): C2\nimport C2", ranges: c2Ranges }]);
+verify.referenceGroups(c2Ranges, [c2s])
 
 verify.referenceGroups(c3Ranges, [c3s]);
 

--- a/tests/cases/fourslash/findAllRefsReExports.ts
+++ b/tests/cases/fourslash/findAllRefsReExports.ts
@@ -33,25 +33,14 @@ const eBoom = { definition: "(alias) function boom(): void\nimport boom", ranges
 verify.referenceGroups([foo0, foo1, foo2], [a, b, eBar, c, d, eBoom, eBaz, eBang]);
 
 verify.referenceGroups(bar0, [b, eBar]);
-verify.referenceGroups(bar1, [eBar, b]);
-verify.referenceGroups(bar2, [{ ...eBar, definition: "(alias) bar(): void\nimport bar" }, b]);
+verify.referenceGroups([bar1, bar2], [eBar, b]);
 
-verify.referenceGroups([defaultC], [c, d, eBoom, eBaz, eBang]);
+verify.referenceGroups([defaultC, defaultE], [c, d, eBoom, eBaz, eBang]);
 verify.referenceGroups(defaultD, [d, eBoom, a, b, eBar,c, eBaz, eBang]);
-verify.referenceGroups(defaultE, [c, d, eBoom, eBaz, eBang]);
-verify.referenceGroups(baz0, [eBaz, c, d, eBoom, eBang]);
-verify.referenceGroups(baz1, [
-    { ...eBaz, definition: "(alias) baz(): void\nimport baz" },
-    c, d, eBoom, eBang,
-]);
+verify.referenceGroups([baz0, baz1], [eBaz, c, d, eBoom, eBang]);
 
-verify.referenceGroups(bang0, [eBang]);
-verify.referenceGroups(bang1, [{ ...eBang, definition: "(alias) bang(): void\nimport bang" }]);
-verify.referenceGroups(boom0, [eBoom, d, a, b, eBar, c, eBaz, eBang]);
-verify.referenceGroups(boom1, [
-    { ...eBoom, definition: "(alias) boom(): void\nimport boom" },
-    d, a, b, eBar, c, eBaz, eBang,
-]);
+verify.referenceGroups([bang0, bang1], [eBang]);
+verify.referenceGroups([boom0, boom1], [eBoom, d, a, b, eBar, c, eBaz, eBang]);
 
 test.rangesByText().forEach((ranges, text) => {
     if (text === "default") {

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -516,7 +516,7 @@ declare namespace FourSlashInterface {
         };
     }
 
-    interface ReferencesDefinition {
+    type ReferencesDefinition = string | {
         text: string;
         range: Range;
     }

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfClass.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfClass.ts
@@ -7,7 +7,4 @@
 ////}
 ////let c = new [|C|]();
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "class C", ranges }]);
-verify.referenceGroups(r1, [{ definition: "constructor C(): C", ranges }]);
+verify.singleReferenceGroup("class C");

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterfaceClassMerge.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterfaceClassMerge.ts
@@ -13,7 +13,4 @@
 ////let i: [|Numbers|] = new [|Numbers|]();
 ////let x = i.f(i.p + i.m);
 
-const ranges = test.ranges();
-const [r0, r1, r2, r3, r4] = ranges;
-verify.referenceGroups([r0, r1, r2, r3], [{ definition: "class Numbers\ninterface Numbers", ranges }]);
-verify.referenceGroups(r4, [{ definition: "constructor Numbers(): Numbers", ranges }]);
+verify.singleReferenceGroup("class Numbers\ninterface Numbers");

--- a/tests/cases/fourslash/referenceToClass.ts
+++ b/tests/cases/fourslash/referenceToClass.ts
@@ -20,7 +20,4 @@
 // @Filename: referenceToClass_2.ts
 ////var k: [|foo|];
 
-const ranges = test.ranges();
-const [r0, r1, r2, r3, r4, r5] = ranges;
-verify.referenceGroups([r0, r1, r2, r4, r5], [{ definition: "class foo", ranges }]);
-verify.referenceGroups(r3, [{ definition: "constructor foo(): foo", ranges }]);
+verify.singleReferenceGroup("class foo");

--- a/tests/cases/fourslash/referencesForGlobalsInExternalModule.ts
+++ b/tests/cases/fourslash/referencesForGlobalsInExternalModule.ts
@@ -22,8 +22,7 @@ const ranges = test.rangesByText();
 verify.singleReferenceGroup("var topLevelVar: number", ranges.get("topLevelVar"));
 
 const topLevelClass = ranges.get("topLevelClass");
-verify.referenceGroups(topLevelClass[0], [{ definition: "class topLevelClass", ranges: topLevelClass }]);
-verify.referenceGroups(topLevelClass[1], [{ definition: "constructor topLevelClass(): topLevelClass", ranges: topLevelClass }]);
+verify.singleReferenceGroup("class topLevelClass", topLevelClass);
 
 verify.singleReferenceGroup("interface topLevelInterface", ranges.get("topLevelInterface"));
 verify.singleReferenceGroup("namespace topLevelModule", ranges.get("topLevelModule"));

--- a/tests/cases/fourslash/referencesForMergedDeclarations.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations.ts
@@ -17,5 +17,4 @@
 const [type1, namespace1, value1, namespace2, type2, value2] = test.ranges();
 verify.singleReferenceGroup("interface Foo\nnamespace Foo\nfunction Foo(): void", [type1, type2]);
 verify.singleReferenceGroup("namespace Foo\nfunction Foo(): void", [namespace1, namespace2]);
-verify.referenceGroups(value1, [{ definition: "function Foo(): void\nnamespace Foo", ranges: [value1, value2] }]);
-verify.referenceGroups(value2, [{ definition: "namespace Foo\nfunction Foo(): void", ranges: [value1, value2] }]);
+verify.singleReferenceGroup("namespace Foo\nfunction Foo(): void", [value1, value2]);

--- a/tests/cases/fourslash/referencesForMergedDeclarations3.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations3.ts
@@ -23,5 +23,4 @@
 const [class0, module0, class1, module1, class2, class3, class4, class5] = test.ranges();
 verify.singleReferenceGroup("class testClass\nnamespace testClass", [module0, module1]);
 const classes = [class0, class1, class2, class3, class4, class5];
-verify.referenceGroups(classes.slice(0, 5), [{ definition: "class testClass\nnamespace testClass", ranges: classes }]);
-verify.referenceGroups(class5, [{ definition: "constructor testClass(): testClass\nnamespace testClass", ranges: classes }]);
+verify.referenceGroups(classes, [{ definition: "class testClass\nnamespace testClass", ranges: classes }]);

--- a/tests/cases/fourslash/referencesForMergedDeclarations4.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations4.ts
@@ -22,6 +22,4 @@
 ////[|testClass|].s;
 ////new [|testClass|]();
 
-const ranges = test.ranges();
-verify.referenceGroups(ranges.slice(0, 8), [{ definition: "class testClass\nnamespace testClass", ranges }]);
-verify.referenceGroups(ranges[8], [{ definition: "constructor testClass(): testClass\nnamespace testClass", ranges }]);
+verify.singleReferenceGroup("class testClass\nnamespace testClass");

--- a/tests/cases/fourslash/referencesForMergedDeclarations5.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations5.ts
@@ -10,5 +10,5 @@ const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
 verify.referenceGroups(r0, [{ definition: "interface Foo\nnamespace Foo\nfunction Foo(): void", ranges: [r0, r3] }]);
 verify.referenceGroups(r1, [{ definition: "namespace Foo\nfunction Foo(): void", ranges: [r1, r3] }]);
-verify.referenceGroups(r2, [{ definition: "function Foo(): void\nnamespace Foo", ranges: [r2, r3] }]);
+verify.referenceGroups(r2, [{ definition: "namespace Foo\nfunction Foo(): void", ranges: [r2, r3] }]);
 verify.referenceGroups(r3, [{ definition: "interface Foo\nnamespace Foo\nfunction Foo(): void", ranges }]);

--- a/tests/cases/fourslash/referencesForMergedDeclarations7.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations7.ts
@@ -14,5 +14,5 @@ const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
 verify.referenceGroups(r0, [{ definition: "interface Foo.Bar\nnamespace Foo.Bar\nfunction Foo.Bar(): void", ranges: [r0, r3] }]);
 verify.referenceGroups(r1, [{ definition: "namespace Foo.Bar\nfunction Foo.Bar(): void", ranges: [r1, r3] }]);
-verify.referenceGroups(r2, [{ definition: "function Foo.Bar(): void\nnamespace Foo.Bar", ranges: [r2, r3] }]);
+verify.referenceGroups(r2, [{ definition: "namespace Foo.Bar\nfunction Foo.Bar(): void", ranges: [r2, r3] }]);
 verify.referenceGroups(r3, [{ definition: "interface Foo.Bar\nnamespace Foo.Bar\nfunction Foo.Bar(): void", ranges }]);

--- a/tests/cases/fourslash/referencesForPropertiesOfGenericType.ts
+++ b/tests/cases/fourslash/referencesForPropertiesOfGenericType.ts
@@ -10,8 +10,4 @@
 ////var y: IFoo<number>;
 ////y.[|doSomething|](12);
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) IFoo<T>.doSomething(v: T): T", ranges }]);
-verify.referenceGroups(r1, [{ definition: "(method) IFoo<T>.doSomething(v: string): string", ranges }]);
-verify.referenceGroups(r2, [{ definition: "(method) IFoo<T>.doSomething(v: number): number", ranges }]);
+verify.singleReferenceGroup("(method) IFoo<T>.doSomething(v: T): T");

--- a/tests/cases/fourslash/referencesForStaticsAndMembersWithSameNames.ts
+++ b/tests/cases/fourslash/referencesForStaticsAndMembersWithSameNames.ts
@@ -34,10 +34,7 @@ verify.singleReferenceGroup("(method) MixedStaticsClassTest.Foo.foo(): void", [f
 verify.singleReferenceGroup("(method) MixedStaticsClassTest.Foo.foo(): void", [fooStaticFoo, staticFoo]);
 
 // References to a member property with the same name as a static.
-//verify.singleReferenceGroup("(property) MixedStaticsClassTest.Foo.bar: Foo", [fooBar, xBar]);
-verify.referenceGroups(fooBar, [{ definition: "(property) MixedStaticsClassTest.Foo.bar: Foo", ranges: [fooBar, xBar] }]);
-verify.referenceGroups(xBar, [{ definition: "(property) MixedStaticsClassTest.Foo.bar: MixedStaticsClassTest.Foo", ranges: [fooBar, xBar] }]);
+verify.singleReferenceGroup("(property) MixedStaticsClassTest.Foo.bar: Foo", [fooBar, xBar]);
 
 // References to a static property with the same name as a member.
-verify.referenceGroups(fooStaticBar, [{ definition: "(property) MixedStaticsClassTest.Foo.bar: Foo", ranges: [fooStaticBar, staticBar] }]);
-verify.referenceGroups(staticBar, [{ definition: "(property) MixedStaticsClassTest.Foo.bar: MixedStaticsClassTest.Foo", ranges: [fooStaticBar, staticBar] }]);
+verify.singleReferenceGroup("(property) MixedStaticsClassTest.Foo.bar: Foo", [fooStaticBar, staticBar]);

--- a/tests/cases/fourslash/remoteGetReferences.ts
+++ b/tests/cases/fourslash/remoteGetReferences.ts
@@ -188,13 +188,5 @@ test.rangesByText().forEach((ranges, text) => {
         }
     })();
 
-    if (text === "remotefooCls") {
-        verify.referenceGroups([ranges[0], ...ranges.slice(2)], [{ definition, ranges }]);
-        verify.referenceGroups(ranges[1], [
-            { definition: "constructor remotefooCls(remoteclsParam: number): remotefooCls", ranges}
-        ]);
-    }
-    else {
-        verify.singleReferenceGroup(definition, ranges);
-    }
+    verify.singleReferenceGroup(definition, ranges);
 });

--- a/tests/cases/fourslash/renameDefaultImport.ts
+++ b/tests/cases/fourslash/renameDefaultImport.ts
@@ -20,11 +20,7 @@ const [C, B0, B1] = ranges;
 const classes = { definition: "class B", ranges: [C] };
 const imports = { definition: "(alias) class B\nimport B", ranges: [B0, B1] };
 verify.referenceGroups(C, [classes, imports]);
-verify.referenceGroups(B0, [imports, classes]);
-verify.referenceGroups(B1, [
-    { definition: "(alias) new B(): B\nimport B", ranges: [B0, B1] },
-    classes
-]);
+verify.referenceGroups([B0, B1], [imports, classes]);
 
 verify.renameLocations(C, ranges);
 verify.rangesAreRenameLocations([B0, B1]);

--- a/tests/cases/fourslash/renameDefaultImportDifferentName.ts
+++ b/tests/cases/fourslash/renameDefaultImportDifferentName.ts
@@ -20,8 +20,8 @@ const bRanges = [B0, B1];
 const classes = { definition: "class C", ranges: [C] };
 const imports = { definition: "(alias) class B\nimport B", ranges: [B0, B1] };
 verify.referenceGroups(C, [classes, imports]);
-verify.referenceGroups(B0, [imports]);
-verify.referenceGroups(B1, [{ definition: "(alias) new B(): B\nimport B", ranges: bRanges }]);
+verify.singleReferenceGroup(imports.definition, [B0, B1]);
+
 
 verify.rangesAreRenameLocations([C]);
 verify.rangesAreRenameLocations(bRanges);

--- a/tests/cases/fourslash/renameJsExports03.ts
+++ b/tests/cases/fourslash/renameJsExports03.ts
@@ -18,7 +18,7 @@ verify.referenceGroups([r0, r2], [
 ]);
 
 verify.referenceGroups(r1, [
-    { definition: "constructor A(): A", ranges: [r1] },
+    { definition: "class A", ranges: [r1] },
     { definition: "const A: typeof A", ranges: [r4] }
 ]);
 
@@ -26,6 +26,6 @@ verify.referenceGroups(r3, [
     { definition: "const A: typeof A", ranges: [r3, r4] }
 ]);
 verify.referenceGroups(r4, [
-    { definition: "const A: new () => A", ranges: [r3, r4] }
+    { definition: "const A: typeof A", ranges: [r3, r4] }
 ]);
 

--- a/tests/cases/fourslash/shims-pp/getReferencesAtPosition.ts
+++ b/tests/cases/fourslash/shims-pp/getReferencesAtPosition.ts
@@ -23,7 +23,4 @@
 ////second.[|start|]();
 ////second.stop();
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) Test.start(): this", ranges }]);
-verify.referenceGroups(r1, [{ definition: "(method) Second.Test.start(): Second.Test", ranges }]);
+verify.singleReferenceGroup("(method) Test.start(): this");

--- a/tests/cases/fourslash/shims/getReferencesAtPosition.ts
+++ b/tests/cases/fourslash/shims/getReferencesAtPosition.ts
@@ -23,7 +23,4 @@
 ////second.[|start|]();
 ////second.stop();
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) Test.start(): this", ranges }]);
-verify.referenceGroups(r1, [{ definition: "(method) Second.Test.start(): Second.Test", ranges }]);
+verify.singleReferenceGroup("(method) Test.start(): this");

--- a/tests/cases/fourslash/transitiveExportImports.ts
+++ b/tests/cases/fourslash/transitiveExportImports.ts
@@ -28,7 +28,7 @@ verify.referenceGroups(aRanges, [
     bGroup
 ]);
 verify.referenceGroups(b0, [bGroup]);
-verify.referenceGroups(c2, [{ ...bGroup, definition: "(alias) new b.b(): b.b\nimport b.b = require('./a')"}]);
+verify.referenceGroups(c2, [{ ...bGroup, definition: "(alias) class b\nimport b = require('./a')"}]);
 verify.singleReferenceGroup("import b = require('./b')", cRanges);
 
 verify.rangesAreRenameLocations(aRanges);


### PR DESCRIPTION
Fixes #21301

Previously the definition info depended on the search location -- which doesn't make sense as the search location is probably not the definition. As of this PR we will mostly only use the definition symbol when getting definition info; the only exception being that we still use the original search location to get the SemanticMeaning, and we may use the search location as a backup if `symbol.declarations` is empty.