### PR TITLE
Fix some Constructor's signature missing null type

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -10,7 +10,7 @@ interface Map<K, V> {
 
 interface MapConstructor {
     new (): Map<any, any>;
-    new <K, V>(entries?: ReadonlyArray<[K, V]>): Map<K, V>;
+    new <K, V>(entries?: ReadonlyArray<[K, V]> | null): Map<K, V>;
     readonly prototype: Map<any, any>;
 }
 declare var Map: MapConstructor;
@@ -31,7 +31,7 @@ interface WeakMap<K extends object, V> {
 
 interface WeakMapConstructor {
     new (): WeakMap<object, any>;
-    new <K extends object, V>(entries?: ReadonlyArray<[K, V]>): WeakMap<K, V>;
+    new <K extends object, V>(entries?: ReadonlyArray<[K, V]> | null): WeakMap<K, V>;
     readonly prototype: WeakMap<object, any>;
 }
 declare var WeakMap: WeakMapConstructor;
@@ -47,7 +47,7 @@ interface Set<T> {
 
 interface SetConstructor {
     new (): Set<any>;
-    new <T>(values?: ReadonlyArray<T>): Set<T>;
+    new <T>(values?: ReadonlyArray<T> | null): Set<T>;
     readonly prototype: Set<any>;
 }
 declare var Set: SetConstructor;
@@ -66,7 +66,7 @@ interface WeakSet<T extends object> {
 
 interface WeakSetConstructor {
     new (): WeakSet<object>;
-    new <T extends object>(values?: ReadonlyArray<T>): WeakSet<T>;
+    new <T extends object>(values?: ReadonlyArray<T> | null): WeakSet<T>;
     readonly prototype: WeakSet<object>;
 }
 declare var WeakSet: WeakSetConstructor;


### PR DESCRIPTION
according to ECMAScript® 2015 Language Specification - http://www.ecma-international.org/ecma-262/6.0

MapConstructor : 23.1.1.1 step6
WeakMapConstructor : 23.2.1.1 step6
SetConstructor : 23.3.1.1 step6
WeakSetConstructor : 23.4.1.1 step6