### PR TITLE
Format unique symmbol string output with `unique symbol` and not `typeof` within checker

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2756,7 +2756,7 @@ namespace ts {
             }
         }
 
-        function typeToString(type: Type, enclosingDeclaration?: Node, flags?: TypeFormatFlags, writer: EmitTextWriter = createTextWriter("")): string {
+        function typeToString(type: Type, enclosingDeclaration?: Node, flags: TypeFormatFlags = TypeFormatFlags.AllowUniqueESSymbolType, writer: EmitTextWriter = createTextWriter("")): string {
             const typeNode = nodeBuilder.typeToTypeNode(type, enclosingDeclaration, toNodeBuilderFlags(flags) | NodeBuilderFlags.IgnoreErrors, writer);
             Debug.assert(typeNode !== undefined, "should always get typenode");
             const options = { removeComments: true };

--- a/tests/baselines/reference/uniqueSymbolsErrors.errors.txt
+++ b/tests/baselines/reference/uniqueSymbolsErrors.errors.txt
@@ -58,7 +58,7 @@ tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(82,29): error 
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(82,45): error TS1335: 'unique symbol' types are not allowed here.
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(83,36): error TS1335: 'unique symbol' types are not allowed here.
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(83,52): error TS1335: 'unique symbol' types are not allowed here.
-tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(87,7): error TS2322: Type 'unique symbol' is not assignable to type 'string'.
+tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(87,7): error TS2322: Type 'typeof shouldNotBeAssignable' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts (61 errors) ====
@@ -270,4 +270,4 @@ tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(87,7): error T
     // https://github.com/Microsoft/TypeScript/issues/21584
     const shouldNotBeAssignable: string = Symbol();
           ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'unique symbol' is not assignable to type 'string'.
+!!! error TS2322: Type 'typeof shouldNotBeAssignable' is not assignable to type 'string'.

--- a/tests/baselines/reference/uniqueSymbolsErrors.errors.txt
+++ b/tests/baselines/reference/uniqueSymbolsErrors.errors.txt
@@ -58,7 +58,7 @@ tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(82,29): error 
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(82,45): error TS1335: 'unique symbol' types are not allowed here.
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(83,36): error TS1335: 'unique symbol' types are not allowed here.
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(83,52): error TS1335: 'unique symbol' types are not allowed here.
-tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(87,7): error TS2322: Type 'typeof shouldNotBeAssignable' is not assignable to type 'string'.
+tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(87,7): error TS2322: Type 'unique symbol' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts (61 errors) ====
@@ -270,4 +270,4 @@ tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts(87,7): error T
     // https://github.com/Microsoft/TypeScript/issues/21584
     const shouldNotBeAssignable: string = Symbol();
           ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'typeof shouldNotBeAssignable' is not assignable to type 'string'.
+!!! error TS2322: Type 'unique symbol' is not assignable to type 'string'.


### PR DESCRIPTION
A tests was added between when #21403 was opened and merged that is affected by it (and is now breaking our build). The output _seems_ fine.