### PR TITLE
Use global NonNullable type for nonnull types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -401,9 +401,6 @@ namespace ts {
         let autoArrayType: Type;
         let anyReadonlyArrayType: Type;
         let deferredGlobalNonNullableTypeAlias: Symbol;
-        let deferredGlobalNonNullableTypeFallback: Type;
-        let deferredGlobalNonNullableTypeFallbackInstantiationCache: Map<Type>;
-        let deferredGlobalNonNullableTypeParameterFallback: TypeParameter;
 
         // The library files are only loaded when the feature is used.
         // This allows users to just specify library files they want to used through --lib
@@ -11049,19 +11046,7 @@ namespace ts {
             if (deferredGlobalNonNullableTypeAlias !== unknownSymbol) {
                 return getTypeAliasInstantiation(deferredGlobalNonNullableTypeAlias, [type]);
             }
-            if (!deferredGlobalNonNullableTypeFallback) {
-                const p = deferredGlobalNonNullableTypeParameterFallback = createType(TypeFlags.TypeParameter) as TypeParameter;
-                deferredGlobalNonNullableTypeFallback = getConditionalType(p, getUnionType([nullType, undefinedType]), neverType, p, /*inferTypeParameters*/ undefined, /*target*/ undefined, /*mapper*/ undefined, /*alias*/ undefined, /*aliasTypeArguments*/ undefined);
-                deferredGlobalNonNullableTypeFallbackInstantiationCache = createMap();
-            }
-            // Fallback to manufacturing an anonymous conditional type instantiation
-            const args = [type];
-            const id = getTypeListId(args);
-            let instantiation = deferredGlobalNonNullableTypeFallbackInstantiationCache.get(id);
-            if (!instantiation) {
-                deferredGlobalNonNullableTypeFallbackInstantiationCache.set(id, instantiation = instantiateType(deferredGlobalNonNullableTypeFallback, createTypeMapper([deferredGlobalNonNullableTypeParameterFallback], [type])));
-            }
-            return instantiation;
+            return getTypeWithFacts(type, TypeFacts.NEUndefinedOrNull); // Type alias unavailable, fall back to non-higherorder behavior
         }
 
         function getNonNullableType(type: Type): Type {

--- a/tests/baselines/reference/nonNullParameterExtendingStringAssignableToString.types
+++ b/tests/baselines/reference/nonNullParameterExtendingStringAssignableToString.types
@@ -23,18 +23,18 @@ function fn<T extends string | undefined, U extends string>(one: T, two: U) {
     foo(one!);
 >foo(one!) : void
 >foo : (p: string) => void
->one! : string
->one : string | undefined
+>one! : NonNullable<T>
+>one : T
 
     foo(two!);
 >foo(two!) : void
 >foo : (p: string) => void
->two! : U
+>two! : NonNullable<U>
 >two : U
 
     foo(three!); // this line is the important one
 >foo(three!) : void
 >foo : (p: string) => void
->three! : string
->three : string
+>three! : NonNullable<T> | NonNullable<U>
+>three : T | U
 }

--- a/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.errors.txt
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.errors.txt
@@ -1,0 +1,52 @@
+error TS2318: Cannot find global type 'Array'.
+error TS2318: Cannot find global type 'Boolean'.
+error TS2318: Cannot find global type 'Function'.
+error TS2318: Cannot find global type 'IArguments'.
+error TS2318: Cannot find global type 'Number'.
+error TS2318: Cannot find global type 'Object'.
+error TS2318: Cannot find global type 'RegExp'.
+error TS2318: Cannot find global type 'String'.
+
+
+!!! error TS2318: Cannot find global type 'Array'.
+!!! error TS2318: Cannot find global type 'Boolean'.
+!!! error TS2318: Cannot find global type 'Function'.
+!!! error TS2318: Cannot find global type 'IArguments'.
+!!! error TS2318: Cannot find global type 'Number'.
+!!! error TS2318: Cannot find global type 'Object'.
+!!! error TS2318: Cannot find global type 'RegExp'.
+!!! error TS2318: Cannot find global type 'String'.
+==== tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts (0 errors) ====
+    type Readonly<T> = {readonly [K in keyof T]: T[K]}
+    interface A {
+        params?: { name: string; };
+    }
+    
+    class Test<T extends A> {
+        attrs: Readonly<T>;
+    
+        m() {
+            this.attrs.params!.name;
+        }
+    }
+    
+    interface Foo {
+        foo?: number;
+    }
+    
+    class FooClass<P extends Foo = Foo> {
+        properties: Readonly<P>;
+    
+        foo(): number {
+            const { foo = 42 } = this.properties;
+            return foo;
+        }
+    }
+    
+    class Test2<T extends A> {
+        attrs: Readonly<T>;
+    
+        m() {
+            return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+        }
+    }

--- a/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.errors.txt
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.errors.txt
@@ -6,6 +6,7 @@ error TS2318: Cannot find global type 'Number'.
 error TS2318: Cannot find global type 'Object'.
 error TS2318: Cannot find global type 'RegExp'.
 error TS2318: Cannot find global type 'String'.
+tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts(10,28): error TS2339: Property 'name' does not exist on type 'T["params"]'.
 
 
 !!! error TS2318: Cannot find global type 'Array'.
@@ -16,7 +17,7 @@ error TS2318: Cannot find global type 'String'.
 !!! error TS2318: Cannot find global type 'Object'.
 !!! error TS2318: Cannot find global type 'RegExp'.
 !!! error TS2318: Cannot find global type 'String'.
-==== tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts (0 errors) ====
+==== tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts (1 errors) ====
     type Readonly<T> = {readonly [K in keyof T]: T[K]}
     interface A {
         params?: { name: string; };
@@ -27,6 +28,8 @@ error TS2318: Cannot find global type 'String'.
     
         m() {
             this.attrs.params!.name;
+                               ~~~~
+!!! error TS2339: Property 'name' does not exist on type 'T["params"]'.
         }
     }
     

--- a/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.js
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.js
@@ -1,0 +1,61 @@
+//// [strictNullNotNullIndexTypeNoLib.ts]
+type Readonly<T> = {readonly [K in keyof T]: T[K]}
+interface A {
+    params?: { name: string; };
+}
+
+class Test<T extends A> {
+    attrs: Readonly<T>;
+
+    m() {
+        this.attrs.params!.name;
+    }
+}
+
+interface Foo {
+    foo?: number;
+}
+
+class FooClass<P extends Foo = Foo> {
+    properties: Readonly<P>;
+
+    foo(): number {
+        const { foo = 42 } = this.properties;
+        return foo;
+    }
+}
+
+class Test2<T extends A> {
+    attrs: Readonly<T>;
+
+    m() {
+        return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+    }
+}
+
+//// [strictNullNotNullIndexTypeNoLib.js]
+var Test = /** @class */ (function () {
+    function Test() {
+    }
+    Test.prototype.m = function () {
+        this.attrs.params.name;
+    };
+    return Test;
+}());
+var FooClass = /** @class */ (function () {
+    function FooClass() {
+    }
+    FooClass.prototype.foo = function () {
+        var _a = this.properties.foo, foo = _a === void 0 ? 42 : _a;
+        return foo;
+    };
+    return FooClass;
+}());
+var Test2 = /** @class */ (function () {
+    function Test2() {
+    }
+    Test2.prototype.m = function () {
+        return this.attrs.params; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+    };
+    return Test2;
+}());

--- a/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.symbols
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.symbols
@@ -1,0 +1,94 @@
+=== tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts ===
+type Readonly<T> = {readonly [K in keyof T]: T[K]}
+>Readonly : Symbol(Readonly, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 0))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 14))
+>K : Symbol(K, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 30))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 14))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 14))
+>K : Symbol(K, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 30))
+
+interface A {
+>A : Symbol(A, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 50))
+
+    params?: { name: string; };
+>params : Symbol(A.params, Decl(strictNullNotNullIndexTypeNoLib.ts, 1, 13))
+>name : Symbol(name, Decl(strictNullNotNullIndexTypeNoLib.ts, 2, 14))
+}
+
+class Test<T extends A> {
+>Test : Symbol(Test, Decl(strictNullNotNullIndexTypeNoLib.ts, 3, 1))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeNoLib.ts, 5, 11))
+>A : Symbol(A, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 50))
+
+    attrs: Readonly<T>;
+>attrs : Symbol(Test.attrs, Decl(strictNullNotNullIndexTypeNoLib.ts, 5, 25))
+>Readonly : Symbol(Readonly, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 0))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeNoLib.ts, 5, 11))
+
+    m() {
+>m : Symbol(Test.m, Decl(strictNullNotNullIndexTypeNoLib.ts, 6, 23))
+
+        this.attrs.params!.name;
+>this.attrs.params!.name : Symbol(name, Decl(strictNullNotNullIndexTypeNoLib.ts, 2, 14))
+>this.attrs.params : Symbol(params, Decl(strictNullNotNullIndexTypeNoLib.ts, 1, 13))
+>this.attrs : Symbol(Test.attrs, Decl(strictNullNotNullIndexTypeNoLib.ts, 5, 25))
+>this : Symbol(Test, Decl(strictNullNotNullIndexTypeNoLib.ts, 3, 1))
+>attrs : Symbol(Test.attrs, Decl(strictNullNotNullIndexTypeNoLib.ts, 5, 25))
+>params : Symbol(params, Decl(strictNullNotNullIndexTypeNoLib.ts, 1, 13))
+>name : Symbol(name, Decl(strictNullNotNullIndexTypeNoLib.ts, 2, 14))
+    }
+}
+
+interface Foo {
+>Foo : Symbol(Foo, Decl(strictNullNotNullIndexTypeNoLib.ts, 11, 1))
+
+    foo?: number;
+>foo : Symbol(Foo.foo, Decl(strictNullNotNullIndexTypeNoLib.ts, 13, 15))
+}
+
+class FooClass<P extends Foo = Foo> {
+>FooClass : Symbol(FooClass, Decl(strictNullNotNullIndexTypeNoLib.ts, 15, 1))
+>P : Symbol(P, Decl(strictNullNotNullIndexTypeNoLib.ts, 17, 15))
+>Foo : Symbol(Foo, Decl(strictNullNotNullIndexTypeNoLib.ts, 11, 1))
+>Foo : Symbol(Foo, Decl(strictNullNotNullIndexTypeNoLib.ts, 11, 1))
+
+    properties: Readonly<P>;
+>properties : Symbol(FooClass.properties, Decl(strictNullNotNullIndexTypeNoLib.ts, 17, 37))
+>Readonly : Symbol(Readonly, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 0))
+>P : Symbol(P, Decl(strictNullNotNullIndexTypeNoLib.ts, 17, 15))
+
+    foo(): number {
+>foo : Symbol(FooClass.foo, Decl(strictNullNotNullIndexTypeNoLib.ts, 18, 28))
+
+        const { foo = 42 } = this.properties;
+>foo : Symbol(foo, Decl(strictNullNotNullIndexTypeNoLib.ts, 21, 15))
+>this.properties : Symbol(FooClass.properties, Decl(strictNullNotNullIndexTypeNoLib.ts, 17, 37))
+>this : Symbol(FooClass, Decl(strictNullNotNullIndexTypeNoLib.ts, 15, 1))
+>properties : Symbol(FooClass.properties, Decl(strictNullNotNullIndexTypeNoLib.ts, 17, 37))
+
+        return foo;
+>foo : Symbol(foo, Decl(strictNullNotNullIndexTypeNoLib.ts, 21, 15))
+    }
+}
+
+class Test2<T extends A> {
+>Test2 : Symbol(Test2, Decl(strictNullNotNullIndexTypeNoLib.ts, 24, 1))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeNoLib.ts, 26, 12))
+>A : Symbol(A, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 50))
+
+    attrs: Readonly<T>;
+>attrs : Symbol(Test2.attrs, Decl(strictNullNotNullIndexTypeNoLib.ts, 26, 26))
+>Readonly : Symbol(Readonly, Decl(strictNullNotNullIndexTypeNoLib.ts, 0, 0))
+>T : Symbol(T, Decl(strictNullNotNullIndexTypeNoLib.ts, 26, 12))
+
+    m() {
+>m : Symbol(Test2.m, Decl(strictNullNotNullIndexTypeNoLib.ts, 27, 23))
+
+        return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+>this.attrs.params : Symbol(params, Decl(strictNullNotNullIndexTypeNoLib.ts, 1, 13))
+>this.attrs : Symbol(Test2.attrs, Decl(strictNullNotNullIndexTypeNoLib.ts, 26, 26))
+>this : Symbol(Test2, Decl(strictNullNotNullIndexTypeNoLib.ts, 24, 1))
+>attrs : Symbol(Test2.attrs, Decl(strictNullNotNullIndexTypeNoLib.ts, 26, 26))
+>params : Symbol(params, Decl(strictNullNotNullIndexTypeNoLib.ts, 1, 13))
+    }
+}

--- a/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.symbols
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.symbols
@@ -29,13 +29,11 @@ class Test<T extends A> {
 >m : Symbol(Test.m, Decl(strictNullNotNullIndexTypeNoLib.ts, 6, 23))
 
         this.attrs.params!.name;
->this.attrs.params!.name : Symbol(name, Decl(strictNullNotNullIndexTypeNoLib.ts, 2, 14))
 >this.attrs.params : Symbol(params, Decl(strictNullNotNullIndexTypeNoLib.ts, 1, 13))
 >this.attrs : Symbol(Test.attrs, Decl(strictNullNotNullIndexTypeNoLib.ts, 5, 25))
 >this : Symbol(Test, Decl(strictNullNotNullIndexTypeNoLib.ts, 3, 1))
 >attrs : Symbol(Test.attrs, Decl(strictNullNotNullIndexTypeNoLib.ts, 5, 25))
 >params : Symbol(params, Decl(strictNullNotNullIndexTypeNoLib.ts, 1, 13))
->name : Symbol(name, Decl(strictNullNotNullIndexTypeNoLib.ts, 2, 14))
     }
 }
 

--- a/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.types
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.types
@@ -1,0 +1,97 @@
+=== tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts ===
+type Readonly<T> = {readonly [K in keyof T]: T[K]}
+>Readonly : Readonly<T>
+>T : T
+>K : K
+>T : T
+>T : T
+>K : K
+
+interface A {
+>A : A
+
+    params?: { name: string; };
+>params : { name: string; } | undefined
+>name : string
+}
+
+class Test<T extends A> {
+>Test : Test<T>
+>T : T
+>A : A
+
+    attrs: Readonly<T>;
+>attrs : Readonly<T>
+>Readonly : Readonly<T>
+>T : T
+
+    m() {
+>m : () => void
+
+        this.attrs.params!.name;
+>this.attrs.params!.name : string
+>this.attrs.params! : T["params"] extends null | undefined ? never : T["params"]
+>this.attrs.params : T["params"]
+>this.attrs : Readonly<T>
+>this : this
+>attrs : Readonly<T>
+>params : T["params"]
+>name : string
+    }
+}
+
+interface Foo {
+>Foo : Foo
+
+    foo?: number;
+>foo : number | undefined
+}
+
+class FooClass<P extends Foo = Foo> {
+>FooClass : FooClass<P>
+>P : P
+>Foo : Foo
+>Foo : Foo
+
+    properties: Readonly<P>;
+>properties : Readonly<P>
+>Readonly : Readonly<T>
+>P : P
+
+    foo(): number {
+>foo : () => number
+
+        const { foo = 42 } = this.properties;
+>foo : number
+>42 : 42
+>this.properties : Readonly<P>
+>this : this
+>properties : Readonly<P>
+
+        return foo;
+>foo : number
+    }
+}
+
+class Test2<T extends A> {
+>Test2 : Test2<T>
+>T : T
+>A : A
+
+    attrs: Readonly<T>;
+>attrs : Readonly<T>
+>Readonly : Readonly<T>
+>T : T
+
+    m() {
+>m : () => T["params"] extends null | undefined ? never : T["params"]
+
+        return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+>this.attrs.params! : T["params"] extends null | undefined ? never : T["params"]
+>this.attrs.params : T["params"]
+>this.attrs : Readonly<T>
+>this : this
+>attrs : Readonly<T>
+>params : T["params"]
+    }
+}

--- a/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.types
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.types
@@ -29,14 +29,14 @@ class Test<T extends A> {
 >m : () => void
 
         this.attrs.params!.name;
->this.attrs.params!.name : string
->this.attrs.params! : T["params"] extends null | undefined ? never : T["params"]
+>this.attrs.params!.name : any
+>this.attrs.params! : T["params"]
 >this.attrs.params : T["params"]
 >this.attrs : Readonly<T>
 >this : this
 >attrs : Readonly<T>
 >params : T["params"]
->name : string
+>name : any
     }
 }
 
@@ -84,10 +84,10 @@ class Test2<T extends A> {
 >T : T
 
     m() {
->m : () => T["params"] extends null | undefined ? never : T["params"]
+>m : () => T["params"]
 
         return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
->this.attrs.params! : T["params"] extends null | undefined ? never : T["params"]
+>this.attrs.params! : T["params"]
 >this.attrs.params : T["params"]
 >this.attrs : Readonly<T>
 >this : this

--- a/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.types
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.types
@@ -22,12 +22,12 @@ class Test<T extends A> {
 
         this.attrs.params!.name;
 >this.attrs.params!.name : string
->this.attrs.params! : { name: string; }
->this.attrs.params : { name: string; } | undefined
+>this.attrs.params! : NonNullable<T["params"]>
+>this.attrs.params : T["params"]
 >this.attrs : Readonly<T>
 >this : this
 >attrs : Readonly<T>
->params : { name: string; } | undefined
+>params : T["params"]
 >name : string
     }
 }
@@ -76,14 +76,14 @@ class Test2<T extends A> {
 >T : T
 
     m() {
->m : () => { name: string; }
+>m : () => NonNullable<T["params"]>
 
         return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
->this.attrs.params! : { name: string; }
->this.attrs.params : { name: string; } | undefined
+>this.attrs.params! : NonNullable<T["params"]>
+>this.attrs.params : T["params"]
 >this.attrs : Readonly<T>
 >this : this
 >attrs : Readonly<T>
->params : { name: string; } | undefined
+>params : T["params"]
     }
 }

--- a/tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts
+++ b/tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts
@@ -1,0 +1,35 @@
+// @strictNullChecks: true
+// @noLib: true
+type Readonly<T> = {readonly [K in keyof T]: T[K]}
+interface A {
+    params?: { name: string; };
+}
+
+class Test<T extends A> {
+    attrs: Readonly<T>;
+
+    m() {
+        this.attrs.params!.name;
+    }
+}
+
+interface Foo {
+    foo?: number;
+}
+
+class FooClass<P extends Foo = Foo> {
+    properties: Readonly<P>;
+
+    foo(): number {
+        const { foo = 42 } = this.properties;
+        return foo;
+    }
+}
+
+class Test2<T extends A> {
+    attrs: Readonly<T>;
+
+    m() {
+        return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
+    }
+}


### PR DESCRIPTION
Also changes NonNullableAssertions to no longer be constraint locations, as it is no longer required to work with the appropriate members/type relationships with this change.

This PR uses the global NonNullable type alias if it can be found, and failing finding it (ie, when an old lib is used), it will manufacture an anonymous conditional type of the appropriate shape to use in its place (which will behave the same way, it just won't be pretty in quick info or declaration emit).

Fixes #21317
