### PR TITLE
Allow for concurrent directory creation in nodeSystem.createDirectory()

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -558,7 +558,14 @@ namespace ts {
                 directoryExists,
                 createDirectory(directoryName: string) {
                     if (!nodeSystem.directoryExists(directoryName)) {
-                        _fs.mkdirSync(directoryName);
+                        try {
+                            _fs.mkdirSync(directoryName);
+                        }
+                        catch (e) {
+                            if (e.code !== "EEXIST") {
+                                throw e;
+                            }
+                        }
                     }
                 },
                 getExecutingFilePath() {


### PR DESCRIPTION
Don't fail if directory is created during function invocation

Fixes #22423

There are no additional tests, because the nature of the bug is significantly different than what the test framework allows for (and by its nature, the bug is sporadic).