### PR TITLE
Add comment to isGlobalCompletion

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -724,6 +724,7 @@ namespace ts {
     }
 
     export interface CompletionInfo {
+        /** Not true for all glboal completions. This will be true if the enclosing scope matches a few syntax kinds. See `isGlobalCompletionScope`. */
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4488,6 +4488,7 @@ declare namespace ts {
         argumentCount: number;
     }
     interface CompletionInfo {
+        /** Not true for all glboal completions. This will be true if the enclosing scope matches a few syntax kinds. See `isGlobalCompletionScope`. */
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
         /**

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4740,6 +4740,7 @@ declare namespace ts {
         argumentCount: number;
     }
     interface CompletionInfo {
+        /** Not true for all glboal completions. This will be true if the enclosing scope matches a few syntax kinds. See `isGlobalCompletionScope`. */
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
         /**


### PR DESCRIPTION
Replaces #21342. We don't know why isGlobalCompletion activates for these particular syntax kinds, but don't feel comfortable changing it.