### PR TITLE
Allow characters in JsxText inside JsxFragment that usually don't scan

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4176,8 +4176,9 @@ namespace ts {
             parseExpected(SyntaxKind.LessThanToken);
 
             if (token() === SyntaxKind.GreaterThanToken) {
-                parseExpected(SyntaxKind.GreaterThanToken);
+                // See below for explanation of scanJsxText
                 const node: JsxOpeningFragment = <JsxOpeningFragment>createNode(SyntaxKind.JsxOpeningFragment, fullStart);
+                scanJsxText();
                 return finishNode(node);
             }
 

--- a/tests/baselines/reference/tsxFragmentPreserveEmit.js
+++ b/tests/baselines/reference/tsxFragmentPreserveEmit.js
@@ -13,6 +13,7 @@ declare var React: any;
 <>hi</>; // text inside
 <><span>hi</span><div>bye</div></>; // children
 <><span>1</span><><span>2.1</span><span>2.2</span></><span>3</span></>; // nested fragments
+<>#</>; // # would cause scanning error if not in jsxtext
 
 //// [file.jsx]
 <></>; // no whitespace
@@ -21,3 +22,4 @@ declare var React: any;
 <>hi</>; // text inside
 <><span>hi</span><div>bye</div></>; // children
 <><span>1</span><><span>2.1</span><span>2.2</span></><span>3</span></>; // nested fragments
+<>#</>; // # would cause scanning error if not in jsxtext

--- a/tests/baselines/reference/tsxFragmentPreserveEmit.symbols
+++ b/tests/baselines/reference/tsxFragmentPreserveEmit.symbols
@@ -35,3 +35,4 @@ declare var React: any;
 >span : Symbol(JSX.IntrinsicElements, Decl(file.tsx, 1, 22))
 >span : Symbol(JSX.IntrinsicElements, Decl(file.tsx, 1, 22))
 
+<>#</>; // # would cause scanning error if not in jsxtext

--- a/tests/baselines/reference/tsxFragmentPreserveEmit.types
+++ b/tests/baselines/reference/tsxFragmentPreserveEmit.types
@@ -52,3 +52,6 @@ declare var React: any;
 >span : any
 >span : any
 
+<>#</>; // # would cause scanning error if not in jsxtext
+><>#</> : JSX.Element
+

--- a/tests/baselines/reference/tsxFragmentReactEmit.js
+++ b/tests/baselines/reference/tsxFragmentReactEmit.js
@@ -13,6 +13,7 @@ declare var React: any;
 <>hi</>; // text inside
 <><span>hi</span><div>bye</div></>; // children
 <><span>1</span><><span>2.1</span><span>2.2</span></><span>3</span></>; // nested fragments
+<>#</>; // # would cause scanning error if not in jsxtext
 
 //// [file.js]
 React.createElement(React.Fragment, null); // no whitespace
@@ -28,3 +29,4 @@ React.createElement(React.Fragment, null,
         React.createElement("span", null, "2.1"),
         React.createElement("span", null, "2.2")),
     React.createElement("span", null, "3")); // nested fragments
+React.createElement(React.Fragment, null, "#"); // # would cause scanning error if not in jsxtext

--- a/tests/baselines/reference/tsxFragmentReactEmit.symbols
+++ b/tests/baselines/reference/tsxFragmentReactEmit.symbols
@@ -35,3 +35,4 @@ declare var React: any;
 >span : Symbol(JSX.IntrinsicElements, Decl(file.tsx, 1, 22))
 >span : Symbol(JSX.IntrinsicElements, Decl(file.tsx, 1, 22))
 
+<>#</>; // # would cause scanning error if not in jsxtext

--- a/tests/baselines/reference/tsxFragmentReactEmit.types
+++ b/tests/baselines/reference/tsxFragmentReactEmit.types
@@ -52,3 +52,6 @@ declare var React: any;
 >span : any
 >span : any
 
+<>#</>; // # would cause scanning error if not in jsxtext
+><>#</> : JSX.Element
+

--- a/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
+++ b/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
@@ -15,3 +15,4 @@ declare var React: any;
 <>hi</>; // text inside
 <><span>hi</span><div>bye</div></>; // children
 <><span>1</span><><span>2.1</span><span>2.2</span></><span>3</span></>; // nested fragments
+<>#</>; // # would cause scanning error if not in jsxtext

--- a/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
+++ b/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
@@ -15,3 +15,4 @@ declare var React: any;
 <>hi</>; // text inside
 <><span>hi</span><div>bye</div></>; // children
 <><span>1</span><><span>2.1</span><span>2.2</span></><span>3</span></>; // nested fragments
+<>#</>; // # would cause scanning error if not in jsxtext


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #22012.
Previously we were not scanning the text following a JsxFragment opening tag as JsxText as we were for JsxElement opening tags. This change aligns the two cases.
