### PR TITLE
Fix emit when binder treats exported const as namespace

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25054,7 +25054,7 @@ namespace ts {
                         // we prefix depends on the kind of entity. SymbolFlags.ExportHasLocal encompasses all the
                         // kinds that we do NOT prefix.
                         const exportSymbol = getMergedSymbol(symbol.exportSymbol);
-                        if (!prefixLocals && exportSymbol.flags & SymbolFlags.ExportHasLocal) {
+                        if (!prefixLocals && exportSymbol.flags & SymbolFlags.ExportHasLocal && !(exportSymbol.flags & SymbolFlags.Variable)) {
                             return undefined;
                         }
                         symbol = exportSymbol;

--- a/tests/baselines/reference/typeFromPropertyAssignmentWithExport.js
+++ b/tests/baselines/reference/typeFromPropertyAssignmentWithExport.js
@@ -1,0 +1,18 @@
+//// [a.js]
+// this is a javascript file...
+
+export const Adapter = {};
+
+Adapter.prop = {};
+
+// comment this out, and it works
+Adapter.asyncMethod = function() {}
+
+//// [a.js]
+"use strict";
+// this is a javascript file...
+exports.__esModule = true;
+exports.Adapter = {};
+exports.Adapter.prop = {};
+// comment this out, and it works
+exports.Adapter.asyncMethod = function () { };

--- a/tests/baselines/reference/typeFromPropertyAssignmentWithExport.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignmentWithExport.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/salsa/a.js ===
+// this is a javascript file...
+
+export const Adapter = {};
+>Adapter : Symbol(Adapter, Decl(a.js, 2, 12), Decl(a.js, 4, 18))
+
+Adapter.prop = {};
+>Adapter : Symbol(Adapter, Decl(a.js, 2, 12), Decl(a.js, 4, 18))
+
+// comment this out, and it works
+Adapter.asyncMethod = function() {}
+>Adapter : Symbol(Adapter, Decl(a.js, 2, 12), Decl(a.js, 4, 18))
+

--- a/tests/baselines/reference/typeFromPropertyAssignmentWithExport.types
+++ b/tests/baselines/reference/typeFromPropertyAssignmentWithExport.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/salsa/a.js ===
+// this is a javascript file...
+
+export const Adapter = {};
+>Adapter : { [x: string]: any; }
+>{} : { [x: string]: any; }
+
+Adapter.prop = {};
+>Adapter.prop = {} : {}
+>Adapter.prop : any
+>Adapter : { [x: string]: any; }
+>prop : any
+>{} : {}
+
+// comment this out, and it works
+Adapter.asyncMethod = function() {}
+>Adapter.asyncMethod = function() {} : () => void
+>Adapter.asyncMethod : any
+>Adapter : { [x: string]: any; }
+>asyncMethod : any
+>function() {} : () => void
+

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignmentWithExport.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignmentWithExport.ts
@@ -1,0 +1,12 @@
+// @allowJs: true
+// @checkJs: true
+// @Filename: a.js
+// @outDir: dist
+// this is a javascript file...
+
+export const Adapter = {};
+
+Adapter.prop = {};
+
+// comment this out, and it works
+Adapter.asyncMethod = function() {}


### PR DESCRIPTION
We recently added heuristics to treat some variables in a js file as a namespace, however this conversion breaks emit when that variable is also exported.

Fixes #21620
