### PR TITLE
Added new compiler option "noImportCycles". 

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -664,6 +664,12 @@ namespace ts {
             description: Diagnostics.Disable_strict_checking_of_generic_signatures_in_function_types,
         },
         {
+            name: "noImportCycles",
+            type: "boolean",
+            category: Diagnostics.Advanced_Options,
+            description: Diagnostics.Raise_error_when_import_cycle_is_detected
+        },
+        {
             // A list of plugins to load in the language service
             name: "plugins",
             type: "list",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3467,6 +3467,14 @@
         "category": "Message",
         "code": 6190
     },
+    "Raise error when import cycle is detected.": {
+        "category": "Message",
+        "code": 6191
+    },
+    "Import cycle detected: {0}.": {
+        "category": "Error",
+        "code": 6192
+    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4067,6 +4067,7 @@ namespace ts {
         noUnusedLocals?: boolean;
         noUnusedParameters?: boolean;
         noImplicitUseStrict?: boolean;
+        noImportCycles?: boolean;
         noLib?: boolean;
         noResolve?: boolean;
         out?: string;
@@ -5122,4 +5123,6 @@ namespace ts {
         Parameters = CommaDelimited | SpaceBetweenSiblings | SingleLine | Parenthesis,
         IndexSignatureParameters = CommaDelimited | SpaceBetweenSiblings | SingleLine | Indented | SquareBrackets,
     }
+
+    export type ImportCycle = SourceFile[];
 }

--- a/tests/baselines/reference/noImportCycles.errors.txt
+++ b/tests/baselines/reference/noImportCycles.errors.txt
@@ -1,0 +1,13 @@
+error TS6192: Import cycle detected: noImportCyclesError2.ts -> noImportCyclesError1.ts.
+
+
+!!! error TS6192: Import cycle detected: noImportCyclesError2.ts -> noImportCyclesError1.ts.
+==== tests/cases/compiler/noImportCyclesError1.ts (0 errors) ====
+    import Dummy2 = require("./noImportCyclesError2");
+    export default class Dummy1 {}
+    
+    
+==== tests/cases/compiler/noImportCyclesError2.ts (0 errors) ====
+    import Dummy1 = require("./noImportCyclesError1");
+    export default class Dummy2 {}
+    

--- a/tests/baselines/reference/noImportCycles.js
+++ b/tests/baselines/reference/noImportCycles.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/noImportCycles.ts] ////
+
+//// [noImportCyclesError2.ts]
+import Dummy1 = require("./noImportCyclesError1");
+export default class Dummy2 {}
+
+//// [noImportCyclesError1.ts]
+import Dummy2 = require("./noImportCyclesError2");
+export default class Dummy1 {}
+
+
+
+//// [noImportCyclesError2.js]
+"use strict";
+exports.__esModule = true;
+var Dummy2 = /** @class */ (function () {
+    function Dummy2() {
+    }
+    return Dummy2;
+}());
+exports["default"] = Dummy2;
+//// [noImportCyclesError1.js]
+"use strict";
+exports.__esModule = true;
+var Dummy1 = /** @class */ (function () {
+    function Dummy1() {
+    }
+    return Dummy1;
+}());
+exports["default"] = Dummy1;

--- a/tests/baselines/reference/noImportCycles.symbols
+++ b/tests/baselines/reference/noImportCycles.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/noImportCyclesError1.ts ===
+import Dummy2 = require("./noImportCyclesError2");
+>Dummy2 : Symbol(Dummy2, Decl(noImportCyclesError1.ts, 0, 0))
+
+export default class Dummy1 {}
+>Dummy1 : Symbol(Dummy1, Decl(noImportCyclesError1.ts, 0, 50))
+
+
+=== tests/cases/compiler/noImportCyclesError2.ts ===
+import Dummy1 = require("./noImportCyclesError1");
+>Dummy1 : Symbol(Dummy1, Decl(noImportCyclesError2.ts, 0, 0))
+
+export default class Dummy2 {}
+>Dummy2 : Symbol(Dummy2, Decl(noImportCyclesError2.ts, 0, 50))
+

--- a/tests/baselines/reference/noImportCycles.types
+++ b/tests/baselines/reference/noImportCycles.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/noImportCyclesError1.ts ===
+import Dummy2 = require("./noImportCyclesError2");
+>Dummy2 : typeof Dummy2
+
+export default class Dummy1 {}
+>Dummy1 : Dummy1
+
+
+=== tests/cases/compiler/noImportCyclesError2.ts ===
+import Dummy1 = require("./noImportCyclesError1");
+>Dummy1 : typeof Dummy1
+
+export default class Dummy2 {}
+>Dummy2 : Dummy2
+

--- a/tests/cases/compiler/noImportCycles.ts
+++ b/tests/cases/compiler/noImportCycles.ts
@@ -1,0 +1,10 @@
+// @noImportCycles: true
+
+// @filename: noImportCyclesError2.ts
+import Dummy1 = require("./noImportCyclesError1");
+export default class Dummy2 {}
+
+// @filename: noImportCyclesError1.ts
+import Dummy2 = require("./noImportCyclesError2");
+export default class Dummy1 {}
+


### PR DESCRIPTION
When enabled, it checks for any cycles in the import graph. Such cycles are legal within TypeScript, but they are often indicative of architectural layering issues in a program, so it is desirable to eliminate them.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
