### PR TITLE
isControlFlowEndingStatement: don't try to enumerate all possible parent kinds

### DIFF
--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -565,26 +565,14 @@ namespace ts.formatting {
         function isControlFlowEndingStatement(kind: SyntaxKind, parent: TextRangeWithKind): boolean {
             switch (kind) {
                 case SyntaxKind.ReturnStatement:
-                case SyntaxKind.ThrowStatement:
-                    switch (parent.kind) {
-                        case SyntaxKind.Block:
-                            const grandParent = (parent as Node).parent;
-                            switch (grandParent && grandParent.kind) {
-                                case SyntaxKind.FunctionDeclaration:
-                                case SyntaxKind.FunctionExpression:
-                                    // We may want to write inner functions after this.
-                                    return false;
-                                default:
-                                    return true;
-                            }
-                        case SyntaxKind.CaseClause:
-                        case SyntaxKind.DefaultClause:
-                        case SyntaxKind.SourceFile:
-                        case SyntaxKind.ModuleBlock:
-                            return true;
-                        default:
-                            throw Debug.fail();
+                case SyntaxKind.ThrowStatement: {
+                    if (parent.kind !== SyntaxKind.Block) {
+                        return true;
                     }
+                    const grandParent = (parent as Node).parent;
+                    // In a function, we may want to write inner functions after this.
+                    return !(grandParent && grandParent.kind === SyntaxKind.FunctionExpression || grandParent.kind === SyntaxKind.FunctionDeclaration);
+                }
                 case SyntaxKind.ContinueStatement:
                 case SyntaxKind.BreakStatement:
                     return true;


### PR DESCRIPTION
Fixes #22027
(was broken by #20016)
