### PR TITLE
Add assertions for bad symbol declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4406,7 +4406,7 @@ namespace ts {
                     type = getWidenedTypeForVariableLikeDeclaration(declaration, /*reportErrors*/ true);
                 }
                 else {
-                    Debug.fail("Unhandled declaration kind! " + (ts as any).SyntaxKind[declaration.kind]);
+                    Debug.fail("Unhandled declaration kind! " + Debug.showSyntaxKind(declaration));
                 }
 
                 if (!popTypeResolution()) {
@@ -20682,7 +20682,7 @@ namespace ts {
                     case SyntaxKind.ImportSpecifier: // https://github.com/Microsoft/TypeScript/pull/7591
                         return DeclarationSpaces.ExportValue;
                     default:
-                        Debug.fail((ts as any).SyntaxKind[d.kind]);
+                        Debug.fail(Debug.showSyntaxKind(d));
                 }
             }
         }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2934,8 +2934,9 @@ namespace ts {
             const out = [];
             for (let pow = 0; pow <= 30; pow++) {
                 const n = 1 << pow;
-                if (flags & n)
+                if (flags & n) {
                     out.push(flagsEnum[n]);
+                }
             }
             return out.join("|");
         }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1466,7 +1466,7 @@ namespace ts {
         if (value !== undefined && test(value)) return value;
 
         if (value && typeof (value as any).kind === "number") {
-            Debug.fail(`Invalid cast. The supplied ${(ts as any).SyntaxKind[(value as any).kind]} did not pass the test '${Debug.getFunctionName(test)}'.`);
+            Debug.fail(`Invalid cast. The supplied ${Debug.showSyntaxKind(value as any as Node)} did not pass the test '${Debug.getFunctionName(test)}'.`);
         }
         else {
             Debug.fail(`Invalid cast. The supplied value did not pass the test '${Debug.getFunctionName(test)}'.`);
@@ -2924,6 +2924,24 @@ namespace ts {
                 const match = /^function\s+([\w\$]+)\s*\(/.exec(text);
                 return match ? match[1] : "";
             }
+        }
+
+        export function showSymbol(symbol: Symbol): string {
+            return `{ flags: ${showFlags(symbol.flags, (ts as any).SymbolFlags)}; declarations: ${map(symbol.declarations, showSyntaxKind)} }`;
+        }
+
+        function showFlags(flags: number, flagsEnum: { [flag: number]: string }): string {
+            const out = [];
+            for (let pow = 0; pow <= 30; pow++) {
+                const n = 1 << pow;
+                if (flags & n)
+                    out.push(flagsEnum[n]);
+            }
+            return out.join("|");
+        }
+
+        export function showSyntaxKind(node: Node): string {
+            return (ts as any).SyntaxKind[node.kind];
         }
     }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -424,7 +424,7 @@ namespace ts.FindAllReferences.Core {
             }
             return isTypeLiteralNode(decl.parent) && isUnionTypeNode(decl.parent.parent)
                 ? checker.getPropertyOfType(checker.getTypeFromTypeNode(decl.parent.parent), symbol.name)
-                : undefined
+                : undefined;
         }) || symbol;
     }
 

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -517,27 +517,10 @@ namespace ts.FindAllReferences {
                 const sym = useLhsSymbol ? checker.getSymbolAtLocation(cast(node.left, isPropertyAccessExpression).name) : symbol;
                 // Better detection for GH#20803
                 if (sym && !(checker.getMergedSymbol(sym.parent).flags & SymbolFlags.Module)) {
-                    Debug.fail(`Special property assignment kind does not have a module as its parent. Assignment is ${showSymbol(sym)}, parent is ${showSymbol(sym.parent)}`);
+                    Debug.fail(`Special property assignment kind does not have a module as its parent. Assignment is ${Debug.showSymbol(sym)}, parent is ${Debug.showSymbol(sym.parent)}`);
                 }
                 return sym && exportInfo(sym, kind);
             }
-        }
-
-        function showSymbol(s: Symbol): string {
-            const decls = s.declarations.map(d => (ts as any).SyntaxKind[d.kind]).join(",");
-            const flags = showFlags(s.flags, (ts as any).SymbolFlags);
-            return `{ declarations: ${decls}, flags: ${flags} }`;
-        }
-
-        function showFlags(f: number, flags: any) {
-            const out = [];
-            for (let pow = 0; pow <= 30; pow++) {
-                const n = 1 << pow;
-                if (f & n) {
-                    out.push(flags[n]);
-                }
-            }
-            return out.join("|");
         }
 
         function getImport(): ImportedSymbol | undefined {


### PR DESCRIPTION
Fixes #21814
Somehow we get a symbol where one of the declarations is a SourceFile. We're supposed to handle SourceFile symbols in `getReferencedSymbolsForModule` instead of here. But somehow the symbol isn't `SymbolFlags.Module` or `!isModuleReferenceLocation(node)`.
