### PR TITLE
Simplify diagnostics fourslash tests

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1239,22 +1239,23 @@ Actual: ${stringify(fullActual)}`);
             return this.languageService.findReferences(this.activeFile.fileName, this.currentCaretPosition);
         }
 
-        public getSyntacticDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>) {
+        public getSyntacticDiagnostics(expected: ReadonlyArray<FourSlashInterface.Diagnostic>) {
             const diagnostics = this.languageService.getSyntacticDiagnostics(this.activeFile.fileName);
-            this.testDiagnostics(expected, diagnostics);
+            this.testDiagnostics(expected, diagnostics, "error");
         }
 
-        public getSemanticDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>) {
+        public getSemanticDiagnostics(expected: ReadonlyArray<FourSlashInterface.Diagnostic>) {
             const diagnostics = this.languageService.getSemanticDiagnostics(this.activeFile.fileName);
-            this.testDiagnostics(expected, diagnostics);
+            this.testDiagnostics(expected, diagnostics, "error");
         }
 
-        public getSuggestionDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>): void {
-            this.testDiagnostics(expected, this.languageService.getSuggestionDiagnostics(this.activeFile.fileName));
+        public getSuggestionDiagnostics(expected: ReadonlyArray<FourSlashInterface.Diagnostic>): void {
+            this.testDiagnostics(expected, this.languageService.getSuggestionDiagnostics(this.activeFile.fileName), "suggestion");
         }
 
-        private testDiagnostics(expected: ReadonlyArray<ts.RealizedDiagnostic>, diagnostics: ReadonlyArray<ts.Diagnostic>) {
-            assert.deepEqual(ts.realizeDiagnostics(diagnostics, ts.newLineCharacter), expected);
+        private testDiagnostics(expected: ReadonlyArray<FourSlashInterface.Diagnostic>, diagnostics: ReadonlyArray<ts.Diagnostic>, category: string) {
+            assert.deepEqual(ts.realizeDiagnostics(diagnostics, ts.newLineCharacter), expected.map<ts.RealizedDiagnostic>(e => (
+                { message: e.message, category, code: e.code, ...ts.createTextSpanFromRange(e.range || this.getRanges()[0]) })));
         }
 
         public verifyQuickInfoAt(markerName: string, expectedText: string, expectedDocumentation?: string) {
@@ -4675,5 +4676,11 @@ namespace FourSlashInterface {
         name: string;
         source?: string;
         description: string;
+    }
+
+    export interface Diagnostic {
+        message: string;
+        range?: FourSlash.Range;
+        code: number;
     }
 }

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -347,9 +347,9 @@ declare namespace FourSlashInterface {
             start: number;
             length: number;
         }, displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[], tags: ts.JSDocTagInfo[]): void;
-        getSyntacticDiagnostics(expected: ReadonlyArray<RealizedDiagnostic>): void;
-        getSemanticDiagnostics(expected: ReadonlyArray<RealizedDiagnostic>): void;
-        getSuggestionDiagnostics(expected: ReadonlyArray<RealizedDiagnostic>): void;
+        getSyntacticDiagnostics(expected: ReadonlyArray<Diagnostic>): void;
+        getSemanticDiagnostics(expected: ReadonlyArray<Diagnostic>): void;
+        getSuggestionDiagnostics(expected: ReadonlyArray<Diagnostic>): void;
         ProjectInfo(expected: string[]): void;
         allRangesAppearInImplementationList(markerName: string): void;
     }
@@ -521,11 +521,10 @@ declare namespace FourSlashInterface {
         text: string;
         range: Range;
     }
-    interface RealizedDiagnostic {
+    interface Diagnostic {
         message: string;
-        start: number;
-        length: number;
-        category: string;
+        /** @default `test.ranges()[0]` */
+        range?: Range;
         code: number;
     }
 }

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics1.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics1.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// import a = b;
+////[|import a = b;|]
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'import ... =' can only be used in a .ts file.",
-    start: 0,
-    length: 13,
-    category: "error",
     code: 8002
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics10.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics10.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// function F<T>() { }
+////function F<[|T|]>() { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'type parameter declarations' can only be used in a .ts file.",
-    start: 11,
-    length: 1,
-    category: "error",
     code: 8004
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics11.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics11.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// function F(): number { }
+////function F(): [|number|] { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'types' can only be used in a .ts file.",
-    start: 14,
-    length: 6,
-    category: "error",
     code: 8010
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics12.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics12.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// declare var v;
+////[|declare|] var v;
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'declare' can only be used in a .ts file.",
-    start: 0,
-    length: 7,
-    category: "error",
     code: 8009
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics13.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics13.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// var v: () => number;
+////var v: [|() => number|];
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'types' can only be used in a .ts file.",
-    start: 7,
-    length: 12,
-    category: "error",
     code: 8010
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics14.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics14.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// Foo<number>();
+////Foo<[|number|]>();
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'type arguments' can only be used in a .ts file.",
-    start: 4,
-    length: 6,
-    category: "error",
     code: 8011
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics15.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics15.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// function F(public p) { }
+////function F([|public|] p) { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'parameter modifiers' can only be used in a .ts file.",
-    start: 11,
-    length: 6,
-    category: "error",
     code: 8012
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics16.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics16.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// function F(p?) { }
+////function F(p[|?|]) { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'?' can only be used in a .ts file.",
-    start: 12,
-    length: 1,
-    category: "error",
     code: 8009
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics17.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics17.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// function F(a: number) { }
+////function F(a: [|number|]) { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'types' can only be used in a .ts file.",
-    start: 14,
-    length: 6,
-    category: "error",
     code: 8010
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics18.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics18.ts
@@ -5,32 +5,23 @@
 ////class C {
 ////    x; // Regular property declaration allowed
 ////    static y; // static allowed
-////    public z; // public not allowed
+////    [|public|] z; // public not allowed
 ////}
 
 goTo.file("a.js");
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "\'public\' can only be used in a .ts file.",
-    start: 93,
-    length: 6,
-    category: "error",
     code: 8009
-  }
-]);
+}]);
 
 // @Filename: b.js
 ////class C {
-////    x: number; // Types not allowed
+////    x: [|number|]; // Types not allowed
 ////}
 
 goTo.file("b.js");
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'types' can only be used in a .ts file.",
-    start: 17,
-    length: 6,
-    category: "error",
+    range: test.ranges()[1],
     code: 8010
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics19.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics19.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// enum E { }
+////enum [|E|] { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'enum declarations' can only be used in a .ts file.",
-    start: 5,
-    length: 1,
-    category: "error",
     code: 8015
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics2.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics2.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// export = b;
+////[|export = b;|]
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'export=' can only be used in a .ts file.",
-    start: 0,
-    length: 11,
-    category: "error",
     code: 8003
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics3.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics3.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// class C<T> { }
+////class C<[|T|]> { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'type parameter declarations' can only be used in a .ts file.",
-    start: 8,
-    length: 1,
-    category: "error",
     code: 8004
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics4.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics4.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// public class C { }
+////[|public|] class C { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'public' can only be used in a .ts file.",
-    start: 0,
-    length: 6,
-    category: "error",
     code: 8009
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics5.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics5.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// class C implements D { }
+////class C [|implements D|] { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'implements clauses' can only be used in a .ts file.",
-    start: 8,
-    length: 12,
-    category: "error",
     code: 8005
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics6.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics6.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// interface I { }
+////interface [|I|] { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'interface declarations' can only be used in a .ts file.",
-    start: 10,
-    length: 1,
-    category: "error",
     code: 8006
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics7.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics7.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// module M { }
+////module [|M|] { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'module declarations' can only be used in a .ts file.",
-    start: 7,
-    length: 1,
-    category: "error",
     code: 8007
-  }
-]);
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics8.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics8.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// type a = b;
+////type [|a|] = b;
 
-verify.getSyntacticDiagnostics([
-  {
-    message: "'type aliases' can only be used in a .ts file.",
-    start: 5,
-    length: 1,
-    category: "error",
-    code: 8008
-  }
-]);
+verify.getSyntacticDiagnostics([{
+  message: "'type aliases' can only be used in a .ts file.",
+  code: 8008
+}]);

--- a/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics9.ts
+++ b/tests/cases/fourslash/getJavaScriptSyntacticDiagnostics9.ts
@@ -2,14 +2,9 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// public function F() { }
+////[|public|] function F() { }
 
-verify.getSyntacticDiagnostics([
-  {
+verify.getSyntacticDiagnostics([{
     message: "'public' can only be used in a .ts file.",
-    start: 0,
-    length: 6,
-    category: "error",
     code: 8009
-  }
-]);
+}]);

--- a/tests/cases/fourslash/jsDocAugmentsAndExtends.ts
+++ b/tests/cases/fourslash/jsDocAugmentsAndExtends.ts
@@ -6,7 +6,7 @@
 
 //// /**
 ////  * @augments {Thing<number>}
-////  * @extends {Thing<string>}
+////  * [|@extends {Thing<string>}|]
 ////  */
 //// class MyStringThing extends Thing {
 ////     constructor() {
@@ -27,8 +27,5 @@ goTo.marker();
 verify.quickInfoIs("(local var) x: number");
 verify.getSemanticDiagnostics([{
     message: "Class declarations cannot have more than one \`@augments\` or \`@extends\` tag.",
-    start: 36,
-    length: 24,
-    category: "error",
     code: 8025
 }]);

--- a/tests/cases/fourslash/jsFileCompilationDuplicateFunctionImplementation.ts
+++ b/tests/cases/fourslash/jsFileCompilationDuplicateFunctionImplementation.ts
@@ -9,16 +9,13 @@
 
 // @Filename: a.ts
 // @emitThisFile: true
-////function foo() { return 30; }/*2*/
+////function [|foo|]() { return 30; }/*2*/
 
 goTo.marker("1");
 verify.getSemanticDiagnostics([]);
 goTo.marker("2");
 verify.getSemanticDiagnostics([{
     message: "Duplicate function implementation.",
-    start: 9,
-    length: 3,
-    category: "error",
     code: 2393
 }]);
 verify.verifyGetEmitOutputContentsForCurrentFile([
@@ -27,9 +24,6 @@ verify.verifyGetEmitOutputContentsForCurrentFile([
 goTo.marker("2");
 verify.getSemanticDiagnostics([{
     message: "Duplicate function implementation.",
-    start: 9,
-    length: 3,
-    category: "error",
     code: 2393
 }]);
 goTo.marker("1");

--- a/tests/cases/fourslash/refactorConvertToEs6Module_export_named.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_export_named.ts
@@ -3,14 +3,12 @@
 // @allowJs: true
 
 // @Filename: /a.js
-////exports.f = function() {}/*diagEnd*/
-////exports.C = class {}
+////[|exports.f = function() {}|];
+////exports.C = class {};
 ////exports.x = 0;
 
 verify.getSuggestionDiagnostics([{
     message: "File is a CommonJS module; it may be converted to an ES6 module.",
-    start: 0,
-    length: test.marker("diagEnd").position,
     category: "suggestion",
     code: 80001,
 }]);

--- a/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics01.ts
+++ b/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics01.ts
@@ -2,21 +2,17 @@
 
 // @allowJs: true
 // @Filename: a.js
-//// var ===;
+////var [|===|][|;|]
 
 verify.getSyntacticDiagnostics([
   {
     message: "Variable declaration expected.",
-    start: 4,
-    length: 3,
-    category: "error",
+    range: test.ranges()[0],
     code: 1134
   },
   {
     message: "Expression expected.",
-    start: 7,
-    length: 1,
-    category: "error",
+    range: test.ranges()[1],
     code: 1109
   },
 ]);

--- a/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics02.ts
+++ b/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics02.ts
@@ -2,45 +2,35 @@
 
 // @allowJs: true
 // @Filename: b.js
-//// var a = "a";
-//// var b: boolean = true;
-//// function foo(): string { }
-//// var var = "c";
+////var a = "a";
+////var b: [|boolean|] = true;
+////function foo(): [|string|] { }
+////var [|var|] [|=|] [|"c"|];
 
 verify.getSyntacticDiagnostics([
   {
     message: "'types' can only be used in a .ts file.",
-    start: 20,
-    length: 7,
-    category: "error",
+    range: test.ranges()[0],
     code: 8010
   },
   {
     message: "\'types\' can only be used in a .ts file.",
-    start: 52,
-    length: 6,
-    category: "error",
+    range: test.ranges()[1],
     code: 8010
   },
   {
     message: "Variable declaration expected.",
-    start: 67,
-    length: 3,
-    category: "error",
+    range: test.ranges()[2],
     code: 1134
   },
   {
     message: "Variable declaration expected.",
-    start: 71,
-    length: 1,
-    category: "error",
+    range: test.ranges()[3],
     code: 1134
   },
   {
     message: "Variable declaration expected.",
-    start: 73,
-    length: 3,
-    category: "error",
+    range: test.ranges()[4],
     code: 1134
   },
 ]);


### PR DESCRIPTION
Uses test ranges instead of manually writing `start` and `length` as numbers.
Also no longer requires to specify `category` since this is given by the kind of diagnostic you're looking for.