### PR TITLE
Set circle timeout to 5 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ workflows:
 base: &base
   environment:
     - workerCount: 4
+    - timeout: 400000
   steps:
     - checkout
     - run: |


### PR DESCRIPTION
This way when resources are in use (eg, at midnight when many cron jobs get run) the CI server is less likely to timeout due to resource starvation.

This is pretty much an analogue to the recent travis PR; it just doesn't happen as often on circle (seems like it's only happened while executing `user` tests during `cron`).
