### PR TITLE
Improved control over mapped type modifiers

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -593,7 +593,9 @@ namespace ts {
                 writeLine();
                 increaseIndent();
                 if (node.readonlyToken) {
-                    write("readonly ");
+                    write(node.readonlyToken.kind === SyntaxKind.PlusToken ? "+readonly " :
+                        node.readonlyToken.kind === SyntaxKind.MinusToken ? "-readonly " :
+                        "readonly ");
                 }
                 write("[");
                 writeEntityName(node.typeParameter.name);
@@ -601,7 +603,9 @@ namespace ts {
                 emitType(node.typeParameter.constraint);
                 write("]");
                 if (node.questionToken) {
-                    write("?");
+                    write(node.questionToken.kind === SyntaxKind.PlusToken ? "+?" :
+                        node.questionToken.kind === SyntaxKind.MinusToken ? "-?" :
+                        "?");
                 }
                 write(": ");
                 emitType(node.type);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1251,14 +1251,20 @@ namespace ts {
             }
             if (node.readonlyToken) {
                 emit(node.readonlyToken);
+                if (node.readonlyToken.kind !== SyntaxKind.ReadonlyKeyword) {
+                    writeKeyword("readonly");
+                }
                 writeSpace();
             }
-
             writePunctuation("[");
             pipelineEmitWithNotification(EmitHint.MappedTypeParameter, node.typeParameter);
             writePunctuation("]");
-
-            emitIfPresent(node.questionToken);
+            if (node.questionToken) {
+                emit(node.questionToken);
+                if (node.questionToken.kind !== SyntaxKind.QuestionToken) {
+                    writePunctuation("?");
+                }
+            }
             writePunctuation(":");
             writeSpace();
             emit(node.type);

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -804,7 +804,7 @@ namespace ts {
             : node;
     }
 
-    export function createMappedTypeNode(readonlyToken: ReadonlyToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | undefined, type: TypeNode | undefined): MappedTypeNode {
+    export function createMappedTypeNode(readonlyToken: ReadonlyToken | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | PlusToken | MinusToken | undefined, type: TypeNode | undefined): MappedTypeNode {
         const node = createSynthesizedNode(SyntaxKind.MappedType) as MappedTypeNode;
         node.readonlyToken = readonlyToken;
         node.typeParameter = typeParameter;
@@ -813,7 +813,7 @@ namespace ts {
         return node;
     }
 
-    export function updateMappedTypeNode(node: MappedTypeNode, readonlyToken: ReadonlyToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | undefined, type: TypeNode | undefined): MappedTypeNode {
+    export function updateMappedTypeNode(node: MappedTypeNode, readonlyToken: ReadonlyToken | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | PlusToken | MinusToken | undefined, type: TypeNode | undefined): MappedTypeNode {
         return node.readonlyToken !== readonlyToken
             || node.typeParameter !== typeParameter
             || node.questionToken !== questionToken

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -661,6 +661,8 @@ namespace ts {
     export type AtToken = Token<SyntaxKind.AtToken>;
     export type ReadonlyToken = Token<SyntaxKind.ReadonlyKeyword>;
     export type AwaitKeywordToken = Token<SyntaxKind.AwaitKeyword>;
+    export type PlusToken = Token<SyntaxKind.PlusToken>;
+    export type MinusToken = Token<SyntaxKind.MinusToken>;
 
     export type Modifier
         = Token<SyntaxKind.AbstractKeyword>
@@ -1158,9 +1160,9 @@ namespace ts {
 
     export interface MappedTypeNode extends TypeNode, Declaration {
         kind: SyntaxKind.MappedType;
-        readonlyToken?: ReadonlyToken;
+        readonlyToken?: ReadonlyToken | PlusToken | MinusToken;
         typeParameter: TypeParameterDeclaration;
-        questionToken?: QuestionToken;
+        questionToken?: QuestionToken | PlusToken | MinusToken;
         type?: TypeNode;
     }
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1318,6 +1318,13 @@ type Partial<T> = {
 };
 
 /**
+ * Make all properties in T required
+ */
+type Required<T> = {
+    [P in keyof T]-?: T[P];
+};
+
+/**
  * Make all properties in T readonly
  */
 type Readonly<T> = {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -477,6 +477,8 @@ declare namespace ts {
     type AtToken = Token<SyntaxKind.AtToken>;
     type ReadonlyToken = Token<SyntaxKind.ReadonlyKeyword>;
     type AwaitKeywordToken = Token<SyntaxKind.AwaitKeyword>;
+    type PlusToken = Token<SyntaxKind.PlusToken>;
+    type MinusToken = Token<SyntaxKind.MinusToken>;
     type Modifier = Token<SyntaxKind.AbstractKeyword> | Token<SyntaxKind.AsyncKeyword> | Token<SyntaxKind.ConstKeyword> | Token<SyntaxKind.DeclareKeyword> | Token<SyntaxKind.DefaultKeyword> | Token<SyntaxKind.ExportKeyword> | Token<SyntaxKind.PublicKeyword> | Token<SyntaxKind.PrivateKeyword> | Token<SyntaxKind.ProtectedKeyword> | Token<SyntaxKind.ReadonlyKeyword> | Token<SyntaxKind.StaticKeyword>;
     type ModifiersArray = NodeArray<Modifier>;
     interface Identifier extends PrimaryExpression, Declaration {
@@ -766,9 +768,9 @@ declare namespace ts {
     }
     interface MappedTypeNode extends TypeNode, Declaration {
         kind: SyntaxKind.MappedType;
-        readonlyToken?: ReadonlyToken;
+        readonlyToken?: ReadonlyToken | PlusToken | MinusToken;
         typeParameter: TypeParameterDeclaration;
-        questionToken?: QuestionToken;
+        questionToken?: QuestionToken | PlusToken | MinusToken;
         type?: TypeNode;
     }
     interface LiteralTypeNode extends TypeNode {
@@ -3515,8 +3517,8 @@ declare namespace ts {
     function updateTypeOperatorNode(node: TypeOperatorNode, type: TypeNode): TypeOperatorNode;
     function createIndexedAccessTypeNode(objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;
     function updateIndexedAccessTypeNode(node: IndexedAccessTypeNode, objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;
-    function createMappedTypeNode(readonlyToken: ReadonlyToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | undefined, type: TypeNode | undefined): MappedTypeNode;
-    function updateMappedTypeNode(node: MappedTypeNode, readonlyToken: ReadonlyToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | undefined, type: TypeNode | undefined): MappedTypeNode;
+    function createMappedTypeNode(readonlyToken: ReadonlyToken | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | PlusToken | MinusToken | undefined, type: TypeNode | undefined): MappedTypeNode;
+    function updateMappedTypeNode(node: MappedTypeNode, readonlyToken: ReadonlyToken | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | PlusToken | MinusToken | undefined, type: TypeNode | undefined): MappedTypeNode;
     function createLiteralTypeNode(literal: LiteralTypeNode["literal"]): LiteralTypeNode;
     function updateLiteralTypeNode(node: LiteralTypeNode, literal: LiteralTypeNode["literal"]): LiteralTypeNode;
     function createObjectBindingPattern(elements: ReadonlyArray<BindingElement>): ObjectBindingPattern;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -477,6 +477,8 @@ declare namespace ts {
     type AtToken = Token<SyntaxKind.AtToken>;
     type ReadonlyToken = Token<SyntaxKind.ReadonlyKeyword>;
     type AwaitKeywordToken = Token<SyntaxKind.AwaitKeyword>;
+    type PlusToken = Token<SyntaxKind.PlusToken>;
+    type MinusToken = Token<SyntaxKind.MinusToken>;
     type Modifier = Token<SyntaxKind.AbstractKeyword> | Token<SyntaxKind.AsyncKeyword> | Token<SyntaxKind.ConstKeyword> | Token<SyntaxKind.DeclareKeyword> | Token<SyntaxKind.DefaultKeyword> | Token<SyntaxKind.ExportKeyword> | Token<SyntaxKind.PublicKeyword> | Token<SyntaxKind.PrivateKeyword> | Token<SyntaxKind.ProtectedKeyword> | Token<SyntaxKind.ReadonlyKeyword> | Token<SyntaxKind.StaticKeyword>;
     type ModifiersArray = NodeArray<Modifier>;
     interface Identifier extends PrimaryExpression, Declaration {
@@ -766,9 +768,9 @@ declare namespace ts {
     }
     interface MappedTypeNode extends TypeNode, Declaration {
         kind: SyntaxKind.MappedType;
-        readonlyToken?: ReadonlyToken;
+        readonlyToken?: ReadonlyToken | PlusToken | MinusToken;
         typeParameter: TypeParameterDeclaration;
-        questionToken?: QuestionToken;
+        questionToken?: QuestionToken | PlusToken | MinusToken;
         type?: TypeNode;
     }
     interface LiteralTypeNode extends TypeNode {
@@ -3462,8 +3464,8 @@ declare namespace ts {
     function updateTypeOperatorNode(node: TypeOperatorNode, type: TypeNode): TypeOperatorNode;
     function createIndexedAccessTypeNode(objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;
     function updateIndexedAccessTypeNode(node: IndexedAccessTypeNode, objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;
-    function createMappedTypeNode(readonlyToken: ReadonlyToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | undefined, type: TypeNode | undefined): MappedTypeNode;
-    function updateMappedTypeNode(node: MappedTypeNode, readonlyToken: ReadonlyToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | undefined, type: TypeNode | undefined): MappedTypeNode;
+    function createMappedTypeNode(readonlyToken: ReadonlyToken | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | PlusToken | MinusToken | undefined, type: TypeNode | undefined): MappedTypeNode;
+    function updateMappedTypeNode(node: MappedTypeNode, readonlyToken: ReadonlyToken | PlusToken | MinusToken | undefined, typeParameter: TypeParameterDeclaration, questionToken: QuestionToken | PlusToken | MinusToken | undefined, type: TypeNode | undefined): MappedTypeNode;
     function createLiteralTypeNode(literal: LiteralTypeNode["literal"]): LiteralTypeNode;
     function updateLiteralTypeNode(node: LiteralTypeNode, literal: LiteralTypeNode["literal"]): LiteralTypeNode;
     function createObjectBindingPattern(elements: ReadonlyArray<BindingElement>): ObjectBindingPattern;

--- a/tests/baselines/reference/mappedTypes6.errors.txt
+++ b/tests/baselines/reference/mappedTypes6.errors.txt
@@ -1,0 +1,195 @@
+tests/cases/conformance/types/mapped/mappedTypes6.ts(23,5): error TS2322: Type 'T' is not assignable to type 'Required<T>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(24,5): error TS2322: Type 'Partial<T>' is not assignable to type 'Required<T>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(27,5): error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(37,5): error TS2322: Type 'Required<T>' is not assignable to type 'Denullified<T>'.
+  Type 'T[P]' is not assignable to type 'NonNullable<T[P]>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(38,5): error TS2322: Type 'T' is not assignable to type 'Denullified<T>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(39,5): error TS2322: Type 'Partial<T>' is not assignable to type 'Denullified<T>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(42,5): error TS2322: Type 'T' is not assignable to type 'Required<T>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(43,5): error TS2322: Type 'Partial<T>' is not assignable to type 'Required<T>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(47,5): error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(56,5): error TS2322: Type '{}' is not assignable to type 'Denullified<T>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(57,5): error TS2322: Type '{}' is not assignable to type 'Required<T>'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(58,5): error TS2322: Type '{}' is not assignable to type 'T'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(92,1): error TS2322: Type '{ a: number; }' is not assignable to type 'Foo'.
+  Property 'b' is missing in type '{ a: number; }'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(104,1): error TS2322: Type '{ a: number; }' is not assignable to type 'Required<Foo>'.
+  Property 'b' is missing in type '{ a: number; }'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(105,1): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Required<Foo>'.
+  Property 'c' is missing in type '{ a: number; b: number; }'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(106,1): error TS2322: Type '{ a: number; b: number; c: number; }' is not assignable to type 'Required<Foo>'.
+  Property 'd' is missing in type '{ a: number; b: number; c: number; }'.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(116,4): error TS2540: Cannot assign to 'b' because it is a constant or a read-only property.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(119,4): error TS2540: Cannot assign to 'a' because it is a constant or a read-only property.
+tests/cases/conformance/types/mapped/mappedTypes6.ts(120,4): error TS2540: Cannot assign to 'b' because it is a constant or a read-only property.
+
+
+==== tests/cases/conformance/types/mapped/mappedTypes6.ts (19 errors) ====
+    type T00<T> = { [P in keyof T]: T[P] };
+    type T01<T> = { [P in keyof T]?: T[P] };
+    type T02<T> = { [P in keyof T]+?: T[P] };
+    type T03<T> = { [P in keyof T]-?: T[P] };
+    
+    type T04<T> = { readonly [P in keyof T]: T[P] };
+    type T05<T> = { readonly [P in keyof T]?: T[P] };
+    type T06<T> = { readonly [P in keyof T]+?: T[P] };
+    type T07<T> = { readonly [P in keyof T]-?: T[P] };
+    
+    type T08<T> = { +readonly [P in keyof T]: T[P] };
+    type T09<T> = { +readonly [P in keyof T]?: T[P] };
+    type T10<T> = { +readonly [P in keyof T]+?: T[P] };
+    type T11<T> = { +readonly [P in keyof T]-?: T[P] };
+    
+    type T12<T> = { -readonly [P in keyof T]: T[P] };
+    type T13<T> = { -readonly [P in keyof T]?: T[P] };
+    type T14<T> = { -readonly [P in keyof T]+?: T[P] };
+    type T15<T> = { -readonly [P in keyof T]-?: T[P] };
+    
+    function f1<T>(x: Required<T>, y: T, z: Partial<T>) {
+        x = x;
+        x = y;  // Error
+        ~
+!!! error TS2322: Type 'T' is not assignable to type 'Required<T>'.
+        x = z;  // Error
+        ~
+!!! error TS2322: Type 'Partial<T>' is not assignable to type 'Required<T>'.
+        y = x;
+        y = y;
+        y = z;  // Error
+        ~
+!!! error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
+        z = x;
+        z = y;
+        z = z;
+    }
+    
+    type Denullified<T> = { [P in keyof T]-?: NonNullable<T[P]> };
+    
+    function f2<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+        w = w;
+        w = x;  // Error
+        ~
+!!! error TS2322: Type 'Required<T>' is not assignable to type 'Denullified<T>'.
+!!! error TS2322:   Type 'T[P]' is not assignable to type 'NonNullable<T[P]>'.
+        w = y;  // Error
+        ~
+!!! error TS2322: Type 'T' is not assignable to type 'Denullified<T>'.
+        w = z;  // Error
+        ~
+!!! error TS2322: Type 'Partial<T>' is not assignable to type 'Denullified<T>'.
+        x = w;
+        x = x;
+        x = y;  // Error
+        ~
+!!! error TS2322: Type 'T' is not assignable to type 'Required<T>'.
+        x = z;  // Error
+        ~
+!!! error TS2322: Type 'Partial<T>' is not assignable to type 'Required<T>'.
+        y = w;
+        y = x;
+        y = y;
+        y = z;  // Error
+        ~
+!!! error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
+        z = w;
+        z = x;
+        z = y;
+        z = z;
+    }
+    
+    
+    function f3<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+        w = {};  // Error
+        ~
+!!! error TS2322: Type '{}' is not assignable to type 'Denullified<T>'.
+        x = {};  // Error
+        ~
+!!! error TS2322: Type '{}' is not assignable to type 'Required<T>'.
+        y = {};  // Error
+        ~
+!!! error TS2322: Type '{}' is not assignable to type 'T'.
+        z = {};
+    }
+    
+    type Readwrite<T> = {
+        -readonly [P in keyof T]: T[P];
+    }
+    
+    function f10<T>(x: Readonly<T>, y: T, z: Readwrite<T>) {
+        x = x;
+        x = y;
+        x = z;
+        y = x;
+        y = y;
+        y = z;
+        z = x;
+        z = y;
+        z = z;
+    }
+    
+    type Foo = {
+        a: number;
+        b: number | undefined;
+        c?: number;
+        d?: number | undefined;
+    }
+    
+    declare let x1: Foo;
+    
+    x1.a;  // number
+    x1.b;  // number | undefined
+    x1.c;  // number | undefined
+    x1.d;  // number | undefined
+    
+    x1 = { a: 1 };  // Error
+    ~~
+!!! error TS2322: Type '{ a: number; }' is not assignable to type 'Foo'.
+!!! error TS2322:   Property 'b' is missing in type '{ a: number; }'.
+    x1 = { a: 1, b: 1 };
+    x1 = { a: 1, b: 1, c: 1 };
+    x1 = { a: 1, b: 1, c: 1, d: 1 };
+    
+    declare let x2: Required<Foo>;
+    
+    x1.a;  // number
+    x1.b;  // number | undefined
+    x1.c;  // number
+    x1.d;  // number
+    
+    x2 = { a: 1 };  // Error
+    ~~
+!!! error TS2322: Type '{ a: number; }' is not assignable to type 'Required<Foo>'.
+!!! error TS2322:   Property 'b' is missing in type '{ a: number; }'.
+    x2 = { a: 1, b: 1 };  // Error
+    ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Required<Foo>'.
+!!! error TS2322:   Property 'c' is missing in type '{ a: number; b: number; }'.
+    x2 = { a: 1, b: 1, c: 1 };  // Error
+    ~~
+!!! error TS2322: Type '{ a: number; b: number; c: number; }' is not assignable to type 'Required<Foo>'.
+!!! error TS2322:   Property 'd' is missing in type '{ a: number; b: number; c: number; }'.
+    x2 = { a: 1, b: 1, c: 1, d: 1 };
+    
+    type Bar = {
+        a: number;
+        readonly b: number;
+    }
+    
+    declare let x3: Bar;
+    x3.a = 1;
+    x3.b = 1;  // Error
+       ~
+!!! error TS2540: Cannot assign to 'b' because it is a constant or a read-only property.
+    
+    declare let x4: Readonly<Bar>;
+    x4.a = 1;  // Error
+       ~
+!!! error TS2540: Cannot assign to 'a' because it is a constant or a read-only property.
+    x4.b = 1;  // Error
+       ~
+!!! error TS2540: Cannot assign to 'b' because it is a constant or a read-only property.
+    
+    declare let x5: Readwrite<Bar>;
+    x5.a = 1;
+    x5.b = 1;
+    

--- a/tests/baselines/reference/mappedTypes6.js
+++ b/tests/baselines/reference/mappedTypes6.js
@@ -1,0 +1,273 @@
+//// [mappedTypes6.ts]
+type T00<T> = { [P in keyof T]: T[P] };
+type T01<T> = { [P in keyof T]?: T[P] };
+type T02<T> = { [P in keyof T]+?: T[P] };
+type T03<T> = { [P in keyof T]-?: T[P] };
+
+type T04<T> = { readonly [P in keyof T]: T[P] };
+type T05<T> = { readonly [P in keyof T]?: T[P] };
+type T06<T> = { readonly [P in keyof T]+?: T[P] };
+type T07<T> = { readonly [P in keyof T]-?: T[P] };
+
+type T08<T> = { +readonly [P in keyof T]: T[P] };
+type T09<T> = { +readonly [P in keyof T]?: T[P] };
+type T10<T> = { +readonly [P in keyof T]+?: T[P] };
+type T11<T> = { +readonly [P in keyof T]-?: T[P] };
+
+type T12<T> = { -readonly [P in keyof T]: T[P] };
+type T13<T> = { -readonly [P in keyof T]?: T[P] };
+type T14<T> = { -readonly [P in keyof T]+?: T[P] };
+type T15<T> = { -readonly [P in keyof T]-?: T[P] };
+
+function f1<T>(x: Required<T>, y: T, z: Partial<T>) {
+    x = x;
+    x = y;  // Error
+    x = z;  // Error
+    y = x;
+    y = y;
+    y = z;  // Error
+    z = x;
+    z = y;
+    z = z;
+}
+
+type Denullified<T> = { [P in keyof T]-?: NonNullable<T[P]> };
+
+function f2<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+    w = w;
+    w = x;  // Error
+    w = y;  // Error
+    w = z;  // Error
+    x = w;
+    x = x;
+    x = y;  // Error
+    x = z;  // Error
+    y = w;
+    y = x;
+    y = y;
+    y = z;  // Error
+    z = w;
+    z = x;
+    z = y;
+    z = z;
+}
+
+
+function f3<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+    w = {};  // Error
+    x = {};  // Error
+    y = {};  // Error
+    z = {};
+}
+
+type Readwrite<T> = {
+    -readonly [P in keyof T]: T[P];
+}
+
+function f10<T>(x: Readonly<T>, y: T, z: Readwrite<T>) {
+    x = x;
+    x = y;
+    x = z;
+    y = x;
+    y = y;
+    y = z;
+    z = x;
+    z = y;
+    z = z;
+}
+
+type Foo = {
+    a: number;
+    b: number | undefined;
+    c?: number;
+    d?: number | undefined;
+}
+
+declare let x1: Foo;
+
+x1.a;  // number
+x1.b;  // number | undefined
+x1.c;  // number | undefined
+x1.d;  // number | undefined
+
+x1 = { a: 1 };  // Error
+x1 = { a: 1, b: 1 };
+x1 = { a: 1, b: 1, c: 1 };
+x1 = { a: 1, b: 1, c: 1, d: 1 };
+
+declare let x2: Required<Foo>;
+
+x1.a;  // number
+x1.b;  // number | undefined
+x1.c;  // number
+x1.d;  // number
+
+x2 = { a: 1 };  // Error
+x2 = { a: 1, b: 1 };  // Error
+x2 = { a: 1, b: 1, c: 1 };  // Error
+x2 = { a: 1, b: 1, c: 1, d: 1 };
+
+type Bar = {
+    a: number;
+    readonly b: number;
+}
+
+declare let x3: Bar;
+x3.a = 1;
+x3.b = 1;  // Error
+
+declare let x4: Readonly<Bar>;
+x4.a = 1;  // Error
+x4.b = 1;  // Error
+
+declare let x5: Readwrite<Bar>;
+x5.a = 1;
+x5.b = 1;
+
+
+//// [mappedTypes6.js]
+"use strict";
+function f1(x, y, z) {
+    x = x;
+    x = y; // Error
+    x = z; // Error
+    y = x;
+    y = y;
+    y = z; // Error
+    z = x;
+    z = y;
+    z = z;
+}
+function f2(w, x, y, z) {
+    w = w;
+    w = x; // Error
+    w = y; // Error
+    w = z; // Error
+    x = w;
+    x = x;
+    x = y; // Error
+    x = z; // Error
+    y = w;
+    y = x;
+    y = y;
+    y = z; // Error
+    z = w;
+    z = x;
+    z = y;
+    z = z;
+}
+function f3(w, x, y, z) {
+    w = {}; // Error
+    x = {}; // Error
+    y = {}; // Error
+    z = {};
+}
+function f10(x, y, z) {
+    x = x;
+    x = y;
+    x = z;
+    y = x;
+    y = y;
+    y = z;
+    z = x;
+    z = y;
+    z = z;
+}
+x1.a; // number
+x1.b; // number | undefined
+x1.c; // number | undefined
+x1.d; // number | undefined
+x1 = { a: 1 }; // Error
+x1 = { a: 1, b: 1 };
+x1 = { a: 1, b: 1, c: 1 };
+x1 = { a: 1, b: 1, c: 1, d: 1 };
+x1.a; // number
+x1.b; // number | undefined
+x1.c; // number
+x1.d; // number
+x2 = { a: 1 }; // Error
+x2 = { a: 1, b: 1 }; // Error
+x2 = { a: 1, b: 1, c: 1 }; // Error
+x2 = { a: 1, b: 1, c: 1, d: 1 };
+x3.a = 1;
+x3.b = 1; // Error
+x4.a = 1; // Error
+x4.b = 1; // Error
+x5.a = 1;
+x5.b = 1;
+
+
+//// [mappedTypes6.d.ts]
+declare type T00<T> = {
+    [P in keyof T]: T[P];
+};
+declare type T01<T> = {
+    [P in keyof T]?: T[P];
+};
+declare type T02<T> = {
+    [P in keyof T]+?: T[P];
+};
+declare type T03<T> = {
+    [P in keyof T]-?: T[P];
+};
+declare type T04<T> = {
+    readonly [P in keyof T]: T[P];
+};
+declare type T05<T> = {
+    readonly [P in keyof T]?: T[P];
+};
+declare type T06<T> = {
+    readonly [P in keyof T]+?: T[P];
+};
+declare type T07<T> = {
+    readonly [P in keyof T]-?: T[P];
+};
+declare type T08<T> = {
+    +readonly [P in keyof T]: T[P];
+};
+declare type T09<T> = {
+    +readonly [P in keyof T]?: T[P];
+};
+declare type T10<T> = {
+    +readonly [P in keyof T]+?: T[P];
+};
+declare type T11<T> = {
+    +readonly [P in keyof T]-?: T[P];
+};
+declare type T12<T> = {
+    -readonly [P in keyof T]: T[P];
+};
+declare type T13<T> = {
+    -readonly [P in keyof T]?: T[P];
+};
+declare type T14<T> = {
+    -readonly [P in keyof T]+?: T[P];
+};
+declare type T15<T> = {
+    -readonly [P in keyof T]-?: T[P];
+};
+declare function f1<T>(x: Required<T>, y: T, z: Partial<T>): void;
+declare type Denullified<T> = {
+    [P in keyof T]-?: NonNullable<T[P]>;
+};
+declare function f2<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>): void;
+declare function f3<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>): void;
+declare type Readwrite<T> = {
+    -readonly [P in keyof T]: T[P];
+};
+declare function f10<T>(x: Readonly<T>, y: T, z: Readwrite<T>): void;
+declare type Foo = {
+    a: number;
+    b: number | undefined;
+    c?: number;
+    d?: number | undefined;
+};
+declare let x1: Foo;
+declare let x2: Required<Foo>;
+declare type Bar = {
+    a: number;
+    readonly b: number;
+};
+declare let x3: Bar;
+declare let x4: Readonly<Bar>;
+declare let x5: Readwrite<Bar>;

--- a/tests/baselines/reference/mappedTypes6.symbols
+++ b/tests/baselines/reference/mappedTypes6.symbols
@@ -1,0 +1,519 @@
+=== tests/cases/conformance/types/mapped/mappedTypes6.ts ===
+type T00<T> = { [P in keyof T]: T[P] };
+>T00 : Symbol(T00, Decl(mappedTypes6.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypes6.ts, 0, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 0, 17))
+>T : Symbol(T, Decl(mappedTypes6.ts, 0, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 0, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 0, 17))
+
+type T01<T> = { [P in keyof T]?: T[P] };
+>T01 : Symbol(T01, Decl(mappedTypes6.ts, 0, 39))
+>T : Symbol(T, Decl(mappedTypes6.ts, 1, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 1, 17))
+>T : Symbol(T, Decl(mappedTypes6.ts, 1, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 1, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 1, 17))
+
+type T02<T> = { [P in keyof T]+?: T[P] };
+>T02 : Symbol(T02, Decl(mappedTypes6.ts, 1, 40))
+>T : Symbol(T, Decl(mappedTypes6.ts, 2, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 2, 17))
+>T : Symbol(T, Decl(mappedTypes6.ts, 2, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 2, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 2, 17))
+
+type T03<T> = { [P in keyof T]-?: T[P] };
+>T03 : Symbol(T03, Decl(mappedTypes6.ts, 2, 41))
+>T : Symbol(T, Decl(mappedTypes6.ts, 3, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 3, 17))
+>T : Symbol(T, Decl(mappedTypes6.ts, 3, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 3, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 3, 17))
+
+type T04<T> = { readonly [P in keyof T]: T[P] };
+>T04 : Symbol(T04, Decl(mappedTypes6.ts, 3, 41))
+>T : Symbol(T, Decl(mappedTypes6.ts, 5, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 5, 26))
+>T : Symbol(T, Decl(mappedTypes6.ts, 5, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 5, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 5, 26))
+
+type T05<T> = { readonly [P in keyof T]?: T[P] };
+>T05 : Symbol(T05, Decl(mappedTypes6.ts, 5, 48))
+>T : Symbol(T, Decl(mappedTypes6.ts, 6, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 6, 26))
+>T : Symbol(T, Decl(mappedTypes6.ts, 6, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 6, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 6, 26))
+
+type T06<T> = { readonly [P in keyof T]+?: T[P] };
+>T06 : Symbol(T06, Decl(mappedTypes6.ts, 6, 49))
+>T : Symbol(T, Decl(mappedTypes6.ts, 7, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 7, 26))
+>T : Symbol(T, Decl(mappedTypes6.ts, 7, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 7, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 7, 26))
+
+type T07<T> = { readonly [P in keyof T]-?: T[P] };
+>T07 : Symbol(T07, Decl(mappedTypes6.ts, 7, 50))
+>T : Symbol(T, Decl(mappedTypes6.ts, 8, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 8, 26))
+>T : Symbol(T, Decl(mappedTypes6.ts, 8, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 8, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 8, 26))
+
+type T08<T> = { +readonly [P in keyof T]: T[P] };
+>T08 : Symbol(T08, Decl(mappedTypes6.ts, 8, 50))
+>T : Symbol(T, Decl(mappedTypes6.ts, 10, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 10, 27))
+>T : Symbol(T, Decl(mappedTypes6.ts, 10, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 10, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 10, 27))
+
+type T09<T> = { +readonly [P in keyof T]?: T[P] };
+>T09 : Symbol(T09, Decl(mappedTypes6.ts, 10, 49))
+>T : Symbol(T, Decl(mappedTypes6.ts, 11, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 11, 27))
+>T : Symbol(T, Decl(mappedTypes6.ts, 11, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 11, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 11, 27))
+
+type T10<T> = { +readonly [P in keyof T]+?: T[P] };
+>T10 : Symbol(T10, Decl(mappedTypes6.ts, 11, 50))
+>T : Symbol(T, Decl(mappedTypes6.ts, 12, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 12, 27))
+>T : Symbol(T, Decl(mappedTypes6.ts, 12, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 12, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 12, 27))
+
+type T11<T> = { +readonly [P in keyof T]-?: T[P] };
+>T11 : Symbol(T11, Decl(mappedTypes6.ts, 12, 51))
+>T : Symbol(T, Decl(mappedTypes6.ts, 13, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 13, 27))
+>T : Symbol(T, Decl(mappedTypes6.ts, 13, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 13, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 13, 27))
+
+type T12<T> = { -readonly [P in keyof T]: T[P] };
+>T12 : Symbol(T12, Decl(mappedTypes6.ts, 13, 51))
+>T : Symbol(T, Decl(mappedTypes6.ts, 15, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 15, 27))
+>T : Symbol(T, Decl(mappedTypes6.ts, 15, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 15, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 15, 27))
+
+type T13<T> = { -readonly [P in keyof T]?: T[P] };
+>T13 : Symbol(T13, Decl(mappedTypes6.ts, 15, 49))
+>T : Symbol(T, Decl(mappedTypes6.ts, 16, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 16, 27))
+>T : Symbol(T, Decl(mappedTypes6.ts, 16, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 16, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 16, 27))
+
+type T14<T> = { -readonly [P in keyof T]+?: T[P] };
+>T14 : Symbol(T14, Decl(mappedTypes6.ts, 16, 50))
+>T : Symbol(T, Decl(mappedTypes6.ts, 17, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 17, 27))
+>T : Symbol(T, Decl(mappedTypes6.ts, 17, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 17, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 17, 27))
+
+type T15<T> = { -readonly [P in keyof T]-?: T[P] };
+>T15 : Symbol(T15, Decl(mappedTypes6.ts, 17, 51))
+>T : Symbol(T, Decl(mappedTypes6.ts, 18, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 18, 27))
+>T : Symbol(T, Decl(mappedTypes6.ts, 18, 9))
+>T : Symbol(T, Decl(mappedTypes6.ts, 18, 9))
+>P : Symbol(P, Decl(mappedTypes6.ts, 18, 27))
+
+function f1<T>(x: Required<T>, y: T, z: Partial<T>) {
+>f1 : Symbol(f1, Decl(mappedTypes6.ts, 18, 51))
+>T : Symbol(T, Decl(mappedTypes6.ts, 20, 12))
+>x : Symbol(x, Decl(mappedTypes6.ts, 20, 15))
+>Required : Symbol(Required, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes6.ts, 20, 12))
+>y : Symbol(y, Decl(mappedTypes6.ts, 20, 30))
+>T : Symbol(T, Decl(mappedTypes6.ts, 20, 12))
+>z : Symbol(z, Decl(mappedTypes6.ts, 20, 36))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes6.ts, 20, 12))
+
+    x = x;
+>x : Symbol(x, Decl(mappedTypes6.ts, 20, 15))
+>x : Symbol(x, Decl(mappedTypes6.ts, 20, 15))
+
+    x = y;  // Error
+>x : Symbol(x, Decl(mappedTypes6.ts, 20, 15))
+>y : Symbol(y, Decl(mappedTypes6.ts, 20, 30))
+
+    x = z;  // Error
+>x : Symbol(x, Decl(mappedTypes6.ts, 20, 15))
+>z : Symbol(z, Decl(mappedTypes6.ts, 20, 36))
+
+    y = x;
+>y : Symbol(y, Decl(mappedTypes6.ts, 20, 30))
+>x : Symbol(x, Decl(mappedTypes6.ts, 20, 15))
+
+    y = y;
+>y : Symbol(y, Decl(mappedTypes6.ts, 20, 30))
+>y : Symbol(y, Decl(mappedTypes6.ts, 20, 30))
+
+    y = z;  // Error
+>y : Symbol(y, Decl(mappedTypes6.ts, 20, 30))
+>z : Symbol(z, Decl(mappedTypes6.ts, 20, 36))
+
+    z = x;
+>z : Symbol(z, Decl(mappedTypes6.ts, 20, 36))
+>x : Symbol(x, Decl(mappedTypes6.ts, 20, 15))
+
+    z = y;
+>z : Symbol(z, Decl(mappedTypes6.ts, 20, 36))
+>y : Symbol(y, Decl(mappedTypes6.ts, 20, 30))
+
+    z = z;
+>z : Symbol(z, Decl(mappedTypes6.ts, 20, 36))
+>z : Symbol(z, Decl(mappedTypes6.ts, 20, 36))
+}
+
+type Denullified<T> = { [P in keyof T]-?: NonNullable<T[P]> };
+>Denullified : Symbol(Denullified, Decl(mappedTypes6.ts, 30, 1))
+>T : Symbol(T, Decl(mappedTypes6.ts, 32, 17))
+>P : Symbol(P, Decl(mappedTypes6.ts, 32, 25))
+>T : Symbol(T, Decl(mappedTypes6.ts, 32, 17))
+>NonNullable : Symbol(NonNullable, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes6.ts, 32, 17))
+>P : Symbol(P, Decl(mappedTypes6.ts, 32, 25))
+
+function f2<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+>f2 : Symbol(f2, Decl(mappedTypes6.ts, 32, 62))
+>T : Symbol(T, Decl(mappedTypes6.ts, 34, 12))
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+>Denullified : Symbol(Denullified, Decl(mappedTypes6.ts, 30, 1))
+>T : Symbol(T, Decl(mappedTypes6.ts, 34, 12))
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+>Required : Symbol(Required, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes6.ts, 34, 12))
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+>T : Symbol(T, Decl(mappedTypes6.ts, 34, 12))
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes6.ts, 34, 12))
+
+    w = w;
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+
+    w = x;  // Error
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+
+    w = y;  // Error
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+
+    w = z;  // Error
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+
+    x = w;
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+
+    x = x;
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+
+    x = y;  // Error
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+
+    x = z;  // Error
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+
+    y = w;
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+
+    y = x;
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+
+    y = y;
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+
+    y = z;  // Error
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+
+    z = w;
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+>w : Symbol(w, Decl(mappedTypes6.ts, 34, 15))
+
+    z = x;
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+>x : Symbol(x, Decl(mappedTypes6.ts, 34, 33))
+
+    z = y;
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+>y : Symbol(y, Decl(mappedTypes6.ts, 34, 49))
+
+    z = z;
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+>z : Symbol(z, Decl(mappedTypes6.ts, 34, 55))
+}
+
+
+function f3<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+>f3 : Symbol(f3, Decl(mappedTypes6.ts, 51, 1))
+>T : Symbol(T, Decl(mappedTypes6.ts, 54, 12))
+>w : Symbol(w, Decl(mappedTypes6.ts, 54, 15))
+>Denullified : Symbol(Denullified, Decl(mappedTypes6.ts, 30, 1))
+>T : Symbol(T, Decl(mappedTypes6.ts, 54, 12))
+>x : Symbol(x, Decl(mappedTypes6.ts, 54, 33))
+>Required : Symbol(Required, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes6.ts, 54, 12))
+>y : Symbol(y, Decl(mappedTypes6.ts, 54, 49))
+>T : Symbol(T, Decl(mappedTypes6.ts, 54, 12))
+>z : Symbol(z, Decl(mappedTypes6.ts, 54, 55))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes6.ts, 54, 12))
+
+    w = {};  // Error
+>w : Symbol(w, Decl(mappedTypes6.ts, 54, 15))
+
+    x = {};  // Error
+>x : Symbol(x, Decl(mappedTypes6.ts, 54, 33))
+
+    y = {};  // Error
+>y : Symbol(y, Decl(mappedTypes6.ts, 54, 49))
+
+    z = {};
+>z : Symbol(z, Decl(mappedTypes6.ts, 54, 55))
+}
+
+type Readwrite<T> = {
+>Readwrite : Symbol(Readwrite, Decl(mappedTypes6.ts, 59, 1))
+>T : Symbol(T, Decl(mappedTypes6.ts, 61, 15))
+
+    -readonly [P in keyof T]: T[P];
+>P : Symbol(P, Decl(mappedTypes6.ts, 62, 15))
+>T : Symbol(T, Decl(mappedTypes6.ts, 61, 15))
+>T : Symbol(T, Decl(mappedTypes6.ts, 61, 15))
+>P : Symbol(P, Decl(mappedTypes6.ts, 62, 15))
+}
+
+function f10<T>(x: Readonly<T>, y: T, z: Readwrite<T>) {
+>f10 : Symbol(f10, Decl(mappedTypes6.ts, 63, 1))
+>T : Symbol(T, Decl(mappedTypes6.ts, 65, 13))
+>x : Symbol(x, Decl(mappedTypes6.ts, 65, 16))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes6.ts, 65, 13))
+>y : Symbol(y, Decl(mappedTypes6.ts, 65, 31))
+>T : Symbol(T, Decl(mappedTypes6.ts, 65, 13))
+>z : Symbol(z, Decl(mappedTypes6.ts, 65, 37))
+>Readwrite : Symbol(Readwrite, Decl(mappedTypes6.ts, 59, 1))
+>T : Symbol(T, Decl(mappedTypes6.ts, 65, 13))
+
+    x = x;
+>x : Symbol(x, Decl(mappedTypes6.ts, 65, 16))
+>x : Symbol(x, Decl(mappedTypes6.ts, 65, 16))
+
+    x = y;
+>x : Symbol(x, Decl(mappedTypes6.ts, 65, 16))
+>y : Symbol(y, Decl(mappedTypes6.ts, 65, 31))
+
+    x = z;
+>x : Symbol(x, Decl(mappedTypes6.ts, 65, 16))
+>z : Symbol(z, Decl(mappedTypes6.ts, 65, 37))
+
+    y = x;
+>y : Symbol(y, Decl(mappedTypes6.ts, 65, 31))
+>x : Symbol(x, Decl(mappedTypes6.ts, 65, 16))
+
+    y = y;
+>y : Symbol(y, Decl(mappedTypes6.ts, 65, 31))
+>y : Symbol(y, Decl(mappedTypes6.ts, 65, 31))
+
+    y = z;
+>y : Symbol(y, Decl(mappedTypes6.ts, 65, 31))
+>z : Symbol(z, Decl(mappedTypes6.ts, 65, 37))
+
+    z = x;
+>z : Symbol(z, Decl(mappedTypes6.ts, 65, 37))
+>x : Symbol(x, Decl(mappedTypes6.ts, 65, 16))
+
+    z = y;
+>z : Symbol(z, Decl(mappedTypes6.ts, 65, 37))
+>y : Symbol(y, Decl(mappedTypes6.ts, 65, 31))
+
+    z = z;
+>z : Symbol(z, Decl(mappedTypes6.ts, 65, 37))
+>z : Symbol(z, Decl(mappedTypes6.ts, 65, 37))
+}
+
+type Foo = {
+>Foo : Symbol(Foo, Decl(mappedTypes6.ts, 75, 1))
+
+    a: number;
+>a : Symbol(a, Decl(mappedTypes6.ts, 77, 12))
+
+    b: number | undefined;
+>b : Symbol(b, Decl(mappedTypes6.ts, 78, 14))
+
+    c?: number;
+>c : Symbol(c, Decl(mappedTypes6.ts, 79, 26))
+
+    d?: number | undefined;
+>d : Symbol(d, Decl(mappedTypes6.ts, 80, 15))
+}
+
+declare let x1: Foo;
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>Foo : Symbol(Foo, Decl(mappedTypes6.ts, 75, 1))
+
+x1.a;  // number
+>x1.a : Symbol(a, Decl(mappedTypes6.ts, 77, 12))
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 77, 12))
+
+x1.b;  // number | undefined
+>x1.b : Symbol(b, Decl(mappedTypes6.ts, 78, 14))
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>b : Symbol(b, Decl(mappedTypes6.ts, 78, 14))
+
+x1.c;  // number | undefined
+>x1.c : Symbol(c, Decl(mappedTypes6.ts, 79, 26))
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>c : Symbol(c, Decl(mappedTypes6.ts, 79, 26))
+
+x1.d;  // number | undefined
+>x1.d : Symbol(d, Decl(mappedTypes6.ts, 80, 15))
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>d : Symbol(d, Decl(mappedTypes6.ts, 80, 15))
+
+x1 = { a: 1 };  // Error
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 91, 6))
+
+x1 = { a: 1, b: 1 };
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 92, 6))
+>b : Symbol(b, Decl(mappedTypes6.ts, 92, 12))
+
+x1 = { a: 1, b: 1, c: 1 };
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 93, 6))
+>b : Symbol(b, Decl(mappedTypes6.ts, 93, 12))
+>c : Symbol(c, Decl(mappedTypes6.ts, 93, 18))
+
+x1 = { a: 1, b: 1, c: 1, d: 1 };
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 94, 6))
+>b : Symbol(b, Decl(mappedTypes6.ts, 94, 12))
+>c : Symbol(c, Decl(mappedTypes6.ts, 94, 18))
+>d : Symbol(d, Decl(mappedTypes6.ts, 94, 24))
+
+declare let x2: Required<Foo>;
+>x2 : Symbol(x2, Decl(mappedTypes6.ts, 96, 11))
+>Required : Symbol(Required, Decl(lib.d.ts, --, --))
+>Foo : Symbol(Foo, Decl(mappedTypes6.ts, 75, 1))
+
+x1.a;  // number
+>x1.a : Symbol(a, Decl(mappedTypes6.ts, 77, 12))
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 77, 12))
+
+x1.b;  // number | undefined
+>x1.b : Symbol(b, Decl(mappedTypes6.ts, 78, 14))
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>b : Symbol(b, Decl(mappedTypes6.ts, 78, 14))
+
+x1.c;  // number
+>x1.c : Symbol(c, Decl(mappedTypes6.ts, 79, 26))
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>c : Symbol(c, Decl(mappedTypes6.ts, 79, 26))
+
+x1.d;  // number
+>x1.d : Symbol(d, Decl(mappedTypes6.ts, 80, 15))
+>x1 : Symbol(x1, Decl(mappedTypes6.ts, 84, 11))
+>d : Symbol(d, Decl(mappedTypes6.ts, 80, 15))
+
+x2 = { a: 1 };  // Error
+>x2 : Symbol(x2, Decl(mappedTypes6.ts, 96, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 103, 6))
+
+x2 = { a: 1, b: 1 };  // Error
+>x2 : Symbol(x2, Decl(mappedTypes6.ts, 96, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 104, 6))
+>b : Symbol(b, Decl(mappedTypes6.ts, 104, 12))
+
+x2 = { a: 1, b: 1, c: 1 };  // Error
+>x2 : Symbol(x2, Decl(mappedTypes6.ts, 96, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 105, 6))
+>b : Symbol(b, Decl(mappedTypes6.ts, 105, 12))
+>c : Symbol(c, Decl(mappedTypes6.ts, 105, 18))
+
+x2 = { a: 1, b: 1, c: 1, d: 1 };
+>x2 : Symbol(x2, Decl(mappedTypes6.ts, 96, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 106, 6))
+>b : Symbol(b, Decl(mappedTypes6.ts, 106, 12))
+>c : Symbol(c, Decl(mappedTypes6.ts, 106, 18))
+>d : Symbol(d, Decl(mappedTypes6.ts, 106, 24))
+
+type Bar = {
+>Bar : Symbol(Bar, Decl(mappedTypes6.ts, 106, 32))
+
+    a: number;
+>a : Symbol(a, Decl(mappedTypes6.ts, 108, 12))
+
+    readonly b: number;
+>b : Symbol(b, Decl(mappedTypes6.ts, 109, 14))
+}
+
+declare let x3: Bar;
+>x3 : Symbol(x3, Decl(mappedTypes6.ts, 113, 11))
+>Bar : Symbol(Bar, Decl(mappedTypes6.ts, 106, 32))
+
+x3.a = 1;
+>x3.a : Symbol(a, Decl(mappedTypes6.ts, 108, 12))
+>x3 : Symbol(x3, Decl(mappedTypes6.ts, 113, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 108, 12))
+
+x3.b = 1;  // Error
+>x3.b : Symbol(b, Decl(mappedTypes6.ts, 109, 14))
+>x3 : Symbol(x3, Decl(mappedTypes6.ts, 113, 11))
+>b : Symbol(b, Decl(mappedTypes6.ts, 109, 14))
+
+declare let x4: Readonly<Bar>;
+>x4 : Symbol(x4, Decl(mappedTypes6.ts, 117, 11))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>Bar : Symbol(Bar, Decl(mappedTypes6.ts, 106, 32))
+
+x4.a = 1;  // Error
+>x4.a : Symbol(a, Decl(mappedTypes6.ts, 108, 12))
+>x4 : Symbol(x4, Decl(mappedTypes6.ts, 117, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 108, 12))
+
+x4.b = 1;  // Error
+>x4.b : Symbol(b, Decl(mappedTypes6.ts, 109, 14))
+>x4 : Symbol(x4, Decl(mappedTypes6.ts, 117, 11))
+>b : Symbol(b, Decl(mappedTypes6.ts, 109, 14))
+
+declare let x5: Readwrite<Bar>;
+>x5 : Symbol(x5, Decl(mappedTypes6.ts, 121, 11))
+>Readwrite : Symbol(Readwrite, Decl(mappedTypes6.ts, 59, 1))
+>Bar : Symbol(Bar, Decl(mappedTypes6.ts, 106, 32))
+
+x5.a = 1;
+>x5.a : Symbol(a, Decl(mappedTypes6.ts, 108, 12))
+>x5 : Symbol(x5, Decl(mappedTypes6.ts, 121, 11))
+>a : Symbol(a, Decl(mappedTypes6.ts, 108, 12))
+
+x5.b = 1;
+>x5.b : Symbol(b, Decl(mappedTypes6.ts, 109, 14))
+>x5 : Symbol(x5, Decl(mappedTypes6.ts, 121, 11))
+>b : Symbol(b, Decl(mappedTypes6.ts, 109, 14))
+

--- a/tests/baselines/reference/mappedTypes6.types
+++ b/tests/baselines/reference/mappedTypes6.types
@@ -1,0 +1,609 @@
+=== tests/cases/conformance/types/mapped/mappedTypes6.ts ===
+type T00<T> = { [P in keyof T]: T[P] };
+>T00 : T00<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T01<T> = { [P in keyof T]?: T[P] };
+>T01 : T01<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T02<T> = { [P in keyof T]+?: T[P] };
+>T02 : T02<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T03<T> = { [P in keyof T]-?: T[P] };
+>T03 : T03<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T04<T> = { readonly [P in keyof T]: T[P] };
+>T04 : T04<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T05<T> = { readonly [P in keyof T]?: T[P] };
+>T05 : T05<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T06<T> = { readonly [P in keyof T]+?: T[P] };
+>T06 : T06<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T07<T> = { readonly [P in keyof T]-?: T[P] };
+>T07 : T07<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T08<T> = { +readonly [P in keyof T]: T[P] };
+>T08 : T08<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T09<T> = { +readonly [P in keyof T]?: T[P] };
+>T09 : T09<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T10<T> = { +readonly [P in keyof T]+?: T[P] };
+>T10 : T10<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T11<T> = { +readonly [P in keyof T]-?: T[P] };
+>T11 : T11<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T12<T> = { -readonly [P in keyof T]: T[P] };
+>T12 : T12<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T13<T> = { -readonly [P in keyof T]?: T[P] };
+>T13 : T13<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T14<T> = { -readonly [P in keyof T]+?: T[P] };
+>T14 : T14<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+type T15<T> = { -readonly [P in keyof T]-?: T[P] };
+>T15 : T15<T>
+>T : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+function f1<T>(x: Required<T>, y: T, z: Partial<T>) {
+>f1 : <T>(x: Required<T>, y: T, z: Partial<T>) => void
+>T : T
+>x : Required<T>
+>Required : Required<T>
+>T : T
+>y : T
+>T : T
+>z : Partial<T>
+>Partial : Partial<T>
+>T : T
+
+    x = x;
+>x = x : Required<T>
+>x : Required<T>
+>x : Required<T>
+
+    x = y;  // Error
+>x = y : T
+>x : Required<T>
+>y : T
+
+    x = z;  // Error
+>x = z : Partial<T>
+>x : Required<T>
+>z : Partial<T>
+
+    y = x;
+>y = x : Required<T>
+>y : T
+>x : Required<T>
+
+    y = y;
+>y = y : T
+>y : T
+>y : T
+
+    y = z;  // Error
+>y = z : Partial<T>
+>y : T
+>z : Partial<T>
+
+    z = x;
+>z = x : Required<T>
+>z : Partial<T>
+>x : Required<T>
+
+    z = y;
+>z = y : T
+>z : Partial<T>
+>y : T
+
+    z = z;
+>z = z : Partial<T>
+>z : Partial<T>
+>z : Partial<T>
+}
+
+type Denullified<T> = { [P in keyof T]-?: NonNullable<T[P]> };
+>Denullified : Denullified<T>
+>T : T
+>P : P
+>T : T
+>NonNullable : NonNullable<T>
+>T : T
+>P : P
+
+function f2<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+>f2 : <T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) => void
+>T : T
+>w : Denullified<T>
+>Denullified : Denullified<T>
+>T : T
+>x : Required<T>
+>Required : Required<T>
+>T : T
+>y : T
+>T : T
+>z : Partial<T>
+>Partial : Partial<T>
+>T : T
+
+    w = w;
+>w = w : Denullified<T>
+>w : Denullified<T>
+>w : Denullified<T>
+
+    w = x;  // Error
+>w = x : Required<T>
+>w : Denullified<T>
+>x : Required<T>
+
+    w = y;  // Error
+>w = y : T
+>w : Denullified<T>
+>y : T
+
+    w = z;  // Error
+>w = z : Partial<T>
+>w : Denullified<T>
+>z : Partial<T>
+
+    x = w;
+>x = w : Denullified<T>
+>x : Required<T>
+>w : Denullified<T>
+
+    x = x;
+>x = x : Required<T>
+>x : Required<T>
+>x : Required<T>
+
+    x = y;  // Error
+>x = y : T
+>x : Required<T>
+>y : T
+
+    x = z;  // Error
+>x = z : Partial<T>
+>x : Required<T>
+>z : Partial<T>
+
+    y = w;
+>y = w : Denullified<T>
+>y : T
+>w : Denullified<T>
+
+    y = x;
+>y = x : Required<T>
+>y : T
+>x : Required<T>
+
+    y = y;
+>y = y : T
+>y : T
+>y : T
+
+    y = z;  // Error
+>y = z : Partial<T>
+>y : T
+>z : Partial<T>
+
+    z = w;
+>z = w : Denullified<T>
+>z : Partial<T>
+>w : Denullified<T>
+
+    z = x;
+>z = x : Required<T>
+>z : Partial<T>
+>x : Required<T>
+
+    z = y;
+>z = y : T
+>z : Partial<T>
+>y : T
+
+    z = z;
+>z = z : Partial<T>
+>z : Partial<T>
+>z : Partial<T>
+}
+
+
+function f3<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+>f3 : <T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) => void
+>T : T
+>w : Denullified<T>
+>Denullified : Denullified<T>
+>T : T
+>x : Required<T>
+>Required : Required<T>
+>T : T
+>y : T
+>T : T
+>z : Partial<T>
+>Partial : Partial<T>
+>T : T
+
+    w = {};  // Error
+>w = {} : {}
+>w : Denullified<T>
+>{} : {}
+
+    x = {};  // Error
+>x = {} : {}
+>x : Required<T>
+>{} : {}
+
+    y = {};  // Error
+>y = {} : {}
+>y : T
+>{} : {}
+
+    z = {};
+>z = {} : {}
+>z : Partial<T>
+>{} : {}
+}
+
+type Readwrite<T> = {
+>Readwrite : Readwrite<T>
+>T : T
+
+    -readonly [P in keyof T]: T[P];
+>P : P
+>T : T
+>T : T
+>P : P
+}
+
+function f10<T>(x: Readonly<T>, y: T, z: Readwrite<T>) {
+>f10 : <T>(x: Readonly<T>, y: T, z: Readwrite<T>) => void
+>T : T
+>x : Readonly<T>
+>Readonly : Readonly<T>
+>T : T
+>y : T
+>T : T
+>z : Readwrite<T>
+>Readwrite : Readwrite<T>
+>T : T
+
+    x = x;
+>x = x : Readonly<T>
+>x : Readonly<T>
+>x : Readonly<T>
+
+    x = y;
+>x = y : T
+>x : Readonly<T>
+>y : T
+
+    x = z;
+>x = z : Readwrite<T>
+>x : Readonly<T>
+>z : Readwrite<T>
+
+    y = x;
+>y = x : Readonly<T>
+>y : T
+>x : Readonly<T>
+
+    y = y;
+>y = y : T
+>y : T
+>y : T
+
+    y = z;
+>y = z : Readwrite<T>
+>y : T
+>z : Readwrite<T>
+
+    z = x;
+>z = x : Readonly<T>
+>z : Readwrite<T>
+>x : Readonly<T>
+
+    z = y;
+>z = y : T
+>z : Readwrite<T>
+>y : T
+
+    z = z;
+>z = z : Readwrite<T>
+>z : Readwrite<T>
+>z : Readwrite<T>
+}
+
+type Foo = {
+>Foo : Foo
+
+    a: number;
+>a : number
+
+    b: number | undefined;
+>b : number | undefined
+
+    c?: number;
+>c : number | undefined
+
+    d?: number | undefined;
+>d : number | undefined
+}
+
+declare let x1: Foo;
+>x1 : Foo
+>Foo : Foo
+
+x1.a;  // number
+>x1.a : number
+>x1 : Foo
+>a : number
+
+x1.b;  // number | undefined
+>x1.b : number | undefined
+>x1 : Foo
+>b : number | undefined
+
+x1.c;  // number | undefined
+>x1.c : number | undefined
+>x1 : Foo
+>c : number | undefined
+
+x1.d;  // number | undefined
+>x1.d : number | undefined
+>x1 : Foo
+>d : number | undefined
+
+x1 = { a: 1 };  // Error
+>x1 = { a: 1 } : { a: number; }
+>x1 : Foo
+>{ a: 1 } : { a: number; }
+>a : number
+>1 : 1
+
+x1 = { a: 1, b: 1 };
+>x1 = { a: 1, b: 1 } : { a: number; b: number; }
+>x1 : Foo
+>{ a: 1, b: 1 } : { a: number; b: number; }
+>a : number
+>1 : 1
+>b : number
+>1 : 1
+
+x1 = { a: 1, b: 1, c: 1 };
+>x1 = { a: 1, b: 1, c: 1 } : { a: number; b: number; c: number; }
+>x1 : Foo
+>{ a: 1, b: 1, c: 1 } : { a: number; b: number; c: number; }
+>a : number
+>1 : 1
+>b : number
+>1 : 1
+>c : number
+>1 : 1
+
+x1 = { a: 1, b: 1, c: 1, d: 1 };
+>x1 = { a: 1, b: 1, c: 1, d: 1 } : { a: number; b: number; c: number; d: number; }
+>x1 : Foo
+>{ a: 1, b: 1, c: 1, d: 1 } : { a: number; b: number; c: number; d: number; }
+>a : number
+>1 : 1
+>b : number
+>1 : 1
+>c : number
+>1 : 1
+>d : number
+>1 : 1
+
+declare let x2: Required<Foo>;
+>x2 : Required<Foo>
+>Required : Required<T>
+>Foo : Foo
+
+x1.a;  // number
+>x1.a : number
+>x1 : Foo
+>a : number
+
+x1.b;  // number | undefined
+>x1.b : number | undefined
+>x1 : Foo
+>b : number | undefined
+
+x1.c;  // number
+>x1.c : number | undefined
+>x1 : Foo
+>c : number | undefined
+
+x1.d;  // number
+>x1.d : number | undefined
+>x1 : Foo
+>d : number | undefined
+
+x2 = { a: 1 };  // Error
+>x2 = { a: 1 } : { a: number; }
+>x2 : Required<Foo>
+>{ a: 1 } : { a: number; }
+>a : number
+>1 : 1
+
+x2 = { a: 1, b: 1 };  // Error
+>x2 = { a: 1, b: 1 } : { a: number; b: number; }
+>x2 : Required<Foo>
+>{ a: 1, b: 1 } : { a: number; b: number; }
+>a : number
+>1 : 1
+>b : number
+>1 : 1
+
+x2 = { a: 1, b: 1, c: 1 };  // Error
+>x2 = { a: 1, b: 1, c: 1 } : { a: number; b: number; c: number; }
+>x2 : Required<Foo>
+>{ a: 1, b: 1, c: 1 } : { a: number; b: number; c: number; }
+>a : number
+>1 : 1
+>b : number
+>1 : 1
+>c : number
+>1 : 1
+
+x2 = { a: 1, b: 1, c: 1, d: 1 };
+>x2 = { a: 1, b: 1, c: 1, d: 1 } : { a: number; b: number; c: number; d: number; }
+>x2 : Required<Foo>
+>{ a: 1, b: 1, c: 1, d: 1 } : { a: number; b: number; c: number; d: number; }
+>a : number
+>1 : 1
+>b : number
+>1 : 1
+>c : number
+>1 : 1
+>d : number
+>1 : 1
+
+type Bar = {
+>Bar : Bar
+
+    a: number;
+>a : number
+
+    readonly b: number;
+>b : number
+}
+
+declare let x3: Bar;
+>x3 : Bar
+>Bar : Bar
+
+x3.a = 1;
+>x3.a = 1 : 1
+>x3.a : number
+>x3 : Bar
+>a : number
+>1 : 1
+
+x3.b = 1;  // Error
+>x3.b = 1 : 1
+>x3.b : any
+>x3 : Bar
+>b : any
+>1 : 1
+
+declare let x4: Readonly<Bar>;
+>x4 : Readonly<Bar>
+>Readonly : Readonly<T>
+>Bar : Bar
+
+x4.a = 1;  // Error
+>x4.a = 1 : 1
+>x4.a : any
+>x4 : Readonly<Bar>
+>a : any
+>1 : 1
+
+x4.b = 1;  // Error
+>x4.b = 1 : 1
+>x4.b : any
+>x4 : Readonly<Bar>
+>b : any
+>1 : 1
+
+declare let x5: Readwrite<Bar>;
+>x5 : Readwrite<Bar>
+>Readwrite : Readwrite<T>
+>Bar : Bar
+
+x5.a = 1;
+>x5.a = 1 : 1
+>x5.a : number
+>x5 : Readwrite<Bar>
+>a : number
+>1 : 1
+
+x5.b = 1;
+>x5.b = 1 : 1
+>x5.b : number
+>x5 : Readwrite<Bar>
+>b : number
+>1 : 1
+

--- a/tests/cases/conformance/types/mapped/mappedTypes6.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypes6.ts
@@ -1,0 +1,127 @@
+// @strict: true
+// @declaration: true
+
+type T00<T> = { [P in keyof T]: T[P] };
+type T01<T> = { [P in keyof T]?: T[P] };
+type T02<T> = { [P in keyof T]+?: T[P] };
+type T03<T> = { [P in keyof T]-?: T[P] };
+
+type T04<T> = { readonly [P in keyof T]: T[P] };
+type T05<T> = { readonly [P in keyof T]?: T[P] };
+type T06<T> = { readonly [P in keyof T]+?: T[P] };
+type T07<T> = { readonly [P in keyof T]-?: T[P] };
+
+type T08<T> = { +readonly [P in keyof T]: T[P] };
+type T09<T> = { +readonly [P in keyof T]?: T[P] };
+type T10<T> = { +readonly [P in keyof T]+?: T[P] };
+type T11<T> = { +readonly [P in keyof T]-?: T[P] };
+
+type T12<T> = { -readonly [P in keyof T]: T[P] };
+type T13<T> = { -readonly [P in keyof T]?: T[P] };
+type T14<T> = { -readonly [P in keyof T]+?: T[P] };
+type T15<T> = { -readonly [P in keyof T]-?: T[P] };
+
+function f1<T>(x: Required<T>, y: T, z: Partial<T>) {
+    x = x;
+    x = y;  // Error
+    x = z;  // Error
+    y = x;
+    y = y;
+    y = z;  // Error
+    z = x;
+    z = y;
+    z = z;
+}
+
+type Denullified<T> = { [P in keyof T]-?: NonNullable<T[P]> };
+
+function f2<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+    w = w;
+    w = x;  // Error
+    w = y;  // Error
+    w = z;  // Error
+    x = w;
+    x = x;
+    x = y;  // Error
+    x = z;  // Error
+    y = w;
+    y = x;
+    y = y;
+    y = z;  // Error
+    z = w;
+    z = x;
+    z = y;
+    z = z;
+}
+
+
+function f3<T>(w: Denullified<T>, x: Required<T>, y: T, z: Partial<T>) {
+    w = {};  // Error
+    x = {};  // Error
+    y = {};  // Error
+    z = {};
+}
+
+type Readwrite<T> = {
+    -readonly [P in keyof T]: T[P];
+}
+
+function f10<T>(x: Readonly<T>, y: T, z: Readwrite<T>) {
+    x = x;
+    x = y;
+    x = z;
+    y = x;
+    y = y;
+    y = z;
+    z = x;
+    z = y;
+    z = z;
+}
+
+type Foo = {
+    a: number;
+    b: number | undefined;
+    c?: number;
+    d?: number | undefined;
+}
+
+declare let x1: Foo;
+
+x1.a;  // number
+x1.b;  // number | undefined
+x1.c;  // number | undefined
+x1.d;  // number | undefined
+
+x1 = { a: 1 };  // Error
+x1 = { a: 1, b: 1 };
+x1 = { a: 1, b: 1, c: 1 };
+x1 = { a: 1, b: 1, c: 1, d: 1 };
+
+declare let x2: Required<Foo>;
+
+x1.a;  // number
+x1.b;  // number | undefined
+x1.c;  // number
+x1.d;  // number
+
+x2 = { a: 1 };  // Error
+x2 = { a: 1, b: 1 };  // Error
+x2 = { a: 1, b: 1, c: 1 };  // Error
+x2 = { a: 1, b: 1, c: 1, d: 1 };
+
+type Bar = {
+    a: number;
+    readonly b: number;
+}
+
+declare let x3: Bar;
+x3.a = 1;
+x3.b = 1;  // Error
+
+declare let x4: Readonly<Bar>;
+x4.a = 1;  // Error
+x4.b = 1;  // Error
+
+declare let x5: Readwrite<Bar>;
+x5.a = 1;
+x5.b = 1;


### PR DESCRIPTION
Mapped types currently support adding a `readonly` or `?` modifier to a mapped property, but they do not provide support the ability to *remove* modifiers. This matters in *homomorphic mapped types* (see #12563 and #12826) which by default preserve the modifiers of the underlying type.

With this PR we provide the ability for a mapped type to either add or remove a particular modifier. Specifically, a `readonly` or `?` property modifier in a mapped type can now be prefixed with either `+` or `-` to indicate that the modifier should be added or removed.

Using this ability, the PR defines a new `Required<T>` type in `lib.d.ts`. This type strips `?` modifiers from all properties of `T`, thus making all properties required:

```ts
type Required<T> = { [P in keyof T]-?: T[P] };
```

Some examples of `+` and `-` on mapped type modifiers:

```ts
type MutableRequired<T> = { -readonly [P in keyof T]-?: T[P] };  // Remove readonly and ?
type ReadonlyPartial<T> = { +readonly [P in keyof T]+?: T[P] };  // Add readonly and ?
```

A modifier with no `+` or `-` prefix is the same as a modifier with a `+` prefix. So, the `ReadonlyPartial<T>` type above corresponds to

```ts
type ReadonlyPartial<T> = { readonly [P in keyof T]?: T[P] };  // Add readonly and ?
```

In `--strictNullChecks` mode, when a homomorphic mapped type removes a `?` modifier from a property in the underlying type it also removes `undefined` from the type of that property:

```ts
type Foo = { a?: string };  // Same as { a?: string | undefined }
type Bar = Required<Foo>;  // Same as { a: string }
```

Fixes #15012.