### PR TITLE
Fix completion of jsx attributes in self closing element

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -862,6 +862,23 @@ namespace ts.Completions {
                     parent = parent.parent;
                 }
 
+                // Fix location
+                if (currentToken.parent === location) {
+                    switch (currentToken.kind) {
+                        case SyntaxKind.GreaterThanToken:
+                            if (currentToken.parent.kind === SyntaxKind.JsxElement || currentToken.parent.kind === SyntaxKind.JsxOpeningElement) {
+                                location = currentToken;
+                            }
+                            break;
+
+                        case SyntaxKind.SlashToken:
+                            if (currentToken.parent.kind === SyntaxKind.JsxSelfClosingElement) {
+                                location = currentToken;
+                            }
+                            break;
+                    }
+                }
+
                 switch (parent.kind) {
                     case SyntaxKind.JsxClosingElement:
                         if (contextToken.kind === SyntaxKind.SlashToken) {
@@ -1042,10 +1059,6 @@ namespace ts.Completions {
                 return true;
             }
 
-            if (tryGetFunctionLikeBodyCompletionContainer(contextToken)) {
-                keywordFilters = KeywordCompletionFilters.FunctionLikeBodyKeywords;
-            }
-
             if (classLikeContainer = tryGetClassLikeCompletionContainer(contextToken)) {
                 // cursor inside class declaration
                 getGetClassLikeCompletionSymbols(classLikeContainer);
@@ -1065,6 +1078,10 @@ namespace ts.Completions {
                         return true;
                     }
                 }
+            }
+
+            if (tryGetFunctionLikeBodyCompletionContainer(contextToken)) {
+                keywordFilters = KeywordCompletionFilters.FunctionLikeBodyKeywords;
             }
 
             // Get all entities in the current scope.

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -79,6 +79,8 @@ namespace ts.SymbolDisplay {
             switch (location.parent && location.parent.kind) {
                 // If we've typed a character of the attribute name, will be 'JsxAttribute', else will be 'JsxOpeningElement'.
                 case SyntaxKind.JsxOpeningElement:
+                case SyntaxKind.JsxElement:
+                case SyntaxKind.JsxSelfClosingElement:
                     return location.kind === SyntaxKind.Identifier ? ScriptElementKind.memberVariableElement : ScriptElementKind.jsxAttribute;
                 case SyntaxKind.JsxAttribute:
                     return ScriptElementKind.jsxAttribute;

--- a/tests/cases/fourslash/completionsInJsxTag.ts
+++ b/tests/cases/fourslash/completionsInJsxTag.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @jsx: preserve
+
+// @Filename: /a.tsx
+////declare namespace JSX {
+////    interface Element {}
+////    interface IntrinsicElements {
+////        div: {
+////            /** Doc */
+////            foo: string
+////        }
+////    }
+////}
+////class Foo {
+////    render() {
+////        <div /*1*/ ></div>;
+////        <div  /*2*/ />
+////    }
+////}
+
+goTo.marker("1");
+verify.completionListCount(1);
+verify.completionListContains("foo", "(JSX attribute) foo: string", "Doc ", "JSX attribute");
+goTo.marker("2");
+verify.completionListCount(1);
+verify.completionListContains("foo", "(JSX attribute) foo: string", "Doc ", "JSX attribute");


### PR DESCRIPTION
Two issues here:
1. Keyword filters are set incorrectly.
2. The location for the symbolKind query wasnt right (esp if the location is not right next to /> in self closing tag and > in opening element resulting in displaying symbols as properties instead of JSX attributes
Fixes #21844

