### PR TITLE
Improve assertion violation message

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -304,7 +304,7 @@ namespace ts {
                 case SyntaxKind.Parameter:
                     // Parameters with names are handled at the top of this function.  Parameters
                     // without names can only come from JSDocFunctionTypes.
-                    Debug.assert(node.parent.kind === SyntaxKind.JSDocFunctionType);
+                    Debug.assert(node.parent.kind === SyntaxKind.JSDocFunctionType, "Impossible parameter parent kind", () => `parent is: ${(ts as any).SyntaxKind ? (ts as any).SyntaxKind[node.parent.kind] : node.parent.kind}, expected JSDocFunctionType`);
                     const functionType = <JSDocFunctionType>node.parent;
                     const index = functionType.parameters.indexOf(node as ParameterDeclaration);
                     return "arg" + index as __String;


### PR DESCRIPTION
Gets more info for #20800 

Best I can tell, `parseParameter` _always_ parses a name out, and `parseJSDocParameter` is only called for jsdoc function types, just like the comment above the assert claims. I'm changing the assert to include information on what the parent node's type was, which should hopefully help identify what parser and/or incremental parser code paths need scrutiny.