### PR TITLE
In getSymbolAtLocation, return undefined instead of unknownSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24624,7 +24624,8 @@ namespace ts {
 
                 if (entityName.kind === SyntaxKind.Identifier) {
                     if (isJSXTagName(entityName) && isJsxIntrinsicIdentifier(entityName)) {
-                        return getIntrinsicTagSymbol(<JsxOpeningLikeElement>entityName.parent);
+                        const symbol = getIntrinsicTagSymbol(<JsxOpeningLikeElement>entityName.parent);
+                        return symbol === unknownSymbol ? undefined : symbol;
                     }
 
                     return resolveEntityName(entityName, SymbolFlags.Value, /*ignoreErrors*/ false, /*dontResolveAlias*/ true);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -923,9 +923,8 @@ namespace ts.Completions {
         }
         else if (isStartingCloseTag) {
             const tagName = (<JsxElement>contextToken.parent.parent).openingElement.tagName;
-            const tagSymbol = Debug.assertDefined(typeChecker.getSymbolAtLocation(tagName));
-
-            if (!typeChecker.isUnknownSymbol(tagSymbol)) {
+            const tagSymbol = typeChecker.getSymbolAtLocation(tagName);
+            if (tagSymbol) {
                 symbols = [tagSymbol];
             }
             completionKind = CompletionKind.MemberLike;

--- a/tests/baselines/reference/conflictMarkerTrivia3.symbols
+++ b/tests/baselines/reference/conflictMarkerTrivia3.symbols
@@ -1,6 +1,5 @@
 === tests/cases/compiler/conflictMarkerTrivia3.tsx ===
 const x = <div>
 >x : Symbol(x, Decl(conflictMarkerTrivia3.tsx, 0, 5))
->div : Symbol(unknown)
 
 <<<<<<< HEAD

--- a/tests/baselines/reference/es3-jsx-preserve.symbols
+++ b/tests/baselines/reference/es3-jsx-preserve.symbols
@@ -4,7 +4,5 @@ const React: any = null;
 
 const elem = <div></div>;
 >elem : Symbol(elem, Decl(es3-jsx-preserve.tsx, 2, 5))
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 

--- a/tests/baselines/reference/es3-jsx-react-native.symbols
+++ b/tests/baselines/reference/es3-jsx-react-native.symbols
@@ -4,7 +4,5 @@ const React: any = null;
 
 const elem = <div></div>;
 >elem : Symbol(elem, Decl(es3-jsx-react-native.tsx, 2, 5))
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 

--- a/tests/baselines/reference/es3-jsx-react.symbols
+++ b/tests/baselines/reference/es3-jsx-react.symbols
@@ -4,7 +4,5 @@ const React: any = null;
 
 const elem = <div></div>;
 >elem : Symbol(elem, Decl(es3-jsx-react.tsx, 2, 5))
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 

--- a/tests/baselines/reference/importHelpersInTsx.symbols
+++ b/tests/baselines/reference/importHelpersInTsx.symbols
@@ -7,7 +7,6 @@ declare var o: any;
 
 export const x = <span {...o} />
 >x : Symbol(x, Decl(external.tsx, 2, 12))
->span : Symbol(unknown)
 >o : Symbol(o, Decl(external.tsx, 1, 11))
 
 === tests/cases/compiler/script.tsx ===
@@ -19,7 +18,6 @@ declare var o: any;
 
 const x = <span {...o} />
 >x : Symbol(x, Decl(script.tsx, 2, 5))
->span : Symbol(unknown)
 >o : Symbol(o, Decl(script.tsx, 1, 11))
 
 === tests/cases/compiler/tslib.d.ts ===

--- a/tests/baselines/reference/jsFileCompilationTypeAssertions.symbols
+++ b/tests/baselines/reference/jsFileCompilationTypeAssertions.symbols
@@ -2,5 +2,4 @@
 0 as number;
 var v = <string>undefined;
 >v : Symbol(v, Decl(a.js, 1, 3))
->string : Symbol(unknown)
 

--- a/tests/baselines/reference/jsxAndTypeAssertion.symbols
+++ b/tests/baselines/reference/jsxAndTypeAssertion.symbols
@@ -10,53 +10,23 @@ var x: any;
 
 x = <any> { test: <any></any> };
 >x : Symbol(x, Decl(jsxAndTypeAssertion.tsx, 4, 3))
->any : Symbol(unknown)
->any : Symbol(unknown)
->any : Symbol(unknown)
 
 x = <any><any></any>;
->any : Symbol(unknown)
->any : Symbol(unknown)
->any : Symbol(unknown)
  
 x = <foo>hello {<foo>{}} </foo>;
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
 
 x = <foo test={<foo>{}}>hello</foo>;
->foo : Symbol(unknown)
 >test : Symbol(test, Decl(jsxAndTypeAssertion.tsx, 11, 8))
->foo : Symbol(unknown)
->foo : Symbol(unknown)
 
 x = <foo test={<foo>{}}>hello{<foo>{}}</foo>;
->foo : Symbol(unknown)
 >test : Symbol(test, Decl(jsxAndTypeAssertion.tsx, 13, 8))
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
 
 x = <foo>x</foo>, x = <foo/>;
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
 
 <foo>{<foo><foo>{/foo/.test(x) ? <foo><foo></foo> : <foo><foo></foo>}</foo>}</foo>
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
 >/foo/.test : Symbol(RegExp.test, Decl(lib.d.ts, --, --))
 >test : Symbol(RegExp.test, Decl(lib.d.ts, --, --))
 >x : Symbol(x, Decl(jsxAndTypeAssertion.tsx, 4, 3))
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
->foo : Symbol(unknown)
 
     
 

--- a/tests/baselines/reference/jsxEmitAttributeWithPreserve.symbols
+++ b/tests/baselines/reference/jsxEmitAttributeWithPreserve.symbols
@@ -3,6 +3,5 @@ declare var React: any;
 >React : Symbol(React, Decl(jsxEmitAttributeWithPreserve.tsx, 0, 11))
 
 <foo data/>
->foo : Symbol(unknown)
 >data : Symbol(data, Decl(jsxEmitAttributeWithPreserve.tsx, 1, 4))
 

--- a/tests/baselines/reference/jsxEmitWithAttributes.symbols
+++ b/tests/baselines/reference/jsxEmitWithAttributes.symbols
@@ -99,19 +99,15 @@ class A {
 
 		return [
 			<meta content="helloworld"></meta>,
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 11, 8))
->meta : Symbol(unknown)
 
 			<meta content={c.a!.b}></meta>
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 12, 8))
 >c.a!.b : Symbol(b, Decl(test.tsx, 3, 6))
 >c.a : Symbol(a, Decl(test.tsx, 2, 8))
 >c : Symbol(c, Decl(test.tsx, 2, 3))
 >a : Symbol(a, Decl(test.tsx, 2, 8))
 >b : Symbol(b, Decl(test.tsx, 3, 6))
->meta : Symbol(unknown)
 
 		];
 	}

--- a/tests/baselines/reference/jsxEsprimaFbTestSuite.symbols
+++ b/tests/baselines/reference/jsxEsprimaFbTestSuite.symbols
@@ -21,14 +21,12 @@ declare var props;
 >props : Symbol(props, Decl(jsxEsprimaFbTestSuite.tsx, 6, 11))
 
 <a />;
->a : Symbol(unknown)
 
 //<n:a n:v />; Namespace unsuported
 
 //<a n:foo="bar"> {value} <b><c /></b></a>;  Namespace unsuported
 
 <a b={" "} c=" " d="&amp;" e="id=1&group=2" f="&#123456789" g="&#123*;" h="&#x;" />;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(jsxEsprimaFbTestSuite.tsx, 14, 2))
 >c : Symbol(c, Decl(jsxEsprimaFbTestSuite.tsx, 14, 10))
 >d : Symbol(d, Decl(jsxEsprimaFbTestSuite.tsx, 14, 16))
@@ -38,12 +36,9 @@ declare var props;
 >h : Symbol(h, Decl(jsxEsprimaFbTestSuite.tsx, 14, 71))
 
 <a b="&notanentity;" />;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(jsxEsprimaFbTestSuite.tsx, 16, 2))
 
 <a
->a : Symbol(unknown)
-
 />;
 
 <日本語></日本語>;
@@ -62,36 +57,21 @@ baz
 >AbC_def : Symbol(AbC_def, Decl(jsxEsprimaFbTestSuite.tsx, 2, 11))
 
 <a b={x ? <c /> : <d />} />;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(jsxEsprimaFbTestSuite.tsx, 28, 2))
 >x : Symbol(x, Decl(jsxEsprimaFbTestSuite.tsx, 4, 11))
->c : Symbol(unknown)
->d : Symbol(unknown)
 
 <a>{}</a>;
->a : Symbol(unknown)
->a : Symbol(unknown)
 
 <a>{/* this is a comment */}</a>;
->a : Symbol(unknown)
->a : Symbol(unknown)
 
 <div>@test content</div>;
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 <div><br />7x invalid-js-identifier</div>;
->div : Symbol(unknown)
->br : Symbol(unknown)
->div : Symbol(unknown)
 
 <LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />;
 >LeftRight : Symbol(LeftRight, Decl(jsxEsprimaFbTestSuite.tsx, 3, 11))
 >left : Symbol(left, Decl(jsxEsprimaFbTestSuite.tsx, 38, 10))
->a : Symbol(unknown)
 >right : Symbol(right, Decl(jsxEsprimaFbTestSuite.tsx, 38, 21))
->b : Symbol(unknown)
->b : Symbol(unknown)
 
 <a.b></a.b>;
 >a : Symbol(a, Decl(jsxEsprimaFbTestSuite.tsx, 5, 11))
@@ -102,26 +82,19 @@ baz
 >a : Symbol(a, Decl(jsxEsprimaFbTestSuite.tsx, 5, 11))
 
 (<div />) < x;
->div : Symbol(unknown)
 >x : Symbol(x, Decl(jsxEsprimaFbTestSuite.tsx, 4, 11))
 
 <div {...props} />;
->div : Symbol(unknown)
 >props : Symbol(props, Decl(jsxEsprimaFbTestSuite.tsx, 6, 11))
 
 <div {...props} post="attribute" />;
->div : Symbol(unknown)
 >props : Symbol(props, Decl(jsxEsprimaFbTestSuite.tsx, 6, 11))
 >post : Symbol(post, Decl(jsxEsprimaFbTestSuite.tsx, 48, 15))
 
 <div pre="leading" pre2="attribute" {...props}></div>;
->div : Symbol(unknown)
 >pre : Symbol(pre, Decl(jsxEsprimaFbTestSuite.tsx, 50, 4))
 >pre2 : Symbol(pre2, Decl(jsxEsprimaFbTestSuite.tsx, 50, 18))
 >props : Symbol(props, Decl(jsxEsprimaFbTestSuite.tsx, 6, 11))
->div : Symbol(unknown)
 
 <a>    </a>;
->a : Symbol(unknown)
->a : Symbol(unknown)
 

--- a/tests/baselines/reference/jsxFactoryAndFragment.symbols
+++ b/tests/baselines/reference/jsxFactoryAndFragment.symbols
@@ -4,10 +4,3 @@ declare var h: any;
 
 <></>;
 <><span>1</span><><span>2.1</span><span>2.2</span></></>;
->span : Symbol(unknown)
->span : Symbol(unknown)
->span : Symbol(unknown)
->span : Symbol(unknown)
->span : Symbol(unknown)
->span : Symbol(unknown)
-

--- a/tests/baselines/reference/jsxFactoryAndReactNamespace.symbols
+++ b/tests/baselines/reference/jsxFactoryAndReactNamespace.symbols
@@ -99,19 +99,15 @@ class A {
 
 		return [
 			<meta content="helloworld"></meta>,
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 11, 8))
->meta : Symbol(unknown)
 
 			<meta content={c.a!.b}></meta>
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 12, 8))
 >c.a!.b : Symbol(b, Decl(test.tsx, 3, 6))
 >c.a : Symbol(a, Decl(test.tsx, 2, 8))
 >c : Symbol(c, Decl(test.tsx, 2, 3))
 >a : Symbol(a, Decl(test.tsx, 2, 8))
 >b : Symbol(b, Decl(test.tsx, 3, 6))
->meta : Symbol(unknown)
 
 		];
 	}

--- a/tests/baselines/reference/jsxFactoryIdentifier.symbols
+++ b/tests/baselines/reference/jsxFactoryIdentifier.symbols
@@ -105,19 +105,15 @@ class A {
 
 		return [
 			<meta content="helloworld"></meta>,
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 11, 8))
->meta : Symbol(unknown)
 
 			<meta content={c.a!.b}></meta>
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 12, 8))
 >c.a!.b : Symbol(b, Decl(test.tsx, 3, 6))
 >c.a : Symbol(a, Decl(test.tsx, 2, 8))
 >c : Symbol(c, Decl(test.tsx, 2, 3))
 >a : Symbol(a, Decl(test.tsx, 2, 8))
 >b : Symbol(b, Decl(test.tsx, 3, 6))
->meta : Symbol(unknown)
 
 		];
 	}

--- a/tests/baselines/reference/jsxFactoryIdentifierAsParameter.symbols
+++ b/tests/baselines/reference/jsxFactoryIdentifierAsParameter.symbols
@@ -18,7 +18,6 @@ export class AppComponent {
 >createElement : Symbol(createElement, Decl(test.tsx, 7, 11))
 
         return <div />;
->div : Symbol(unknown)
     }
 }
 

--- a/tests/baselines/reference/jsxFactoryIdentifierWithAbsentParameter.symbols
+++ b/tests/baselines/reference/jsxFactoryIdentifierWithAbsentParameter.symbols
@@ -17,7 +17,6 @@ export class AppComponent {
 >render : Symbol(AppComponent.render, Decl(test.tsx, 6, 27))
 
         return <div />;
->div : Symbol(unknown)
     }
 }
 

--- a/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName.symbols
+++ b/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName.symbols
@@ -99,19 +99,15 @@ class A {
 
 		return [
 			<meta content="helloworld"></meta>,
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 11, 8))
->meta : Symbol(unknown)
 
 			<meta content={c.a!.b}></meta>
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 12, 8))
 >c.a!.b : Symbol(b, Decl(test.tsx, 3, 6))
 >c.a : Symbol(a, Decl(test.tsx, 2, 8))
 >c : Symbol(c, Decl(test.tsx, 2, 3))
 >a : Symbol(a, Decl(test.tsx, 2, 8))
 >b : Symbol(b, Decl(test.tsx, 3, 6))
->meta : Symbol(unknown)
 
 		];
 	}

--- a/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName2.symbols
+++ b/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName2.symbols
@@ -99,19 +99,15 @@ class A {
 
 		return [
 			<meta content="helloworld"></meta>,
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 11, 8))
->meta : Symbol(unknown)
 
 			<meta content={c.a!.b}></meta>
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 12, 8))
 >c.a!.b : Symbol(b, Decl(test.tsx, 3, 6))
 >c.a : Symbol(a, Decl(test.tsx, 2, 8))
 >c : Symbol(c, Decl(test.tsx, 2, 3))
 >a : Symbol(a, Decl(test.tsx, 2, 8))
 >b : Symbol(b, Decl(test.tsx, 3, 6))
->meta : Symbol(unknown)
 
 		];
 	}

--- a/tests/baselines/reference/jsxFactoryQualifiedName.symbols
+++ b/tests/baselines/reference/jsxFactoryQualifiedName.symbols
@@ -99,19 +99,15 @@ class A {
 
 		return [
 			<meta content="helloworld"></meta>,
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 11, 8))
->meta : Symbol(unknown)
 
 			<meta content={c.a!.b}></meta>
->meta : Symbol(unknown)
 >content : Symbol(content, Decl(test.tsx, 12, 8))
 >c.a!.b : Symbol(b, Decl(test.tsx, 3, 6))
 >c.a : Symbol(a, Decl(test.tsx, 2, 8))
 >c : Symbol(c, Decl(test.tsx, 2, 3))
 >a : Symbol(a, Decl(test.tsx, 2, 8))
 >b : Symbol(b, Decl(test.tsx, 3, 6))
->meta : Symbol(unknown)
 
 		];
 	}

--- a/tests/baselines/reference/jsxFactoryQualifiedNameResolutionError.symbols
+++ b/tests/baselines/reference/jsxFactoryQualifiedNameResolutionError.symbols
@@ -18,6 +18,5 @@ export class AppComponent {
 >createElement : Symbol(createElement, Decl(test.tsx, 7, 11))
 
         return <div />;
->div : Symbol(unknown)
     }
 }

--- a/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.symbols
+++ b/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.symbols
@@ -16,7 +16,5 @@ class Component {
 >renderCallback : Symbol(Component.renderCallback, Decl(index.tsx, 5, 17))
 
         return <div>test</div>;
->div : Symbol(unknown)
->div : Symbol(unknown)
     }
 };

--- a/tests/baselines/reference/jsxHash.symbols
+++ b/tests/baselines/reference/jsxHash.symbols
@@ -1,68 +1,34 @@
 === tests/cases/compiler/jsxHash.tsx ===
 var t02 = <a>{0}#</a>;
 >t02 : Symbol(t02, Decl(jsxHash.tsx, 0, 3))
->a : Symbol(unknown)
->a : Symbol(unknown)
 
 var t03 = <a>#{0}</a>;
 >t03 : Symbol(t03, Decl(jsxHash.tsx, 1, 3))
->a : Symbol(unknown)
->a : Symbol(unknown)
 
 var t04 = <a>#{0}#</a>;
 >t04 : Symbol(t04, Decl(jsxHash.tsx, 2, 3))
->a : Symbol(unknown)
->a : Symbol(unknown)
 
 var t05 = <a>#<i></i></a>;
 >t05 : Symbol(t05, Decl(jsxHash.tsx, 3, 3))
->a : Symbol(unknown)
->i : Symbol(unknown)
->i : Symbol(unknown)
->a : Symbol(unknown)
 
 var t06 = <a>#<i></i></a>;
 >t06 : Symbol(t06, Decl(jsxHash.tsx, 4, 3))
->a : Symbol(unknown)
->i : Symbol(unknown)
->i : Symbol(unknown)
->a : Symbol(unknown)
 
 var t07 = <a>#<i>#</i></a>;
 >t07 : Symbol(t07, Decl(jsxHash.tsx, 5, 3))
->a : Symbol(unknown)
->i : Symbol(unknown)
->i : Symbol(unknown)
->a : Symbol(unknown)
 
 var t08 = <a><i></i>#</a>;
 >t08 : Symbol(t08, Decl(jsxHash.tsx, 6, 3))
->a : Symbol(unknown)
->i : Symbol(unknown)
->i : Symbol(unknown)
->a : Symbol(unknown)
 
 var t09 = <a>#<i></i>#</a>;
 >t09 : Symbol(t09, Decl(jsxHash.tsx, 7, 3))
->a : Symbol(unknown)
->i : Symbol(unknown)
->i : Symbol(unknown)
->a : Symbol(unknown)
 
 var t10 = <a><i/>#</a>;
 >t10 : Symbol(t10, Decl(jsxHash.tsx, 8, 3))
->a : Symbol(unknown)
->i : Symbol(unknown)
->a : Symbol(unknown)
 
 var t11 = <a>#<i/></a>;
 >t11 : Symbol(t11, Decl(jsxHash.tsx, 9, 3))
->a : Symbol(unknown)
->i : Symbol(unknown)
->a : Symbol(unknown)
 
 var t12 = <a>#</a>;
 >t12 : Symbol(t12, Decl(jsxHash.tsx, 10, 3))
->a : Symbol(unknown)
->a : Symbol(unknown)
 

--- a/tests/baselines/reference/jsxImportInAttribute.symbols
+++ b/tests/baselines/reference/jsxImportInAttribute.symbols
@@ -8,7 +8,6 @@ let x = Test; // emit test_1.default
 >Test : Symbol(Test, Decl(consumer.tsx, 1, 6))
 
 <anything attr={Test} />; // ?
->anything : Symbol(unknown)
 >attr : Symbol(attr, Decl(consumer.tsx, 4, 9))
 >Test : Symbol(Test, Decl(consumer.tsx, 1, 6))
 

--- a/tests/baselines/reference/jsxInExtendsClause.symbols
+++ b/tests/baselines/reference/jsxInExtendsClause.symbols
@@ -36,7 +36,5 @@ class Foo extends createComponentClass(() => class extends React.Component<{}, {
 >render : Symbol((Anonymous class).render, Decl(jsxInExtendsClause.tsx, 6, 84))
 
     return <span>Hello, world!</span>;
->span : Symbol(unknown)
->span : Symbol(unknown)
   }
 }) {}

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.symbols
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.symbols
@@ -5,41 +5,28 @@ declare var React: any;
 </>;
 === tests/cases/conformance/jsx/2.tsx ===
 <a: />;
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/3.tsx ===
+No type information for this code.=== tests/cases/conformance/jsx/3.tsx ===
 <:a />;
 No type information for this code.=== tests/cases/conformance/jsx/4.tsx ===
 <a b=d />;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(4.tsx, 0, 2))
 
 === tests/cases/conformance/jsx/5.tsx ===
 <a>;
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/6.tsx ===
+No type information for this code.=== tests/cases/conformance/jsx/6.tsx ===
 <a></b>;
->a : Symbol(unknown)
->b : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/7.tsx ===
+No type information for this code.=== tests/cases/conformance/jsx/7.tsx ===
 <a foo="bar;
->a : Symbol(unknown)
 >foo : Symbol(foo, Decl(7.tsx, 0, 2))
 
 === tests/cases/conformance/jsx/8.tsx ===
 <a:b></b>;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(8.tsx, 0, 3))
->b : Symbol(unknown)
 
 === tests/cases/conformance/jsx/9.tsx ===
 <a:b.c></a:b.c>;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(9.tsx, 0, 3))
 >c : Symbol(c, Decl(9.tsx, 0, 5))
->a : Symbol(unknown)
 
 === tests/cases/conformance/jsx/10.tsx ===
 <a.b:c></a.b:c>;
@@ -47,104 +34,67 @@ No type information for this code.=== tests/cases/conformance/jsx/4.tsx ===
 
 === tests/cases/conformance/jsx/11.tsx ===
 <a.b.c></a>;
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/12.tsx ===
+No type information for this code.=== tests/cases/conformance/jsx/12.tsx ===
 <.a></.a>;
 No type information for this code.=== tests/cases/conformance/jsx/13.tsx ===
 <a.></a.>;
 No type information for this code.=== tests/cases/conformance/jsx/14.tsx ===
 <a[foo]></a[foo]>;
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/15.tsx ===
+No type information for this code.=== tests/cases/conformance/jsx/15.tsx ===
 <a['foo']></a['foo']>;
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/16.tsx ===
+No type information for this code.=== tests/cases/conformance/jsx/16.tsx ===
 <a><a />;
->a : Symbol(unknown)
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/17.tsx ===
+No type information for this code.=== tests/cases/conformance/jsx/17.tsx ===
 <a b={}>;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(17.tsx, 0, 2))
 
 === tests/cases/conformance/jsx/18.tsx ===
 var x = <div>one</div><div>two</div>;;
 >x : Symbol(x, Decl(18.tsx, 0, 3), Decl(19.tsx, 0, 3))
->div : Symbol(unknown)
->div : Symbol(unknown)
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 === tests/cases/conformance/jsx/19.tsx ===
 var x = <div>one</div> /* intervening comment */ <div>two</div>;;
 >x : Symbol(x, Decl(18.tsx, 0, 3), Decl(19.tsx, 0, 3))
->div : Symbol(unknown)
->div : Symbol(unknown)
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 === tests/cases/conformance/jsx/20.tsx ===
 <a>{"str";}</a>;
->a : Symbol(unknown)
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/21.tsx ===
+No type information for this code.=== tests/cases/conformance/jsx/21.tsx ===
 <span className="a", id="b" />;
->span : Symbol(unknown)
 >className : Symbol(className, Decl(21.tsx, 0, 5))
 >id : Symbol(id, Decl(21.tsx, 0, 20))
 
 === tests/cases/conformance/jsx/22.tsx ===
 <div className"app">;
->div : Symbol(unknown)
 >className : Symbol(className, Decl(22.tsx, 0, 4))
 
 === tests/cases/conformance/jsx/23.tsx ===
 <div {props} />;
->div : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/24.tsx ===
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/jsx/24.tsx ===
 <div>stuff</div {...props}>;
->div : Symbol(unknown)
->div : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/25.tsx ===
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/jsx/25.tsx ===
 <div {...props}>stuff</div {...props}>;
->div : Symbol(unknown)
->div : Symbol(unknown)
-
-
-=== tests/cases/conformance/jsx/26.tsx ===
+No type information for this code.
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/jsx/26.tsx ===
 <a>></a>;
->a : Symbol(unknown)
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/27.tsx ===
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/jsx/27.tsx ===
 <a> ></a>;
->a : Symbol(unknown)
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/28.tsx ===
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/jsx/28.tsx ===
 <a b=}>;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(28.tsx, 0, 2))
 
 === tests/cases/conformance/jsx/29.tsx ===
 <a b=<}>;
->a : Symbol(unknown)
 >b : Symbol(b, Decl(29.tsx, 0, 2))
 
 === tests/cases/conformance/jsx/30.tsx ===
 <a>}</a>;
->a : Symbol(unknown)
->a : Symbol(unknown)
-
-=== tests/cases/conformance/jsx/31.tsx ===
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/jsx/31.tsx ===
 <a .../*hai*/asdf/>;
->a : Symbol(unknown)
 >asdf : Symbol(asdf, Decl(31.tsx, 0, 6))
 

--- a/tests/baselines/reference/jsxMultilineAttributeStringValues.symbols
+++ b/tests/baselines/reference/jsxMultilineAttributeStringValues.symbols
@@ -1,19 +1,14 @@
 === tests/cases/compiler/jsxMultilineAttributeStringValues.tsx ===
 const a = <input value="
 >a : Symbol(a, Decl(jsxMultilineAttributeStringValues.tsx, 0, 5))
->input : Symbol(unknown)
 >value : Symbol(value, Decl(jsxMultilineAttributeStringValues.tsx, 0, 16))
 
   foo: 23
 "></input>;
->input : Symbol(unknown)
-
 const b = <input value='
 >b : Symbol(b, Decl(jsxMultilineAttributeStringValues.tsx, 3, 5))
->input : Symbol(unknown)
 >value : Symbol(value, Decl(jsxMultilineAttributeStringValues.tsx, 3, 16))
 
 foo: 23
 '></input>;
->input : Symbol(unknown)
 

--- a/tests/baselines/reference/jsxMultilineAttributeValuesReact.symbols
+++ b/tests/baselines/reference/jsxMultilineAttributeValuesReact.symbols
@@ -4,28 +4,20 @@ declare var React: any;
 
 const a = <input value="
 >a : Symbol(a, Decl(jsxMultilineAttributeValuesReact.tsx, 1, 5))
->input : Symbol(unknown)
 >value : Symbol(value, Decl(jsxMultilineAttributeValuesReact.tsx, 1, 16))
 
 foo: 23
 "></input>;
->input : Symbol(unknown)
-
 const b = <input value='
 >b : Symbol(b, Decl(jsxMultilineAttributeValuesReact.tsx, 4, 5))
->input : Symbol(unknown)
 >value : Symbol(value, Decl(jsxMultilineAttributeValuesReact.tsx, 4, 16))
 
 foo: 23
 '></input>;
->input : Symbol(unknown)
-
 const c = <input value='
 >c : Symbol(c, Decl(jsxMultilineAttributeValuesReact.tsx, 7, 5))
->input : Symbol(unknown)
 >value : Symbol(value, Decl(jsxMultilineAttributeValuesReact.tsx, 7, 16))
 
 foo: 23\n
 '></input>;
->input : Symbol(unknown)
 

--- a/tests/baselines/reference/jsxPreserveWithJsInput.symbols
+++ b/tests/baselines/reference/jsxPreserveWithJsInput.symbols
@@ -5,14 +5,10 @@ var elemA = 42;
 === tests/cases/compiler/b.jsx ===
 var elemB = <b>{"test"}</b>;
 >elemB : Symbol(elemB, Decl(b.jsx, 0, 3))
->b : Symbol(unknown)
->b : Symbol(unknown)
 
 === tests/cases/compiler/c.js ===
 var elemC = <c>{42}</c>;
 >elemC : Symbol(elemC, Decl(c.js, 0, 3))
->c : Symbol(unknown)
->c : Symbol(unknown)
 
 === tests/cases/compiler/d.ts ===
 var elemD = 42;
@@ -21,6 +17,4 @@ var elemD = 42;
 === tests/cases/compiler/e.tsx ===
 var elemE = <e>{true}</e>;
 >elemE : Symbol(elemE, Decl(e.tsx, 0, 3))
->e : Symbol(unknown)
->e : Symbol(unknown)
 

--- a/tests/baselines/reference/jsxPropsAsIdentifierNames.symbols
+++ b/tests/baselines/reference/jsxPropsAsIdentifierNames.symbols
@@ -18,6 +18,5 @@ declare namespace JSX {
     }
 }
 export default <div static={true} />;
->div : Symbol(unknown)
 >static : Symbol(static, Decl(index.tsx, 8, 19))
 

--- a/tests/baselines/reference/jsxReactTestSuite.symbols
+++ b/tests/baselines/reference/jsxReactTestSuite.symbols
@@ -36,36 +36,21 @@ declare var hasOwnProperty:any;
 >hasOwnProperty : Symbol(hasOwnProperty, Decl(jsxReactTestSuite.tsx, 11, 11))
 
 <div>text</div>;
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 <div>
->div : Symbol(unknown)
-
   {this.props.children}
 </div>;
->div : Symbol(unknown)
 
 <div>
->div : Symbol(unknown)
-
   <div><br /></div>
->div : Symbol(unknown)
->br : Symbol(unknown)
->div : Symbol(unknown)
-
   <Component>{foo}<br />{bar}</Component>
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 1, 11))
 >foo : Symbol(foo, Decl(jsxReactTestSuite.tsx, 6, 11))
->br : Symbol(unknown)
 >bar : Symbol(bar, Decl(jsxReactTestSuite.tsx, 7, 11))
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 1, 11))
 
   <br />
->br : Symbol(unknown)
-
 </div>;
->div : Symbol(unknown)
 
 
 <Composite>
@@ -88,8 +73,6 @@ var x =
 >x : Symbol(x, Decl(jsxReactTestSuite.tsx, 9, 11), Decl(jsxReactTestSuite.tsx, 34, 3))
 
   <div
->div : Symbol(unknown)
-
     attr1={
 >attr1 : Symbol(attr1, Decl(jsxReactTestSuite.tsx, 35, 6))
 
@@ -113,64 +96,41 @@ var x =
 >attr4 : Symbol(attr4, Decl(jsxReactTestSuite.tsx, 48, 5))
 
   </div>;
->div : Symbol(unknown)
 
 (
   <div>
->div : Symbol(unknown)
-
     {/* A comment at the beginning */}
     {/* A second comment at the beginning */}
     <span>
->span : Symbol(unknown)
-
       {/* A nested comment */}
     </span>
->span : Symbol(unknown)
-
     {/* A sandwiched comment */}
     <br />
->br : Symbol(unknown)
-
     {/* A comment at the end */}
     {/* A second comment at the end */}
   </div>
->div : Symbol(unknown)
-
 );
 
 (
   <div
->div : Symbol(unknown)
-
     /* a multi-line
        comment */
     attr1="foo">
 >attr1 : Symbol(attr1, Decl(jsxReactTestSuite.tsx, 67, 6))
 
     <span // a double-slash comment
->span : Symbol(unknown)
-
       attr2="bar"
 >attr2 : Symbol(attr2, Decl(jsxReactTestSuite.tsx, 71, 9))
 
     />
   </div>
->div : Symbol(unknown)
-
 );
 
 <div>&nbsp;</div>;
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 <div>&nbsp; </div>;
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 <hasOwnProperty>testing</hasOwnProperty>;
->hasOwnProperty : Symbol(unknown)
->hasOwnProperty : Symbol(unknown)
 
 <Component constructor="foo" />;
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 1, 11))
@@ -197,7 +157,6 @@ var x =
 >sound : Symbol(sound, Decl(jsxReactTestSuite.tsx, 93, 19))
 
 <font-face />;
->font-face : Symbol(unknown)
 
 <Component x={y} />;
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 1, 11))
@@ -205,7 +164,6 @@ var x =
 >y : Symbol(y, Decl(jsxReactTestSuite.tsx, 8, 11))
 
 <x-component />;
->x-component : Symbol(unknown)
 
 <Component {...x} />;
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 1, 11))

--- a/tests/baselines/reference/keywordInJsxIdentifier.symbols
+++ b/tests/baselines/reference/keywordInJsxIdentifier.symbols
@@ -3,18 +3,14 @@ declare var React: any;
 >React : Symbol(React, Decl(keywordInJsxIdentifier.tsx, 0, 11))
 
 <foo class-id/>;
->foo : Symbol(unknown)
 >class-id : Symbol(class-id, Decl(keywordInJsxIdentifier.tsx, 1, 4))
 
 <foo class/>;
->foo : Symbol(unknown)
 >class : Symbol(class, Decl(keywordInJsxIdentifier.tsx, 2, 4))
 
 <foo class-id="1"/>;
->foo : Symbol(unknown)
 >class-id : Symbol(class-id, Decl(keywordInJsxIdentifier.tsx, 3, 4))
 
 <foo class="1"/>;
->foo : Symbol(unknown)
 >class : Symbol(class, Decl(keywordInJsxIdentifier.tsx, 4, 4))
 

--- a/tests/baselines/reference/reactNamespaceImportPresevation.symbols
+++ b/tests/baselines/reference/reactNamespaceImportPresevation.symbols
@@ -17,6 +17,5 @@ declare var foo: any;
 >foo : Symbol(foo, Decl(test.tsx, 1, 11))
 
 <foo data/>;
->foo : Symbol(unknown)
 >data : Symbol(data, Decl(test.tsx, 3, 4))
 

--- a/tests/baselines/reference/reactNamespaceInvalidInput.symbols
+++ b/tests/baselines/reference/reactNamespaceInvalidInput.symbols
@@ -1,5 +1,4 @@
 === tests/cases/compiler/reactNamespaceInvalidInput.tsx ===
 <foo data/>;
->foo : Symbol(unknown)
 >data : Symbol(data, Decl(reactNamespaceInvalidInput.tsx, 0, 4))
 

--- a/tests/baselines/reference/reactNamespaceJSXEmit.symbols
+++ b/tests/baselines/reference/reactNamespaceJSXEmit.symbols
@@ -15,7 +15,6 @@ declare var x: any;
 >x : Symbol(x, Decl(reactNamespaceJSXEmit.tsx, 4, 11))
 
 <foo data/>;
->foo : Symbol(unknown)
 >data : Symbol(data, Decl(reactNamespaceJSXEmit.tsx, 6, 4))
 
 <Bar x={x} />;
@@ -24,8 +23,6 @@ declare var x: any;
 >x : Symbol(x, Decl(reactNamespaceJSXEmit.tsx, 4, 11))
 
 <x-component />;
->x-component : Symbol(unknown)
-
 <Bar {...x} />;
 >Bar : Symbol(Bar, Decl(reactNamespaceJSXEmit.tsx, 2, 11))
 >x : Symbol(x, Decl(reactNamespaceJSXEmit.tsx, 4, 11))

--- a/tests/baselines/reference/reactNamespaceMissingDeclaration.symbols
+++ b/tests/baselines/reference/reactNamespaceMissingDeclaration.symbols
@@ -1,6 +1,5 @@
 === tests/cases/compiler/reactNamespaceMissingDeclaration.tsx ===
 // Error myReactLib not declared
 <foo data/>
->foo : Symbol(unknown)
 >data : Symbol(data, Decl(reactNamespaceMissingDeclaration.tsx, 1, 4))
 

--- a/tests/baselines/reference/spreadIntersectionJsx.symbols
+++ b/tests/baselines/reference/spreadIntersectionJsx.symbols
@@ -17,6 +17,5 @@ let intersected: A & C;
 
 let element = <div { ...intersected } />;
 >element : Symbol(element, Decl(spreadIntersectionJsx.tsx, 4, 3))
->div : Symbol(unknown)
 >intersected : Symbol(intersected, Decl(spreadIntersectionJsx.tsx, 3, 3))
 

--- a/tests/baselines/reference/tsxCorrectlyParseLessThanComparison1.symbols
+++ b/tests/baselines/reference/tsxCorrectlyParseLessThanComparison1.symbols
@@ -48,8 +48,6 @@ export class ShortDetails extends React.Component<{ id: number }, {}> {
 >id : Symbol(id, Decl(tsxCorrectlyParseLessThanComparison1.tsx, 12, 51))
 
             return (<div></div>);
->div : Symbol(unknown)
->div : Symbol(unknown)
         }
     }
 }

--- a/tests/baselines/reference/tsxDynamicTagName2.symbols
+++ b/tests/baselines/reference/tsxDynamicTagName2.symbols
@@ -17,6 +17,3 @@ var customTag = "h1";
 >customTag : Symbol(customTag, Decl(tsxDynamicTagName2.tsx, 7, 3))
 
 <customTag> Hello World </customTag>  // This should be an error. The lower-case is look up as an intrinsic element name
->customTag : Symbol(unknown)
->customTag : Symbol(unknown)
-

--- a/tests/baselines/reference/tsxElementResolution1.symbols
+++ b/tests/baselines/reference/tsxElementResolution1.symbols
@@ -19,5 +19,3 @@ declare module JSX {
 
 // Fail
 <span />;
->span : Symbol(unknown)
-

--- a/tests/baselines/reference/tsxElementResolution13.symbols
+++ b/tests/baselines/reference/tsxElementResolution13.symbols
@@ -22,6 +22,5 @@ var obj1: Obj1;
 >Obj1 : Symbol(Obj1, Decl(file.tsx, 3, 1))
 
 <obj1 x={10} />; // Error
->obj1 : Symbol(unknown)
 >x : Symbol(x, Decl(file.tsx, 9, 5))
 

--- a/tests/baselines/reference/tsxElementResolution14.symbols
+++ b/tests/baselines/reference/tsxElementResolution14.symbols
@@ -17,6 +17,5 @@ var obj1: Obj1;
 >Obj1 : Symbol(Obj1, Decl(file.tsx, 2, 1))
 
 <obj1 x={10} />; // OK
->obj1 : Symbol(unknown)
 >x : Symbol(x, Decl(file.tsx, 8, 5))
 

--- a/tests/baselines/reference/tsxElementResolution16.symbols
+++ b/tests/baselines/reference/tsxElementResolution16.symbols
@@ -14,6 +14,5 @@ var obj1: Obj1;
 >Obj1 : Symbol(Obj1, Decl(file.tsx, 1, 1))
 
 <obj1 x={10} />; // Error (JSX.Element is implicit any)
->obj1 : Symbol(unknown)
 >x : Symbol(x, Decl(file.tsx, 7, 5))
 

--- a/tests/baselines/reference/tsxElementResolution18.symbols
+++ b/tests/baselines/reference/tsxElementResolution18.symbols
@@ -8,6 +8,5 @@ declare module JSX {
 
 // Error under implicit any
 <div n='x' />;
->div : Symbol(unknown)
 >n : Symbol(n, Decl(file1.tsx, 5, 4))
 

--- a/tests/baselines/reference/tsxElementResolution5.symbols
+++ b/tests/baselines/reference/tsxElementResolution5.symbols
@@ -8,6 +8,5 @@ declare module JSX {
 
 // OK, but implicit any
 <div n='x' />;
->div : Symbol(unknown)
 >n : Symbol(n, Decl(file1.tsx, 5, 4))
 

--- a/tests/baselines/reference/tsxElementResolution6.symbols
+++ b/tests/baselines/reference/tsxElementResolution6.symbols
@@ -14,6 +14,5 @@ var div: any;
 
 // Still an error
 <div n='x' />;
->div : Symbol(unknown)
 >n : Symbol(n, Decl(file.tsx, 7, 4))
 

--- a/tests/baselines/reference/tsxErrorRecovery1.symbols
+++ b/tests/baselines/reference/tsxErrorRecovery1.symbols
@@ -8,7 +8,6 @@ function foo() {
 
 	var x = <div>  { </div>
 >x : Symbol(x, Decl(file.tsx, 3, 4))
->div : Symbol(unknown)
 }
 // Shouldn't see any errors down here
 var y = { a: 1 };

--- a/tests/baselines/reference/tsxErrorRecovery2.symbols
+++ b/tests/baselines/reference/tsxErrorRecovery2.symbols
@@ -4,18 +4,9 @@ declare namespace JSX { interface Element { } }
 >Element : Symbol(Element, Decl(file1.tsx, 0, 23))
 
 <div></div>
->div : Symbol(unknown)
->div : Symbol(unknown)
-
 <div></div>
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 === tests/cases/conformance/jsx/file2.tsx ===
 var x = <div></div><div></div>
 >x : Symbol(x, Decl(file2.tsx, 0, 3))
->div : Symbol(unknown)
->div : Symbol(unknown)
->div : Symbol(unknown)
->div : Symbol(unknown)
 

--- a/tests/baselines/reference/tsxErrorRecovery3.symbols
+++ b/tests/baselines/reference/tsxErrorRecovery3.symbols
@@ -4,18 +4,9 @@ declare namespace JSX { interface Element { } }
 >Element : Symbol(Element, Decl(file1.tsx, 0, 23))
 
 <div></div>
->div : Symbol(unknown)
->div : Symbol(unknown)
-
 <div></div>
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 === tests/cases/conformance/jsx/file2.tsx ===
 var x = <div></div><div></div>
 >x : Symbol(x, Decl(file2.tsx, 0, 3))
->div : Symbol(unknown)
->div : Symbol(unknown)
->div : Symbol(unknown)
->div : Symbol(unknown)
 

--- a/tests/baselines/reference/tsxExternalModuleEmit1.symbols
+++ b/tests/baselines/reference/tsxExternalModuleEmit1.symbols
@@ -45,8 +45,6 @@ export class Button extends React.Component<any, any> {
 >render : Symbol(Button.render, Decl(button.tsx, 2, 55))
 
         return <button>Some button</button>;
->button : Symbol(unknown)
->button : Symbol(unknown)
     }
 
 }

--- a/tests/baselines/reference/tsxInferenceShouldNotYieldAnyOnUnions.symbols
+++ b/tests/baselines/reference/tsxInferenceShouldNotYieldAnyOnUnions.symbols
@@ -44,7 +44,6 @@ function ShouldInferFromData<T>(props: Props<T>): JSX.Element {
 >Element : Symbol(JSX.Element, Decl(index.tsx, 0, 15))
 
     return <div />;
->div : Symbol(unknown)
 }
 
 // Sanity check: function call equivalent versions work fine

--- a/tests/baselines/reference/tsxNoJsx.symbols
+++ b/tests/baselines/reference/tsxNoJsx.symbols
@@ -1,4 +1,4 @@
 === tests/cases/conformance/jsx/tsxNoJsx.tsx ===
 <nope />;
->nope : Symbol(unknown)
-
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/tsxReactEmitNesting.symbols
+++ b/tests/baselines/reference/tsxReactEmitNesting.symbols
@@ -15,19 +15,13 @@ let render = (ctrl, model) =>
 >model : Symbol(model, Decl(file.tsx, 5, 19))
 
     <section class="todoapp">
->section : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 6, 12))
 
         <header class="header">
->header : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 7, 15))
 
             <h1>todos &lt;x&gt;</h1>
->h1 : Symbol(unknown)
->h1 : Symbol(unknown)
-
             <input class="new-todo" autofocus autocomplete="off" placeholder="What needs to be done?" value={model.newTodo} onKeyup={ctrl.addTodo.bind(ctrl, model)} />
->input : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 9, 18))
 >autofocus : Symbol(autofocus, Decl(file.tsx, 9, 35))
 >autocomplete : Symbol(autocomplete, Decl(file.tsx, 9, 45))
@@ -40,10 +34,7 @@ let render = (ctrl, model) =>
 >model : Symbol(model, Decl(file.tsx, 5, 19))
 
         </header>
->header : Symbol(unknown)
-
         <section class="main" style={{display:(model.todos && model.todos.length) ? "block" : "none"}}>
->section : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 11, 16))
 >style : Symbol(style, Decl(file.tsx, 11, 29))
 >display : Symbol(display, Decl(file.tsx, 11, 38))
@@ -51,7 +42,6 @@ let render = (ctrl, model) =>
 >model : Symbol(model, Decl(file.tsx, 5, 19))
 
             <input class="toggle-all" type="checkbox" onChange={ctrl.toggleAll.bind(ctrl)}/>
->input : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 12, 18))
 >type : Symbol(type, Decl(file.tsx, 12, 37))
 >onChange : Symbol(onChange, Decl(file.tsx, 12, 53))
@@ -59,7 +49,6 @@ let render = (ctrl, model) =>
 >ctrl : Symbol(ctrl, Decl(file.tsx, 5, 14))
 
             <ul class="todo-list">
->ul : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 13, 15))
 
                 {model.filteredTodos.map((todo) =>
@@ -67,7 +56,6 @@ let render = (ctrl, model) =>
 >todo : Symbol(todo, Decl(file.tsx, 14, 42))
 
                     <li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>
->li : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 15, 23))
 >todo : Symbol(todo, Decl(file.tsx, 15, 32))
 >completed : Symbol(completed, Decl(file.tsx, 15, 43))
@@ -77,62 +65,42 @@ let render = (ctrl, model) =>
 >model : Symbol(model, Decl(file.tsx, 5, 19))
 
                         <div class="view">
->div : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 16, 28))
 
                             {(!todo.editable) ?
 >todo : Symbol(todo, Decl(file.tsx, 14, 42))
 
                                 <input class="toggle" type="checkbox"></input>
->input : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 18, 38))
 >type : Symbol(type, Decl(file.tsx, 18, 53))
->input : Symbol(unknown)
 
                                 : null
                             }
                             <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>
->label : Symbol(unknown)
 >onDoubleClick : Symbol(onDoubleClick, Decl(file.tsx, 21, 34))
 >ctrl : Symbol(ctrl, Decl(file.tsx, 5, 14))
 >todo : Symbol(todo, Decl(file.tsx, 14, 42))
 >todo : Symbol(todo, Decl(file.tsx, 14, 42))
->label : Symbol(unknown)
 
                             <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>
->button : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 22, 35))
 >onClick : Symbol(onClick, Decl(file.tsx, 22, 51))
 >ctrl : Symbol(ctrl, Decl(file.tsx, 5, 14))
 >ctrl : Symbol(ctrl, Decl(file.tsx, 5, 14))
 >todo : Symbol(todo, Decl(file.tsx, 14, 42))
->button : Symbol(unknown)
 
                             <div class="iconBorder">
->div : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 23, 32))
 
                                 <div class="icon"/>
->div : Symbol(unknown)
 >class : Symbol(class, Decl(file.tsx, 24, 36))
 
                             </div>
->div : Symbol(unknown)
-
                         </div>
->div : Symbol(unknown)
-
                     </li>
->li : Symbol(unknown)
-
                 )}
             </ul>
->ul : Symbol(unknown)
-
         </section>
->section : Symbol(unknown)
-
     </section>
->section : Symbol(unknown)
 
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution17.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution17.symbols
@@ -24,8 +24,6 @@ export class Empty extends React.Component<{}, {}> {
 >render : Symbol(Empty.render, Decl(file.tsx, 8, 52))
 
         return <div>Hello</div>;
->div : Symbol(unknown)
->div : Symbol(unknown)
     }
 }
 

--- a/tests/baselines/reference/tsxTypeErrors.symbols
+++ b/tests/baselines/reference/tsxTypeErrors.symbols
@@ -2,13 +2,11 @@
 // A built-in element (OK)
 var a1 = <div id="foo" />;
 >a1 : Symbol(a1, Decl(tsxTypeErrors.tsx, 1, 3))
->div : Symbol(unknown)
 >id : Symbol(id, Decl(tsxTypeErrors.tsx, 1, 13))
 
 // A built-in element with a mistyped property (error)
 var a2 = <img srce="foo.jpg" />
 >a2 : Symbol(a2, Decl(tsxTypeErrors.tsx, 4, 3))
->img : Symbol(unknown)
 >srce : Symbol(srce, Decl(tsxTypeErrors.tsx, 4, 13))
 
 // A built-in element with a badly-typed attribute value (error)
@@ -18,14 +16,12 @@ var thing = { oops: 100 };
 
 var a3 = <div id={thing} />
 >a3 : Symbol(a3, Decl(tsxTypeErrors.tsx, 8, 3))
->div : Symbol(unknown)
 >id : Symbol(id, Decl(tsxTypeErrors.tsx, 8, 13))
 >thing : Symbol(thing, Decl(tsxTypeErrors.tsx, 7, 3))
 
 // Mistyped html name (error)
 var e1 = <imag src="bar.jpg" />
 >e1 : Symbol(e1, Decl(tsxTypeErrors.tsx, 11, 3))
->imag : Symbol(unknown)
 >src : Symbol(src, Decl(tsxTypeErrors.tsx, 11, 14))
 
 // A custom type

--- a/tests/baselines/reference/unusedImports13.symbols
+++ b/tests/baselines/reference/unusedImports13.symbols
@@ -4,8 +4,6 @@ import React = require("react");
 
 export const FooComponent = <div></div>
 >FooComponent : Symbol(FooComponent, Decl(foo.tsx, 2, 12))
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 === tests/cases/compiler/node_modules/@types/react/index.d.ts ===
 export = React;

--- a/tests/baselines/reference/unusedImports14.symbols
+++ b/tests/baselines/reference/unusedImports14.symbols
@@ -4,8 +4,6 @@ import React = require("react");
 
 export const FooComponent = <div></div>
 >FooComponent : Symbol(FooComponent, Decl(foo.tsx, 2, 12))
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 === tests/cases/compiler/node_modules/@types/react/index.d.ts ===
 export = React;

--- a/tests/baselines/reference/unusedImports15.symbols
+++ b/tests/baselines/reference/unusedImports15.symbols
@@ -4,8 +4,6 @@ import Element = require("react");
 
 export const FooComponent = <div></div>
 >FooComponent : Symbol(FooComponent, Decl(foo.tsx, 2, 12))
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 === tests/cases/compiler/node_modules/@types/react/index.d.ts ===
 export = React;

--- a/tests/baselines/reference/unusedImports16.symbols
+++ b/tests/baselines/reference/unusedImports16.symbols
@@ -4,8 +4,6 @@ import Element = require("react");
 
 export const FooComponent = <div></div>
 >FooComponent : Symbol(FooComponent, Decl(foo.tsx, 2, 12))
->div : Symbol(unknown)
->div : Symbol(unknown)
 
 === tests/cases/compiler/node_modules/@types/react/index.d.ts ===
 export = React;

--- a/tests/cases/fourslash/extract-method_jsxIntrinsicTagSymbol.ts
+++ b/tests/cases/fourslash/extract-method_jsxIntrinsicTagSymbol.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.tsx
+
+// Test that we don't get `unknownSymbol`, which causes a crash when we try getting its declarations.
+
+/////*a*/<div></div>/*b*/
+
+goTo.select("a", "b");
+verify.refactorAvailable("Extract Symbol", "constant_scope_0");


### PR DESCRIPTION
This is more consistent with the other return values from `getSymbolAtLocation`.
Also fixes a bug discovered while investigating #21772, since we check for `undefined` but not `unknownSymbol` in `recordUsagebySymbol` in `extractSymbol.ts`.