### PR TITLE
textChanges: Clean up handling of newLineCharacter

### DIFF
--- a/src/harness/unittests/textChanges.ts
+++ b/src/harness/unittests/textChanges.ts
@@ -57,7 +57,7 @@ namespace ts {
                 Harness.Baseline.runBaseline(`textChanges/${caption}.js`, () => {
                     const sourceFile = createSourceFile("source.ts", text, ScriptTarget.ES2015, /*setParentNodes*/ true);
                     const rulesProvider = getRuleProvider(placeOpenBraceOnNewLineForFunctions);
-                    const changeTracker = new textChanges.ChangeTracker(printerOptions.newLine, rulesProvider, validateNodes ? verifyPositions : undefined);
+                    const changeTracker = new textChanges.ChangeTracker(newLineCharacter, rulesProvider, validateNodes ? verifyPositions : undefined);
                     testBlock(sourceFile, changeTracker);
                     const changes = changeTracker.getChanges();
                     assert.equal(changes.length, 1);

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -197,13 +197,12 @@ namespace ts.textChanges {
 
     export class ChangeTracker {
         private readonly changes: Change[] = [];
-        private readonly newLineCharacter: string;
         private readonly deletedNodesInLists: true[] = []; // Stores ids of nodes in lists that we already deleted. Used to avoid deleting `, ` twice in `a, b`.
         // Map from class id to nodes to insert at the start
         private readonly nodesInsertedAtClassStarts = createMap<{ sourceFile: SourceFile, cls: ClassLikeDeclaration, members: ClassElement[] }>();
 
         public static fromContext(context: TextChangesContext): ChangeTracker {
-            return new ChangeTracker(getNewLineOrDefaultFromHost(context.host, context.formatContext.options) === "\n" ? NewLineKind.LineFeed : NewLineKind.CarriageReturnLineFeed, context.formatContext);
+            return new ChangeTracker(getNewLineOrDefaultFromHost(context.host, context.formatContext.options), context.formatContext);
         }
 
         public static with(context: TextChangesContext, cb: (tracker: ChangeTracker) => void): FileTextChanges[] {
@@ -212,11 +211,11 @@ namespace ts.textChanges {
             return tracker.getChanges();
         }
 
+        /** Public for tests only. Other callers should use `ChangeTracker.with`. */
         constructor(
-            private readonly newLine: NewLineKind,
+            private readonly newLineCharacter: string,
             private readonly formatContext: ts.formatting.FormatContext,
             private readonly validator?: (text: NonFormattedText) => void) {
-            this.newLineCharacter = getNewLineCharacter({ newLine });
         }
 
         public deleteRange(sourceFile: SourceFile, range: TextRange) {
@@ -651,7 +650,7 @@ namespace ts.textChanges {
         }
 
         private getFormattedTextOfNode(node: Node, sourceFile: SourceFile, pos: number, options: ChangeNodeOptions): string {
-            const nonformattedText = getNonformattedText(node, sourceFile, this.newLine);
+            const nonformattedText = getNonformattedText(node, sourceFile, this.newLineCharacter);
             if (this.validator) {
                 this.validator(nonformattedText);
             }
@@ -691,10 +690,9 @@ namespace ts.textChanges {
         readonly node: Node;
     }
 
-    function getNonformattedText(node: Node, sourceFile: SourceFile | undefined, newLine: NewLineKind): NonFormattedText {
-        const options = { newLine, target: sourceFile && sourceFile.languageVersion };
-        const writer = new Writer(getNewLineCharacter(options));
-        const printer = createPrinter(options, writer);
+    function getNonformattedText(node: Node, sourceFile: SourceFile | undefined, newLine: string): NonFormattedText {
+        const writer = new Writer(newLine);
+        const printer = createPrinter({ newLine: newLine === "\n" ? NewLineKind.LineFeed : NewLineKind.CarriageReturnLineFeed }, writer);
         printer.writeNode(EmitHint.Unspecified, node, sourceFile, writer);
         return { text: writer.getText(), node: assignPositionsToNode(node) };
     }


### PR DESCRIPTION
No need to keep `this.newLine` as we only need to use the `NewLine` enum in one place, and can just do the conversion there.