### PR TITLE
Added --clearWatchOutput flag

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -63,6 +63,13 @@ namespace ts {
             description: Diagnostics.Stylize_errors_and_messages_using_color_and_context_experimental
         },
         {
+            name: "clearWatchOutput",
+            type: "boolean",
+            showInSimplifiedHelpView: false,
+            category: Diagnostics.Command_line_Options,
+            description: Diagnostics.Whether_to_clear_the_console_in_watch_mode_on_new_results,
+        },
+        {
             name: "watch",
             shortName: "w",
             type: "boolean",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3472,6 +3472,10 @@
         "category": "Message",
         "code": 6190
     },
+    "Whether to clear the console in watch mode on new results": {
+        "category": "Message",
+        "code": 6191
+    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4048,6 +4048,7 @@ namespace ts {
         baseUrl?: string;
         charset?: string;
         checkJs?: boolean;
+        /* @internal */ clearWatchOutput?: boolean;
         /* @internal */ configFilePath?: string;
         /** configFile is set as non enumerable property so as to avoid checking of json source files */
         /* @internal */ readonly configFile?: JsonSourceFile;

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -33,6 +33,7 @@ namespace ts {
 
     function clearScreenIfNotWatchingForFileChanges(system: System, diagnostic: Diagnostic, options: CompilerOptions) {
         if (system.clearScreen &&
+            options.clearWatchOutput &&
             diagnostic.code !== Diagnostics.Compilation_complete_Watching_for_file_changes.code &&
             !options.extendedDiagnostics &&
             !options.diagnostics) {

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -2161,8 +2161,9 @@ declare module "fs" {
         });
     });
 
+
     describe("tsc-watch console clearing", () => {
-        function checkConsoleClearing(diagnostics: boolean, extendedDiagnostics: boolean) {
+        function checkConsoleClearing(options: CompilerOptions = {}) {
             const file = {
                 path: "f.ts",
                 content: ""
@@ -2172,7 +2173,7 @@ declare module "fs" {
             let clearCount: number | undefined;
             checkConsoleClears();
 
-            createWatchOfFilesAndCompilerOptions([file.path], host, { diagnostics, extendedDiagnostics });
+            createWatchOfFilesAndCompilerOptions([file.path], host, options);
             checkConsoleClears();
 
             file.content = "//";
@@ -2182,10 +2183,10 @@ declare module "fs" {
             checkConsoleClears();
 
             function checkConsoleClears() {
-                if (clearCount === undefined) {
+                if (clearCount === undefined || !options.clearWatchOutput) {
                     clearCount = 0;
                 }
-                else if (!diagnostics && !extendedDiagnostics) {
+                else if (!options.diagnostics && !options.extendedDiagnostics) {
                     clearCount++;
                 }
                 host.checkScreenClears(clearCount);
@@ -2194,13 +2195,24 @@ declare module "fs" {
         }
 
         it("without --diagnostics or --extendedDiagnostics", () => {
-            checkConsoleClearing(/*diagnostics*/ false, /*extendedDiagnostics*/ false);
+            checkConsoleClearing({
+                clearWatchOutput: true,
+            });
         });
         it("with --diagnostics", () => {
-            checkConsoleClearing(/*diagnostics*/ true, /*extendedDiagnostics*/ false);
+            checkConsoleClearing({
+                clearWatchOutput: true,
+                diagnostics: true,
+            });
         });
         it("with --extendedDiagnostics", () => {
-            checkConsoleClearing(/*diagnostics*/ false, /*extendedDiagnostics*/ true);
+            checkConsoleClearing({
+                clearWatchOutput: true,
+                extendedDiagnostics: true,
+            });
+        });
+        it("without --clearWatchOutput", () => {
+            checkConsoleClearing();
         });
     });
 }


### PR DESCRIPTION
Makes the 2.7 behavior of clearing the console on recompiles opt-in.

Description: "Whether to clear the console in watch mode on new results."
Since the `pretty?` compiler options flag is marked as `@internal`, made this one too.

Sibling PR to #21303. IMO this is a better fix, as the added behavior of clearing the console has proven itself troublesome. 

Fixes #21295.