### PR TITLE
typingsInstaller:Remove triple-slash references

### DIFF
--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -1,4 +1,3 @@
-/// <reference path="typingsInstaller.ts"/>
 /// <reference types="node" />
 
 namespace ts.server.typingsInstaller {

--- a/src/server/typingsInstaller/tsconfig.json
+++ b/src/server/typingsInstaller/tsconfig.json
@@ -12,6 +12,18 @@
         ]
     },
     "files": [
+        "../../compiler/types.ts",
+        "../../compiler/performance.ts",
+        "../../compiler/core.ts",
+        "../../compiler/sys.ts",
+        "../../compiler/diagnosticInformationMap.generated.ts",
+        "../../compiler/utilities.ts",
+        "../../compiler/scanner.ts",
+        "../../compiler/parser.ts",
+        "../../compiler/commandLineParser.ts",
+        "../../compiler/moduleNameResolver.ts",
+        "../../services/semver.ts",
+        "../../services/jsTyping.ts",
         "../types.ts",
         "../shared.ts",
         "typingsInstaller.ts",

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -1,10 +1,3 @@
-/// <reference path="../../compiler/core.ts" />
-/// <reference path="../../compiler/moduleNameResolver.ts" />
-/// <reference path="../../services/jsTyping.ts"/>
-/// <reference path="../../services/semver.ts"/>
-/// <reference path="../types.ts"/>
-/// <reference path="../shared.ts"/>
-
 namespace ts.server.typingsInstaller {
     interface NpmConfig {
         devDependencies: MapLike<any>;


### PR DESCRIPTION
Replace them with an explicit list of files in tsconfig. I got this list by adding --listFiles to the jake-generated command.

I did this because I mistakenly added a depedency from compiler/utilities.ts to compiler/factory.ts and couldn't figure out how dependencies were resolved because I forgot about triple-slash references.