### PR TITLE
Store import nodes in SourceFile.imports instead of StringLiteral nodes

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2485,7 +2485,7 @@ namespace ts {
         function bindCallExpression(node: CallExpression) {
             // We're only inspecting call expressions to detect CommonJS modules, so we can skip
             // this check if we've already seen the module indicator
-            if (!file.commonJsModuleIndicator && isRequireCall(node, /*checkArgumentIsStringLiteral*/ false)) {
+            if (!file.commonJsModuleIndicator && isRequireCall(node, /*checkArgumentIsStringLiteralLike*/ false)) {
                 setCommonJsModuleIndicator(node);
             }
         }

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -83,7 +83,7 @@ namespace ts.BuilderState {
         if (sourceFile.imports && sourceFile.imports.length > 0) {
             const checker: TypeChecker = program.getTypeChecker();
             for (const importName of sourceFile.imports) {
-                const symbol = checker.getSymbolAtLocation(importName);
+                const symbol = checker.getSymbolAtLocation(moduleSpecifierFromImport(importName));
                 if (symbol && symbol.declarations && symbol.declarations[0]) {
                     const declarationSourceFile = getSourceFileOfNode(symbol.declarations[0]);
                     if (declarationSourceFile) {

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -83,7 +83,7 @@ namespace ts.BuilderState {
         if (sourceFile.imports && sourceFile.imports.length > 0) {
             const checker: TypeChecker = program.getTypeChecker();
             for (const importName of sourceFile.imports) {
-                const symbol = checker.getSymbolAtLocation(moduleSpecifierFromImport(importName));
+                const symbol = checker.getSymbolAtLocation(importName);
                 if (symbol && symbol.declarations && symbol.declarations[0]) {
                     const declarationSourceFile = getSourceFileOfNode(symbol.declarations[0]);
                     if (declarationSourceFile) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18231,7 +18231,7 @@ namespace ts {
         }
 
         function isCommonJsRequire(node: Node): boolean {
-            if (!isRequireCall(node, /*checkArgumentIsStringLiteral*/ true)) {
+            if (!isRequireCall(node, /*checkArgumentIsStringLiteralLike*/ true)) {
                 return false;
             }
 
@@ -19692,7 +19692,7 @@ namespace ts {
         function getTypeOfExpression(node: Expression, cache?: boolean) {
             // Optimize for the common case of a call to a function with a single non-generic call
             // signature where we can just fetch the return type without checking the arguments.
-            if (node.kind === SyntaxKind.CallExpression && (<CallExpression>node).expression.kind !== SyntaxKind.SuperKeyword && !isRequireCall(node, /*checkArgumentIsStringLiteral*/ true) && !isSymbolOrSymbolForCall(node)) {
+            if (node.kind === SyntaxKind.CallExpression && (<CallExpression>node).expression.kind !== SyntaxKind.SuperKeyword && !isRequireCall(node, /*checkArgumentIsStringLiteralLike*/ true) && !isSymbolOrSymbolForCall(node)) {
                 const funcType = checkNonNullExpression((<CallExpression>node).expression);
                 const signature = getSingleCallSignature(funcType);
                 if (signature && !signature.typeParameters) {
@@ -25023,7 +25023,7 @@ namespace ts {
                     // 3). Dynamic import call or require in javascript
                     if ((isExternalModuleImportEqualsDeclaration(node.parent.parent) && getExternalModuleImportEqualsDeclarationExpression(node.parent.parent) === node) ||
                         ((node.parent.kind === SyntaxKind.ImportDeclaration || node.parent.kind === SyntaxKind.ExportDeclaration) && (<ImportDeclaration>node.parent).moduleSpecifier === node) ||
-                        ((isInJavaScriptFile(node) && isRequireCall(node.parent, /*checkArgumentIsStringLiteral*/ false)) || isImportCall(node.parent))) {
+                        ((isInJavaScriptFile(node) && isRequireCall(node.parent, /*checkArgumentIsStringLiteralLike*/ false)) || isImportCall(node.parent))) {
                         return resolveExternalModuleName(node, <LiteralExpression>node);
                     }
                     // falls through

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25846,8 +25846,8 @@ namespace ts {
             }
         }
 
-        function getExternalModuleFileFromDeclaration(declaration: ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ModuleDeclaration): SourceFile {
-            const specifier = getExternalModuleName(declaration);
+        function getExternalModuleFileFromDeclaration(declaration: AnyImportOrReExport | ModuleDeclaration): SourceFile {
+            const specifier = declaration.kind === SyntaxKind.ModuleDeclaration ? tryCast(declaration.name, isStringLiteral) : getExternalModuleName(declaration);
             const moduleSymbol = resolveExternalModuleNameWorker(specifier, specifier, /*moduleNotFoundError*/ undefined);
             if (!moduleSymbol) {
                 return undefined;

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -1953,7 +1953,7 @@ namespace ts {
         decorators: ReadonlyArray<Decorator> | undefined,
         modifiers: ReadonlyArray<Modifier> | undefined,
         importClause: ImportClause | undefined,
-        moduleSpecifier?: Expression): ImportDeclaration {
+        moduleSpecifier: Expression): ImportDeclaration {
         const node = <ImportDeclaration>createSynthesizedNode(SyntaxKind.ImportDeclaration);
         node.decorators = asNodeArray(decorators);
         node.modifiers = asNodeArray(modifiers);

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1668,8 +1668,8 @@ namespace ts {
                     imports = append(imports, node.arguments[0]);
                 }
                 // we have to check the argument list has length of 1. We will still have to process these even though we have parsing error.
-                else if (isImportCall(node) && node.arguments.length === 1 && node.arguments[0].kind === SyntaxKind.StringLiteral) {
-                    imports = append(imports, node.arguments[0] as StringLiteral);
+                else if (isImportCall(node) && node.arguments.length === 1 && isStringLiteralLike(node.arguments[0])) {
+                    imports = append(imports, node.arguments[0] as StringLiteralLike);
                 }
                 else {
                     forEachChild(node, collectDynamicImportOrRequireCalls);

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1600,7 +1600,7 @@ namespace ts {
                 && !file.isDeclarationFile) {
                 // synthesize 'import "tslib"' declaration
                 const externalHelpersModuleReference = createLiteral(externalHelpersModuleNameText);
-                const importDecl = createImportDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, /*importClause*/ undefined);
+                const importDecl = createImportDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, /*importClause*/ undefined, externalHelpersModuleReference);
                 addEmitFlags(importDecl, EmitFlags.NeverApplyImportHelper);
                 externalHelpersModuleReference.parent = importDecl;
                 importDecl.parent = file;
@@ -1664,7 +1664,7 @@ namespace ts {
             }
 
             function collectDynamicImportOrRequireCalls(node: Node): void {
-                if (isRequireCall(node, /*checkArgumentIsStringLiteral*/ true)) {
+                if (isRequireCall(node, /*checkArgumentIsStringLiteralLike*/ true)) {
                     imports = append(imports, node.arguments[0]);
                 }
                 // we have to check the argument list has length of 1. We will still have to process these even though we have parsing error.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2557,7 +2557,7 @@ namespace ts {
         // Content of this field should never be used directly - use getResolvedModuleFileName/setResolvedModuleFileName functions instead
         /* @internal */ resolvedModules: Map<ResolvedModuleFull | undefined>;
         /* @internal */ resolvedTypeReferenceDirectiveNames: Map<ResolvedTypeReferenceDirective>;
-        /* @internal */ imports: ReadonlyArray<AnyValidImportOrReExport>;
+        /* @internal */ imports: ReadonlyArray<StringLiteralLike>;
         // Identifier only if `declare global`
         /* @internal */ moduleAugmentations: ReadonlyArray<StringLiteral | Identifier>;
         /* @internal */ patternAmbientModules?: PatternAmbientModule[];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2557,7 +2557,7 @@ namespace ts {
         // Content of this field should never be used directly - use getResolvedModuleFileName/setResolvedModuleFileName functions instead
         /* @internal */ resolvedModules: Map<ResolvedModuleFull | undefined>;
         /* @internal */ resolvedTypeReferenceDirectiveNames: Map<ResolvedTypeReferenceDirective>;
-        /* @internal */ imports: ReadonlyArray<StringLiteral>;
+        /* @internal */ imports: ReadonlyArray<AnyValidImportOrReExport>;
         // Identifier only if `declare global`
         /* @internal */ moduleAugmentations: ReadonlyArray<StringLiteral | Identifier>;
         /* @internal */ patternAmbientModules?: PatternAmbientModule[];
@@ -3145,6 +3145,18 @@ namespace ts {
 
     /* @internal */
     export type AnyImportSyntax = ImportDeclaration | ImportEqualsDeclaration;
+
+    /* @internal */
+    export type AnyImportOrReExport = AnyImportSyntax | ExportDeclaration;
+
+    /* @internal */
+    export type AnyValidImportOrReExport =
+        | (ImportDeclaration | ExportDeclaration) & { moduleSpecifier: StringLiteral }
+        | ImportEqualsDeclaration & { moduleReference: ExternalModuleReference & { expression: StringLiteral } }
+        | RequireOrImportCall;
+
+    /* @internal */
+    export type RequireOrImportCall = CallExpression & { arguments: [StringLiteralLike] };
 
     /* @internal */
     export interface SymbolVisibilityResult {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1448,9 +1448,9 @@ namespace ts {
      * exactly one argument (of the form 'require("name")').
      * This function does not test if the node is in a JavaScript file or not.
      */
-    export function isRequireCall(callExpression: Node, checkArgumentIsStringLiteral: true): callExpression is RequireOrImportCall & { expression: Identifier, arguments: [StringLiteralLike] };
-    export function isRequireCall(callExpression: Node, checkArgumentIsStringLiteral: boolean): callExpression is CallExpression;
-    export function isRequireCall(callExpression: Node, checkArgumentIsStringLiteral: boolean): callExpression is CallExpression {
+    export function isRequireCall(callExpression: Node, checkArgumentIsStringLiteralLike: true): callExpression is RequireOrImportCall & { expression: Identifier, arguments: [StringLiteralLike] };
+    export function isRequireCall(callExpression: Node, checkArgumentIsStringLiteralLike: boolean): callExpression is CallExpression;
+    export function isRequireCall(callExpression: Node, checkArgumentIsStringLiteralLike: boolean): callExpression is CallExpression {
         if (callExpression.kind !== SyntaxKind.CallExpression) {
             return false;
         }
@@ -1464,7 +1464,7 @@ namespace ts {
             return false;
         }
         const arg = args[0];
-        return !checkArgumentIsStringLiteral || isStringLiteralLike(arg);
+        return !checkArgumentIsStringLiteralLike || isStringLiteralLike(arg);
     }
 
     export function isSingleOrDoubleQuote(charCode: number) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1654,18 +1654,17 @@ namespace ts {
             !!getJSDocTypeTag(expr.parent);
     }
 
-    /* @internal */
-    export function moduleSpecifierFromImport(node: AnyValidImportOrReExport): StringLiteralLike {
-        switch (node.kind) {
+    export function importFromModuleSpecifier(node: StringLiteralLike): AnyValidImportOrReExport {
+        switch (node.parent.kind) {
             case SyntaxKind.ImportDeclaration:
             case SyntaxKind.ExportDeclaration:
-                return node.moduleSpecifier;
-            case SyntaxKind.ImportEqualsDeclaration:
-                return node.moduleReference.expression;
+                return node.parent as AnyValidImportOrReExport;
+            case SyntaxKind.ExternalModuleReference:
+                return (node.parent as ExternalModuleReference).parent as AnyValidImportOrReExport;
             case SyntaxKind.CallExpression:
-                return first(node.arguments);
+                return node.parent as AnyValidImportOrReExport;
             default:
-                return Debug.assertNever(node);
+                return Debug.fail(Debug.showSyntaxKind(node));
         }
     }
 

--- a/src/services/codefixes/convertToEs6Module.ts
+++ b/src/services/codefixes/convertToEs6Module.ts
@@ -19,13 +19,14 @@ namespace ts.codefix {
     });
 
     function fixImportOfModuleExports(importingFile: SourceFile, exportingFile: SourceFile, changes: textChanges.ChangeTracker) {
-        for (const importNode of importingFile.imports) {
-            const { text } = moduleSpecifierFromImport(importNode);
+        for (const moduleSpecifier of importingFile.imports) {
+            const { text } = moduleSpecifier;
             const imported = getResolvedModule(importingFile, text);
             if (!imported || imported.resolvedFileName !== exportingFile.fileName) {
                 continue;
             }
 
+            const importNode = importFromModuleSpecifier(moduleSpecifier);
             switch (importNode.kind) {
                 case SyntaxKind.ImportEqualsDeclaration:
                     changes.replaceNode(importingFile, importNode, makeImport(importNode.name, /*namedImports*/ undefined, text));

--- a/src/services/codefixes/convertToEs6Module.ts
+++ b/src/services/codefixes/convertToEs6Module.ts
@@ -32,7 +32,7 @@ namespace ts.codefix {
                     changes.replaceNode(importingFile, importNode, makeImport(importNode.name, /*namedImports*/ undefined, text));
                     break;
                 case SyntaxKind.CallExpression:
-                    if (isRequireCall(importNode, /*checkArgumentIsStringLiteral*/ false)) {
+                    if (isRequireCall(importNode, /*checkArgumentIsStringLiteralLike*/ false)) {
                         changes.replaceNode(importingFile, importNode, createPropertyAccess(getSynthesizedDeepClone(importNode), "default"));
                     }
                     break;
@@ -109,7 +109,7 @@ namespace ts.codefix {
                 const { expression } = statement as ExpressionStatement;
                 switch (expression.kind) {
                     case SyntaxKind.CallExpression: {
-                        if (isRequireCall(expression, /*checkArgumentIsStringLiteral*/ true)) {
+                        if (isRequireCall(expression, /*checkArgumentIsStringLiteralLike*/ true)) {
                             // For side-effecting require() call, just make a side-effecting import.
                             changes.replaceNode(sourceFile, statement, makeImport(/*name*/ undefined, /*namedImports*/ undefined, expression.arguments[0].text));
                         }
@@ -137,11 +137,11 @@ namespace ts.codefix {
                 foundImport = true;
                 return [];
             }
-            if (isRequireCall(initializer, /*checkArgumentIsStringLiteral*/ true)) {
+            if (isRequireCall(initializer, /*checkArgumentIsStringLiteralLike*/ true)) {
                 foundImport = true;
                 return convertSingleImport(sourceFile, name, initializer.arguments[0].text, changes, checker, identifiers, target);
             }
-            else if (isPropertyAccessExpression(initializer) && isRequireCall(initializer.expression, /*checkArgumentIsStringLiteral*/ true)) {
+            else if (isPropertyAccessExpression(initializer) && isRequireCall(initializer.expression, /*checkArgumentIsStringLiteralLike*/ true)) {
                 foundImport = true;
                 return convertPropertyAccessImport(name, initializer.name.text, initializer.expression.arguments[0].text, identifiers);
             }
@@ -276,7 +276,7 @@ namespace ts.codefix {
                 return [[classExpressionToDeclaration(cls.name && cls.name.text, modifiers, cls)], true];
             }
             case SyntaxKind.CallExpression:
-                if (isRequireCall(exported, /*checkArgumentIsStringLiteral*/ true)) {
+                if (isRequireCall(exported, /*checkArgumentIsStringLiteralLike*/ true)) {
                     return convertReExportAll(exported.arguments[0], checker);
                 }
                 // falls through

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -406,7 +406,7 @@ namespace ts.Completions {
 
             case SyntaxKind.CallExpression:
             case SyntaxKind.NewExpression:
-                if (!isRequireCall(node.parent, /*checkArgumentIsStringLiteral*/ false) && !isImportCall(node.parent)) {
+                if (!isRequireCall(node.parent, /*checkArgumentIsStringLiteralLike*/ false) && !isImportCall(node.parent)) {
                     const argumentInfo = SignatureHelp.getImmediatelyContainingArgumentInfo(node, position, sourceFile);
                     // Get string literal completions from specialized signatures of the target
                     // i.e. declare function f(a: 'A');

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -278,7 +278,7 @@ namespace ts.FindAllReferences.Core {
             case SyntaxKind.ExportDeclaration:
                 return true;
             case SyntaxKind.CallExpression:
-                return isRequireCall(node.parent as CallExpression, /*checkArgumentIsStringLiteral*/ false) || isImportCall(node.parent as CallExpression);
+                return isRequireCall(node.parent as CallExpression, /*checkArgumentIsStringLiteralLike*/ false) || isImportCall(node.parent as CallExpression);
             default:
                 return false;
         }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -385,7 +385,7 @@ namespace ts.FindAllReferences {
     function forEachImport(sourceFile: SourceFile, action: (importStatement: ImporterOrCallExpression, imported: StringLiteralLike) => void): void {
         if (sourceFile.externalModuleIndicator || sourceFile.imports !== undefined) {
             for (const i of sourceFile.imports) {
-                action(i, moduleSpecifierFromImport(i));
+                action(importFromModuleSpecifier(i), i);
             }
         }
         else {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -646,7 +646,7 @@ namespace ts {
         public nameTable: UnderscoreEscapedMap<number>;
         public resolvedModules: Map<ResolvedModuleFull>;
         public resolvedTypeReferenceDirectiveNames: Map<ResolvedTypeReferenceDirective>;
-        public imports: ReadonlyArray<AnyValidImportOrReExport>;
+        public imports: ReadonlyArray<StringLiteralLike>;
         public moduleAugmentations: StringLiteral[];
         private namedDeclarations: Map<Declaration[]>;
         public ambientModuleNames: string[];

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -646,7 +646,7 @@ namespace ts {
         public nameTable: UnderscoreEscapedMap<number>;
         public resolvedModules: Map<ResolvedModuleFull>;
         public resolvedTypeReferenceDirectiveNames: Map<ResolvedTypeReferenceDirective>;
-        public imports: StringLiteral[];
+        public imports: ReadonlyArray<AnyValidImportOrReExport>;
         public moduleAugmentations: StringLiteral[];
         private namedDeclarations: Map<Declaration[]>;
         public ambientModuleNames: string[];

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -33,10 +33,11 @@ namespace ts {
         check(sourceFile);
 
         if (getAllowSyntheticDefaultImports(program.getCompilerOptions())) {
-            for (const importNode of sourceFile.imports) {
+            for (const moduleSpecifier of sourceFile.imports) {
+                const importNode = importFromModuleSpecifier(moduleSpecifier);
                 const name = importNameForConvertToDefaultImport(importNode);
                 if (!name) continue;
-                const module = getResolvedModule(sourceFile, moduleSpecifierFromImport(importNode).text);
+                const module = getResolvedModule(sourceFile, moduleSpecifier.text);
                 const resolvedFile = module && program.getSourceFile(module.resolvedFileName);
                 if (resolvedFile && resolvedFile.externalModuleIndicator && isExportAssignment(resolvedFile.externalModuleIndicator) && resolvedFile.externalModuleIndicator.isExportEquals) {
                     diags.push(createDiagnosticForNode(name, Diagnostics.Import_may_be_converted_to_a_default_import));

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3644,7 +3644,7 @@ declare namespace ts {
     function updateNamespaceExportDeclaration(node: NamespaceExportDeclaration, name: Identifier): NamespaceExportDeclaration;
     function createImportEqualsDeclaration(decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, name: string | Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
     function updateImportEqualsDeclaration(node: ImportEqualsDeclaration, decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
-    function createImportDeclaration(decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, importClause: ImportClause | undefined, moduleSpecifier?: Expression): ImportDeclaration;
+    function createImportDeclaration(decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression): ImportDeclaration;
     function updateImportDeclaration(node: ImportDeclaration, decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression | undefined): ImportDeclaration;
     function createImportClause(name: Identifier | undefined, namedBindings: NamedImportBindings | undefined): ImportClause;
     function updateImportClause(node: ImportClause, name: Identifier | undefined, namedBindings: NamedImportBindings | undefined): ImportClause;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3591,7 +3591,7 @@ declare namespace ts {
     function updateNamespaceExportDeclaration(node: NamespaceExportDeclaration, name: Identifier): NamespaceExportDeclaration;
     function createImportEqualsDeclaration(decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, name: string | Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
     function updateImportEqualsDeclaration(node: ImportEqualsDeclaration, decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, name: Identifier, moduleReference: ModuleReference): ImportEqualsDeclaration;
-    function createImportDeclaration(decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, importClause: ImportClause | undefined, moduleSpecifier?: Expression): ImportDeclaration;
+    function createImportDeclaration(decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression): ImportDeclaration;
     function updateImportDeclaration(node: ImportDeclaration, decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, importClause: ImportClause | undefined, moduleSpecifier: Expression | undefined): ImportDeclaration;
     function createImportClause(name: Identifier | undefined, namedBindings: NamedImportBindings | undefined): ImportClause;
     function updateImportClause(node: ImportClause, name: Identifier | undefined, namedBindings: NamedImportBindings | undefined): ImportClause;


### PR DESCRIPTION
Fixes #20562 
Previously `SourceFile.imports` was a list of `StringLiteral`s and we had to climb parents to get to the importer node, which is error-prone as `node.parent` is just a `Node`. Now we store the import nodes directly and climb *down* if we need the `StringLiteral`.