### PR TITLE
Create the action only if the text change creation is successful.

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2923,6 +2923,10 @@ Actual: ${stringify(fullActual)}`);
             if (!codeFixes.length) {
                 this.raiseError(`verifyCodeFixAvailable failed - expected code fixes but none found.`);
             }
+            codeFixes.forEach(fix => fix.changes.forEach(change => {
+                assert.isObject(change, `Invalid change in code fix: ${JSON.stringify(fix)}`);
+                change.textChanges.forEach(textChange => assert.isObject(textChange, `Invalid textChange in codeFix: ${JSON.stringify(fix)}`));
+            }));
             if (info) {
                 assert.equal(info.length, codeFixes.length);
                 ts.zipWith(codeFixes, info, (fix, info) => {

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -186,7 +186,8 @@ namespace ts.codefix {
     }
 
     function makeFix(declaration: Declaration, start: number, type: Type | undefined, program: Program): Fix | undefined {
-        return type && { declaration, textChanges: [makeChange(declaration, start, type, program)] };
+        const change = makeChange(declaration, start, type, program);
+        return change && { declaration, textChanges: [change] };
     }
 
     function makeChange(declaration: Declaration, start: number, type: Type | undefined, program: Program): TextChange | undefined {

--- a/tests/cases/fourslash/codeFixInferFromUsageSetterWithInaccessibleType.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageSetterWithInaccessibleType.ts
@@ -13,4 +13,4 @@
 ////}
 
 goTo.file("/b.ts");
-verify.codeFixAvailable();
+verify.not.codeFixAvailable();

--- a/tests/cases/fourslash/codeFixInferFromUsageSetterWithInaccessibleType.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageSetterWithInaccessibleType.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitAny: true
+
+// @Filename: /a.ts
+////export class D {}
+////export default new D();
+
+// @Filename: /b.ts
+////export class C {
+////    [|set x(val) {}|]
+////    method() { this.x = import("./a"); }
+////}
+
+goTo.file("/b.ts");
+verify.codeFixAvailable();


### PR DESCRIPTION
Make change for the infer type from usage could return undefined even if type is present if the type cannot be named
Fixes #22184