### PR TITLE
Fix `jake lint`

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -1305,7 +1305,7 @@ task("lint", ["build-rules"], () => {
     
     const files = fileMatcher
         ? `src/**/${fileMatcher}`
-        : `Gulpfile.ts scripts/generateLocalizedDiagnosticMessages.ts "scripts/tslint/**/*.ts" "src/**/*.ts" --exclude "src/lib/*.d.ts"`;
+        : "Gulpfile.ts 'scripts/*generateLocalizedDiagnosticMessages.ts' 'scripts/tslint/**/*.ts' 'src/**/*.ts' --exclude 'src/lib/*.d.ts'";
     const cmd = `node node_modules/tslint/bin/tslint ${files} --formatters-dir ./built/local/tslint/formatters --format autolinkableStylish`;
     console.log("Linting: " + cmd);
     jake.exec([cmd], { interactive: true }, () => {


### PR DESCRIPTION
...by partially reverting d0ab1642fe7327f486b41d97e6c6f81e082403e0, which seems to have prevented jake from waiting for the output of linting.

Mitigate the issue that that change was trying to mitigate (warning that scripts/generateLocalizedDiagnosticMessages.ts does not exist) by introducing a superfluous wildcard into the filter.

TODO: follow up with tslint to figure out why an existing file is reported as not existing.