### PR TITLE
useNonAdjustedEndPosition when replacing import node

### DIFF
--- a/src/services/codefixes/useDefaultImport.ts
+++ b/src/services/codefixes/useDefaultImport.ts
@@ -38,6 +38,6 @@ namespace ts.codefix {
     }
 
     function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, info: Info): void {
-        changes.replaceNode(sourceFile, info.importNode, makeImportDeclaration(info.name, /*namedImports*/ undefined, info.moduleSpecifier));
+        changes.replaceNode(sourceFile, info.importNode, makeImportDeclaration(info.name, /*namedImports*/ undefined, info.moduleSpecifier), { useNonAdjustedEndPosition: true });
     }
 }

--- a/src/services/codefixes/useDefaultImport.ts
+++ b/src/services/codefixes/useDefaultImport.ts
@@ -38,6 +38,6 @@ namespace ts.codefix {
     }
 
     function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, info: Info): void {
-        changes.replaceNode(sourceFile, info.importNode, makeImportDeclaration(info.name, /*namedImports*/ undefined, info.moduleSpecifier), { useNonAdjustedEndPosition: true });
+        changes.replaceNode(sourceFile, info.importNode, makeImportDeclaration(info.name, /*namedImports*/ undefined, info.moduleSpecifier), textChanges.useNonAdjustedPositions);
     }
 }

--- a/tests/cases/fourslash/codeFixUseDefaultImport.ts
+++ b/tests/cases/fourslash/codeFixUseDefaultImport.ts
@@ -7,10 +7,10 @@
 ////export = x;
 
 // @Filename: /b.ts
-////import * as [|a|] from "./a";
+/////*com ment*/import * as [|a|] from "./a";/*tnem moc*/
 
 // @Filename: /c.ts
-////import [|a|] = require("./a");
+/////*com ment*/import [|a|] = require("./a");/*tnem moc*/
 
 // @Filename: /d.ts
 ////import "./a";
@@ -29,7 +29,7 @@ for (const file of ["/b.ts", "/c.ts"]) {
 
     verify.codeFix({
         description: "Convert to default import",
-        newFileContent: `import a from "./a";`,
+        newFileContent: `/*com ment*/import a from "./a";/*tnem moc*/`,
     });
 }
 

--- a/tests/cases/fourslash/codeFixUseDefaultImport_all.ts
+++ b/tests/cases/fourslash/codeFixUseDefaultImport_all.ts
@@ -13,6 +13,7 @@
 goTo.file("/b.ts");
 verify.codeFixAll({
     fixId: "useDefaultImport",
-    // TODO: GH#22337
-    newFileContent: `import a1 from "./a";import a2 from "./a";`,
+    newFileContent:
+`import a1 from "./a";
+import a2 from "./a";`,
 });


### PR DESCRIPTION
Fixes #22337 
Adjusting the end position eats up the newline after it, which we don't want as it causes the imports to all end up on the same line.