### PR TITLE
fourslash diagnostics tests: use objects instead of strings

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1236,20 +1236,18 @@ Actual: ${stringify(fullActual)}`);
             return this.languageService.findReferences(this.activeFile.fileName, this.currentCaretPosition);
         }
 
-        public getSyntacticDiagnostics(expected: string) {
+        public getSyntacticDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>) {
             const diagnostics = this.languageService.getSyntacticDiagnostics(this.activeFile.fileName);
             this.testDiagnostics(expected, diagnostics);
         }
 
-        public getSemanticDiagnostics(expected: string) {
+        public getSemanticDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>) {
             const diagnostics = this.languageService.getSemanticDiagnostics(this.activeFile.fileName);
             this.testDiagnostics(expected, diagnostics);
         }
 
-        private testDiagnostics(expected: string, diagnostics: ReadonlyArray<ts.Diagnostic>) {
-            const realized = ts.realizeDiagnostics(diagnostics, "\r\n");
-            const actual = stringify(realized);
-            assert.equal(actual, expected);
+        private testDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>, diagnostics: ReadonlyArray<ts.Diagnostic>) {
+            assert.deepEqual(ts.realizeDiagnostics(diagnostics, ts.newLineCharacter), expected);
         }
 
         public verifyQuickInfoAt(markerName: string, expectedText: string, expectedDocumentation?: string) {
@@ -4321,11 +4319,11 @@ namespace FourSlashInterface {
             this.state.verifyQuickInfoDisplayParts(kind, kindModifiers, textSpan, displayParts, documentation, tags);
         }
 
-        public getSyntacticDiagnostics(expected: string) {
+        public getSyntacticDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>) {
             this.state.getSyntacticDiagnostics(expected);
         }
 
-        public getSemanticDiagnostics(expected: string) {
+        public getSemanticDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>) {
             this.state.getSemanticDiagnostics(expected);
         }
 

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -581,7 +581,7 @@ namespace ts {
         }
     }
 
-    interface RealizedDiagnostic {
+    export interface RealizedDiagnostic {
         message: string;
         start: number;
         length: number;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -347,8 +347,8 @@ declare namespace FourSlashInterface {
             start: number;
             length: number;
         }, displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[], tags: ts.JSDocTagInfo[]): void;
-        getSyntacticDiagnostics(expected: string): void;
-        getSemanticDiagnostics(expected: string): void;
+        getSyntacticDiagnostics(expected: ReadonlyArray<RealizedDiagnostic>): void;
+        getSemanticDiagnostics(expected: ReadonlyArray<RealizedDiagnostic>): void;
         ProjectInfo(expected: string[]): void;
         allRangesAppearInImplementationList(markerName: string): void;
     }
@@ -519,6 +519,13 @@ declare namespace FourSlashInterface {
     interface ReferencesDefinition {
         text: string;
         range: Range;
+    }
+    interface RealizedDiagnostic {
+        message: string;
+        start: number;
+        length: number;
+        category: string;
+        code: number;
     }
 }
 declare function verifyOperationIsCancelled(f: any): void;

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics1.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics1.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// import a = b;
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'import ... =' can only be used in a .ts file.",
-    "start": 0,
-    "length": 13,
-    "category": "error",
-    "code": 8002
+    message: "'import ... =' can only be used in a .ts file.",
+    start: 0,
+    length: 13,
+    category: "error",
+    code: 8002
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics10.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics10.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// function F<T>() { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'type parameter declarations' can only be used in a .ts file.",
-    "start": 11,
-    "length": 1,
-    "category": "error",
-    "code": 8004
+    message: "'type parameter declarations' can only be used in a .ts file.",
+    start: 11,
+    length: 1,
+    category: "error",
+    code: 8004
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics11.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics11.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// function F(): number { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'types' can only be used in a .ts file.",
-    "start": 14,
-    "length": 6,
-    "category": "error",
-    "code": 8010
+    message: "'types' can only be used in a .ts file.",
+    start: 14,
+    length: 6,
+    category: "error",
+    code: 8010
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics12.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics12.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// declare var v;
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'declare' can only be used in a .ts file.",
-    "start": 0,
-    "length": 7,
-    "category": "error",
-    "code": 8009
+    message: "'declare' can only be used in a .ts file.",
+    start: 0,
+    length: 7,
+    category: "error",
+    code: 8009
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics13.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics13.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// var v: () => number;
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'types' can only be used in a .ts file.",
-    "start": 7,
-    "length": 12,
-    "category": "error",
-    "code": 8010
+    message: "'types' can only be used in a .ts file.",
+    start: 7,
+    length: 12,
+    category: "error",
+    code: 8010
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics14.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics14.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// Foo<number>();
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'type arguments' can only be used in a .ts file.",
-    "start": 4,
-    "length": 6,
-    "category": "error",
-    "code": 8011
+    message: "'type arguments' can only be used in a .ts file.",
+    start: 4,
+    length: 6,
+    category: "error",
+    code: 8011
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics15.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics15.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// function F(public p) { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'parameter modifiers' can only be used in a .ts file.",
-    "start": 11,
-    "length": 6,
-    "category": "error",
-    "code": 8012
+    message: "'parameter modifiers' can only be used in a .ts file.",
+    start: 11,
+    length: 6,
+    category: "error",
+    code: 8012
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics16.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics16.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// function F(p?) { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'?' can only be used in a .ts file.",
-    "start": 12,
-    "length": 1,
-    "category": "error",
-    "code": 8009
+    message: "'?' can only be used in a .ts file.",
+    start: 12,
+    length: 1,
+    category: "error",
+    code: 8009
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics17.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics17.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// function F(a: number) { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'types' can only be used in a .ts file.",
-    "start": 14,
-    "length": 6,
-    "category": "error",
-    "code": 8010
+    message: "'types' can only be used in a .ts file.",
+    start: 14,
+    length: 6,
+    category: "error",
+    code: 8010
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics18.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics18.ts
@@ -9,15 +9,15 @@
 ////}
 
 goTo.file("a.js");
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "\'public\' can only be used in a .ts file.",
-    "start": 93,
-    "length": 6,
-    "category": "error",
-    "code": 8009
+    message: "\'public\' can only be used in a .ts file.",
+    start: 93,
+    length: 6,
+    category: "error",
+    code: 8009
   }
-]`);
+]);
 
 // @Filename: b.js
 ////class C {
@@ -25,12 +25,12 @@ verify.getSyntacticDiagnostics(`[
 ////}
 
 goTo.file("b.js");
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'types' can only be used in a .ts file.",
-    "start": 17,
-    "length": 6,
-    "category": "error",
-    "code": 8010
+    message: "'types' can only be used in a .ts file.",
+    start: 17,
+    length: 6,
+    category: "error",
+    code: 8010
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics19.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics19.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// enum E { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'enum declarations' can only be used in a .ts file.",
-    "start": 5,
-    "length": 1,
-    "category": "error",
-    "code": 8015
+    message: "'enum declarations' can only be used in a .ts file.",
+    start: 5,
+    length: 1,
+    category: "error",
+    code: 8015
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics2.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics2.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// export = b;
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'export=' can only be used in a .ts file.",
-    "start": 0,
-    "length": 11,
-    "category": "error",
-    "code": 8003
+    message: "'export=' can only be used in a .ts file.",
+    start: 0,
+    length: 11,
+    category: "error",
+    code: 8003
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics21.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics21.ts
@@ -5,4 +5,4 @@
 // @Filename: a.js
 //// @internal class C {}
 
-verify.getSemanticDiagnostics(`[]`);
+verify.getSemanticDiagnostics([]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics22.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics22.ts
@@ -4,4 +4,4 @@
 // @Filename: a.js
 //// function foo(...a) {}
 
-verify.getSemanticDiagnostics(`[]`);
+verify.getSemanticDiagnostics([]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics23.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics23.ts
@@ -10,5 +10,5 @@
 ////     }
 //// }
 
-verify.getSyntacticDiagnostics(`[]`);
-verify.getSemanticDiagnostics(`[]`);
+verify.getSyntacticDiagnostics([]);
+verify.getSemanticDiagnostics([]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics3.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics3.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// class C<T> { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'type parameter declarations' can only be used in a .ts file.",
-    "start": 8,
-    "length": 1,
-    "category": "error",
-    "code": 8004
+    message: "'type parameter declarations' can only be used in a .ts file.",
+    start: 8,
+    length: 1,
+    category: "error",
+    code: 8004
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics4.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics4.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// public class C { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'public' can only be used in a .ts file.",
-    "start": 0,
-    "length": 6,
-    "category": "error",
-    "code": 8009
+    message: "'public' can only be used in a .ts file.",
+    start: 0,
+    length: 6,
+    category: "error",
+    code: 8009
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics5.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics5.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// class C implements D { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'implements clauses' can only be used in a .ts file.",
-    "start": 8,
-    "length": 12,
-    "category": "error",
-    "code": 8005
+    message: "'implements clauses' can only be used in a .ts file.",
+    start: 8,
+    length: 12,
+    category: "error",
+    code: 8005
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics6.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics6.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// interface I { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'interface declarations' can only be used in a .ts file.",
-    "start": 10,
-    "length": 1,
-    "category": "error",
-    "code": 8006
+    message: "'interface declarations' can only be used in a .ts file.",
+    start: 10,
+    length: 1,
+    category: "error",
+    code: 8006
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics7.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics7.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// module M { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'module declarations' can only be used in a .ts file.",
-    "start": 7,
-    "length": 1,
-    "category": "error",
-    "code": 8007
+    message: "'module declarations' can only be used in a .ts file.",
+    start: 7,
+    length: 1,
+    category: "error",
+    code: 8007
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics8.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics8.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// type a = b;
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'type aliases' can only be used in a .ts file.",
-    "start": 5,
-    "length": 1,
-    "category": "error",
-    "code": 8008
+    message: "'type aliases' can only be used in a .ts file.",
+    start: 5,
+    length: 1,
+    category: "error",
+    code: 8008
   }
-]`);
+]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics9.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics9.ts
@@ -4,12 +4,12 @@
 // @Filename: a.js
 //// public function F() { }
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "'public' can only be used in a .ts file.",
-    "start": 0,
-    "length": 6,
-    "category": "error",
-    "code": 8009
+    message: "'public' can only be used in a .ts file.",
+    start: 0,
+    length: 6,
+    category: "error",
+    code: 8009
   }
-]`);
+]);

--- a/tests/cases/fourslash/jsDocAugmentsAndExtends.ts
+++ b/tests/cases/fourslash/jsDocAugmentsAndExtends.ts
@@ -25,13 +25,10 @@
 
 goTo.marker();
 verify.quickInfoIs("(local var) x: number");
-verify.getSemanticDiagnostics(
-`[
-  {
-    "message": "Class declarations cannot have more than one \`@augments\` or \`@extends\` tag.",
-    "start": 36,
-    "length": 24,
-    "category": "error",
-    "code": 8025
-  }
-]`);
+verify.getSemanticDiagnostics([{
+    message: "Class declarations cannot have more than one \`@augments\` or \`@extends\` tag.",
+    start: 36,
+    length: 24,
+    category: "error",
+    code: 8025
+}]);

--- a/tests/cases/fourslash/jsFileCompilationDuplicateFunctionImplementation.ts
+++ b/tests/cases/fourslash/jsFileCompilationDuplicateFunctionImplementation.ts
@@ -12,13 +12,25 @@
 ////function foo() { return 30; }/*2*/
 
 goTo.marker("1");
-verify.getSemanticDiagnostics('[]');
+verify.getSemanticDiagnostics([]);
 goTo.marker("2");
-verify.getSemanticDiagnostics('[\n  {\n    "message": "Duplicate function implementation.",\n    "start": 9,\n    "length": 3,\n    "category": "error",\n    "code": 2393\n  }\n]');
+verify.getSemanticDiagnostics([{
+    message: "Duplicate function implementation.",
+    start: 9,
+    length: 3,
+    category: "error",
+    code: 2393
+}]);
 verify.verifyGetEmitOutputContentsForCurrentFile([
     { name: "out.js", text: "function foo() { return 10; }\r\nfunction foo() { return 30; }\r\n", writeByteOrderMark: false },
     { name: "out.d.ts", text: "", writeByteOrderMark: false }]);
 goTo.marker("2");
-verify.getSemanticDiagnostics('[\n  {\n    "message": "Duplicate function implementation.",\n    "start": 9,\n    "length": 3,\n    "category": "error",\n    "code": 2393\n  }\n]');
+verify.getSemanticDiagnostics([{
+    message: "Duplicate function implementation.",
+    start: 9,
+    length: 3,
+    category: "error",
+    code: 2393
+}]);
 goTo.marker("1");
-verify.getSemanticDiagnostics('[]');
+verify.getSemanticDiagnostics([]);

--- a/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics01.ts
+++ b/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics01.ts
@@ -4,20 +4,20 @@
 // @Filename: a.js
 //// var ===;
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "Variable declaration expected.",
-    "start": 4,
-    "length": 3,
-    "category": "error",
-    "code": 1134
+    message: "Variable declaration expected.",
+    start: 4,
+    length: 3,
+    category: "error",
+    code: 1134
   },
   {
-    "message": "Expression expected.",
-    "start": 7,
-    "length": 1,
-    "category": "error",
-    "code": 1109
-  }
-]`);
-verify.getSemanticDiagnostics(`[]`);
+    message: "Expression expected.",
+    start: 7,
+    length: 1,
+    category: "error",
+    code: 1109
+  },
+]);
+verify.getSemanticDiagnostics([]);

--- a/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics02.ts
+++ b/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics02.ts
@@ -7,41 +7,41 @@
 //// function foo(): string { }
 //// var var = "c";
 
-verify.getSyntacticDiagnostics(`[
+verify.getSyntacticDiagnostics([
   {
-    "message": "\'types\' can only be used in a .ts file.",
-    "start": 20,
-    "length": 7,
-    "category": "error",
-    "code": 8010
+    message: "'types' can only be used in a .ts file.",
+    start: 20,
+    length: 7,
+    category: "error",
+    code: 8010
   },
   {
-    "message": "\'types\' can only be used in a .ts file.",
-    "start": 52,
-    "length": 6,
-    "category": "error",
-    "code": 8010
+    message: "\'types\' can only be used in a .ts file.",
+    start: 52,
+    length: 6,
+    category: "error",
+    code: 8010
   },
   {
-    "message": "Variable declaration expected.",
-    "start": 67,
-    "length": 3,
-    "category": "error",
-    "code": 1134
+    message: "Variable declaration expected.",
+    start: 67,
+    length: 3,
+    category: "error",
+    code: 1134
   },
   {
-    "message": "Variable declaration expected.",
-    "start": 71,
-    "length": 1,
-    "category": "error",
-    "code": 1134
+    message: "Variable declaration expected.",
+    start: 71,
+    length: 1,
+    category: "error",
+    code: 1134
   },
   {
-    "message": "Variable declaration expected.",
-    "start": 73,
-    "length": 3,
-    "category": "error",
-    "code": 1134
-  }
-]`);
-verify.getSemanticDiagnostics(`[]`);
+    message: "Variable declaration expected.",
+    start: 73,
+    length: 3,
+    category: "error",
+    code: 1134
+  },
+]);
+verify.getSemanticDiagnostics([]);


### PR DESCRIPTION
Currently one writes a string literal that is compared to the result of `stringify(realized)`. We can just directly compare objects instead.