### PR TITLE
Simplify implementation of firstOrUndefined and lastOrUndefined

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1077,7 +1077,7 @@ namespace ts {
      * Returns the first element of an array if non-empty, `undefined` otherwise.
      */
     export function firstOrUndefined<T>(array: ReadonlyArray<T>): T | undefined {
-        return elementAt(array, 0);
+        return array.length === 0 ? undefined : array[0];
     }
 
     export function first<T>(array: ReadonlyArray<T>): T {
@@ -1089,7 +1089,7 @@ namespace ts {
      * Returns the last element of an array if non-empty, `undefined` otherwise.
      */
     export function lastOrUndefined<T>(array: ReadonlyArray<T>): T | undefined {
-        return elementAt(array, -1);
+        return array.length === 0 ? undefined : array[array.length - 1];
     }
 
     export function last<T>(array: ReadonlyArray<T>): T {


### PR DESCRIPTION
@sandersn mentioned this having a confusing implementation. As of this PR `elementAt` will only be used in one place -- now we use non-negative indexing everywhere else.