### PR TITLE
Allowed trailing comma in type arguments, tuples

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20349,8 +20349,7 @@ namespace ts {
 
         function checkTupleType(node: TupleTypeNode) {
             // Grammar checking
-            const hasErrorFromDisallowedTrailingComma = checkGrammarForDisallowedTrailingComma(node.elementTypes);
-            if (!hasErrorFromDisallowedTrailingComma && node.elementTypes.length === 0) {
+            if (node.elementTypes.length === 0) {
                 grammarErrorOnNode(node, Diagnostics.A_tuple_type_element_list_cannot_be_empty);
             }
 
@@ -26207,8 +26206,7 @@ namespace ts {
         }
 
         function checkGrammarTypeArguments(node: Node, typeArguments: NodeArray<TypeNode>): boolean {
-            return checkGrammarForDisallowedTrailingComma(typeArguments) ||
-                checkGrammarForAtLeastOneTypeArgument(node, typeArguments);
+            return checkGrammarForAtLeastOneTypeArgument(node, typeArguments);
         }
 
         function checkGrammarForOmittedArgument(args: NodeArray<Expression>): boolean {

--- a/tests/baselines/reference/TupleType5.errors.txt
+++ b/tests/baselines/reference/TupleType5.errors.txt
@@ -1,7 +1,0 @@
-tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType5.ts(1,15): error TS1009: Trailing comma not allowed.
-
-
-==== tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType5.ts (1 errors) ====
-    var v: [number,]
-                  ~
-!!! error TS1009: Trailing comma not allowed.

--- a/tests/baselines/reference/syntaxErrors.errors.txt
+++ b/tests/baselines/reference/syntaxErrors.errors.txt
@@ -1,17 +1,14 @@
 tests/cases/conformance/jsdoc/badTypeArguments.js(1,15): error TS1099: Type argument list cannot be empty.
-tests/cases/conformance/jsdoc/badTypeArguments.js(2,22): error TS1009: Trailing comma not allowed.
 
 
 ==== tests/cases/conformance/jsdoc/dummyType.d.ts (0 errors) ====
     declare class C<T> { t: T }
     
-==== tests/cases/conformance/jsdoc/badTypeArguments.js (2 errors) ====
+==== tests/cases/conformance/jsdoc/badTypeArguments.js (1 errors) ====
     /** @param {C.<>} x */
                   ~~
 !!! error TS1099: Type argument list cannot be empty.
     /** @param {C.<number,>} y */
-                         ~
-!!! error TS1009: Trailing comma not allowed.
     // @ts-ignore
     /** @param {C.<number,>} skipped */
     function f(x, y, skipped) {


### PR DESCRIPTION
Another purely subtractive change: removes calls to `checkGrammarForDisallowedTrailingComma` for those checks in `checker.ts`.

Errata: the branch name is misleading. I first removed the diagnostic code altogether, but noticed it's used in some places where it's debatably useful (like class extends lists).

Fixes #21984
