### PR TITLE
Remove unnecessary length check in  `getSyntacticDocumentHighlights`

### DIFF
--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -42,11 +42,7 @@ namespace ts.DocumentHighlights {
 
     function getSyntacticDocumentHighlights(node: Node, sourceFile: SourceFile): DocumentHighlights[] {
         const highlightSpans = getHighlightSpans(node, sourceFile);
-        if (!highlightSpans || highlightSpans.length === 0) {
-            return undefined;
-        }
-
-        return [{ fileName: sourceFile.fileName, highlightSpans }];
+        return highlightSpans && [{ fileName: sourceFile.fileName, highlightSpans }];
     }
 
     function getHighlightSpans(node: Node, sourceFile: SourceFile): HighlightSpan[] | undefined {


### PR DESCRIPTION
`getHighlightSpans` should always return at least the current keyword, or else `undefined`.