### PR TITLE
Fix #21617: Give detailed message on `for-of` of iterators without downlevelIteration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22316,13 +22316,18 @@ namespace ts {
                     // want to say that number is not an array type. But if the input was just
                     // number and string input is allowed, we want to say that number is not an
                     // array type or a string type.
+                    const isIterable = !!getIteratedTypeOfIterable(inputType, /* errorNode */ undefined, allowAsyncIterables, /*allowSyncIterables*/ true, checkAssignability);
                     const diagnostic = !allowStringInput || hasStringConstituent
                         ? downlevelIteration
                             ? Diagnostics.Type_0_is_not_an_array_type_or_does_not_have_a_Symbol_iterator_method_that_returns_an_iterator
-                            : Diagnostics.Type_0_is_not_an_array_type
+                            : isIterable
+                                ? Diagnostics.Type_0_is_not_an_array_type_Use_compiler_option_downlevelIteration_to_allow_iterating_of_iterators
+                                : Diagnostics.Type_0_is_not_an_array_type
                         : downlevelIteration
                             ? Diagnostics.Type_0_is_not_an_array_type_or_a_string_type_or_does_not_have_a_Symbol_iterator_method_that_returns_an_iterator
-                            : Diagnostics.Type_0_is_not_an_array_type_or_a_string_type;
+                            : isIterable
+                                ? Diagnostics.Type_0_is_not_an_array_type_or_a_string_type_Use_compiler_option_downlevelIteration_to_allow_iterating_of_iterators
+                                : Diagnostics.Type_0_is_not_an_array_type_or_a_string_type;
                     error(errorNode, diagnostic, typeToString(arrayType));
                 }
                 return hasStringConstituent ? stringType : undefined;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1988,6 +1988,14 @@
         "category": "Error",
         "code": 2567
     },
+    "Type '{0}' is not an array type. Use compiler option '--downlevelIteration' to allow iterating of iterators.": {
+        "category": "Error",
+        "code": 2568
+    },
+    "Type '{0}' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.": {
+        "category": "Error",
+        "code": 2569
+    },
 
     "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",

--- a/tests/baselines/reference/ES5For-ofTypeCheck10.errors.txt
+++ b/tests/baselines/reference/ES5For-ofTypeCheck10.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(9,6): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(14,15): error TS2495: Type 'StringIterator' is not an array type or a string type.
+tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(14,15): error TS2569: Type 'StringIterator' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.
 
 
 ==== tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts (2 errors) ====
@@ -20,4 +20,4 @@ tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(14,1
     
     for (var v of new StringIterator) { }
                   ~~~~~~~~~~~~~~~~~~
-!!! error TS2495: Type 'StringIterator' is not an array type or a string type.
+!!! error TS2569: Type 'StringIterator' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.

--- a/tests/baselines/reference/ES5For-ofTypeCheck13.errors.txt
+++ b/tests/baselines/reference/ES5For-ofTypeCheck13.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck13.ts(4,19): error TS2569: Type 'Set<string>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.
+
+
+==== tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck13.ts (1 errors) ====
+    const strSet: Set<string> = new Set()
+    strSet.add('Hello')
+    strSet.add('World')
+    for (const str of strSet) { }
+                      ~~~~~~
+!!! error TS2569: Type 'Set<string>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.

--- a/tests/baselines/reference/ES5For-ofTypeCheck13.js
+++ b/tests/baselines/reference/ES5For-ofTypeCheck13.js
@@ -1,0 +1,13 @@
+//// [ES5For-ofTypeCheck13.ts]
+const strSet: Set<string> = new Set()
+strSet.add('Hello')
+strSet.add('World')
+for (const str of strSet) { }
+
+//// [ES5For-ofTypeCheck13.js]
+var strSet = new Set();
+strSet.add('Hello');
+strSet.add('World');
+for (var _i = 0, strSet_1 = strSet; _i < strSet_1.length; _i++) {
+    var str = strSet_1[_i];
+}

--- a/tests/baselines/reference/ES5For-ofTypeCheck13.symbols
+++ b/tests/baselines/reference/ES5For-ofTypeCheck13.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck13.ts ===
+const strSet: Set<string> = new Set()
+>strSet : Symbol(strSet, Decl(ES5For-ofTypeCheck13.ts, 0, 5))
+>Set : Symbol(Set, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --))
+>Set : Symbol(Set, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --))
+
+strSet.add('Hello')
+>strSet.add : Symbol(Set.add, Decl(lib.es2015.collection.d.ts, --, --))
+>strSet : Symbol(strSet, Decl(ES5For-ofTypeCheck13.ts, 0, 5))
+>add : Symbol(Set.add, Decl(lib.es2015.collection.d.ts, --, --))
+
+strSet.add('World')
+>strSet.add : Symbol(Set.add, Decl(lib.es2015.collection.d.ts, --, --))
+>strSet : Symbol(strSet, Decl(ES5For-ofTypeCheck13.ts, 0, 5))
+>add : Symbol(Set.add, Decl(lib.es2015.collection.d.ts, --, --))
+
+for (const str of strSet) { }
+>str : Symbol(str, Decl(ES5For-ofTypeCheck13.ts, 3, 10))
+>strSet : Symbol(strSet, Decl(ES5For-ofTypeCheck13.ts, 0, 5))
+

--- a/tests/baselines/reference/ES5For-ofTypeCheck13.types
+++ b/tests/baselines/reference/ES5For-ofTypeCheck13.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck13.ts ===
+const strSet: Set<string> = new Set()
+>strSet : Set<string>
+>Set : Set<T>
+>new Set() : Set<any>
+>Set : SetConstructor
+
+strSet.add('Hello')
+>strSet.add('Hello') : Set<string>
+>strSet.add : (value: string) => Set<string>
+>strSet : Set<string>
+>add : (value: string) => Set<string>
+>'Hello' : "Hello"
+
+strSet.add('World')
+>strSet.add('World') : Set<string>
+>strSet.add : (value: string) => Set<string>
+>strSet : Set<string>
+>add : (value: string) => Set<string>
+>'World' : "World"
+
+for (const str of strSet) { }
+>str : any
+>strSet : Set<string>
+

--- a/tests/baselines/reference/ES5For-ofTypeCheck14.errors.txt
+++ b/tests/baselines/reference/ES5For-ofTypeCheck14.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts(2,17): error TS2568: Type 'Set<number>' is not an array type. Use compiler option '--downlevelIteration' to allow iterating of iterators.
+
+
+==== tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts (1 errors) ====
+    var union: string | Set<number>
+    for (const e of union) { }
+                    ~~~~~
+!!! error TS2568: Type 'Set<number>' is not an array type. Use compiler option '--downlevelIteration' to allow iterating of iterators.

--- a/tests/baselines/reference/ES5For-ofTypeCheck14.js
+++ b/tests/baselines/reference/ES5For-ofTypeCheck14.js
@@ -1,0 +1,9 @@
+//// [ES5For-ofTypeCheck14.ts]
+var union: string | Set<number>
+for (const e of union) { }
+
+//// [ES5For-ofTypeCheck14.js]
+var union;
+for (var _i = 0, union_1 = union; _i < union_1.length; _i++) {
+    var e = union_1[_i];
+}

--- a/tests/baselines/reference/ES5For-ofTypeCheck14.symbols
+++ b/tests/baselines/reference/ES5For-ofTypeCheck14.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts ===
+var union: string | Set<number>
+>union : Symbol(union, Decl(ES5For-ofTypeCheck14.ts, 0, 3))
+>Set : Symbol(Set, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --))
+
+for (const e of union) { }
+>e : Symbol(e, Decl(ES5For-ofTypeCheck14.ts, 1, 10))
+>union : Symbol(union, Decl(ES5For-ofTypeCheck14.ts, 0, 3))
+

--- a/tests/baselines/reference/ES5For-ofTypeCheck14.types
+++ b/tests/baselines/reference/ES5For-ofTypeCheck14.types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts ===
+var union: string | Set<number>
+>union : string | Set<number>
+>Set : Set<T>
+
+for (const e of union) { }
+>e : string
+>union : string | Set<number>
+

--- a/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck13.ts
+++ b/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck13.ts
@@ -1,0 +1,6 @@
+//@target: ES5
+//@lib: ES6
+const strSet: Set<string> = new Set()
+strSet.add('Hello')
+strSet.add('World')
+for (const str of strSet) { }

--- a/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts
+++ b/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts
@@ -1,0 +1,4 @@
+//@target: ES5
+//@lib: ES6
+var union: string | Set<number>
+for (const e of union) { }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #21617

Added a check whether the type that is attempted to be iterated is an Iterable.
If this is the case, the error message will propose the `--downlevelIteration` flag.
If this is not the case, the error message remains the same as before.

@weswigham @DanielRosenwasser 