### PR TITLE
PropertyAssignment#initializer should be non-optional

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2287,7 +2287,7 @@ namespace ts {
         const node = <PropertyAssignment>createSynthesizedNode(SyntaxKind.PropertyAssignment);
         node.name = asName(name);
         node.questionToken = undefined;
-        node.initializer = initializer !== undefined ? parenthesizeExpressionForList(initializer) : undefined;
+        node.initializer = parenthesizeExpressionForList(initializer);
         return node;
     }
 


### PR DESCRIPTION
If there is no initializer we should parse a `ShorthandPropertyAssignment` instead. Relevant to #22088.