### PR TITLE
Predefined conditional types

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1339,6 +1339,31 @@ type Record<K extends string, T> = {
 };
 
 /**
+ * Exclude from T those types that are assignable to U
+ */
+type Exclude<T, U> = T extends U ? never : T;
+
+/**
+ * Extract from T those types that are assignable to U
+ */
+type Extract<T, U> = T extends U ? T : never;
+
+/**
+ * Exclude null and undefined from T
+ */
+type NonNullable<T> = T extends null | undefined ? never : T;
+
+/**
+ * Obtain the return type of a function type
+ */
+type ReturnType<T extends (...args: any[]) => any> = T extends (...args: any[]) => infer R ? R : any;
+
+/**
+ * Obtain the return type of a constructor function type
+ */
+type InstanceType<T extends new (...args: any[]) => any> = T extends new (...args: any[]) => infer R ? R : any;
+
+/**
  * Marker for contextual 'this' type
  */
 interface ThisType<T> { }

--- a/tests/baselines/reference/conditionalTypes1.errors.txt
+++ b/tests/baselines/reference/conditionalTypes1.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(16,5): error TS2322: Type 'T' is not assignable to type 'Diff<T, null | undefined>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(21,5): error TS2322: Type 'T' is not assignable to type 'Diff<T, null | undefined>'.
-  Type 'string | undefined' is not assignable to type 'Diff<T, null | undefined>'.
-    Type 'undefined' is not assignable to type 'Diff<T, null | undefined>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(22,9): error TS2322: Type 'T' is not assignable to type 'string'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(12,5): error TS2322: Type 'T' is not assignable to type 'NonNullable<T>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(17,5): error TS2322: Type 'T' is not assignable to type 'NonNullable<T>'.
+  Type 'string | undefined' is not assignable to type 'NonNullable<T>'.
+    Type 'undefined' is not assignable to type 'NonNullable<T>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(18,9): error TS2322: Type 'T' is not assignable to type 'string'.
   Type 'string | undefined' is not assignable to type 'string'.
     Type 'undefined' is not assignable to type 'string'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(28,5): error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
-  Type 'T[keyof T] | undefined' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
-    Type 'undefined' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(100,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(101,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(103,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(24,5): error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+  Type 'T[keyof T] | undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+    Type 'undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(96,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'T'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(97,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'T'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(99,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>'.
   Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
     Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
       Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
@@ -19,7 +19,7 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(103,5): error TS2
             Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
               Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
                 Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(105,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(101,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
   Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
     Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
       Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
@@ -28,49 +28,45 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(105,5): error TS2
             Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
               Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
                 Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(111,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(107,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
   Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(112,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(108,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
   Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
     Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
       Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
         Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
           Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
             Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(113,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(109,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
   Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(114,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(110,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
   Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
     Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
       Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
         Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
           Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
             Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(131,10): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(132,5): error TS2542: Index signature in type 'DeepReadonlyArray<Part>' only permits reading.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(133,22): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(134,10): error TS2339: Property 'updatePart' does not exist on type 'DeepReadonlyObject<Part>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(156,5): error TS2322: Type 'ZeroOf<T>' is not assignable to type 'T'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(127,10): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(128,5): error TS2542: Index signature in type 'DeepReadonlyArray<Part>' only permits reading.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(129,22): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(130,10): error TS2339: Property 'updatePart' does not exist on type 'DeepReadonlyObject<Part>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(152,5): error TS2322: Type 'ZeroOf<T>' is not assignable to type 'T'.
   Type '0 | (T extends string ? "" : false)' is not assignable to type 'T'.
     Type '0' is not assignable to type 'T'.
       Type '"" | 0' is not assignable to type 'T'.
         Type '""' is not assignable to type 'T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(157,5): error TS2322: Type 'T' is not assignable to type 'ZeroOf<T>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(153,5): error TS2322: Type 'T' is not assignable to type 'ZeroOf<T>'.
   Type 'string | number' is not assignable to type 'ZeroOf<T>'.
     Type 'string' is not assignable to type 'ZeroOf<T>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'z' must be of type 'T1', but here has type 'Foo<T & U>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(243,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'z' must be of type 'T1', but here has type 'Foo<T & U>'.
 
 
 ==== tests/cases/conformance/types/conditional/conditionalTypes1.ts (19 errors) ====
-    type Diff<T, U> = T extends U ? never : T;
-    type Filter<T, U> = T extends U ? T : never;
-    type NonNullable<T> = Diff<T, null | undefined>;
+    type T00 = Exclude<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
+    type T01 = Extract<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
     
-    type T00 = Diff<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
-    type T01 = Filter<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
-    
-    type T02 = Diff<string | number | (() => void), Function>;  // string | number
-    type T03 = Filter<string | number | (() => void), Function>;  // () => void
+    type T02 = Exclude<string | number | (() => void), Function>;  // string | number
+    type T03 = Extract<string | number | (() => void), Function>;  // () => void
     
     type T04 = NonNullable<string | number | undefined>;  // string | number
     type T05 = NonNullable<(() => string) | string[] | null | undefined>;  // (() => string) | string[]
@@ -79,16 +75,16 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
         x = y;
         y = x;  // Error
         ~
-!!! error TS2322: Type 'T' is not assignable to type 'Diff<T, null | undefined>'.
+!!! error TS2322: Type 'T' is not assignable to type 'NonNullable<T>'.
     }
     
     function f2<T extends string | undefined>(x: T, y: NonNullable<T>) {
         x = y;
         y = x;  // Error
         ~
-!!! error TS2322: Type 'T' is not assignable to type 'Diff<T, null | undefined>'.
-!!! error TS2322:   Type 'string | undefined' is not assignable to type 'Diff<T, null | undefined>'.
-!!! error TS2322:     Type 'undefined' is not assignable to type 'Diff<T, null | undefined>'.
+!!! error TS2322: Type 'T' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:   Type 'string | undefined' is not assignable to type 'NonNullable<T>'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'NonNullable<T>'.
         let s1: string = x;  // Error
             ~~
 !!! error TS2322: Type 'T' is not assignable to type 'string'.
@@ -101,30 +97,30 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(247,9): error TS2
         x = y;
         y = x;  // Error
         ~
-!!! error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
-!!! error TS2322:   Type 'T[keyof T] | undefined' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
-!!! error TS2322:     Type 'undefined' is not assignable to type 'Diff<Partial<T>[keyof T], null | undefined>'.
+!!! error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+!!! error TS2322:   Type 'T[keyof T] | undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
     }
     
     type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
     
-    type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
-    type T11 = Filter<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+    type T10 = Exclude<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
+    type T11 = Extract<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
     
-    type T12 = Diff<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
-    type T13 = Filter<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+    type T12 = Exclude<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
+    type T13 = Extract<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
     
-    type T14 = Diff<Options, { q: "a" }>;  // Options
-    type T15 = Filter<Options, { q: "a" }>;  // never
+    type T14 = Exclude<Options, { q: "a" }>;  // Options
+    type T15 = Extract<Options, { q: "a" }>;  // never
     
-    declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
+    declare function f4<T extends Options, K extends string>(p: K): Extract<T, { k: K }>;
     let x0 = f4("a");  // { k: "a", a: number }
     
-    type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
+    type OptionsOfKind<K extends Options["k"]> = Extract<Options, { k: K }>;
     
     type T16 = OptionsOfKind<"a" | "b">;  // { k: "a", a: number } | { k: "b", b: string }
     
-    type Select<T, K extends keyof T, V extends T[K]> = Filter<T, { [P in K]: V }>;
+    type Select<T, K extends keyof T, V extends T[K]> = Extract<T, { [P in K]: V }>;
     
     type T17 = Select<Options, "k", "a" | "b">;  // // { k: "a", a: number } | { k: "b", b: string }
     

--- a/tests/baselines/reference/conditionalTypes1.js
+++ b/tests/baselines/reference/conditionalTypes1.js
@@ -1,13 +1,9 @@
 //// [conditionalTypes1.ts]
-type Diff<T, U> = T extends U ? never : T;
-type Filter<T, U> = T extends U ? T : never;
-type NonNullable<T> = Diff<T, null | undefined>;
+type T00 = Exclude<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
+type T01 = Extract<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
 
-type T00 = Diff<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
-type T01 = Filter<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
-
-type T02 = Diff<string | number | (() => void), Function>;  // string | number
-type T03 = Filter<string | number | (() => void), Function>;  // () => void
+type T02 = Exclude<string | number | (() => void), Function>;  // string | number
+type T03 = Extract<string | number | (() => void), Function>;  // () => void
 
 type T04 = NonNullable<string | number | undefined>;  // string | number
 type T05 = NonNullable<(() => string) | string[] | null | undefined>;  // (() => string) | string[]
@@ -31,23 +27,23 @@ function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) {
 
 type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
 
-type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
-type T11 = Filter<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+type T10 = Exclude<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
+type T11 = Extract<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
 
-type T12 = Diff<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
-type T13 = Filter<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+type T12 = Exclude<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
+type T13 = Extract<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
 
-type T14 = Diff<Options, { q: "a" }>;  // Options
-type T15 = Filter<Options, { q: "a" }>;  // never
+type T14 = Exclude<Options, { q: "a" }>;  // Options
+type T15 = Extract<Options, { q: "a" }>;  // never
 
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
+declare function f4<T extends Options, K extends string>(p: K): Extract<T, { k: K }>;
 let x0 = f4("a");  // { k: "a", a: number }
 
-type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
+type OptionsOfKind<K extends Options["k"]> = Extract<Options, { k: K }>;
 
 type T16 = OptionsOfKind<"a" | "b">;  // { k: "a", a: number } | { k: "b", b: string }
 
-type Select<T, K extends keyof T, V extends T[K]> = Filter<T, { [P in K]: V }>;
+type Select<T, K extends keyof T, V extends T[K]> = Extract<T, { [P in K]: V }>;
 
 type T17 = Select<Options, "k", "a" | "b">;  // // { k: "a", a: number } | { k: "b", b: string }
 
@@ -332,13 +328,10 @@ function f33() {
 
 
 //// [conditionalTypes1.d.ts]
-declare type Diff<T, U> = T extends U ? never : T;
-declare type Filter<T, U> = T extends U ? T : never;
-declare type NonNullable<T> = Diff<T, null | undefined>;
-declare type T00 = Diff<"a" | "b" | "c" | "d", "a" | "c" | "f">;
-declare type T01 = Filter<"a" | "b" | "c" | "d", "a" | "c" | "f">;
-declare type T02 = Diff<string | number | (() => void), Function>;
-declare type T03 = Filter<string | number | (() => void), Function>;
+declare type T00 = Exclude<"a" | "b" | "c" | "d", "a" | "c" | "f">;
+declare type T01 = Extract<"a" | "b" | "c" | "d", "a" | "c" | "f">;
+declare type T02 = Exclude<string | number | (() => void), Function>;
+declare type T03 = Extract<string | number | (() => void), Function>;
 declare type T04 = NonNullable<string | number | undefined>;
 declare type T05 = NonNullable<(() => string) | string[] | null | undefined>;
 declare function f1<T>(x: T, y: NonNullable<T>): void;
@@ -354,40 +347,40 @@ declare type Options = {
     k: "c";
     c: boolean;
 };
-declare type T10 = Diff<Options, {
+declare type T10 = Exclude<Options, {
     k: "a" | "b";
 }>;
-declare type T11 = Filter<Options, {
+declare type T11 = Extract<Options, {
     k: "a" | "b";
 }>;
-declare type T12 = Diff<Options, {
+declare type T12 = Exclude<Options, {
     k: "a";
 } | {
     k: "b";
 }>;
-declare type T13 = Filter<Options, {
+declare type T13 = Extract<Options, {
     k: "a";
 } | {
     k: "b";
 }>;
-declare type T14 = Diff<Options, {
+declare type T14 = Exclude<Options, {
     q: "a";
 }>;
-declare type T15 = Filter<Options, {
+declare type T15 = Extract<Options, {
     q: "a";
 }>;
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, {
+declare function f4<T extends Options, K extends string>(p: K): Extract<T, {
     k: K;
 }>;
 declare let x0: {
     k: "a";
     a: number;
 };
-declare type OptionsOfKind<K extends Options["k"]> = Filter<Options, {
+declare type OptionsOfKind<K extends Options["k"]> = Extract<Options, {
     k: K;
 }>;
 declare type T16 = OptionsOfKind<"a" | "b">;
-declare type Select<T, K extends keyof T, V extends T[K]> = Filter<T, {
+declare type Select<T, K extends keyof T, V extends T[K]> = Extract<T, {
     [P in K]: V;
 }>;
 declare type T17 = Select<Options, "k", "a" | "b">;

--- a/tests/baselines/reference/conditionalTypes1.symbols
+++ b/tests/baselines/reference/conditionalTypes1.symbols
@@ -1,964 +1,942 @@
 === tests/cases/conformance/types/conditional/conditionalTypes1.ts ===
-type Diff<T, U> = T extends U ? never : T;
->Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
->T : Symbol(T, Decl(conditionalTypes1.ts, 0, 10))
->U : Symbol(U, Decl(conditionalTypes1.ts, 0, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 0, 10))
->U : Symbol(U, Decl(conditionalTypes1.ts, 0, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 0, 10))
+type T00 = Exclude<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
+>T00 : Symbol(T00, Decl(conditionalTypes1.ts, 0, 0))
+>Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
 
-type Filter<T, U> = T extends U ? T : never;
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->T : Symbol(T, Decl(conditionalTypes1.ts, 1, 12))
->U : Symbol(U, Decl(conditionalTypes1.ts, 1, 14))
->T : Symbol(T, Decl(conditionalTypes1.ts, 1, 12))
->U : Symbol(U, Decl(conditionalTypes1.ts, 1, 14))
->T : Symbol(T, Decl(conditionalTypes1.ts, 1, 12))
+type T01 = Extract<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
+>T01 : Symbol(T01, Decl(conditionalTypes1.ts, 0, 59))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
 
-type NonNullable<T> = Diff<T, null | undefined>;
->NonNullable : Symbol(NonNullable, Decl(conditionalTypes1.ts, 1, 44))
->T : Symbol(T, Decl(conditionalTypes1.ts, 2, 17))
->Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
->T : Symbol(T, Decl(conditionalTypes1.ts, 2, 17))
-
-type T00 = Diff<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
->T00 : Symbol(T00, Decl(conditionalTypes1.ts, 2, 48))
->Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
-
-type T01 = Filter<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
->T01 : Symbol(T01, Decl(conditionalTypes1.ts, 4, 56))
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
-
-type T02 = Diff<string | number | (() => void), Function>;  // string | number
->T02 : Symbol(T02, Decl(conditionalTypes1.ts, 5, 58))
->Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
+type T02 = Exclude<string | number | (() => void), Function>;  // string | number
+>T02 : Symbol(T02, Decl(conditionalTypes1.ts, 1, 59))
+>Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
-type T03 = Filter<string | number | (() => void), Function>;  // () => void
->T03 : Symbol(T03, Decl(conditionalTypes1.ts, 7, 58))
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
+type T03 = Extract<string | number | (() => void), Function>;  // () => void
+>T03 : Symbol(T03, Decl(conditionalTypes1.ts, 3, 61))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 type T04 = NonNullable<string | number | undefined>;  // string | number
->T04 : Symbol(T04, Decl(conditionalTypes1.ts, 8, 60))
->NonNullable : Symbol(NonNullable, Decl(conditionalTypes1.ts, 1, 44))
+>T04 : Symbol(T04, Decl(conditionalTypes1.ts, 4, 61))
+>NonNullable : Symbol(NonNullable, Decl(lib.d.ts, --, --))
 
 type T05 = NonNullable<(() => string) | string[] | null | undefined>;  // (() => string) | string[]
->T05 : Symbol(T05, Decl(conditionalTypes1.ts, 10, 52))
->NonNullable : Symbol(NonNullable, Decl(conditionalTypes1.ts, 1, 44))
+>T05 : Symbol(T05, Decl(conditionalTypes1.ts, 6, 52))
+>NonNullable : Symbol(NonNullable, Decl(lib.d.ts, --, --))
 
 function f1<T>(x: T, y: NonNullable<T>) {
->f1 : Symbol(f1, Decl(conditionalTypes1.ts, 11, 69))
->T : Symbol(T, Decl(conditionalTypes1.ts, 13, 12))
->x : Symbol(x, Decl(conditionalTypes1.ts, 13, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 13, 12))
->y : Symbol(y, Decl(conditionalTypes1.ts, 13, 20))
->NonNullable : Symbol(NonNullable, Decl(conditionalTypes1.ts, 1, 44))
->T : Symbol(T, Decl(conditionalTypes1.ts, 13, 12))
+>f1 : Symbol(f1, Decl(conditionalTypes1.ts, 7, 69))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 9, 12))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 9, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 9, 12))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 9, 20))
+>NonNullable : Symbol(NonNullable, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 9, 12))
 
     x = y;
->x : Symbol(x, Decl(conditionalTypes1.ts, 13, 15))
->y : Symbol(y, Decl(conditionalTypes1.ts, 13, 20))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 9, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 9, 20))
 
     y = x;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 13, 20))
->x : Symbol(x, Decl(conditionalTypes1.ts, 13, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 9, 20))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 9, 15))
 }
 
 function f2<T extends string | undefined>(x: T, y: NonNullable<T>) {
->f2 : Symbol(f2, Decl(conditionalTypes1.ts, 16, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 18, 12))
->x : Symbol(x, Decl(conditionalTypes1.ts, 18, 42))
->T : Symbol(T, Decl(conditionalTypes1.ts, 18, 12))
->y : Symbol(y, Decl(conditionalTypes1.ts, 18, 47))
->NonNullable : Symbol(NonNullable, Decl(conditionalTypes1.ts, 1, 44))
->T : Symbol(T, Decl(conditionalTypes1.ts, 18, 12))
+>f2 : Symbol(f2, Decl(conditionalTypes1.ts, 12, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 14, 12))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 14, 42))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 14, 12))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 14, 47))
+>NonNullable : Symbol(NonNullable, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 14, 12))
 
     x = y;
->x : Symbol(x, Decl(conditionalTypes1.ts, 18, 42))
->y : Symbol(y, Decl(conditionalTypes1.ts, 18, 47))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 14, 42))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 14, 47))
 
     y = x;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 18, 47))
->x : Symbol(x, Decl(conditionalTypes1.ts, 18, 42))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 14, 47))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 14, 42))
 
     let s1: string = x;  // Error
->s1 : Symbol(s1, Decl(conditionalTypes1.ts, 21, 7))
->x : Symbol(x, Decl(conditionalTypes1.ts, 18, 42))
+>s1 : Symbol(s1, Decl(conditionalTypes1.ts, 17, 7))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 14, 42))
 
     let s2: string = y;
->s2 : Symbol(s2, Decl(conditionalTypes1.ts, 22, 7))
->y : Symbol(y, Decl(conditionalTypes1.ts, 18, 47))
+>s2 : Symbol(s2, Decl(conditionalTypes1.ts, 18, 7))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 14, 47))
 }
 
 function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) {
->f3 : Symbol(f3, Decl(conditionalTypes1.ts, 23, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 25, 12))
->x : Symbol(x, Decl(conditionalTypes1.ts, 25, 15))
+>f3 : Symbol(f3, Decl(conditionalTypes1.ts, 19, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 21, 12))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 21, 15))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes1.ts, 25, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 25, 12))
->y : Symbol(y, Decl(conditionalTypes1.ts, 25, 38))
->NonNullable : Symbol(NonNullable, Decl(conditionalTypes1.ts, 1, 44))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 21, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 21, 12))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 21, 38))
+>NonNullable : Symbol(NonNullable, Decl(lib.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes1.ts, 25, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 25, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 21, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 21, 12))
 
     x = y;
->x : Symbol(x, Decl(conditionalTypes1.ts, 25, 15))
->y : Symbol(y, Decl(conditionalTypes1.ts, 25, 38))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 21, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 21, 38))
 
     y = x;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 25, 38))
->x : Symbol(x, Decl(conditionalTypes1.ts, 25, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 21, 38))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 21, 15))
 }
 
 type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 30, 16))
->a : Symbol(a, Decl(conditionalTypes1.ts, 30, 24))
->k : Symbol(k, Decl(conditionalTypes1.ts, 30, 40))
->b : Symbol(b, Decl(conditionalTypes1.ts, 30, 48))
->k : Symbol(k, Decl(conditionalTypes1.ts, 30, 64))
->c : Symbol(c, Decl(conditionalTypes1.ts, 30, 72))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 26, 16))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 26, 24))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 26, 40))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 26, 48))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 26, 64))
+>c : Symbol(c, Decl(conditionalTypes1.ts, 26, 72))
 
-type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
->T10 : Symbol(T10, Decl(conditionalTypes1.ts, 30, 86))
->Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 32, 26))
+type T10 = Exclude<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
+>T10 : Symbol(T10, Decl(conditionalTypes1.ts, 26, 86))
+>Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 28, 29))
 
-type T11 = Filter<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
->T11 : Symbol(T11, Decl(conditionalTypes1.ts, 32, 43))
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 33, 28))
+type T11 = Extract<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+>T11 : Symbol(T11, Decl(conditionalTypes1.ts, 28, 46))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 29, 29))
 
-type T12 = Diff<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
->T12 : Symbol(T12, Decl(conditionalTypes1.ts, 33, 45))
->Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 35, 26))
->k : Symbol(k, Decl(conditionalTypes1.ts, 35, 39))
+type T12 = Exclude<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
+>T12 : Symbol(T12, Decl(conditionalTypes1.ts, 29, 46))
+>Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 31, 29))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 31, 42))
 
-type T13 = Filter<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
->T13 : Symbol(T13, Decl(conditionalTypes1.ts, 35, 50))
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 36, 28))
->k : Symbol(k, Decl(conditionalTypes1.ts, 36, 41))
+type T13 = Extract<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+>T13 : Symbol(T13, Decl(conditionalTypes1.ts, 31, 53))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 32, 29))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 32, 42))
 
-type T14 = Diff<Options, { q: "a" }>;  // Options
->T14 : Symbol(T14, Decl(conditionalTypes1.ts, 36, 52))
->Diff : Symbol(Diff, Decl(conditionalTypes1.ts, 0, 0))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->q : Symbol(q, Decl(conditionalTypes1.ts, 38, 26))
+type T14 = Exclude<Options, { q: "a" }>;  // Options
+>T14 : Symbol(T14, Decl(conditionalTypes1.ts, 32, 53))
+>Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>q : Symbol(q, Decl(conditionalTypes1.ts, 34, 29))
 
-type T15 = Filter<Options, { q: "a" }>;  // never
->T15 : Symbol(T15, Decl(conditionalTypes1.ts, 38, 37))
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->q : Symbol(q, Decl(conditionalTypes1.ts, 39, 28))
+type T15 = Extract<Options, { q: "a" }>;  // never
+>T15 : Symbol(T15, Decl(conditionalTypes1.ts, 34, 40))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>q : Symbol(q, Decl(conditionalTypes1.ts, 35, 29))
 
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
->f4 : Symbol(f4, Decl(conditionalTypes1.ts, 39, 39))
->T : Symbol(T, Decl(conditionalTypes1.ts, 41, 20))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->K : Symbol(K, Decl(conditionalTypes1.ts, 41, 38))
->p : Symbol(p, Decl(conditionalTypes1.ts, 41, 57))
->K : Symbol(K, Decl(conditionalTypes1.ts, 41, 38))
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->T : Symbol(T, Decl(conditionalTypes1.ts, 41, 20))
->k : Symbol(k, Decl(conditionalTypes1.ts, 41, 75))
->K : Symbol(K, Decl(conditionalTypes1.ts, 41, 38))
+declare function f4<T extends Options, K extends string>(p: K): Extract<T, { k: K }>;
+>f4 : Symbol(f4, Decl(conditionalTypes1.ts, 35, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 37, 20))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 37, 38))
+>p : Symbol(p, Decl(conditionalTypes1.ts, 37, 57))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 37, 38))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 37, 20))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 37, 76))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 37, 38))
 
 let x0 = f4("a");  // { k: "a", a: number }
->x0 : Symbol(x0, Decl(conditionalTypes1.ts, 42, 3))
->f4 : Symbol(f4, Decl(conditionalTypes1.ts, 39, 39))
+>x0 : Symbol(x0, Decl(conditionalTypes1.ts, 38, 3))
+>f4 : Symbol(f4, Decl(conditionalTypes1.ts, 35, 40))
 
-type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
->OptionsOfKind : Symbol(OptionsOfKind, Decl(conditionalTypes1.ts, 42, 17))
->K : Symbol(K, Decl(conditionalTypes1.ts, 44, 19))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
->k : Symbol(k, Decl(conditionalTypes1.ts, 44, 62))
->K : Symbol(K, Decl(conditionalTypes1.ts, 44, 19))
+type OptionsOfKind<K extends Options["k"]> = Extract<Options, { k: K }>;
+>OptionsOfKind : Symbol(OptionsOfKind, Decl(conditionalTypes1.ts, 38, 17))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 40, 19))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
+>k : Symbol(k, Decl(conditionalTypes1.ts, 40, 63))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 40, 19))
 
 type T16 = OptionsOfKind<"a" | "b">;  // { k: "a", a: number } | { k: "b", b: string }
->T16 : Symbol(T16, Decl(conditionalTypes1.ts, 44, 71))
->OptionsOfKind : Symbol(OptionsOfKind, Decl(conditionalTypes1.ts, 42, 17))
+>T16 : Symbol(T16, Decl(conditionalTypes1.ts, 40, 72))
+>OptionsOfKind : Symbol(OptionsOfKind, Decl(conditionalTypes1.ts, 38, 17))
 
-type Select<T, K extends keyof T, V extends T[K]> = Filter<T, { [P in K]: V }>;
->Select : Symbol(Select, Decl(conditionalTypes1.ts, 46, 36))
->T : Symbol(T, Decl(conditionalTypes1.ts, 48, 12))
->K : Symbol(K, Decl(conditionalTypes1.ts, 48, 14))
->T : Symbol(T, Decl(conditionalTypes1.ts, 48, 12))
->V : Symbol(V, Decl(conditionalTypes1.ts, 48, 33))
->T : Symbol(T, Decl(conditionalTypes1.ts, 48, 12))
->K : Symbol(K, Decl(conditionalTypes1.ts, 48, 14))
->Filter : Symbol(Filter, Decl(conditionalTypes1.ts, 0, 42))
->T : Symbol(T, Decl(conditionalTypes1.ts, 48, 12))
->P : Symbol(P, Decl(conditionalTypes1.ts, 48, 65))
->K : Symbol(K, Decl(conditionalTypes1.ts, 48, 14))
->V : Symbol(V, Decl(conditionalTypes1.ts, 48, 33))
+type Select<T, K extends keyof T, V extends T[K]> = Extract<T, { [P in K]: V }>;
+>Select : Symbol(Select, Decl(conditionalTypes1.ts, 42, 36))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 44, 12))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 44, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 44, 12))
+>V : Symbol(V, Decl(conditionalTypes1.ts, 44, 33))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 44, 12))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 44, 14))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 44, 12))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 44, 66))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 44, 14))
+>V : Symbol(V, Decl(conditionalTypes1.ts, 44, 33))
 
 type T17 = Select<Options, "k", "a" | "b">;  // // { k: "a", a: number } | { k: "b", b: string }
->T17 : Symbol(T17, Decl(conditionalTypes1.ts, 48, 79))
->Select : Symbol(Select, Decl(conditionalTypes1.ts, 46, 36))
->Options : Symbol(Options, Decl(conditionalTypes1.ts, 28, 1))
+>T17 : Symbol(T17, Decl(conditionalTypes1.ts, 44, 80))
+>Select : Symbol(Select, Decl(conditionalTypes1.ts, 42, 36))
+>Options : Symbol(Options, Decl(conditionalTypes1.ts, 24, 1))
 
 type TypeName<T> =
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 46, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 48, 14))
 
     T extends string ? "string" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 48, 14))
 
     T extends number ? "number" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 48, 14))
 
     T extends boolean ? "boolean" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 48, 14))
 
     T extends undefined ? "undefined" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 48, 14))
 
     T extends Function ? "function" :
->T : Symbol(T, Decl(conditionalTypes1.ts, 52, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 48, 14))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
     "object";
 
 type T20 = TypeName<string | (() => void)>;  // "string" | "function"
->T20 : Symbol(T20, Decl(conditionalTypes1.ts, 58, 13))
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
+>T20 : Symbol(T20, Decl(conditionalTypes1.ts, 54, 13))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 46, 43))
 
 type T21 = TypeName<any>;  // "string" | "number" | "boolean" | "undefined" | "function" | "object"
->T21 : Symbol(T21, Decl(conditionalTypes1.ts, 60, 43))
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
+>T21 : Symbol(T21, Decl(conditionalTypes1.ts, 56, 43))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 46, 43))
 
 type T22 = TypeName<never>;  // "string" | "number" | "boolean" | "undefined" | "function" | "object"
->T22 : Symbol(T22, Decl(conditionalTypes1.ts, 61, 25))
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
+>T22 : Symbol(T22, Decl(conditionalTypes1.ts, 57, 25))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 46, 43))
 
 type T23 = TypeName<{}>;  // "object"
->T23 : Symbol(T23, Decl(conditionalTypes1.ts, 62, 27))
->TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 50, 43))
+>T23 : Symbol(T23, Decl(conditionalTypes1.ts, 58, 27))
+>TypeName : Symbol(TypeName, Decl(conditionalTypes1.ts, 46, 43))
 
 type KnockoutObservable<T> = { object: T };
->KnockoutObservable : Symbol(KnockoutObservable, Decl(conditionalTypes1.ts, 63, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 65, 24))
->object : Symbol(object, Decl(conditionalTypes1.ts, 65, 30))
->T : Symbol(T, Decl(conditionalTypes1.ts, 65, 24))
+>KnockoutObservable : Symbol(KnockoutObservable, Decl(conditionalTypes1.ts, 59, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 61, 24))
+>object : Symbol(object, Decl(conditionalTypes1.ts, 61, 30))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 61, 24))
 
 type KnockoutObservableArray<T> = { array: T };
->KnockoutObservableArray : Symbol(KnockoutObservableArray, Decl(conditionalTypes1.ts, 65, 43))
->T : Symbol(T, Decl(conditionalTypes1.ts, 66, 29))
->array : Symbol(array, Decl(conditionalTypes1.ts, 66, 35))
->T : Symbol(T, Decl(conditionalTypes1.ts, 66, 29))
+>KnockoutObservableArray : Symbol(KnockoutObservableArray, Decl(conditionalTypes1.ts, 61, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 62, 29))
+>array : Symbol(array, Decl(conditionalTypes1.ts, 62, 35))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 62, 29))
 
 type KnockedOut<T> = T extends any[] ? KnockoutObservableArray<T[number]> : KnockoutObservable<T>;
->KnockedOut : Symbol(KnockedOut, Decl(conditionalTypes1.ts, 66, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 68, 16))
->T : Symbol(T, Decl(conditionalTypes1.ts, 68, 16))
->KnockoutObservableArray : Symbol(KnockoutObservableArray, Decl(conditionalTypes1.ts, 65, 43))
->T : Symbol(T, Decl(conditionalTypes1.ts, 68, 16))
->KnockoutObservable : Symbol(KnockoutObservable, Decl(conditionalTypes1.ts, 63, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 68, 16))
+>KnockedOut : Symbol(KnockedOut, Decl(conditionalTypes1.ts, 62, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 64, 16))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 64, 16))
+>KnockoutObservableArray : Symbol(KnockoutObservableArray, Decl(conditionalTypes1.ts, 61, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 64, 16))
+>KnockoutObservable : Symbol(KnockoutObservable, Decl(conditionalTypes1.ts, 59, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 64, 16))
 
 type KnockedOutObj<T> = {
->KnockedOutObj : Symbol(KnockedOutObj, Decl(conditionalTypes1.ts, 68, 98))
->T : Symbol(T, Decl(conditionalTypes1.ts, 70, 19))
+>KnockedOutObj : Symbol(KnockedOutObj, Decl(conditionalTypes1.ts, 64, 98))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 66, 19))
 
     [P in keyof T]: KnockedOut<T[P]>;
->P : Symbol(P, Decl(conditionalTypes1.ts, 71, 5))
->T : Symbol(T, Decl(conditionalTypes1.ts, 70, 19))
->KnockedOut : Symbol(KnockedOut, Decl(conditionalTypes1.ts, 66, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 70, 19))
->P : Symbol(P, Decl(conditionalTypes1.ts, 71, 5))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 67, 5))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 66, 19))
+>KnockedOut : Symbol(KnockedOut, Decl(conditionalTypes1.ts, 62, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 66, 19))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 67, 5))
 }
 
 interface Item {
->Item : Symbol(Item, Decl(conditionalTypes1.ts, 72, 1))
+>Item : Symbol(Item, Decl(conditionalTypes1.ts, 68, 1))
 
     id: number;
->id : Symbol(Item.id, Decl(conditionalTypes1.ts, 74, 16))
+>id : Symbol(Item.id, Decl(conditionalTypes1.ts, 70, 16))
 
     name: string;
->name : Symbol(Item.name, Decl(conditionalTypes1.ts, 75, 15))
+>name : Symbol(Item.name, Decl(conditionalTypes1.ts, 71, 15))
 
     subitems: string[];
->subitems : Symbol(Item.subitems, Decl(conditionalTypes1.ts, 76, 17))
+>subitems : Symbol(Item.subitems, Decl(conditionalTypes1.ts, 72, 17))
 }
 
 type KOItem = KnockedOutObj<Item>;
->KOItem : Symbol(KOItem, Decl(conditionalTypes1.ts, 78, 1))
->KnockedOutObj : Symbol(KnockedOutObj, Decl(conditionalTypes1.ts, 68, 98))
->Item : Symbol(Item, Decl(conditionalTypes1.ts, 72, 1))
+>KOItem : Symbol(KOItem, Decl(conditionalTypes1.ts, 74, 1))
+>KnockedOutObj : Symbol(KnockedOutObj, Decl(conditionalTypes1.ts, 64, 98))
+>Item : Symbol(Item, Decl(conditionalTypes1.ts, 68, 1))
 
 interface Part {
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 76, 34))
 
     id: number;
->id : Symbol(Part.id, Decl(conditionalTypes1.ts, 82, 16))
+>id : Symbol(Part.id, Decl(conditionalTypes1.ts, 78, 16))
 
     name: string;
->name : Symbol(Part.name, Decl(conditionalTypes1.ts, 83, 15))
+>name : Symbol(Part.name, Decl(conditionalTypes1.ts, 79, 15))
 
     subparts: Part[];
->subparts : Symbol(Part.subparts, Decl(conditionalTypes1.ts, 84, 17))
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>subparts : Symbol(Part.subparts, Decl(conditionalTypes1.ts, 80, 17))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 76, 34))
 
     updatePart(newName: string): void;
->updatePart : Symbol(Part.updatePart, Decl(conditionalTypes1.ts, 85, 21))
->newName : Symbol(newName, Decl(conditionalTypes1.ts, 86, 15))
+>updatePart : Symbol(Part.updatePart, Decl(conditionalTypes1.ts, 81, 21))
+>newName : Symbol(newName, Decl(conditionalTypes1.ts, 82, 15))
 }
 
 type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
->FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
->K : Symbol(K, Decl(conditionalTypes1.ts, 89, 35))
->T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
->T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
->K : Symbol(K, Decl(conditionalTypes1.ts, 89, 35))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 83, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 85, 27))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 85, 35))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 85, 27))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 85, 27))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 85, 35))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->K : Symbol(K, Decl(conditionalTypes1.ts, 89, 35))
->T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 85, 35))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 85, 27))
 
 type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>;
->FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 89, 95))
->T : Symbol(T, Decl(conditionalTypes1.ts, 90, 24))
+>FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 85, 95))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 86, 24))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes1.ts, 90, 24))
->FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 90, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 86, 24))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 83, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 86, 24))
 
 type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
->NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 90, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 92, 30))
->K : Symbol(K, Decl(conditionalTypes1.ts, 92, 38))
->T : Symbol(T, Decl(conditionalTypes1.ts, 92, 30))
->T : Symbol(T, Decl(conditionalTypes1.ts, 92, 30))
->K : Symbol(K, Decl(conditionalTypes1.ts, 92, 38))
+>NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 86, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 88, 30))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 88, 38))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 88, 30))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 88, 30))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 88, 38))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->K : Symbol(K, Decl(conditionalTypes1.ts, 92, 38))
->T : Symbol(T, Decl(conditionalTypes1.ts, 92, 30))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 88, 38))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 88, 30))
 
 type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
->NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 92, 98))
->T : Symbol(T, Decl(conditionalTypes1.ts, 93, 27))
+>NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 88, 98))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes1.ts, 93, 27))
->NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 90, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 93, 27))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
+>NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 86, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 89, 27))
 
 type T30 = FunctionProperties<Part>;
->T30 : Symbol(T30, Decl(conditionalTypes1.ts, 93, 69))
->FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 89, 95))
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>T30 : Symbol(T30, Decl(conditionalTypes1.ts, 89, 69))
+>FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 85, 95))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 76, 34))
 
 type T31 = NonFunctionProperties<Part>;
->T31 : Symbol(T31, Decl(conditionalTypes1.ts, 95, 36))
->NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 92, 98))
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>T31 : Symbol(T31, Decl(conditionalTypes1.ts, 91, 36))
+>NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 88, 98))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 76, 34))
 
 function f7<T>(x: T, y: FunctionProperties<T>, z: NonFunctionProperties<T>) {
->f7 : Symbol(f7, Decl(conditionalTypes1.ts, 96, 39))
->T : Symbol(T, Decl(conditionalTypes1.ts, 98, 12))
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 98, 12))
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
->FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 89, 95))
->T : Symbol(T, Decl(conditionalTypes1.ts, 98, 12))
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
->NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 92, 98))
->T : Symbol(T, Decl(conditionalTypes1.ts, 98, 12))
+>f7 : Symbol(f7, Decl(conditionalTypes1.ts, 92, 39))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 94, 12))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 94, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 94, 12))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 94, 20))
+>FunctionProperties : Symbol(FunctionProperties, Decl(conditionalTypes1.ts, 85, 95))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 94, 12))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 94, 46))
+>NonFunctionProperties : Symbol(NonFunctionProperties, Decl(conditionalTypes1.ts, 88, 98))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 94, 12))
 
     x = y;  // Error
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 94, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 94, 20))
 
     x = z;  // Error
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 94, 15))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 94, 46))
 
     y = x;
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 94, 20))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 94, 15))
 
     y = z;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 94, 20))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 94, 46))
 
     z = x;
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
->x : Symbol(x, Decl(conditionalTypes1.ts, 98, 15))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 94, 46))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 94, 15))
 
     z = y;  // Error
->z : Symbol(z, Decl(conditionalTypes1.ts, 98, 46))
->y : Symbol(y, Decl(conditionalTypes1.ts, 98, 20))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 94, 46))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 94, 20))
 }
 
 function f8<T>(x: keyof T, y: FunctionPropertyNames<T>, z: NonFunctionPropertyNames<T>) {
->f8 : Symbol(f8, Decl(conditionalTypes1.ts, 105, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 107, 12))
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 107, 12))
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
->FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 107, 12))
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
->NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 90, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 107, 12))
+>f8 : Symbol(f8, Decl(conditionalTypes1.ts, 101, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 103, 12))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 103, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 103, 12))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 103, 26))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(conditionalTypes1.ts, 83, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 103, 12))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 103, 55))
+>NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 86, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 103, 12))
 
     x = y;
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 103, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 103, 26))
 
     x = z;
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 103, 15))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 103, 55))
 
     y = x;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 103, 26))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 103, 15))
 
     y = z;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 103, 26))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 103, 55))
 
     z = x;  // Error
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
->x : Symbol(x, Decl(conditionalTypes1.ts, 107, 15))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 103, 55))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 103, 15))
 
     z = y;  // Error
->z : Symbol(z, Decl(conditionalTypes1.ts, 107, 55))
->y : Symbol(y, Decl(conditionalTypes1.ts, 107, 26))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 103, 55))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 103, 26))
 }
 
 type DeepReadonly<T> =
->DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 114, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
+>DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 110, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 112, 18))
 
     T extends any[] ? DeepReadonlyArray<T[number]> :
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
->DeepReadonlyArray : Symbol(DeepReadonlyArray, Decl(conditionalTypes1.ts, 119, 6))
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 112, 18))
+>DeepReadonlyArray : Symbol(DeepReadonlyArray, Decl(conditionalTypes1.ts, 115, 6))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 112, 18))
 
     T extends object ? DeepReadonlyObject<T> :
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
->DeepReadonlyObject : Symbol(DeepReadonlyObject, Decl(conditionalTypes1.ts, 121, 72))
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 112, 18))
+>DeepReadonlyObject : Symbol(DeepReadonlyObject, Decl(conditionalTypes1.ts, 117, 72))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 112, 18))
 
     T;
->T : Symbol(T, Decl(conditionalTypes1.ts, 116, 18))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 112, 18))
 
 interface DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
->DeepReadonlyArray : Symbol(DeepReadonlyArray, Decl(conditionalTypes1.ts, 119, 6))
->T : Symbol(T, Decl(conditionalTypes1.ts, 121, 28))
+>DeepReadonlyArray : Symbol(DeepReadonlyArray, Decl(conditionalTypes1.ts, 115, 6))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 117, 28))
 >ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.d.ts, --, --))
->DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 114, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 121, 28))
+>DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 110, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 117, 28))
 
 type DeepReadonlyObject<T> = {
->DeepReadonlyObject : Symbol(DeepReadonlyObject, Decl(conditionalTypes1.ts, 121, 72))
->T : Symbol(T, Decl(conditionalTypes1.ts, 123, 24))
+>DeepReadonlyObject : Symbol(DeepReadonlyObject, Decl(conditionalTypes1.ts, 117, 72))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 119, 24))
 
     readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
->P : Symbol(P, Decl(conditionalTypes1.ts, 124, 14))
->NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 90, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 123, 24))
->DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 114, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 123, 24))
->P : Symbol(P, Decl(conditionalTypes1.ts, 124, 14))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 120, 14))
+>NonFunctionPropertyNames : Symbol(NonFunctionPropertyNames, Decl(conditionalTypes1.ts, 86, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 119, 24))
+>DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 110, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 119, 24))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 120, 14))
 
 };
 
 function f10(part: DeepReadonly<Part>) {
->f10 : Symbol(f10, Decl(conditionalTypes1.ts, 125, 2))
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
->DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 114, 1))
->Part : Symbol(Part, Decl(conditionalTypes1.ts, 80, 34))
+>f10 : Symbol(f10, Decl(conditionalTypes1.ts, 121, 2))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
+>DeepReadonly : Symbol(DeepReadonly, Decl(conditionalTypes1.ts, 110, 1))
+>Part : Symbol(Part, Decl(conditionalTypes1.ts, 76, 34))
 
     let name: string = part.name;
->name : Symbol(name, Decl(conditionalTypes1.ts, 128, 7))
+>name : Symbol(name, Decl(conditionalTypes1.ts, 124, 7))
 >part.name : Symbol(name)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 >name : Symbol(name)
 
     let id: number = part.subparts[0].id;
->id : Symbol(id, Decl(conditionalTypes1.ts, 129, 7))
+>id : Symbol(id, Decl(conditionalTypes1.ts, 125, 7))
 >part.subparts[0].id : Symbol(id)
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 >subparts : Symbol(subparts)
 >id : Symbol(id)
 
     part.id = part.id;  // Error
 >part.id : Symbol(id)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 >id : Symbol(id)
 >part.id : Symbol(id)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 >id : Symbol(id)
 
     part.subparts[0] = part.subparts[0];  // Error
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 >subparts : Symbol(subparts)
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 >subparts : Symbol(subparts)
 
     part.subparts[0].id = part.subparts[0].id;  // Error
 >part.subparts[0].id : Symbol(id)
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 >subparts : Symbol(subparts)
 >id : Symbol(id)
 >part.subparts[0].id : Symbol(id)
 >part.subparts : Symbol(subparts)
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 >subparts : Symbol(subparts)
 >id : Symbol(id)
 
     part.updatePart("hello");  // Error
->part : Symbol(part, Decl(conditionalTypes1.ts, 127, 13))
+>part : Symbol(part, Decl(conditionalTypes1.ts, 123, 13))
 }
 
 type ZeroOf<T extends number | string | boolean> = T extends number ? 0 : T extends string ? "" : false;
->ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 134, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 136, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 136, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 136, 12))
+>ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 130, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 132, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 132, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 132, 12))
 
 function zeroOf<T extends number | string | boolean>(value: T) {
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->T : Symbol(T, Decl(conditionalTypes1.ts, 138, 16))
->value : Symbol(value, Decl(conditionalTypes1.ts, 138, 53))
->T : Symbol(T, Decl(conditionalTypes1.ts, 138, 16))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 132, 104))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 134, 16))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 134, 53))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 134, 16))
 
     return <ZeroOf<T>>(typeof value === "number" ? 0 : typeof value === "string" ? "" : false);
->ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 134, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 138, 16))
->value : Symbol(value, Decl(conditionalTypes1.ts, 138, 53))
->value : Symbol(value, Decl(conditionalTypes1.ts, 138, 53))
+>ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 130, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 134, 16))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 134, 53))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 134, 53))
 }
 
 function f20<T extends string>(n: number, b: boolean, x: number | boolean, y: T) {
->f20 : Symbol(f20, Decl(conditionalTypes1.ts, 140, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 142, 13))
->n : Symbol(n, Decl(conditionalTypes1.ts, 142, 31))
->b : Symbol(b, Decl(conditionalTypes1.ts, 142, 41))
->x : Symbol(x, Decl(conditionalTypes1.ts, 142, 53))
->y : Symbol(y, Decl(conditionalTypes1.ts, 142, 74))
->T : Symbol(T, Decl(conditionalTypes1.ts, 142, 13))
+>f20 : Symbol(f20, Decl(conditionalTypes1.ts, 136, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 138, 13))
+>n : Symbol(n, Decl(conditionalTypes1.ts, 138, 31))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 138, 41))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 138, 53))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 138, 74))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 138, 13))
 
     zeroOf(5);  // 0
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 132, 104))
 
     zeroOf("hello");  // ""
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 132, 104))
 
     zeroOf(true);  // false
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 132, 104))
 
     zeroOf(n);  // 0
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->n : Symbol(n, Decl(conditionalTypes1.ts, 142, 31))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 132, 104))
+>n : Symbol(n, Decl(conditionalTypes1.ts, 138, 31))
 
     zeroOf(b);  // False
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->b : Symbol(b, Decl(conditionalTypes1.ts, 142, 41))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 132, 104))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 138, 41))
 
     zeroOf(x);  // 0 | false
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->x : Symbol(x, Decl(conditionalTypes1.ts, 142, 53))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 132, 104))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 138, 53))
 
     zeroOf(y);  // ZeroOf<T>
->zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 136, 104))
->y : Symbol(y, Decl(conditionalTypes1.ts, 142, 74))
+>zeroOf : Symbol(zeroOf, Decl(conditionalTypes1.ts, 132, 104))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 138, 74))
 }
 
 function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
->f21 : Symbol(f21, Decl(conditionalTypes1.ts, 150, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 152, 13))
->x : Symbol(x, Decl(conditionalTypes1.ts, 152, 40))
->T : Symbol(T, Decl(conditionalTypes1.ts, 152, 13))
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
->ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 134, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 152, 13))
+>f21 : Symbol(f21, Decl(conditionalTypes1.ts, 146, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 148, 13))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 148, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 148, 13))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 148, 45))
+>ZeroOf : Symbol(ZeroOf, Decl(conditionalTypes1.ts, 130, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 148, 13))
 
     let z1: number | string = y;
->z1 : Symbol(z1, Decl(conditionalTypes1.ts, 153, 7))
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
+>z1 : Symbol(z1, Decl(conditionalTypes1.ts, 149, 7))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 148, 45))
 
     let z2: 0 | "" = y;
->z2 : Symbol(z2, Decl(conditionalTypes1.ts, 154, 7))
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
+>z2 : Symbol(z2, Decl(conditionalTypes1.ts, 150, 7))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 148, 45))
 
     x = y;  // Error
->x : Symbol(x, Decl(conditionalTypes1.ts, 152, 40))
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 148, 40))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 148, 45))
 
     y = x;  // Error
->y : Symbol(y, Decl(conditionalTypes1.ts, 152, 45))
->x : Symbol(x, Decl(conditionalTypes1.ts, 152, 40))
+>y : Symbol(y, Decl(conditionalTypes1.ts, 148, 45))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 148, 40))
 }
 
 type Extends<T, U> = T extends U ? true : false;
->Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 157, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 159, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 159, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 159, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 159, 15))
+>Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 153, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 155, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 155, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 155, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 155, 15))
 
 type If<C extends boolean, T, F> = C extends true ? T : F;
->If : Symbol(If, Decl(conditionalTypes1.ts, 159, 48))
->C : Symbol(C, Decl(conditionalTypes1.ts, 160, 8))
->T : Symbol(T, Decl(conditionalTypes1.ts, 160, 26))
->F : Symbol(F, Decl(conditionalTypes1.ts, 160, 29))
->C : Symbol(C, Decl(conditionalTypes1.ts, 160, 8))
->T : Symbol(T, Decl(conditionalTypes1.ts, 160, 26))
->F : Symbol(F, Decl(conditionalTypes1.ts, 160, 29))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 155, 48))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 156, 8))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 156, 26))
+>F : Symbol(F, Decl(conditionalTypes1.ts, 156, 29))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 156, 8))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 156, 26))
+>F : Symbol(F, Decl(conditionalTypes1.ts, 156, 29))
 
 type Not<C extends boolean> = If<C, false, true>;
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 160, 58))
->C : Symbol(C, Decl(conditionalTypes1.ts, 161, 9))
->If : Symbol(If, Decl(conditionalTypes1.ts, 159, 48))
->C : Symbol(C, Decl(conditionalTypes1.ts, 161, 9))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 156, 58))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 157, 9))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 155, 48))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 157, 9))
 
 type And<A extends boolean, B extends boolean> = If<A, B, false>;
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
->A : Symbol(A, Decl(conditionalTypes1.ts, 162, 9))
->B : Symbol(B, Decl(conditionalTypes1.ts, 162, 27))
->If : Symbol(If, Decl(conditionalTypes1.ts, 159, 48))
->A : Symbol(A, Decl(conditionalTypes1.ts, 162, 9))
->B : Symbol(B, Decl(conditionalTypes1.ts, 162, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 158, 9))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 158, 27))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 155, 48))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 158, 9))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 158, 27))
 
 type Or<A extends boolean, B extends boolean> = If<A, true, B>;
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
->A : Symbol(A, Decl(conditionalTypes1.ts, 163, 8))
->B : Symbol(B, Decl(conditionalTypes1.ts, 163, 26))
->If : Symbol(If, Decl(conditionalTypes1.ts, 159, 48))
->A : Symbol(A, Decl(conditionalTypes1.ts, 163, 8))
->B : Symbol(B, Decl(conditionalTypes1.ts, 163, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 159, 8))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 159, 26))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 155, 48))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 159, 8))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 159, 26))
 
 type IsString<T> = Extends<T, string>;
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 165, 14))
->Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 157, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 165, 14))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 159, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 161, 14))
+>Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 153, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 161, 14))
 
 type Q1 = IsString<number>;  // false
->Q1 : Symbol(Q1, Decl(conditionalTypes1.ts, 165, 38))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
+>Q1 : Symbol(Q1, Decl(conditionalTypes1.ts, 161, 38))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 159, 63))
 
 type Q2 = IsString<"abc">;  // true
->Q2 : Symbol(Q2, Decl(conditionalTypes1.ts, 167, 27))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
+>Q2 : Symbol(Q2, Decl(conditionalTypes1.ts, 163, 27))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 159, 63))
 
 type Q3 = IsString<any>;  // boolean
->Q3 : Symbol(Q3, Decl(conditionalTypes1.ts, 168, 26))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
+>Q3 : Symbol(Q3, Decl(conditionalTypes1.ts, 164, 26))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 159, 63))
 
 type Q4 = IsString<never>;  // boolean
->Q4 : Symbol(Q4, Decl(conditionalTypes1.ts, 169, 24))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 163, 63))
+>Q4 : Symbol(Q4, Decl(conditionalTypes1.ts, 165, 24))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 159, 63))
 
 type N1 = Not<false>;  // true
->N1 : Symbol(N1, Decl(conditionalTypes1.ts, 170, 26))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 160, 58))
+>N1 : Symbol(N1, Decl(conditionalTypes1.ts, 166, 26))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 156, 58))
 
 type N2 = Not<true>;  // false
->N2 : Symbol(N2, Decl(conditionalTypes1.ts, 172, 21))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 160, 58))
+>N2 : Symbol(N2, Decl(conditionalTypes1.ts, 168, 21))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 156, 58))
 
 type N3 = Not<boolean>;  // boolean
->N3 : Symbol(N3, Decl(conditionalTypes1.ts, 173, 20))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 160, 58))
+>N3 : Symbol(N3, Decl(conditionalTypes1.ts, 169, 20))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 156, 58))
 
 type A1 = And<false, false>;  // false
->A1 : Symbol(A1, Decl(conditionalTypes1.ts, 174, 23))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A1 : Symbol(A1, Decl(conditionalTypes1.ts, 170, 23))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type A2 = And<false, true>;  // false
->A2 : Symbol(A2, Decl(conditionalTypes1.ts, 176, 28))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A2 : Symbol(A2, Decl(conditionalTypes1.ts, 172, 28))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type A3 = And<true, false>;  // false
->A3 : Symbol(A3, Decl(conditionalTypes1.ts, 177, 27))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A3 : Symbol(A3, Decl(conditionalTypes1.ts, 173, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type A4 = And<true, true>;  // true
->A4 : Symbol(A4, Decl(conditionalTypes1.ts, 178, 27))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A4 : Symbol(A4, Decl(conditionalTypes1.ts, 174, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type A5 = And<boolean, false>;  // false
->A5 : Symbol(A5, Decl(conditionalTypes1.ts, 179, 26))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A5 : Symbol(A5, Decl(conditionalTypes1.ts, 175, 26))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type A6 = And<false, boolean>;  // false
->A6 : Symbol(A6, Decl(conditionalTypes1.ts, 180, 30))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A6 : Symbol(A6, Decl(conditionalTypes1.ts, 176, 30))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type A7 = And<boolean, true>;  // boolean
->A7 : Symbol(A7, Decl(conditionalTypes1.ts, 181, 30))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A7 : Symbol(A7, Decl(conditionalTypes1.ts, 177, 30))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type A8 = And<true, boolean>;  // boolean
->A8 : Symbol(A8, Decl(conditionalTypes1.ts, 182, 29))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A8 : Symbol(A8, Decl(conditionalTypes1.ts, 178, 29))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type A9 = And<boolean, boolean>;  // boolean
->A9 : Symbol(A9, Decl(conditionalTypes1.ts, 183, 29))
->And : Symbol(And, Decl(conditionalTypes1.ts, 161, 49))
+>A9 : Symbol(A9, Decl(conditionalTypes1.ts, 179, 29))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 157, 49))
 
 type O1 = Or<false, false>;  // false
->O1 : Symbol(O1, Decl(conditionalTypes1.ts, 184, 32))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O1 : Symbol(O1, Decl(conditionalTypes1.ts, 180, 32))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type O2 = Or<false, true>;  // true
->O2 : Symbol(O2, Decl(conditionalTypes1.ts, 186, 27))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O2 : Symbol(O2, Decl(conditionalTypes1.ts, 182, 27))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type O3 = Or<true, false>;  // true
->O3 : Symbol(O3, Decl(conditionalTypes1.ts, 187, 26))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O3 : Symbol(O3, Decl(conditionalTypes1.ts, 183, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type O4 = Or<true, true>;  // true
->O4 : Symbol(O4, Decl(conditionalTypes1.ts, 188, 26))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O4 : Symbol(O4, Decl(conditionalTypes1.ts, 184, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type O5 = Or<boolean, false>;  // boolean
->O5 : Symbol(O5, Decl(conditionalTypes1.ts, 189, 25))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O5 : Symbol(O5, Decl(conditionalTypes1.ts, 185, 25))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type O6 = Or<false, boolean>;  // boolean
->O6 : Symbol(O6, Decl(conditionalTypes1.ts, 190, 29))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O6 : Symbol(O6, Decl(conditionalTypes1.ts, 186, 29))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type O7 = Or<boolean, true>;  // true
->O7 : Symbol(O7, Decl(conditionalTypes1.ts, 191, 29))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O7 : Symbol(O7, Decl(conditionalTypes1.ts, 187, 29))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type O8 = Or<true, boolean>;  // true
->O8 : Symbol(O8, Decl(conditionalTypes1.ts, 192, 28))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O8 : Symbol(O8, Decl(conditionalTypes1.ts, 188, 28))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type O9 = Or<boolean, boolean>;  // boolean
->O9 : Symbol(O9, Decl(conditionalTypes1.ts, 193, 28))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 162, 65))
+>O9 : Symbol(O9, Decl(conditionalTypes1.ts, 189, 28))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 158, 65))
 
 type T40 = never extends never ? true : false;  // true
->T40 : Symbol(T40, Decl(conditionalTypes1.ts, 194, 31))
+>T40 : Symbol(T40, Decl(conditionalTypes1.ts, 190, 31))
 
 type T41 = number extends never ? true : false;  // false
->T41 : Symbol(T41, Decl(conditionalTypes1.ts, 196, 46))
+>T41 : Symbol(T41, Decl(conditionalTypes1.ts, 192, 46))
 
 type T42 = never extends number ? true : false;  // boolean
->T42 : Symbol(T42, Decl(conditionalTypes1.ts, 197, 47))
+>T42 : Symbol(T42, Decl(conditionalTypes1.ts, 193, 47))
 
 type IsNever<T> = T extends never ? true : false;
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 198, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 200, 13))
->T : Symbol(T, Decl(conditionalTypes1.ts, 200, 13))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 194, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 196, 13))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 196, 13))
 
 type T50 = IsNever<never>;  // true
->T50 : Symbol(T50, Decl(conditionalTypes1.ts, 200, 49))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 198, 47))
+>T50 : Symbol(T50, Decl(conditionalTypes1.ts, 196, 49))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 194, 47))
 
 type T51 = IsNever<number>;  // false
->T51 : Symbol(T51, Decl(conditionalTypes1.ts, 202, 26))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 198, 47))
+>T51 : Symbol(T51, Decl(conditionalTypes1.ts, 198, 26))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 194, 47))
 
 type T52 = IsNever<any>;  // false
->T52 : Symbol(T52, Decl(conditionalTypes1.ts, 203, 27))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 198, 47))
+>T52 : Symbol(T52, Decl(conditionalTypes1.ts, 199, 27))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 194, 47))
 
 // Repros from #21664
 
 type Eq<T, U> = T extends U ? U extends T ? true : false : false;
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 208, 8))
->U : Symbol(U, Decl(conditionalTypes1.ts, 208, 10))
->T : Symbol(T, Decl(conditionalTypes1.ts, 208, 8))
->U : Symbol(U, Decl(conditionalTypes1.ts, 208, 10))
->U : Symbol(U, Decl(conditionalTypes1.ts, 208, 10))
->T : Symbol(T, Decl(conditionalTypes1.ts, 208, 8))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 200, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 204, 8))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 204, 10))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 204, 8))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 204, 10))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 204, 10))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 204, 8))
 
 type T60 = Eq<true, true>;  // true
->T60 : Symbol(T60, Decl(conditionalTypes1.ts, 208, 65))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
+>T60 : Symbol(T60, Decl(conditionalTypes1.ts, 204, 65))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 200, 24))
 
 type T61 = Eq<true, false>;  // false
->T61 : Symbol(T61, Decl(conditionalTypes1.ts, 209, 26))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
+>T61 : Symbol(T61, Decl(conditionalTypes1.ts, 205, 26))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 200, 24))
 
 type T62 = Eq<false, true>;  // false
->T62 : Symbol(T62, Decl(conditionalTypes1.ts, 210, 27))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
+>T62 : Symbol(T62, Decl(conditionalTypes1.ts, 206, 27))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 200, 24))
 
 type T63 = Eq<false, false>;  // true
->T63 : Symbol(T63, Decl(conditionalTypes1.ts, 211, 27))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
+>T63 : Symbol(T63, Decl(conditionalTypes1.ts, 207, 27))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 200, 24))
 
 type Eq1<T, U> = Eq<T, U> extends false ? false : true;
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
->T : Symbol(T, Decl(conditionalTypes1.ts, 214, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 214, 11))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 214, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 214, 11))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 208, 28))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 210, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 210, 11))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 200, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 210, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 210, 11))
 
 type T70 = Eq1<true, true>;  // true
->T70 : Symbol(T70, Decl(conditionalTypes1.ts, 214, 55))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
+>T70 : Symbol(T70, Decl(conditionalTypes1.ts, 210, 55))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 208, 28))
 
 type T71 = Eq1<true, false>;  // false
->T71 : Symbol(T71, Decl(conditionalTypes1.ts, 215, 27))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
+>T71 : Symbol(T71, Decl(conditionalTypes1.ts, 211, 27))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 208, 28))
 
 type T72 = Eq1<false, true>;  // false
->T72 : Symbol(T72, Decl(conditionalTypes1.ts, 216, 28))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
+>T72 : Symbol(T72, Decl(conditionalTypes1.ts, 212, 28))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 208, 28))
 
 type T73 = Eq1<false, false>;  // true
->T73 : Symbol(T73, Decl(conditionalTypes1.ts, 217, 28))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 212, 28))
+>T73 : Symbol(T73, Decl(conditionalTypes1.ts, 213, 28))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 208, 28))
 
 type Eq2<T, U> = Eq<T, U> extends true ? true : false;
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 220, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 220, 11))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 204, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 220, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 220, 11))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 214, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 216, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 216, 11))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 200, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 216, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 216, 11))
 
 type T80 = Eq2<true, true>;  // true
->T80 : Symbol(T80, Decl(conditionalTypes1.ts, 220, 54))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
+>T80 : Symbol(T80, Decl(conditionalTypes1.ts, 216, 54))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 214, 29))
 
 type T81 = Eq2<true, false>;  // false
->T81 : Symbol(T81, Decl(conditionalTypes1.ts, 221, 27))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
+>T81 : Symbol(T81, Decl(conditionalTypes1.ts, 217, 27))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 214, 29))
 
 type T82 = Eq2<false, true>;  // false
->T82 : Symbol(T82, Decl(conditionalTypes1.ts, 222, 28))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
+>T82 : Symbol(T82, Decl(conditionalTypes1.ts, 218, 28))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 214, 29))
 
 type T83 = Eq2<false, false>;  // true
->T83 : Symbol(T83, Decl(conditionalTypes1.ts, 223, 28))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 218, 29))
+>T83 : Symbol(T83, Decl(conditionalTypes1.ts, 219, 28))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 214, 29))
 
 // Repro from #21756
 
 type Foo<T> = T extends string ? boolean : number;
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 228, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 228, 9))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 220, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 224, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 224, 9))
 
 type Bar<T> = T extends string ? boolean : number;
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 228, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 229, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 229, 9))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 224, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 225, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 225, 9))
 
 const convert = <U>(value: Foo<U>): Bar<U> => value;
->convert : Symbol(convert, Decl(conditionalTypes1.ts, 230, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 230, 17))
->value : Symbol(value, Decl(conditionalTypes1.ts, 230, 20))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->U : Symbol(U, Decl(conditionalTypes1.ts, 230, 17))
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 228, 50))
->U : Symbol(U, Decl(conditionalTypes1.ts, 230, 17))
->value : Symbol(value, Decl(conditionalTypes1.ts, 230, 20))
+>convert : Symbol(convert, Decl(conditionalTypes1.ts, 226, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 226, 17))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 226, 20))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 220, 29))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 226, 17))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 224, 50))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 226, 17))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 226, 20))
 
 type Baz<T> = Foo<T>;
->Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 230, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 232, 9))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 232, 9))
+>Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 226, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 228, 9))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 220, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 228, 9))
 
 const convert2 = <T>(value: Foo<T>): Baz<T> => value;
->convert2 : Symbol(convert2, Decl(conditionalTypes1.ts, 233, 5))
->T : Symbol(T, Decl(conditionalTypes1.ts, 233, 18))
->value : Symbol(value, Decl(conditionalTypes1.ts, 233, 21))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 233, 18))
->Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 230, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 233, 18))
->value : Symbol(value, Decl(conditionalTypes1.ts, 233, 21))
+>convert2 : Symbol(convert2, Decl(conditionalTypes1.ts, 229, 5))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 229, 18))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 229, 21))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 220, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 229, 18))
+>Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 226, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 229, 18))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 229, 21))
 
 function f31<T>() {
->f31 : Symbol(f31, Decl(conditionalTypes1.ts, 233, 53))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 13))
+>f31 : Symbol(f31, Decl(conditionalTypes1.ts, 229, 53))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 231, 13))
 
     type T1 = T extends string ? boolean : number;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 235, 19))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 13))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 231, 19))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 231, 13))
 
     type T2 = T extends string ? boolean : number;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 236, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 13))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 232, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 231, 13))
 
     var x: T1;
->x : Symbol(x, Decl(conditionalTypes1.ts, 238, 7), Decl(conditionalTypes1.ts, 239, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 235, 19))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 234, 7), Decl(conditionalTypes1.ts, 235, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 231, 19))
 
     var x: T2;
->x : Symbol(x, Decl(conditionalTypes1.ts, 238, 7), Decl(conditionalTypes1.ts, 239, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 236, 50))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 234, 7), Decl(conditionalTypes1.ts, 235, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 232, 50))
 }
 
 function f32<T, U>() {
->f32 : Symbol(f32, Decl(conditionalTypes1.ts, 240, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 242, 15))
+>f32 : Symbol(f32, Decl(conditionalTypes1.ts, 236, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 238, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 238, 15))
 
     type T1 = T & U extends string ? boolean : number;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 22))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 242, 15))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 238, 22))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 238, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 238, 15))
 
     type T2 = Foo<T & U>;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 54))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 242, 15))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 239, 54))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 220, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 238, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 238, 15))
 
     var z: T1;
->z : Symbol(z, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 22))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 241, 7), Decl(conditionalTypes1.ts, 242, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 238, 22))
 
     var z: T2;  // Error, T2 is distributive, T1 isn't
->z : Symbol(z, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 54))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 241, 7), Decl(conditionalTypes1.ts, 242, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 239, 54))
 }
 
 function f33<T, U>() {
->f33 : Symbol(f33, Decl(conditionalTypes1.ts, 247, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>f33 : Symbol(f33, Decl(conditionalTypes1.ts, 243, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 245, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 245, 15))
 
     type T1 = Foo<T & U>;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 224, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 245, 22))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 220, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 245, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 245, 15))
 
     type T2 = Bar<T & U>;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 25))
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 228, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 246, 25))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 224, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 245, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 245, 15))
 
     var z: T1;
->z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 248, 7), Decl(conditionalTypes1.ts, 249, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 245, 22))
 
     var z: T2;
->z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 25))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 248, 7), Decl(conditionalTypes1.ts, 249, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 246, 25))
 }
 

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -1,91 +1,68 @@
 === tests/cases/conformance/types/conditional/conditionalTypes1.ts ===
-type Diff<T, U> = T extends U ? never : T;
->Diff : Diff<T, U>
->T : T
->U : U
->T : T
->U : U
->T : T
-
-type Filter<T, U> = T extends U ? T : never;
->Filter : Filter<T, U>
->T : T
->U : U
->T : T
->U : U
->T : T
-
-type NonNullable<T> = Diff<T, null | undefined>;
->NonNullable : Diff<T, null | undefined>
->T : T
->Diff : Diff<T, U>
->T : T
->null : null
-
-type T00 = Diff<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
+type T00 = Exclude<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
 >T00 : "b" | "d"
->Diff : Diff<T, U>
+>Exclude : Exclude<T, U>
 
-type T01 = Filter<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
+type T01 = Extract<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
 >T01 : "a" | "c"
->Filter : Filter<T, U>
+>Extract : Extract<T, U>
 
-type T02 = Diff<string | number | (() => void), Function>;  // string | number
+type T02 = Exclude<string | number | (() => void), Function>;  // string | number
 >T02 : string | number
->Diff : Diff<T, U>
+>Exclude : Exclude<T, U>
 >Function : Function
 
-type T03 = Filter<string | number | (() => void), Function>;  // () => void
+type T03 = Extract<string | number | (() => void), Function>;  // () => void
 >T03 : () => void
->Filter : Filter<T, U>
+>Extract : Extract<T, U>
 >Function : Function
 
 type T04 = NonNullable<string | number | undefined>;  // string | number
 >T04 : string | number
->NonNullable : Diff<T, null | undefined>
+>NonNullable : NonNullable<T>
 
 type T05 = NonNullable<(() => string) | string[] | null | undefined>;  // (() => string) | string[]
 >T05 : (() => string) | string[]
->NonNullable : Diff<T, null | undefined>
+>NonNullable : NonNullable<T>
 >null : null
 
 function f1<T>(x: T, y: NonNullable<T>) {
->f1 : <T>(x: T, y: Diff<T, null | undefined>) => void
+>f1 : <T>(x: T, y: NonNullable<T>) => void
 >T : T
 >x : T
 >T : T
->y : Diff<T, null | undefined>
->NonNullable : Diff<T, null | undefined>
+>y : NonNullable<T>
+>NonNullable : NonNullable<T>
 >T : T
 
     x = y;
->x = y : Diff<T, null | undefined>
+>x = y : NonNullable<T>
 >x : T
->y : Diff<T, null | undefined>
+>y : NonNullable<T>
 
     y = x;  // Error
 >y = x : T
->y : Diff<T, null | undefined>
+>y : NonNullable<T>
 >x : T
 }
 
 function f2<T extends string | undefined>(x: T, y: NonNullable<T>) {
->f2 : <T extends string | undefined>(x: T, y: Diff<T, null | undefined>) => void
+>f2 : <T extends string | undefined>(x: T, y: NonNullable<T>) => void
 >T : T
 >x : T
 >T : T
->y : Diff<T, null | undefined>
->NonNullable : Diff<T, null | undefined>
+>y : NonNullable<T>
+>NonNullable : NonNullable<T>
 >T : T
 
     x = y;
->x = y : Diff<T, null | undefined>
+>x = y : NonNullable<T>
 >x : T
->y : Diff<T, null | undefined>
+>y : NonNullable<T>
 
     y = x;  // Error
 >y = x : T
->y : Diff<T, null | undefined>
+>y : NonNullable<T>
 >x : T
 
     let s1: string = x;  // Error
@@ -94,30 +71,30 @@ function f2<T extends string | undefined>(x: T, y: NonNullable<T>) {
 
     let s2: string = y;
 >s2 : string
->y : Diff<T, null | undefined>
+>y : NonNullable<T>
 }
 
 function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) {
->f3 : <T>(x: Partial<T>[keyof T], y: Diff<Partial<T>[keyof T], null | undefined>) => void
+>f3 : <T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) => void
 >T : T
 >x : Partial<T>[keyof T]
 >Partial : Partial<T>
 >T : T
 >T : T
->y : Diff<Partial<T>[keyof T], null | undefined>
->NonNullable : Diff<T, null | undefined>
+>y : NonNullable<Partial<T>[keyof T]>
+>NonNullable : NonNullable<T>
 >Partial : Partial<T>
 >T : T
 >T : T
 
     x = y;
->x = y : Diff<Partial<T>[keyof T], null | undefined>
+>x = y : NonNullable<Partial<T>[keyof T]>
 >x : Partial<T>[keyof T]
->y : Diff<Partial<T>[keyof T], null | undefined>
+>y : NonNullable<Partial<T>[keyof T]>
 
     y = x;  // Error
 >y = x : Partial<T>[keyof T]
->y : Diff<Partial<T>[keyof T], null | undefined>
+>y : NonNullable<Partial<T>[keyof T]>
 >x : Partial<T>[keyof T]
 }
 
@@ -130,52 +107,52 @@ type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: bool
 >k : "c"
 >c : boolean
 
-type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
+type T10 = Exclude<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
 >T10 : { k: "c"; c: boolean; }
->Diff : Diff<T, U>
+>Exclude : Exclude<T, U>
 >Options : Options
 >k : "a" | "b"
 
-type T11 = Filter<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+type T11 = Extract<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
 >T11 : { k: "a"; a: number; } | { k: "b"; b: string; }
->Filter : Filter<T, U>
+>Extract : Extract<T, U>
 >Options : Options
 >k : "a" | "b"
 
-type T12 = Diff<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
+type T12 = Exclude<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
 >T12 : { k: "c"; c: boolean; }
->Diff : Diff<T, U>
+>Exclude : Exclude<T, U>
 >Options : Options
 >k : "a"
 >k : "b"
 
-type T13 = Filter<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+type T13 = Extract<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
 >T13 : { k: "a"; a: number; } | { k: "b"; b: string; }
->Filter : Filter<T, U>
+>Extract : Extract<T, U>
 >Options : Options
 >k : "a"
 >k : "b"
 
-type T14 = Diff<Options, { q: "a" }>;  // Options
+type T14 = Exclude<Options, { q: "a" }>;  // Options
 >T14 : Options
->Diff : Diff<T, U>
+>Exclude : Exclude<T, U>
 >Options : Options
 >q : "a"
 
-type T15 = Filter<Options, { q: "a" }>;  // never
+type T15 = Extract<Options, { q: "a" }>;  // never
 >T15 : never
->Filter : Filter<T, U>
+>Extract : Extract<T, U>
 >Options : Options
 >q : "a"
 
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
->f4 : <T extends Options, K extends string>(p: K) => Filter<T, { k: K; }>
+declare function f4<T extends Options, K extends string>(p: K): Extract<T, { k: K }>;
+>f4 : <T extends Options, K extends string>(p: K) => Extract<T, { k: K; }>
 >T : T
 >Options : Options
 >K : K
 >p : K
 >K : K
->Filter : Filter<T, U>
+>Extract : Extract<T, U>
 >T : T
 >k : K
 >K : K
@@ -183,31 +160,31 @@ declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K
 let x0 = f4("a");  // { k: "a", a: number }
 >x0 : { k: "a"; a: number; }
 >f4("a") : { k: "a"; a: number; }
->f4 : <T extends Options, K extends string>(p: K) => Filter<T, { k: K; }>
+>f4 : <T extends Options, K extends string>(p: K) => Extract<T, { k: K; }>
 >"a" : "a"
 
-type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
->OptionsOfKind : Filter<{ k: "a"; a: number; }, { k: K; }> | Filter<{ k: "b"; b: string; }, { k: K; }> | Filter<{ k: "c"; c: boolean; }, { k: K; }>
+type OptionsOfKind<K extends Options["k"]> = Extract<Options, { k: K }>;
+>OptionsOfKind : Extract<{ k: "a"; a: number; }, { k: K; }> | Extract<{ k: "b"; b: string; }, { k: K; }> | Extract<{ k: "c"; c: boolean; }, { k: K; }>
 >K : K
 >Options : Options
->Filter : Filter<T, U>
+>Extract : Extract<T, U>
 >Options : Options
 >k : K
 >K : K
 
 type T16 = OptionsOfKind<"a" | "b">;  // { k: "a", a: number } | { k: "b", b: string }
 >T16 : { k: "a"; a: number; } | { k: "b"; b: string; }
->OptionsOfKind : Filter<{ k: "a"; a: number; }, { k: K; }> | Filter<{ k: "b"; b: string; }, { k: K; }> | Filter<{ k: "c"; c: boolean; }, { k: K; }>
+>OptionsOfKind : Extract<{ k: "a"; a: number; }, { k: K; }> | Extract<{ k: "b"; b: string; }, { k: K; }> | Extract<{ k: "c"; c: boolean; }, { k: K; }>
 
-type Select<T, K extends keyof T, V extends T[K]> = Filter<T, { [P in K]: V }>;
->Select : Filter<T, { [P in K]: V; }>
+type Select<T, K extends keyof T, V extends T[K]> = Extract<T, { [P in K]: V }>;
+>Select : Extract<T, { [P in K]: V; }>
 >T : T
 >K : K
 >T : T
 >V : V
 >T : T
 >K : K
->Filter : Filter<T, U>
+>Extract : Extract<T, U>
 >T : T
 >P : P
 >K : K
@@ -215,7 +192,7 @@ type Select<T, K extends keyof T, V extends T[K]> = Filter<T, { [P in K]: V }>;
 
 type T17 = Select<Options, "k", "a" | "b">;  // // { k: "a", a: number } | { k: "b", b: string }
 >T17 : { k: "a"; a: number; } | { k: "b"; b: string; }
->Select : Filter<T, { [P in K]: V; }>
+>Select : Extract<T, { [P in K]: V; }>
 >Options : Options
 
 type TypeName<T> =

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -1,21 +1,26 @@
-tests/cases/conformance/types/conditional/inferTypes1.ts(34,23): error TS2344: Type 'string' does not satisfy the constraint 'Function'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(43,25): error TS2344: Type '(x: string, y: string) => number' does not satisfy the constraint '(x: any) => any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(44,25): error TS2344: Type 'Function' does not satisfy the constraint '(x: any) => any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(31,23): error TS2344: Type 'string' does not satisfy the constraint '(...args: any[]) => any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(32,23): error TS2344: Type 'Function' does not satisfy the constraint '(...args: any[]) => any'.
+  Type 'Function' provides no match for the signature '(...args: any[]): any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(37,25): error TS2344: Type 'string' does not satisfy the constraint 'new (...args: any[]) => any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(38,25): error TS2344: Type 'Function' does not satisfy the constraint 'new (...args: any[]) => any'.
+  Type 'Function' provides no match for the signature 'new (...args: any[]): any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(46,25): error TS2344: Type '(x: string, y: string) => number' does not satisfy the constraint '(x: any) => any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(47,25): error TS2344: Type 'Function' does not satisfy the constraint '(x: any) => any'.
   Type 'Function' provides no match for the signature '(x: any): any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(70,12): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
-tests/cases/conformance/types/conditional/inferTypes1.ts(71,15): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
-tests/cases/conformance/types/conditional/inferTypes1.ts(71,41): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
-tests/cases/conformance/types/conditional/inferTypes1.ts(71,51): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
-tests/cases/conformance/types/conditional/inferTypes1.ts(72,15): error TS2304: Cannot find name 'U'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(72,15): error TS4081: Exported type alias 'T62' has or is using private name 'U'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(72,43): error TS2304: Cannot find name 'U'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(72,43): error TS4081: Exported type alias 'T62' has or is using private name 'U'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(78,44): error TS2344: Type 'U' does not satisfy the constraint 'string'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(73,12): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+tests/cases/conformance/types/conditional/inferTypes1.ts(74,15): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+tests/cases/conformance/types/conditional/inferTypes1.ts(74,41): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+tests/cases/conformance/types/conditional/inferTypes1.ts(74,51): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+tests/cases/conformance/types/conditional/inferTypes1.ts(75,15): error TS2304: Cannot find name 'U'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(75,15): error TS4081: Exported type alias 'T62' has or is using private name 'U'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(75,43): error TS2304: Cannot find name 'U'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(75,43): error TS4081: Exported type alias 'T62' has or is using private name 'U'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(81,44): error TS2344: Type 'U' does not satisfy the constraint 'string'.
   Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(131,40): error TS2322: Type 'T' is not assignable to type 'string'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(134,40): error TS2322: Type 'T' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/types/conditional/inferTypes1.ts (13 errors) ====
+==== tests/cases/conformance/types/conditional/inferTypes1.ts (16 errors) ====
     type Unpacked<T> =
         T extends (infer U)[] ? U :
         T extends (...args: any[]) => infer U ? U :
@@ -29,8 +34,6 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(131,40): error TS2322: 
     type T04 = Unpacked<Unpacked<Promise<string>[]>>;  // string
     type T05 = Unpacked<any>;  // any
     type T06 = Unpacked<never>;  // never
-    
-    type ReturnType<T extends Function> = T extends ((...args: any[]) => infer R) | (new (...args: any[]) => infer R) ? R : any;
     
     function f1(s: string) {
         return { a: 1, b: s };
@@ -46,13 +49,26 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(131,40): error TS2322: 
     type T12 = ReturnType<(<T>() => T)>;  // {}
     type T13 = ReturnType<(<T extends U, U extends number[]>() => T)>;  // number[]
     type T14 = ReturnType<typeof f1>;  // { a: number, b: string }
-    type T15 = ReturnType<typeof C>;  // C
-    type T16 = ReturnType<any>;  // any
-    type T17 = ReturnType<never>;  // any
-    type T18 = ReturnType<string>;  // Error
+    type T15 = ReturnType<any>;  // any
+    type T16 = ReturnType<never>;  // any
+    type T17 = ReturnType<string>;  // Error
                           ~~~~~~
-!!! error TS2344: Type 'string' does not satisfy the constraint 'Function'.
-    type T19 = ReturnType<Function>;  // any
+!!! error TS2344: Type 'string' does not satisfy the constraint '(...args: any[]) => any'.
+    type T18 = ReturnType<Function>;  // Error
+                          ~~~~~~~~
+!!! error TS2344: Type 'Function' does not satisfy the constraint '(...args: any[]) => any'.
+!!! error TS2344:   Type 'Function' provides no match for the signature '(...args: any[]): any'.
+    
+    type U10 = InstanceType<typeof C>;  // C
+    type U11 = InstanceType<any>;  // any
+    type U12 = InstanceType<never>;  // any
+    type U13 = InstanceType<string>;  // Error
+                            ~~~~~~
+!!! error TS2344: Type 'string' does not satisfy the constraint 'new (...args: any[]) => any'.
+    type U14 = InstanceType<Function>;  // Error
+                            ~~~~~~~~
+!!! error TS2344: Type 'Function' does not satisfy the constraint 'new (...args: any[]) => any'.
+!!! error TS2344:   Type 'Function' provides no match for the signature 'new (...args: any[]): any'.
     
     type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;
     

--- a/tests/baselines/reference/inferTypes1.js
+++ b/tests/baselines/reference/inferTypes1.js
@@ -13,8 +13,6 @@ type T04 = Unpacked<Unpacked<Promise<string>[]>>;  // string
 type T05 = Unpacked<any>;  // any
 type T06 = Unpacked<never>;  // never
 
-type ReturnType<T extends Function> = T extends ((...args: any[]) => infer R) | (new (...args: any[]) => infer R) ? R : any;
-
 function f1(s: string) {
     return { a: 1, b: s };
 }
@@ -29,11 +27,16 @@ type T11 = ReturnType<(s: string) => void>;  // void
 type T12 = ReturnType<(<T>() => T)>;  // {}
 type T13 = ReturnType<(<T extends U, U extends number[]>() => T)>;  // number[]
 type T14 = ReturnType<typeof f1>;  // { a: number, b: string }
-type T15 = ReturnType<typeof C>;  // C
-type T16 = ReturnType<any>;  // any
-type T17 = ReturnType<never>;  // any
-type T18 = ReturnType<string>;  // Error
-type T19 = ReturnType<Function>;  // any
+type T15 = ReturnType<any>;  // any
+type T16 = ReturnType<never>;  // any
+type T17 = ReturnType<string>;  // Error
+type T18 = ReturnType<Function>;  // Error
+
+type U10 = InstanceType<typeof C>;  // C
+type U11 = InstanceType<any>;  // any
+type U12 = InstanceType<never>;  // any
+type U13 = InstanceType<string>;  // Error
+type U14 = InstanceType<Function>;  // Error
 
 type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;
 

--- a/tests/baselines/reference/inferTypes1.symbols
+++ b/tests/baselines/reference/inferTypes1.symbols
@@ -54,518 +54,524 @@ type T06 = Unpacked<never>;  // never
 >T06 : Symbol(T06, Decl(inferTypes1.ts, 11, 25))
 >Unpacked : Symbol(Unpacked, Decl(inferTypes1.ts, 0, 0))
 
-type ReturnType<T extends Function> = T extends ((...args: any[]) => infer R) | (new (...args: any[]) => infer R) ? R : any;
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
->T : Symbol(T, Decl(inferTypes1.ts, 14, 16))
->Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(inferTypes1.ts, 14, 16))
->args : Symbol(args, Decl(inferTypes1.ts, 14, 50))
->R : Symbol(R, Decl(inferTypes1.ts, 14, 74), Decl(inferTypes1.ts, 14, 110))
->args : Symbol(args, Decl(inferTypes1.ts, 14, 86))
->R : Symbol(R, Decl(inferTypes1.ts, 14, 74), Decl(inferTypes1.ts, 14, 110))
->R : Symbol(R, Decl(inferTypes1.ts, 14, 74), Decl(inferTypes1.ts, 14, 110))
-
 function f1(s: string) {
->f1 : Symbol(f1, Decl(inferTypes1.ts, 14, 124))
->s : Symbol(s, Decl(inferTypes1.ts, 16, 12))
+>f1 : Symbol(f1, Decl(inferTypes1.ts, 12, 27))
+>s : Symbol(s, Decl(inferTypes1.ts, 14, 12))
 
     return { a: 1, b: s };
->a : Symbol(a, Decl(inferTypes1.ts, 17, 12))
->b : Symbol(b, Decl(inferTypes1.ts, 17, 18))
->s : Symbol(s, Decl(inferTypes1.ts, 16, 12))
+>a : Symbol(a, Decl(inferTypes1.ts, 15, 12))
+>b : Symbol(b, Decl(inferTypes1.ts, 15, 18))
+>s : Symbol(s, Decl(inferTypes1.ts, 14, 12))
 }
 
 class C {
->C : Symbol(C, Decl(inferTypes1.ts, 18, 1))
+>C : Symbol(C, Decl(inferTypes1.ts, 16, 1))
 
     x = 0;
->x : Symbol(C.x, Decl(inferTypes1.ts, 20, 9))
+>x : Symbol(C.x, Decl(inferTypes1.ts, 18, 9))
 
     y = 0;
->y : Symbol(C.y, Decl(inferTypes1.ts, 21, 10))
+>y : Symbol(C.y, Decl(inferTypes1.ts, 19, 10))
 }
 
 type T10 = ReturnType<() => string>;  // string
->T10 : Symbol(T10, Decl(inferTypes1.ts, 23, 1))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
+>T10 : Symbol(T10, Decl(inferTypes1.ts, 21, 1))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
 
 type T11 = ReturnType<(s: string) => void>;  // void
->T11 : Symbol(T11, Decl(inferTypes1.ts, 25, 36))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
->s : Symbol(s, Decl(inferTypes1.ts, 26, 23))
+>T11 : Symbol(T11, Decl(inferTypes1.ts, 23, 36))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
+>s : Symbol(s, Decl(inferTypes1.ts, 24, 23))
 
 type T12 = ReturnType<(<T>() => T)>;  // {}
->T12 : Symbol(T12, Decl(inferTypes1.ts, 26, 43))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
->T : Symbol(T, Decl(inferTypes1.ts, 27, 24))
->T : Symbol(T, Decl(inferTypes1.ts, 27, 24))
+>T12 : Symbol(T12, Decl(inferTypes1.ts, 24, 43))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(inferTypes1.ts, 25, 24))
+>T : Symbol(T, Decl(inferTypes1.ts, 25, 24))
 
 type T13 = ReturnType<(<T extends U, U extends number[]>() => T)>;  // number[]
->T13 : Symbol(T13, Decl(inferTypes1.ts, 27, 36))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
->T : Symbol(T, Decl(inferTypes1.ts, 28, 24))
->U : Symbol(U, Decl(inferTypes1.ts, 28, 36))
->U : Symbol(U, Decl(inferTypes1.ts, 28, 36))
->T : Symbol(T, Decl(inferTypes1.ts, 28, 24))
+>T13 : Symbol(T13, Decl(inferTypes1.ts, 25, 36))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(inferTypes1.ts, 26, 24))
+>U : Symbol(U, Decl(inferTypes1.ts, 26, 36))
+>U : Symbol(U, Decl(inferTypes1.ts, 26, 36))
+>T : Symbol(T, Decl(inferTypes1.ts, 26, 24))
 
 type T14 = ReturnType<typeof f1>;  // { a: number, b: string }
->T14 : Symbol(T14, Decl(inferTypes1.ts, 28, 66))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
->f1 : Symbol(f1, Decl(inferTypes1.ts, 14, 124))
+>T14 : Symbol(T14, Decl(inferTypes1.ts, 26, 66))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
+>f1 : Symbol(f1, Decl(inferTypes1.ts, 12, 27))
 
-type T15 = ReturnType<typeof C>;  // C
->T15 : Symbol(T15, Decl(inferTypes1.ts, 29, 33))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
->C : Symbol(C, Decl(inferTypes1.ts, 18, 1))
+type T15 = ReturnType<any>;  // any
+>T15 : Symbol(T15, Decl(inferTypes1.ts, 27, 33))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
 
-type T16 = ReturnType<any>;  // any
->T16 : Symbol(T16, Decl(inferTypes1.ts, 30, 32))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
+type T16 = ReturnType<never>;  // any
+>T16 : Symbol(T16, Decl(inferTypes1.ts, 28, 27))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
 
-type T17 = ReturnType<never>;  // any
->T17 : Symbol(T17, Decl(inferTypes1.ts, 31, 27))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
+type T17 = ReturnType<string>;  // Error
+>T17 : Symbol(T17, Decl(inferTypes1.ts, 29, 29))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
 
-type T18 = ReturnType<string>;  // Error
->T18 : Symbol(T18, Decl(inferTypes1.ts, 32, 29))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
+type T18 = ReturnType<Function>;  // Error
+>T18 : Symbol(T18, Decl(inferTypes1.ts, 30, 30))
+>ReturnType : Symbol(ReturnType, Decl(lib.d.ts, --, --))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
-type T19 = ReturnType<Function>;  // any
->T19 : Symbol(T19, Decl(inferTypes1.ts, 33, 30))
->ReturnType : Symbol(ReturnType, Decl(inferTypes1.ts, 12, 27))
+type U10 = InstanceType<typeof C>;  // C
+>U10 : Symbol(U10, Decl(inferTypes1.ts, 31, 32))
+>InstanceType : Symbol(InstanceType, Decl(lib.d.ts, --, --))
+>C : Symbol(C, Decl(inferTypes1.ts, 16, 1))
+
+type U11 = InstanceType<any>;  // any
+>U11 : Symbol(U11, Decl(inferTypes1.ts, 33, 34))
+>InstanceType : Symbol(InstanceType, Decl(lib.d.ts, --, --))
+
+type U12 = InstanceType<never>;  // any
+>U12 : Symbol(U12, Decl(inferTypes1.ts, 34, 29))
+>InstanceType : Symbol(InstanceType, Decl(lib.d.ts, --, --))
+
+type U13 = InstanceType<string>;  // Error
+>U13 : Symbol(U13, Decl(inferTypes1.ts, 35, 31))
+>InstanceType : Symbol(InstanceType, Decl(lib.d.ts, --, --))
+
+type U14 = InstanceType<Function>;  // Error
+>U14 : Symbol(U14, Decl(inferTypes1.ts, 36, 32))
+>InstanceType : Symbol(InstanceType, Decl(lib.d.ts, --, --))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
->T : Symbol(T, Decl(inferTypes1.ts, 36, 18))
->x : Symbol(x, Decl(inferTypes1.ts, 36, 29))
->T : Symbol(T, Decl(inferTypes1.ts, 36, 18))
->a : Symbol(a, Decl(inferTypes1.ts, 36, 58))
->A : Symbol(A, Decl(inferTypes1.ts, 36, 66))
->A : Symbol(A, Decl(inferTypes1.ts, 36, 66))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
+>T : Symbol(T, Decl(inferTypes1.ts, 39, 18))
+>x : Symbol(x, Decl(inferTypes1.ts, 39, 29))
+>T : Symbol(T, Decl(inferTypes1.ts, 39, 18))
+>a : Symbol(a, Decl(inferTypes1.ts, 39, 58))
+>A : Symbol(A, Decl(inferTypes1.ts, 39, 66))
+>A : Symbol(A, Decl(inferTypes1.ts, 39, 66))
 
 type T20 = ArgumentType<() => void>;  // never
->T20 : Symbol(T20, Decl(inferTypes1.ts, 36, 87))
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
+>T20 : Symbol(T20, Decl(inferTypes1.ts, 39, 87))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
 
 type T21 = ArgumentType<(x: string) => number>;  // string
->T21 : Symbol(T21, Decl(inferTypes1.ts, 38, 36))
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
->x : Symbol(x, Decl(inferTypes1.ts, 39, 25))
+>T21 : Symbol(T21, Decl(inferTypes1.ts, 41, 36))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
+>x : Symbol(x, Decl(inferTypes1.ts, 42, 25))
 
 type T22 = ArgumentType<(x?: string) => number>;  // string | undefined
->T22 : Symbol(T22, Decl(inferTypes1.ts, 39, 47))
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
->x : Symbol(x, Decl(inferTypes1.ts, 40, 25))
+>T22 : Symbol(T22, Decl(inferTypes1.ts, 42, 47))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
+>x : Symbol(x, Decl(inferTypes1.ts, 43, 25))
 
 type T23 = ArgumentType<(...args: string[]) => number>;  // string
->T23 : Symbol(T23, Decl(inferTypes1.ts, 40, 48))
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
->args : Symbol(args, Decl(inferTypes1.ts, 41, 25))
+>T23 : Symbol(T23, Decl(inferTypes1.ts, 43, 48))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
+>args : Symbol(args, Decl(inferTypes1.ts, 44, 25))
 
 type T24 = ArgumentType<(x: string, y: string) => number>;  // Error
->T24 : Symbol(T24, Decl(inferTypes1.ts, 41, 55))
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
->x : Symbol(x, Decl(inferTypes1.ts, 42, 25))
->y : Symbol(y, Decl(inferTypes1.ts, 42, 35))
+>T24 : Symbol(T24, Decl(inferTypes1.ts, 44, 55))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
+>x : Symbol(x, Decl(inferTypes1.ts, 45, 25))
+>y : Symbol(y, Decl(inferTypes1.ts, 45, 35))
 
 type T25 = ArgumentType<Function>;  // Error
->T25 : Symbol(T25, Decl(inferTypes1.ts, 42, 58))
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
+>T25 : Symbol(T25, Decl(inferTypes1.ts, 45, 58))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 type T26 = ArgumentType<any>;  // any
->T26 : Symbol(T26, Decl(inferTypes1.ts, 43, 34))
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
+>T26 : Symbol(T26, Decl(inferTypes1.ts, 46, 34))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
 
 type T27 = ArgumentType<never>;  // any
->T27 : Symbol(T27, Decl(inferTypes1.ts, 44, 29))
->ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 34, 32))
+>T27 : Symbol(T27, Decl(inferTypes1.ts, 47, 29))
+>ArgumentType : Symbol(ArgumentType, Decl(inferTypes1.ts, 37, 34))
 
 type X1<T extends { x: any, y: any }> = T extends { x: infer X, y: infer Y } ? [X, Y] : any;
->X1 : Symbol(X1, Decl(inferTypes1.ts, 45, 31))
->T : Symbol(T, Decl(inferTypes1.ts, 47, 8))
->x : Symbol(x, Decl(inferTypes1.ts, 47, 19))
->y : Symbol(y, Decl(inferTypes1.ts, 47, 27))
->T : Symbol(T, Decl(inferTypes1.ts, 47, 8))
->x : Symbol(x, Decl(inferTypes1.ts, 47, 51))
->X : Symbol(X, Decl(inferTypes1.ts, 47, 60))
->y : Symbol(y, Decl(inferTypes1.ts, 47, 63))
->Y : Symbol(Y, Decl(inferTypes1.ts, 47, 72))
->X : Symbol(X, Decl(inferTypes1.ts, 47, 60))
->Y : Symbol(Y, Decl(inferTypes1.ts, 47, 72))
+>X1 : Symbol(X1, Decl(inferTypes1.ts, 48, 31))
+>T : Symbol(T, Decl(inferTypes1.ts, 50, 8))
+>x : Symbol(x, Decl(inferTypes1.ts, 50, 19))
+>y : Symbol(y, Decl(inferTypes1.ts, 50, 27))
+>T : Symbol(T, Decl(inferTypes1.ts, 50, 8))
+>x : Symbol(x, Decl(inferTypes1.ts, 50, 51))
+>X : Symbol(X, Decl(inferTypes1.ts, 50, 60))
+>y : Symbol(y, Decl(inferTypes1.ts, 50, 63))
+>Y : Symbol(Y, Decl(inferTypes1.ts, 50, 72))
+>X : Symbol(X, Decl(inferTypes1.ts, 50, 60))
+>Y : Symbol(Y, Decl(inferTypes1.ts, 50, 72))
 
 type T30 = X1<{ x: any, y: any }>;  // [any, any]
->T30 : Symbol(T30, Decl(inferTypes1.ts, 47, 92))
->X1 : Symbol(X1, Decl(inferTypes1.ts, 45, 31))
->x : Symbol(x, Decl(inferTypes1.ts, 49, 15))
->y : Symbol(y, Decl(inferTypes1.ts, 49, 23))
+>T30 : Symbol(T30, Decl(inferTypes1.ts, 50, 92))
+>X1 : Symbol(X1, Decl(inferTypes1.ts, 48, 31))
+>x : Symbol(x, Decl(inferTypes1.ts, 52, 15))
+>y : Symbol(y, Decl(inferTypes1.ts, 52, 23))
 
 type T31 = X1<{ x: number, y: string }>;  // [number, string]
->T31 : Symbol(T31, Decl(inferTypes1.ts, 49, 34))
->X1 : Symbol(X1, Decl(inferTypes1.ts, 45, 31))
->x : Symbol(x, Decl(inferTypes1.ts, 50, 15))
->y : Symbol(y, Decl(inferTypes1.ts, 50, 26))
+>T31 : Symbol(T31, Decl(inferTypes1.ts, 52, 34))
+>X1 : Symbol(X1, Decl(inferTypes1.ts, 48, 31))
+>x : Symbol(x, Decl(inferTypes1.ts, 53, 15))
+>y : Symbol(y, Decl(inferTypes1.ts, 53, 26))
 
 type T32 = X1<{ x: number, y: string, z: boolean }>;  // [number, string]
->T32 : Symbol(T32, Decl(inferTypes1.ts, 50, 40))
->X1 : Symbol(X1, Decl(inferTypes1.ts, 45, 31))
->x : Symbol(x, Decl(inferTypes1.ts, 51, 15))
->y : Symbol(y, Decl(inferTypes1.ts, 51, 26))
->z : Symbol(z, Decl(inferTypes1.ts, 51, 37))
+>T32 : Symbol(T32, Decl(inferTypes1.ts, 53, 40))
+>X1 : Symbol(X1, Decl(inferTypes1.ts, 48, 31))
+>x : Symbol(x, Decl(inferTypes1.ts, 54, 15))
+>y : Symbol(y, Decl(inferTypes1.ts, 54, 26))
+>z : Symbol(z, Decl(inferTypes1.ts, 54, 37))
 
 type X2<T> = T extends { a: infer U, b: infer U } ? U : never;
->X2 : Symbol(X2, Decl(inferTypes1.ts, 51, 52))
->T : Symbol(T, Decl(inferTypes1.ts, 53, 8))
->T : Symbol(T, Decl(inferTypes1.ts, 53, 8))
->a : Symbol(a, Decl(inferTypes1.ts, 53, 24))
->U : Symbol(U, Decl(inferTypes1.ts, 53, 33), Decl(inferTypes1.ts, 53, 45))
->b : Symbol(b, Decl(inferTypes1.ts, 53, 36))
->U : Symbol(U, Decl(inferTypes1.ts, 53, 33), Decl(inferTypes1.ts, 53, 45))
->U : Symbol(U, Decl(inferTypes1.ts, 53, 33), Decl(inferTypes1.ts, 53, 45))
+>X2 : Symbol(X2, Decl(inferTypes1.ts, 54, 52))
+>T : Symbol(T, Decl(inferTypes1.ts, 56, 8))
+>T : Symbol(T, Decl(inferTypes1.ts, 56, 8))
+>a : Symbol(a, Decl(inferTypes1.ts, 56, 24))
+>U : Symbol(U, Decl(inferTypes1.ts, 56, 33), Decl(inferTypes1.ts, 56, 45))
+>b : Symbol(b, Decl(inferTypes1.ts, 56, 36))
+>U : Symbol(U, Decl(inferTypes1.ts, 56, 33), Decl(inferTypes1.ts, 56, 45))
+>U : Symbol(U, Decl(inferTypes1.ts, 56, 33), Decl(inferTypes1.ts, 56, 45))
 
 type T40 = X2<{}>;  // never
->T40 : Symbol(T40, Decl(inferTypes1.ts, 53, 62))
->X2 : Symbol(X2, Decl(inferTypes1.ts, 51, 52))
+>T40 : Symbol(T40, Decl(inferTypes1.ts, 56, 62))
+>X2 : Symbol(X2, Decl(inferTypes1.ts, 54, 52))
 
 type T41 = X2<{ a: string }>;  // never
->T41 : Symbol(T41, Decl(inferTypes1.ts, 55, 18))
->X2 : Symbol(X2, Decl(inferTypes1.ts, 51, 52))
->a : Symbol(a, Decl(inferTypes1.ts, 56, 15))
+>T41 : Symbol(T41, Decl(inferTypes1.ts, 58, 18))
+>X2 : Symbol(X2, Decl(inferTypes1.ts, 54, 52))
+>a : Symbol(a, Decl(inferTypes1.ts, 59, 15))
 
 type T42 = X2<{ a: string, b: string }>;  // string
->T42 : Symbol(T42, Decl(inferTypes1.ts, 56, 29))
->X2 : Symbol(X2, Decl(inferTypes1.ts, 51, 52))
->a : Symbol(a, Decl(inferTypes1.ts, 57, 15))
->b : Symbol(b, Decl(inferTypes1.ts, 57, 26))
+>T42 : Symbol(T42, Decl(inferTypes1.ts, 59, 29))
+>X2 : Symbol(X2, Decl(inferTypes1.ts, 54, 52))
+>a : Symbol(a, Decl(inferTypes1.ts, 60, 15))
+>b : Symbol(b, Decl(inferTypes1.ts, 60, 26))
 
 type T43 = X2<{ a: number, b: string }>;  // string | number
->T43 : Symbol(T43, Decl(inferTypes1.ts, 57, 40))
->X2 : Symbol(X2, Decl(inferTypes1.ts, 51, 52))
->a : Symbol(a, Decl(inferTypes1.ts, 58, 15))
->b : Symbol(b, Decl(inferTypes1.ts, 58, 26))
+>T43 : Symbol(T43, Decl(inferTypes1.ts, 60, 40))
+>X2 : Symbol(X2, Decl(inferTypes1.ts, 54, 52))
+>a : Symbol(a, Decl(inferTypes1.ts, 61, 15))
+>b : Symbol(b, Decl(inferTypes1.ts, 61, 26))
 
 type T44 = X2<{ a: number, b: string, c: boolean }>;  // string | number
->T44 : Symbol(T44, Decl(inferTypes1.ts, 58, 40))
->X2 : Symbol(X2, Decl(inferTypes1.ts, 51, 52))
->a : Symbol(a, Decl(inferTypes1.ts, 59, 15))
->b : Symbol(b, Decl(inferTypes1.ts, 59, 26))
->c : Symbol(c, Decl(inferTypes1.ts, 59, 37))
+>T44 : Symbol(T44, Decl(inferTypes1.ts, 61, 40))
+>X2 : Symbol(X2, Decl(inferTypes1.ts, 54, 52))
+>a : Symbol(a, Decl(inferTypes1.ts, 62, 15))
+>b : Symbol(b, Decl(inferTypes1.ts, 62, 26))
+>c : Symbol(c, Decl(inferTypes1.ts, 62, 37))
 
 type X3<T> = T extends { a: (x: infer U) => void, b: (x: infer U) => void } ? U : never;
->X3 : Symbol(X3, Decl(inferTypes1.ts, 59, 52))
->T : Symbol(T, Decl(inferTypes1.ts, 61, 8))
->T : Symbol(T, Decl(inferTypes1.ts, 61, 8))
->a : Symbol(a, Decl(inferTypes1.ts, 61, 24))
->x : Symbol(x, Decl(inferTypes1.ts, 61, 29))
->U : Symbol(U, Decl(inferTypes1.ts, 61, 37), Decl(inferTypes1.ts, 61, 62))
->b : Symbol(b, Decl(inferTypes1.ts, 61, 49))
->x : Symbol(x, Decl(inferTypes1.ts, 61, 54))
->U : Symbol(U, Decl(inferTypes1.ts, 61, 37), Decl(inferTypes1.ts, 61, 62))
->U : Symbol(U, Decl(inferTypes1.ts, 61, 37), Decl(inferTypes1.ts, 61, 62))
+>X3 : Symbol(X3, Decl(inferTypes1.ts, 62, 52))
+>T : Symbol(T, Decl(inferTypes1.ts, 64, 8))
+>T : Symbol(T, Decl(inferTypes1.ts, 64, 8))
+>a : Symbol(a, Decl(inferTypes1.ts, 64, 24))
+>x : Symbol(x, Decl(inferTypes1.ts, 64, 29))
+>U : Symbol(U, Decl(inferTypes1.ts, 64, 37), Decl(inferTypes1.ts, 64, 62))
+>b : Symbol(b, Decl(inferTypes1.ts, 64, 49))
+>x : Symbol(x, Decl(inferTypes1.ts, 64, 54))
+>U : Symbol(U, Decl(inferTypes1.ts, 64, 37), Decl(inferTypes1.ts, 64, 62))
+>U : Symbol(U, Decl(inferTypes1.ts, 64, 37), Decl(inferTypes1.ts, 64, 62))
 
 type T50 = X3<{}>;  // never
->T50 : Symbol(T50, Decl(inferTypes1.ts, 61, 88))
->X3 : Symbol(X3, Decl(inferTypes1.ts, 59, 52))
+>T50 : Symbol(T50, Decl(inferTypes1.ts, 64, 88))
+>X3 : Symbol(X3, Decl(inferTypes1.ts, 62, 52))
 
 type T51 = X3<{ a: (x: string) => void }>;  // never
->T51 : Symbol(T51, Decl(inferTypes1.ts, 63, 18))
->X3 : Symbol(X3, Decl(inferTypes1.ts, 59, 52))
->a : Symbol(a, Decl(inferTypes1.ts, 64, 15))
->x : Symbol(x, Decl(inferTypes1.ts, 64, 20))
-
-type T52 = X3<{ a: (x: string) => void, b: (x: string) => void }>;  // string
->T52 : Symbol(T52, Decl(inferTypes1.ts, 64, 42))
->X3 : Symbol(X3, Decl(inferTypes1.ts, 59, 52))
->a : Symbol(a, Decl(inferTypes1.ts, 65, 15))
->x : Symbol(x, Decl(inferTypes1.ts, 65, 20))
->b : Symbol(b, Decl(inferTypes1.ts, 65, 39))
->x : Symbol(x, Decl(inferTypes1.ts, 65, 44))
-
-type T53 = X3<{ a: (x: number) => void, b: (x: string) => void }>;  // string & number
->T53 : Symbol(T53, Decl(inferTypes1.ts, 65, 66))
->X3 : Symbol(X3, Decl(inferTypes1.ts, 59, 52))
->a : Symbol(a, Decl(inferTypes1.ts, 66, 15))
->x : Symbol(x, Decl(inferTypes1.ts, 66, 20))
->b : Symbol(b, Decl(inferTypes1.ts, 66, 39))
->x : Symbol(x, Decl(inferTypes1.ts, 66, 44))
-
-type T54 = X3<{ a: (x: number) => void, b: () => void }>;  // number
->T54 : Symbol(T54, Decl(inferTypes1.ts, 66, 66))
->X3 : Symbol(X3, Decl(inferTypes1.ts, 59, 52))
+>T51 : Symbol(T51, Decl(inferTypes1.ts, 66, 18))
+>X3 : Symbol(X3, Decl(inferTypes1.ts, 62, 52))
 >a : Symbol(a, Decl(inferTypes1.ts, 67, 15))
 >x : Symbol(x, Decl(inferTypes1.ts, 67, 20))
->b : Symbol(b, Decl(inferTypes1.ts, 67, 39))
+
+type T52 = X3<{ a: (x: string) => void, b: (x: string) => void }>;  // string
+>T52 : Symbol(T52, Decl(inferTypes1.ts, 67, 42))
+>X3 : Symbol(X3, Decl(inferTypes1.ts, 62, 52))
+>a : Symbol(a, Decl(inferTypes1.ts, 68, 15))
+>x : Symbol(x, Decl(inferTypes1.ts, 68, 20))
+>b : Symbol(b, Decl(inferTypes1.ts, 68, 39))
+>x : Symbol(x, Decl(inferTypes1.ts, 68, 44))
+
+type T53 = X3<{ a: (x: number) => void, b: (x: string) => void }>;  // string & number
+>T53 : Symbol(T53, Decl(inferTypes1.ts, 68, 66))
+>X3 : Symbol(X3, Decl(inferTypes1.ts, 62, 52))
+>a : Symbol(a, Decl(inferTypes1.ts, 69, 15))
+>x : Symbol(x, Decl(inferTypes1.ts, 69, 20))
+>b : Symbol(b, Decl(inferTypes1.ts, 69, 39))
+>x : Symbol(x, Decl(inferTypes1.ts, 69, 44))
+
+type T54 = X3<{ a: (x: number) => void, b: () => void }>;  // number
+>T54 : Symbol(T54, Decl(inferTypes1.ts, 69, 66))
+>X3 : Symbol(X3, Decl(inferTypes1.ts, 62, 52))
+>a : Symbol(a, Decl(inferTypes1.ts, 70, 15))
+>x : Symbol(x, Decl(inferTypes1.ts, 70, 20))
+>b : Symbol(b, Decl(inferTypes1.ts, 70, 39))
 
 type T60 = infer U;  // Error
->T60 : Symbol(T60, Decl(inferTypes1.ts, 67, 57))
->U : Symbol(U, Decl(inferTypes1.ts, 69, 16))
+>T60 : Symbol(T60, Decl(inferTypes1.ts, 70, 57))
+>U : Symbol(U, Decl(inferTypes1.ts, 72, 16))
 
 type T61<T> = infer A extends infer B ? infer C : infer D;  // Error
->T61 : Symbol(T61, Decl(inferTypes1.ts, 69, 19))
->T : Symbol(T, Decl(inferTypes1.ts, 70, 9))
->A : Symbol(A, Decl(inferTypes1.ts, 70, 19))
->B : Symbol(B, Decl(inferTypes1.ts, 70, 35))
->C : Symbol(C, Decl(inferTypes1.ts, 70, 45))
->D : Symbol(D, Decl(inferTypes1.ts, 70, 55))
+>T61 : Symbol(T61, Decl(inferTypes1.ts, 72, 19))
+>T : Symbol(T, Decl(inferTypes1.ts, 73, 9))
+>A : Symbol(A, Decl(inferTypes1.ts, 73, 19))
+>B : Symbol(B, Decl(inferTypes1.ts, 73, 35))
+>C : Symbol(C, Decl(inferTypes1.ts, 73, 45))
+>D : Symbol(D, Decl(inferTypes1.ts, 73, 55))
 
 type T62<T> = U extends (infer U)[] ? U : U;  // Error
->T62 : Symbol(T62, Decl(inferTypes1.ts, 70, 58))
->T : Symbol(T, Decl(inferTypes1.ts, 71, 9))
->U : Symbol(U, Decl(inferTypes1.ts, 71, 30))
->U : Symbol(U, Decl(inferTypes1.ts, 71, 30))
+>T62 : Symbol(T62, Decl(inferTypes1.ts, 73, 58))
+>T : Symbol(T, Decl(inferTypes1.ts, 74, 9))
+>U : Symbol(U, Decl(inferTypes1.ts, 74, 30))
+>U : Symbol(U, Decl(inferTypes1.ts, 74, 30))
 
 type T70<T extends string> = { x: T };
->T70 : Symbol(T70, Decl(inferTypes1.ts, 71, 44))
->T : Symbol(T, Decl(inferTypes1.ts, 73, 9))
->x : Symbol(x, Decl(inferTypes1.ts, 73, 30))
->T : Symbol(T, Decl(inferTypes1.ts, 73, 9))
+>T70 : Symbol(T70, Decl(inferTypes1.ts, 74, 44))
+>T : Symbol(T, Decl(inferTypes1.ts, 76, 9))
+>x : Symbol(x, Decl(inferTypes1.ts, 76, 30))
+>T : Symbol(T, Decl(inferTypes1.ts, 76, 9))
 
 type T71<T> = T extends T70<infer U> ? T70<U> : never;
->T71 : Symbol(T71, Decl(inferTypes1.ts, 73, 38))
->T : Symbol(T, Decl(inferTypes1.ts, 74, 9))
->T : Symbol(T, Decl(inferTypes1.ts, 74, 9))
->T70 : Symbol(T70, Decl(inferTypes1.ts, 71, 44))
->U : Symbol(U, Decl(inferTypes1.ts, 74, 33))
->T70 : Symbol(T70, Decl(inferTypes1.ts, 71, 44))
->U : Symbol(U, Decl(inferTypes1.ts, 74, 33))
+>T71 : Symbol(T71, Decl(inferTypes1.ts, 76, 38))
+>T : Symbol(T, Decl(inferTypes1.ts, 77, 9))
+>T : Symbol(T, Decl(inferTypes1.ts, 77, 9))
+>T70 : Symbol(T70, Decl(inferTypes1.ts, 74, 44))
+>U : Symbol(U, Decl(inferTypes1.ts, 77, 33))
+>T70 : Symbol(T70, Decl(inferTypes1.ts, 74, 44))
+>U : Symbol(U, Decl(inferTypes1.ts, 77, 33))
 
 type T72<T extends number> = { y: T };
->T72 : Symbol(T72, Decl(inferTypes1.ts, 74, 54))
->T : Symbol(T, Decl(inferTypes1.ts, 76, 9))
->y : Symbol(y, Decl(inferTypes1.ts, 76, 30))
->T : Symbol(T, Decl(inferTypes1.ts, 76, 9))
+>T72 : Symbol(T72, Decl(inferTypes1.ts, 77, 54))
+>T : Symbol(T, Decl(inferTypes1.ts, 79, 9))
+>y : Symbol(y, Decl(inferTypes1.ts, 79, 30))
+>T : Symbol(T, Decl(inferTypes1.ts, 79, 9))
 
 type T73<T> = T extends T72<infer U> ? T70<U> : never;  // Error
->T73 : Symbol(T73, Decl(inferTypes1.ts, 76, 38))
->T : Symbol(T, Decl(inferTypes1.ts, 77, 9))
->T : Symbol(T, Decl(inferTypes1.ts, 77, 9))
->T72 : Symbol(T72, Decl(inferTypes1.ts, 74, 54))
->U : Symbol(U, Decl(inferTypes1.ts, 77, 33))
->T70 : Symbol(T70, Decl(inferTypes1.ts, 71, 44))
->U : Symbol(U, Decl(inferTypes1.ts, 77, 33))
+>T73 : Symbol(T73, Decl(inferTypes1.ts, 79, 38))
+>T : Symbol(T, Decl(inferTypes1.ts, 80, 9))
+>T : Symbol(T, Decl(inferTypes1.ts, 80, 9))
+>T72 : Symbol(T72, Decl(inferTypes1.ts, 77, 54))
+>U : Symbol(U, Decl(inferTypes1.ts, 80, 33))
+>T70 : Symbol(T70, Decl(inferTypes1.ts, 74, 44))
+>U : Symbol(U, Decl(inferTypes1.ts, 80, 33))
 
 type T74<T extends number, U extends string> = { x: T, y: U };
->T74 : Symbol(T74, Decl(inferTypes1.ts, 77, 54))
->T : Symbol(T, Decl(inferTypes1.ts, 79, 9))
->U : Symbol(U, Decl(inferTypes1.ts, 79, 26))
->x : Symbol(x, Decl(inferTypes1.ts, 79, 48))
->T : Symbol(T, Decl(inferTypes1.ts, 79, 9))
->y : Symbol(y, Decl(inferTypes1.ts, 79, 54))
->U : Symbol(U, Decl(inferTypes1.ts, 79, 26))
+>T74 : Symbol(T74, Decl(inferTypes1.ts, 80, 54))
+>T : Symbol(T, Decl(inferTypes1.ts, 82, 9))
+>U : Symbol(U, Decl(inferTypes1.ts, 82, 26))
+>x : Symbol(x, Decl(inferTypes1.ts, 82, 48))
+>T : Symbol(T, Decl(inferTypes1.ts, 82, 9))
+>y : Symbol(y, Decl(inferTypes1.ts, 82, 54))
+>U : Symbol(U, Decl(inferTypes1.ts, 82, 26))
 
 type T75<T> = T extends T74<infer U, infer U> ? T70<U> | T72<U> | T74<U, U> : never;
->T75 : Symbol(T75, Decl(inferTypes1.ts, 79, 62))
->T : Symbol(T, Decl(inferTypes1.ts, 80, 9))
->T : Symbol(T, Decl(inferTypes1.ts, 80, 9))
->T74 : Symbol(T74, Decl(inferTypes1.ts, 77, 54))
->U : Symbol(U, Decl(inferTypes1.ts, 80, 33), Decl(inferTypes1.ts, 80, 42))
->U : Symbol(U, Decl(inferTypes1.ts, 80, 33), Decl(inferTypes1.ts, 80, 42))
->T70 : Symbol(T70, Decl(inferTypes1.ts, 71, 44))
->U : Symbol(U, Decl(inferTypes1.ts, 80, 33), Decl(inferTypes1.ts, 80, 42))
->T72 : Symbol(T72, Decl(inferTypes1.ts, 74, 54))
->U : Symbol(U, Decl(inferTypes1.ts, 80, 33), Decl(inferTypes1.ts, 80, 42))
->T74 : Symbol(T74, Decl(inferTypes1.ts, 77, 54))
->U : Symbol(U, Decl(inferTypes1.ts, 80, 33), Decl(inferTypes1.ts, 80, 42))
->U : Symbol(U, Decl(inferTypes1.ts, 80, 33), Decl(inferTypes1.ts, 80, 42))
+>T75 : Symbol(T75, Decl(inferTypes1.ts, 82, 62))
+>T : Symbol(T, Decl(inferTypes1.ts, 83, 9))
+>T : Symbol(T, Decl(inferTypes1.ts, 83, 9))
+>T74 : Symbol(T74, Decl(inferTypes1.ts, 80, 54))
+>U : Symbol(U, Decl(inferTypes1.ts, 83, 33), Decl(inferTypes1.ts, 83, 42))
+>U : Symbol(U, Decl(inferTypes1.ts, 83, 33), Decl(inferTypes1.ts, 83, 42))
+>T70 : Symbol(T70, Decl(inferTypes1.ts, 74, 44))
+>U : Symbol(U, Decl(inferTypes1.ts, 83, 33), Decl(inferTypes1.ts, 83, 42))
+>T72 : Symbol(T72, Decl(inferTypes1.ts, 77, 54))
+>U : Symbol(U, Decl(inferTypes1.ts, 83, 33), Decl(inferTypes1.ts, 83, 42))
+>T74 : Symbol(T74, Decl(inferTypes1.ts, 80, 54))
+>U : Symbol(U, Decl(inferTypes1.ts, 83, 33), Decl(inferTypes1.ts, 83, 42))
+>U : Symbol(U, Decl(inferTypes1.ts, 83, 33), Decl(inferTypes1.ts, 83, 42))
 
 type T76<T extends T[], U extends T> = { x: T };
->T76 : Symbol(T76, Decl(inferTypes1.ts, 80, 84))
->T : Symbol(T, Decl(inferTypes1.ts, 82, 9))
->T : Symbol(T, Decl(inferTypes1.ts, 82, 9))
->U : Symbol(U, Decl(inferTypes1.ts, 82, 23))
->T : Symbol(T, Decl(inferTypes1.ts, 82, 9))
->x : Symbol(x, Decl(inferTypes1.ts, 82, 40))
->T : Symbol(T, Decl(inferTypes1.ts, 82, 9))
+>T76 : Symbol(T76, Decl(inferTypes1.ts, 83, 84))
+>T : Symbol(T, Decl(inferTypes1.ts, 85, 9))
+>T : Symbol(T, Decl(inferTypes1.ts, 85, 9))
+>U : Symbol(U, Decl(inferTypes1.ts, 85, 23))
+>T : Symbol(T, Decl(inferTypes1.ts, 85, 9))
+>x : Symbol(x, Decl(inferTypes1.ts, 85, 40))
+>T : Symbol(T, Decl(inferTypes1.ts, 85, 9))
 
 type T77<T> = T extends T76<infer X, infer Y> ? T76<X, Y> : never;
->T77 : Symbol(T77, Decl(inferTypes1.ts, 82, 48))
->T : Symbol(T, Decl(inferTypes1.ts, 83, 9))
->T : Symbol(T, Decl(inferTypes1.ts, 83, 9))
->T76 : Symbol(T76, Decl(inferTypes1.ts, 80, 84))
->X : Symbol(X, Decl(inferTypes1.ts, 83, 33))
->Y : Symbol(Y, Decl(inferTypes1.ts, 83, 42))
->T76 : Symbol(T76, Decl(inferTypes1.ts, 80, 84))
->X : Symbol(X, Decl(inferTypes1.ts, 83, 33))
->Y : Symbol(Y, Decl(inferTypes1.ts, 83, 42))
+>T77 : Symbol(T77, Decl(inferTypes1.ts, 85, 48))
+>T : Symbol(T, Decl(inferTypes1.ts, 86, 9))
+>T : Symbol(T, Decl(inferTypes1.ts, 86, 9))
+>T76 : Symbol(T76, Decl(inferTypes1.ts, 83, 84))
+>X : Symbol(X, Decl(inferTypes1.ts, 86, 33))
+>Y : Symbol(Y, Decl(inferTypes1.ts, 86, 42))
+>T76 : Symbol(T76, Decl(inferTypes1.ts, 83, 84))
+>X : Symbol(X, Decl(inferTypes1.ts, 86, 33))
+>Y : Symbol(Y, Decl(inferTypes1.ts, 86, 42))
 
 type T78<T> = T extends T76<infer X, infer X> ? T76<X, X> : never;
->T78 : Symbol(T78, Decl(inferTypes1.ts, 83, 66))
->T : Symbol(T, Decl(inferTypes1.ts, 84, 9))
->T : Symbol(T, Decl(inferTypes1.ts, 84, 9))
->T76 : Symbol(T76, Decl(inferTypes1.ts, 80, 84))
->X : Symbol(X, Decl(inferTypes1.ts, 84, 33), Decl(inferTypes1.ts, 84, 42))
->X : Symbol(X, Decl(inferTypes1.ts, 84, 33), Decl(inferTypes1.ts, 84, 42))
->T76 : Symbol(T76, Decl(inferTypes1.ts, 80, 84))
->X : Symbol(X, Decl(inferTypes1.ts, 84, 33), Decl(inferTypes1.ts, 84, 42))
->X : Symbol(X, Decl(inferTypes1.ts, 84, 33), Decl(inferTypes1.ts, 84, 42))
+>T78 : Symbol(T78, Decl(inferTypes1.ts, 86, 66))
+>T : Symbol(T, Decl(inferTypes1.ts, 87, 9))
+>T : Symbol(T, Decl(inferTypes1.ts, 87, 9))
+>T76 : Symbol(T76, Decl(inferTypes1.ts, 83, 84))
+>X : Symbol(X, Decl(inferTypes1.ts, 87, 33), Decl(inferTypes1.ts, 87, 42))
+>X : Symbol(X, Decl(inferTypes1.ts, 87, 33), Decl(inferTypes1.ts, 87, 42))
+>T76 : Symbol(T76, Decl(inferTypes1.ts, 83, 84))
+>X : Symbol(X, Decl(inferTypes1.ts, 87, 33), Decl(inferTypes1.ts, 87, 42))
+>X : Symbol(X, Decl(inferTypes1.ts, 87, 33), Decl(inferTypes1.ts, 87, 42))
 
 // Example from #21496
 
 type JsonifiedObject<T extends object> = { [K in keyof T]: Jsonified<T[K]> };
->JsonifiedObject : Symbol(JsonifiedObject, Decl(inferTypes1.ts, 84, 66))
->T : Symbol(T, Decl(inferTypes1.ts, 88, 21))
->K : Symbol(K, Decl(inferTypes1.ts, 88, 44))
->T : Symbol(T, Decl(inferTypes1.ts, 88, 21))
->Jsonified : Symbol(Jsonified, Decl(inferTypes1.ts, 88, 77))
->T : Symbol(T, Decl(inferTypes1.ts, 88, 21))
->K : Symbol(K, Decl(inferTypes1.ts, 88, 44))
+>JsonifiedObject : Symbol(JsonifiedObject, Decl(inferTypes1.ts, 87, 66))
+>T : Symbol(T, Decl(inferTypes1.ts, 91, 21))
+>K : Symbol(K, Decl(inferTypes1.ts, 91, 44))
+>T : Symbol(T, Decl(inferTypes1.ts, 91, 21))
+>Jsonified : Symbol(Jsonified, Decl(inferTypes1.ts, 91, 77))
+>T : Symbol(T, Decl(inferTypes1.ts, 91, 21))
+>K : Symbol(K, Decl(inferTypes1.ts, 91, 44))
 
 type Jsonified<T> =
->Jsonified : Symbol(Jsonified, Decl(inferTypes1.ts, 88, 77))
->T : Symbol(T, Decl(inferTypes1.ts, 90, 15))
+>Jsonified : Symbol(Jsonified, Decl(inferTypes1.ts, 91, 77))
+>T : Symbol(T, Decl(inferTypes1.ts, 93, 15))
 
     T extends string | number | boolean | null ? T
->T : Symbol(T, Decl(inferTypes1.ts, 90, 15))
->T : Symbol(T, Decl(inferTypes1.ts, 90, 15))
+>T : Symbol(T, Decl(inferTypes1.ts, 93, 15))
+>T : Symbol(T, Decl(inferTypes1.ts, 93, 15))
 
     : T extends undefined | Function ? never // undefined and functions are removed
->T : Symbol(T, Decl(inferTypes1.ts, 90, 15))
+>T : Symbol(T, Decl(inferTypes1.ts, 93, 15))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
     : T extends { toJSON(): infer R } ? R // toJSON is called if it exists (e.g. Date)
->T : Symbol(T, Decl(inferTypes1.ts, 90, 15))
->toJSON : Symbol(toJSON, Decl(inferTypes1.ts, 93, 17))
->R : Symbol(R, Decl(inferTypes1.ts, 93, 33))
->R : Symbol(R, Decl(inferTypes1.ts, 93, 33))
+>T : Symbol(T, Decl(inferTypes1.ts, 93, 15))
+>toJSON : Symbol(toJSON, Decl(inferTypes1.ts, 96, 17))
+>R : Symbol(R, Decl(inferTypes1.ts, 96, 33))
+>R : Symbol(R, Decl(inferTypes1.ts, 96, 33))
 
     : T extends object ? JsonifiedObject<T>
->T : Symbol(T, Decl(inferTypes1.ts, 90, 15))
->JsonifiedObject : Symbol(JsonifiedObject, Decl(inferTypes1.ts, 84, 66))
->T : Symbol(T, Decl(inferTypes1.ts, 90, 15))
+>T : Symbol(T, Decl(inferTypes1.ts, 93, 15))
+>JsonifiedObject : Symbol(JsonifiedObject, Decl(inferTypes1.ts, 87, 66))
+>T : Symbol(T, Decl(inferTypes1.ts, 93, 15))
 
     : "what is this";
 
 type Example = {
->Example : Symbol(Example, Decl(inferTypes1.ts, 95, 21))
+>Example : Symbol(Example, Decl(inferTypes1.ts, 98, 21))
 
     str: "literalstring",
->str : Symbol(str, Decl(inferTypes1.ts, 97, 16))
+>str : Symbol(str, Decl(inferTypes1.ts, 100, 16))
 
     fn: () => void,
->fn : Symbol(fn, Decl(inferTypes1.ts, 98, 25))
+>fn : Symbol(fn, Decl(inferTypes1.ts, 101, 25))
 
     date: Date,
->date : Symbol(date, Decl(inferTypes1.ts, 99, 19))
+>date : Symbol(date, Decl(inferTypes1.ts, 102, 19))
 >Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
     customClass: MyClass,
->customClass : Symbol(customClass, Decl(inferTypes1.ts, 100, 15))
->MyClass : Symbol(MyClass, Decl(inferTypes1.ts, 107, 1))
+>customClass : Symbol(customClass, Decl(inferTypes1.ts, 103, 15))
+>MyClass : Symbol(MyClass, Decl(inferTypes1.ts, 110, 1))
 
     obj: {
->obj : Symbol(obj, Decl(inferTypes1.ts, 101, 25))
+>obj : Symbol(obj, Decl(inferTypes1.ts, 104, 25))
 
         prop: "property",
->prop : Symbol(prop, Decl(inferTypes1.ts, 102, 10))
+>prop : Symbol(prop, Decl(inferTypes1.ts, 105, 10))
 
         clz: MyClass,
->clz : Symbol(clz, Decl(inferTypes1.ts, 103, 25))
->MyClass : Symbol(MyClass, Decl(inferTypes1.ts, 107, 1))
+>clz : Symbol(clz, Decl(inferTypes1.ts, 106, 25))
+>MyClass : Symbol(MyClass, Decl(inferTypes1.ts, 110, 1))
 
         nested: { attr: Date }
->nested : Symbol(nested, Decl(inferTypes1.ts, 104, 21))
->attr : Symbol(attr, Decl(inferTypes1.ts, 105, 17))
+>nested : Symbol(nested, Decl(inferTypes1.ts, 107, 21))
+>attr : Symbol(attr, Decl(inferTypes1.ts, 108, 17))
 >Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
     },
 }
 
 declare class MyClass {
->MyClass : Symbol(MyClass, Decl(inferTypes1.ts, 107, 1))
+>MyClass : Symbol(MyClass, Decl(inferTypes1.ts, 110, 1))
 
     toJSON(): "correct";
->toJSON : Symbol(MyClass.toJSON, Decl(inferTypes1.ts, 109, 23))
+>toJSON : Symbol(MyClass.toJSON, Decl(inferTypes1.ts, 112, 23))
 }
 
 type JsonifiedExample = Jsonified<Example>;
->JsonifiedExample : Symbol(JsonifiedExample, Decl(inferTypes1.ts, 111, 1))
->Jsonified : Symbol(Jsonified, Decl(inferTypes1.ts, 88, 77))
->Example : Symbol(Example, Decl(inferTypes1.ts, 95, 21))
+>JsonifiedExample : Symbol(JsonifiedExample, Decl(inferTypes1.ts, 114, 1))
+>Jsonified : Symbol(Jsonified, Decl(inferTypes1.ts, 91, 77))
+>Example : Symbol(Example, Decl(inferTypes1.ts, 98, 21))
 
 declare let ex: JsonifiedExample;
->ex : Symbol(ex, Decl(inferTypes1.ts, 114, 11))
->JsonifiedExample : Symbol(JsonifiedExample, Decl(inferTypes1.ts, 111, 1))
+>ex : Symbol(ex, Decl(inferTypes1.ts, 117, 11))
+>JsonifiedExample : Symbol(JsonifiedExample, Decl(inferTypes1.ts, 114, 1))
 
 const z1: "correct" = ex.customClass;
->z1 : Symbol(z1, Decl(inferTypes1.ts, 115, 5))
->ex.customClass : Symbol(customClass, Decl(inferTypes1.ts, 100, 15))
->ex : Symbol(ex, Decl(inferTypes1.ts, 114, 11))
->customClass : Symbol(customClass, Decl(inferTypes1.ts, 100, 15))
+>z1 : Symbol(z1, Decl(inferTypes1.ts, 118, 5))
+>ex.customClass : Symbol(customClass, Decl(inferTypes1.ts, 103, 15))
+>ex : Symbol(ex, Decl(inferTypes1.ts, 117, 11))
+>customClass : Symbol(customClass, Decl(inferTypes1.ts, 103, 15))
 
 const z2: string = ex.obj.nested.attr;
->z2 : Symbol(z2, Decl(inferTypes1.ts, 116, 5))
->ex.obj.nested.attr : Symbol(attr, Decl(inferTypes1.ts, 105, 17))
->ex.obj.nested : Symbol(nested, Decl(inferTypes1.ts, 104, 21))
->ex.obj : Symbol(obj, Decl(inferTypes1.ts, 101, 25))
->ex : Symbol(ex, Decl(inferTypes1.ts, 114, 11))
->obj : Symbol(obj, Decl(inferTypes1.ts, 101, 25))
->nested : Symbol(nested, Decl(inferTypes1.ts, 104, 21))
->attr : Symbol(attr, Decl(inferTypes1.ts, 105, 17))
+>z2 : Symbol(z2, Decl(inferTypes1.ts, 119, 5))
+>ex.obj.nested.attr : Symbol(attr, Decl(inferTypes1.ts, 108, 17))
+>ex.obj.nested : Symbol(nested, Decl(inferTypes1.ts, 107, 21))
+>ex.obj : Symbol(obj, Decl(inferTypes1.ts, 104, 25))
+>ex : Symbol(ex, Decl(inferTypes1.ts, 117, 11))
+>obj : Symbol(obj, Decl(inferTypes1.ts, 104, 25))
+>nested : Symbol(nested, Decl(inferTypes1.ts, 107, 21))
+>attr : Symbol(attr, Decl(inferTypes1.ts, 108, 17))
 
 // Repros from #21631
 
 type A1<T, U extends A1<any, any>> = [T, U];
->A1 : Symbol(A1, Decl(inferTypes1.ts, 116, 38))
->T : Symbol(T, Decl(inferTypes1.ts, 120, 8))
->U : Symbol(U, Decl(inferTypes1.ts, 120, 10))
->A1 : Symbol(A1, Decl(inferTypes1.ts, 116, 38))
->T : Symbol(T, Decl(inferTypes1.ts, 120, 8))
->U : Symbol(U, Decl(inferTypes1.ts, 120, 10))
+>A1 : Symbol(A1, Decl(inferTypes1.ts, 119, 38))
+>T : Symbol(T, Decl(inferTypes1.ts, 123, 8))
+>U : Symbol(U, Decl(inferTypes1.ts, 123, 10))
+>A1 : Symbol(A1, Decl(inferTypes1.ts, 119, 38))
+>T : Symbol(T, Decl(inferTypes1.ts, 123, 8))
+>U : Symbol(U, Decl(inferTypes1.ts, 123, 10))
 
 type B1<S> = S extends A1<infer T, infer U> ? [T, U] : never;
->B1 : Symbol(B1, Decl(inferTypes1.ts, 120, 44))
->S : Symbol(S, Decl(inferTypes1.ts, 121, 8))
->S : Symbol(S, Decl(inferTypes1.ts, 121, 8))
->A1 : Symbol(A1, Decl(inferTypes1.ts, 116, 38))
->T : Symbol(T, Decl(inferTypes1.ts, 121, 31))
->U : Symbol(U, Decl(inferTypes1.ts, 121, 40))
->T : Symbol(T, Decl(inferTypes1.ts, 121, 31))
->U : Symbol(U, Decl(inferTypes1.ts, 121, 40))
+>B1 : Symbol(B1, Decl(inferTypes1.ts, 123, 44))
+>S : Symbol(S, Decl(inferTypes1.ts, 124, 8))
+>S : Symbol(S, Decl(inferTypes1.ts, 124, 8))
+>A1 : Symbol(A1, Decl(inferTypes1.ts, 119, 38))
+>T : Symbol(T, Decl(inferTypes1.ts, 124, 31))
+>U : Symbol(U, Decl(inferTypes1.ts, 124, 40))
+>T : Symbol(T, Decl(inferTypes1.ts, 124, 31))
+>U : Symbol(U, Decl(inferTypes1.ts, 124, 40))
 
 type A2<T, U extends void> = [T, U];
->A2 : Symbol(A2, Decl(inferTypes1.ts, 121, 61))
->T : Symbol(T, Decl(inferTypes1.ts, 123, 8))
->U : Symbol(U, Decl(inferTypes1.ts, 123, 10))
->T : Symbol(T, Decl(inferTypes1.ts, 123, 8))
->U : Symbol(U, Decl(inferTypes1.ts, 123, 10))
+>A2 : Symbol(A2, Decl(inferTypes1.ts, 124, 61))
+>T : Symbol(T, Decl(inferTypes1.ts, 126, 8))
+>U : Symbol(U, Decl(inferTypes1.ts, 126, 10))
+>T : Symbol(T, Decl(inferTypes1.ts, 126, 8))
+>U : Symbol(U, Decl(inferTypes1.ts, 126, 10))
 
 type B2<S> = S extends A2<infer T, infer U> ? [T, U] : never;
->B2 : Symbol(B2, Decl(inferTypes1.ts, 123, 36))
->S : Symbol(S, Decl(inferTypes1.ts, 124, 8))
->S : Symbol(S, Decl(inferTypes1.ts, 124, 8))
->A2 : Symbol(A2, Decl(inferTypes1.ts, 121, 61))
->T : Symbol(T, Decl(inferTypes1.ts, 124, 31))
->U : Symbol(U, Decl(inferTypes1.ts, 124, 40))
->T : Symbol(T, Decl(inferTypes1.ts, 124, 31))
->U : Symbol(U, Decl(inferTypes1.ts, 124, 40))
+>B2 : Symbol(B2, Decl(inferTypes1.ts, 126, 36))
+>S : Symbol(S, Decl(inferTypes1.ts, 127, 8))
+>S : Symbol(S, Decl(inferTypes1.ts, 127, 8))
+>A2 : Symbol(A2, Decl(inferTypes1.ts, 124, 61))
+>T : Symbol(T, Decl(inferTypes1.ts, 127, 31))
+>U : Symbol(U, Decl(inferTypes1.ts, 127, 40))
+>T : Symbol(T, Decl(inferTypes1.ts, 127, 31))
+>U : Symbol(U, Decl(inferTypes1.ts, 127, 40))
 
 type C2<S, U extends void> = S extends A2<infer T, U> ? [T, U] : never;
->C2 : Symbol(C2, Decl(inferTypes1.ts, 124, 61))
->S : Symbol(S, Decl(inferTypes1.ts, 125, 8))
->U : Symbol(U, Decl(inferTypes1.ts, 125, 10))
->S : Symbol(S, Decl(inferTypes1.ts, 125, 8))
->A2 : Symbol(A2, Decl(inferTypes1.ts, 121, 61))
->T : Symbol(T, Decl(inferTypes1.ts, 125, 47))
->U : Symbol(U, Decl(inferTypes1.ts, 125, 10))
->T : Symbol(T, Decl(inferTypes1.ts, 125, 47))
->U : Symbol(U, Decl(inferTypes1.ts, 125, 10))
+>C2 : Symbol(C2, Decl(inferTypes1.ts, 127, 61))
+>S : Symbol(S, Decl(inferTypes1.ts, 128, 8))
+>U : Symbol(U, Decl(inferTypes1.ts, 128, 10))
+>S : Symbol(S, Decl(inferTypes1.ts, 128, 8))
+>A2 : Symbol(A2, Decl(inferTypes1.ts, 124, 61))
+>T : Symbol(T, Decl(inferTypes1.ts, 128, 47))
+>U : Symbol(U, Decl(inferTypes1.ts, 128, 10))
+>T : Symbol(T, Decl(inferTypes1.ts, 128, 47))
+>U : Symbol(U, Decl(inferTypes1.ts, 128, 10))
 
 // Repro from #21735
 
 type A<T> = T extends string ? { [P in T]: void; } : T;
->A : Symbol(A, Decl(inferTypes1.ts, 125, 71))
->T : Symbol(T, Decl(inferTypes1.ts, 129, 7))
->T : Symbol(T, Decl(inferTypes1.ts, 129, 7))
->P : Symbol(P, Decl(inferTypes1.ts, 129, 34))
->T : Symbol(T, Decl(inferTypes1.ts, 129, 7))
->T : Symbol(T, Decl(inferTypes1.ts, 129, 7))
+>A : Symbol(A, Decl(inferTypes1.ts, 128, 71))
+>T : Symbol(T, Decl(inferTypes1.ts, 132, 7))
+>T : Symbol(T, Decl(inferTypes1.ts, 132, 7))
+>P : Symbol(P, Decl(inferTypes1.ts, 132, 34))
+>T : Symbol(T, Decl(inferTypes1.ts, 132, 7))
+>T : Symbol(T, Decl(inferTypes1.ts, 132, 7))
 
 type B<T> = string extends T ? { [P in T]: void; } : T;  // Error
->B : Symbol(B, Decl(inferTypes1.ts, 129, 55))
->T : Symbol(T, Decl(inferTypes1.ts, 130, 7))
->T : Symbol(T, Decl(inferTypes1.ts, 130, 7))
->P : Symbol(P, Decl(inferTypes1.ts, 130, 34))
->T : Symbol(T, Decl(inferTypes1.ts, 130, 7))
->T : Symbol(T, Decl(inferTypes1.ts, 130, 7))
+>B : Symbol(B, Decl(inferTypes1.ts, 132, 55))
+>T : Symbol(T, Decl(inferTypes1.ts, 133, 7))
+>T : Symbol(T, Decl(inferTypes1.ts, 133, 7))
+>P : Symbol(P, Decl(inferTypes1.ts, 133, 34))
+>T : Symbol(T, Decl(inferTypes1.ts, 133, 7))
+>T : Symbol(T, Decl(inferTypes1.ts, 133, 7))
 

--- a/tests/baselines/reference/inferTypes1.types
+++ b/tests/baselines/reference/inferTypes1.types
@@ -54,17 +54,6 @@ type T06 = Unpacked<never>;  // never
 >T06 : never
 >Unpacked : Unpacked<T>
 
-type ReturnType<T extends Function> = T extends ((...args: any[]) => infer R) | (new (...args: any[]) => infer R) ? R : any;
->ReturnType : ReturnType<T>
->T : T
->Function : Function
->T : T
->args : any[]
->R : R
->args : any[]
->R : R
->R : R
-
 function f1(s: string) {
 >f1 : (s: string) => { a: number; b: string; }
 >s : string
@@ -117,26 +106,43 @@ type T14 = ReturnType<typeof f1>;  // { a: number, b: string }
 >ReturnType : ReturnType<T>
 >f1 : (s: string) => { a: number; b: string; }
 
-type T15 = ReturnType<typeof C>;  // C
->T15 : C
+type T15 = ReturnType<any>;  // any
+>T15 : any
 >ReturnType : ReturnType<T>
->C : typeof C
 
-type T16 = ReturnType<any>;  // any
+type T16 = ReturnType<never>;  // any
 >T16 : any
 >ReturnType : ReturnType<T>
 
-type T17 = ReturnType<never>;  // any
+type T17 = ReturnType<string>;  // Error
 >T17 : any
 >ReturnType : ReturnType<T>
 
-type T18 = ReturnType<string>;  // Error
+type T18 = ReturnType<Function>;  // Error
 >T18 : any
 >ReturnType : ReturnType<T>
+>Function : Function
 
-type T19 = ReturnType<Function>;  // any
->T19 : any
->ReturnType : ReturnType<T>
+type U10 = InstanceType<typeof C>;  // C
+>U10 : C
+>InstanceType : InstanceType<T>
+>C : typeof C
+
+type U11 = InstanceType<any>;  // any
+>U11 : any
+>InstanceType : InstanceType<T>
+
+type U12 = InstanceType<never>;  // any
+>U12 : any
+>InstanceType : InstanceType<T>
+
+type U13 = InstanceType<string>;  // Error
+>U13 : any
+>InstanceType : InstanceType<T>
+
+type U14 = InstanceType<Function>;  // Error
+>U14 : any
+>InstanceType : InstanceType<T>
 >Function : Function
 
 type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;

--- a/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes1.ts
@@ -1,15 +1,11 @@
 // @strict: true
 // @declaration: true
 
-type Diff<T, U> = T extends U ? never : T;
-type Filter<T, U> = T extends U ? T : never;
-type NonNullable<T> = Diff<T, null | undefined>;
+type T00 = Exclude<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
+type T01 = Extract<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
 
-type T00 = Diff<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
-type T01 = Filter<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"
-
-type T02 = Diff<string | number | (() => void), Function>;  // string | number
-type T03 = Filter<string | number | (() => void), Function>;  // () => void
+type T02 = Exclude<string | number | (() => void), Function>;  // string | number
+type T03 = Extract<string | number | (() => void), Function>;  // () => void
 
 type T04 = NonNullable<string | number | undefined>;  // string | number
 type T05 = NonNullable<(() => string) | string[] | null | undefined>;  // (() => string) | string[]
@@ -33,23 +29,23 @@ function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>) {
 
 type Options = { k: "a", a: number } | { k: "b", b: string } | { k: "c", c: boolean };
 
-type T10 = Diff<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
-type T11 = Filter<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+type T10 = Exclude<Options, { k: "a" | "b" }>;  // { k: "c", c: boolean }
+type T11 = Extract<Options, { k: "a" | "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
 
-type T12 = Diff<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
-type T13 = Filter<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
+type T12 = Exclude<Options, { k: "a" } | { k: "b" }>;  // { k: "c", c: boolean }
+type T13 = Extract<Options, { k: "a" } | { k: "b" }>;  // { k: "a", a: number } | { k: "b", b: string }
 
-type T14 = Diff<Options, { q: "a" }>;  // Options
-type T15 = Filter<Options, { q: "a" }>;  // never
+type T14 = Exclude<Options, { q: "a" }>;  // Options
+type T15 = Extract<Options, { q: "a" }>;  // never
 
-declare function f4<T extends Options, K extends string>(p: K): Filter<T, { k: K }>;
+declare function f4<T extends Options, K extends string>(p: K): Extract<T, { k: K }>;
 let x0 = f4("a");  // { k: "a", a: number }
 
-type OptionsOfKind<K extends Options["k"]> = Filter<Options, { k: K }>;
+type OptionsOfKind<K extends Options["k"]> = Extract<Options, { k: K }>;
 
 type T16 = OptionsOfKind<"a" | "b">;  // { k: "a", a: number } | { k: "b", b: string }
 
-type Select<T, K extends keyof T, V extends T[K]> = Filter<T, { [P in K]: V }>;
+type Select<T, K extends keyof T, V extends T[K]> = Extract<T, { [P in K]: V }>;
 
 type T17 = Select<Options, "k", "a" | "b">;  // // { k: "a", a: number } | { k: "b", b: string }
 

--- a/tests/cases/conformance/types/conditional/inferTypes1.ts
+++ b/tests/cases/conformance/types/conditional/inferTypes1.ts
@@ -15,8 +15,6 @@ type T04 = Unpacked<Unpacked<Promise<string>[]>>;  // string
 type T05 = Unpacked<any>;  // any
 type T06 = Unpacked<never>;  // never
 
-type ReturnType<T extends Function> = T extends ((...args: any[]) => infer R) | (new (...args: any[]) => infer R) ? R : any;
-
 function f1(s: string) {
     return { a: 1, b: s };
 }
@@ -31,11 +29,16 @@ type T11 = ReturnType<(s: string) => void>;  // void
 type T12 = ReturnType<(<T>() => T)>;  // {}
 type T13 = ReturnType<(<T extends U, U extends number[]>() => T)>;  // number[]
 type T14 = ReturnType<typeof f1>;  // { a: number, b: string }
-type T15 = ReturnType<typeof C>;  // C
-type T16 = ReturnType<any>;  // any
-type T17 = ReturnType<never>;  // any
-type T18 = ReturnType<string>;  // Error
-type T19 = ReturnType<Function>;  // any
+type T15 = ReturnType<any>;  // any
+type T16 = ReturnType<never>;  // any
+type T17 = ReturnType<string>;  // Error
+type T18 = ReturnType<Function>;  // Error
+
+type U10 = InstanceType<typeof C>;  // C
+type U11 = InstanceType<any>;  // any
+type U12 = InstanceType<never>;  // any
+type U13 = InstanceType<string>;  // Error
+type U14 = InstanceType<Function>;  // Error
 
 type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;
 


### PR DESCRIPTION
This PR adds several predefined conditional types to `lib.d.ts`:

* `Exclude<T, U>` -- Exclude from `T` those types that are assignable to `U`.
* `Extract<T, U>` -- Extract from `T` those types that are assignable to `U`.
* `NonNullable<T>` -- Exclude `null` and `undefined` from `T`.
* `ReturnType<T>` -- Obtain the return type of a function type.
* `InstanceType<T>` -- Obtain the instance type of a constructor function type.

Some examples:

```ts
type T00 = Exclude<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "b" | "d"
type T01 = Extract<"a" | "b" | "c" | "d", "a" | "c" | "f">;  // "a" | "c"

type T02 = Exclude<string | number | (() => void), Function>;  // string | number
type T03 = Extract<string | number | (() => void), Function>;  // () => void

type T04 = NonNullable<string | number | undefined>;  // string | number
type T05 = NonNullable<(() => string) | string[] | null | undefined>;  // (() => string) | string[]

function f1(s: string) {
    return { a: 1, b: s };
}

class C {
    x = 0;
    y = 0;
}

type T10 = ReturnType<() => string>;  // string
type T11 = ReturnType<(s: string) => void>;  // void
type T12 = ReturnType<(<T>() => T)>;  // {}
type T13 = ReturnType<(<T extends U, U extends number[]>() => T)>;  // number[]
type T14 = ReturnType<typeof f1>;  // { a: number, b: string }
type T15 = ReturnType<any>;  // any
type T16 = ReturnType<never>;  // any
type T17 = ReturnType<string>;  // Error
type T18 = ReturnType<Function>;  // Error

type T20 = InstanceType<typeof C>;  // C
type T21 = InstanceType<any>;  // any
type T22 = InstanceType<never>;  // any
type T23 = InstanceType<string>;  // Error
type T24 = InstanceType<Function>;  // Error
```

The `Exclude` type is a proper implementation of the `Diff` type suggested here https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458. We've used the name `Exclude` to avoid breaking existing code that defines a `Diff`, plus we feel that name better conveys the semantics of the type. We did not include the `Omit<T, K>` type because it is trivially written as `Record<T, Exclude<keyof T, K>>`.

When applying `ReturnType<T>` and `InstanceType<T>` to types with multiple call or construct signatures (such as the type of an overloaded function), inferences are made from the *last* signature (which, presumably, is the most permissive catch-all case). It is not possible to perform overload resolution based on a list of argument types (this would require us to support typeof for arbitrary expressions, as suggested in #6606, or something similar).

Fixes #19569.
