### PR TITLE
In tsc--watch, fix the leaking watch when old source file is not part of program any more

### DIFF
--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -749,6 +749,9 @@ namespace ts {
                     (missingFilePathsRequestedForRelease || (missingFilePathsRequestedForRelease = [])).push(oldSourceFile.path);
                 }
                 else if ((hostSourceFileInfo as FilePresentOnHost).sourceFile === oldSourceFile) {
+                    if ((hostSourceFileInfo as FilePresentOnHost).fileWatcher) {
+                        (hostSourceFileInfo as FilePresentOnHost).fileWatcher.close();
+                    }
                     sourceFilesCache.delete(oldSourceFile.path);
                     resolutionCache.removeResolutionsOfFile(oldSourceFile.path);
                 }


### PR DESCRIPTION
Found this issue when merging master into #21243