### PR TITLE
Do not use unguarded process in tsc.ts

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -456,6 +456,7 @@ namespace ts {
         setTimeout?(callback: (...args: any[]) => void, ms: number, ...args: any[]): any;
         clearTimeout?(timeoutId: any): void;
         clearScreen?(): void;
+        /*@internal*/ setBlocking?(): void;
     }
 
     export interface FileWatcher {
@@ -614,6 +615,11 @@ namespace ts {
                 clearTimeout,
                 clearScreen: () => {
                     process.stdout.write("\x1Bc");
+                },
+                setBlocking: () => {
+                    if (process.stdout && process.stdout._handle && process.stdout._handle.setBlocking) {
+                        process.stdout._handle.setBlocking(true);
+                    }
                 }
             };
             return nodeSystem;

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -399,8 +399,9 @@ if (ts.Debug.isDebugging) {
 if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
     ts.sys.tryEnableSourceMapsForHost();
 }
-declare var process: any;
-if (process && process.stdout && process.stdout._handle && process.stdout._handle.setBlocking) {
-    process.stdout._handle.setBlocking(true);
+
+if (ts.sys.setBlocking) {
+    ts.sys.setBlocking();
 }
+
 ts.executeCommandLine(ts.sys.args);


### PR DESCRIPTION
`process` is undefined outside of node, so `tsc.exe` for instance would fail on `process` with undefined access. the check should have been `if (typeof process !== "undefined")` instead, or better used through our sys wrapper where we do verify we are on node.