### PR TITLE
Remove redundant call to `checkNodeDeferred`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -422,6 +422,7 @@ namespace ts {
 
         let deferredNodes: Node[];
         let deferredUnusedIdentifierNodes: Node[];
+        const seenDeferredUnusedIdentifiers = createMap<true>(); // For assertion that we don't defer the same identifier twice
 
         let flowLoopStart = 0;
         let flowLoopCount = 0;
@@ -21563,7 +21564,7 @@ namespace ts {
 
         function registerForUnusedIdentifiersCheck(node: Node) {
             if (deferredUnusedIdentifierNodes) {
-                Debug.assert(!contains(deferredUnusedIdentifierNodes, node), "Registering unused identifier twice");
+                Debug.assert(addToSeen(seenDeferredUnusedIdentifiers, getNodeId(node)), "Deferring unused identifier check twice");
                 deferredUnusedIdentifierNodes.push(node);
             }
         }
@@ -24573,6 +24574,7 @@ namespace ts {
                 }
 
                 deferredNodes = undefined;
+                seenDeferredUnusedIdentifiers.clear();
                 deferredUnusedIdentifierNodes = undefined;
 
                 if (isExternalOrCommonJsModule(node)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18674,7 +18674,6 @@ namespace ts {
 
             // The identityMapper object is used to indicate that function expressions are wildcards
             if (checkMode === CheckMode.SkipContextSensitive && isContextSensitive(node)) {
-                checkNodeDeferred(node);
                 return anyFunctionType;
             }
 
@@ -21564,6 +21563,7 @@ namespace ts {
 
         function registerForUnusedIdentifiersCheck(node: Node) {
             if (deferredUnusedIdentifierNodes) {
+                Debug.assert(!contains(deferredUnusedIdentifierNodes, node), "Registering unused identifier twice");
                 deferredUnusedIdentifierNodes.push(node);
             }
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3839,6 +3839,16 @@ namespace ts {
     export function showModuleSpecifier({ moduleSpecifier }: ImportDeclaration): string {
         return isStringLiteral(moduleSpecifier) ? moduleSpecifier.text : getTextOfNode(moduleSpecifier);
     }
+
+    /** Add a value to a set, and return true if it wasn't already present. */
+    export function addToSeen(seen: Map<true>, key: string | number): boolean {
+        key = String(key);
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.set(key, true);
+        return true;
+    }
 }
 
 namespace ts {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1205,16 +1205,6 @@ namespace ts {
         };
     }
 
-    /** Add a value to a set, and return true if it wasn't already present. */
-    export function addToSeen(seen: Map<true>, key: string | number): boolean {
-        key = String(key);
-        if (seen.has(key)) {
-            return false;
-        }
-        seen.set(key, true);
-        return true;
-    }
-
     export function getSnapshotText(snap: IScriptSnapshot): string {
         return snap.getText(0, snap.getLength());
     }


### PR DESCRIPTION
Fixes #22491 
If I have this right, we will always do one more check after all `SkipContextSensitive` checks.
Before this PR, the assertion (also added in this PR) would have failed for most arrow functions in call expressions.

For posterity, a simple test case that failed was:
```ts
// @noUnusedLocals: true
// @noUnusedParameters: true
declare function f<T>(a: (s: string) => T): void;
f(s => s);
```
(we have lots of test cases like this already, so didn't see a need to add a new one.)