### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,3 +23,4 @@ Jakefile.js
 .parallelperf.json
 test.config
 package-lock.json
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -15,8 +15,11 @@ tslint.json
 Jakefile.js
 .editorconfig
 .gitattributes
+.gitmodules
 .settings/
 .travis.yml
+.circleci
 .vscode/
+.parallelperf.json
 test.config
 package-lock.json


### PR DESCRIPTION
Ignore `.circleci` folder, `.gitmodules`, `.parallelperf.json` and 2.7.2 even contains `yarn.lock. These are useless for every consumer of the package.