### PR TITLE
Fix typo in inference

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11647,7 +11647,7 @@ namespace ts {
                     }
                 }
                 else {
-                    if (!(priority && InferencePriority.NoConstraints && source.flags & (TypeFlags.Intersection | TypeFlags.Instantiable))) {
+                    if (!(priority & InferencePriority.NoConstraints && source.flags & (TypeFlags.Intersection | TypeFlags.Instantiable))) {
                         source = getApparentType(source);
                     }
                     if (source.flags & (TypeFlags.Object | TypeFlags.Intersection)) {


### PR DESCRIPTION
`InferencePriority.NoConstraints` is always truthy, so this was definitely a typo 😄 
