### PR TITLE
organizeImports: Avoid using full FindAllReferences

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -709,6 +709,16 @@ namespace ts.FindAllReferences.Core {
         return exposedByParent ? scope.getSourceFile() : scope;
     }
 
+    /** Used as a quick check for whether a symbol is used at all in a file (besides its definition). */
+    export function isSymbolReferencedInFile(definition: Identifier, checker: TypeChecker, sourceFile: SourceFile) {
+        const symbol = checker.getSymbolAtLocation(definition);
+        if (!symbol) return true; // Be lenient with invalid code.
+        return getPossibleSymbolReferencePositions(sourceFile, symbol.name).some(position => {
+            const token = tryCast(getTouchingPropertyName(sourceFile, position, /*includeJsDocComment*/ true), isIdentifier);
+            return token && token !== definition && token.escapedText === definition.escapedText && checker.getSymbolAtLocation(token) === symbol;
+        });
+    }
+
     function getPossibleSymbolReferencePositions(sourceFile: SourceFile, symbolName: string, container: Node = sourceFile): ReadonlyArray<number> {
         const positions: number[] = [];
 

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -104,23 +104,8 @@ namespace ts.OrganizeImports {
         return usedImports;
 
         function isDeclarationUsed(identifier: Identifier) {
-            const symbol = typeChecker.getSymbolAtLocation(identifier);
-
-            // Be lenient with invalid code.
-            if (symbol === undefined) {
-                return true;
-            }
-
             // The JSX factory symbol is always used.
-            if (jsxContext && symbol.name === jsxNamespace) {
-                return true;
-            }
-
-            const entries = FindAllReferences.getReferenceEntriesForNode(identifier.pos, identifier, program, [sourceFile], {
-                isCancellationRequested: () => false,
-                throwIfCancellationRequested: () => { /*noop*/ },
-            }).filter(e => e.type === "node" && e.node.getSourceFile() === sourceFile);
-            return entries.length > 1;
+            return jsxContext && identifier.text === jsxNamespace || FindAllReferences.Core.isSymbolReferencedInFile(identifier, typeChecker, sourceFile);
         }
     }
 

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -105,7 +105,7 @@ namespace ts.OrganizeImports {
 
         function isDeclarationUsed(identifier: Identifier) {
             // The JSX factory symbol is always used.
-            return jsxContext && identifier.text === jsxNamespace || FindAllReferences.Core.isSymbolReferencedInFile(identifier, typeChecker, sourceFile);
+            return jsxContext && (identifier.text === jsxNamespace) || FindAllReferences.Core.isSymbolReferencedInFile(identifier, typeChecker, sourceFile);
         }
     }
 


### PR DESCRIPTION
For imports, all we really need is `getPossibleSymbolReferencePositions` followed by checking for *exact* symbol match. FindAllReferences would look for related symbols, but we don't actually want those in this case.