### PR TITLE
Fix structural identity relations

### DIFF
--- a/tests/baselines/reference/conditionalTypes1.errors.txt
+++ b/tests/baselines/reference/conditionalTypes1.errors.txt
@@ -8,9 +8,15 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(22,9): error TS23
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(28,5): error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
   Type 'T[keyof T] | undefined' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
     Type 'undefined' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(100,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(101,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(103,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(33,5): error TS2322: Type 'T["x"]' is not assignable to type 'Diff<T["x"], null | undefined>'.
+  Type 'string | undefined' is not assignable to type 'Diff<T["x"], null | undefined>'.
+    Type 'undefined' is not assignable to type 'Diff<T["x"], null | undefined>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(34,9): error TS2322: Type 'T["x"]' is not assignable to type 'string'.
+  Type 'string | undefined' is not assignable to type 'string'.
+    Type 'undefined' is not assignable to type 'string'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(107,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'T'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(108,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'T'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(110,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>'.
   Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
     Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
       Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
@@ -18,8 +24,8 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(103,5): error TS2
           Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
             Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
               Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-                Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(105,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
+                Type 'keyof T' is not assignable to type 'never'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(112,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
   Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
     Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
       Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
@@ -27,41 +33,43 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(105,5): error TS2
           Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
             Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
               Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-                Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(111,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
+                Type 'keyof T' is not assignable to type 'never'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(118,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
   Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(112,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(119,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
   Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
     Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
       Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
         Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
           Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-            Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(113,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
+            Type 'keyof T' is not assignable to type 'never'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(120,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
   Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(114,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(121,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
   Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
     Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
       Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
         Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
           Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-            Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(131,10): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(132,5): error TS2542: Index signature in type 'DeepReadonlyArray<Part>' only permits reading.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(133,22): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(134,10): error TS2339: Property 'updatePart' does not exist on type 'DeepReadonlyObject<Part>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(156,5): error TS2322: Type 'ZeroOf<T>' is not assignable to type 'T'.
+            Type 'keyof T' is not assignable to type 'never'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(138,10): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(139,5): error TS2542: Index signature in type 'DeepReadonlyArray<Part>' only permits reading.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(140,22): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(141,10): error TS2339: Property 'updatePart' does not exist on type 'DeepReadonlyObject<Part>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(163,5): error TS2322: Type 'ZeroOf<T>' is not assignable to type 'T'.
   Type '0 | (T extends string ? "" : false)' is not assignable to type 'T'.
     Type '0' is not assignable to type 'T'.
       Type '"" | 0' is not assignable to type 'T'.
         Type '""' is not assignable to type 'T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(157,5): error TS2322: Type 'T' is not assignable to type 'ZeroOf<T>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(164,5): error TS2322: Type 'T' is not assignable to type 'ZeroOf<T>'.
   Type 'string | number' is not assignable to type 'ZeroOf<T>'.
     Type 'string' is not assignable to type 'ZeroOf<T>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'z' must be of type 'T1', but here has type 'Foo<T & U>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(254,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'z' must be of type 'T1', but here has type 'Foo<T & U>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(279,43): error TS2322: Type 'T95<U>' is not assignable to type 'T94<U>'.
+  Type 'boolean' is not assignable to type 'true'.
 
 
-==== tests/cases/conformance/types/conditional/conditionalTypes1.ts (19 errors) ====
+==== tests/cases/conformance/types/conditional/conditionalTypes1.ts (22 errors) ====
     type Diff<T, U> = T extends U ? never : T;
     type Filter<T, U> = T extends U ? T : never;
     type NonNullable<T> = Diff<T, null | undefined>;
@@ -106,6 +114,21 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
 !!! error TS2322:     Type 'undefined' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
     }
     
+    function f4<T extends { x: string | undefined }>(x: T["x"], y: NonNullable<T["x"]>) {
+        x = y;
+        y = x;  // Error
+        ~
+!!! error TS2322: Type 'T["x"]' is not assignable to type 'Diff<T["x"], null | undefined>'.
+!!! error TS2322:   Type 'string | undefined' is not assignable to type 'Diff<T["x"], null | undefined>'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'Diff<T["x"], null | undefined>'.
+        let s1: string = x;  // Error
+            ~~
+!!! error TS2322: Type 'T["x"]' is not assignable to type 'string'.
+!!! error TS2322:   Type 'string | undefined' is not assignable to type 'string'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'string'.
+        let s2: string = y;
+    }
+    
     type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
     
     type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
@@ -117,8 +140,8 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
     type T14 = Diff<Options, { q: "a" }>;  // Options
     type T15 = Filter<Options, { q: "a" }>;  // never
     
-    declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
-    let x0 = f4("a");  // { k: "a", a: number }
+    declare function f5<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
+    let x0 = f5("a");  // { k: "a", a: number }
     
     type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
     
@@ -192,7 +215,7 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
 !!! error TS2322:           Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
 !!! error TS2322:             Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
 !!! error TS2322:               Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:                 Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+!!! error TS2322:                 Type 'keyof T' is not assignable to type 'never'.
         z = x;
         z = y;  // Error
         ~
@@ -204,7 +227,7 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
 !!! error TS2322:           Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:             Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:               Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:                 Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+!!! error TS2322:                 Type 'keyof T' is not assignable to type 'never'.
     }
     
     function f8<T>(x: keyof T, y: FunctionPropertyNames<T>, z: NonFunctionPropertyNames<T>) {
@@ -222,7 +245,7 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
 !!! error TS2322:       Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:         Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:           Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:             Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+!!! error TS2322:             Type 'keyof T' is not assignable to type 'never'.
         z = x;  // Error
         ~
 !!! error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
@@ -235,7 +258,7 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
 !!! error TS2322:       Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
 !!! error TS2322:         Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
 !!! error TS2322:           Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:             Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+!!! error TS2322:             Type 'keyof T' is not assignable to type 'never'.
     }
     
     type DeepReadonly<T> =
@@ -397,4 +420,24 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
         var z: T1;
         var z: T2;
     }
+    
+    // Repro from #21823
+    
+    type T90<T> = T extends 0 ? 0 : () => 0;
+    type T91<T> = T extends 0 ? 0 : () => 0;
+    const f40 = <U>(a: T90<U>): T91<U> => a;
+    const f41 = <U>(a: T91<U>): T90<U> => a;
+    
+    type T92<T> = T extends () => 0 ? () => 1 : () => 2;
+    type T93<T> = T extends () => 0 ? () => 1 : () => 2;
+    const f42 = <U>(a: T92<U>): T93<U> => a;
+    const f43 = <U>(a: T93<U>): T92<U> => a;
+    
+    type T94<T> = T extends string ? true : 42;
+    type T95<T> = T extends string ? boolean : number;
+    const f44 = <U>(value: T94<U>): T95<U> => value;
+    const f45 = <U>(value: T95<U>): T94<U> => value;  // Error
+                                              ~~~~~
+!!! error TS2322: Type 'T95<U>' is not assignable to type 'T94<U>'.
+!!! error TS2322:   Type 'boolean' is not assignable to type 'true'.
     

--- a/tests/baselines/reference/conditionalTypes1.js
+++ b/tests/baselines/reference/conditionalTypes1.js
@@ -29,6 +29,13 @@ function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) {
     y = x;  // Error
 }
 
+function f4<T extends { x: string | undefined }>(x: T["x"], y: NonNullable<T["x"]>) {
+    x = y;
+    y = x;  // Error
+    let s1: string = x;  // Error
+    let s2: string = y;
+}
+
 type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
 
 type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
@@ -40,8 +47,8 @@ type T13 = Filter<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } |
 type T14 = Diff<Options, { q: "a" }>;  // Options
 type T15 = Filter<Options, { q: "a" }>;  // never
 
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
-let x0 = f4("a");  // { k: "a", a: number }
+declare function f5<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
+let x0 = f5("a");  // { k: "a", a: number }
 
 type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
 
@@ -255,6 +262,23 @@ function f33<T, U>() {
     var z: T2;
 }
 
+// Repro from #21823
+
+type T90<T> = T extends 0 ? 0 : () => 0;
+type T91<T> = T extends 0 ? 0 : () => 0;
+const f40 = <U>(a: T90<U>): T91<U> => a;
+const f41 = <U>(a: T91<U>): T90<U> => a;
+
+type T92<T> = T extends () => 0 ? () => 1 : () => 2;
+type T93<T> = T extends () => 0 ? () => 1 : () => 2;
+const f42 = <U>(a: T92<U>): T93<U> => a;
+const f43 = <U>(a: T93<U>): T92<U> => a;
+
+type T94<T> = T extends string ? true : 42;
+type T95<T> = T extends string ? boolean : number;
+const f44 = <U>(value: T94<U>): T95<U> => value;
+const f45 = <U>(value: T95<U>): T94<U> => value;  // Error
+
 
 //// [conditionalTypes1.js]
 "use strict";
@@ -272,7 +296,13 @@ function f3(x, y) {
     x = y;
     y = x; // Error
 }
-var x0 = f4("a"); // { k: "a", a: number }
+function f4(x, y) {
+    x = y;
+    y = x; // Error
+    var s1 = x; // Error
+    var s2 = y;
+}
+var x0 = f5("a"); // { k: "a", a: number }
 function f7(x, y, z) {
     x = y; // Error
     x = z; // Error
@@ -329,6 +359,12 @@ function f33() {
     var z;
     var z;
 }
+var f40 = function (a) { return a; };
+var f41 = function (a) { return a; };
+var f42 = function (a) { return a; };
+var f43 = function (a) { return a; };
+var f44 = function (value) { return value; };
+var f45 = function (value) { return value; }; // Error
 
 
 //// [conditionalTypes1.d.ts]
@@ -344,6 +380,9 @@ declare type T05 = NonNullable<(() => string) | string[] | null | undefined>;
 declare function f1<T>(x: T, y: NonNullable<T>): void;
 declare function f2<T extends string | undefined>(x: T, y: NonNullable<T>): void;
 declare function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>): void;
+declare function f4<T extends {
+    x: string | undefined;
+}>(x: T["x"], y: NonNullable<T["x"]>): void;
 declare type Options = {
     k: "a";
     a: number;
@@ -376,7 +415,7 @@ declare type T14 = Diff<Options, {
 declare type T15 = Filter<Options, {
     q: "a";
 }>;
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, {
+declare function f5<T extends Options, K extends string>(p: K): Filter<T, {
     k: K;
 }>;
 declare let x0: {
@@ -502,3 +541,15 @@ declare const convert2: <T>(value: Foo<T>) => Foo<T>;
 declare function f31<T>(): void;
 declare function f32<T, U>(): void;
 declare function f33<T, U>(): void;
+declare type T90<T> = T extends 0 ? 0 : () => 0;
+declare type T91<T> = T extends 0 ? 0 : () => 0;
+declare const f40: <U>(a: T90<U>) => T91<U>;
+declare const f41: <U>(a: T91<U>) => T90<U>;
+declare type T92<T> = T extends () => 0 ? () => 1 : () => 2;
+declare type T93<T> = T extends () => 0 ? () => 1 : () => 2;
+declare const f42: <U>(a: T92<U>) => T93<U>;
+declare const f43: <U>(a: T93<U>) => T92<U>;
+declare type T94<T> = T extends string ? true : 42;
+declare type T95<T> = T extends string ? boolean : number;
+declare const f44: <U>(value: T94<U>) => T95<U>;
+declare const f45: <U>(value: T95<U>) => T94<U>;

--- a/tests/baselines/reference/conditionalTypes1.symbols
+++ b/tests/baselines/reference/conditionalTypes1.symbols
@@ -113,852 +113,971 @@ function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) {
 >x : Symbol(x, Decl(conditionalTypes1.ts, 25, 15))
 }
 
+function f4<T extends { x: string | undefined }>(x: T["x"], y: NonNullable<T["x"]>) {
+>f4 : Symbol(f4, Decl(conditionalTypes1.ts, 28, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 30, 12))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 30, 23))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 30, 49))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 30, 12))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 30, 59))
+>NonNullable : Symbol(NonNullable, Decl(conditionalTypes1.ts, 1, 44))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 30, 12))
+
+    x = y;
+>x : Symbol(x, Decl(conditionalTypes1.ts, 30, 49))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 30, 59))
+
+    y = x;  // Error
+>y : Symbol(y, Decl(conditionalTypes1.ts, 30, 59))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 30, 49))
+
+    let s1: string = x;  // Error
+>s1 : Symbol(s1, Decl(conditionalTypes1.ts, 33, 7))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 30, 49))
+
+    let s2: string = y;
+>s2 : Symbol(s2, Decl(conditionalTypes1.ts, 34, 7))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 30, 59))
+}
+
 type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 30, 16))
->a : Symbol(a, Decl(conditionalTypes1.ts, 30, 24))
->k : Symbol(k, Decl(conditionalTypes1.ts, 30, 40))
->b : Symbol(b, Decl(conditionalTypes1.ts, 30, 48))
->k : Symbol(k, Decl(conditionalTypes1.ts, 30, 64))
->c : Symbol(c, Decl(conditionalTypes1.ts, 30, 72))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 37, 16))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 37, 24))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 37, 40))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 37, 48))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 37, 64))
+>c : Symbol(c, Decl(conditionalTypes1.ts, 37, 72))
 
 type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
->T10 : Symbol(T10, Decl(conditionalTypes1.ts, 30, 86))
+>T10 : Symbol(T10, Decl(conditionalTypes1.ts, 37, 86))
 >Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 32, 26))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 39, 26))
 
 type T11 = Filter<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
->T11 : Symbol(T11, Decl(conditionalTypes1.ts, 32, 43))
+>T11 : Symbol(T11, Decl(conditionalTypes1.ts, 39, 43))
 >Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 33, 28))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 40, 28))
 
 type T12 = Diff<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
->T12 : Symbol(T12, Decl(conditionalTypes1.ts, 33, 45))
+>T12 : Symbol(T12, Decl(conditionalTypes1.ts, 40, 45))
 >Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 35, 26))
->k : Symbol(k, Decl(conditionalTypes1.ts, 35, 39))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 42, 26))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 42, 39))
 
 type T13 = Filter<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
->T13 : Symbol(T13, Decl(conditionalTypes1.ts, 35, 50))
+>T13 : Symbol(T13, Decl(conditionalTypes1.ts, 42, 50))
 >Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 36, 28))
->k : Symbol(k, Decl(conditionalTypes1.ts, 36, 41))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 43, 28))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 43, 41))
 
 type T14 = Diff<Options, { q: "a" }>;  // Options
->T14 : Symbol(T14, Decl(conditionalTypes1.ts, 36, 52))
+>T14 : Symbol(T14, Decl(conditionalTypes1.ts, 43, 52))
 >Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->q : Symbol(q, Decl(conditionalTypes1.ts, 38, 26))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>q : Symbol(q, Decl(conditionalTypes1.ts, 45, 26))
 
 type T15 = Filter<Options, { q: "a" }>;  // never
->T15 : Symbol(T15, Decl(conditionalTypes1.ts, 38, 37))
+>T15 : Symbol(T15, Decl(conditionalTypes1.ts, 45, 37))
 >Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->q : Symbol(q, Decl(conditionalTypes1.ts, 39, 28))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>q : Symbol(q, Decl(conditionalTypes1.ts, 46, 28))
 
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
->f4 : Symbol(f4, Decl(conditionalTypes1.ts, 39, 39))
->T : Symbol(T, Decl(conditionalTypes1.ts, 41, 20))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->K : Symbol(K, Decl(conditionalTypes1.ts, 41, 38))
->p : Symbol(p, Decl(conditionalTypes1.ts, 41, 57))
->K : Symbol(K, Decl(conditionalTypes1.ts, 41, 38))
+declare function f5<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
+>f5 : Symbol(f5, Decl(conditionalTypes1.ts, 46, 39))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 48, 20))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 48, 38))
+>p : Symbol(p, Decl(conditionalTypes1.ts, 48, 57))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 48, 38))
 >Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->T : Symbol(T, Decl(conditionalTypes1.ts, 41, 20))
->k : Symbol(k, Decl(conditionalTypes1.ts, 41, 75))
->K : Symbol(K, Decl(conditionalTypes1.ts, 41, 38))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 48, 20))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 48, 75))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 48, 38))
 
-let x0 = f4("a");  // { k: "a", a: number }
->x0 : Symbol(x0, Decl(conditionalTypes1.ts, 42, 3))
->f4 : Symbol(f4, Decl(conditionalTypes1.ts, 39, 39))
+let x0 = f5("a");  // { k: "a", a: number }
+>x0 : Symbol(x0, Decl(conditionalTypes1.ts, 49, 3))
+>f5 : Symbol(f5, Decl(conditionalTypes1.ts, 46, 39))
 
 type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
->OptionsOfKind : Symbol(OptionsOfKind, Decl(conditionalTypes1.ts, 42, 17))
->K : Symbol(K, Decl(conditionalTypes1.ts, 44, 19))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
+>OptionsOfKind : Symbol(OptionsOfKind, Decl(conditionalTypes1.ts, 49, 17))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 51, 19))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
 >Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 44, 62))
->K : Symbol(K, Decl(conditionalTypes1.ts, 44, 19))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 51, 62))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 51, 19))
 
 type T16 = OptionsOfKind<"a" | "b">;  // { k: "a", a: number } | { k: "b", b: string }
->T16 : Symbol(T16, Decl(conditionalTypes1.ts, 44, 71))
->OptionsOfKind : Symbol(OptionsOfKind, Decl(conditionalTypes1.ts, 42, 17))
+>T16 : Symbol(T16, Decl(conditionalTypes1.ts, 51, 71))
+>OptionsOfKind : Symbol(OptionsOfKind, Decl(conditionalTypes1.ts, 49, 17))
 
 type Select<T, K extends keyof T, V extends T[K]> = Filter<T, { [P in K]: V }>;
->Select : Symbol(Select, Decl(conditionalTypes1.ts, 46, 36))
->T : Symbol(T, Decl(conditionalTypes1.ts, 48, 12))
->K : Symbol(K, Decl(conditionalTypes1.ts, 48, 14))
->T : Symbol(T, Decl(conditionalTypes1.ts, 48, 12))
->V : Symbol(V, Decl(conditionalTypes1.ts, 48, 33))
->T : Symbol(T, Decl(conditionalTypes1.ts, 48, 12))
->K : Symbol(K, Decl(conditionalTypes1.ts, 48, 14))
+>Select : Symbol(Select, Decl(conditionalTypes1.ts, 53, 36))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 55, 12))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 55, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 55, 12))
+>V : Symbol(V, Decl(conditionalTypes1.ts, 55, 33))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 55, 12))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 55, 14))
 >Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->T : Symbol(T, Decl(conditionalTypes1.ts, 48, 12))
->P : Symbol(P, Decl(conditionalTypes1.ts, 48, 65))
->K : Symbol(K, Decl(conditionalTypes1.ts, 48, 14))
->V : Symbol(V, Decl(conditionalTypes1.ts, 48, 33))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 55, 12))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 55, 65))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 55, 14))
+>V : Symbol(V, Decl(conditionalTypes1.ts, 55, 33))
 
 type T17 = Select<Options, "k", "a" | "b">;  // // { k: "a", a: number } | { k: "b", b: string }
->T17 : Symbol(T17, Decl(conditionalTypes1.ts, 48, 79))
->Select : Symbol(Select, Decl(conditionalTypes1.ts, 46, 36))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
+>T17 : Symbol(T17, Decl(conditionalTypes1.ts, 55, 79))
+>Select : Symbol(Select, Decl(conditionalTypes1.ts, 53, 36))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 35, 1))
 
 type TypeName<T> =
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 57, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 59, 14))
 
     T extends string ? "string" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 59, 14))
 
     T extends number ? "number" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 59, 14))
 
     T extends boolean ? "boolean" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 59, 14))
 
     T extends undefined ? "undefined" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 59, 14))
 
     T extends Function ? "function" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 59, 14))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
     "object";
 
 type T20 = TypeName<string | (() => void)>;  // "string" | "function"
->T20 : Symbol(T20, Decl(conditionalTypes1.ts, 58, 13))
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
+>T20 : Symbol(T20, Decl(conditionalTypes1.ts, 65, 13))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 57, 43))
 
 type T21 = TypeName<any>;  // "string" | "number" | "boolean" | "undefined" | "function" | "object"
->T21 : Symbol(T21, Decl(conditionalTypes1.ts, 60, 43))
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
+>T21 : Symbol(T21, Decl(conditionalTypes1.ts, 67, 43))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 57, 43))
 
 type T22 = TypeName<never>;  // "string" | "number" | "boolean" | "undefined" | "function" | "object"
->T22 : Symbol(T22, Decl(conditionalTypes1.ts, 61, 25))
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
+>T22 : Symbol(T22, Decl(conditionalTypes1.ts, 68, 25))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 57, 43))
 
 type T23 = TypeName<{}>;  // "object"
->T23 : Symbol(T23, Decl(conditionalTypes1.ts, 62, 27))
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
+>T23 : Symbol(T23, Decl(conditionalTypes1.ts, 69, 27))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 57, 43))
 
 type KnockoutObservable<T> = { object: T };
->KnockoutObservable : Symbol(KnockoutObservable, Decl(conditionalTypes1.ts, 63, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 65, 24))
->object : Symbol(object, Decl(conditionalTypes1.ts, 65, 30))
->T : Symbol(T, Decl(conditionalTypes1.ts, 65, 24))
+>KnockoutObservable : Symbol(KnockoutObservable, Decl(conditionalTypes1.ts, 70, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 72, 24))
+>object : Symbol(object, Decl(conditionalTypes1.ts, 72, 30))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 72, 24))
 
 type KnockoutObservableArray<T> = { array: T };
->KnockoutObservableArray : Symbol(KnockoutObservableArray, Decl(conditionalTypes1.ts, 65, 43))
->T : Symbol(T, Decl(conditionalTypes1.ts, 66, 29))
->array : Symbol(array, Decl(conditionalTypes1.ts, 66, 35))
->T : Symbol(T, Decl(conditionalTypes1.ts, 66, 29))
+>KnockoutObservableArray : Symbol(KnockoutObservableArray, Decl(conditionalTypes1.ts, 72, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 73, 29))
+>array : Symbol(array, Decl(conditionalTypes1.ts, 73, 35))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 73, 29))
 
 type KnockedOut<T> = T extends any[] ? KnockoutObservableArray<T[number]> : KnockoutObservable<T>;
->KnockedOut : Symbol(KnockedOut, Decl(conditionalTypes1.ts, 66, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 68, 16))
->T : Symbol(T, Decl(conditionalTypes1.ts, 68, 16))
->KnockoutObservableArray : Symbol(KnockoutObservableArray, Decl(conditionalTypes1.ts, 65, 43))
->T : Symbol(T, Decl(conditionalTypes1.ts, 68, 16))
->KnockoutObservable : Symbol(KnockoutObservable, Decl(conditionalTypes1.ts, 63, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 68, 16))
+>KnockedOut : Symbol(KnockedOut, Decl(conditionalTypes1.ts, 73, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 75, 16))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 75, 16))
+>KnockoutObservableArray : Symbol(KnockoutObservableArray, Decl(conditionalTypes1.ts, 72, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 75, 16))
+>KnockoutObservable : Symbol(KnockoutObservable, Decl(conditionalTypes1.ts, 70, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 75, 16))
 
 type KnockedOutObj<T> = {
->KnockedOutObj : Symbol(KnockedOutObj, Decl(conditionalTypes1.ts, 68, 98))
->T : Symbol(T, Decl(conditionalTypes1.ts, 70, 19))
+>KnockedOutObj : Symbol(KnockedOutObj, Decl(conditionalTypes1.ts, 75, 98))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 77, 19))
 
     [P in keyof T]: KnockedOut<T[P]>;
->P : Symbol(P, Decl(conditionalTypes1.ts, 71, 5))
->T : Symbol(T, Decl(conditionalTypes1.ts, 70, 19))
->KnockedOut : Symbol(KnockedOut, Decl(conditionalTypes1.ts, 66, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 70, 19))
->P : Symbol(P, Decl(conditionalTypes1.ts, 71, 5))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 78, 5))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 77, 19))
+>KnockedOut : Symbol(KnockedOut, Decl(conditionalTypes1.ts, 73, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 77, 19))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 78, 5))
 }
 
 interface Item {
->Item : Symbol(Item, Decl(conditionalTypes1.ts, 72, 1))
+>Item : Symbol(Item, Decl(conditionalTypes1.ts, 79, 1))
 
     id: number;
->id : Symbol(Item.id, Decl(conditionalTypes1.ts, 74, 16))
+>id : Symbol(Item.id, Decl(conditionalTypes1.ts, 81, 16))
 
     name: string;
->name : Symbol(Item.name, Decl(conditionalTypes1.ts, 75, 15))
+>name : Symbol(Item.name, Decl(conditionalTypes1.ts, 82, 15))
 
     subitems: string[];
->subitems : Symbol(Item.subitems, Decl(conditionalTypes1.ts, 76, 17))
+>subitems : Symbol(Item.subitems, Decl(conditionalTypes1.ts, 83, 17))
 }
 
 type KOItem = KnockedOutObj<Item>;
->KOItem : Symbol(KOItem, Decl(conditionalTypes1.ts, 78, 1))
->KnockedOutObj : Symbol(KnockedOutObj, Decl(conditionalTypes1.ts, 68, 98))
->Item : Symbol(Item, Decl(conditionalTypes1.ts, 72, 1))
+>KOItem : Symbol(KOItem, Decl(conditionalTypes1.ts, 85, 1))
+>KnockedOutObj : Symbol(KnockedOutObj, Decl(conditionalTypes1.ts, 75, 98))
+>Item : Symbol(Item, Decl(conditionalTypes1.ts, 79, 1))
 
 interface Part {
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 87, 34))
 
     id: number;
->id : Symbol(Part.id, Decl(conditionalTypes1.ts, 82, 16))
+>id : Symbol(Part.id, Decl(conditionalTypes1.ts, 89, 16))
 
     name: string;
->name : Symbol(Part.name, Decl(conditionalTypes1.ts, 83, 15))
+>name : Symbol(Part.name, Decl(conditionalTypes1.ts, 90, 15))
 
     subparts: Part[];
->subparts : Symbol(Part.subparts, Decl(conditionalTypes1.ts, 84, 17))
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>subparts : Symbol(Part.subparts, Decl(conditionalTypes1.ts, 91, 17))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 87, 34))
 
     updatePart(newName: string): void;
->updatePart : Symbol(Part.updatePart, Decl(conditionalTypes1.ts, 85, 21))
->newName : Symbol(newName, Decl(conditionalTypes1.ts, 86, 15))
+>updatePart : Symbol(Part.updatePart, Decl(conditionalTypes1.ts, 92, 21))
+>newName : Symbol(newName, Decl(conditionalTypes1.ts, 93, 15))
 }
 
 type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
->FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
->K : Symbol(K, Decl(conditionalTypes1.ts, 89, 35))
->T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
->T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
->K : Symbol(K, Decl(conditionalTypes1.ts, 89, 35))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 94, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 96, 27))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 96, 35))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 96, 27))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 96, 27))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 96, 35))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->K : Symbol(K, Decl(conditionalTypes1.ts, 89, 35))
->T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 96, 35))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 96, 27))
 
 type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>;
->FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 89, 95))
->T : Symbol(T, Decl(conditionalTypes1.ts, 90, 24))
+>FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 96, 95))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 97, 24))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes1.ts, 90, 24))
->FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 90, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 97, 24))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 94, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 97, 24))
 
 type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
->NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 90, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 92, 30))
->K : Symbol(K, Decl(conditionalTypes1.ts, 92, 38))
->T : Symbol(T, Decl(conditionalTypes1.ts, 92, 30))
->T : Symbol(T, Decl(conditionalTypes1.ts, 92, 30))
->K : Symbol(K, Decl(conditionalTypes1.ts, 92, 38))
+>NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 97, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 99, 30))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 99, 38))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 99, 30))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 99, 30))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 99, 38))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->K : Symbol(K, Decl(conditionalTypes1.ts, 92, 38))
->T : Symbol(T, Decl(conditionalTypes1.ts, 92, 30))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 99, 38))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 99, 30))
 
 type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
->NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 92, 98))
->T : Symbol(T, Decl(conditionalTypes1.ts, 93, 27))
+>NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 99, 98))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 100, 27))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes1.ts, 93, 27))
->NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 90, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 93, 27))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 100, 27))
+>NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 97, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 100, 27))
 
 type T30 = FunctionProperties<Part>;
->T30 : Symbol(T30, Decl(conditionalTypes1.ts, 93, 69))
->FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 89, 95))
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>T30 : Symbol(T30, Decl(conditionalTypes1.ts, 100, 69))
+>FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 96, 95))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 87, 34))
 
 type T31 = NonFunctionProperties<Part>;
->T31 : Symbol(T31, Decl(conditionalTypes1.ts, 95, 36))
->NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 92, 98))
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>T31 : Symbol(T31, Decl(conditionalTypes1.ts, 102, 36))
+>NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 99, 98))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 87, 34))
 
 function f7<T>(x: T, y: FunctionProperties<T>, z: NonFunctionProperties<T>) {
->f7 : Symbol(f7, Decl(conditionalTypes1.ts, 96, 39))
->T : Symbol(T, Decl(conditionalTypes1.ts, 98, 12))
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 98, 12))
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
->FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 89, 95))
->T : Symbol(T, Decl(conditionalTypes1.ts, 98, 12))
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
->NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 92, 98))
->T : Symbol(T, Decl(conditionalTypes1.ts, 98, 12))
+>f7 : Symbol(f7, Decl(conditionalTypes1.ts, 103, 39))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 105, 12))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 105, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 105, 12))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 105, 20))
+>FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 96, 95))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 105, 12))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 105, 46))
+>NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 99, 98))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 105, 12))
 
     x = y;  // Error
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 105, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 105, 20))
 
     x = z;  // Error
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 105, 15))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 105, 46))
 
     y = x;
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 105, 20))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 105, 15))
 
     y = z;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 105, 20))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 105, 46))
 
     z = x;
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 105, 46))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 105, 15))
 
     z = y;  // Error
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 105, 46))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 105, 20))
 }
 
 function f8<T>(x: keyof T, y: FunctionPropertyNames<T>, z: NonFunctionPropertyNames<T>) {
->f8 : Symbol(f8, Decl(conditionalTypes1.ts, 105, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 107, 12))
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 107, 12))
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
->FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 107, 12))
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
->NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 90, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 107, 12))
+>f8 : Symbol(f8, Decl(conditionalTypes1.ts, 112, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 114, 12))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 114, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 114, 12))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 114, 26))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 94, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 114, 12))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 114, 55))
+>NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 97, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 114, 12))
 
     x = y;
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 114, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 114, 26))
 
     x = z;
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 114, 15))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 114, 55))
 
     y = x;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 114, 26))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 114, 15))
 
     y = z;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 114, 26))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 114, 55))
 
     z = x;  // Error
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 114, 55))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 114, 15))
 
     z = y;  // Error
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 114, 55))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 114, 26))
 }
 
 type DeepReadonly<T> =
->DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 114, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
+>DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 121, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 123, 18))
 
     T extends any[] ? DeepReadonlyArray<T[number]> :
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
->DeepReadonlyArray : Symbol(DeepReadonlyArray, Decl(conditionalTypes1.ts, 119, 6))
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 123, 18))
+>DeepReadonlyArray : Symbol(DeepReadonlyArray, Decl(conditionalTypes1.ts, 126, 6))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 123, 18))
 
     T extends object ? DeepReadonlyObject<T> :
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
->DeepReadonlyObject : Symbol(DeepReadonlyObject, Decl(conditionalTypes1.ts, 121, 72))
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 123, 18))
+>DeepReadonlyObject : Symbol(DeepReadonlyObject, Decl(conditionalTypes1.ts, 128, 72))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 123, 18))
 
     T;
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 123, 18))
 
 interface DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
->DeepReadonlyArray : Symbol(DeepReadonlyArray, Decl(conditionalTypes1.ts, 119, 6))
->T : Symbol(T, Decl(conditionalTypes1.ts, 121, 28))
+>DeepReadonlyArray : Symbol(DeepReadonlyArray, Decl(conditionalTypes1.ts, 126, 6))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 128, 28))
 >ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.d.ts, --, --))
->DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 114, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 121, 28))
+>DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 121, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 128, 28))
 
 type DeepReadonlyObject<T> = {
->DeepReadonlyObject : Symbol(DeepReadonlyObject, Decl(conditionalTypes1.ts, 121, 72))
->T : Symbol(T, Decl(conditionalTypes1.ts, 123, 24))
+>DeepReadonlyObject : Symbol(DeepReadonlyObject, Decl(conditionalTypes1.ts, 128, 72))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 130, 24))
 
     readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
->P : Symbol(P, Decl(conditionalTypes1.ts, 124, 14))
->NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 90, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 123, 24))
->DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 114, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 123, 24))
->P : Symbol(P, Decl(conditionalTypes1.ts, 124, 14))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 131, 14))
+>NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 97, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 130, 24))
+>DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 121, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 130, 24))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 131, 14))
 
 };
 
 function f10(part: DeepReadonly<Part>) {
->f10 : Symbol(f10, Decl(conditionalTypes1.ts, 125, 2))
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
->DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 114, 1))
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>f10 : Symbol(f10, Decl(conditionalTypes1.ts, 132, 2))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
+>DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 121, 1))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 87, 34))
 
     let name: string = part.name;
->name : Symbol(name, Decl(conditionalTypes1.ts, 128, 7))
+>name : Symbol(name, Decl(conditionalTypes1.ts, 135, 7))
 >part.name : Symbol(name)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 >name : Symbol(name)
 
     let id: number = part.subparts[0].id;
->id : Symbol(id, Decl(conditionalTypes1.ts, 129, 7))
+>id : Symbol(id, Decl(conditionalTypes1.ts, 136, 7))
 >part.subparts[0].id : Symbol(id)
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 >subparts : Symbol(subparts)
 >id : Symbol(id)
 
     part.id = part.id;  // Error
 >part.id : Symbol(id)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 >id : Symbol(id)
 >part.id : Symbol(id)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 >id : Symbol(id)
 
     part.subparts[0] = part.subparts[0];  // Error
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 >subparts : Symbol(subparts)
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 >subparts : Symbol(subparts)
 
     part.subparts[0].id = part.subparts[0].id;  // Error
 >part.subparts[0].id : Symbol(id)
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 >subparts : Symbol(subparts)
 >id : Symbol(id)
 >part.subparts[0].id : Symbol(id)
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 >subparts : Symbol(subparts)
 >id : Symbol(id)
 
     part.updatePart("hello");  // Error
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 134, 13))
 }
 
 type ZeroOf<T extends number | string | boolean> = T extends number ? 0 : T extends string ? "" : false;
->ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 134, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 136, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 136, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 136, 12))
+>ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 141, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 143, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 143, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 143, 12))
 
 function zeroOf<T extends number | string | boolean>(value: T) {
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->T : Symbol(T, Decl(conditionalTypes1.ts, 138, 16))
->value : Symbol(value, Decl(conditionalTypes1.ts, 138, 53))
->T : Symbol(T, Decl(conditionalTypes1.ts, 138, 16))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 143, 104))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 145, 16))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 145, 53))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 145, 16))
 
     return <ZeroOf<T>>(typeof value === "number" ? 0 : typeof value === "string" ? "" : false);
->ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 134, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 138, 16))
->value : Symbol(value, Decl(conditionalTypes1.ts, 138, 53))
->value : Symbol(value, Decl(conditionalTypes1.ts, 138, 53))
+>ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 141, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 145, 16))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 145, 53))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 145, 53))
 }
 
 function f20<T extends string>(n: number, b: boolean, x: number | boolean, y: T) {
->f20 : Symbol(f20, Decl(conditionalTypes1.ts, 140, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 142, 13))
->n : Symbol(n, Decl(conditionalTypes1.ts, 142, 31))
->b : Symbol(b, Decl(conditionalTypes1.ts, 142, 41))
->x : Symbol(x, Decl(conditionalTypes1.ts, 142, 53))
->y : Symbol(y, Decl(conditionalTypes1.ts, 142, 74))
->T : Symbol(T, Decl(conditionalTypes1.ts, 142, 13))
+>f20 : Symbol(f20, Decl(conditionalTypes1.ts, 147, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 149, 13))
+>n : Symbol(n, Decl(conditionalTypes1.ts, 149, 31))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 149, 41))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 149, 53))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 149, 74))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 149, 13))
 
     zeroOf(5);  // 0
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 143, 104))
 
     zeroOf("hello");  // ""
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 143, 104))
 
     zeroOf(true);  // false
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 143, 104))
 
     zeroOf(n);  // 0
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->n : Symbol(n, Decl(conditionalTypes1.ts, 142, 31))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 143, 104))
+>n : Symbol(n, Decl(conditionalTypes1.ts, 149, 31))
 
     zeroOf(b);  // False
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->b : Symbol(b, Decl(conditionalTypes1.ts, 142, 41))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 143, 104))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 149, 41))
 
     zeroOf(x);  // 0 | false
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->x : Symbol(x, Decl(conditionalTypes1.ts, 142, 53))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 143, 104))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 149, 53))
 
     zeroOf(y);  // ZeroOf<T>
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->y : Symbol(y, Decl(conditionalTypes1.ts, 142, 74))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 143, 104))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 149, 74))
 }
 
 function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
->f21 : Symbol(f21, Decl(conditionalTypes1.ts, 150, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 152, 13))
->x : Symbol(x, Decl(conditionalTypes1.ts, 152, 40))
->T : Symbol(T, Decl(conditionalTypes1.ts, 152, 13))
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
->ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 134, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 152, 13))
+>f21 : Symbol(f21, Decl(conditionalTypes1.ts, 157, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 159, 13))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 159, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 159, 13))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 159, 45))
+>ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 141, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 159, 13))
 
     let z1: number | string = y;
->z1 : Symbol(z1, Decl(conditionalTypes1.ts, 153, 7))
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
+>z1 : Symbol(z1, Decl(conditionalTypes1.ts, 160, 7))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 159, 45))
 
     let z2: 0 | "" = y;
->z2 : Symbol(z2, Decl(conditionalTypes1.ts, 154, 7))
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
+>z2 : Symbol(z2, Decl(conditionalTypes1.ts, 161, 7))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 159, 45))
 
     x = y;  // Error
->x : Symbol(x, Decl(conditionalTypes1.ts, 152, 40))
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 159, 40))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 159, 45))
 
     y = x;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
->x : Symbol(x, Decl(conditionalTypes1.ts, 152, 40))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 159, 45))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 159, 40))
 }
 
 type Extends<T, U> = T extends U ? true : false;
->Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 157, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 159, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 159, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 159, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 159, 15))
+>Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 164, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 166, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 166, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 166, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 166, 15))
 
 type If<C extends boolean, T, F> = C extends true ? T : F;
->If : Symbol(If, Decl(conditionalTypes1.ts, 159, 48))
->C : Symbol(C, Decl(conditionalTypes1.ts, 160, 8))
->T : Symbol(T, Decl(conditionalTypes1.ts, 160, 26))
->F : Symbol(F, Decl(conditionalTypes1.ts, 160, 29))
->C : Symbol(C, Decl(conditionalTypes1.ts, 160, 8))
->T : Symbol(T, Decl(conditionalTypes1.ts, 160, 26))
->F : Symbol(F, Decl(conditionalTypes1.ts, 160, 29))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 167, 8))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 167, 26))
+>F : Symbol(F, Decl(conditionalTypes1.ts, 167, 29))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 167, 8))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 167, 26))
+>F : Symbol(F, Decl(conditionalTypes1.ts, 167, 29))
 
 type Not<C extends boolean> = If<C, false, true>;
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 160, 58))
->C : Symbol(C, Decl(conditionalTypes1.ts, 161, 9))
->If : Symbol(If, Decl(conditionalTypes1.ts, 159, 48))
->C : Symbol(C, Decl(conditionalTypes1.ts, 161, 9))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 168, 9))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 168, 9))
 
 type And<A extends boolean, B extends boolean> = If<A, B, false>;
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
->A : Symbol(A, Decl(conditionalTypes1.ts, 162, 9))
->B : Symbol(B, Decl(conditionalTypes1.ts, 162, 27))
->If : Symbol(If, Decl(conditionalTypes1.ts, 159, 48))
->A : Symbol(A, Decl(conditionalTypes1.ts, 162, 9))
->B : Symbol(B, Decl(conditionalTypes1.ts, 162, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 169, 9))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 169, 27))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 169, 9))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 169, 27))
 
 type Or<A extends boolean, B extends boolean> = If<A, true, B>;
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
->A : Symbol(A, Decl(conditionalTypes1.ts, 163, 8))
->B : Symbol(B, Decl(conditionalTypes1.ts, 163, 26))
->If : Symbol(If, Decl(conditionalTypes1.ts, 159, 48))
->A : Symbol(A, Decl(conditionalTypes1.ts, 163, 8))
->B : Symbol(B, Decl(conditionalTypes1.ts, 163, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 170, 8))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 170, 26))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 170, 8))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 170, 26))
 
 type IsString<T> = Extends<T, string>;
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 165, 14))
->Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 157, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 165, 14))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 172, 14))
+>Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 164, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 172, 14))
 
 type Q1 = IsString<number>;  // false
->Q1 : Symbol(Q1, Decl(conditionalTypes1.ts, 165, 38))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
+>Q1 : Symbol(Q1, Decl(conditionalTypes1.ts, 172, 38))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
 
 type Q2 = IsString<"abc">;  // true
->Q2 : Symbol(Q2, Decl(conditionalTypes1.ts, 167, 27))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
+>Q2 : Symbol(Q2, Decl(conditionalTypes1.ts, 174, 27))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
 
 type Q3 = IsString<any>;  // boolean
->Q3 : Symbol(Q3, Decl(conditionalTypes1.ts, 168, 26))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
+>Q3 : Symbol(Q3, Decl(conditionalTypes1.ts, 175, 26))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
 
 type Q4 = IsString<never>;  // boolean
->Q4 : Symbol(Q4, Decl(conditionalTypes1.ts, 169, 24))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
+>Q4 : Symbol(Q4, Decl(conditionalTypes1.ts, 176, 24))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
 
 type N1 = Not<false>;  // true
->N1 : Symbol(N1, Decl(conditionalTypes1.ts, 170, 26))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 160, 58))
+>N1 : Symbol(N1, Decl(conditionalTypes1.ts, 177, 26))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
 
 type N2 = Not<true>;  // false
->N2 : Symbol(N2, Decl(conditionalTypes1.ts, 172, 21))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 160, 58))
+>N2 : Symbol(N2, Decl(conditionalTypes1.ts, 179, 21))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
 
 type N3 = Not<boolean>;  // boolean
->N3 : Symbol(N3, Decl(conditionalTypes1.ts, 173, 20))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 160, 58))
+>N3 : Symbol(N3, Decl(conditionalTypes1.ts, 180, 20))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
 
 type A1 = And<false, false>;  // false
->A1 : Symbol(A1, Decl(conditionalTypes1.ts, 174, 23))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A1 : Symbol(A1, Decl(conditionalTypes1.ts, 181, 23))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A2 = And<false, true>;  // false
->A2 : Symbol(A2, Decl(conditionalTypes1.ts, 176, 28))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A2 : Symbol(A2, Decl(conditionalTypes1.ts, 183, 28))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A3 = And<true, false>;  // false
->A3 : Symbol(A3, Decl(conditionalTypes1.ts, 177, 27))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A3 : Symbol(A3, Decl(conditionalTypes1.ts, 184, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A4 = And<true, true>;  // true
->A4 : Symbol(A4, Decl(conditionalTypes1.ts, 178, 27))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A4 : Symbol(A4, Decl(conditionalTypes1.ts, 185, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A5 = And<boolean, false>;  // false
->A5 : Symbol(A5, Decl(conditionalTypes1.ts, 179, 26))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A5 : Symbol(A5, Decl(conditionalTypes1.ts, 186, 26))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A6 = And<false, boolean>;  // false
->A6 : Symbol(A6, Decl(conditionalTypes1.ts, 180, 30))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A6 : Symbol(A6, Decl(conditionalTypes1.ts, 187, 30))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A7 = And<boolean, true>;  // boolean
->A7 : Symbol(A7, Decl(conditionalTypes1.ts, 181, 30))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A7 : Symbol(A7, Decl(conditionalTypes1.ts, 188, 30))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A8 = And<true, boolean>;  // boolean
->A8 : Symbol(A8, Decl(conditionalTypes1.ts, 182, 29))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A8 : Symbol(A8, Decl(conditionalTypes1.ts, 189, 29))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A9 = And<boolean, boolean>;  // boolean
->A9 : Symbol(A9, Decl(conditionalTypes1.ts, 183, 29))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A9 : Symbol(A9, Decl(conditionalTypes1.ts, 190, 29))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type O1 = Or<false, false>;  // false
->O1 : Symbol(O1, Decl(conditionalTypes1.ts, 184, 32))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O1 : Symbol(O1, Decl(conditionalTypes1.ts, 191, 32))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O2 = Or<false, true>;  // true
->O2 : Symbol(O2, Decl(conditionalTypes1.ts, 186, 27))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O2 : Symbol(O2, Decl(conditionalTypes1.ts, 193, 27))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O3 = Or<true, false>;  // true
->O3 : Symbol(O3, Decl(conditionalTypes1.ts, 187, 26))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O3 : Symbol(O3, Decl(conditionalTypes1.ts, 194, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O4 = Or<true, true>;  // true
->O4 : Symbol(O4, Decl(conditionalTypes1.ts, 188, 26))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O4 : Symbol(O4, Decl(conditionalTypes1.ts, 195, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O5 = Or<boolean, false>;  // boolean
->O5 : Symbol(O5, Decl(conditionalTypes1.ts, 189, 25))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O5 : Symbol(O5, Decl(conditionalTypes1.ts, 196, 25))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O6 = Or<false, boolean>;  // boolean
->O6 : Symbol(O6, Decl(conditionalTypes1.ts, 190, 29))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O6 : Symbol(O6, Decl(conditionalTypes1.ts, 197, 29))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O7 = Or<boolean, true>;  // true
->O7 : Symbol(O7, Decl(conditionalTypes1.ts, 191, 29))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O7 : Symbol(O7, Decl(conditionalTypes1.ts, 198, 29))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O8 = Or<true, boolean>;  // true
->O8 : Symbol(O8, Decl(conditionalTypes1.ts, 192, 28))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O8 : Symbol(O8, Decl(conditionalTypes1.ts, 199, 28))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O9 = Or<boolean, boolean>;  // boolean
->O9 : Symbol(O9, Decl(conditionalTypes1.ts, 193, 28))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O9 : Symbol(O9, Decl(conditionalTypes1.ts, 200, 28))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type T40 = never extends never ? true : false;  // true
->T40 : Symbol(T40, Decl(conditionalTypes1.ts, 194, 31))
+>T40 : Symbol(T40, Decl(conditionalTypes1.ts, 201, 31))
 
 type T41 = number extends never ? true : false;  // false
->T41 : Symbol(T41, Decl(conditionalTypes1.ts, 196, 46))
+>T41 : Symbol(T41, Decl(conditionalTypes1.ts, 203, 46))
 
 type T42 = never extends number ? true : false;  // boolean
->T42 : Symbol(T42, Decl(conditionalTypes1.ts, 197, 47))
+>T42 : Symbol(T42, Decl(conditionalTypes1.ts, 204, 47))
 
 type IsNever<T> = T extends never ? true : false;
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 198, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 200, 13))
->T : Symbol(T, Decl(conditionalTypes1.ts, 200, 13))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 207, 13))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 207, 13))
 
 type T50 = IsNever<never>;  // true
->T50 : Symbol(T50, Decl(conditionalTypes1.ts, 200, 49))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 198, 47))
+>T50 : Symbol(T50, Decl(conditionalTypes1.ts, 207, 49))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
 
 type T51 = IsNever<number>;  // false
->T51 : Symbol(T51, Decl(conditionalTypes1.ts, 202, 26))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 198, 47))
+>T51 : Symbol(T51, Decl(conditionalTypes1.ts, 209, 26))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
 
 type T52 = IsNever<any>;  // false
->T52 : Symbol(T52, Decl(conditionalTypes1.ts, 203, 27))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 198, 47))
+>T52 : Symbol(T52, Decl(conditionalTypes1.ts, 210, 27))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
 
 // Repros from #21664
 
 type Eq<T, U> = T extends U ? U extends T ? true : false : false;
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 208, 8))
->U : Symbol(U, Decl(conditionalTypes1.ts, 208, 10))
->T : Symbol(T, Decl(conditionalTypes1.ts, 208, 8))
->U : Symbol(U, Decl(conditionalTypes1.ts, 208, 10))
->U : Symbol(U, Decl(conditionalTypes1.ts, 208, 10))
->T : Symbol(T, Decl(conditionalTypes1.ts, 208, 8))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
 
 type T60 = Eq<true, true>;  // true
->T60 : Symbol(T60, Decl(conditionalTypes1.ts, 208, 65))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
+>T60 : Symbol(T60, Decl(conditionalTypes1.ts, 215, 65))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
 
 type T61 = Eq<true, false>;  // false
->T61 : Symbol(T61, Decl(conditionalTypes1.ts, 209, 26))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
+>T61 : Symbol(T61, Decl(conditionalTypes1.ts, 216, 26))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
 
 type T62 = Eq<false, true>;  // false
->T62 : Symbol(T62, Decl(conditionalTypes1.ts, 210, 27))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
+>T62 : Symbol(T62, Decl(conditionalTypes1.ts, 217, 27))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
 
 type T63 = Eq<false, false>;  // true
->T63 : Symbol(T63, Decl(conditionalTypes1.ts, 211, 27))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
+>T63 : Symbol(T63, Decl(conditionalTypes1.ts, 218, 27))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
 
 type Eq1<T, U> = Eq<T, U> extends false ? false : true;
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
->T : Symbol(T, Decl(conditionalTypes1.ts, 214, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 214, 11))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 214, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 214, 11))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 221, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 221, 11))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 221, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 221, 11))
 
 type T70 = Eq1<true, true>;  // true
->T70 : Symbol(T70, Decl(conditionalTypes1.ts, 214, 55))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
+>T70 : Symbol(T70, Decl(conditionalTypes1.ts, 221, 55))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
 
 type T71 = Eq1<true, false>;  // false
->T71 : Symbol(T71, Decl(conditionalTypes1.ts, 215, 27))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
+>T71 : Symbol(T71, Decl(conditionalTypes1.ts, 222, 27))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
 
 type T72 = Eq1<false, true>;  // false
->T72 : Symbol(T72, Decl(conditionalTypes1.ts, 216, 28))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
+>T72 : Symbol(T72, Decl(conditionalTypes1.ts, 223, 28))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
 
 type T73 = Eq1<false, false>;  // true
->T73 : Symbol(T73, Decl(conditionalTypes1.ts, 217, 28))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
+>T73 : Symbol(T73, Decl(conditionalTypes1.ts, 224, 28))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
 
 type Eq2<T, U> = Eq<T, U> extends true ? true : false;
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 220, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 220, 11))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 220, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 220, 11))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 227, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 227, 11))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 227, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 227, 11))
 
 type T80 = Eq2<true, true>;  // true
->T80 : Symbol(T80, Decl(conditionalTypes1.ts, 220, 54))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
+>T80 : Symbol(T80, Decl(conditionalTypes1.ts, 227, 54))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
 
 type T81 = Eq2<true, false>;  // false
->T81 : Symbol(T81, Decl(conditionalTypes1.ts, 221, 27))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
+>T81 : Symbol(T81, Decl(conditionalTypes1.ts, 228, 27))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
 
 type T82 = Eq2<false, true>;  // false
->T82 : Symbol(T82, Decl(conditionalTypes1.ts, 222, 28))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
+>T82 : Symbol(T82, Decl(conditionalTypes1.ts, 229, 28))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
 
 type T83 = Eq2<false, false>;  // true
->T83 : Symbol(T83, Decl(conditionalTypes1.ts, 223, 28))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
+>T83 : Symbol(T83, Decl(conditionalTypes1.ts, 230, 28))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
 
 // Repro from #21756
 
 type Foo<T> = T extends string ? boolean : number;
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 228, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 228, 9))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 235, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 235, 9))
 
 type Bar<T> = T extends string ? boolean : number;
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 228, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 229, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 229, 9))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 236, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 236, 9))
 
 const convert = <U>(value: Foo<U>): Bar<U> => value;
->convert : Symbol(convert, Decl(conditionalTypes1.ts, 230, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 230, 17))
->value : Symbol(value, Decl(conditionalTypes1.ts, 230, 20))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->U : Symbol(U, Decl(conditionalTypes1.ts, 230, 17))
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 228, 50))
->U : Symbol(U, Decl(conditionalTypes1.ts, 230, 17))
->value : Symbol(value, Decl(conditionalTypes1.ts, 230, 20))
+>convert : Symbol(convert, Decl(conditionalTypes1.ts, 237, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 237, 20))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 237, 20))
 
 type Baz<T> = Foo<T>;
->Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 230, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 232, 9))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 232, 9))
+>Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 237, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 239, 9))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 239, 9))
 
 const convert2 = <T>(value: Foo<T>): Baz<T> => value;
->convert2 : Symbol(convert2, Decl(conditionalTypes1.ts, 233, 5))
->T : Symbol(T, Decl(conditionalTypes1.ts, 233, 18))
->value : Symbol(value, Decl(conditionalTypes1.ts, 233, 21))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 233, 18))
->Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 230, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 233, 18))
->value : Symbol(value, Decl(conditionalTypes1.ts, 233, 21))
+>convert2 : Symbol(convert2, Decl(conditionalTypes1.ts, 240, 5))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 240, 21))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
+>Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 237, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 240, 21))
 
 function f31<T>() {
->f31 : Symbol(f31, Decl(conditionalTypes1.ts, 233, 53))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 13))
+>f31 : Symbol(f31, Decl(conditionalTypes1.ts, 240, 53))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
 
     type T1 = T extends string ? boolean : number;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 235, 19))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 13))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 19))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
 
     type T2 = T extends string ? boolean : number;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 236, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 13))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
 
     var x: T1;
->x : Symbol(x, Decl(conditionalTypes1.ts, 238, 7), Decl(conditionalTypes1.ts, 239, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 235, 19))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 19))
 
     var x: T2;
->x : Symbol(x, Decl(conditionalTypes1.ts, 238, 7), Decl(conditionalTypes1.ts, 239, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 236, 50))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 50))
 }
 
 function f32<T, U>() {
->f32 : Symbol(f32, Decl(conditionalTypes1.ts, 240, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 242, 15))
+>f32 : Symbol(f32, Decl(conditionalTypes1.ts, 247, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
 
     type T1 = T & U extends string ? boolean : number;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 22))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 242, 15))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
 
     type T2 = Foo<T & U>;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 54))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 242, 15))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 54))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
 
     var z: T1;
->z : Symbol(z, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 22))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
 
     var z: T2;  // Error, T2 is distributive, T1 isn't
->z : Symbol(z, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 54))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 54))
 }
 
 function f33<T, U>() {
->f33 : Symbol(f33, Decl(conditionalTypes1.ts, 247, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>f33 : Symbol(f33, Decl(conditionalTypes1.ts, 254, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
 
     type T1 = Foo<T & U>;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 256, 22))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
 
     type T2 = Bar<T & U>;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 25))
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 228, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 257, 25))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
 
     var z: T1;
->z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 259, 7), Decl(conditionalTypes1.ts, 260, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 256, 22))
 
     var z: T2;
->z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 25))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 259, 7), Decl(conditionalTypes1.ts, 260, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 257, 25))
 }
+
+// Repro from #21823
+
+type T90<T> = T extends 0 ? 0 : () => 0;
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 265, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 265, 9))
+
+type T91<T> = T extends 0 ? 0 : () => 0;
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
+
+const f40 = <U>(a: T90<U>): T91<U> => a;
+>f40 : Symbol(f40, Decl(conditionalTypes1.ts, 267, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 267, 16))
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 267, 16))
+
+const f41 = <U>(a: T91<U>): T90<U> => a;
+>f41 : Symbol(f41, Decl(conditionalTypes1.ts, 268, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
+
+type T92<T> = T extends () => 0 ? () => 1 : () => 2;
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 270, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 270, 9))
+
+type T93<T> = T extends () => 0 ? () => 1 : () => 2;
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
+
+const f42 = <U>(a: T92<U>): T93<U> => a;
+>f42 : Symbol(f42, Decl(conditionalTypes1.ts, 272, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 272, 16))
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 272, 16))
+
+const f43 = <U>(a: T93<U>): T92<U> => a;
+>f43 : Symbol(f43, Decl(conditionalTypes1.ts, 273, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 273, 16))
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 273, 16))
+
+type T94<T> = T extends string ? true : 42;
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 275, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 275, 9))
+
+type T95<T> = T extends string ? boolean : number;
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 276, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 276, 9))
+
+const f44 = <U>(value: T94<U>): T95<U> => value;
+>f44 : Symbol(f44, Decl(conditionalTypes1.ts, 277, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 277, 16))
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 277, 16))
+
+const f45 = <U>(value: T95<U>): T94<U> => value;  // Error
+>f45 : Symbol(f45, Decl(conditionalTypes1.ts, 278, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 278, 16))
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 278, 16))
 

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -121,6 +121,35 @@ function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) {
 >x : Partial<T>[keyof T]
 }
 
+function f4<T extends { x: string | undefined }>(x: T["x"], y: NonNullable<T["x"]>) {
+>f4 : <T extends { x: string | undefined; }>(x: T["x"], y: Diff<T["x"], null | undefined>) => void
+>T : T
+>x : string | undefined
+>x : T["x"]
+>T : T
+>y : Diff<T["x"], null | undefined>
+>NonNullable : Diff<T, null | undefined>
+>T : T
+
+    x = y;
+>x = y : Diff<T["x"], null | undefined>
+>x : T["x"]
+>y : Diff<T["x"], null | undefined>
+
+    y = x;  // Error
+>y = x : T["x"]
+>y : Diff<T["x"], null | undefined>
+>x : T["x"]
+
+    let s1: string = x;  // Error
+>s1 : string
+>x : T["x"]
+
+    let s2: string = y;
+>s2 : string
+>y : Diff<T["x"], null | undefined>
+}
+
 type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
 >Options : Options
 >k : "a"
@@ -168,8 +197,8 @@ type T15 = Filter<Options, { q: "a" }>;  // never
 >Options : Options
 >q : "a"
 
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
->f4 : <T extends Options, K extends string>(p: K) => Filter<T, { k: K; }>
+declare function f5<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
+>f5 : <T extends Options, K extends string>(p: K) => Filter<T, { k: K; }>
 >T : T
 >Options : Options
 >K : K
@@ -180,10 +209,10 @@ declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K
 >k : K
 >K : K
 
-let x0 = f4("a");  // { k: "a", a: number }
+let x0 = f5("a");  // { k: "a", a: number }
 >x0 : { k: "a"; a: number; }
->f4("a") : { k: "a"; a: number; }
->f4 : <T extends Options, K extends string>(p: K) => Filter<T, { k: K; }>
+>f5("a") : { k: "a"; a: number; }
+>f5 : <T extends Options, K extends string>(p: K) => Filter<T, { k: K; }>
 >"a" : "a"
 
 type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
@@ -1102,4 +1131,103 @@ function f33<T, U>() {
 >z : Foo<T & U>
 >T2 : Foo<T & U>
 }
+
+// Repro from #21823
+
+type T90<T> = T extends 0 ? 0 : () => 0;
+>T90 : T90<T>
+>T : T
+>T : T
+
+type T91<T> = T extends 0 ? 0 : () => 0;
+>T91 : T91<T>
+>T : T
+>T : T
+
+const f40 = <U>(a: T90<U>): T91<U> => a;
+>f40 : <U>(a: T90<U>) => T91<U>
+><U>(a: T90<U>): T91<U> => a : <U>(a: T90<U>) => T91<U>
+>U : U
+>a : T90<U>
+>T90 : T90<T>
+>U : U
+>T91 : T91<T>
+>U : U
+>a : T90<U>
+
+const f41 = <U>(a: T91<U>): T90<U> => a;
+>f41 : <U>(a: T91<U>) => T90<U>
+><U>(a: T91<U>): T90<U> => a : <U>(a: T91<U>) => T90<U>
+>U : U
+>a : T91<U>
+>T91 : T91<T>
+>U : U
+>T90 : T90<T>
+>U : U
+>a : T91<U>
+
+type T92<T> = T extends () => 0 ? () => 1 : () => 2;
+>T92 : T92<T>
+>T : T
+>T : T
+
+type T93<T> = T extends () => 0 ? () => 1 : () => 2;
+>T93 : T93<T>
+>T : T
+>T : T
+
+const f42 = <U>(a: T92<U>): T93<U> => a;
+>f42 : <U>(a: T92<U>) => T93<U>
+><U>(a: T92<U>): T93<U> => a : <U>(a: T92<U>) => T93<U>
+>U : U
+>a : T92<U>
+>T92 : T92<T>
+>U : U
+>T93 : T93<T>
+>U : U
+>a : T92<U>
+
+const f43 = <U>(a: T93<U>): T92<U> => a;
+>f43 : <U>(a: T93<U>) => T92<U>
+><U>(a: T93<U>): T92<U> => a : <U>(a: T93<U>) => T92<U>
+>U : U
+>a : T93<U>
+>T93 : T93<T>
+>U : U
+>T92 : T92<T>
+>U : U
+>a : T93<U>
+
+type T94<T> = T extends string ? true : 42;
+>T94 : T94<T>
+>T : T
+>T : T
+>true : true
+
+type T95<T> = T extends string ? boolean : number;
+>T95 : T95<T>
+>T : T
+>T : T
+
+const f44 = <U>(value: T94<U>): T95<U> => value;
+>f44 : <U>(value: T94<U>) => T95<U>
+><U>(value: T94<U>): T95<U> => value : <U>(value: T94<U>) => T95<U>
+>U : U
+>value : T94<U>
+>T94 : T94<T>
+>U : U
+>T95 : T95<T>
+>U : U
+>value : T94<U>
+
+const f45 = <U>(value: T95<U>): T94<U> => value;  // Error
+>f45 : <U>(value: T95<U>) => T94<U>
+><U>(value: T95<U>): T94<U> => value : <U>(value: T95<U>) => T94<U>
+>U : U
+>value : T95<U>
+>T95 : T95<T>
+>U : U
+>T94 : T94<T>
+>U : U
+>value : T95<U>
 

--- a/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes1.ts
@@ -31,6 +31,13 @@ function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) {
     y = x;  // Error
 }
 
+function f4<T extends { x: string | undefined }>(x: T["x"], y: NonNullable<T["x"]>) {
+    x = y;
+    y = x;  // Error
+    let s1: string = x;  // Error
+    let s2: string = y;
+}
+
 type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
 
 type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
@@ -42,8 +49,8 @@ type T13 = Filter<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } |
 type T14 = Diff<Options, { q: "a" }>;  // Options
 type T15 = Filter<Options, { q: "a" }>;  // never
 
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
-let x0 = f4("a");  // { k: "a", a: number }
+declare function f5<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
+let x0 = f5("a");  // { k: "a", a: number }
 
 type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
 
@@ -256,3 +263,20 @@ function f33<T, U>() {
     var z: T1;
     var z: T2;
 }
+
+// Repro from #21823
+
+type T90<T> = T extends 0 ? 0 : () => 0;
+type T91<T> = T extends 0 ? 0 : () => 0;
+const f40 = <U>(a: T90<U>): T91<U> => a;
+const f41 = <U>(a: T91<U>): T90<U> => a;
+
+type T92<T> = T extends () => 0 ? () => 1 : () => 2;
+type T93<T> = T extends () => 0 ? () => 1 : () => 2;
+const f42 = <U>(a: T92<U>): T93<U> => a;
+const f43 = <U>(a: T93<U>): T92<U> => a;
+
+type T94<T> = T extends string ? true : 42;
+type T95<T> = T extends string ? boolean : number;
+const f44 = <U>(value: T94<U>): T95<U> => value;
+const f45 = <U>(value: T95<U>): T94<U> => value;  // Error


### PR DESCRIPTION
This PR adds several missing structural identity relations for higher order types, specifically index types, indexed access types, conditional types, and substitution types. Previously we'd only consider such types identical when they have the same object identity, now we properly check their constituents for structural identity.

This PR also more consistently handles distributive conditional types.

Finally, the PR introduces a new type relation: A conditional type `X extends Y ? S1 : S2` is related to a conditional type `X extends Y ? T1 : T2` if `S1` is related to `T1` and `S2` is related to `T2`. In other words, two conditional types with identical conditions are related if their true and false branch types are pairwise related.

Fixes #21823.