### PR TITLE
Add 'isNamedDeclaration' helper to reduce casts

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -315,7 +315,7 @@ namespace ts {
         }
 
         function getDisplayName(node: Declaration): string {
-            return (node as NamedDeclaration).name ? declarationNameToString((node as NamedDeclaration).name) : unescapeLeadingUnderscores(getDeclarationName(node));
+            return isNamedDeclaration(node) ? declarationNameToString(node.name) : unescapeLeadingUnderscores(getDeclarationName(node));
         }
 
         /**
@@ -383,8 +383,8 @@ namespace ts {
                         symbolTable.set(name, symbol = createSymbol(SymbolFlags.None, name));
                     }
                     else {
-                        if ((node as NamedDeclaration).name) {
-                            (node as NamedDeclaration).name.parent = node;
+                        if (isNamedDeclaration(node)) {
+                            node.name.parent = node;
                         }
 
                         // Report errors every position with duplicate declaration

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4298,6 +4298,11 @@ namespace ts {
         return declaration.name || nameForNamelessJSDocTypedef(declaration);
     }
 
+    /** @internal */
+    export function isNamedDeclaration(node: Node): node is NamedDeclaration & { name: DeclarationName } {
+        return !!(node as NamedDeclaration).name;
+    }
+
     export function getNameOfDeclaration(declaration: Declaration | Expression): DeclarationName | undefined {
         if (!declaration) {
             return undefined;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4300,9 +4300,7 @@ namespace ts {
 
     /** @internal */
     export function isNamedDeclaration(node: Node): node is NamedDeclaration & { name: DeclarationName } {
-        const name = (node as NamedDeclaration).name;
-        Debug.assert(!name || isDeclaration(node) && node.name === name, "A 'name' property should always be a DeclarationName.");
-        return !!name;
+        return !!(node as NamedDeclaration).name; // A 'name' property should always be a DeclarationName.
     }
 
     export function getNameOfDeclaration(declaration: Declaration | Expression): DeclarationName | undefined {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4300,7 +4300,9 @@ namespace ts {
 
     /** @internal */
     export function isNamedDeclaration(node: Node): node is NamedDeclaration & { name: DeclarationName } {
-        return !!(node as NamedDeclaration).name;
+        const name = (node as NamedDeclaration).name;
+        Debug.assert(!name || isDeclaration(node) && node.name === name, "A 'name' property should always be a DeclarationName.");
+        return !!name;
     }
 
     export function getNameOfDeclaration(declaration: Declaration | Expression): DeclarationName | undefined {


### PR DESCRIPTION
Especially helps with #22088 because testing `(node as NamedDeclaration).name` doesn't make `(node as NamedDeclaration).name` defined in future uses.