### PR TITLE
Allow partial unions for indexed type access

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6383,8 +6383,9 @@ namespace ts {
          *
          * @param type a type to look up property from
          * @param name a name of property to look up in a given type
+         * @param allowPartialUnions return partial unions instead of undefined
          */
-        function getPropertyOfType(type: Type, name: __String): Symbol | undefined {
+        function getPropertyOfType(type: Type, name: __String, allowPartialUnions = false): Symbol | undefined {
             type = getApparentType(type);
             if (type.flags & TypeFlags.Object) {
                 const resolved = resolveStructuredTypeMembers(<ObjectType>type);
@@ -6401,7 +6402,12 @@ namespace ts {
                 return getPropertyOfObjectType(globalObjectType, name);
             }
             if (type.flags & TypeFlags.UnionOrIntersection) {
-                return getPropertyOfUnionOrIntersectionType(<UnionOrIntersectionType>type, name);
+                if (allowPartialUnions) {
+                    return getUnionOrIntersectionProperty(<UnionOrIntersectionType>type, name);
+                }
+                else {
+                    return getPropertyOfUnionOrIntersectionType(<UnionOrIntersectionType>type, name);
+                }
             }
             return undefined;
         }
@@ -7997,7 +8003,7 @@ namespace ts {
                     getPropertyNameForKnownSymbolName(idText((<PropertyAccessExpression>accessExpression.argumentExpression).name)) :
                     undefined;
             if (propName !== undefined) {
-                const prop = getPropertyOfType(objectType, propName);
+                const prop = getPropertyOfType(objectType, propName, /*allowPartialUnions*/ true);
                 if (prop) {
                     if (accessExpression) {
                         markPropertyAsReferenced(prop, accessExpression, /*isThisAccess*/ accessExpression.expression.kind === SyntaxKind.ThisKeyword);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8003,7 +8003,7 @@ namespace ts {
                     getPropertyNameForKnownSymbolName(idText((<PropertyAccessExpression>accessExpression.argumentExpression).name)) :
                     undefined;
             if (propName !== undefined) {
-                const prop = getPropertyOfType(objectType, propName, /*allowPartialUnions*/ true);
+                const prop = getPropertyOfType(objectType, propName, /*allowPartialUnions*/ !accessExpression);
                 if (prop) {
                     if (accessExpression) {
                         markPropertyAsReferenced(prop, accessExpression, /*isThisAccess*/ accessExpression.expression.kind === SyntaxKind.ThisKeyword);

--- a/tests/baselines/reference/indexedAccessPartialUnions.errors.txt
+++ b/tests/baselines/reference/indexedAccessPartialUnions.errors.txt
@@ -1,0 +1,39 @@
+tests/cases/compiler/indexedAccessPartialUnions.ts(14,12): error TS7017: Element implicitly has an 'any' type because type '{ baz: string; } | { qux: number; }' has no index signature.
+tests/cases/compiler/indexedAccessPartialUnions.ts(18,20): error TS2339: Property 'baz' does not exist on type '{ baz: string; } | { qux: number; }'.
+  Property 'baz' does not exist on type '{ qux: number; }'.
+
+
+==== tests/cases/compiler/indexedAccessPartialUnions.ts (2 errors) ====
+    // Repro from #21975
+    
+    interface Foo {
+        bar: {
+            baz: string;
+        } | {
+            qux: number;
+        }
+    }
+    
+    type ShouldBeString = Foo['bar']['baz'];
+    
+    function f(foo: Foo) {
+        return foo['bar']['baz']; // Error
+               ~~~~~~~~~~~~~~~~~
+!!! error TS7017: Element implicitly has an 'any' type because type '{ baz: string; } | { qux: number; }' has no index signature.
+    }
+    
+    function g(foo: Foo) {
+        return foo.bar.baz; // Error
+                       ~~~
+!!! error TS2339: Property 'baz' does not exist on type '{ baz: string; } | { qux: number; }'.
+!!! error TS2339:   Property 'baz' does not exist on type '{ qux: number; }'.
+    }
+    
+    interface HasOptionalMember {
+        bar?: {
+            baz: string;
+        }
+    }
+    
+    type ShouldBeString2 = HasOptionalMember['bar']['baz'];
+    

--- a/tests/baselines/reference/indexedAccessPartialUnions.js
+++ b/tests/baselines/reference/indexedAccessPartialUnions.js
@@ -11,6 +11,14 @@ interface Foo {
 
 type ShouldBeString = Foo['bar']['baz'];
 
+function f(foo: Foo) {
+    return foo['bar']['baz']; // Error
+}
+
+function g(foo: Foo) {
+    return foo.bar.baz; // Error
+}
+
 interface HasOptionalMember {
     bar?: {
         baz: string;
@@ -23,3 +31,9 @@ type ShouldBeString2 = HasOptionalMember['bar']['baz'];
 //// [indexedAccessPartialUnions.js]
 "use strict";
 // Repro from #21975
+function f(foo) {
+    return foo['bar']['baz']; // Error
+}
+function g(foo) {
+    return foo.bar.baz; // Error
+}

--- a/tests/baselines/reference/indexedAccessPartialUnions.js
+++ b/tests/baselines/reference/indexedAccessPartialUnions.js
@@ -1,0 +1,25 @@
+//// [indexedAccessPartialUnions.ts]
+// Repro from #21975
+
+interface Foo {
+    bar: {
+        baz: string;
+    } | {
+        qux: number;
+    }
+}
+
+type ShouldBeString = Foo['bar']['baz'];
+
+interface HasOptionalMember {
+    bar?: {
+        baz: string;
+    }
+}
+
+type ShouldBeString2 = HasOptionalMember['bar']['baz'];
+
+
+//// [indexedAccessPartialUnions.js]
+"use strict";
+// Repro from #21975

--- a/tests/baselines/reference/indexedAccessPartialUnions.symbols
+++ b/tests/baselines/reference/indexedAccessPartialUnions.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/indexedAccessPartialUnions.ts ===
+// Repro from #21975
+
+interface Foo {
+>Foo : Symbol(Foo, Decl(indexedAccessPartialUnions.ts, 0, 0))
+
+    bar: {
+>bar : Symbol(Foo.bar, Decl(indexedAccessPartialUnions.ts, 2, 15))
+
+        baz: string;
+>baz : Symbol(baz, Decl(indexedAccessPartialUnions.ts, 3, 10))
+
+    } | {
+        qux: number;
+>qux : Symbol(qux, Decl(indexedAccessPartialUnions.ts, 5, 9))
+    }
+}
+
+type ShouldBeString = Foo['bar']['baz'];
+>ShouldBeString : Symbol(ShouldBeString, Decl(indexedAccessPartialUnions.ts, 8, 1))
+>Foo : Symbol(Foo, Decl(indexedAccessPartialUnions.ts, 0, 0))
+
+interface HasOptionalMember {
+>HasOptionalMember : Symbol(HasOptionalMember, Decl(indexedAccessPartialUnions.ts, 10, 40))
+
+    bar?: {
+>bar : Symbol(HasOptionalMember.bar, Decl(indexedAccessPartialUnions.ts, 12, 29))
+
+        baz: string;
+>baz : Symbol(baz, Decl(indexedAccessPartialUnions.ts, 13, 11))
+    }
+}
+
+type ShouldBeString2 = HasOptionalMember['bar']['baz'];
+>ShouldBeString2 : Symbol(ShouldBeString2, Decl(indexedAccessPartialUnions.ts, 16, 1))
+>HasOptionalMember : Symbol(HasOptionalMember, Decl(indexedAccessPartialUnions.ts, 10, 40))
+

--- a/tests/baselines/reference/indexedAccessPartialUnions.symbols
+++ b/tests/baselines/reference/indexedAccessPartialUnions.symbols
@@ -20,18 +20,39 @@ type ShouldBeString = Foo['bar']['baz'];
 >ShouldBeString : Symbol(ShouldBeString, Decl(indexedAccessPartialUnions.ts, 8, 1))
 >Foo : Symbol(Foo, Decl(indexedAccessPartialUnions.ts, 0, 0))
 
+function f(foo: Foo) {
+>f : Symbol(f, Decl(indexedAccessPartialUnions.ts, 10, 40))
+>foo : Symbol(foo, Decl(indexedAccessPartialUnions.ts, 12, 11))
+>Foo : Symbol(Foo, Decl(indexedAccessPartialUnions.ts, 0, 0))
+
+    return foo['bar']['baz']; // Error
+>foo : Symbol(foo, Decl(indexedAccessPartialUnions.ts, 12, 11))
+>'bar' : Symbol(Foo.bar, Decl(indexedAccessPartialUnions.ts, 2, 15))
+}
+
+function g(foo: Foo) {
+>g : Symbol(g, Decl(indexedAccessPartialUnions.ts, 14, 1))
+>foo : Symbol(foo, Decl(indexedAccessPartialUnions.ts, 16, 11))
+>Foo : Symbol(Foo, Decl(indexedAccessPartialUnions.ts, 0, 0))
+
+    return foo.bar.baz; // Error
+>foo.bar : Symbol(Foo.bar, Decl(indexedAccessPartialUnions.ts, 2, 15))
+>foo : Symbol(foo, Decl(indexedAccessPartialUnions.ts, 16, 11))
+>bar : Symbol(Foo.bar, Decl(indexedAccessPartialUnions.ts, 2, 15))
+}
+
 interface HasOptionalMember {
->HasOptionalMember : Symbol(HasOptionalMember, Decl(indexedAccessPartialUnions.ts, 10, 40))
+>HasOptionalMember : Symbol(HasOptionalMember, Decl(indexedAccessPartialUnions.ts, 18, 1))
 
     bar?: {
->bar : Symbol(HasOptionalMember.bar, Decl(indexedAccessPartialUnions.ts, 12, 29))
+>bar : Symbol(HasOptionalMember.bar, Decl(indexedAccessPartialUnions.ts, 20, 29))
 
         baz: string;
->baz : Symbol(baz, Decl(indexedAccessPartialUnions.ts, 13, 11))
+>baz : Symbol(baz, Decl(indexedAccessPartialUnions.ts, 21, 11))
     }
 }
 
 type ShouldBeString2 = HasOptionalMember['bar']['baz'];
->ShouldBeString2 : Symbol(ShouldBeString2, Decl(indexedAccessPartialUnions.ts, 16, 1))
->HasOptionalMember : Symbol(HasOptionalMember, Decl(indexedAccessPartialUnions.ts, 10, 40))
+>ShouldBeString2 : Symbol(ShouldBeString2, Decl(indexedAccessPartialUnions.ts, 24, 1))
+>HasOptionalMember : Symbol(HasOptionalMember, Decl(indexedAccessPartialUnions.ts, 18, 1))
 

--- a/tests/baselines/reference/indexedAccessPartialUnions.types
+++ b/tests/baselines/reference/indexedAccessPartialUnions.types
@@ -20,6 +20,32 @@ type ShouldBeString = Foo['bar']['baz'];
 >ShouldBeString : string
 >Foo : Foo
 
+function f(foo: Foo) {
+>f : (foo: Foo) => any
+>foo : Foo
+>Foo : Foo
+
+    return foo['bar']['baz']; // Error
+>foo['bar']['baz'] : any
+>foo['bar'] : { baz: string; } | { qux: number; }
+>foo : Foo
+>'bar' : "bar"
+>'baz' : "baz"
+}
+
+function g(foo: Foo) {
+>g : (foo: Foo) => any
+>foo : Foo
+>Foo : Foo
+
+    return foo.bar.baz; // Error
+>foo.bar.baz : any
+>foo.bar : { baz: string; } | { qux: number; }
+>foo : Foo
+>bar : { baz: string; } | { qux: number; }
+>baz : any
+}
+
 interface HasOptionalMember {
 >HasOptionalMember : HasOptionalMember
 

--- a/tests/baselines/reference/indexedAccessPartialUnions.types
+++ b/tests/baselines/reference/indexedAccessPartialUnions.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/indexedAccessPartialUnions.ts ===
+// Repro from #21975
+
+interface Foo {
+>Foo : Foo
+
+    bar: {
+>bar : { baz: string; } | { qux: number; }
+
+        baz: string;
+>baz : string
+
+    } | {
+        qux: number;
+>qux : number
+    }
+}
+
+type ShouldBeString = Foo['bar']['baz'];
+>ShouldBeString : string
+>Foo : Foo
+
+interface HasOptionalMember {
+>HasOptionalMember : HasOptionalMember
+
+    bar?: {
+>bar : { baz: string; } | undefined
+
+        baz: string;
+>baz : string
+    }
+}
+
+type ShouldBeString2 = HasOptionalMember['bar']['baz'];
+>ShouldBeString2 : string
+>HasOptionalMember : HasOptionalMember
+

--- a/tests/cases/compiler/indexedAccessPartialUnions.ts
+++ b/tests/cases/compiler/indexedAccessPartialUnions.ts
@@ -12,6 +12,14 @@ interface Foo {
 
 type ShouldBeString = Foo['bar']['baz'];
 
+function f(foo: Foo) {
+    return foo['bar']['baz']; // Error
+}
+
+function g(foo: Foo) {
+    return foo.bar.baz; // Error
+}
+
 interface HasOptionalMember {
     bar?: {
         baz: string;

--- a/tests/cases/compiler/indexedAccessPartialUnions.ts
+++ b/tests/cases/compiler/indexedAccessPartialUnions.ts
@@ -1,0 +1,21 @@
+// @strict: true
+
+// Repro from #21975
+
+interface Foo {
+    bar: {
+        baz: string;
+    } | {
+        qux: number;
+    }
+}
+
+type ShouldBeString = Foo['bar']['baz'];
+
+interface HasOptionalMember {
+    bar?: {
+        baz: string;
+    }
+}
+
+type ShouldBeString2 = HasOptionalMember['bar']['baz'];


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Solves #21975 and #14366 by allowing partial union types for indexed type access as opposed to creating a null assertion type operator.
@mhegazy @DanielRosenwasser 

Fixes #21975
Fixes #14366
Related #16108