### PR TITLE
Added .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "tsconfig*.json": "jsonc",
         "tslint*.json": "jsonc"
     },
+    "tslint.alwaysShowRuleFailuresAsWarnings": true,
     "tslint.autoFixOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+	"editor.insertSpaces": false,
+	"editor.renderWhitespace": "all",
+	"editor.tabSize": 4,
+	"files.associations": {
+		"tsconfig*.json": "jsonc",
+		"tslint*.json": "jsonc"
+	},
+	"tslint.autoFixOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "editor.insertSpaces": false,
-    "editor.renderWhitespace": "all",
-    "editor.tabSize": 4,
     "files.associations": {
         "tsconfig*.json": "jsonc",
         "tslint*.json": "jsonc"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
-	"editor.insertSpaces": false,
-	"editor.renderWhitespace": "all",
-	"editor.tabSize": 4,
-	"files.associations": {
-		"tsconfig*.json": "jsonc",
-		"tslint*.json": "jsonc"
-	},
-	"tslint.autoFixOnSave": true
+    "editor.insertSpaces": false,
+    "editor.renderWhitespace": "all",
+    "editor.tabSize": 4,
+    "files.associations": {
+        "tsconfig*.json": "jsonc",
+        "tslint*.json": "jsonc"
+    },
+    "tslint.autoFixOnSave": true
 }


### PR DESCRIPTION
Most notably tells VS Code to show lint complaints as green squigglies. Also enables auto-fixing them on save.

Fixes #21874 