### PR TITLE
Fix error message for implicit-any property in object literal with symbol key

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11203,7 +11203,7 @@ namespace ts {
                         const t = getTypeOfSymbol(p);
                         if (t.flags & TypeFlags.ContainsWideningType) {
                             if (!reportWideningErrorsInType(t)) {
-                                error(p.valueDeclaration, Diagnostics.Object_literal_s_property_0_implicitly_has_an_1_type, symbolName(p), typeToString(getWidenedType(t)));
+                                error(p.valueDeclaration, Diagnostics.Object_literal_s_property_0_implicitly_has_an_1_type, symbolToString(p), typeToString(getWidenedType(t)));
                             }
                             errorReported = true;
                         }

--- a/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.errors.txt
+++ b/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts(2,13): error TS7018: Object literal's property '[foo]' implicitly has an 'any' type.
+
+
+==== tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts (1 errors) ====
+    const foo = Symbol.for("foo");
+    const o = { [foo]: undefined };
+                ~~~~~~~~~~~~~~~~
+!!! error TS7018: Object literal's property '[foo]' implicitly has an 'any' type.
+    

--- a/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.js
+++ b/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.js
@@ -1,0 +1,8 @@
+//// [objectLiteralPropertyImplicitlyAny.ts]
+const foo = Symbol.for("foo");
+const o = { [foo]: undefined };
+
+
+//// [objectLiteralPropertyImplicitlyAny.js]
+const foo = Symbol.for("foo");
+const o = { [foo]: undefined };

--- a/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.symbols
+++ b/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts ===
+const foo = Symbol.for("foo");
+>foo : Symbol(foo, Decl(objectLiteralPropertyImplicitlyAny.ts, 0, 5))
+>Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
+
+const o = { [foo]: undefined };
+>o : Symbol(o, Decl(objectLiteralPropertyImplicitlyAny.ts, 1, 5))
+>foo : Symbol(foo, Decl(objectLiteralPropertyImplicitlyAny.ts, 0, 5))
+>undefined : Symbol(undefined)
+

--- a/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.types
+++ b/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts ===
+const foo = Symbol.for("foo");
+>foo : unique symbol
+>Symbol.for("foo") : unique symbol
+>Symbol.for : (key: string) => symbol
+>Symbol : SymbolConstructor
+>for : (key: string) => symbol
+>"foo" : "foo"
+
+const o = { [foo]: undefined };
+>o : { [foo]: any; }
+>{ [foo]: undefined } : { [foo]: undefined; }
+>foo : unique symbol
+>undefined : undefined
+

--- a/tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts
+++ b/tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts
@@ -1,0 +1,5 @@
+// @target: esnext
+// @noImplicitAny: true
+
+const foo = Symbol.for("foo");
+const o = { [foo]: undefined };


### PR DESCRIPTION
Fixes #21009
This is the only use of `symbolName` I saw that didn't look valid. One exception is the call in `getSPellingSuggestionForName`, but I couldn't find a case where a name like `__@foo@1234` would ever be a spelling suggestion, though see my note at #21882.