### PR TITLE
Supports more locations for completions contextual types

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2835,6 +2835,8 @@ namespace ts {
         getAugmentedPropertiesOfType(type: Type): Symbol[];
         getRootSymbols(symbol: Symbol): Symbol[];
         getContextualType(node: Expression): Type | undefined;
+        /* @internal */ getContextualTypeForArgumentAtIndex(call: CallLikeExpression, argIndex: number): Type;
+        /* @internal */ getContextualTypeForJsxAttribute(attribute: JsxAttribute | JsxSpreadAttribute): Type | undefined;
         /* @internal */ isContextSensitive(node: Expression | MethodDeclaration | ObjectLiteralElementLike | JsxAttributeLike): boolean;
 
         /**

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -95,7 +95,7 @@ namespace ts.SignatureHelp {
      * Returns relevant information for the argument list and the current argument if we are
      * in the argument of an invocation; returns undefined otherwise.
      */
-    export function getImmediatelyContainingArgumentInfo(node: Node, position: number, sourceFile: SourceFile): ArgumentListInfo {
+    export function getImmediatelyContainingArgumentInfo(node: Node, position: number, sourceFile: SourceFile): ArgumentListInfo | undefined {
         if (isCallOrNewExpression(node.parent)) {
             const invocation = node.parent;
             let list: Node;
@@ -207,8 +207,7 @@ namespace ts.SignatureHelp {
         // that trailing comma in the list, and we'll have generated the appropriate
         // arg index.
         let argumentIndex = 0;
-        const listChildren = argumentsList.getChildren();
-        for (const child of listChildren) {
+        for (const child of argumentsList.getChildren()) {
             if (child === node) {
                 break;
             }
@@ -270,9 +269,7 @@ namespace ts.SignatureHelp {
 
     function getArgumentListInfoForTemplate(tagExpression: TaggedTemplateExpression, argumentIndex: number, sourceFile: SourceFile): ArgumentListInfo {
         // argumentCount is either 1 or (numSpans + 1) to account for the template strings array argument.
-        const argumentCount = tagExpression.template.kind === SyntaxKind.NoSubstitutionTemplateLiteral
-            ? 1
-            : (<TemplateExpression>tagExpression.template).templateSpans.length + 1;
+        const argumentCount = isNoSubstitutionTemplateLiteral(tagExpression.template) ? 1 : tagExpression.template.templateSpans.length + 1;
 
         if (argumentIndex !== 0) {
             Debug.assertLessThan(argumentIndex, argumentCount);

--- a/tests/cases/fourslash/completionsRecommended_contextualTypes.ts
+++ b/tests/cases/fourslash/completionsRecommended_contextualTypes.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @jsx: preserve
+
+// @Filename: /a.tsx
+////enum E {}
+////enum F {}
+////function f(e: E, f: F) {}
+////f(/*arg0*/, /*arg1*/);
+////
+////function tag(arr: TemplateStringsArray, x: E) {}
+////tag`${/*tag*/}`;
+////
+////declare function MainButton(props: { e: E }): any;
+////<MainButton e={/*jsx*/} />
+////<MainButton e=/*jsx2*/ />
+
+recommended("arg0");
+recommended("arg1", "F");
+recommended("tag");
+recommended("jsx");
+recommended("jsx2");
+
+function recommended(markerName: string, enumName = "E") {
+    goTo.marker(markerName);
+    verify.completionListContains(enumName, `enum ${enumName}`, "", "enum", undefined, undefined , { isRecommended: true });
+}

--- a/tests/cases/fourslash/signatureHelpIncompleteCalls.ts
+++ b/tests/cases/fourslash/signatureHelpIncompleteCalls.ts
@@ -27,5 +27,5 @@ verify.currentSignatureParameterCountIs(2);
 verify.currentSignatureHelpIs("f3(n: number, s: string): string");
 
 verify.currentParameterHelpArgumentNameIs("s");
-verify.currentParameterSpanIs("s: string");  
+verify.currentParameterSpanIs("s: string");
 


### PR DESCRIPTION
Supports more cases where we didn't get a contextual type before. As in #20020, adding this functionality to `completions.ts` instead of the checker, because e.g. the contextual type at a `(` will only matter in completions.
