### PR TITLE
Pass stack trace limit to parallel workers, and always convert to number

### DIFF
--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -144,7 +144,7 @@ namespace Harness.Parallel.Host {
         let closedWorkers = 0;
         for (let i = 0; i < workerCount; i++) {
             // TODO: Just send the config over the IPC channel or in the command line arguments
-            const config: TestConfig = { light: lightMode, listenForWork: true, runUnitTests };
+            const config: TestConfig = { light: lightMode, listenForWork: true, runUnitTests, stackTraceLimit };
             const configPath = ts.combinePaths(taskConfigsFolder, `task-config${i}.json`);
             IO.writeFile(configPath, JSON.stringify(config));
             const child = fork(__filename, [`--config="${configPath}"`]);

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -88,6 +88,7 @@ let testConfigContent =
 let taskConfigsFolder: string;
 let workerCount: number;
 let runUnitTests: boolean | undefined;
+let stackTraceLimit: number | "full" | undefined;
 let noColors = false;
 
 interface TestConfig {
@@ -132,9 +133,11 @@ function handleTestConfig() {
 
         if (testConfig.stackTraceLimit === "full") {
             (<any>Error).stackTraceLimit = Infinity;
+            stackTraceLimit = testConfig.stackTraceLimit;
         }
         else if ((+testConfig.stackTraceLimit | 0) > 0) {
             (<any>Error).stackTraceLimit = testConfig.stackTraceLimit;
+            stackTraceLimit = testConfig.stackTraceLimit;
         }
         if (testConfig.listenForWork) {
             return true;

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -136,8 +136,8 @@ function handleTestConfig() {
             stackTraceLimit = testConfig.stackTraceLimit;
         }
         else if ((+testConfig.stackTraceLimit | 0) > 0) {
-            (<any>Error).stackTraceLimit = testConfig.stackTraceLimit;
-            stackTraceLimit = testConfig.stackTraceLimit;
+            (<any>Error).stackTraceLimit = +testConfig.stackTraceLimit | 0;
+            stackTraceLimit = +testConfig.stackTraceLimit | 0;
         }
         if (testConfig.listenForWork) {
             return true;

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -421,13 +421,17 @@ namespace ts.server {
 
         // Disable sourcemap support for the duration of the test, as sourcemapping the errors generated during this test is slow and not something we care to test
         let oldPrepare: AnyFunction;
+        let oldStackTraceLimit: number;
         before(() => {
+            oldStackTraceLimit = (Error as any).stackTraceLimit;
             oldPrepare = (Error as any).prepareStackTrace;
             delete (Error as any).prepareStackTrace;
+            (Error as any).stackTraceLimit = 10;
         });
 
         after(() => {
             (Error as any).prepareStackTrace = oldPrepare;
+            (Error as any).stackTraceLimit = oldStackTraceLimit;
         });
 
         const command = "testhandler";


### PR DESCRIPTION
Now you can pass the `stackTraceLimit=4` without breaking anything, with both `runtests` and `runtests-parallel`