### PR TITLE
add beautifier rule for space after close paren and destructure bracket

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -92,6 +92,9 @@ namespace ts.formatting {
             rule("SpaceBetweenCloseBraceAndWhile", SyntaxKind.CloseBraceToken, SyntaxKind.WhileKeyword, [isNonJsxSameLineTokenContext], RuleAction.Space),
             rule("NoSpaceBetweenEmptyBraceBrackets", SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken, [isNonJsxSameLineTokenContext, isObjectContext], RuleAction.Delete),
 
+            // Add a space after control dec context if the next character is an open bracket ex: 'if (false)[a, b] = [1, 2];' -> 'if (false) [a, b] = [1, 2];'
+            rule("SpaceAfterConditionalClosingParen", SyntaxKind.CloseParenToken, SyntaxKind.OpenBracketToken, [isControlDeclContext], RuleAction.Space),
+
             rule("NoSpaceBetweenFunctionKeywordAndStar", SyntaxKind.FunctionKeyword, SyntaxKind.AsteriskToken, [isFunctionDeclarationOrFunctionExpressionContext], RuleAction.Delete),
             rule("SpaceAfterStarInGeneratorDeclaration", SyntaxKind.AsteriskToken, [SyntaxKind.Identifier, SyntaxKind.OpenParenToken], [isFunctionDeclarationOrFunctionExpressionContext], RuleAction.Space),
 

--- a/tests/cases/fourslash/formattingInDestructuring5.ts
+++ b/tests/cases/fourslash/formattingInDestructuring5.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts'/>
+
+//// let a, b;
+//// /*1*/if (false)[a, b] = [1, 2];
+//// /*2*/if (true)        [a, b] = [1, 2];
+//// /*3*/var a = [1, 2, 3].map(num => num) [0];
+
+format.document();
+
+goTo.marker("1");
+verify.currentLineContentIs("if (false) [a, b] = [1, 2];");
+goTo.marker("2");
+verify.currentLineContentIs("if (true) [a, b] = [1, 2];");
+goTo.marker("3");
+verify.currentLineContentIs("var a = [1, 2, 3].map(num => num)[0];");


### PR DESCRIPTION
Fixes #21675 

Adds a new rule to the javascript beautifier to add a space after a closing parenthesis if the next token is an open bracket and the context is a control declaration.

Tests added as well.
