### PR TITLE
No error on unmatchable `@param` tags

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21447,7 +21447,8 @@ namespace ts {
 
         function checkJSDocParameterTag(node: JSDocParameterTag) {
             checkSourceElement(node.typeExpression);
-            if (!getParameterSymbolFromJSDoc(node)) {
+            const decl = getHostSignatureFromJSDoc(node);
+            if (!getParameterSymbolFromJSDoc(node) && decl && !containsArgumentsReference(decl)) {
                 error(node.name,
                     Diagnostics.JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name,
                     idText(node.name.kind === SyntaxKind.QualifiedName ? node.name.right : node.name));

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3720,7 +3720,7 @@
         "category": "Error",
         "code": 8028
     },
-    "JSDoc '...' must appear on the last @param tag of a function that uses 'arguments'.": {
+    "The last @param tag of a function that uses 'arguments' must have an array type.": {
         "category": "Error",
         "code": 8029
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3720,6 +3720,10 @@
         "category": "Error",
         "code": 8028
     },
+    "JSDoc '...' must appear on the last @param tag of a function that uses 'arguments'.": {
+        "category": "Error",
+        "code": 8029
+    },
     "Only identifiers/qualified-names with optional type arguments are currently supported in a class 'extends' clause.": {
         "category": "Error",
         "code": 9002

--- a/tests/baselines/reference/jsdocPrefixPostfixParsing.types
+++ b/tests/baselines/reference/jsdocPrefixPostfixParsing.types
@@ -16,7 +16,7 @@
  * @param {...number?[]!} k - (number[] | null)[]
  */
 function f(x, y, z, a, b, c, d, e, f, g, h, i, j, k) {
->f : (x: number[], y: number[], z: number[], a: (number | null)[], b: number[] | null, c: number[] | null, d: number | null | undefined, e: number | null | undefined, f: number | null | undefined, g: number | null | undefined, h: number | null | undefined, i: number[] | undefined, j: number[] | null | undefined, ...args: (number | null)[][]) => void
+>f : (x: number[], y: number[], z: number[], a: (number | null)[], b: number[] | null, c: number[] | null, d: number | null | undefined, e: number | null | undefined, f: number | null | undefined, g: number | null | undefined, h: number | null | undefined, i: number[] | undefined, j: number[] | null | undefined, k: (number | null)[] | undefined) => void
 >x : number[]
 >y : number[]
 >z : number[]

--- a/tests/baselines/reference/paramTagOnCallExpression.symbols
+++ b/tests/baselines/reference/paramTagOnCallExpression.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/decls.d.ts ===
+declare function factory(type: string): {};
+>factory : Symbol(factory, Decl(decls.d.ts, 0, 0))
+>type : Symbol(type, Decl(decls.d.ts, 0, 25))
+
+=== tests/cases/conformance/jsdoc/a.js ===
+// from util
+/** @param {function} ctor - A big long explanation follows */
+exports.inherits = factory('inherits')
+>exports.inherits : Symbol(inherits, Decl(a.js, 0, 0))
+>exports : Symbol(inherits, Decl(a.js, 0, 0))
+>inherits : Symbol(inherits, Decl(a.js, 0, 0))
+>factory : Symbol(factory, Decl(decls.d.ts, 0, 0))
+

--- a/tests/baselines/reference/paramTagOnCallExpression.types
+++ b/tests/baselines/reference/paramTagOnCallExpression.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/jsdoc/decls.d.ts ===
+declare function factory(type: string): {};
+>factory : (type: string) => {}
+>type : string
+
+=== tests/cases/conformance/jsdoc/a.js ===
+// from util
+/** @param {function} ctor - A big long explanation follows */
+exports.inherits = factory('inherits')
+>exports.inherits = factory('inherits') : {}
+>exports.inherits : {}
+>exports : typeof "tests/cases/conformance/jsdoc/a"
+>inherits : {}
+>factory('inherits') : {}
+>factory : (type: string) => {}
+>'inherits' : "inherits"
+

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments.errors.txt
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/conformance/jsdoc/a.js(2,20): error TS8029: JSDoc '...' must appear on the last @param tag of a function that uses 'arguments'.
+tests/cases/conformance/jsdoc/a.js(19,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'string'.
+
+
+==== tests/cases/conformance/jsdoc/decls.d.ts (0 errors) ====
+    declare function factory(type: string): {};
+==== tests/cases/conformance/jsdoc/a.js (2 errors) ====
+    /**
+     * @param {string} first
+                       ~~~~~
+!!! error TS8029: JSDoc '...' must appear on the last @param tag of a function that uses 'arguments'.
+     */
+    function concat(/* first, second, ... */) {
+      var s = ''
+      for (var i = 0, l = arguments.length; i < l; i++) {
+        s += arguments[i]
+      }
+      return s
+    }
+    
+    /**
+     * @param {...string} strings
+     */
+    function correct() {
+        arguments
+    }
+    
+    correct(1,2,3) // oh no
+            ~
+!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'string'.
+    

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments.errors.txt
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsdoc/a.js(2,20): error TS8029: JSDoc '...' must appear on the last @param tag of a function that uses 'arguments'.
+tests/cases/conformance/jsdoc/a.js(2,20): error TS8029: The last @param tag of a function that uses 'arguments' must have an array type.
 tests/cases/conformance/jsdoc/a.js(19,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'string'.
 
 
@@ -8,7 +8,7 @@ tests/cases/conformance/jsdoc/a.js(19,9): error TS2345: Argument of type '1' is 
     /**
      * @param {string} first
                        ~~~~~
-!!! error TS8029: JSDoc '...' must appear on the last @param tag of a function that uses 'arguments'.
+!!! error TS8029: The last @param tag of a function that uses 'arguments' must have an array type.
      */
     function concat(/* first, second, ... */) {
       var s = ''

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments.symbols
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments.symbols
@@ -32,3 +32,16 @@ function concat(/* first, second, ... */) {
 >s : Symbol(s, Decl(a.js, 4, 5))
 }
 
+/**
+ * @param {...string} strings
+ */
+function correct() {
+>correct : Symbol(correct, Decl(a.js, 9, 1))
+
+    arguments
+>arguments : Symbol(arguments)
+}
+
+correct(1,2,3) // oh no
+>correct : Symbol(correct, Decl(a.js, 9, 1))
+

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments.symbols
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments.symbols
@@ -1,0 +1,34 @@
+=== tests/cases/conformance/jsdoc/decls.d.ts ===
+declare function factory(type: string): {};
+>factory : Symbol(factory, Decl(decls.d.ts, 0, 0))
+>type : Symbol(type, Decl(decls.d.ts, 0, 25))
+
+=== tests/cases/conformance/jsdoc/a.js ===
+/**
+ * @param {string} first
+ */
+function concat(/* first, second, ... */) {
+>concat : Symbol(concat, Decl(a.js, 0, 0))
+
+  var s = ''
+>s : Symbol(s, Decl(a.js, 4, 5))
+
+  for (var i = 0, l = arguments.length; i < l; i++) {
+>i : Symbol(i, Decl(a.js, 5, 10))
+>l : Symbol(l, Decl(a.js, 5, 17))
+>arguments.length : Symbol(IArguments.length, Decl(lib.d.ts, --, --))
+>arguments : Symbol(arguments)
+>length : Symbol(IArguments.length, Decl(lib.d.ts, --, --))
+>i : Symbol(i, Decl(a.js, 5, 10))
+>l : Symbol(l, Decl(a.js, 5, 17))
+>i : Symbol(i, Decl(a.js, 5, 10))
+
+    s += arguments[i]
+>s : Symbol(s, Decl(a.js, 4, 5))
+>arguments : Symbol(arguments)
+>i : Symbol(i, Decl(a.js, 5, 10))
+  }
+  return s
+>s : Symbol(s, Decl(a.js, 4, 5))
+}
+

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments.types
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments.types
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/jsdoc/decls.d.ts ===
+declare function factory(type: string): {};
+>factory : (type: string) => {}
+>type : string
+
+=== tests/cases/conformance/jsdoc/a.js ===
+/**
+ * @param {string} first
+ */
+function concat(/* first, second, ... */) {
+>concat : (...args: any[]) => string
+
+  var s = ''
+>s : string
+>'' : ""
+
+  for (var i = 0, l = arguments.length; i < l; i++) {
+>i : number
+>0 : 0
+>l : number
+>arguments.length : number
+>arguments : IArguments
+>length : number
+>i < l : boolean
+>i : number
+>l : number
+>i++ : number
+>i : number
+
+    s += arguments[i]
+>s += arguments[i] : string
+>s : string
+>arguments[i] : any
+>arguments : IArguments
+>i : number
+  }
+  return s
+>s : string
+}
+

--- a/tests/baselines/reference/paramTagOnFunctionUsingArguments.types
+++ b/tests/baselines/reference/paramTagOnFunctionUsingArguments.types
@@ -38,3 +38,20 @@ function concat(/* first, second, ... */) {
 >s : string
 }
 
+/**
+ * @param {...string} strings
+ */
+function correct() {
+>correct : (...args: string[]) => void
+
+    arguments
+>arguments : IArguments
+}
+
+correct(1,2,3) // oh no
+>correct(1,2,3) : void
+>correct : (...args: string[]) => void
+>1 : 1
+>2 : 2
+>3 : 3
+

--- a/tests/cases/conformance/jsdoc/paramTagOnCallExpression.ts
+++ b/tests/cases/conformance/jsdoc/paramTagOnCallExpression.ts
@@ -1,7 +1,6 @@
 // @noEmit: true
 // @allowJs: true
 // @checkJs: true
-// @strict: true
 // @Filename: decls.d.ts
 declare function factory(type: string): {};
 // @Filename: a.js

--- a/tests/cases/conformance/jsdoc/paramTagOnCallExpression.ts
+++ b/tests/cases/conformance/jsdoc/paramTagOnCallExpression.ts
@@ -1,0 +1,11 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @strict: true
+// @Filename: decls.d.ts
+declare function factory(type: string): {};
+// @Filename: a.js
+
+// from util
+/** @param {function} ctor - A big long explanation follows */
+exports.inherits = factory('inherits')

--- a/tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments.ts
+++ b/tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments.ts
@@ -16,3 +16,12 @@ function concat(/* first, second, ... */) {
   }
   return s
 }
+
+/**
+ * @param {...string} strings
+ */
+function correct() {
+    arguments
+}
+
+correct(1,2,3) // oh no

--- a/tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments.ts
+++ b/tests/cases/conformance/jsdoc/paramTagOnFunctionUsingArguments.ts
@@ -1,0 +1,18 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @strict: true
+// @Filename: decls.d.ts
+declare function factory(type: string): {};
+// @Filename: a.js
+
+/**
+ * @param {string} first
+ */
+function concat(/* first, second, ... */) {
+  var s = ''
+  for (var i = 0, l = arguments.length; i < l; i++) {
+    s += arguments[i]
+  }
+  return s
+}


### PR DESCRIPTION
Such as when the initializer is not a function, or when the function mentions `arguments` in its body.

Fixes #22410 
Fixes #22411  

This will need to be ported to 2.8 as well.
