### PR TITLE
Handle resolving and unknown symbols in getLiteralTypeFromPropertyName

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8014,7 +8014,7 @@ namespace ts {
         function getLiteralTypeFromPropertyName(prop: Symbol) {
             const links = getSymbolLinks(getLateBoundSymbol(prop));
             if (!links.nameType) {
-                if (links.target) {
+                if (links.target && links.target !== unknownSymbol && links.target !== resolvingSymbol) {
                     Debug.assert(links.target.escapedName === prop.escapedName || links.target.escapedName === InternalSymbolName.Computed, "Target symbol and symbol do not have the same name");
                     links.nameType = getLiteralTypeFromPropertyName(links.target);
                 }

--- a/tests/baselines/reference/literalTypeNameAssertionNotTriggered.errors.txt
+++ b/tests/baselines/reference/literalTypeNameAssertionNotTriggered.errors.txt
@@ -1,0 +1,17 @@
+/a.ts(1,20): error TS2307: Cannot find module 'something'.
+/b.ts(3,6): error TS2345: Argument of type '""' is not assignable to parameter of type '"x"'.
+
+
+==== /b.ts (1 errors) ====
+    import a = require('./a');
+    declare function f<T>(obj: T, key: keyof T): void;
+    f(a, "");
+         ~~
+!!! error TS2345: Argument of type '""' is not assignable to parameter of type '"x"'.
+    
+==== /a.ts (1 errors) ====
+    import x = require("something");
+                       ~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'something'.
+    export { x };
+    

--- a/tests/baselines/reference/literalTypeNameAssertionNotTriggered.js
+++ b/tests/baselines/reference/literalTypeNameAssertionNotTriggered.js
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/literalTypeNameAssertionNotTriggered.ts] ////
+
+//// [a.ts]
+import x = require("something");
+export { x };
+
+//// [b.ts]
+import a = require('./a');
+declare function f<T>(obj: T, key: keyof T): void;
+f(a, "");
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+var x = require("something");
+exports.x = x;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+var a = require("./a");
+f(a, "");

--- a/tests/baselines/reference/literalTypeNameAssertionNotTriggered.symbols
+++ b/tests/baselines/reference/literalTypeNameAssertionNotTriggered.symbols
@@ -1,0 +1,23 @@
+=== /b.ts ===
+import a = require('./a');
+>a : Symbol(a, Decl(b.ts, 0, 0))
+
+declare function f<T>(obj: T, key: keyof T): void;
+>f : Symbol(f, Decl(b.ts, 0, 26))
+>T : Symbol(T, Decl(b.ts, 1, 19))
+>obj : Symbol(obj, Decl(b.ts, 1, 22))
+>T : Symbol(T, Decl(b.ts, 1, 19))
+>key : Symbol(key, Decl(b.ts, 1, 29))
+>T : Symbol(T, Decl(b.ts, 1, 19))
+
+f(a, "");
+>f : Symbol(f, Decl(b.ts, 0, 26))
+>a : Symbol(a, Decl(b.ts, 0, 0))
+
+=== /a.ts ===
+import x = require("something");
+>x : Symbol(x, Decl(a.ts, 0, 0))
+
+export { x };
+>x : Symbol(x, Decl(a.ts, 1, 8))
+

--- a/tests/baselines/reference/literalTypeNameAssertionNotTriggered.types
+++ b/tests/baselines/reference/literalTypeNameAssertionNotTriggered.types
@@ -1,0 +1,25 @@
+=== /b.ts ===
+import a = require('./a');
+>a : typeof a
+
+declare function f<T>(obj: T, key: keyof T): void;
+>f : <T>(obj: T, key: keyof T) => void
+>T : T
+>obj : T
+>T : T
+>key : keyof T
+>T : T
+
+f(a, "");
+>f(a, "") : any
+>f : <T>(obj: T, key: keyof T) => void
+>a : typeof a
+>"" : ""
+
+=== /a.ts ===
+import x = require("something");
+>x : any
+
+export { x };
+>x : any
+

--- a/tests/cases/compiler/literalTypeNameAssertionNotTriggered.ts
+++ b/tests/cases/compiler/literalTypeNameAssertionNotTriggered.ts
@@ -1,0 +1,8 @@
+// @Filename: /a.ts
+import x = require("something");
+export { x };
+
+// @Filename: /b.ts
+import a = require('./a');
+declare function f<T>(obj: T, key: keyof T): void;
+f(a, "");


### PR DESCRIPTION
These are set to be a symbol's target when an alias can't be resolved or is resolving, and, ofc, have differing names than the symbol targeting them (meaning there can't be a cached name on the target anyway, since the symbol is shared across many possible names).

Fixes #22403
