### PR TITLE
Signature#declaration can be undefined

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3875,7 +3875,7 @@ namespace ts {
     }
 
     export interface Signature {
-        declaration: SignatureDeclaration;  // Originating declaration
+        declaration?: SignatureDeclaration; // Originating declaration
         typeParameters?: TypeParameter[];   // Type parameters (undefined if non-generic)
         parameters: Symbol[];               // Parameters
         /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2223,7 +2223,7 @@ declare namespace ts {
         Construct = 1,
     }
     interface Signature {
-        declaration: SignatureDeclaration;
+        declaration?: SignatureDeclaration;
         typeParameters?: TypeParameter[];
         parameters: Symbol[];
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2223,7 +2223,7 @@ declare namespace ts {
         Construct = 1,
     }
     interface Signature {
-        declaration: SignatureDeclaration;
+        declaration?: SignatureDeclaration;
         typeParameters?: TypeParameter[];
         parameters: Symbol[];
     }


### PR DESCRIPTION
Signature#declaration is undefined when instantiating classes with a default constructor or calling the global `Function` type.
