### PR TITLE
Try out CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,48 @@ workflows:
                 - release-2.6
                 - release-2.7
                 - circleci
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 8 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - node9:
+          filters:
+            branches:
+              only:
+                - master
+                - release-2.5
+                - release-2.6
+                - release-2.7
+                - circleci
+          context: nightlies
+      - node8:
+          filters:
+            branches:
+              only:
+                - master
+                - release-2.5
+                - release-2.6
+                - release-2.7
+                - circleci
+          context: nightlies
+      - node6:
+          filters:
+            branches:
+              only:
+                - master
+                - release-2.5
+                - release-2.6
+                - release-2.7
+                - circleci
+          context: nightlies
 
 base: &base
   environment:
-    - workerCount: 3
+    - workerCount: 4
   steps:
     - checkout
     - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,58 @@
+workflows:
+  version: 2
+  main:
+    jobs:
+      - node9:
+          filters:
+            branches:
+              only:
+                - master
+                - release-2.5
+                - release-2.6
+                - release-2.7
+                - circleci
+      - node8:
+          filters:
+            branches:
+              only:
+                - master
+                - release-2.5
+                - release-2.6
+                - release-2.7
+                - circleci
+      - node6:
+          filters:
+            branches:
+              only:
+                - master
+                - release-2.5
+                - release-2.6
+                - release-2.7
+                - circleci
+
+base: &base
+  environment:
+    - workerCount: 3
+  steps:
+    - checkout
+    - run: |
+        npm uninstall typescript --no-save
+        npm uninstall tslint --no-save
+        npm install
+        #npm update Appeared in Jenkins only
+        npm test
+
+version: 2
+jobs:
+  node9:
+    docker:
+      - image: circleci/node:9
+    <<: *base
+  node8:
+    docker:
+      - image: circleci/node:8
+    <<: *base
+  node6:
+    docker:
+      - image: circleci/node:6
+    <<: *base


### PR DESCRIPTION
- [x] You've signed the CLA

P.S. The sign in link on <https://cla.opensource.microsoft.com/> is white text on a white background so it was hard to find.

---

I can see that this repo is being build with multiple CI providers in mind. I created a config for CircleCI 2.0 and wanted to demo that it brings with it reduced build times.

| Node.js Version | Travis CI | CircleCI |
| --- | --- | -- |
| 9 | 10min 30sec | 6min 15sec |
| 8 | 9min 40sec | 7min 23sec |
| 6 | 14min 28sec | 9min 28sec |

Here's my fork on CircleCI: https://circleci.com/workflow-run/a2a9cad4-53d9-4238-a78c-3f20d6ff03a9

CircleCI is free just like Travis CI for something like TypeScript and clearly has better performance. Something to consider. Also, this PR shouldn't be merged as is. There's a `circleci` branch mentioned in the config that I put there for my testing purposes. Depending on your maintenance schedule, we could probably use regex for the release branches. If there's any questions on additional customization, please let me know.

---

Sidenote, you can see from this table, regardless of the provider, that Node.js has more or less been building faster with each new major release. That's encouraging.

cc @DanielRosenwasser 