### PR TITLE
Stop binding type predicate types twice

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2071,7 +2071,7 @@ namespace ts {
                     seenThisKeyword = true;
                     return;
                 case SyntaxKind.TypePredicate:
-                    return checkTypePredicate(node as TypePredicateNode);
+                    break; // Binding the children will handle everything
                 case SyntaxKind.TypeParameter:
                     return bindTypeParameter(node as TypeParameterDeclaration);
                 case SyntaxKind.Parameter:
@@ -2202,17 +2202,6 @@ namespace ts {
 
         function bindAnonymousTypeWorker(node: TypeLiteralNode | MappedTypeNode | JSDocTypeLiteral) {
             return bindAnonymousDeclaration(<Declaration>node, SymbolFlags.TypeLiteral, InternalSymbolName.Type);
-        }
-
-        function checkTypePredicate(node: TypePredicateNode) {
-            const { parameterName, type } = node;
-            if (parameterName && parameterName.kind === SyntaxKind.Identifier) {
-                checkStrictModeIdentifier(parameterName);
-            }
-            if (parameterName && parameterName.kind === SyntaxKind.ThisType) {
-                seenThisKeyword = true;
-            }
-            bind(type);
         }
 
         function bindSourceFileIfExternalModule() {

--- a/tests/baselines/reference/typeGuardOnContainerTypeNoHang.js
+++ b/tests/baselines/reference/typeGuardOnContainerTypeNoHang.js
@@ -1,0 +1,18 @@
+//// [typeGuardOnContainerTypeNoHang.ts]
+export namespace TypeGuards {
+    export function IsObject(value: any) : value is {[index:string]:any} {
+        return typeof(value) === 'object'
+    }
+
+}
+
+//// [typeGuardOnContainerTypeNoHang.js]
+"use strict";
+exports.__esModule = true;
+var TypeGuards;
+(function (TypeGuards) {
+    function IsObject(value) {
+        return typeof (value) === 'object';
+    }
+    TypeGuards.IsObject = IsObject;
+})(TypeGuards = exports.TypeGuards || (exports.TypeGuards = {}));

--- a/tests/baselines/reference/typeGuardOnContainerTypeNoHang.symbols
+++ b/tests/baselines/reference/typeGuardOnContainerTypeNoHang.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts ===
+export namespace TypeGuards {
+>TypeGuards : Symbol(TypeGuards, Decl(typeGuardOnContainerTypeNoHang.ts, 0, 0))
+
+    export function IsObject(value: any) : value is {[index:string]:any} {
+>IsObject : Symbol(IsObject, Decl(typeGuardOnContainerTypeNoHang.ts, 0, 29))
+>value : Symbol(value, Decl(typeGuardOnContainerTypeNoHang.ts, 1, 29))
+>value : Symbol(value, Decl(typeGuardOnContainerTypeNoHang.ts, 1, 29))
+>index : Symbol(index, Decl(typeGuardOnContainerTypeNoHang.ts, 1, 54))
+
+        return typeof(value) === 'object'
+>value : Symbol(value, Decl(typeGuardOnContainerTypeNoHang.ts, 1, 29))
+    }
+
+}

--- a/tests/baselines/reference/typeGuardOnContainerTypeNoHang.types
+++ b/tests/baselines/reference/typeGuardOnContainerTypeNoHang.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts ===
+export namespace TypeGuards {
+>TypeGuards : typeof TypeGuards
+
+    export function IsObject(value: any) : value is {[index:string]:any} {
+>IsObject : (value: any) => value is { [index: string]: any; }
+>value : any
+>value : any
+>index : string
+
+        return typeof(value) === 'object'
+>typeof(value) === 'object' : boolean
+>typeof(value) : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>(value) : any
+>value : any
+>'object' : "object"
+    }
+
+}

--- a/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
+++ b/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
@@ -1,0 +1,6 @@
+export namespace TypeGuards {
+    export function IsObject(value: any) : value is {[index:string]:any} {
+        return typeof(value) === 'object'
+    }
+
+}


### PR DESCRIPTION
`checkTypePredicate` was doing the same work `bindChildren` ended up doing, which caused a container type in a predicate to get its `nextContainer` set to itself, causing an infinite loop elsewhere.

Fixes #22076
