### PR TITLE
add template to jsdoc completion

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -37,6 +37,7 @@ namespace ts.JsDoc {
         "see",
         "since",
         "static",
+        "template",
         "throws",
         "type",
         "typedef",

--- a/tests/cases/fourslash/completionInJsDoc.ts
+++ b/tests/cases/fourslash/completionInJsDoc.ts
@@ -59,6 +59,7 @@ verify.completionListContains("constructor");
 verify.completionListContains("param");
 verify.completionListContains("type");
 verify.completionListContains("method");
+verify.completionListContains("template");
 
 goTo.marker('2');
 verify.completionListContains("constructor");


### PR DESCRIPTION
Fixes #21932 

Added `@template` to jsDoc completion list.


