### PR TITLE
Fix bug: Interface type parameter merged with property is not unused

### DIFF
--- a/tests/baselines/reference/noUnusedLocals_selfReference.errors.txt
+++ b/tests/baselines/reference/noUnusedLocals_selfReference.errors.txt
@@ -2,10 +2,13 @@ tests/cases/compiler/noUnusedLocals_selfReference.ts(3,10): error TS6133: 'f' is
 tests/cases/compiler/noUnusedLocals_selfReference.ts(5,14): error TS6133: 'g' is declared but its value is never read.
 tests/cases/compiler/noUnusedLocals_selfReference.ts(9,7): error TS6133: 'C' is declared but its value is never read.
 tests/cases/compiler/noUnusedLocals_selfReference.ts(12,6): error TS6133: 'E' is declared but its value is never read.
-tests/cases/compiler/noUnusedLocals_selfReference.ts(14,19): error TS6133: 'm' is declared but its value is never read.
+tests/cases/compiler/noUnusedLocals_selfReference.ts(13,11): error TS6133: 'I' is declared but its value is never read.
+tests/cases/compiler/noUnusedLocals_selfReference.ts(14,6): error TS6133: 'T' is declared but its value is never read.
+tests/cases/compiler/noUnusedLocals_selfReference.ts(15,11): error TS6133: 'N' is declared but its value is never read.
+tests/cases/compiler/noUnusedLocals_selfReference.ts(22,19): error TS6133: 'm' is declared but its value is never read.
 
 
-==== tests/cases/compiler/noUnusedLocals_selfReference.ts (5 errors) ====
+==== tests/cases/compiler/noUnusedLocals_selfReference.ts (8 errors) ====
     export {}; // Make this a module scope, so these are local variables.
     
     function f() {
@@ -26,6 +29,20 @@ tests/cases/compiler/noUnusedLocals_selfReference.ts(14,19): error TS6133: 'm' i
     enum E { A = 0, B = E.A }
          ~
 !!! error TS6133: 'E' is declared but its value is never read.
+    interface I { x: I };
+              ~
+!!! error TS6133: 'I' is declared but its value is never read.
+    type T = { x: T };
+         ~
+!!! error TS6133: 'T' is declared but its value is never read.
+    namespace N { N; }
+              ~
+!!! error TS6133: 'N' is declared but its value is never read.
+    
+    // Avoid a false positive.
+    // Previously `T` was considered unused due to merging with the property,
+    // back when all non-blocks were checked for recursion.
+    export interface A<T> { T: T }
     
     class P { private m() { this.m; } }
                       ~

--- a/tests/baselines/reference/noUnusedLocals_selfReference.js
+++ b/tests/baselines/reference/noUnusedLocals_selfReference.js
@@ -11,6 +11,14 @@ class C {
     m() { C; }
 }
 enum E { A = 0, B = E.A }
+interface I { x: I };
+type T = { x: T };
+namespace N { N; }
+
+// Avoid a false positive.
+// Previously `T` was considered unused due to merging with the property,
+// back when all non-blocks were checked for recursion.
+export interface A<T> { T: T }
 
 class P { private m() { this.m; } }
 P;
@@ -40,6 +48,11 @@ var E;
     E[E["A"] = 0] = "A";
     E[E["B"] = 0] = "B";
 })(E || (E = {}));
+;
+var N;
+(function (N) {
+    N;
+})(N || (N = {}));
 var P = /** @class */ (function () {
     function P() {
     }

--- a/tests/baselines/reference/noUnusedLocals_selfReference.symbols
+++ b/tests/baselines/reference/noUnusedLocals_selfReference.symbols
@@ -29,23 +29,46 @@ enum E { A = 0, B = E.A }
 >E : Symbol(E, Decl(noUnusedLocals_selfReference.ts, 10, 1))
 >A : Symbol(E.A, Decl(noUnusedLocals_selfReference.ts, 11, 8))
 
+interface I { x: I };
+>I : Symbol(I, Decl(noUnusedLocals_selfReference.ts, 11, 25))
+>x : Symbol(I.x, Decl(noUnusedLocals_selfReference.ts, 12, 13))
+>I : Symbol(I, Decl(noUnusedLocals_selfReference.ts, 11, 25))
+
+type T = { x: T };
+>T : Symbol(T, Decl(noUnusedLocals_selfReference.ts, 12, 21))
+>x : Symbol(x, Decl(noUnusedLocals_selfReference.ts, 13, 10))
+>T : Symbol(T, Decl(noUnusedLocals_selfReference.ts, 12, 21))
+
+namespace N { N; }
+>N : Symbol(N, Decl(noUnusedLocals_selfReference.ts, 13, 18))
+>N : Symbol(N, Decl(noUnusedLocals_selfReference.ts, 13, 18))
+
+// Avoid a false positive.
+// Previously `T` was considered unused due to merging with the property,
+// back when all non-blocks were checked for recursion.
+export interface A<T> { T: T }
+>A : Symbol(A, Decl(noUnusedLocals_selfReference.ts, 14, 18))
+>T : Symbol(T, Decl(noUnusedLocals_selfReference.ts, 19, 19), Decl(noUnusedLocals_selfReference.ts, 19, 23))
+>T : Symbol(T, Decl(noUnusedLocals_selfReference.ts, 19, 19), Decl(noUnusedLocals_selfReference.ts, 19, 23))
+>T : Symbol(T, Decl(noUnusedLocals_selfReference.ts, 19, 19), Decl(noUnusedLocals_selfReference.ts, 19, 23))
+
 class P { private m() { this.m; } }
->P : Symbol(P, Decl(noUnusedLocals_selfReference.ts, 11, 25))
->m : Symbol(P.m, Decl(noUnusedLocals_selfReference.ts, 13, 9))
->this.m : Symbol(P.m, Decl(noUnusedLocals_selfReference.ts, 13, 9))
->this : Symbol(P, Decl(noUnusedLocals_selfReference.ts, 11, 25))
->m : Symbol(P.m, Decl(noUnusedLocals_selfReference.ts, 13, 9))
+>P : Symbol(P, Decl(noUnusedLocals_selfReference.ts, 19, 30))
+>m : Symbol(P.m, Decl(noUnusedLocals_selfReference.ts, 21, 9))
+>this.m : Symbol(P.m, Decl(noUnusedLocals_selfReference.ts, 21, 9))
+>this : Symbol(P, Decl(noUnusedLocals_selfReference.ts, 19, 30))
+>m : Symbol(P.m, Decl(noUnusedLocals_selfReference.ts, 21, 9))
 
 P;
->P : Symbol(P, Decl(noUnusedLocals_selfReference.ts, 11, 25))
+>P : Symbol(P, Decl(noUnusedLocals_selfReference.ts, 19, 30))
 
 // Does not detect mutual recursion.
 function g() { D; }
->g : Symbol(g, Decl(noUnusedLocals_selfReference.ts, 14, 2))
->D : Symbol(D, Decl(noUnusedLocals_selfReference.ts, 17, 19))
+>g : Symbol(g, Decl(noUnusedLocals_selfReference.ts, 22, 2))
+>D : Symbol(D, Decl(noUnusedLocals_selfReference.ts, 25, 19))
 
 class D { m() { g; } }
->D : Symbol(D, Decl(noUnusedLocals_selfReference.ts, 17, 19))
->m : Symbol(D.m, Decl(noUnusedLocals_selfReference.ts, 18, 9))
->g : Symbol(g, Decl(noUnusedLocals_selfReference.ts, 14, 2))
+>D : Symbol(D, Decl(noUnusedLocals_selfReference.ts, 25, 19))
+>m : Symbol(D.m, Decl(noUnusedLocals_selfReference.ts, 26, 9))
+>g : Symbol(g, Decl(noUnusedLocals_selfReference.ts, 22, 2))
 

--- a/tests/baselines/reference/noUnusedLocals_selfReference.types
+++ b/tests/baselines/reference/noUnusedLocals_selfReference.types
@@ -30,6 +30,29 @@ enum E { A = 0, B = E.A }
 >E : typeof E
 >A : E
 
+interface I { x: I };
+>I : I
+>x : I
+>I : I
+
+type T = { x: T };
+>T : { x: T; }
+>x : { x: T; }
+>T : { x: T; }
+
+namespace N { N; }
+>N : typeof N
+>N : typeof N
+
+// Avoid a false positive.
+// Previously `T` was considered unused due to merging with the property,
+// back when all non-blocks were checked for recursion.
+export interface A<T> { T: T }
+>A : A<T>
+>T : T
+>T : T
+>T : T
+
 class P { private m() { this.m; } }
 >P : P
 >m : () => void

--- a/tests/cases/compiler/noUnusedLocals_selfReference.ts
+++ b/tests/cases/compiler/noUnusedLocals_selfReference.ts
@@ -1,4 +1,5 @@
 // @noUnusedLocals: true
+// @noUnusedParameters: true
 
 export {}; // Make this a module scope, so these are local variables.
 
@@ -12,6 +13,14 @@ class C {
     m() { C; }
 }
 enum E { A = 0, B = E.A }
+interface I { x: I };
+type T = { x: T };
+namespace N { N; }
+
+// Avoid a false positive.
+// Previously `T` was considered unused due to merging with the property,
+// back when all non-blocks were checked for recursion.
+export interface A<T> { T: T }
 
 class P { private m() { this.m; } }
 P;

--- a/tests/cases/compiler/nounusedTypeParameterConstraint.ts
+++ b/tests/cases/compiler/nounusedTypeParameterConstraint.ts
@@ -1,4 +1,5 @@
-//@noUnusedLocals:true
+// @noUnusedLocals: true
+// @noUnusedParameters:true
 
 //@filename: bar.ts
 export interface IEventSourcedEntity { }


### PR DESCRIPTION
Fixes #21931 
The bug was because the type parameter `T` was merged with the property `T`. We considered this to be a case of the PropertySignature referencing itself.
Now we will only consider certain declaration kinds as potential self-references (since we've had a few bugs like this in the past.) I think I've got them all.