### PR TITLE
Improve error message for untyped import of scoped package

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2092,7 +2092,7 @@ namespace ts {
                 else if (noImplicitAny && moduleNotFoundError) {
                     let errorInfo = resolvedModule.packageId && chainDiagnosticMessages(/*details*/ undefined,
                         Diagnostics.Try_npm_install_types_Slash_0_if_it_exists_or_add_a_new_declaration_d_ts_file_containing_declare_module_0,
-                        resolvedModule.packageId.name);
+                        getMangledNameForScopedPackage(resolvedModule.packageId.name));
                     errorInfo = chainDiagnosticMessages(errorInfo,
                         Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type,
                         moduleReference,

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1157,7 +1157,8 @@ namespace ts {
         return `@types/${getMangledNameForScopedPackage(packageName)}`;
     }
 
-    function getMangledNameForScopedPackage(packageName: string): string {
+    /* @internal */
+    export function getMangledNameForScopedPackage(packageName: string): string {
         if (startsWith(packageName, "@")) {
             const replaceSlash = packageName.replace(ts.directorySeparator, mangledScopedPackageSeparator);
             if (replaceSlash !== packageName) {

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.errors.txt
@@ -1,0 +1,16 @@
+/a.ts(1,22): error TS7016: Could not find a declaration file for module '@foo/bar'. '/node_modules/@foo/bar/index.js' implicitly has an 'any' type.
+  Try `npm install @types/foo__bar` if it exists or add a new declaration (.d.ts) file containing `declare module 'foo__bar';`
+
+
+==== /a.ts (1 errors) ====
+    import * as foo from "@foo/bar";
+                         ~~~~~~~~~~
+!!! error TS7016: Could not find a declaration file for module '@foo/bar'. '/node_modules/@foo/bar/index.js' implicitly has an 'any' type.
+!!! error TS7016:   Try `npm install @types/foo__bar` if it exists or add a new declaration (.d.ts) file containing `declare module 'foo__bar';`
+    
+==== /node_modules/@foo/bar/package.json (0 errors) ====
+    { "name": "@foo/bar", "version": "1.2.3" }
+    
+==== /node_modules/@foo/bar/index.js (0 errors) ====
+    This file is not processed.
+    

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.js
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.js
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_scoped.ts] ////
+
+//// [package.json]
+{ "name": "@foo/bar", "version": "1.2.3" }
+
+//// [index.js]
+This file is not processed.
+
+//// [a.ts]
+import * as foo from "@foo/bar";
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.symbols
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.symbols
@@ -1,0 +1,4 @@
+=== /a.ts ===
+import * as foo from "@foo/bar";
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.types
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.types
@@ -1,0 +1,4 @@
+=== /a.ts ===
+import * as foo from "@foo/bar";
+>foo : any
+

--- a/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_scoped.ts
+++ b/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_scoped.ts
@@ -1,0 +1,11 @@
+// @noImplicitReferences: true
+// @noImplicitAny: true
+
+// @filename: /node_modules/@foo/bar/package.json
+{ "name": "@foo/bar", "version": "1.2.3" }
+
+// @filename: /node_modules/@foo/bar/index.js
+This file is not processed.
+
+// @filename: /a.ts
+import * as foo from "@foo/bar";


### PR DESCRIPTION
Previously we would recommend to install `@types/@foo/bar`, now we recommend `@types/foo__bar`.