### PR TITLE
Fix bug: don't call `addIndirectUser` if we're not tracking indirect users

### DIFF
--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -109,7 +109,9 @@ namespace ts.FindAllReferences {
                             }
                             else if (isDefaultImport(direct)) {
                                 const sourceFileLike = getSourceFileLikeForImportDeclaration(direct);
-                                addIndirectUser(sourceFileLike); // Add a check for indirect uses to handle synthetic default imports
+                                if (!isAvailableThroughGlobal) {
+                                    addIndirectUser(sourceFileLike); // Add a check for indirect uses to handle synthetic default imports
+                                }
                                 directImports.push(direct);
                             }
                             else {
@@ -651,8 +653,8 @@ namespace ts.FindAllReferences {
         if (parent.kind === SyntaxKind.SourceFile) {
             return parent as SourceFile;
         }
-        Debug.assert(parent.kind === SyntaxKind.ModuleBlock && isAmbientModuleDeclaration(parent.parent));
-        return parent.parent as AmbientModuleDeclaration;
+        Debug.assert(parent.kind === SyntaxKind.ModuleBlock);
+        return cast(parent.parent, isAmbientModuleDeclaration);
     }
 
     function isAmbientModuleDeclaration(node: Node): node is AmbientModuleDeclaration {

--- a/tests/cases/fourslash/esModuleInteropFindAllReferences.ts
+++ b/tests/cases/fourslash/esModuleInteropFindAllReferences.ts
@@ -1,3 +1,5 @@
+/// <reference path="fourslash.ts"/>
+
 // @esModuleInterop: true
 
 // @Filename: /abc.d.ts
@@ -6,7 +8,7 @@
 ////}
 
 // @Filename: /b.ts
-////import * as a from "a";
+////import a from "a";
 ////a.[|x|];
 
 verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/esModuleInteropFindAllReferences2.ts
+++ b/tests/cases/fourslash/esModuleInteropFindAllReferences2.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts"/>
+
+// Tests that we don't always add an indirect user, which causes problems if the module is already available globally.
+
+// @esModuleInterop: true
+
+// @Filename: /a.d.ts
+////export as namespace abc;
+////export const [|x|]: number;
+
+// @Filename: /b.ts
+////import a from "./a";
+////a.[|x|];
+
+verify.rangesReferenceEachOther();


### PR DESCRIPTION
Fixes  #22104

@weswigham Is there a way we can avoid calling `addIndirectUser` on every default import -- only if it's acting like a namespace import?