### PR TITLE
Improved error diagnostics for misplaced commas and semicolons in class expressions

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -435,9 +435,17 @@
         "category": "Error",
         "code": 1142
     },
+    "Comma not permitted here.": {
+        "category": "Error",
+        "code": 1143
+    },
     "'{' or ';' expected.": {
         "category": "Error",
         "code": 1144
+    },
+    "Semicolon not permitted here.": {
+        "category": "Error",
+        "code": 1145
     },
     "Declaration expected.": {
         "category": "Error",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5664,13 +5664,27 @@ namespace ts {
             }
 
             if (node.decorators || node.modifiers) {
-                // treat this as a property declaration with a missing name.
-                node.name = createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, Diagnostics.Declaration_expected);
+                const diagnosticMessage = getDiagnosticMessageForMissingNameWithToken(token());
+                node.name = createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, diagnosticMessage);
                 return parsePropertyDeclaration(<PropertyDeclaration>node);
             }
 
             // 'isClassMemberStart' should have hinted not to attempt parsing.
             Debug.fail("Should not have attempted to parse class member declaration.");
+        }
+
+        function getDiagnosticMessageForMissingNameWithToken(token: SyntaxKind): DiagnosticMessage {
+            switch (token) {
+                // Trailing commas and semicolons are common user mistakes that deserve their own message.
+                case SyntaxKind.CommaToken:
+                    return Diagnostics.Comma_not_permitted_here;
+                case SyntaxKind.SemicolonToken:
+                    return Diagnostics.Semicolon_not_permitted_here;
+
+                // For all other cases, treat this as a property declaration with a missing name.
+                default:
+                    return Diagnostics.Declaration_expected;
+            }
         }
 
         function parseClassExpression(): ClassExpression {

--- a/tests/baselines/reference/decoratorWithOrWithoutComma.errors.txt
+++ b/tests/baselines/reference/decoratorWithOrWithoutComma.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/compiler/decoratorWithOrWithoutComma.ts(11,17): error TS1143: Comma not permitted here.
+
+
+==== tests/cases/compiler/decoratorWithOrWithoutComma.ts (1 errors) ====
+    function decorated(): Function {
+        return (target: any): any => target;
+    }
+    
+    class Member { }
+    
+    class Example {
+        @decorated()
+        public readonly member: Member;
+    
+        @decorated(),
+                    
+!!! error TS1143: Comma not permitted here.
+        public readonly memberComma: Member;
+    }
+    

--- a/tests/baselines/reference/decoratorWithOrWithoutComma.js
+++ b/tests/baselines/reference/decoratorWithOrWithoutComma.js
@@ -1,0 +1,36 @@
+//// [decoratorWithOrWithoutComma.ts]
+function decorated(): Function {
+    return (target: any): any => target;
+}
+
+class Member { }
+
+class Example {
+    @decorated()
+    public readonly member: Member;
+
+    @decorated(),
+    public readonly memberComma: Member;
+}
+
+
+//// [decoratorWithOrWithoutComma.js]
+function decorated() {
+    return function (target) { return target; };
+}
+var Member = /** @class */ (function () {
+    function Member() {
+    }
+    return Member;
+}());
+var Example = /** @class */ (function () {
+    function Example() {
+    }
+    __decorate([
+        decorated()
+    ], Example.prototype, "member");
+    __decorate([
+        decorated()
+    ], Example.prototype, "");
+    return Example;
+}());

--- a/tests/baselines/reference/decoratorWithOrWithoutComma.symbols
+++ b/tests/baselines/reference/decoratorWithOrWithoutComma.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/decoratorWithOrWithoutComma.ts ===
+function decorated(): Function {
+>decorated : Symbol(decorated, Decl(decoratorWithOrWithoutComma.ts, 0, 0))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+    return (target: any): any => target;
+>target : Symbol(target, Decl(decoratorWithOrWithoutComma.ts, 1, 12))
+>target : Symbol(target, Decl(decoratorWithOrWithoutComma.ts, 1, 12))
+}
+
+class Member { }
+>Member : Symbol(Member, Decl(decoratorWithOrWithoutComma.ts, 2, 1))
+
+class Example {
+>Example : Symbol(Example, Decl(decoratorWithOrWithoutComma.ts, 4, 16))
+
+    @decorated()
+>decorated : Symbol(decorated, Decl(decoratorWithOrWithoutComma.ts, 0, 0))
+
+    public readonly member: Member;
+>member : Symbol(Example.member, Decl(decoratorWithOrWithoutComma.ts, 6, 15))
+>Member : Symbol(Member, Decl(decoratorWithOrWithoutComma.ts, 2, 1))
+
+    @decorated(),
+>decorated : Symbol(decorated, Decl(decoratorWithOrWithoutComma.ts, 0, 0))
+> : Symbol(Example[(Missing)], Decl(decoratorWithOrWithoutComma.ts, 8, 35))
+
+    public readonly memberComma: Member;
+>memberComma : Symbol(Example.memberComma, Decl(decoratorWithOrWithoutComma.ts, 10, 17))
+>Member : Symbol(Member, Decl(decoratorWithOrWithoutComma.ts, 2, 1))
+}
+

--- a/tests/baselines/reference/decoratorWithOrWithoutComma.types
+++ b/tests/baselines/reference/decoratorWithOrWithoutComma.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/decoratorWithOrWithoutComma.ts ===
+function decorated(): Function {
+>decorated : () => Function
+>Function : Function
+
+    return (target: any): any => target;
+>(target: any): any => target : (target: any) => any
+>target : any
+>target : any
+}
+
+class Member { }
+>Member : Member
+
+class Example {
+>Example : Example
+
+    @decorated()
+>decorated() : Function
+>decorated : () => Function
+
+    public readonly member: Member;
+>member : Member
+>Member : Member
+
+    @decorated(),
+>decorated() : Function
+>decorated : () => Function
+> : any
+
+    public readonly memberComma: Member;
+>memberComma : Member
+>Member : Member
+}
+

--- a/tests/baselines/reference/decoratorWithOrWithoutSemicolon.errors.txt
+++ b/tests/baselines/reference/decoratorWithOrWithoutSemicolon.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/compiler/decoratorWithOrWithoutSemicolon.ts(11,17): error TS1145: Semicolon not permitted here.
+
+
+==== tests/cases/compiler/decoratorWithOrWithoutSemicolon.ts (1 errors) ====
+    function decorated(): Function {
+        return (target: any): any => target;
+    }
+    
+    class Member { }
+    
+    class Example {
+        @decorated()
+        public readonly member: Member;
+    
+        @decorated();
+                    
+!!! error TS1145: Semicolon not permitted here.
+        public readonly memberSemicolon: Member;
+    }
+    

--- a/tests/baselines/reference/decoratorWithOrWithoutSemicolon.js
+++ b/tests/baselines/reference/decoratorWithOrWithoutSemicolon.js
@@ -1,0 +1,36 @@
+//// [decoratorWithOrWithoutSemicolon.ts]
+function decorated(): Function {
+    return (target: any): any => target;
+}
+
+class Member { }
+
+class Example {
+    @decorated()
+    public readonly member: Member;
+
+    @decorated();
+    public readonly memberSemicolon: Member;
+}
+
+
+//// [decoratorWithOrWithoutSemicolon.js]
+function decorated() {
+    return function (target) { return target; };
+}
+var Member = /** @class */ (function () {
+    function Member() {
+    }
+    return Member;
+}());
+var Example = /** @class */ (function () {
+    function Example() {
+    }
+    __decorate([
+        decorated()
+    ], Example.prototype, "member");
+    __decorate([
+        decorated()
+    ], Example.prototype, "");
+    return Example;
+}());

--- a/tests/baselines/reference/decoratorWithOrWithoutSemicolon.symbols
+++ b/tests/baselines/reference/decoratorWithOrWithoutSemicolon.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/decoratorWithOrWithoutSemicolon.ts ===
+function decorated(): Function {
+>decorated : Symbol(decorated, Decl(decoratorWithOrWithoutSemicolon.ts, 0, 0))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+    return (target: any): any => target;
+>target : Symbol(target, Decl(decoratorWithOrWithoutSemicolon.ts, 1, 12))
+>target : Symbol(target, Decl(decoratorWithOrWithoutSemicolon.ts, 1, 12))
+}
+
+class Member { }
+>Member : Symbol(Member, Decl(decoratorWithOrWithoutSemicolon.ts, 2, 1))
+
+class Example {
+>Example : Symbol(Example, Decl(decoratorWithOrWithoutSemicolon.ts, 4, 16))
+
+    @decorated()
+>decorated : Symbol(decorated, Decl(decoratorWithOrWithoutSemicolon.ts, 0, 0))
+
+    public readonly member: Member;
+>member : Symbol(Example.member, Decl(decoratorWithOrWithoutSemicolon.ts, 6, 15))
+>Member : Symbol(Member, Decl(decoratorWithOrWithoutSemicolon.ts, 2, 1))
+
+    @decorated();
+>decorated : Symbol(decorated, Decl(decoratorWithOrWithoutSemicolon.ts, 0, 0))
+> : Symbol(Example[(Missing)], Decl(decoratorWithOrWithoutSemicolon.ts, 8, 35))
+
+    public readonly memberSemicolon: Member;
+>memberSemicolon : Symbol(Example.memberSemicolon, Decl(decoratorWithOrWithoutSemicolon.ts, 10, 17))
+>Member : Symbol(Member, Decl(decoratorWithOrWithoutSemicolon.ts, 2, 1))
+}
+

--- a/tests/baselines/reference/decoratorWithOrWithoutSemicolon.types
+++ b/tests/baselines/reference/decoratorWithOrWithoutSemicolon.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/decoratorWithOrWithoutSemicolon.ts ===
+function decorated(): Function {
+>decorated : () => Function
+>Function : Function
+
+    return (target: any): any => target;
+>(target: any): any => target : (target: any) => any
+>target : any
+>target : any
+}
+
+class Member { }
+>Member : Member
+
+class Example {
+>Example : Example
+
+    @decorated()
+>decorated() : Function
+>decorated : () => Function
+
+    public readonly member: Member;
+>member : Member
+>Member : Member
+
+    @decorated();
+>decorated() : Function
+>decorated : () => Function
+> : any
+
+    public readonly memberSemicolon: Member;
+>memberSemicolon : Member
+>Member : Member
+}
+

--- a/tests/cases/compiler/decoratorWithOrWithoutComma.ts
+++ b/tests/cases/compiler/decoratorWithOrWithoutComma.ts
@@ -1,0 +1,16 @@
+// @noemithelpers: true
+// @experimentaldecorators: true
+
+function decorated(): Function {
+    return (target: any): any => target;
+}
+
+class Member { }
+
+class Example {
+    @decorated()
+    public readonly member: Member;
+
+    @decorated(),
+    public readonly memberComma: Member;
+}

--- a/tests/cases/compiler/decoratorWithOrWithoutSemicolon.ts
+++ b/tests/cases/compiler/decoratorWithOrWithoutSemicolon.ts
@@ -1,0 +1,16 @@
+// @noemithelpers: true
+// @experimentaldecorators: true
+
+function decorated(): Function {
+    return (target: any): any => target;
+}
+
+class Member { }
+
+class Example {
+    @decorated()
+    public readonly member: Member;
+
+    @decorated();
+    public readonly memberSemicolon: Member;
+}


### PR DESCRIPTION
If there's a comma or semicolon after a decorator in a class expression, it's useful to have a more specific error message than "declaration expected" as it's easy (even common) to accidentally place a semicolon after the decorator.

Fixes #21050