### PR TITLE
Tidy up textChanges.replace*

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -968,7 +968,7 @@ namespace ts.refactor.extractSymbol {
         }
 
         if (isReadonlyArray(range.range)) {
-            changeTracker.replaceNodesWithNodes(context.file, range.range, newNodes);
+            changeTracker.replaceNodeRangeWithNodes(context.file, first(range.range), last(range.range), newNodes);
         }
         else {
             changeTracker.replaceNodeWithNodes(context.file, range.range, newNodes);

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -28,9 +28,11 @@ namespace ts.textChanges {
     }
 
     export interface ConfigurableStart {
+        /** True to use getStart() (NB, not getFullStart()) without adjustment. */
         useNonAdjustedStartPosition?: boolean;
     }
     export interface ConfigurableEnd {
+        /** True to use getEnd() without adjustment. */
         useNonAdjustedEndPosition?: boolean;
     }
 
@@ -132,7 +134,7 @@ namespace ts.textChanges {
 
     export function getAdjustedStartPosition(sourceFile: SourceFile, node: Node, options: ConfigurableStart, position: Position) {
         if (options.useNonAdjustedStartPosition) {
-            return node.getFullStart();
+            return node.getStart();
         }
         const fullStart = node.getFullStart();
         const start = node.getStart(sourceFile);

--- a/tests/baselines/reference/textChanges/deleteNode2.js
+++ b/tests/baselines/reference/textChanges/deleteNode2.js
@@ -9,4 +9,8 @@ var z = 3; // comment 4
 
 ===MODIFIED===
 
-var x = 1;var z = 3; // comment 4
+var x = 1; // some comment - 1
+/**
+ * comment 2
+ */
+var z = 3; // comment 4

--- a/tests/baselines/reference/textChanges/deleteNode4.js
+++ b/tests/baselines/reference/textChanges/deleteNode4.js
@@ -9,5 +9,9 @@ var z = 3; // comment 4
 
 ===MODIFIED===
 
-var x = 1; // comment 3
+var x = 1; // some comment - 1
+/**
+ * comment 2
+ */
+ // comment 3
 var z = 3; // comment 4

--- a/tests/baselines/reference/textChanges/deleteNodeRange2.js
+++ b/tests/baselines/reference/textChanges/deleteNodeRange2.js
@@ -11,5 +11,7 @@ var a = 4; // comment 7
 ===MODIFIED===
 
 // comment 1
-var x = 1;// comment 6
+var x = 1; // comment 2
+// comment 3
+// comment 6
 var a = 4; // comment 7

--- a/tests/baselines/reference/textChanges/deleteNodeRange4.js
+++ b/tests/baselines/reference/textChanges/deleteNodeRange4.js
@@ -11,6 +11,8 @@ var a = 4; // comment 7
 ===MODIFIED===
 
 // comment 1
-var x = 1; // comment 5
+var x = 1; // comment 2
+// comment 3
+ // comment 5
 // comment 6
 var a = 4; // comment 7

--- a/tests/baselines/reference/textChanges/replaceNode2.js
+++ b/tests/baselines/reference/textChanges/replaceNode2.js
@@ -10,7 +10,9 @@ var a = 4; // comment 7
 ===MODIFIED===
 
 // comment 1
-var x = 1;
+var x = 1; // comment 2
+// comment 3
+
 public class class1 implements interface1
 {
     property1: boolean;

--- a/tests/baselines/reference/textChanges/replaceNode4.js
+++ b/tests/baselines/reference/textChanges/replaceNode4.js
@@ -10,7 +10,9 @@ var a = 4; // comment 7
 ===MODIFIED===
 
 // comment 1
-var x = 1;public class class1 implements interface1
+var x = 1; // comment 2
+// comment 3
+public class class1 implements interface1
 {
     property1: boolean;
 } // comment 4

--- a/tests/baselines/reference/textChanges/replaceNode5.js
+++ b/tests/baselines/reference/textChanges/replaceNode5.js
@@ -8,6 +8,8 @@ var z = 3; // comment 5
 // comment 6
 var a = 4; // comment 7
 ===MODIFIED===
+
+// comment 1
 public class class1 implements interface1
 {
     property1: boolean;

--- a/tests/baselines/reference/textChanges/replaceNodeRange2.js
+++ b/tests/baselines/reference/textChanges/replaceNodeRange2.js
@@ -10,7 +10,9 @@ var a = 4; // comment 7
 ===MODIFIED===
 
 // comment 1
-var x = 1;
+var x = 1; // comment 2
+// comment 3
+
 public class class1 implements interface1
 {
     property1: boolean;

--- a/tests/baselines/reference/textChanges/replaceNodeRange4.js
+++ b/tests/baselines/reference/textChanges/replaceNodeRange4.js
@@ -10,7 +10,9 @@ var a = 4; // comment 7
 ===MODIFIED===
 
 // comment 1
-var x = 1;public class class1 implements interface1
+var x = 1; // comment 2
+// comment 3
+public class class1 implements interface1
 {
     property1: boolean;
 } // comment 5


### PR DESCRIPTION
Details in individual commit messages.  Intention was to leave product behavior unchanged.