### PR TITLE
WIP - Allow infer types in expression type argument positions

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1434,6 +1434,8 @@ namespace ts {
                     return ContainerFlags.IsContainer | ContainerFlags.HasLocals;
 
                 case SyntaxKind.ConditionalType:
+                case SyntaxKind.CallExpression:
+                case SyntaxKind.NewExpression:
                     return ContainerFlags.IsInferenceContainer;
 
                 case SyntaxKind.SourceFile:

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -414,6 +414,17 @@ namespace ts {
         array.length = 0;
     }
 
+    export function mapIndexless<T, U>(array: ReadonlyArray<T>, f: (x: T) => U): U[] {
+        let result: U[];
+        if (array) {
+            result = [];
+            for (const elem of array) {
+                result.push(f(elem));
+            }
+        }
+        return result;
+    }
+
     export function map<T, U>(array: ReadonlyArray<T>, f: (x: T, i: number) => U): U[] {
         let result: U[];
         if (array) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -947,7 +947,7 @@
         "category": "Error",
         "code": 1337
     },
-    "'infer' declarations are only permitted in the 'extends' clause of a conditional type.": {
+    "'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.": {
         "category": "Error",
         "code": 1338
     },

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3538,6 +3538,7 @@ namespace ts {
         /* @internal */
         ContainsAnyFunctionType = 1 << 26,  // Type is or contains the anyFunctionType
         NonPrimitive            = 1 << 27,  // intrinsic object type
+        InferType               = 1 << 28,  // A type whose concrete value upon instantiation will be inferred at a given site
         /* @internal */
         GenericMappedType       = 1 << 29,  // Flag used by maybeTypeOfKind
 
@@ -3562,7 +3563,7 @@ namespace ts {
         ESSymbolLike = ESSymbol | UniqueESSymbol,
         UnionOrIntersection = Union | Intersection,
         StructuredType = Object | Union | Intersection,
-        TypeVariable = TypeParameter | IndexedAccess,
+        TypeVariable = TypeParameter | IndexedAccess | InferType,
         InstantiableNonPrimitive = TypeVariable | Conditional | Substitution,
         InstantiablePrimitive = Index,
         Instantiable = InstantiableNonPrimitive | InstantiablePrimitive,
@@ -3817,6 +3818,11 @@ namespace ts {
         resolvedDefaultType?: Type;
     }
 
+    // Infer Types (TypeFlags.InferType)
+    export interface InferType extends Type {
+        target: TypeParameter;
+    }
+
     // Indexed access types (TypeFlags.IndexedAccess)
     // Possible forms are T[xxx], xxx[T], or xxx[keyof T], where T is a type variable
     export interface IndexedAccessType extends InstantiableType {
@@ -3919,7 +3925,7 @@ namespace ts {
     }
 
     /* @internal */
-    export type TypeMapper = (t: TypeParameter) => Type;
+    export type TypeMapper = (t: TypeParameter, isInferDeclaration?: boolean) => Type;
 
     export const enum InferencePriority {
         NakedTypeVariable           = 1 << 0,  // Naked type variable in union or intersection type

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3925,7 +3925,7 @@ namespace ts {
     }
 
     /* @internal */
-    export type TypeMapper = (t: TypeParameter, isInferDeclaration?: boolean) => Type;
+    export type TypeMapper = (t: TypeParameter) => Type;
 
     export const enum InferencePriority {
         NakedTypeVariable           = 1 << 0,  // Naked type variable in union or intersection type

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2074,6 +2074,7 @@ declare namespace ts {
         Conditional = 2097152,
         Substitution = 4194304,
         NonPrimitive = 134217728,
+        InferType = 268435456,
         Literal = 224,
         Unit = 13536,
         StringOrNumberLiteral = 96,
@@ -2085,12 +2086,12 @@ declare namespace ts {
         ESSymbolLike = 1536,
         UnionOrIntersection = 393216,
         StructuredType = 458752,
-        TypeVariable = 1081344,
-        InstantiableNonPrimitive = 7372800,
+        TypeVariable = 269516800,
+        InstantiableNonPrimitive = 275808256,
         InstantiablePrimitive = 524288,
-        Instantiable = 7897088,
-        StructuredOrInstantiable = 8355840,
-        Narrowable = 142575359,
+        Instantiable = 276332544,
+        StructuredOrInstantiable = 276791296,
+        Narrowable = 411010815,
         NotUnionOrUnit = 134283777,
     }
     type DestructuringPattern = BindingPattern | ObjectLiteralExpression | ArrayLiteralExpression;
@@ -2183,6 +2184,9 @@ declare namespace ts {
     interface InstantiableType extends Type {
     }
     interface TypeParameter extends InstantiableType {
+    }
+    interface InferType extends Type {
+        target: TypeParameter;
     }
     interface IndexedAccessType extends InstantiableType {
         objectType: Type;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2074,6 +2074,7 @@ declare namespace ts {
         Conditional = 2097152,
         Substitution = 4194304,
         NonPrimitive = 134217728,
+        InferType = 268435456,
         Literal = 224,
         Unit = 13536,
         StringOrNumberLiteral = 96,
@@ -2085,12 +2086,12 @@ declare namespace ts {
         ESSymbolLike = 1536,
         UnionOrIntersection = 393216,
         StructuredType = 458752,
-        TypeVariable = 1081344,
-        InstantiableNonPrimitive = 7372800,
+        TypeVariable = 269516800,
+        InstantiableNonPrimitive = 275808256,
         InstantiablePrimitive = 524288,
-        Instantiable = 7897088,
-        StructuredOrInstantiable = 8355840,
-        Narrowable = 142575359,
+        Instantiable = 276332544,
+        StructuredOrInstantiable = 276791296,
+        Narrowable = 411010815,
         NotUnionOrUnit = 134283777,
     }
     type DestructuringPattern = BindingPattern | ObjectLiteralExpression | ArrayLiteralExpression;
@@ -2183,6 +2184,9 @@ declare namespace ts {
     interface InstantiableType extends Type {
     }
     interface TypeParameter extends InstantiableType {
+    }
+    interface InferType extends Type {
+        target: TypeParameter;
     }
     interface IndexedAccessType extends InstantiableType {
         objectType: Type;

--- a/tests/baselines/reference/inferTypeArgumentKeyword.errors.txt
+++ b/tests/baselines/reference/inferTypeArgumentKeyword.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts(7,51): error TS2345: Argument of type '{ z: number; }' is not assignable to parameter of type '{ z: { y: number; }; }'.
+  Types of property 'z' are incompatible.
+    Type 'number' is not assignable to type '{ y: number; }'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts(10,30): error TS2345: Argument of type '{ y: number; }' is not assignable to parameter of type 'number'.
+
+
+==== tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts (2 errors) ====
+    declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
+    
+    // good
+    foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+    
+    // error on 3rd arg
+    foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+                                                      ~~~~~~~
+!!! error TS2345: Argument of type '{ z: number; }' is not assignable to parameter of type '{ z: { y: number; }; }'.
+!!! error TS2345:   Types of property 'z' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type '{ y: number; }'.
+    
+    // error on first arg
+    foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+                                 ~~~~~~~
+!!! error TS2345: Argument of type '{ y: number; }' is not assignable to parameter of type 'number'.
+    

--- a/tests/baselines/reference/inferTypeArgumentKeyword.errors.txt
+++ b/tests/baselines/reference/inferTypeArgumentKeyword.errors.txt
@@ -1,24 +1,50 @@
-tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts(7,51): error TS2345: Argument of type '{ z: number; }' is not assignable to parameter of type '{ z: { y: number; }; }'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts(7,59): error TS2345: Argument of type '{ z: number; }' is not assignable to parameter of type '{ z: { y: number; }; }'.
   Types of property 'z' are incompatible.
     Type 'number' is not assignable to type '{ y: number; }'.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts(10,30): error TS2345: Argument of type '{ y: number; }' is not assignable to parameter of type 'number'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts(10,38): error TS2345: Argument of type '{ y: number; }' is not assignable to parameter of type 'number'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts(17,63): error TS2345: Argument of type '{ z: string; }' is not assignable to parameter of type '{ z: number; }'.
+  Types of property 'z' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts(23,47): error TS2345: Argument of type '{ y: string; }' is not assignable to parameter of type '{ y: number; }'.
+  Types of property 'y' are incompatible.
+    Type 'string' is not assignable to type 'number'.
 
 
-==== tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts (2 errors) ====
+==== tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts (4 errors) ====
     declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
     
     // good
-    foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+    var a = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
     
     // error on 3rd arg
-    foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
-                                                      ~~~~~~~
+    var b = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+                                                              ~~~~~~~
 !!! error TS2345: Argument of type '{ z: number; }' is not assignable to parameter of type '{ z: { y: number; }; }'.
 !!! error TS2345:   Types of property 'z' are incompatible.
 !!! error TS2345:     Type 'number' is not assignable to type '{ y: number; }'.
     
     // error on first arg
-    foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
-                                 ~~~~~~~
+    var c = foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+                                         ~~~~~~~
 !!! error TS2345: Argument of type '{ y: number; }' is not assignable to parameter of type 'number'.
     
+    type Ob<T> = {y: T};
+    // good
+    var d = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+    
+    // error on 3rd arg
+    var e = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: "no"});
+                                                                  ~~~~~~~~~
+!!! error TS2345: Argument of type '{ z: string; }' is not assignable to parameter of type '{ z: number; }'.
+!!! error TS2345:   Types of property 'z' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    
+    // good
+    var e = foo<{y: A}, {x: string}, Ob<infer A>>({y: 12}, {x: "yes"}, {z: { y: 12 }});
+    
+    // error on 1st arg
+    var f = foo<{y: A}, {x: string}, Ob<infer A>>({y: "no"}, {x: "yes"}, {z: { y: 12 }});
+                                                  ~~~~~~~~~
+!!! error TS2345: Argument of type '{ y: string; }' is not assignable to parameter of type '{ y: number; }'.
+!!! error TS2345:   Types of property 'y' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/inferTypeArgumentKeyword.js
+++ b/tests/baselines/reference/inferTypeArgumentKeyword.js
@@ -2,19 +2,39 @@
 declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
 
 // good
-foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+var a = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
 
 // error on 3rd arg
-foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+var b = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
 
 // error on first arg
-foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+var c = foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
 
+type Ob<T> = {y: T};
+// good
+var d = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+
+// error on 3rd arg
+var e = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: "no"});
+
+// good
+var e = foo<{y: A}, {x: string}, Ob<infer A>>({y: 12}, {x: "yes"}, {z: { y: 12 }});
+
+// error on 1st arg
+var f = foo<{y: A}, {x: string}, Ob<infer A>>({y: "no"}, {x: "yes"}, {z: { y: 12 }});
 
 //// [inferTypeArgumentKeyword.js]
 // good
-foo({ y: 12 }, { x: "yes" }, { z: { y: 12 } });
+var a = foo({ y: 12 }, { x: "yes" }, { z: { y: 12 } });
 // error on 3rd arg
-foo({ y: 12 }, { x: "yes" }, { z: 12 });
+var b = foo({ y: 12 }, { x: "yes" }, { z: 12 });
 // error on first arg
-foo({ y: 12 }, { x: "yes" }, { z: 12 });
+var c = foo({ y: 12 }, { x: "yes" }, { z: 12 });
+// good
+var d = foo({ y: 12 }, { x: "yes" }, { z: 12 });
+// error on 3rd arg
+var e = foo({ y: 12 }, { x: "yes" }, { z: "no" });
+// good
+var e = foo({ y: 12 }, { x: "yes" }, { z: { y: 12 } });
+// error on 1st arg
+var f = foo({ y: "no" }, { x: "yes" }, { z: { y: 12 } });

--- a/tests/baselines/reference/inferTypeArgumentKeyword.js
+++ b/tests/baselines/reference/inferTypeArgumentKeyword.js
@@ -1,0 +1,20 @@
+//// [inferTypeArgumentKeyword.ts]
+declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
+
+// good
+foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+
+// error on 3rd arg
+foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+
+// error on first arg
+foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+
+
+//// [inferTypeArgumentKeyword.js]
+// good
+foo({ y: 12 }, { x: "yes" }, { z: { y: 12 } });
+// error on 3rd arg
+foo({ y: 12 }, { x: "yes" }, { z: 12 });
+// error on first arg
+foo({ y: 12 }, { x: "yes" }, { z: 12 });

--- a/tests/baselines/reference/inferTypeArgumentKeyword.symbols
+++ b/tests/baselines/reference/inferTypeArgumentKeyword.symbols
@@ -1,0 +1,48 @@
+=== tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts ===
+declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
+>foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 0, 21))
+>B : Symbol(B, Decl(inferTypeArgumentKeyword.ts, 0, 23))
+>C : Symbol(C, Decl(inferTypeArgumentKeyword.ts, 0, 26))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 0, 30))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 0, 21))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 0, 35))
+>B : Symbol(B, Decl(inferTypeArgumentKeyword.ts, 0, 23))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 0, 41))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 0, 46))
+>C : Symbol(C, Decl(inferTypeArgumentKeyword.ts, 0, 26))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 0, 21))
+>B : Symbol(B, Decl(inferTypeArgumentKeyword.ts, 0, 23))
+>C : Symbol(C, Decl(inferTypeArgumentKeyword.ts, 0, 26))
+
+// good
+foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+>foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 3, 9))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 3, 14))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 3, 9))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 3, 30))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 3, 39))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 3, 51))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 3, 55))
+
+// error on 3rd arg
+foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+>foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 6, 9))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 6, 14))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 6, 9))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 6, 30))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 6, 39))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 6, 51))
+
+// error on first arg
+foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+>foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 9, 25))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 9, 8))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 9, 25))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 9, 30))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 9, 39))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 9, 51))
+

--- a/tests/baselines/reference/inferTypeArgumentKeyword.symbols
+++ b/tests/baselines/reference/inferTypeArgumentKeyword.symbols
@@ -16,33 +16,94 @@ declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
 >C : Symbol(C, Decl(inferTypeArgumentKeyword.ts, 0, 26))
 
 // good
-foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+var a = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+>a : Symbol(a, Decl(inferTypeArgumentKeyword.ts, 3, 3))
 >foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
->A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 3, 9))
->x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 3, 14))
->A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 3, 9))
->y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 3, 30))
->x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 3, 39))
->z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 3, 51))
->y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 3, 55))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 3, 17))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 3, 22))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 3, 17))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 3, 38))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 3, 47))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 3, 59))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 3, 63))
 
 // error on 3rd arg
-foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+var b = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+>b : Symbol(b, Decl(inferTypeArgumentKeyword.ts, 6, 3))
 >foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
->A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 6, 9))
->x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 6, 14))
->A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 6, 9))
->y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 6, 30))
->x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 6, 39))
->z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 6, 51))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 6, 17))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 6, 22))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 6, 17))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 6, 38))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 6, 47))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 6, 59))
 
 // error on first arg
-foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+var c = foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+>c : Symbol(c, Decl(inferTypeArgumentKeyword.ts, 9, 3))
 >foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
->A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 9, 25))
->x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 9, 8))
->A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 9, 25))
->y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 9, 30))
->x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 9, 39))
->z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 9, 51))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 9, 33))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 9, 16))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 9, 33))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 9, 38))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 9, 47))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 9, 59))
+
+type Ob<T> = {y: T};
+>Ob : Symbol(Ob, Decl(inferTypeArgumentKeyword.ts, 9, 67))
+>T : Symbol(T, Decl(inferTypeArgumentKeyword.ts, 11, 8))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 11, 14))
+>T : Symbol(T, Decl(inferTypeArgumentKeyword.ts, 11, 8))
+
+// good
+var d = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+>d : Symbol(d, Decl(inferTypeArgumentKeyword.ts, 13, 3))
+>foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
+>Ob : Symbol(Ob, Decl(inferTypeArgumentKeyword.ts, 9, 67))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 13, 20))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 13, 26))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 13, 20))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 13, 42))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 13, 51))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 13, 63))
+
+// error on 3rd arg
+var e = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: "no"});
+>e : Symbol(e, Decl(inferTypeArgumentKeyword.ts, 16, 3), Decl(inferTypeArgumentKeyword.ts, 19, 3))
+>foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
+>Ob : Symbol(Ob, Decl(inferTypeArgumentKeyword.ts, 9, 67))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 16, 20))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 16, 26))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 16, 20))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 16, 42))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 16, 51))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 16, 63))
+
+// good
+var e = foo<{y: A}, {x: string}, Ob<infer A>>({y: 12}, {x: "yes"}, {z: { y: 12 }});
+>e : Symbol(e, Decl(inferTypeArgumentKeyword.ts, 16, 3), Decl(inferTypeArgumentKeyword.ts, 19, 3))
+>foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 19, 13))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 19, 41))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 19, 21))
+>Ob : Symbol(Ob, Decl(inferTypeArgumentKeyword.ts, 9, 67))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 19, 41))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 19, 47))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 19, 56))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 19, 68))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 19, 72))
+
+// error on 1st arg
+var f = foo<{y: A}, {x: string}, Ob<infer A>>({y: "no"}, {x: "yes"}, {z: { y: 12 }});
+>f : Symbol(f, Decl(inferTypeArgumentKeyword.ts, 22, 3))
+>foo : Symbol(foo, Decl(inferTypeArgumentKeyword.ts, 0, 0))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 22, 13))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 22, 41))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 22, 21))
+>Ob : Symbol(Ob, Decl(inferTypeArgumentKeyword.ts, 9, 67))
+>A : Symbol(A, Decl(inferTypeArgumentKeyword.ts, 22, 41))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 22, 47))
+>x : Symbol(x, Decl(inferTypeArgumentKeyword.ts, 22, 58))
+>z : Symbol(z, Decl(inferTypeArgumentKeyword.ts, 22, 70))
+>y : Symbol(y, Decl(inferTypeArgumentKeyword.ts, 22, 74))
 

--- a/tests/baselines/reference/inferTypeArgumentKeyword.types
+++ b/tests/baselines/reference/inferTypeArgumentKeyword.types
@@ -1,0 +1,70 @@
+=== tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts ===
+declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
+>foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
+>A : A
+>B : B
+>C : C
+>x : A
+>A : A
+>y : B
+>B : B
+>z : { z: C; }
+>z : C
+>C : C
+>A : A
+>B : B
+>C : C
+
+// good
+foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+>foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}}) : { y: number; } & { x: string; }
+>foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
+>A : A
+>x : string
+>A : A
+>{y: 12} : { y: number; }
+>y : number
+>12 : 12
+>{x: "yes"} : { x: string; }
+>x : string
+>"yes" : "yes"
+>{z: {y: 12}} : { z: { y: number; }; }
+>z : { y: number; }
+>{y: 12} : { y: number; }
+>y : number
+>12 : 12
+
+// error on 3rd arg
+foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+>foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12}) : any
+>foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
+>A : A
+>x : string
+>A : A
+>{y: 12} : { y: number; }
+>y : number
+>12 : 12
+>{x: "yes"} : { x: string; }
+>x : string
+>"yes" : "yes"
+>{z: 12} : { z: number; }
+>z : number
+>12 : 12
+
+// error on first arg
+foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+>foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12}) : any
+>foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
+>A : A
+>x : string
+>A : A
+>{y: 12} : { y: number; }
+>y : number
+>12 : 12
+>{x: "yes"} : { x: string; }
+>x : string
+>"yes" : "yes"
+>{z: 12} : { z: number; }
+>z : number
+>12 : 12
+

--- a/tests/baselines/reference/inferTypeArgumentKeyword.types
+++ b/tests/baselines/reference/inferTypeArgumentKeyword.types
@@ -16,7 +16,8 @@ declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
 >C : C
 
 // good
-foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+var a = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+>a : { y: number; } & { x: string; }
 >foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}}) : { y: number; } & { x: string; }
 >foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
 >A : A
@@ -35,7 +36,8 @@ foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
 >12 : 12
 
 // error on 3rd arg
-foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+var b = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+>b : any
 >foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12}) : any
 >foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
 >A : A
@@ -52,7 +54,8 @@ foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
 >12 : 12
 
 // error on first arg
-foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+var c = foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+>c : any
 >foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12}) : any
 >foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
 >A : A
@@ -66,5 +69,93 @@ foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
 >"yes" : "yes"
 >{z: 12} : { z: number; }
 >z : number
+>12 : 12
+
+type Ob<T> = {y: T};
+>Ob : Ob<T>
+>T : T
+>y : T
+>T : T
+
+// good
+var d = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+>d : Ob<number> & { x: string; } & number
+>foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12}) : Ob<number> & { x: string; } & number
+>foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
+>Ob : Ob<T>
+>A : A
+>x : string
+>A : A
+>{y: 12} : { y: number; }
+>y : number
+>12 : 12
+>{x: "yes"} : { x: string; }
+>x : string
+>"yes" : "yes"
+>{z: 12} : { z: number; }
+>z : number
+>12 : 12
+
+// error on 3rd arg
+var e = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: "no"});
+>e : any
+>foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: "no"}) : any
+>foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
+>Ob : Ob<T>
+>A : A
+>x : string
+>A : A
+>{y: 12} : { y: number; }
+>y : number
+>12 : 12
+>{x: "yes"} : { x: string; }
+>x : string
+>"yes" : "yes"
+>{z: "no"} : { z: string; }
+>z : string
+>"no" : "no"
+
+// good
+var e = foo<{y: A}, {x: string}, Ob<infer A>>({y: 12}, {x: "yes"}, {z: { y: 12 }});
+>e : any
+>foo<{y: A}, {x: string}, Ob<infer A>>({y: 12}, {x: "yes"}, {z: { y: 12 }}) : { y: number; } & { x: string; } & Ob<number>
+>foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
+>y : A
+>A : A
+>x : string
+>Ob : Ob<T>
+>A : A
+>{y: 12} : { y: number; }
+>y : number
+>12 : 12
+>{x: "yes"} : { x: string; }
+>x : string
+>"yes" : "yes"
+>{z: { y: 12 }} : { z: { y: number; }; }
+>z : { y: number; }
+>{ y: 12 } : { y: number; }
+>y : number
+>12 : 12
+
+// error on 1st arg
+var f = foo<{y: A}, {x: string}, Ob<infer A>>({y: "no"}, {x: "yes"}, {z: { y: 12 }});
+>f : any
+>foo<{y: A}, {x: string}, Ob<infer A>>({y: "no"}, {x: "yes"}, {z: { y: 12 }}) : any
+>foo : <A, B, C>(x: A, y: B, z: { z: C; }) => A & B & C
+>y : A
+>A : A
+>x : string
+>Ob : Ob<T>
+>A : A
+>{y: "no"} : { y: string; }
+>y : string
+>"no" : "no"
+>{x: "yes"} : { x: string; }
+>x : string
+>"yes" : "yes"
+>{z: { y: 12 }} : { z: { y: number; }; }
+>z : { y: number; }
+>{ y: 12 } : { y: number; }
+>y : number
 >12 : 12
 

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -7,10 +7,10 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(38,25): error TS2344: T
 tests/cases/conformance/types/conditional/inferTypes1.ts(46,25): error TS2344: Type '(x: string, y: string) => number' does not satisfy the constraint '(x: any) => any'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(47,25): error TS2344: Type 'Function' does not satisfy the constraint '(x: any) => any'.
   Type 'Function' provides no match for the signature '(x: any): any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(73,12): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
-tests/cases/conformance/types/conditional/inferTypes1.ts(74,15): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
-tests/cases/conformance/types/conditional/inferTypes1.ts(74,41): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
-tests/cases/conformance/types/conditional/inferTypes1.ts(74,51): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+tests/cases/conformance/types/conditional/inferTypes1.ts(73,12): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.
+tests/cases/conformance/types/conditional/inferTypes1.ts(74,15): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.
+tests/cases/conformance/types/conditional/inferTypes1.ts(74,41): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.
+tests/cases/conformance/types/conditional/inferTypes1.ts(74,51): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.
 tests/cases/conformance/types/conditional/inferTypes1.ts(75,15): error TS2304: Cannot find name 'U'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(75,15): error TS4081: Exported type alias 'T62' has or is using private name 'U'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(75,43): error TS2304: Cannot find name 'U'.
@@ -110,14 +110,14 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(143,40): error TS2322: 
     
     type T60 = infer U;  // Error
                ~~~~~~~
-!!! error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+!!! error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.
     type T61<T> = infer A extends infer B ? infer C : infer D;  // Error
                   ~~~~~~~
-!!! error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+!!! error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.
                                             ~~~~~~~
-!!! error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+!!! error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.
                                                       ~~~~~~~
-!!! error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
+!!! error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type or in call or new expression type argument lists.
     type T62<T> = U extends (infer U)[] ? U : U;  // Error
                   ~
 !!! error TS2304: Cannot find name 'U'.

--- a/tests/baselines/reference/inferTypes1.types
+++ b/tests/baselines/reference/inferTypes1.types
@@ -150,7 +150,7 @@ type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A
 >T : T
 >x : any
 >T : T
->a : A
+>a : infer A
 >A : A
 >A : A
 
@@ -198,9 +198,9 @@ type X1<T extends { x: any, y: any }> = T extends { x: infer X, y: infer Y } ? [
 >x : any
 >y : any
 >T : T
->x : X
+>x : infer X
 >X : X
->y : Y
+>y : infer Y
 >Y : Y
 >X : X
 >Y : Y
@@ -228,9 +228,9 @@ type X2<T> = T extends { a: infer U, b: infer U } ? U : never;
 >X2 : X2<T>
 >T : T
 >T : T
->a : U
+>a : infer U
 >U : U
->b : U
+>b : infer U
 >U : U
 >U : U
 
@@ -266,11 +266,11 @@ type X3<T> = T extends { a: (x: infer U) => void, b: (x: infer U) => void } ? U 
 >X3 : X3<T>
 >T : T
 >T : T
->a : (x: U) => void
->x : U
+>a : (x: infer U) => void
+>x : infer U
 >U : U
->b : (x: U) => void
->x : U
+>b : (x: infer U) => void
+>x : infer U
 >U : U
 >U : U
 
@@ -308,11 +308,11 @@ type T54 = X3<{ a: (x: number) => void, b: () => void }>;  // number
 >b : () => void
 
 type T60 = infer U;  // Error
->T60 : U
+>T60 : infer U
 >U : U
 
 type T61<T> = infer A extends infer B ? infer C : infer D;  // Error
->T61 : T61<T>
+>T61 : {}
 >T : T
 >A : A
 >B : B
@@ -478,7 +478,7 @@ type Jsonified<T> =
 
     : T extends { toJSON(): infer R } ? R // toJSON is called if it exists (e.g. Date)
 >T : T
->toJSON : () => R
+>toJSON : () => infer R
 >R : R
 >R : R
 

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts
@@ -1,10 +1,13 @@
 declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
 
 // good
-foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+var a = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
 
 // error on 3rd arg
-foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+var b = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
 
 // error on first arg
-foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+var c = foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
+
+// good
+var d = foo<{y: infer A}, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts
@@ -9,5 +9,15 @@ var b = foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
 // error on first arg
 var c = foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});
 
+type Ob<T> = {y: T};
 // good
-var d = foo<{y: infer A}, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+var d = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+
+// error on 3rd arg
+var e = foo<Ob<infer A>, {x: string}, A>({y: 12}, {x: "yes"}, {z: "no"});
+
+// good
+var e = foo<{y: A}, {x: string}, Ob<infer A>>({y: 12}, {x: "yes"}, {z: { y: 12 }});
+
+// error on 1st arg
+var f = foo<{y: A}, {x: string}, Ob<infer A>>({y: "no"}, {x: "yes"}, {z: { y: 12 }});

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/inferTypeArgumentKeyword.ts
@@ -1,0 +1,10 @@
+declare function foo<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;
+
+// good
+foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
+
+// error on 3rd arg
+foo<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: 12});
+
+// error on first arg
+foo<A, {x: string}, infer A>({y: 12}, {x: "yes"}, {z: 12});


### PR DESCRIPTION
This allows you to write `infer T` anywhere in the types inside a call or new expression argument list and have that position inferred. Additionally, the same `T` may be referenced elsewhere in the arguments and be reused as may be expected (with only the `infer`'d declaration as sole inference site), since type parameters are able to reference one another, so, too, would be the expectation of arguments:

```ts
declare function merge<A, B, C>(x: A, y: B, z: { z: C }): A & B & C;

const result = merge<infer A, {x: string}, A>({y: 12}, {x: "yes"}, {z: {y: 12}});
```

Enables #10571

If this is too complex a feature (though it's really neat, since you can infer one argument (or just part of one!) while also locking another argument into a corresponding shape), it's possible to either scale back to, or in addition to this, allow omitted type parameters to implicitly be an `infer`'d type that works similarly to still enable #10571. In any case, I'd like to discuss this direction.

Incidentally, I believe this fixes #21836.