### PR TITLE
Use single replacer for string escaping

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2466,7 +2466,6 @@ namespace ts {
     const singleQuoteEscapedCharsRegExp = /[\\\'\u0000-\u001f\t\v\f\b\r\n\u2028\u2029\u0085]/g;
     const backtickQuoteEscapedCharsRegExp = /[\\\`\u0000-\u001f\t\v\f\b\r\n\u2028\u2029\u0085]/g;
     const escapedCharsMap = createMapFromTemplate({
-        "\0": "\\0",
         "\t": "\\t",
         "\v": "\\v",
         "\f": "\\f",
@@ -2481,7 +2480,6 @@ namespace ts {
         "\u2029": "\\u2029", // paragraphSeparator
         "\u0085": "\\u0085"  // nextLine
     });
-    const escapedNullRegExp = /\\0[0-9]/g;
 
     /**
      * Based heavily on the abstract 'Quote'/'QuoteJSONString' operation from ECMA-262 (24.3.2.2),
@@ -2493,14 +2491,19 @@ namespace ts {
             quoteChar === CharacterCodes.backtick ? backtickQuoteEscapedCharsRegExp :
             quoteChar === CharacterCodes.singleQuote ? singleQuoteEscapedCharsRegExp :
             doubleQuoteEscapedCharsRegExp;
-        return s.replace(escapedCharsRegExp, getReplacement).replace(escapedNullRegExp, nullReplacement);
+        return s.replace(escapedCharsRegExp, getReplacement);
     }
 
-    function nullReplacement(c: string) {
-        return "\\x00" + c.charAt(c.length - 1);
-    }
-
-    function getReplacement(c: string) {
+    function getReplacement(c: string, offset: number, input: string) {
+        if (c.charCodeAt(0) === CharacterCodes.nullCharacter) {
+            const lookAhead = input.charCodeAt(offset + c.length);
+            if (lookAhead >= CharacterCodes._0 && lookAhead <= CharacterCodes._9) {
+                // If the null character is followed by digits, print as a hex escape to prevent the result from parsing as an octal (which is forbidden in strict mode)
+                return "\\x00";
+            }
+            // Otherwise, keep printing a literal \0 for the null character
+            return "\\0";
+        }
         return escapedCharsMap.get(c) || get16BitUnicodeEscapeSequence(c.charCodeAt(0));
     }
 

--- a/tests/baselines/reference/nonstrictTemplateWithNotOctalPrintsAsIs.js
+++ b/tests/baselines/reference/nonstrictTemplateWithNotOctalPrintsAsIs.js
@@ -1,0 +1,8 @@
+//// [nonstrictTemplateWithNotOctalPrintsAsIs.ts]
+// https://github.com/Microsoft/TypeScript/issues/21828
+const d2 = `\\0041`;
+
+
+//// [nonstrictTemplateWithNotOctalPrintsAsIs.js]
+// https://github.com/Microsoft/TypeScript/issues/21828
+var d2 = "\\0041";

--- a/tests/baselines/reference/nonstrictTemplateWithNotOctalPrintsAsIs.symbols
+++ b/tests/baselines/reference/nonstrictTemplateWithNotOctalPrintsAsIs.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21828
+const d2 = `\\0041`;
+>d2 : Symbol(d2, Decl(nonstrictTemplateWithNotOctalPrintsAsIs.ts, 1, 5))
+

--- a/tests/baselines/reference/nonstrictTemplateWithNotOctalPrintsAsIs.types
+++ b/tests/baselines/reference/nonstrictTemplateWithNotOctalPrintsAsIs.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts ===
+// https://github.com/Microsoft/TypeScript/issues/21828
+const d2 = `\\0041`;
+>d2 : "\\0041"
+>`\\0041` : "\\0041"
+

--- a/tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts
+++ b/tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts
@@ -1,0 +1,2 @@
+// https://github.com/Microsoft/TypeScript/issues/21828
+const d2 = `\\0041`;


### PR DESCRIPTION
The two-stage replacement was making non-null characters look like null chracters to the second replacer, which is no good. Now all the replacing is handled within one replacer, which also does the lookahead for potential octalyness conflicts.

Fixes #21828
