### PR TITLE
Debug assert on parent rebind, mitigate circularity in symbol access checking

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -427,7 +427,12 @@ namespace ts {
             }
 
             addDeclarationToSymbol(symbol, node, includes);
-            symbol.parent = parent;
+            if (symbol.parent) {
+                Debug.assert(symbol.parent === parent, "Existing symbol parent should match new one");
+            }
+            else {
+                symbol.parent = parent;
+            }
 
             return symbol;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5445,7 +5445,12 @@ namespace ts {
                     }
 
                     addDeclarationToLateBoundSymbol(lateSymbol, decl, symbolFlags);
-                    lateSymbol.parent = parent;
+                    if (lateSymbol.parent) {
+                        Debug.assert(lateSymbol.parent === parent, "Existing symbol parent should match new one");
+                    }
+                    else {
+                        lateSymbol.parent = parent;
+                    }
                     return links.resolvedSymbol = lateSymbol;
                 }
             }


### PR DESCRIPTION
Ref #20808

I can't think of or find an actual test case to repro the telemetry issue, but by adding an assertion that parent pointers are never rebound to a different parent, the source of a crash if caused by bad binder behavior should be moved to somewhere where it should be possible to see what structure could produce such behavior. Additionally, by making a stackmap that is shared between recursive calls to `getAccessibleSymbolChain`, it should avoid ever running out of stack on a circular parent structure, as well (if for some reason something other than the binder is intentionally introducing one), since the visibility logic works fine in the presence of such a structure.
