### PR TITLE
Fix crash after `var = require('x')` type resolution

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2051,6 +2051,7 @@ namespace ts {
                     }
                     if (namespace.valueDeclaration &&
                         isVariableDeclaration(namespace.valueDeclaration) &&
+                        namespace.valueDeclaration.initializer &&
                         isCommonJsRequire(namespace.valueDeclaration.initializer)) {
                         const moduleName = (namespace.valueDeclaration.initializer as CallExpression).arguments[0] as StringLiteral;
                         const moduleSym = resolveExternalModuleName(moduleName, moduleName);

--- a/tests/baselines/reference/user/chrome-devtools-frontend.log
+++ b/tests/baselines/reference/user/chrome-devtools-frontend.log
@@ -1,20 +1,24 @@
 Exit Code: 1
 Standard output:
-../../../../built/local/lib.dom.d.ts(2255,11): error TS2300: Duplicate identifier 'CSSRule'.
-../../../../built/local/lib.dom.d.ts(2274,13): error TS2300: Duplicate identifier 'CSSRule'.
-../../../../built/local/lib.dom.d.ts(2964,11): error TS2300: Duplicate identifier 'Comment'.
-../../../../built/local/lib.dom.d.ts(2968,13): error TS2300: Duplicate identifier 'Comment'.
-../../../../built/local/lib.dom.d.ts(4605,11): error TS2300: Duplicate identifier 'Event'.
-../../../../built/local/lib.dom.d.ts(4630,13): error TS2300: Duplicate identifier 'Event'.
-../../../../built/local/lib.dom.d.ts(10082,11): error TS2300: Duplicate identifier 'Position'.
-../../../../built/local/lib.dom.d.ts(10087,13): error TS2300: Duplicate identifier 'Position'.
-../../../../built/local/lib.dom.d.ts(10575,11): error TS2300: Duplicate identifier 'Request'.
-../../../../built/local/lib.dom.d.ts(10593,13): error TS2300: Duplicate identifier 'Request'.
-../../../../built/local/lib.dom.d.ts(14907,11): error TS2300: Duplicate identifier 'Window'.
-../../../../built/local/lib.dom.d.ts(15102,13): error TS2300: Duplicate identifier 'Window'.
+../../../../built/local/lib.dom.d.ts(2257,11): error TS2300: Duplicate identifier 'CSSRule'.
+../../../../built/local/lib.dom.d.ts(2276,13): error TS2300: Duplicate identifier 'CSSRule'.
+../../../../built/local/lib.dom.d.ts(2966,11): error TS2300: Duplicate identifier 'Comment'.
+../../../../built/local/lib.dom.d.ts(2970,13): error TS2300: Duplicate identifier 'Comment'.
+../../../../built/local/lib.dom.d.ts(4607,11): error TS2300: Duplicate identifier 'Event'.
+../../../../built/local/lib.dom.d.ts(4632,13): error TS2300: Duplicate identifier 'Event'.
+../../../../built/local/lib.dom.d.ts(10084,11): error TS2300: Duplicate identifier 'Position'.
+../../../../built/local/lib.dom.d.ts(10089,13): error TS2300: Duplicate identifier 'Position'.
+../../../../built/local/lib.dom.d.ts(10577,11): error TS2300: Duplicate identifier 'Request'.
+../../../../built/local/lib.dom.d.ts(10595,13): error TS2300: Duplicate identifier 'Request'.
+../../../../built/local/lib.dom.d.ts(14909,11): error TS2300: Duplicate identifier 'Window'.
+../../../../built/local/lib.dom.d.ts(15104,13): error TS2300: Duplicate identifier 'Window'.
 ../../../../built/local/lib.es5.d.ts(1328,11): error TS2300: Duplicate identifier 'ArrayLike'.
 ../../../../built/local/lib.es5.d.ts(1364,6): error TS2300: Duplicate identifier 'Record'.
 ../../../../node_modules/@types/node/index.d.ts(150,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'module' must be of type '{ [x: string]: any; }', but here has type 'NodeModule'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(42,47): error TS2339: Property 'origin' does not exist on type 'string | Location'.
+  Property 'origin' does not exist on type 'string'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(42,70): error TS2339: Property 'pathname' does not exist on type 'string | Location'.
+  Property 'pathname' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(43,8): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(95,28): error TS2339: Property 'response' does not exist on type 'EventTarget'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(147,37): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
@@ -27,6 +31,10 @@ node_modules/chrome-devtools-frontend/front_end/Runtime.js(270,9): error TS2322:
   Type 'void' is not assignable to type 'undefined'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(280,5): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(283,7): error TS2554: Expected 2-3 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(299,5): error TS2322: Type 'string | { (regexp: string | RegExp): number; (searcher: { [Symbol.search](string: string): numbe...' is not assignable to type 'string'.
+  Type '{ (regexp: string | RegExp): number; (searcher: { [Symbol.search](string: string): number; }): nu...' is not assignable to type 'string'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(355,35): error TS2339: Property 'href' does not exist on type 'string | Location'.
+  Property 'href' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(398,24): error TS1138: Parameter declaration expected.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(398,24): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(527,9): error TS2322: Type 'Function' is not assignable to type 'new () => any'.
@@ -42,6 +50,10 @@ node_modules/chrome-devtools-frontend/front_end/Runtime.js(715,7): error TS2322:
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(721,5): error TS2322: Type 'Promise<undefined[]>' is not assignable to type 'Promise<undefined>'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(729,7): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(854,36): error TS2339: Property 'eval' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(1060,16): error TS2339: Property 'href' does not exist on type 'string | Location'.
+  Property 'href' does not exist on type 'string'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(1063,41): error TS2339: Property 'origin' does not exist on type 'string | Location'.
+  Property 'origin' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(1083,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(1088,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/Tests.js(107,5): error TS2322: Type 'Timer' is not assignable to type 'number'.
@@ -4614,6 +4626,8 @@ node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(769,67):
 node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(770,23): error TS2495: Type 'IterableIterator<string>' is not an array type or a string type.
 node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(779,64): error TS2339: Property 'copyText' does not exist on type 'typeof InspectorFrontendHost'.
 node_modules/chrome-devtools-frontend/front_end/components/Reload.js(7,27): error TS2339: Property 'setIsDocked' does not exist on type 'typeof InspectorFrontendHost'.
+node_modules/chrome-devtools-frontend/front_end/components/Reload.js(8,19): error TS2339: Property 'reload' does not exist on type 'string | Location'.
+  Property 'reload' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleContextSelector.js(8,9): error TS2339: Property 'ConsoleContextSelector' does not exist on type '{ new (): Console; prototype: Console; }'.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleContextSelector.js(10,17): error TS2315: Type '(Anonymous class)' is not generic.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleContextSelector.js(12,17): error TS2315: Type '(Anonymous class)' is not generic.
@@ -6001,6 +6015,8 @@ node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(692,21
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(741,50): error TS2694: Namespace 'InspectorFrontendHostAPI' has no exported member 'ContextMenuDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(872,10): error TS2339: Property 'InspectorFrontendHost' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1123,12): error TS2339: Property 'Object' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1203,32): error TS2339: Property 'indexOf' does not exist on type 'string | { (regexp: string | RegExp): number; (searcher: { [Symbol.search](string: string): numbe...'.
+  Property 'indexOf' does not exist on type '{ (regexp: string | RegExp): number; (searcher: { [Symbol.search](string: string): number; }): nu...'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1207,17): error TS2339: Property 'KeyboardEvent' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1208,36): error TS2339: Property 'KeyboardEvent' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1214,46): error TS2339: Property 'keyCode' does not exist on type 'PropertyDescriptor'.
@@ -6958,6 +6974,8 @@ node_modules/chrome-devtools-frontend/front_end/elements_test_runner/StylesUpdat
 node_modules/chrome-devtools-frontend/front_end/elements_test_runner/StylesUpdateLinksTestRunner.js(119,24): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(31,5): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(56,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(65,31): error TS2339: Property 'href' does not exist on type 'string | Location'.
+  Property 'href' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(88,7): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(92,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(105,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
@@ -7444,6 +7462,8 @@ node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(145,2
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(149,19): error TS1110: Type expected.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(203,23): error TS2339: Property 'sendRequest' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(207,23): error TS2339: Property 'sendRequest' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
+node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(208,96): error TS2339: Property 'hostname' does not exist on type 'string | Location'.
+  Property 'hostname' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(224,23): error TS2339: Property 'sendRequest' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(243,23): error TS2339: Property 'sendRequest' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(249,53): error TS2339: Property 'nextObjectId' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
@@ -7518,6 +7538,8 @@ node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(68
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(708,31): error TS2339: Property 'setInjectedScriptForOrigin' does not exist on type 'typeof InspectorFrontendHost'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(712,14): error TS2339: Property 'src' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(713,14): error TS2339: Property 'style' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(724,38): error TS2339: Property 'origin' does not exist on type 'string | Location'.
+  Property 'origin' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(765,31): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(777,31): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(839,43): error TS2694: Namespace '(Anonymous class)' has no exported member 'Record'.
@@ -8710,6 +8732,8 @@ node_modules/chrome-devtools-frontend/front_end/main/Main.js(820,47): error TS25
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(822,25): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(823,9): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(824,38): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/main/Main.js(824,99): error TS2339: Property 'reload' does not exist on type 'string | Location'.
+  Property 'reload' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(825,25): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(833,28): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; SetExactSize: symbol; SetExactWidthMaxHeight: symbol; MeasureContent: symbol; }'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(836,5): error TS2554: Expected 2 arguments, but got 1.
@@ -15140,8 +15164,8 @@ node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1258,2
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1279,81): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(value: any) => any'.
   Type 'Function' provides no match for the signature '(value: any): any'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1304,3): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
-node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1310,30): error TS2339: Property 'getAttribute' does not exist on type 'Node'.
-node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1311,44): error TS2339: Property 'getAttribute' does not exist on type 'Node'.
+node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1310,30): error TS2339: Property 'getAttribute' does not exist on type 'Node & ChildNode'.
+node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1311,44): error TS2339: Property 'getAttribute' does not exist on type 'Node & ChildNode'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1388,16): error TS2339: Property 'testRunner' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1424,14): error TS2339: Property '_initializeTargetForStartupTest' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1425,37): error TS2339: Property '_instanceForTest' does not exist on type 'typeof (Anonymous class)'.


### PR DESCRIPTION
1. The new entity name resolution introduced for resolving types from `var = require('x')` forgot to check whether the variable declaration had an initializer. This crashed caused the compiler to crash on chrome-devtools-frontend.
2. Update chrome-devtools-frontend baseline. These changes come from lib.d.ts changes.