### PR TITLE
Update user tests for new jsdoc fixes

### DIFF
--- a/tests/baselines/reference/user/adonis-framework.log
+++ b/tests/baselines/reference/user/adonis-framework.log
@@ -40,7 +40,6 @@ node_modules/adonis-framework/src/Event/index.js(128,5): error TS2322: Type '() 
   Property 'push' is missing in type '() => {}[]'.
 node_modules/adonis-framework/src/Event/index.js(153,25): error TS2339: Property 'wildcard' does not exist on type 'EventEmitter2'.
 node_modules/adonis-framework/src/Event/index.js(188,17): error TS2304: Cannot find name 'Spread'.
-node_modules/adonis-framework/src/Event/index.js(188,25): error TS8024: JSDoc '@param' tag has name 'data', but there is no parameter with that name.
 node_modules/adonis-framework/src/Event/index.js(207,24): error TS2304: Cannot find name 'Sring'.
 node_modules/adonis-framework/src/Event/index.js(256,52): error TS2345: Argument of type 'Function' is not assignable to parameter of type 'Listener'.
   Type 'Function' provides no match for the signature '(...values: any[]): void'.
@@ -76,15 +75,16 @@ node_modules/adonis-framework/src/Helpers/index.js(330,23): error TS2532: Object
 node_modules/adonis-framework/src/Helpers/index.js(331,22): error TS2339: Property 'endsWith' does not exist on type 'string'.
 node_modules/adonis-framework/src/Middleware/index.js(13,21): error TS2307: Cannot find module 'adonis-fold'.
 node_modules/adonis-framework/src/Middleware/index.js(57,18): error TS2539: Cannot assign to '"/home/nathansa/ts/tests/cases/user/adonis-framework/node_modules/adonis-framework/src/Middleware/index"' because it is not a variable.
+node_modules/adonis-framework/src/Middleware/index.js(92,19): error TS2538: Type 'undefined' cannot be used as an index type.
 node_modules/adonis-framework/src/Middleware/index.js(230,20): error TS8024: JSDoc '@param' tag has name 'Middleware', but there is no parameter with that name.
 node_modules/adonis-framework/src/Request/index.js(64,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Request/index.js(66,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Request/index.js(95,14): error TS2304: Cannot find name 'Mixed'.
-node_modules/adonis-framework/src/Request/index.js(95,21): error TS8024: JSDoc '@param' tag has name 'keys', but there is no parameter with that name.
+node_modules/adonis-framework/src/Request/index.js(95,21): error TS8029: JSDoc '@param' tag has name 'keys', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/adonis-framework/src/Request/index.js(112,14): error TS2304: Cannot find name 'Mixed'.
-node_modules/adonis-framework/src/Request/index.js(112,21): error TS8024: JSDoc '@param' tag has name 'keys', but there is no parameter with that name.
+node_modules/adonis-framework/src/Request/index.js(112,21): error TS8029: JSDoc '@param' tag has name 'keys', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/adonis-framework/src/Request/index.js(131,14): error TS2304: Cannot find name 'Mixed'.
-node_modules/adonis-framework/src/Request/index.js(131,21): error TS8024: JSDoc '@param' tag has name 'keys', but there is no parameter with that name.
+node_modules/adonis-framework/src/Request/index.js(131,21): error TS8029: JSDoc '@param' tag has name 'keys', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/adonis-framework/src/Request/index.js(188,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Request/index.js(190,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Request/index.js(415,15): error TS2304: Cannot find name 'Mixed'.
@@ -95,7 +95,7 @@ node_modules/adonis-framework/src/Request/index.js(480,14): error TS2304: Cannot
 node_modules/adonis-framework/src/Request/index.js(482,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Request/index.js(499,17): error TS2551: Property '_params' does not exist on type 'Request'. Did you mean 'param'?
 node_modules/adonis-framework/src/Request/index.js(523,15): error TS2304: Cannot find name 'Objecr'.
-node_modules/adonis-framework/src/Request/index.js(572,23): error TS8024: JSDoc '@param' tag has name 'pattern', but there is no parameter with that name.
+node_modules/adonis-framework/src/Request/index.js(572,23): error TS8029: JSDoc '@param' tag has name 'pattern', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/adonis-framework/src/Request/index.js(600,12): error TS2554: Expected 2 arguments, but got 1.
 node_modules/adonis-framework/src/Request/index.js(600,35): error TS2554: Expected 2 arguments, but got 1.
 node_modules/adonis-framework/src/Request/index.js(663,23): error TS8024: JSDoc '@param' tag has name 'encodings', but there is no parameter with that name.
@@ -121,20 +121,22 @@ node_modules/adonis-framework/src/Route/index.js(30,5): error TS2322: Type 'null
 node_modules/adonis-framework/src/Route/index.js(36,13): error TS2539: Cannot assign to '"/home/nathansa/ts/tests/cases/user/adonis-framework/node_modules/adonis-framework/src/Route/index"' because it is not a variable.
 node_modules/adonis-framework/src/Route/index.js(58,3): error TS2322: Type 'null' is not assignable to type 'string'.
 node_modules/adonis-framework/src/Route/index.js(321,13): error TS2304: Cannot find name 'Mixed'.
-node_modules/adonis-framework/src/Route/index.js(321,20): error TS8024: JSDoc '@param' tag has name 'keys', but there is no parameter with that name.
+node_modules/adonis-framework/src/Route/index.js(321,20): error TS8029: JSDoc '@param' tag has name 'keys', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/adonis-framework/src/Route/index.js(354,20): error TS2694: Namespace 'Route' has no exported member 'Group'.
 node_modules/adonis-framework/src/Route/index.js(368,3): error TS2322: Type 'null' is not assignable to type 'string'.
 node_modules/adonis-framework/src/Route/index.js(396,10): error TS2554: Expected 2 arguments, but got 3.
 node_modules/adonis-framework/src/Route/index.js(407,20): error TS2694: Namespace 'Route' has no exported member 'resources'.
+node_modules/adonis-framework/src/Route/index.js(501,42): error TS2345: Argument of type 'boolean | undefined' is not assignable to parameter of type 'boolean'.
+  Type 'undefined' is not assignable to type 'boolean'.
 node_modules/adonis-framework/src/Route/resource.js(92,25): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
 node_modules/adonis-framework/src/Route/resource.js(93,25): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
 node_modules/adonis-framework/src/Route/resource.js(95,25): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
 node_modules/adonis-framework/src/Route/resource.js(96,25): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
 node_modules/adonis-framework/src/Route/resource.js(97,25): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
 node_modules/adonis-framework/src/Route/resource.js(172,15): error TS2304: Cannot find name 'Mixed'.
-node_modules/adonis-framework/src/Route/resource.js(172,22): error TS8024: JSDoc '@param' tag has name 'methods', but there is no parameter with that name.
+node_modules/adonis-framework/src/Route/resource.js(172,22): error TS8029: JSDoc '@param' tag has name 'methods', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/adonis-framework/src/Route/resource.js(198,15): error TS2304: Cannot find name 'Mixed'.
-node_modules/adonis-framework/src/Route/resource.js(198,22): error TS8024: JSDoc '@param' tag has name 'methods', but there is no parameter with that name.
+node_modules/adonis-framework/src/Route/resource.js(198,22): error TS8029: JSDoc '@param' tag has name 'methods', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/adonis-framework/src/Route/resource.js(233,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Route/resource.js(261,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Route/resource.js(296,15): error TS2304: Cannot find name 'Mixed'.
@@ -190,6 +192,7 @@ node_modules/adonis-framework/src/Session/index.js(267,15): error TS2304: Cannot
 node_modules/adonis-framework/src/Session/index.js(287,15): error TS2322: Type 'IterableIterator<any>' is not assignable to type 'boolean'.
 node_modules/adonis-framework/src/Session/index.js(293,12): error TS2532: Object is possibly 'undefined'.
 node_modules/adonis-framework/src/Static/index.js(42,16): error TS2693: 'Promise' only refers to a type, but is being used as a value here.
+node_modules/adonis-framework/src/View/Form/index.js(75,11): error TS2532: Object is possibly 'undefined'.
 node_modules/adonis-framework/src/View/Form/index.js(115,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/View/Form/index.js(147,63): error TS2345: Argument of type 'string | any[]' is not assignable to parameter of type 'any[]'.
   Type 'string' is not assignable to type 'any[]'.

--- a/tests/baselines/reference/user/async.log
+++ b/tests/baselines/reference/user/async.log
@@ -1,71 +1,43 @@
 Exit Code: 1
 Standard output:
-node_modules/async/all.js(31,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/all.js(32,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/all.js(32,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/all.js(36,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/all.js(49,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/all"'.
 node_modules/async/all.js(49,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/all.js(49,46): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/all.js(50,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/allLimit.js(31,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/allLimit.js(32,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/allLimit.js(33,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/allLimit.js(33,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/allLimit.js(37,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/allLimit.js(41,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/allLimit"'.
 node_modules/async/allLimit.js(41,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/allLimit.js(41,51): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/allLimit.js(42,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/allSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/allSeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/allSeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/allSeries.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/allSeries.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/allSeries"'.
 node_modules/async/allSeries.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/allSeries.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/any.js(32,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/any.js(33,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/any.js(33,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/any.js(37,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/any.js(51,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/any"'.
 node_modules/async/any.js(51,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/any.js(51,46): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/any.js(52,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/anyLimit.js(31,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/anyLimit.js(32,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/anyLimit.js(33,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/anyLimit.js(33,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/anyLimit.js(37,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/anyLimit.js(42,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/anyLimit"'.
 node_modules/async/anyLimit.js(42,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/anyLimit.js(42,51): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/anyLimit.js(43,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/anySeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/anySeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/anySeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/anySeries.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/anySeries.js(37,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/anySeries"'.
 node_modules/async/anySeries.js(37,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/anySeries.js(38,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/apply.js(7,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/apply"'.
 node_modules/async/apply.js(8,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/apply.js(10,25): error TS2695: Left side of comma operator is unused and has no side effects.
-node_modules/async/apply.js(35,22): error TS8024: JSDoc '@param' tag has name 'fn', but there is no parameter with that name.
-node_modules/async/apply.js(37,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/apply.js(37,28): error TS1003: Identifier expected.
 node_modules/async/apply.js(37,29): error TS1003: Identifier expected.
 node_modules/async/apply.js(37,30): error TS1003: Identifier expected.
 node_modules/async/apply.js(68,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/applyEach.js(29,35): error TS8024: JSDoc '@param' tag has name 'fns', but there is no parameter with that name.
-node_modules/async/applyEach.js(31,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/async/applyEach.js(33,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/applyEach.js(50,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/applyEach"'.
 node_modules/async/applyEach.js(50,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/applyEach.js(51,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/applyEachSeries.js(26,35): error TS8024: JSDoc '@param' tag has name 'fns', but there is no parameter with that name.
-node_modules/async/applyEachSeries.js(28,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/async/applyEachSeries.js(30,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/applyEachSeries.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/applyEachSeries"'.
 node_modules/async/applyEachSeries.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/applyEachSeries.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -110,12 +82,8 @@ node_modules/async/cargo.js(94,1): error TS2309: An export assignment cannot be 
 node_modules/async/compose.js(7,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/compose"'.
 node_modules/async/compose.js(8,37): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/compose.js(36,15): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/compose.js(36,30): error TS8024: JSDoc '@param' tag has name 'functions', but there is no parameter with that name.
 node_modules/async/compose.js(58,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/concat.js(29,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/concat.js(30,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/concat.js(30,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/concat.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/concat.js(32,31): error TS1005: ']' expected.
 node_modules/async/concat.js(42,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/concat"'.
 node_modules/async/concat.js(42,20): error TS2695: Left side of comma operator is unused and has no side effects.
@@ -124,54 +92,34 @@ node_modules/async/concatLimit.js(7,9): error TS2339: Property 'default' does no
 node_modules/async/concatLimit.js(9,22): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/concatLimit.js(10,6): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/concatLimit.js(13,36): error TS2695: Left side of comma operator is unused and has no side effects.
-node_modules/async/concatLimit.js(56,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/concatLimit.js(57,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/concatLimit.js(58,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/concatLimit.js(58,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/concatLimit.js(60,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/concatLimit.js(65,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/concatSeries.js(26,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/concatSeries.js(27,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/concatSeries.js(27,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/concatSeries.js(30,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/concatSeries.js(30,31): error TS1005: ']' expected.
 node_modules/async/concatSeries.js(35,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/concatSeries"'.
 node_modules/async/concatSeries.js(35,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/concatSeries.js(36,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/constant.js(7,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/constant"'.
 node_modules/async/constant.js(8,19): error TS2695: Left side of comma operator is unused and has no side effects.
-node_modules/async/constant.js(34,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/constant.js(34,28): error TS1003: Identifier expected.
 node_modules/async/constant.js(34,29): error TS1003: Identifier expected.
 node_modules/async/constant.js(34,30): error TS1003: Identifier expected.
 node_modules/async/constant.js(66,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/detect.js(41,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/detect.js(42,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/detect.js(42,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/detect.js(45,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/detect.js(60,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/detect"'.
 node_modules/async/detect.js(60,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/detect.js(60,46): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/detect.js(61,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/detectLimit.js(36,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/detectLimit.js(37,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/detectLimit.js(38,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/detectLimit.js(38,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/detectLimit.js(41,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/detectLimit.js(47,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/detectLimit"'.
 node_modules/async/detectLimit.js(47,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/detectLimit.js(47,51): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/detectLimit.js(48,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/detectSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/detectSeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/detectSeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/detectSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/detectSeries.js(37,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/detectSeries"'.
 node_modules/async/detectSeries.js(37,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/detectSeries.js(38,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/dir.js(26,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/dir.js(26,27): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
-node_modules/async/dir.js(28,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/dir.js(28,28): error TS1003: Identifier expected.
 node_modules/async/dir.js(28,29): error TS1003: Identifier expected.
 node_modules/async/dir.js(28,30): error TS1003: Identifier expected.
@@ -181,7 +129,7 @@ node_modules/async/dir.js(43,1): error TS2309: An export assignment cannot be us
 node_modules/async/dist/async.js(3,10): error TS2304: Cannot find name 'define'.
 node_modules/async/dist/async.js(3,35): error TS2304: Cannot find name 'define'.
 node_modules/async/dist/async.js(3,48): error TS2304: Cannot find name 'define'.
-node_modules/async/dist/async.js(31,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/async/dist/async.js(31,18): error TS8029: JSDoc '@param' tag has name '', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/async/dist/async.js(31,28): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(31,29): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(31,30): error TS1003: Identifier expected.
@@ -189,39 +137,37 @@ node_modules/async/dist/async.js(228,40): error TS2339: Property 'toStringTag' d
 node_modules/async/dist/async.js(257,56): error TS2339: Property 'Object' does not exist on type 'Window'.
 node_modules/async/dist/async.js(298,7): error TS2454: Variable 'unmasked' is used before being assigned.
 node_modules/async/dist/async.js(477,61): error TS2339: Property 'iterator' does not exist on type 'never'.
-node_modules/async/dist/async.js(560,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/async/dist/async.js(583,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/async/dist/async.js(622,80): error TS2339: Property 'nodeType' does not exist on type 'NodeModule'.
-node_modules/async/dist/async.js(640,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/async/dist/async.js(745,84): error TS2339: Property 'nodeType' does not exist on type 'NodeModule'.
 node_modules/async/dist/async.js(751,49): error TS2339: Property 'process' does not exist on type 'false | Global'.
   Property 'process' does not exist on type 'false'.
-node_modules/async/dist/async.js(770,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/async/dist/async.js(912,32): error TS2554: Expected 2 arguments, but got 1.
-node_modules/async/dist/async.js(1152,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(1153,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(1157,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(1180,35): error TS8024: JSDoc '@param' tag has name 'fns', but there is no parameter with that name.
-node_modules/async/dist/async.js(1182,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/async/dist/async.js(1184,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(1218,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(1219,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/dist/async.js(1220,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(1224,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(1239,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(1240,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(1244,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(1259,35): error TS8024: JSDoc '@param' tag has name 'fns', but there is no parameter with that name.
-node_modules/async/dist/async.js(1261,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/async/dist/async.js(1263,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(1322,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/async/dist/async.js(1323,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(1324,22): error TS8024: JSDoc '@param' tag has name 'keysFunc', but there is no parameter with that name.
-node_modules/async/dist/async.js(1495,9): error TS2322: Type 'null' is not assignable to type 'number'.
+node_modules/async/dist/async.js(1285,18): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1289,3): error TS2322: Type 'any[] | undefined' is not assignable to type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
+node_modules/async/dist/async.js(1495,9): error TS2322: Type 'null' is not assignable to type 'number | undefined'.
+node_modules/async/dist/async.js(1564,20): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(1566,51): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1608,17): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(1673,30): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1747,7): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1748,14): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1748,45): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1750,9): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1751,7): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1752,5): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1754,12): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1754,20): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1754,32): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1754,38): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1755,3): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(1759,35): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(1937,10): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(1937,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/dist/async.js(1976,16): error TS2554: Expected 3 arguments, but got 1.
-node_modules/async/dist/async.js(2102,20): error TS2345: Argument of type 'Function' is not assignable to parameter of type 'number'.
+node_modules/async/dist/async.js(2102,20): error TS2345: Argument of type 'Function | undefined' is not assignable to parameter of type 'number | undefined'.
+  Type 'Function' is not assignable to type 'number | undefined'.
+    Type 'Function' is not assignable to type 'number'.
 node_modules/async/dist/async.js(2126,5): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(2141,5): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(2150,5): error TS2532: Object is possibly 'undefined'.
@@ -235,85 +181,36 @@ node_modules/async/dist/async.js(2344,20): error TS2532: Object is possibly 'und
 node_modules/async/dist/async.js(2411,20): error TS1005: '}' expected.
 node_modules/async/dist/async.js(2436,5): error TS2322: Type '{ [x: string]: any; _tasks: { head: null | undefined; tail: null | undefined; length: number | un...' is not assignable to type 'NodeModule'.
   Property 'exports' is missing in type '{ [x: string]: any; _tasks: { head: null | undefined; tail: null | undefined; length: number | un...'.
-node_modules/async/dist/async.js(2449,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(2450,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(2453,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(2524,30): error TS8024: JSDoc '@param' tag has name 'functions', but there is no parameter with that name.
-node_modules/async/dist/async.js(2550,31): error TS2345: Argument of type 'IArguments' is not assignable to parameter of type 'any[]'.
-  Property 'push' is missing in type 'IArguments'.
-node_modules/async/dist/async.js(2587,30): error TS8024: JSDoc '@param' tag has name 'functions', but there is no parameter with that name.
-node_modules/async/dist/async.js(2665,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(2666,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(2668,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
+node_modules/async/dist/async.js(2507,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(2550,31): error TS2345: Argument of type 'IArguments' is not assignable to parameter of type 'any[] | undefined'.
+  Type 'IArguments' is not assignable to type 'any[]'.
+    Property 'push' is missing in type 'IArguments'.
+node_modules/async/dist/async.js(2649,16): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(2668,31): error TS1005: ']' expected.
-node_modules/async/dist/async.js(2689,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(2690,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(2693,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/dist/async.js(2693,31): error TS1005: ']' expected.
-node_modules/async/dist/async.js(2710,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/dist/async.js(2710,28): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(2710,29): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(2710,30): error TS1003: Identifier expected.
-node_modules/async/dist/async.js(2818,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(2819,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(2822,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(2850,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(2851,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/dist/async.js(2852,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(2855,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(2873,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(2874,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(2877,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(2919,27): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
-node_modules/async/dist/async.js(2921,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/dist/async.js(2921,28): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(2921,29): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(2921,30): error TS1003: Identifier expected.
-node_modules/async/dist/async.js(3195,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3196,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3201,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3274,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3275,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3279,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3304,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3305,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/dist/async.js(3306,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3310,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3326,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3327,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3331,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3407,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3408,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3411,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3436,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3437,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/dist/async.js(3438,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3441,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3456,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3457,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3460,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3570,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3571,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3575,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3601,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(3602,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/dist/async.js(3603,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3607,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3624,27): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
-node_modules/async/dist/async.js(3626,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/async/dist/async.js(2963,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(2970,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(2971,28): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(3005,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(3008,9): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(3008,9): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
+node_modules/async/dist/async.js(3081,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(3086,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(3087,28): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(3550,16): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(3626,28): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(3626,29): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(3626,30): error TS1003: Identifier expected.
-node_modules/async/dist/async.js(3696,20): error TS8024: JSDoc '@param' tag has name 'obj', but there is no parameter with that name.
-node_modules/async/dist/async.js(3697,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3701,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3734,20): error TS8024: JSDoc '@param' tag has name 'obj', but there is no parameter with that name.
-node_modules/async/dist/async.js(3735,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(3739,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
+node_modules/async/dist/async.js(3674,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(3813,14): error TS2339: Property 'memo' does not exist on type '(...args: any[]) => void'.
 node_modules/async/dist/async.js(3814,14): error TS2339: Property 'unmemoized' does not exist on type '(...args: any[]) => void'.
-node_modules/async/dist/async.js(3832,22): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(3834,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/dist/async.js(3834,23): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(3834,24): error TS1003: Identifier expected.
 node_modules/async/dist/async.js(3834,25): error TS1003: Identifier expected.
@@ -331,43 +228,32 @@ node_modules/async/dist/async.js(4153,14): error TS2339: Property 'unshift' does
 node_modules/async/dist/async.js(4367,5): error TS2322: Type 'any[] | {}' is not assignable to type 'any[]'.
   Type '{}' is not assignable to type 'any[]'.
     Property 'length' is missing in type '{}'.
-node_modules/async/dist/async.js(4387,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(4388,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(4392,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(4417,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(4418,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/dist/async.js(4419,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(4423,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(4437,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(4438,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(4442,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(4735,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(4736,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(4740,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(4766,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(4767,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/dist/async.js(4768,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(4772,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(4789,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/dist/async.js(4790,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(4794,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
+node_modules/async/dist/async.js(4603,17): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(4603,17): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/async/dist/async.js(4915,32): error TS2339: Property 'name' does not exist on type 'Function'.
 node_modules/async/dist/async.js(4917,19): error TS2339: Property 'code' does not exist on type 'Error'.
 node_modules/async/dist/async.js(4919,23): error TS2339: Property 'info' does not exist on type 'Error'.
-node_modules/async/dist/async.js(4996,20): error TS8024: JSDoc '@param' tag has name 'n', but there is no parameter with that name.
-node_modules/async/dist/async.js(4997,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(4999,22): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/dist/async.js(5029,20): error TS8024: JSDoc '@param' tag has name 'n', but there is no parameter with that name.
-node_modules/async/dist/async.js(5030,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/dist/async.js(5032,22): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
+node_modules/async/dist/async.js(5090,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(5146,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(5165,20): error TS2339: Property 'unmemoized' does not exist on type 'Function'.
+node_modules/async/dist/async.js(5208,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/dist/async.js(5211,9): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(5211,9): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
+node_modules/async/dist/async.js(5315,20): error TS2532: Object is possibly 'undefined'.
+node_modules/async/dist/async.js(5315,20): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/async/doDuring.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/doDuring"'.
 node_modules/async/doDuring.js(37,12): error TS2304: Cannot find name 'AsyncFunction'.
 node_modules/async/doDuring.js(39,12): error TS2304: Cannot find name 'AsyncFunction'.
 node_modules/async/doDuring.js(47,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/doDuring.js(48,16): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/doDuring.js(49,18): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/doDuring.js(52,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/doDuring.js(53,21): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/doDuring.js(59,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/doDuring.js(60,28): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/doDuring.js(66,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/doUntil.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/doUntil"'.
 node_modules/async/doUntil.js(24,12): error TS2304: Cannot find name 'AsyncFunction'.
@@ -377,7 +263,11 @@ node_modules/async/doWhilst.js(6,9): error TS2339: Property 'default' does not e
 node_modules/async/doWhilst.js(38,12): error TS2304: Cannot find name 'AsyncFunction'.
 node_modules/async/doWhilst.js(49,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/doWhilst.js(50,22): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/doWhilst.js(52,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/doWhilst.js(53,21): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/doWhilst.js(55,9): error TS2532: Object is possibly 'undefined'.
+node_modules/async/doWhilst.js(55,9): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/async/doWhilst.js(59,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/during.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/during"'.
 node_modules/async/during.js(34,12): error TS2304: Cannot find name 'AsyncFunction'.
@@ -385,6 +275,9 @@ node_modules/async/during.js(36,12): error TS2304: Cannot find name 'AsyncFuncti
 node_modules/async/during.js(59,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/during.js(60,16): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/during.js(61,18): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/during.js(64,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/during.js(69,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/during.js(70,28): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/during.js(76,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/each.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/each"'.
 node_modules/async/each.js(39,12): error TS2304: Cannot find name 'AsyncFunction'.
@@ -404,27 +297,18 @@ node_modules/async/eachOf.js(9,33): error TS2695: Left side of comma operator is
 node_modules/async/eachOf.js(48,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/eachOf.js(65,39): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/eachOf.js(70,22): error TS2695: Left side of comma operator is unused and has no side effects.
-node_modules/async/eachOf.js(83,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/eachOf.js(84,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/eachOf.js(84,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/eachOf.js(88,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/eachOf.js(111,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/eachOfLimit.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/eachOfLimit"'.
 node_modules/async/eachOfLimit.js(31,12): error TS2304: Cannot find name 'AsyncFunction'.
 node_modules/async/eachOfLimit.js(39,4): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/eachOfLimit.js(39,44): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/eachOfLimit.js(41,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/eachOfSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/eachOfSeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/eachOfSeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/eachOfSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/eachOfSeries.js(34,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/eachOfSeries"'.
 node_modules/async/eachOfSeries.js(34,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/eachOfSeries.js(35,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/eachSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/eachSeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/eachSeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/eachSeries.js(33,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/eachSeries.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/eachSeries"'.
 node_modules/async/eachSeries.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/eachSeries.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -437,70 +321,40 @@ node_modules/async/ensureAsync.js(56,10): error TS2695: Left side of comma opera
 node_modules/async/ensureAsync.js(57,13): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/ensureAsync.js(62,18): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/ensureAsync.js(73,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/every.js(31,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/every.js(32,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/every.js(32,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/every.js(36,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/every.js(49,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/every"'.
 node_modules/async/every.js(49,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/every.js(49,46): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/every.js(50,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/everyLimit.js(31,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/everyLimit.js(32,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/everyLimit.js(33,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/everyLimit.js(33,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/everyLimit.js(37,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/everyLimit.js(41,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/everyLimit"'.
 node_modules/async/everyLimit.js(41,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/everyLimit.js(41,51): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/everyLimit.js(42,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/everySeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/everySeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/everySeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/everySeries.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/everySeries.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/everySeries"'.
 node_modules/async/everySeries.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/everySeries.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/filter.js(28,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/filter.js(29,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/filter.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/filter.js(44,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/filter"'.
 node_modules/async/filter.js(44,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/filter.js(45,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/filterLimit.js(28,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/filterLimit.js(29,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/filterLimit.js(30,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/filterLimit.js(33,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/filterLimit.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/filterLimit"'.
 node_modules/async/filterLimit.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/filterLimit.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/filterSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/filterSeries.js(28,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/filterSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/filterSeries.js(34,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/filterSeries"'.
 node_modules/async/filterSeries.js(34,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/filterSeries.js(35,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/find.js(41,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/find.js(42,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/find.js(42,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/find.js(45,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/find.js(60,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/find"'.
 node_modules/async/find.js(60,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/find.js(60,46): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/find.js(61,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/findLimit.js(36,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/findLimit.js(37,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/findLimit.js(38,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/findLimit.js(38,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/findLimit.js(41,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/findLimit.js(47,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/findLimit"'.
 node_modules/async/findLimit.js(47,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/findLimit.js(47,51): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/findLimit.js(48,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/findSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/findSeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/findSeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/findSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/findSeries.js(37,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/findSeries"'.
 node_modules/async/findSeries.js(37,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/findSeries.js(38,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -509,6 +363,7 @@ node_modules/async/foldl.js(46,12): error TS2304: Cannot find name 'AsyncFunctio
 node_modules/async/foldl.js(67,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/foldl.js(68,22): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/foldl.js(69,6): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/foldl.js(75,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/foldl.js(78,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/foldr.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/foldr"'.
 node_modules/async/foldr.js(30,12): error TS2304: Cannot find name 'AsyncFunction'.
@@ -533,27 +388,18 @@ node_modules/async/forEachOf.js(9,33): error TS2695: Left side of comma operator
 node_modules/async/forEachOf.js(48,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/forEachOf.js(65,39): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/forEachOf.js(70,22): error TS2695: Left side of comma operator is unused and has no side effects.
-node_modules/async/forEachOf.js(83,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/forEachOf.js(84,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/forEachOf.js(84,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/forEachOf.js(88,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/forEachOf.js(111,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/forEachOfLimit.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/forEachOfLimit"'.
 node_modules/async/forEachOfLimit.js(31,12): error TS2304: Cannot find name 'AsyncFunction'.
 node_modules/async/forEachOfLimit.js(39,4): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/forEachOfLimit.js(39,44): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/forEachOfLimit.js(41,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/forEachOfSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/forEachOfSeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/forEachOfSeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/forEachOfSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/forEachOfSeries.js(34,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/forEachOfSeries"'.
 node_modules/async/forEachOfSeries.js(34,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/forEachOfSeries.js(35,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/forEachSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/forEachSeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/forEachSeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/forEachSeries.js(33,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/forEachSeries.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/forEachSeries"'.
 node_modules/async/forEachSeries.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/forEachSeries.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -563,27 +409,16 @@ node_modules/async/forever.js(56,17): error TS2695: Left side of comma operator 
 node_modules/async/forever.js(57,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/forever.js(57,42): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/forever.js(65,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/groupBy.js(33,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/groupBy.js(34,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/groupBy.js(34,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/groupBy.js(38,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/groupBy.js(53,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/groupBy"'.
 node_modules/async/groupBy.js(53,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/groupBy.js(54,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/groupByLimit.js(7,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/groupByLimit"'.
 node_modules/async/groupByLimit.js(9,22): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/groupByLimit.js(10,6): error TS2695: Left side of comma operator is unused and has no side effects.
-node_modules/async/groupByLimit.js(61,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/groupByLimit.js(62,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/groupByLimit.js(63,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/groupByLimit.js(63,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/groupByLimit.js(67,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/groupByLimit.js(71,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/groupBySeries.js(26,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/groupBySeries.js(27,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/groupBySeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/groupBySeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/groupBySeries.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/groupBySeries.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/groupBySeries"'.
 node_modules/async/groupBySeries.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/groupBySeries.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -790,6 +625,7 @@ node_modules/async/inject.js(46,12): error TS2304: Cannot find name 'AsyncFuncti
 node_modules/async/inject.js(67,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/inject.js(68,22): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/inject.js(69,6): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/inject.js(75,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/inject.js(78,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/internal/DoublyLinkedList.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/internal/DoublyLinkedList"'.
 node_modules/async/internal/DoublyLinkedList.js(26,5): error TS2532: Object is possibly 'undefined'.
@@ -888,40 +724,25 @@ node_modules/async/internal/wrapAsync.js(17,40): error TS2339: Property 'toStrin
 node_modules/async/internal/wrapAsync.js(21,32): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/internal/wrapAsync.js(25,1): error TS2323: Cannot redeclare exported variable 'isAsync'.
 node_modules/async/log.js(24,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/log.js(24,27): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
-node_modules/async/log.js(26,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/log.js(26,28): error TS1003: Identifier expected.
 node_modules/async/log.js(26,29): error TS1003: Identifier expected.
 node_modules/async/log.js(26,30): error TS1003: Identifier expected.
 node_modules/async/log.js(40,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/log"'.
 node_modules/async/log.js(40,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/log.js(41,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/map.js(39,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/map.js(40,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/map.js(40,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/map.js(44,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/map.js(53,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/map"'.
 node_modules/async/map.js(53,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/map.js(54,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/mapLimit.js(26,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/mapLimit.js(27,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/mapLimit.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/mapLimit.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/mapLimit.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/mapLimit.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/mapLimit"'.
 node_modules/async/mapLimit.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/mapLimit.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/mapSeries.js(26,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/mapSeries.js(27,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/mapSeries.js(27,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/mapSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/mapSeries.js(35,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/mapSeries"'.
 node_modules/async/mapSeries.js(35,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/mapSeries.js(36,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/mapValues.js(35,20): error TS8024: JSDoc '@param' tag has name 'obj', but there is no parameter with that name.
 node_modules/async/mapValues.js(36,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/mapValues.js(36,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/mapValues.js(40,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/mapValues.js(62,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/mapValues"'.
 node_modules/async/mapValues.js(62,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/mapValues.js(63,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -930,11 +751,9 @@ node_modules/async/mapValuesLimit.js(38,12): error TS2304: Cannot find name 'Asy
 node_modules/async/mapValuesLimit.js(48,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/mapValuesLimit.js(50,22): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/mapValuesLimit.js(51,6): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/mapValuesLimit.js(58,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/mapValuesLimit.js(61,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/mapValuesSeries.js(26,20): error TS8024: JSDoc '@param' tag has name 'obj', but there is no parameter with that name.
 node_modules/async/mapValuesSeries.js(27,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/mapValuesSeries.js(27,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/mapValuesSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/mapValuesSeries.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/mapValuesSeries"'.
 node_modules/async/mapValuesSeries.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/mapValuesSeries.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -946,8 +765,6 @@ node_modules/async/memoize.js(76,21): error TS2695: Left side of comma operator 
 node_modules/async/memoize.js(79,14): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/memoize.js(87,29): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/memoize.js(101,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/nextTick.js(23,22): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/nextTick.js(25,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/nextTick.js(25,23): error TS1003: Identifier expected.
 node_modules/async/nextTick.js(25,24): error TS1003: Identifier expected.
 node_modules/async/nextTick.js(25,25): error TS1003: Identifier expected.
@@ -983,6 +800,7 @@ node_modules/async/reduce.js(46,12): error TS2304: Cannot find name 'AsyncFuncti
 node_modules/async/reduce.js(67,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/reduce.js(68,22): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/reduce.js(69,6): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/reduce.js(75,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/reduce.js(78,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/reduceRight.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/reduceRight"'.
 node_modules/async/reduceRight.js(30,12): error TS2304: Cannot find name 'AsyncFunction'.
@@ -1000,22 +818,12 @@ node_modules/async/reflectAll.js(95,10): error TS2695: Left side of comma operat
 node_modules/async/reflectAll.js(96,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/reflectAll.js(99,10): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/reflectAll.js(105,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/reject.js(26,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/reject.js(27,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/reject.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/reject.js(44,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/reject"'.
 node_modules/async/reject.js(44,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/reject.js(45,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/rejectLimit.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/rejectLimit.js(28,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/rejectLimit.js(29,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/rejectLimit.js(33,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/rejectLimit.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/rejectLimit"'.
 node_modules/async/rejectLimit.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/rejectLimit.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/rejectSeries.js(26,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/rejectSeries.js(27,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/rejectSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/rejectSeries.js(34,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/rejectSeries"'.
 node_modules/async/rejectSeries.js(34,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/rejectSeries.js(35,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -1024,6 +832,9 @@ node_modules/async/retry.js(48,12): error TS2304: Cannot find name 'AsyncFunctio
 node_modules/async/retry.js(112,24): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/retry.js(119,81): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/retry.js(141,18): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/retry.js(149,17): error TS2532: Object is possibly 'undefined'.
+node_modules/async/retry.js(149,17): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/async/retry.js(156,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/retryable.js(7,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/retryable"'.
 node_modules/async/retryable.js(12,18): error TS2695: Left side of comma operator is unused and has no side effects.
@@ -1031,28 +842,17 @@ node_modules/async/retryable.js(13,13): error TS2695: Left side of comma operato
 node_modules/async/retryable.js(18,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/retryable.js(18,70): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/retryable.js(36,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/select.js(28,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/select.js(29,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/select.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/select.js(44,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/select"'.
 node_modules/async/select.js(44,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/select.js(45,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/selectLimit.js(28,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/selectLimit.js(29,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
-node_modules/async/selectLimit.js(30,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/selectLimit.js(33,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/selectLimit.js(36,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/selectLimit"'.
 node_modules/async/selectLimit.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/selectLimit.js(37,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/selectSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/selectSeries.js(28,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/selectSeries.js(31,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/selectSeries.js(34,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/selectSeries"'.
 node_modules/async/selectSeries.js(34,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/selectSeries.js(35,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/seq.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/seq"'.
 node_modules/async/seq.js(43,15): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/seq.js(43,30): error TS8024: JSDoc '@param' tag has name 'functions', but there is no parameter with that name.
 node_modules/async/seq.js(69,23): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/seq.js(71,21): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/seq.js(81,10): error TS2695: Left side of comma operator is unused and has no side effects.
@@ -1061,34 +861,22 @@ node_modules/async/seq.js(91,1): error TS2309: An export assignment cannot be us
 node_modules/async/series.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/series"'.
 node_modules/async/series.js(83,4): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/series.js(85,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/setImmediate.js(27,22): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
-node_modules/async/setImmediate.js(29,18): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/async/setImmediate.js(29,23): error TS1003: Identifier expected.
 node_modules/async/setImmediate.js(29,24): error TS1003: Identifier expected.
 node_modules/async/setImmediate.js(29,25): error TS1003: Identifier expected.
 node_modules/async/setImmediate.js(44,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/setImmediate"'.
 node_modules/async/setImmediate.js(45,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/some.js(32,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/some.js(33,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/some.js(33,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/some.js(37,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/some.js(51,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/some"'.
 node_modules/async/some.js(51,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/some.js(51,46): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/some.js(52,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/someLimit.js(31,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
-node_modules/async/someLimit.js(32,20): error TS8024: JSDoc '@param' tag has name 'limit', but there is no parameter with that name.
 node_modules/async/someLimit.js(33,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/someLimit.js(33,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/someLimit.js(37,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/someLimit.js(42,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/someLimit"'.
 node_modules/async/someLimit.js(42,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/someLimit.js(42,51): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/someLimit.js(43,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/someSeries.js(27,35): error TS8024: JSDoc '@param' tag has name 'coll', but there is no parameter with that name.
 node_modules/async/someSeries.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/someSeries.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/someSeries.js(32,23): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/someSeries.js(37,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/someSeries"'.
 node_modules/async/someSeries.js(37,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/someSeries.js(38,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -1107,10 +895,7 @@ node_modules/async/timeout.js(62,13): error TS2695: Left side of comma operator 
 node_modules/async/timeout.js(69,19): error TS2339: Property 'code' does not exist on type 'Error'.
 node_modules/async/timeout.js(71,23): error TS2339: Property 'info' does not exist on type 'Error'.
 node_modules/async/timeout.js(89,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/times.js(27,20): error TS8024: JSDoc '@param' tag has name 'n', but there is no parameter with that name.
 node_modules/async/times.js(28,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/times.js(28,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/times.js(30,22): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/times.js(49,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/times"'.
 node_modules/async/times.js(49,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/times.js(50,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -1120,10 +905,7 @@ node_modules/async/timesLimit.js(39,20): error TS2695: Left side of comma operat
 node_modules/async/timesLimit.js(40,4): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/timesLimit.js(40,28): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/timesLimit.js(42,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
-node_modules/async/timesSeries.js(26,20): error TS8024: JSDoc '@param' tag has name 'n', but there is no parameter with that name.
 node_modules/async/timesSeries.js(27,12): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/timesSeries.js(27,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/async/timesSeries.js(29,22): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/async/timesSeries.js(31,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/timesSeries"'.
 node_modules/async/timesSeries.js(31,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/timesSeries.js(32,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
@@ -1133,11 +915,13 @@ node_modules/async/transform.js(76,24): error TS2695: Left side of comma operato
 node_modules/async/transform.js(78,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/transform.js(79,22): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/transform.js(81,6): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/transform.js(84,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/transform.js(87,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/tryEach.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/tryEach"'.
 node_modules/async/tryEach.js(67,6): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/tryEach.js(68,10): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/tryEach.js(70,27): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/tryEach.js(78,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/tryEach.js(81,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/unmemoize.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/unmemoize"'.
 node_modules/async/unmemoize.js(17,12): error TS2304: Cannot find name 'AsyncFunction'.
@@ -1158,7 +942,12 @@ node_modules/async/whilst.js(6,9): error TS2339: Property 'default' does not exi
 node_modules/async/whilst.js(37,12): error TS2304: Cannot find name 'AsyncFunction'.
 node_modules/async/whilst.js(61,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/whilst.js(62,22): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/whilst.js(63,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/whilst.js(65,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/whilst.js(67,21): error TS2695: Left side of comma operator is unused and has no side effects.
+node_modules/async/whilst.js(68,9): error TS2532: Object is possibly 'undefined'.
+node_modules/async/whilst.js(68,9): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/async/whilst.js(72,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 node_modules/async/wrapSync.js(6,9): error TS2339: Property 'default' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/async/node_modules/async/wrapSync"'.
 node_modules/async/wrapSync.js(43,14): error TS2304: Cannot find name 'AsyncFunction'.

--- a/tests/baselines/reference/user/bcryptjs.log
+++ b/tests/baselines/reference/user/bcryptjs.log
@@ -5,8 +5,6 @@ Standard output:
 ../../../../node_modules/@types/node/index.d.ts(174,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Buffer' must be of type '(s: string) => void', but here has type '{ new (str: string, encoding?: string | undefined): Buffer; new (size: number): Buffer; new (arra...'.
 node_modules/bcryptjs/dist/bcrypt.js(37,16): error TS2345: Argument of type 'never[]' is not assignable to parameter of type 'string'.
 node_modules/bcryptjs/dist/bcrypt.js(134,18): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
-node_modules/bcryptjs/dist/bcrypt.js(141,13): error TS2322: Type 'undefined' is not assignable to type 'number | ((arg0: Error, arg1?: string) => any)'.
-node_modules/bcryptjs/dist/bcrypt.js(144,13): error TS2322: Type 'undefined' is not assignable to type 'number | ((arg0: Error, arg1?: string) => any)'.
 node_modules/bcryptjs/dist/bcrypt.js(165,24): error TS2693: 'Promise' only refers to a type, but is being used as a value here.
 node_modules/bcryptjs/dist/bcrypt.js(190,9): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
   Type 'undefined' is not assignable to type 'string'.
@@ -15,7 +13,6 @@ node_modules/bcryptjs/dist/bcrypt.js(222,24): error TS2693: 'Promise' only refer
 node_modules/bcryptjs/dist/bcrypt.js(278,18): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
 node_modules/bcryptjs/dist/bcrypt.js(306,24): error TS2693: 'Promise' only refers to a type, but is being used as a value here.
 node_modules/bcryptjs/dist/bcrypt.js(348,25): error TS8028: JSDoc '...' may only appear in the last parameter of a signature.
-node_modules/bcryptjs/dist/bcrypt.js(348,34): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/bcryptjs/dist/bcrypt.js(401,9): error TS2322: Type '(...codes: number[]) => string' is not assignable to type '(arg0: number | undefined) => string'.
   Types of parameters 'codes' and 'arg0' are incompatible.
     Type 'number | undefined' is not assignable to type 'number'.
@@ -32,12 +29,10 @@ node_modules/bcryptjs/dist/bcrypt.js(1203,26): error TS2345: Argument of type 'n
 node_modules/bcryptjs/dist/bcrypt.js(1233,30): error TS2345: Argument of type 'null' is not assignable to parameter of type 'Error'.
 node_modules/bcryptjs/dist/bcrypt.js(1345,27): error TS2345: Argument of type 'number[] | undefined' is not assignable to parameter of type 'number[]'.
   Type 'undefined' is not assignable to type 'number[]'.
-node_modules/bcryptjs/dist/bcrypt.js(1351,35): error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
+node_modules/bcryptjs/dist/bcrypt.js(1351,35): error TS2345: Argument of type 'null' is not assignable to parameter of type 'string | undefined'.
 node_modules/bcryptjs/dist/bcrypt.js(1353,30): error TS2345: Argument of type 'null' is not assignable to parameter of type 'Error'.
-node_modules/bcryptjs/dist/bcrypt.js(1361,33): error TS8024: JSDoc '@param' tag has name 'b', but there is no parameter with that name.
-node_modules/bcryptjs/dist/bcrypt.js(1362,24): error TS8024: JSDoc '@param' tag has name 'len', but there is no parameter with that name.
-node_modules/bcryptjs/dist/bcrypt.js(1371,24): error TS8024: JSDoc '@param' tag has name 's', but there is no parameter with that name.
-node_modules/bcryptjs/dist/bcrypt.js(1372,24): error TS8024: JSDoc '@param' tag has name 'len', but there is no parameter with that name.
+node_modules/bcryptjs/dist/bcrypt.js(1353,43): error TS2345: Argument of type 'number[] | undefined' is not assignable to parameter of type 'number[]'.
+  Type 'undefined' is not assignable to type 'number[]'.
 node_modules/bcryptjs/externs/bcrypt.js(36,14): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/bcryptjs/externs/bcrypt.js(50,14): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/bcryptjs/externs/bcrypt.js(65,14): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
@@ -73,8 +68,6 @@ node_modules/bcryptjs/scripts/build.js(36,16): error TS2339: Property 'transform
 node_modules/bcryptjs/scripts/build.js(36,29): error TS2339: Property 'readFileSync' does not exist on type 'void'.
 node_modules/bcryptjs/scripts/build.js(36,58): error TS2339: Property 'join' does not exist on type 'void'.
 node_modules/bcryptjs/src/bcrypt.js(94,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
-node_modules/bcryptjs/src/bcrypt.js(101,9): error TS2322: Type 'undefined' is not assignable to type 'number | ((arg0: Error, arg1?: string) => any)'.
-node_modules/bcryptjs/src/bcrypt.js(104,9): error TS2322: Type 'undefined' is not assignable to type 'number | ((arg0: Error, arg1?: string) => any)'.
 node_modules/bcryptjs/src/bcrypt.js(125,20): error TS2693: 'Promise' only refers to a type, but is being used as a value here.
 node_modules/bcryptjs/src/bcrypt.js(150,5): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
   Type 'undefined' is not assignable to type 'string'.
@@ -82,17 +75,15 @@ node_modules/bcryptjs/src/bcrypt.js(160,14): error TS2366: Function lacks ending
 node_modules/bcryptjs/src/bcrypt.js(182,20): error TS2693: 'Promise' only refers to a type, but is being used as a value here.
 node_modules/bcryptjs/src/bcrypt.js(238,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
 node_modules/bcryptjs/src/bcrypt.js(266,20): error TS2693: 'Promise' only refers to a type, but is being used as a value here.
-node_modules/bcryptjs/src/bcrypt.js(312,29): error TS8024: JSDoc '@param' tag has name 'b', but there is no parameter with that name.
-node_modules/bcryptjs/src/bcrypt.js(313,20): error TS8024: JSDoc '@param' tag has name 'len', but there is no parameter with that name.
-node_modules/bcryptjs/src/bcrypt.js(322,20): error TS8024: JSDoc '@param' tag has name 's', but there is no parameter with that name.
-node_modules/bcryptjs/src/bcrypt.js(323,20): error TS8024: JSDoc '@param' tag has name 'len', but there is no parameter with that name.
 node_modules/bcryptjs/src/bcrypt/impl.js(516,22): error TS2345: Argument of type 'number[] | Int32Array' is not assignable to parameter of type 'number[]'.
   Type 'Int32Array' is not assignable to type 'number[]'.
 node_modules/bcryptjs/src/bcrypt/impl.js(546,26): error TS2345: Argument of type 'null' is not assignable to parameter of type 'Error'.
 node_modules/bcryptjs/src/bcrypt/impl.js(658,23): error TS2345: Argument of type 'number[] | undefined' is not assignable to parameter of type 'number[]'.
   Type 'undefined' is not assignable to type 'number[]'.
-node_modules/bcryptjs/src/bcrypt/impl.js(664,31): error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
+node_modules/bcryptjs/src/bcrypt/impl.js(664,31): error TS2345: Argument of type 'null' is not assignable to parameter of type 'string | undefined'.
 node_modules/bcryptjs/src/bcrypt/impl.js(666,26): error TS2345: Argument of type 'null' is not assignable to parameter of type 'Error'.
+node_modules/bcryptjs/src/bcrypt/impl.js(666,39): error TS2345: Argument of type 'number[] | undefined' is not assignable to parameter of type 'number[]'.
+  Type 'undefined' is not assignable to type 'number[]'.
 node_modules/bcryptjs/src/bcrypt/prng/accum.js(51,74): error TS2339: Property 'attachEvent' does not exist on type 'Document'.
 node_modules/bcryptjs/src/bcrypt/prng/accum.js(52,22): error TS2339: Property 'attachEvent' does not exist on type 'Document'.
 node_modules/bcryptjs/src/bcrypt/prng/accum.js(53,22): error TS2339: Property 'attachEvent' does not exist on type 'Document'.
@@ -100,7 +91,6 @@ node_modules/bcryptjs/src/bcrypt/prng/accum.js(65,74): error TS2339: Property 'd
 node_modules/bcryptjs/src/bcrypt/prng/accum.js(66,22): error TS2339: Property 'detachEvent' does not exist on type 'Document'.
 node_modules/bcryptjs/src/bcrypt/prng/accum.js(67,22): error TS2339: Property 'detachEvent' does not exist on type 'Document'.
 node_modules/bcryptjs/src/bcrypt/util.js(4,21): error TS8028: JSDoc '...' may only appear in the last parameter of a signature.
-node_modules/bcryptjs/src/bcrypt/util.js(4,30): error TS8024: JSDoc '@param' tag has name 'callback', but there is no parameter with that name.
 node_modules/bcryptjs/src/bcrypt/util.js(20,5): error TS2304: Cannot find name 'utfx'.
 node_modules/bcryptjs/src/bcrypt/util/base64.js(29,5): error TS2322: Type '(...codes: number[]) => string' is not assignable to type '(arg0: number | undefined) => string'.
   Types of parameters 'codes' and 'arg0' are incompatible.

--- a/tests/baselines/reference/user/chrome-devtools-frontend.log
+++ b/tests/baselines/reference/user/chrome-devtools-frontend.log
@@ -15,10 +15,6 @@ Standard output:
 ../../../../built/local/lib.es5.d.ts(1328,11): error TS2300: Duplicate identifier 'ArrayLike'.
 ../../../../built/local/lib.es5.d.ts(1364,6): error TS2300: Duplicate identifier 'Record'.
 ../../../../node_modules/@types/node/index.d.ts(150,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'module' must be of type '{ [x: string]: any; }', but here has type 'NodeModule'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(42,47): error TS2339: Property 'origin' does not exist on type 'string | Location'.
-  Property 'origin' does not exist on type 'string'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(42,70): error TS2339: Property 'pathname' does not exist on type 'string | Location'.
-  Property 'pathname' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(43,8): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(95,28): error TS2339: Property 'response' does not exist on type 'EventTarget'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(147,37): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
@@ -31,10 +27,6 @@ node_modules/chrome-devtools-frontend/front_end/Runtime.js(270,9): error TS2322:
   Type 'void' is not assignable to type 'undefined'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(280,5): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(283,7): error TS2554: Expected 2-3 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(299,5): error TS2322: Type 'string | { (regexp: string | RegExp): number; (searcher: { [Symbol.search](string: string): numbe...' is not assignable to type 'string'.
-  Type '{ (regexp: string | RegExp): number; (searcher: { [Symbol.search](string: string): number; }): nu...' is not assignable to type 'string'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(355,35): error TS2339: Property 'href' does not exist on type 'string | Location'.
-  Property 'href' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(398,24): error TS1138: Parameter declaration expected.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(398,24): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(527,9): error TS2322: Type 'Function' is not assignable to type 'new () => any'.
@@ -50,14 +42,9 @@ node_modules/chrome-devtools-frontend/front_end/Runtime.js(715,7): error TS2322:
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(721,5): error TS2322: Type 'Promise<undefined[]>' is not assignable to type 'Promise<undefined>'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(729,7): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(854,36): error TS2339: Property 'eval' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(1060,16): error TS2339: Property 'href' does not exist on type 'string | Location'.
-  Property 'href' does not exist on type 'string'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(1063,41): error TS2339: Property 'origin' does not exist on type 'string | Location'.
-  Property 'origin' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(1083,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(1088,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/Tests.js(107,5): error TS2322: Type 'Timer' is not assignable to type 'number'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(160,29): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
 node_modules/chrome-devtools-frontend/front_end/Tests.js(208,5): error TS2554: Expected 4 arguments, but got 3.
 node_modules/chrome-devtools-frontend/front_end/Tests.js(221,7): error TS2554: Expected 4 arguments, but got 3.
 node_modules/chrome-devtools-frontend/front_end/Tests.js(378,10): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
@@ -136,8 +123,8 @@ node_modules/chrome-devtools-frontend/front_end/Tests.js(1199,9): error TS2554: 
 node_modules/chrome-devtools-frontend/front_end/Tests.js(1199,28): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
 node_modules/chrome-devtools-frontend/front_end/Tests.js(1229,10): error TS2339: Property 'uiTests' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/Tests.js(1229,41): error TS2339: Property 'domAutomationController' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(9,11): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(11,46): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(9,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(11,46): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(45,27): error TS2694: Namespace '(Anonymous class)' has no exported member 'Attribute'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(64,18): error TS2339: Property 'setTextContentTruncatedIfNeeded' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(77,26): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
@@ -158,7 +145,7 @@ node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(56
 node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(57,32): error TS2339: Property '_instance' does not exist on type 'typeof (Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(57,102): error TS2339: Property '_config' does not exist on type 'typeof (Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(58,37): error TS2339: Property '_instance' does not exist on type 'typeof (Anonymous class)'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(10,11): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(10,11): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(14,18): error TS2339: Property 'tabIndex' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(24,38): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(40,51): error TS2339: Property 'focus' does not exist on type 'Element'.
@@ -179,7 +166,7 @@ node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(184,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(208,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(265,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(274,42): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(274,42): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(298,19): error TS2339: Property 'breadcrumb' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(302,23): error TS2339: Property 'tabIndex' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(314,15): error TS1110: Type expected.
@@ -192,7 +179,7 @@ node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(457,30): error TS2339: Property 'breadcrumb' does not exist on type 'Node'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(473,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(481,17): error TS2339: Property 'setTextContentTruncatedIfNeeded' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(488,38): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(488,38): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(10,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(54,32): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(61,25): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
@@ -210,9 +197,9 @@ node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(245,15): error TS1055: Type 'Promise<any>' is not a valid async function return type in ES5/ES3 because it does not refer to a Promise-compatible constructor value.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(255,24): error TS2495: Type 'IterableIterator<(Anonymous class)>' is not an array type or a string type.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(303,26): error TS2339: Property 'printSelfAndChildren' does not exist on type '(Anonymous class)'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(9,11): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(13,40): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(14,41): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(9,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(13,40): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(14,41): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(56,28): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(58,16): error TS1251: Function declarations are not allowed inside blocks in strict mode when targeting 'ES3' or 'ES5'. Class definitions are automatically in strict mode.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(62,61): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
@@ -226,7 +213,7 @@ node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeV
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(144,18): error TS2339: Property 'title' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(155,24): error TS2339: Property 'type' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(156,24): error TS2339: Property 'title' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(167,33): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(167,33): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(168,19): error TS2339: Property 'title' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(179,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(182,32): error TS2339: Property 'Accessibility' does not exist on type 'typeof Protocol'.
@@ -257,24 +244,24 @@ node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeV
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(369,33): error TS2339: Property 'Accessibility' does not exist on type 'typeof Protocol'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(382,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(386,38): error TS2339: Property 'Accessibility' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(395,37): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(395,37): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(396,23): error TS2339: Property 'title' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(396,31): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(407,37): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(396,31): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(407,37): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(408,23): error TS2339: Property 'title' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(408,31): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(412,37): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(408,31): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(412,37): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(419,26): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(422,91): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(422,91): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(431,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(435,28): error TS2339: Property 'createTextChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(438,28): error TS2339: Property 'createTextChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(445,20): error TS2339: Property 'Accessibility' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(445,62): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(445,62): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(461,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(481,20): error TS2339: Property 'Accessibility' does not exist on type 'typeof Protocol'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(492,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(521,84): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(521,84): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(522,20): error TS2339: Property 'createTextChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(535,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeView.js(619,26): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
@@ -362,7 +349,7 @@ node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(8
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(14,38): error TS2339: Property 'createSVGChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(19,53): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(20,44): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(21,32): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(21,32): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(26,32): error TS2694: Namespace 'Protocol' has no exported member 'DOM'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(36,47): error TS2339: Property 'AnimationModel' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(36,63): error TS2345: Argument of type 'this' is not assignable to parameter of type '{ [x: string]: any; modelAdded(model: T): void; modelRemoved(model: T): void; }'.
@@ -381,23 +368,23 @@ node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(9
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(103,57): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(105,28): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(110,48): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(112,44): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(112,44): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(114,34): error TS2345: Argument of type '(Anonymous class)' is not assignable to parameter of type '{ [x: string]: any; item(): any & (Anonymous class); } & (Anonymous class)'.
   Type '(Anonymous class)' is not assignable to type '{ [x: string]: any; item(): any & (Anonymous class); }'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(117,46): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(117,46): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(119,34): error TS2345: Argument of type '(Anonymous class)' is not assignable to parameter of type '{ [x: string]: any; item(): any & (Anonymous class); } & (Anonymous class)'.
   Type '(Anonymous class)' is not assignable to type '{ [x: string]: any; item(): any & (Anonymous class); }'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(123,40): error TS2339: Property 'AnimationTimeline' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(125,45): error TS2345: Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string | string[]'.
   Type 'TemplateStringsArray' is not assignable to type 'string[]'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(125,72): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(125,72): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(128,24): error TS2345: Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string | string[]'.
   Type 'TemplateStringsArray' is not assignable to type 'string[]'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(133,50): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(137,47): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(138,35): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(138,35): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(139,41): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(144,48): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(144,48): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(145,36): error TS2339: Property 'AnimationTimeline' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(148,31): error TS2345: Argument of type '(Anonymous class)' is not assignable to parameter of type '{ [x: string]: any; item(): any & (Anonymous class); } & (Anonymous class)'.
   Type '(Anonymous class)' is not assignable to type '{ [x: string]: any; item(): any & (Anonymous class); }'.
@@ -410,18 +397,18 @@ node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(1
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(177,63): error TS2339: Property 'parentElement' does not exist on type 'EventTarget'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(194,30): error TS2304: Cannot find name 'Image'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(197,25): error TS2339: Property 'AnimationScreenshotPopover' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(208,50): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(208,67): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(208,50): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(208,67): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(216,67): error TS2339: Property 'AnimationModel' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(218,34): error TS2345: Argument of type 'number' is not assignable to parameter of type '{ [x: string]: any; WindowDocked: number; WindowUndocked: number; ScriptsBreakpointSet: number; T...'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(233,42): error TS2339: Property 'AnimationTimeline' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(235,47): error TS2339: Property 'AnimationTimeline' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(244,38): error TS2339: Property 'AnimationTimeline' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(246,36): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(246,36): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(249,38): error TS2339: Property 'AnimationTimeline' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(251,36): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(251,36): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(254,38): error TS2339: Property 'AnimationTimeline' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
-node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(256,36): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(256,36): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(334,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationTimeline.js(359,28): error TS2345: Argument of type '(left: (Anonymous class), right: (Anonymous class)) => boolean' is not assignable to parameter of type '(a: any, b: any) => number'.
   Type 'boolean' is not assignable to type 'number'.
@@ -624,7 +611,7 @@ node_modules/chrome-devtools-frontend/front_end/audits2/Audits2Panel.js(342,26):
 node_modules/chrome-devtools-frontend/front_end/audits2/Audits2Panel.js(356,23): error TS2339: Property 'disabled' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/audits2/Audits2Panel.js(363,24): error TS2345: Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string | string[]'.
   Type 'TemplateStringsArray' is not assignable to type 'string[]'.
-node_modules/chrome-devtools-frontend/front_end/audits2/Audits2Panel.js(363,55): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/audits2/Audits2Panel.js(363,55): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/audits2/Audits2Panel.js(365,46): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/audits2/Audits2Panel.js(379,15): error TS1055: Type 'Promise<undefined>' is not a valid async function return type in ES5/ES3 because it does not refer to a Promise-compatible constructor value.
 node_modules/chrome-devtools-frontend/front_end/audits2/Audits2Panel.js(384,31): error TS2339: Property 'singleton' does not exist on type 'Window'.
@@ -3829,11 +3816,11 @@ node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(45,37): e
   Type '(Anonymous class)' is not assignable to type '{ [x: string]: any; item(): any & (Anonymous class); }'.
 node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(47,37): error TS2345: Argument of type '(Anonymous class)' is not assignable to parameter of type '{ [x: string]: any; item(): any & (Anonymous class); } & (Anonymous class)'.
   Type '(Anonymous class)' is not assignable to type '{ [x: string]: any; item(): any & (Anonymous class); }'.
-node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(50,20): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(50,20): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(75,11): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(111,22): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(111,22): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(133,20): error TS2694: Namespace 'Diff' has no exported member 'Diff'.
-node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(139,22): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(139,22): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(155,26): error TS2339: Property 'pushAll' does not exist on type 'any[]'.
 node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(156,25): error TS2339: Property 'pushAll' does not exist on type 'any[]'.
 node_modules/chrome-devtools-frontend/front_end/changes/ChangesView.js(157,24): error TS2339: Property 'pushAll' does not exist on type 'any[]'.
@@ -4536,8 +4523,8 @@ node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.
 node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(238,13): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(239,13): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(251,11): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(256,13): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(259,13): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(256,13): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(259,13): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(643,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(657,19): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/components/DockController.js(42,46): error TS2555: Expected at least 2 arguments, but got 1.
@@ -4626,8 +4613,6 @@ node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(769,67):
 node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(770,23): error TS2495: Type 'IterableIterator<string>' is not an array type or a string type.
 node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(779,64): error TS2339: Property 'copyText' does not exist on type 'typeof InspectorFrontendHost'.
 node_modules/chrome-devtools-frontend/front_end/components/Reload.js(7,27): error TS2339: Property 'setIsDocked' does not exist on type 'typeof InspectorFrontendHost'.
-node_modules/chrome-devtools-frontend/front_end/components/Reload.js(8,19): error TS2339: Property 'reload' does not exist on type 'string | Location'.
-  Property 'reload' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleContextSelector.js(8,9): error TS2339: Property 'ConsoleContextSelector' does not exist on type '{ new (): Console; prototype: Console; }'.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleContextSelector.js(10,17): error TS2315: Type '(Anonymous class)' is not generic.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleContextSelector.js(12,17): error TS2315: Type '(Anonymous class)' is not generic.
@@ -5047,7 +5032,7 @@ node_modules/chrome-devtools-frontend/front_end/console/ConsoleViewMessage.js(13
   Type 'TemplateStringsArray' is not assignable to type 'string[]'.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleViewMessage.js(1381,63): error TS2339: Property 'withThousandsSeparator' does not exist on type 'NumberConstructor'.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleViewMessage.js(1388,33): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
-node_modules/chrome-devtools-frontend/front_end/console/ConsoleViewMessage.js(1389,44): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/console/ConsoleViewMessage.js(1389,44): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleViewMessage.js(1391,31): error TS2339: Property 'copyText' does not exist on type 'typeof InspectorFrontendHost'.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleViewMessage.js(1402,20): error TS2339: Property 'ConsoleViewMessage' does not exist on type '{ new (): Console; prototype: Console; }'.
 node_modules/chrome-devtools-frontend/front_end/console/ConsoleViewMessage.js(1412,18): error TS2339: Property 'ConsoleViewMessage' does not exist on type '{ new (): Console; prototype: Console; }'.
@@ -6015,8 +6000,6 @@ node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(692,21
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(741,50): error TS2694: Namespace 'InspectorFrontendHostAPI' has no exported member 'ContextMenuDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(872,10): error TS2339: Property 'InspectorFrontendHost' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1123,12): error TS2339: Property 'Object' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1203,32): error TS2339: Property 'indexOf' does not exist on type 'string | { (regexp: string | RegExp): number; (searcher: { [Symbol.search](string: string): numbe...'.
-  Property 'indexOf' does not exist on type '{ (regexp: string | RegExp): number; (searcher: { [Symbol.search](string: string): number; }): nu...'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1207,17): error TS2339: Property 'KeyboardEvent' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1208,36): error TS2339: Property 'KeyboardEvent' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/devtools_compatibility.js(1214,46): error TS2339: Property 'keyCode' does not exist on type 'PropertyDescriptor'.
@@ -6450,8 +6433,8 @@ node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(534,54): error TS2339: Property 'toggleHideElement' does not exist on type '(Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(535,21): error TS2339: Property 'isToggledToHidden' does not exist on type '(Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(539,44): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(541,42): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(542,42): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(541,42): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(542,42): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(546,26): error TS2339: Property 'selectedDOMNode' does not exist on type '(Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(575,10): error TS2339: Property 'style' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(576,10): error TS2339: Property 'style' does not exist on type 'Element'.
@@ -6974,8 +6957,6 @@ node_modules/chrome-devtools-frontend/front_end/elements_test_runner/StylesUpdat
 node_modules/chrome-devtools-frontend/front_end/elements_test_runner/StylesUpdateLinksTestRunner.js(119,24): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(31,5): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(56,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(65,31): error TS2339: Property 'href' does not exist on type 'string | Location'.
-  Property 'href' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(88,7): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(92,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/emulation/AdvancedApp.js(105,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
@@ -7462,8 +7443,6 @@ node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(145,2
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(149,19): error TS1110: Type expected.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(203,23): error TS2339: Property 'sendRequest' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(207,23): error TS2339: Property 'sendRequest' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
-node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(208,96): error TS2339: Property 'hostname' does not exist on type 'string | Location'.
-  Property 'hostname' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(224,23): error TS2339: Property 'sendRequest' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(243,23): error TS2339: Property 'sendRequest' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionAPI.js(249,53): error TS2339: Property 'nextObjectId' does not exist on type '{ _callbacks: { [x: string]: any; }; _handlers: { [x: string]: any; }; _lastRequestId: number; _l...'.
@@ -7538,8 +7517,6 @@ node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(68
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(708,31): error TS2339: Property 'setInjectedScriptForOrigin' does not exist on type 'typeof InspectorFrontendHost'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(712,14): error TS2339: Property 'src' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(713,14): error TS2339: Property 'style' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(724,38): error TS2339: Property 'origin' does not exist on type 'string | Location'.
-  Property 'origin' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(765,31): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(777,31): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/extensions/ExtensionServer.js(839,43): error TS2694: Namespace '(Anonymous class)' has no exported member 'Record'.
@@ -8732,8 +8709,6 @@ node_modules/chrome-devtools-frontend/front_end/main/Main.js(820,47): error TS25
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(822,25): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(823,9): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(824,38): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/main/Main.js(824,99): error TS2339: Property 'reload' does not exist on type 'string | Location'.
-  Property 'reload' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(825,25): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(833,28): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; SetExactSize: symbol; SetExactWidthMaxHeight: symbol; MeasureContent: symbol; }'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(836,5): error TS2554: Expected 2 arguments, but got 1.
@@ -9794,8 +9769,8 @@ node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSectio
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(326,20): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(328,20): error TS2339: Property 'title' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(343,35): error TS2694: Namespace '(Anonymous class)' has no exported member 'FunctionDetails'.
-node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(392,11): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(395,11): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(392,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(395,11): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(468,48): error TS2339: Property '_skipProto' does not exist on type '(Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(565,16): error TS2339: Property 'parentObject' does not exist on type '(Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(571,38): error TS2339: Property 'getter' does not exist on type '(Anonymous class)'.
@@ -9830,10 +9805,10 @@ node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSectio
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(820,46): error TS2339: Property 'title' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(821,51): error TS2339: Property 'copyText' does not exist on type 'typeof InspectorFrontendHost'.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(821,105): error TS2339: Property 'title' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(822,49): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(822,49): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(824,23): error TS2339: Property 'parentObject' does not exist on type '(Anonymous class)'.
-node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(825,44): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(826,44): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(825,44): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(826,44): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(832,43): error TS2339: Property '_editable' does not exist on type '(Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(832,61): error TS2339: Property '_readOnly' does not exist on type '(Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/object_ui/ObjectPropertiesSection.js(835,46): error TS2339: Property 'createChild' does not exist on type 'Element'.
@@ -10342,7 +10317,6 @@ node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(545,5): er
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(580,34): error TS2339: Property 'length' does not exist on type 'PropertyDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(581,30): error TS2339: Property 'length' does not exist on type 'PropertyDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(595,30): error TS2339: Property 'length' does not exist on type 'PropertyDescriptor'.
-node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(612,5): error TS2322: Type 'PropertyDescriptor' is not assignable to type 'T[]'.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(612,5): error TS2322: Type 'PropertyDescriptor' is not assignable to type 'T[]'.
   Property 'includes' is missing in type 'PropertyDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(624,28): error TS2339: Property 'length' does not exist on type 'PropertyDescriptor'.
@@ -13095,7 +13069,7 @@ node_modules/chrome-devtools-frontend/front_end/sdk/SecurityOriginManager.js(26,
 node_modules/chrome-devtools-frontend/front_end/sdk/SecurityOriginManager.js(31,24): error TS2495: Type 'Set<string>' is not an array type or a string type.
 node_modules/chrome-devtools-frontend/front_end/sdk/SecurityOriginManager.js(41,34): error TS2339: Property 'valuesArray' does not exist on type 'Set<string>'.
 node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(20,41): error TS2694: Namespace '(Anonymous class)' has no exported member 'NameValue'.
-node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(110,26): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(110,26): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(129,32): error TS2345: Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string | string[]'.
   Type 'TemplateStringsArray' is not assignable to type 'string[]'.
     Property 'push' is missing in type 'TemplateStringsArray'.
@@ -13103,9 +13077,8 @@ node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(134,32): err
   Type 'TemplateStringsArray' is not assignable to type 'string[]'.
 node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(139,30): error TS2345: Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string | string[]'.
   Type 'TemplateStringsArray' is not assignable to type 'string[]'.
-node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(149,24): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(165,34): error TS2345: Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string | string[]'.
-  Type 'TemplateStringsArray' is not assignable to type 'string[]'.
+node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(149,24): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(165,32): error TS2554: Expected 2 arguments, but got 3.
 node_modules/chrome-devtools-frontend/front_end/sdk/ServerTiming.js(186,25): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/sdk/ServiceWorkerCacheModel.js(15,12): error TS2339: Property 'registerStorageDispatcher' does not exist on type '(Anonymous class)'.
 node_modules/chrome-devtools-frontend/front_end/sdk/ServiceWorkerCacheModel.js(20,31): error TS2339: Property 'cacheStorageAgent' does not exist on type '(Anonymous class)'.
@@ -13483,7 +13456,7 @@ node_modules/chrome-devtools-frontend/front_end/security/SecurityPanel.js(761,9)
 node_modules/chrome-devtools-frontend/front_end/security/SecurityPanel.js(771,38): error TS2694: Namespace '(Anonymous class)' has no exported member 'Origin'.
 node_modules/chrome-devtools-frontend/front_end/security/SecurityPanel.js(772,38): error TS2694: Namespace '(Anonymous class)' has no exported member 'OriginState'.
 node_modules/chrome-devtools-frontend/front_end/security/SecurityPanel.js(783,37): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/security/SecurityPanel.js(784,75): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/security/SecurityPanel.js(784,75): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/security/SecurityPanel.js(794,9): error TS2339: Property 'consume' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/security/SecurityPanel.js(796,44): error TS2345: Argument of type '{ filterType: string; filterValue: string; }[]' is not assignable to parameter of type '{ filterType: { [x: string]: any; Domain: string; HasResponseHeader: string; Is: string; LargerTh...'.
   Type '{ filterType: string; filterValue: string; }' is not assignable to type '{ filterType: { [x: string]: any; Domain: string; HasResponseHeader: string; Is: string; LargerTh...'.

--- a/tests/baselines/reference/user/lodash.log
+++ b/tests/baselines/reference/user/lodash.log
@@ -1,53 +1,79 @@
 Exit Code: 1
 Standard output:
+node_modules/lodash/_Hash.js(20,17): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_ListCache.js(20,17): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_MapCache.js(20,17): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_SetCache.js(19,14): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_Stack.js(17,20): error TS2339: Property 'size' does not exist on type '{ clear: () => void; get: (key: string) => any; has: (key: string) => boolean; set: (key: string,...'.
+node_modules/lodash/_arrayAggregator.js(16,17): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayEach.js(15,18): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayEach.js(19,3): error TS2322: Type 'any[] | undefined' is not assignable to type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
+node_modules/lodash/_arrayEachRight.js(14,18): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayEachRight.js(18,3): error TS2322: Type 'any[] | undefined' is not assignable to type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
+node_modules/lodash/_arrayEvery.js(16,20): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayFilter.js(17,17): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_arrayIncludes.js(9,15): error TS8024: JSDoc '@param' tag has name 'target', but there is no parameter with that name.
+node_modules/lodash/_arrayIncludes.js(14,34): error TS2345: Argument of type 'any[] | undefined' is not assignable to parameter of type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
 node_modules/lodash/_arrayIncludesWith.js(6,15): error TS8024: JSDoc '@param' tag has name 'target', but there is no parameter with that name.
-node_modules/lodash/_asciiSize.js(7,20): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
+node_modules/lodash/_arrayIncludesWith.js(15,27): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayMap.js(16,30): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayReduce.js(18,19): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayReduce.js(21,41): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayReduceRight.js(16,19): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arrayReduceRight.js(19,41): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_arraySome.js(16,19): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_asciiWords.js(8,20): error TS8024: JSDoc '@param' tag has name 'The', but there is no parameter with that name.
 node_modules/lodash/_baseClone.js(91,16): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 node_modules/lodash/_baseClone.js(92,16): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 node_modules/lodash/_baseClone.js(93,16): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-node_modules/lodash/_baseClone.js(115,33): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/_baseClone.js(128,43): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+node_modules/lodash/_baseClone.js(115,33): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean | undefined'.
+node_modules/lodash/_baseClone.js(128,43): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean | undefined'.
 node_modules/lodash/_baseClone.js(157,17): error TS2552: Cannot find name 'keysIn'. Did you mean 'keys'?
-node_modules/lodash/_baseCreate.js(11,20): error TS8024: JSDoc '@param' tag has name 'proto', but there is no parameter with that name.
-node_modules/lodash/_baseDifference.js(37,5): error TS2322: Type '(array?: any[], value: any, comparator: Function) => boolean' is not assignable to type '(array?: any[], value: any) => boolean'.
+node_modules/lodash/_baseDifference.js(37,5): error TS2322: Type '(array?: any[] | undefined, value: any, comparator: Function) => boolean' is not assignable to type '(array?: any[] | undefined, value: any) => boolean'.
 node_modules/lodash/_baseDifference.js(43,5): error TS2322: Type '{ __data__: { clear: () => void; get: (key: string) => any; has: (key: string) => boolean; set: (...' is not assignable to type 'any[]'.
   Property 'length' is missing in type '{ __data__: { clear: () => void; get: (key: string) => any; has: (key: string) => boolean; set: (...'.
 node_modules/lodash/_baseDifference.js(60,15): error TS2554: Expected 2 arguments, but got 3.
-node_modules/lodash/_baseEach.js(8,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/_baseEach.js(9,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/_baseEachRight.js(8,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/_baseEachRight.js(9,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/_baseFlatten.js(19,17): error TS2322: Type '(value: any) => boolean' is not assignable to type 'boolean'.
+node_modules/lodash/_baseFlatten.js(19,17): error TS2322: Type '(value: any) => boolean' is not assignable to type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/_baseFlatten.js(24,22): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseFlatten.js(24,22): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/_baseFlatten.js(24,22): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Boolean' has no compatible call signatures.
-node_modules/lodash/_baseFor.js(9,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/_baseFor.js(10,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/_baseFor.js(11,22): error TS8024: JSDoc '@param' tag has name 'keysFunc', but there is no parameter with that name.
-node_modules/lodash/_baseForRight.js(8,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/_baseForRight.js(9,22): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/_baseForRight.js(10,22): error TS8024: JSDoc '@param' tag has name 'keysFunc', but there is no parameter with that name.
+node_modules/lodash/_baseIntersection.js(53,40): error TS2345: Argument of type 'Function | undefined' is not assignable to parameter of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
+node_modules/lodash/_baseIntersection.js(60,54): error TS2345: Argument of type 'Function | undefined' is not assignable to parameter of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/_baseIsEqual.js(25,40): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'number'.
 node_modules/lodash/_baseIsMatch.js(52,47): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/_baseMatchesProperty.js(23,36): error TS2345: Argument of type 'string | symbol' is not assignable to parameter of type 'string'.
   Type 'symbol' is not assignable to type 'string'.
 node_modules/lodash/_baseMatchesProperty.js(29,41): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+node_modules/lodash/_basePullAll.js(41,60): error TS2345: Argument of type 'Function | undefined' is not assignable to parameter of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/_basePullAt.js(30,26): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string | any[]'.
 node_modules/lodash/_baseSet.js(41,25): error TS2345: Argument of type 'string | symbol' is not assignable to parameter of type 'string'.
   Type 'symbol' is not assignable to type 'string'.
-node_modules/lodash/_baseSetData.js(8,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/_baseSetData.js(9,15): error TS8024: JSDoc '@param' tag has name 'data', but there is no parameter with that name.
-node_modules/lodash/_baseSetToString.js(9,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/_baseSetToString.js(10,22): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
+node_modules/lodash/_baseSlice.js(14,7): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(15,14): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(15,45): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(17,9): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(18,7): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(19,5): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(21,12): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(21,20): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(21,32): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(21,38): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(22,3): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_baseSlice.js(26,35): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_baseSortBy.js(14,14): error TS2345: Argument of type 'Function' is not assignable to parameter of type '((a: any, b: any) => number) | undefined'.
   Type 'Function' is not assignable to type '(a: any, b: any) => number'.
     Type 'Function' provides no match for the signature '(a: any, b: any): number'.
-node_modules/lodash/_baseUniq.js(30,5): error TS2322: Type '(array?: any[], value: any, comparator: Function) => boolean' is not assignable to type '(array?: any[], value: any) => boolean'.
+node_modules/lodash/_baseUniq.js(30,5): error TS2322: Type '(array?: any[] | undefined, value: any, comparator: Function) => boolean' is not assignable to type '(array?: any[] | undefined, value: any) => boolean'.
 node_modules/lodash/_baseUniq.js(33,33): error TS2554: Expected 0 arguments, but got 1.
 node_modules/lodash/_baseUniq.js(39,5): error TS2322: Type '{ __data__: { clear: () => void; get: (key: string) => any; has: (key: string) => boolean; set: (...' is not assignable to type 'any[]'.
 node_modules/lodash/_baseUniq.js(62,15): error TS2554: Expected 2 arguments, but got 3.
-node_modules/lodash/_castRest.js(9,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
 node_modules/lodash/_cloneArrayBuffer.js(11,16): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 node_modules/lodash/_cloneBuffer.js(4,69): error TS2339: Property 'nodeType' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/lodash/node_modules/lodash/_cloneBuffer"'.
 node_modules/lodash/_cloneBuffer.js(7,80): error TS2339: Property 'nodeType' does not exist on type 'NodeModule'.
@@ -64,7 +90,6 @@ node_modules/lodash/_createCtor.js(24,22): error TS2351: Cannot use 'new' with a
 node_modules/lodash/_createCtor.js(25,22): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 node_modules/lodash/_createCtor.js(26,22): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 node_modules/lodash/_createCurry.js(37,46): error TS2339: Property 'placeholder' does not exist on type '(...args: any[]) => any'.
-node_modules/lodash/_createCurry.js(38,24): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'any[]'.
 node_modules/lodash/_createFind.js(16,22): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/_createFind.js(21,34): error TS2454: Variable 'iteratee' is used before being assigned.
 node_modules/lodash/_createFlow.js(38,22): error TS2454: Variable 'wrapper' is used before being assigned.
@@ -78,45 +103,41 @@ node_modules/lodash/_createFlow.js(57,21): error TS2339: Property 'thru' does no
 node_modules/lodash/_createFlow.js(65,24): error TS2339: Property 'plant' does not exist on type '{ __wrapped__: any; __actions__: never[] | undefined; __chain__: boolean | undefined; __index__: ...'.
 node_modules/lodash/_createHybrid.js(44,49): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
+node_modules/lodash/_createHybrid.js(59,42): error TS2345: Argument of type 'any[] | undefined' is not assignable to parameter of type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
+node_modules/lodash/_createHybrid.js(62,52): error TS2345: Argument of type 'any[] | undefined' is not assignable to parameter of type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
 node_modules/lodash/_createHybrid.js(64,15): error TS2454: Variable 'holdersCount' is used before being assigned.
+node_modules/lodash/_createHybrid.js(65,31): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_createHybrid.js(68,9): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
 node_modules/lodash/_createHybrid.js(68,46): error TS2339: Property 'placeholder' does not exist on type '(...args: any[]) => any'.
+node_modules/lodash/_createHybrid.js(69,40): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_createHybrid.js(73,38): error TS2538: Type 'Function' cannot be used as an index type.
-node_modules/lodash/_createSet.js(12,19): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/_createWrap.js(59,5): error TS2322: Type 'undefined' is not assignable to type 'any[]'.
-node_modules/lodash/_createWrap.js(59,16): error TS2322: Type 'undefined' is not assignable to type 'any[]'.
-node_modules/lodash/_createWrap.js(69,5): error TS2322: Type 'undefined' is not assignable to type 'any[]'.
-node_modules/lodash/_createWrap.js(69,16): error TS2322: Type 'undefined' is not assignable to type 'any[]'.
+node_modules/lodash/_createHybrid.js(81,18): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_createHybrid.js(82,7): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/_createWrap.js(71,38): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/_createWrap.js(74,48): error TS2454: Variable 'partialsRight' is used before being assigned.
-node_modules/lodash/_createWrap.js(74,63): error TS2454: Variable 'holdersRight' is used before being assigned.
 node_modules/lodash/_createWrap.js(94,29): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
 node_modules/lodash/_createWrap.js(96,26): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
+node_modules/lodash/_createWrap.js(97,100): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_createWrap.js(98,28): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
 node_modules/lodash/_createWrap.js(103,51): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
 node_modules/lodash/_customDefaultsMerge.js(22,35): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'number'.
 node_modules/lodash/_customOmitClone.js(9,20): error TS8024: JSDoc '@param' tag has name 'key', but there is no parameter with that name.
-node_modules/lodash/_deburrLetter.js(66,20): error TS8024: JSDoc '@param' tag has name 'letter', but there is no parameter with that name.
 node_modules/lodash/_equalArrays.js(64,22): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_equalByTag.js(86,7): error TS2454: Variable 'convert' is used before being assigned.
 node_modules/lodash/_equalObjects.js(70,18): error TS2322: Type 'boolean' is not assignable to type 'number'.
-node_modules/lodash/_escapeHtmlChar.js(16,20): error TS8024: JSDoc '@param' tag has name 'chr', but there is no parameter with that name.
-node_modules/lodash/_flatRest.js(13,37): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'number'.
-node_modules/lodash/_getData.js(8,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
 node_modules/lodash/_getFuncName.js(17,22): error TS2339: Property 'name' does not exist on type 'Function'.
 node_modules/lodash/_getHolder.js(10,17): error TS2339: Property 'placeholder' does not exist on type 'Function'.
 node_modules/lodash/_getRawTag.js(36,7): error TS2454: Variable 'unmasked' is used before being assigned.
 node_modules/lodash/_getSymbols.js(11,31): error TS2551: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Did you mean 'getOwnPropertyNames'?
-node_modules/lodash/_getSymbols.js(17,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
 node_modules/lodash/_getSymbolsIn.js(7,31): error TS2551: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Did you mean 'getOwnPropertyNames'?
-node_modules/lodash/_getSymbolsIn.js(13,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
 node_modules/lodash/_getSymbolsIn.js(19,23): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/_getTag.js(29,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/_hasPath.js(35,50): error TS2454: Variable 'key' is used before being assigned.
 node_modules/lodash/_hashDelete.js(7,20): error TS8024: JSDoc '@param' tag has name 'hash', but there is no parameter with that name.
 node_modules/lodash/_initCloneArray.js(16,16): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
@@ -126,7 +147,6 @@ node_modules/lodash/_insertWrapDetails.js(10,5): error TS1223: 'returns' tag alr
 node_modules/lodash/_insertWrapDetails.js(15,5): error TS2322: Type 'string' is not assignable to type 'any[]'.
 node_modules/lodash/_insertWrapDetails.js(20,3): error TS2322: Type 'string' is not assignable to type 'any[]'.
 node_modules/lodash/_isLaziable.js(24,14): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/_isMaskable.js(9,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/_lazyClone.js(14,3): error TS2322: Type 'any[]' is not assignable to type 'never[] | undefined'.
   Type 'any[]' is not assignable to type 'never[]'.
     Type 'any' is not assignable to type 'never'.
@@ -142,137 +162,85 @@ node_modules/lodash/_nodeUtil.js(4,69): error TS2339: Property 'nodeType' does n
 node_modules/lodash/_nodeUtil.js(7,80): error TS2339: Property 'nodeType' does not exist on type 'NodeModule'.
 node_modules/lodash/_nodeUtil.js(13,47): error TS2339: Property 'process' does not exist on type 'boolean | Global'.
   Property 'process' does not exist on type 'true'.
+node_modules/lodash/_overRest.js(20,42): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_overRest.js(24,27): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_overRest.js(27,27): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_overRest.js(28,22): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_overRest.js(31,15): error TS2538: Type 'undefined' cannot be used as an index type.
 node_modules/lodash/_root.js(4,56): error TS2339: Property 'Object' does not exist on type 'Window'.
-node_modules/lodash/_setData.js(14,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/_setData.js(15,15): error TS8024: JSDoc '@param' tag has name 'data', but there is no parameter with that name.
-node_modules/lodash/_setToString.js(8,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/_setToString.js(9,22): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/_stringToPath.js(13,20): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/_unescapeHtmlChar.js(16,20): error TS8024: JSDoc '@param' tag has name 'chr', but there is no parameter with that name.
 node_modules/lodash/_unicodeWords.js(62,20): error TS8024: JSDoc '@param' tag has name 'The', but there is no parameter with that name.
 node_modules/lodash/_updateWrapDetails.js(34,5): error TS1223: 'returns' tag already specified.
 node_modules/lodash/_wrapperClone.js(17,3): error TS2322: Type 'any[]' is not assignable to type 'never[] | undefined'.
   Type 'any[]' is not assignable to type 'never[]'.
-node_modules/lodash/add.js(10,20): error TS8024: JSDoc '@param' tag has name 'augend', but there is no parameter with that name.
-node_modules/lodash/add.js(11,20): error TS8024: JSDoc '@param' tag has name 'addend', but there is no parameter with that name.
 node_modules/lodash/ary.js(16,10): error TS1003: Identifier expected.
 node_modules/lodash/ary.js(16,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/ary.js(24,3): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-  Type 'undefined' is not assignable to type 'number'.
-node_modules/lodash/ary.js(26,53): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'any[]'.
-node_modules/lodash/assign.js(26,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/assign.js(27,24): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/assignIn.js(16,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/assignIn.js(17,24): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/assignInWith.js(18,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/assignInWith.js(19,23): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/assignInWith.js(20,23): error TS8024: JSDoc '@param' tag has name 'customizer', but there is no parameter with that name.
-node_modules/lodash/assignWith.js(17,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/assignWith.js(18,23): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/assignWith.js(19,23): error TS8024: JSDoc '@param' tag has name 'customizer', but there is no parameter with that name.
-node_modules/lodash/at.js(11,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/at.js(12,35): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
-node_modules/lodash/attempt.js(13,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/attempt.js(14,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
 node_modules/lodash/before.js(34,7): error TS2322: Type 'undefined' is not assignable to type 'Function'.
-node_modules/lodash/bind.js(24,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/bind.js(25,15): error TS8024: JSDoc '@param' tag has name 'thisArg', but there is no parameter with that name.
-node_modules/lodash/bind.js(26,19): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
 node_modules/lodash/bind.js(51,55): error TS2454: Variable 'holders' is used before being assigned.
 node_modules/lodash/bind.js(55,6): error TS2339: Property 'placeholder' does not exist on type 'Function'.
-node_modules/lodash/bindAll.js(17,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/bindAll.js(18,34): error TS8024: JSDoc '@param' tag has name 'methodNames', but there is no parameter with that name.
-node_modules/lodash/bindKey.js(27,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/bindKey.js(28,20): error TS8024: JSDoc '@param' tag has name 'key', but there is no parameter with that name.
-node_modules/lodash/bindKey.js(29,19): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
 node_modules/lodash/bindKey.js(62,53): error TS2454: Variable 'holders' is used before being assigned.
 node_modules/lodash/bindKey.js(66,9): error TS2339: Property 'placeholder' does not exist on type 'Function'.
-node_modules/lodash/camelCase.js(11,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/castArray.js(10,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/ceil.js(10,20): error TS8024: JSDoc '@param' tag has name 'number', but there is no parameter with that name.
-node_modules/lodash/ceil.js(11,21): error TS8024: JSDoc '@param' tag has name 'precision', but there is no parameter with that name.
+node_modules/lodash/castArray.js(10,15): error TS8029: JSDoc '@param' tag has name 'value', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/lodash/chunk.js(20,10): error TS1003: Identifier expected.
 node_modules/lodash/chunk.js(20,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/clamp.js(26,5): error TS2322: Type 'undefined' is not assignable to type 'number'.
+node_modules/lodash/clamp.js(25,5): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/clone.js(33,27): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/cloneDeep.js(26,27): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/cloneDeepWith.js(36,3): error TS2322: Type 'Function | undefined' is not assignable to type 'Function'.
-  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/cloneDeepWith.js(37,27): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/cloneWith.js(38,3): error TS2322: Type 'Function | undefined' is not assignable to type 'Function'.
-  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/cloneWith.js(39,27): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/concat.js(14,19): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/concat.js(15,19): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
 node_modules/lodash/conforms.js(32,41): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/core.js(68,58): error TS2339: Property 'Object' does not exist on type 'Window'.
 node_modules/lodash/core.js(77,82): error TS2339: Property 'nodeType' does not exist on type 'NodeModule'.
-node_modules/lodash/core.js(185,22): error TS8024: JSDoc '@param' tag has name 'chr', but there is no parameter with that name.
-node_modules/lodash/core.js(365,22): error TS8024: JSDoc '@param' tag has name 'proto', but there is no parameter with that name.
-node_modules/lodash/core.js(454,28): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/core.js(455,24): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/core.js(540,19): error TS2322: Type '(value: any) => boolean' is not assignable to type 'boolean'.
+node_modules/lodash/core.js(540,19): error TS2322: Type '(value: any) => boolean' is not assignable to type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/core.js(545,24): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(545,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/core.js(545,24): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Boolean' has no compatible call signatures.
-node_modules/lodash/core.js(565,22): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/core.js(566,24): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/core.js(567,24): error TS8024: JSDoc '@param' tag has name 'keysFunc', but there is no parameter with that name.
-node_modules/lodash/core.js(627,17): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/core.js(664,42): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'number'.
 node_modules/lodash/core.js(721,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'result' must be of type 'boolean', but here has type 'any'.
 node_modules/lodash/core.js(749,18): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/core.js(811,53): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/core.js(826,24): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
 node_modules/lodash/core.js(848,12): error TS2554: Expected 1 arguments, but got 2.
+node_modules/lodash/core.js(864,9): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(865,16): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(865,47): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(867,11): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(868,9): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(869,7): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(871,14): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(871,22): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(871,34): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(871,40): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(872,5): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(876,37): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/core.js(886,22): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
 node_modules/lodash/core.js(1118,24): error TS2554: Expected 1 arguments, but got 2.
 node_modules/lodash/core.js(1123,36): error TS2454: Variable 'iteratee' is used before being assigned.
 node_modules/lodash/core.js(1313,20): error TS2322: Type 'boolean' is not assignable to type 'number'.
 node_modules/lodash/core.js(1338,12): error TS2554: Expected 1 arguments, but got 2.
 node_modules/lodash/core.js(1349,30): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/core.js(1458,24): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/core.js(1459,24): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/core.js(1493,21): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/core.js(1494,21): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
+node_modules/lodash/core.js(1434,23): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+node_modules/lodash/core.js(1438,44): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(1442,29): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(1445,29): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(1446,24): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/core.js(1449,17): error TS2538: Type 'undefined' cannot be used as an index type.
 node_modules/lodash/core.js(1566,33): error TS2554: Expected 1 arguments, but got 2.
+node_modules/lodash/core.js(1709,41): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/core.js(1872,12): error TS1003: Identifier expected.
 node_modules/lodash/core.js(1872,12): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/core.js(1952,28): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/core.js(1953,25): error TS8024: JSDoc '@param' tag has name 'predicate', but there is no parameter with that name.
-node_modules/lodash/core.js(1954,23): error TS8024: JSDoc '@param' tag has name 'fromIndex', but there is no parameter with that name.
 node_modules/lodash/core.js(2142,12): error TS1003: Identifier expected.
 node_modules/lodash/core.js(2142,12): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/core.js(2183,41): error TS8024: JSDoc '@param' tag has name 'iteratees', but there is no parameter with that name.
-node_modules/lodash/core.js(2262,24): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/core.js(2263,17): error TS8024: JSDoc '@param' tag has name 'thisArg', but there is no parameter with that name.
-node_modules/lodash/core.js(2264,21): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
-node_modules/lodash/core.js(2295,24): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/core.js(2296,21): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/core.js(2317,24): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/core.js(2318,22): error TS8024: JSDoc '@param' tag has name 'wait', but there is no parameter with that name.
-node_modules/lodash/core.js(2319,21): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/core.js(2462,17): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/core.js(2473,21): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/core.js(2485,17): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/core.js(2561,17): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/core.js(2609,39): error TS2554: Expected 0 arguments, but got 1.
 node_modules/lodash/core.js(2644,12): error TS2554: Expected 3-5 arguments, but got 2.
-node_modules/lodash/core.js(2887,17): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/core.js(2982,17): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/core.js(3007,17): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/core.js(3067,22): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/core.js(3068,26): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/core.js(3102,22): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/core.js(3103,26): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/core.js(3177,22): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/core.js(3178,26): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/core.js(3259,22): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/core.js(3287,22): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/core.js(3310,22): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/core.js(3311,37): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
 node_modules/lodash/core.js(3354,53): error TS2538: Type 'any[]' cannot be used as an index type.
 node_modules/lodash/core.js(3424,41): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
   Type 'Function' provides no match for the signature '(substring: string, ...args: any[]): string'.
-node_modules/lodash/core.js(3461,18): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
+node_modules/lodash/core.js(3573,51): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/core.js(3590,63): error TS2345: Argument of type 'IArguments' is not assignable to parameter of type 'any[]'.
   Property 'push' is missing in type 'IArguments'.
 node_modules/lodash/core.js(3830,14): error TS2304: Cannot find name 'define'.
@@ -280,45 +248,26 @@ node_modules/lodash/core.js(3830,45): error TS2304: Cannot find name 'define'.
 node_modules/lodash/core.js(3830,71): error TS2304: Cannot find name 'define'.
 node_modules/lodash/core.js(3839,5): error TS2304: Cannot find name 'define'.
 node_modules/lodash/core.js(3846,35): error TS2339: Property '_' does not exist on type '{ (value: any): any; assignIn: Function; before: (n: number, func: Function) => Function; bind: F...'.
-node_modules/lodash/countBy.js(20,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/countBy.js(21,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
 node_modules/lodash/curry.js(24,10): error TS1003: Identifier expected.
 node_modules/lodash/curry.js(24,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/curry.js(48,3): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-  Type 'undefined' is not assignable to type 'number'.
-node_modules/lodash/curry.js(49,61): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'any[]'.
 node_modules/lodash/curry.js(50,10): error TS2339: Property 'placeholder' does not exist on type 'Function'.
 node_modules/lodash/curryRight.js(21,10): error TS1003: Identifier expected.
 node_modules/lodash/curryRight.js(21,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/curryRight.js(45,3): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-  Type 'undefined' is not assignable to type 'number'.
-node_modules/lodash/curryRight.js(46,67): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'any[]'.
 node_modules/lodash/curryRight.js(47,10): error TS2339: Property 'placeholder' does not exist on type 'Function'.
+node_modules/lodash/debounce.js(83,17): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/debounce.js(84,27): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/debounce.js(85,43): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/debounce.js(86,30): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/debounce.js(111,23): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/debounce.js(125,65): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/deburr.js(42,44): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
-node_modules/lodash/defaults.js(24,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/defaults.js(25,24): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/defaultsDeep.js(16,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/defaultsDeep.js(17,24): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/defer.js(12,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/defer.js(13,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/delay.js(13,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/delay.js(14,20): error TS8024: JSDoc '@param' tag has name 'wait', but there is no parameter with that name.
-node_modules/lodash/delay.js(15,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/difference.js(18,19): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/difference.js(19,23): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/difference.js(29,52): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/differenceBy.js(21,19): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/differenceBy.js(22,23): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/differenceBy.js(23,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/differenceBy.js(40,52): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
+node_modules/lodash/difference.js(29,52): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/differenceBy.js(40,52): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
 node_modules/lodash/differenceBy.js(40,78): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/differenceWith.js(19,19): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/differenceWith.js(20,23): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/differenceWith.js(21,23): error TS8024: JSDoc '@param' tag has name 'comparator', but there is no parameter with that name.
-node_modules/lodash/differenceWith.js(36,52): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/differenceWith.js(36,78): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'.
-node_modules/lodash/divide.js(10,20): error TS8024: JSDoc '@param' tag has name 'dividend', but there is no parameter with that name.
-node_modules/lodash/divide.js(11,20): error TS8024: JSDoc '@param' tag has name 'divisor', but there is no parameter with that name.
+node_modules/lodash/differenceWith.js(36,52): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
 node_modules/lodash/drop.js(13,10): error TS1003: Identifier expected.
 node_modules/lodash/drop.js(13,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/dropRight.js(13,10): error TS1003: Identifier expected.
@@ -328,25 +277,15 @@ node_modules/lodash/dropWhile.js(41,24): error TS2554: Expected 0-1 arguments, b
 node_modules/lodash/escape.js(39,39): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
 node_modules/lodash/every.js(23,10): error TS1003: Identifier expected.
 node_modules/lodash/every.js(23,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/every.js(51,5): error TS2322: Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/every.js(53,27): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/filter.js(45,27): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/find.js(13,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/find.js(14,23): error TS8024: JSDoc '@param' tag has name 'predicate', but there is no parameter with that name.
-node_modules/lodash/find.js(15,21): error TS8024: JSDoc '@param' tag has name 'fromIndex', but there is no parameter with that name.
 node_modules/lodash/findIndex.js(52,31): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/findKey.js(41,30): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/findLast.js(12,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/findLast.js(13,23): error TS8024: JSDoc '@param' tag has name 'predicate', but there is no parameter with that name.
-node_modules/lodash/findLast.js(14,21): error TS8024: JSDoc '@param' tag has name 'fromIndex', but there is no parameter with that name.
 node_modules/lodash/findLastIndex.js(56,31): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/findLastKey.js(41,30): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/floor.js(10,20): error TS8024: JSDoc '@param' tag has name 'number', but there is no parameter with that name.
-node_modules/lodash/floor.js(11,21): error TS8024: JSDoc '@param' tag has name 'precision', but there is no parameter with that name.
-node_modules/lodash/flow.js(12,39): error TS8024: JSDoc '@param' tag has name 'funcs', but there is no parameter with that name.
-node_modules/lodash/flowRight.js(11,39): error TS8024: JSDoc '@param' tag has name 'funcs', but there is no parameter with that name.
 node_modules/lodash/fp.js(2,18): error TS2554: Expected 3-4 arguments, but got 2.
-node_modules/lodash/fp/_baseConvert.js(144,5): error TS2559: Type 'Function' has no properties in common with type '{ cap?: boolean; curry?: boolean; fixed?: boolean; immutable?: boolean; rearg?: boolean; }'.
+node_modules/lodash/fp/_baseConvert.js(144,5): error TS2322: Type 'Function' is not assignable to type '{ cap?: boolean; curry?: boolean; fixed?: boolean; immutable?: boolean; rearg?: boolean; } | unde...'.
+  Type 'Function' has no properties in common with type '{ cap?: boolean; curry?: boolean; fixed?: boolean; immutable?: boolean; rearg?: boolean; }'.
 node_modules/lodash/fp/_baseConvert.js(145,5): error TS2322: Type 'string' is not assignable to type 'Function'.
 node_modules/lodash/fp/_baseConvert.js(146,5): error TS2322: Type 'undefined' is not assignable to type 'string'.
 node_modules/lodash/fp/_baseConvert.js(165,31): error TS2339: Property 'runInContext' does not exist on type 'Function'.
@@ -376,8 +315,8 @@ node_modules/lodash/fp/_baseConvert.js(195,27): error TS2339: Property 'toIntege
   Property 'toInteger' does not exist on type 'Function'.
 node_modules/lodash/fp/_baseConvert.js(196,24): error TS2339: Property 'toPath' does not exist on type 'Function | { [x: string]: any; 'ary': any; 'assign': any; 'clone': any; 'curry': any; 'forEach': ...'.
   Property 'toPath' does not exist on type 'Function'.
-node_modules/lodash/fp/_baseConvert.js(263,57): error TS2345: Argument of type '{ cap?: boolean; curry?: boolean; fixed?: boolean; immutable?: boolean; rearg?: boolean; }' is not assignable to parameter of type 'Function'.
-  Property 'apply' is missing in type '{ cap?: boolean; curry?: boolean; fixed?: boolean; immutable?: boolean; rearg?: boolean; }'.
+node_modules/lodash/fp/_baseConvert.js(263,57): error TS2345: Argument of type '{ cap?: boolean; curry?: boolean; fixed?: boolean; immutable?: boolean; rearg?: boolean; } | unde...' is not assignable to parameter of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/fp/_baseConvert.js(379,14): error TS2339: Property 'runInContext' does not exist on type 'Function'.
 node_modules/lodash/fp/_baseConvert.js(516,33): error TS2339: Property 'placeholder' does not exist on type 'Function'.
 node_modules/lodash/fp/_baseConvert.js(559,5): error TS2339: Property 'convert' does not exist on type 'Function'.
@@ -387,80 +326,57 @@ node_modules/lodash/fp/_convertBrowser.js(15,12): error TS2304: Cannot find name
 node_modules/lodash/fp/_convertBrowser.js(15,38): error TS2304: Cannot find name '_'.
 node_modules/lodash/fp/_convertBrowser.js(16,3): error TS2304: Cannot find name '_'.
 node_modules/lodash/fp/_convertBrowser.js(16,22): error TS2304: Cannot find name '_'.
-node_modules/lodash/fp/array.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'chunk': (array: any[], size?: number, guard: any) => any[]; 'compact': (arra...' is not assignable to parameter of type 'string'.
-node_modules/lodash/fp/collection.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'countBy': Function; 'each': (collection: any, iteratee?: Function) => any; '...' is not assignable to parameter of type 'string'.
+node_modules/lodash/fp/array.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'chunk': (array: any[], size?: number | undefined, guard: any) => any[]; 'com...' is not assignable to parameter of type 'string'.
+node_modules/lodash/fp/collection.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'countBy': Function; 'each': (collection: any, iteratee?: Function | undefine...' is not assignable to parameter of type 'string'.
+node_modules/lodash/fp/convert.js(15,34): error TS2345: Argument of type 'Function | undefined' is not assignable to parameter of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/fp/date.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'now': () => number; }' is not assignable to parameter of type 'string'.
 node_modules/lodash/fp/function.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'after': (n: number, func: Function) => Function; 'ary': (func: Function, n?:...' is not assignable to parameter of type 'string'.
 node_modules/lodash/fp/lang.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'castArray': (...args: any[]) => any[]; 'clone': (value: any) => any; 'cloneD...' is not assignable to parameter of type 'string'.
 node_modules/lodash/fp/math.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'add': Function; 'ceil': Function; 'divide': Function; 'floor': Function; 'ma...' is not assignable to parameter of type 'string'.
-node_modules/lodash/fp/number.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'clamp': (number: number, lower?: number, upper: number) => number; 'inRange'...' is not assignable to parameter of type 'string'.
+node_modules/lodash/fp/number.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'clamp': (number: number, lower?: number | undefined, upper: number) => numbe...' is not assignable to parameter of type 'string'.
 node_modules/lodash/fp/object.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'assign': Function; 'assignIn': Function; 'assignInWith': Function; 'assignWi...' is not assignable to parameter of type 'string'.
 node_modules/lodash/fp/seq.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'at': Function; 'chain': (value: any) => any; 'commit': () => any; 'lodash': ...' is not assignable to parameter of type 'string'.
-node_modules/lodash/fp/string.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'camelCase': Function; 'capitalize': (string?: string) => string; 'deburr': (...' is not assignable to parameter of type 'string'.
+node_modules/lodash/fp/string.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'camelCase': Function; 'capitalize': (string?: string | undefined) => string;...' is not assignable to parameter of type 'string'.
 node_modules/lodash/fp/util.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'attempt': Function; 'bindAll': Function; 'cond': (pairs: any[]) => Function;...' is not assignable to parameter of type 'string'.
-node_modules/lodash/groupBy.js(21,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/groupBy.js(22,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/gt.js(11,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/gt.js(12,15): error TS8024: JSDoc '@param' tag has name 'other', but there is no parameter with that name.
-node_modules/lodash/gte.js(10,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/gte.js(11,15): error TS8024: JSDoc '@param' tag has name 'other', but there is no parameter with that name.
 node_modules/lodash/includes.js(24,10): error TS1003: Identifier expected.
 node_modules/lodash/includes.js(24,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/index.js(1,26): error TS2306: File '/home/nathansa/ts/tests/cases/user/lodash/node_modules/lodash/lodash.js' is not a module.
-node_modules/lodash/intersection.js(16,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/intersectionBy.js(19,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/intersectionBy.js(20,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
 node_modules/lodash/intersectionBy.js(41,32): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/intersectionWith.js(17,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/intersectionWith.js(18,23): error TS8024: JSDoc '@param' tag has name 'comparator', but there is no parameter with that name.
-node_modules/lodash/intersectionWith.js(37,32): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'.
-node_modules/lodash/invert.js(24,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/invertBy.js(28,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/invertBy.js(29,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/invoke.js(11,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/invoke.js(12,26): error TS8024: JSDoc '@param' tag has name 'path', but there is no parameter with that name.
-node_modules/lodash/invoke.js(13,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/invokeMap.js(17,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/invokeMap.js(18,35): error TS8024: JSDoc '@param' tag has name 'path', but there is no parameter with that name.
-node_modules/lodash/invokeMap.js(20,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/isArguments.js(20,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/isArray.js(8,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/isArrayBuffer.js(15,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/isBuffer.js(5,69): error TS2339: Property 'nodeType' does not exist on type 'typeof "/home/nathansa/ts/tests/cases/user/lodash/node_modules/lodash/isBuffer"'.
 node_modules/lodash/isBuffer.js(8,80): error TS2339: Property 'nodeType' does not exist on type 'NodeModule'.
-node_modules/lodash/isBuffer.js(26,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/isDate.js(15,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/isEqual.js(32,10): error TS2554: Expected 3-5 arguments, but got 2.
-node_modules/lodash/isEqualWith.js(36,3): error TS2322: Type 'Function | undefined' is not assignable to type 'Function'.
-  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/isEqualWith.js(38,59): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/isMap.js(15,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/isMatchWith.js(37,3): error TS2322: Type 'Function | undefined' is not assignable to type 'Function'.
-  Type 'undefined' is not assignable to type 'Function'.
-node_modules/lodash/isRegExp.js(15,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/isSet.js(15,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/isTypedArray.js(15,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/iteratee.js(50,74): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/kebabCase.js(11,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/keyBy.js(14,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/keyBy.js(15,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
 node_modules/lodash/keys.js(34,32): error TS2554: Expected 2 arguments, but got 1.
 node_modules/lodash/lodash.js(419,58): error TS2339: Property 'Object' does not exist on type 'Window'.
 node_modules/lodash/lodash.js(428,82): error TS2339: Property 'nodeType' does not exist on type 'NodeModule'.
 node_modules/lodash/lodash.js(434,49): error TS2339: Property 'process' does not exist on type 'false | Global'.
   Property 'process' does not exist on type 'false'.
+node_modules/lodash/lodash.js(488,19): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(508,20): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(512,5): error TS2322: Type 'any[] | undefined' is not assignable to type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
+node_modules/lodash/lodash.js(528,20): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(532,5): error TS2322: Type 'any[] | undefined' is not assignable to type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
+node_modules/lodash/lodash.js(550,22): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(573,19): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(587,17): error TS8024: JSDoc '@param' tag has name 'target', but there is no parameter with that name.
+node_modules/lodash/lodash.js(592,36): error TS2345: Argument of type 'any[] | undefined' is not assignable to parameter of type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
 node_modules/lodash/lodash.js(600,17): error TS8024: JSDoc '@param' tag has name 'target', but there is no parameter with that name.
-node_modules/lodash/lodash.js(729,22): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
+node_modules/lodash/lodash.js(609,29): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(631,32): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(672,21): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(675,43): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(695,21): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(698,43): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(718,21): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(749,22): error TS8024: JSDoc '@param' tag has name 'The', but there is no parameter with that name.
 node_modules/lodash/lodash.js(924,16): error TS2345: Argument of type 'Function' is not assignable to parameter of type '((a: any, b: any) => number) | undefined'.
   Type 'Function' is not assignable to type '(a: any, b: any) => number'.
-node_modules/lodash/lodash.js(1087,22): error TS8024: JSDoc '@param' tag has name 'letter', but there is no parameter with that name.
-node_modules/lodash/lodash.js(1096,22): error TS8024: JSDoc '@param' tag has name 'chr', but there is no parameter with that name.
-node_modules/lodash/lodash.js(1339,22): error TS8024: JSDoc '@param' tag has name 'chr', but there is no parameter with that name.
 node_modules/lodash/lodash.js(1374,22): error TS8024: JSDoc '@param' tag has name 'The', but there is no parameter with that name.
-node_modules/lodash/lodash.js(1390,23): error TS8024: JSDoc '@param' tag has name 'context', but there is no parameter with that name.
-node_modules/lodash/lodash.js(1671,24): error TS8024: JSDoc '@param' tag has name 'proto', but there is no parameter with that name.
 node_modules/lodash/lodash.js(1771,9): error TS2322: Type '{ (value: any): any; templateSettings: any; prototype: any; after: (n: number, func: Function) =>...' is not assignable to type 'Function'.
   Types of property 'bind' are incompatible.
     Type 'Function' is not assignable to type '(this: Function, thisArg: any, ...argArray: any[]) => any'.
@@ -472,48 +388,65 @@ node_modules/lodash/lodash.js(1814,7): error TS2322: Type 'any[]' is not assigna
 node_modules/lodash/lodash.js(1816,7): error TS2322: Type 'any[]' is not assignable to type 'never[] | undefined'.
   Type 'any[]' is not assignable to type 'never[]'.
 node_modules/lodash/lodash.js(1835,9): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(1916,21): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(1939,24): error TS8024: JSDoc '@param' tag has name 'hash', but there is no parameter with that name.
+node_modules/lodash/lodash.js(2020,21): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(2137,21): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(2241,18): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(2288,24): error TS2339: Property 'size' does not exist on type '{ clear: () => void; get: (key: string) => any; has: (key: string) => boolean; set: (key: string,...'.
+node_modules/lodash/lodash.js(2604,11): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+node_modules/lodash/lodash.js(2604,30): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(2628,20): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 node_modules/lodash/lodash.js(2629,20): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 node_modules/lodash/lodash.js(2630,20): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-node_modules/lodash/lodash.js(2652,37): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(2665,47): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(2791,9): error TS2322: Type '(array?: any[], value: any, comparator: Function) => boolean' is not assignable to type '(array?: any[], value: any) => boolean'.
+node_modules/lodash/lodash.js(2652,37): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean | undefined'.
+node_modules/lodash/lodash.js(2665,47): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean | undefined'.
+node_modules/lodash/lodash.js(2791,9): error TS2322: Type '(array?: any[] | undefined, value: any, comparator: Function) => boolean' is not assignable to type '(array?: any[] | undefined, value: any) => boolean'.
 node_modules/lodash/lodash.js(2797,9): error TS2322: Type '{ __data__: { clear: () => void; get: (key: string) => any; has: (key: string) => boolean; set: (...' is not assignable to type 'any[]'.
   Property 'length' is missing in type '{ __data__: { clear: () => void; get: (key: string) => any; has: (key: string) => boolean; set: (...'.
 node_modules/lodash/lodash.js(2814,19): error TS2554: Expected 2 arguments, but got 3.
-node_modules/lodash/lodash.js(2825,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2826,26): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2835,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2836,26): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2949,21): error TS2322: Type '(value: any) => boolean' is not assignable to type 'boolean'.
+node_modules/lodash/lodash.js(2905,35): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(2949,21): error TS2322: Type '(value: any) => boolean' is not assignable to type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/lodash.js(2954,26): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(2954,26): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/lodash.js(2954,26): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Boolean' has no compatible call signatures.
-node_modules/lodash/lodash.js(2974,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2975,26): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2976,26): error TS8024: JSDoc '@param' tag has name 'keysFunc', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2986,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2987,26): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(2988,26): error TS8024: JSDoc '@param' tag has name 'keysFunc', but there is no parameter with that name.
+node_modules/lodash/lodash.js(3176,44): error TS2345: Argument of type 'Function | undefined' is not assignable to parameter of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
+node_modules/lodash/lodash.js(3183,58): error TS2345: Argument of type 'Function | undefined' is not assignable to parameter of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/lodash.js(3286,44): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'number'.
 node_modules/lodash/lodash.js(3403,51): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/lodash.js(3587,40): error TS2345: Argument of type 'string | symbol' is not assignable to parameter of type 'string'.
   Type 'symbol' is not assignable to type 'string'.
 node_modules/lodash/lodash.js(3593,45): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+node_modules/lodash/lodash.js(3830,64): error TS2345: Argument of type 'Function | undefined' is not assignable to parameter of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/lodash.js(3860,30): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string | any[]'.
 node_modules/lodash/lodash.js(4001,29): error TS2345: Argument of type 'string | symbol' is not assignable to parameter of type 'string'.
   Type 'symbol' is not assignable to type 'string'.
-node_modules/lodash/lodash.js(4011,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(4012,19): error TS8024: JSDoc '@param' tag has name 'data', but there is no parameter with that name.
-node_modules/lodash/lodash.js(4024,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(4025,26): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lodash.js(4271,9): error TS2322: Type '(array?: any[], value: any, comparator: Function) => boolean' is not assignable to type '(array?: any[], value: any) => boolean'.
+node_modules/lodash/lodash.js(4061,11): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4062,18): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4062,49): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4064,13): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4065,11): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4066,9): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4068,16): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4068,24): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4068,36): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4068,42): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4069,7): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4073,39): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4271,9): error TS2322: Type '(array?: any[] | undefined, value: any, comparator: Function) => boolean' is not assignable to type '(array?: any[] | undefined, value: any) => boolean'.
 node_modules/lodash/lodash.js(4274,37): error TS2554: Expected 0 arguments, but got 1.
 node_modules/lodash/lodash.js(4280,9): error TS2322: Type '{ __data__: { clear: () => void; get: (key: string) => any; has: (key: string) => boolean; set: (...' is not assignable to type 'any[]'.
 node_modules/lodash/lodash.js(4303,19): error TS2554: Expected 2 arguments, but got 3.
-node_modules/lodash/lodash.js(4480,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(4504,31): error TS8024: JSDoc '@param' tag has name 'id', but there is no parameter with that name.
+node_modules/lodash/lodash.js(4497,25): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(4537,20): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
+node_modules/lodash/lodash.js(4757,9): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(4759,7): error TS2322: Type 'any[] | undefined' is not assignable to type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
 node_modules/lodash/lodash.js(4807,33): error TS2554: Expected 0 arguments, but got 1.
 node_modules/lodash/lodash.js(4819,33): error TS2554: Expected 0 arguments, but got 1.
 node_modules/lodash/lodash.js(4982,28): error TS2554: Expected 3 arguments, but got 1.
@@ -538,19 +471,24 @@ node_modules/lodash/lodash.js(5116,25): error TS2339: Property 'thru' does not e
 node_modules/lodash/lodash.js(5124,28): error TS2339: Property 'plant' does not exist on type '{ __wrapped__: any; __actions__: never[] | undefined; __chain__: boolean | undefined; __index__: ...'.
 node_modules/lodash/lodash.js(5162,53): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
+node_modules/lodash/lodash.js(5177,46): error TS2345: Argument of type 'any[] | undefined' is not assignable to parameter of type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
+node_modules/lodash/lodash.js(5180,56): error TS2345: Argument of type 'any[] | undefined' is not assignable to parameter of type 'any[]'.
+  Type 'undefined' is not assignable to type 'any[]'.
 node_modules/lodash/lodash.js(5182,19): error TS2454: Variable 'holdersCount' is used before being assigned.
+node_modules/lodash/lodash.js(5183,35): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(5186,13): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
 node_modules/lodash/lodash.js(5186,50): error TS2339: Property 'placeholder' does not exist on type '(...args: any[]) => any'.
+node_modules/lodash/lodash.js(5187,44): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(5191,42): error TS2538: Type 'Function' cannot be used as an index type.
-node_modules/lodash/lodash.js(5448,23): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
+node_modules/lodash/lodash.js(5199,22): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(5520,42): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/lodash.js(5523,52): error TS2454: Variable 'partialsRight' is used before being assigned.
-node_modules/lodash/lodash.js(5523,67): error TS2454: Variable 'holdersRight' is used before being assigned.
 node_modules/lodash/lodash.js(5543,33): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
 node_modules/lodash/lodash.js(5545,30): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
+node_modules/lodash/lodash.js(5546,104): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(5547,32): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
   Type 'string' is not assignable to type 'Function'.
 node_modules/lodash/lodash.js(5552,55): error TS2345: Argument of type 'string | Function' is not assignable to parameter of type 'Function'.
@@ -558,18 +496,13 @@ node_modules/lodash/lodash.js(5552,55): error TS2345: Argument of type 'string |
 node_modules/lodash/lodash.js(5605,24): error TS8024: JSDoc '@param' tag has name 'key', but there is no parameter with that name.
 node_modules/lodash/lodash.js(5742,11): error TS2454: Variable 'convert' is used before being assigned.
 node_modules/lodash/lodash.js(5826,22): error TS2322: Type 'boolean' is not assignable to type 'number'.
-node_modules/lodash/lodash.js(5883,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
 node_modules/lodash/lodash.js(5898,26): error TS2339: Property 'name' does not exist on type 'Function'.
 node_modules/lodash/lodash.js(5921,21): error TS2339: Property 'placeholder' does not exist on type 'Function | { (value: any): any; templateSettings: any; prototype: any; after: (n: number, func: F...'.
   Property 'placeholder' does not exist on type 'Function'.
-node_modules/lodash/lodash.js(5931,20): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(5932,25): error TS8024: JSDoc '@param' tag has name 'arity', but there is no parameter with that name.
+node_modules/lodash/lodash.js(5932,25): error TS8029: JSDoc '@param' tag has name 'arity', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/lodash/lodash.js(5938,33): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/lodash.js(6006,11): error TS2454: Variable 'unmasked' is used before being assigned.
-node_modules/lodash/lodash.js(6020,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6037,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
 node_modules/lodash/lodash.js(6043,27): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/lodash.js(6053,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/lodash.js(6149,54): error TS2454: Variable 'key' is used before being assigned.
 node_modules/lodash/lodash.js(6162,20): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 node_modules/lodash/lodash.js(6166,30): error TS2339: Property 'index' does not exist on type 'any[]'.
@@ -578,213 +511,126 @@ node_modules/lodash/lodash.js(6239,9): error TS1223: 'returns' tag already speci
 node_modules/lodash/lodash.js(6244,9): error TS2322: Type 'string' is not assignable to type 'any[]'.
 node_modules/lodash/lodash.js(6249,7): error TS2322: Type 'string' is not assignable to type 'any[]'.
 node_modules/lodash/lodash.js(6359,18): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/lodash.js(6378,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/lodash.js(6444,26): error TS2339: Property 'cache' does not exist on type 'Function'.
 node_modules/lodash/lodash.js(6489,30): error TS2554: Expected 4 arguments, but got 3.
 node_modules/lodash/lodash.js(6496,30): error TS2554: Expected 4 arguments, but got 3.
-node_modules/lodash/lodash.js(6623,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6624,19): error TS8024: JSDoc '@param' tag has name 'data', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6633,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6634,24): error TS8024: JSDoc '@param' tag has name 'wait', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6645,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6646,26): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6724,24): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
+node_modules/lodash/lodash.js(6563,46): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(6567,31): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(6570,31): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(6571,26): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(6574,19): error TS2538: Type 'undefined' cannot be used as an index type.
+node_modules/lodash/lodash.js(6709,24): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(6716,7): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/lodash.js(6778,9): error TS1223: 'returns' tag already specified.
 node_modules/lodash/lodash.js(6802,7): error TS2322: Type 'any[]' is not assignable to type 'never[] | undefined'.
   Type 'any[]' is not assignable to type 'never[]'.
 node_modules/lodash/lodash.js(6821,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(6821,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6889,23): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6890,23): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6930,23): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6931,27): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6941,56): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(6958,23): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6959,27): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6960,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6977,56): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(6993,23): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6994,27): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/lodash.js(6995,27): error TS8024: JSDoc '@param' tag has name 'comparator', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7010,56): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
+node_modules/lodash/lodash.js(6838,22): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(6843,46): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(6846,64): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(6941,56): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/lodash.js(6977,56): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/lodash.js(7010,56): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
 node_modules/lodash/lodash.js(7023,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(7023,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/lodash.js(7057,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(7057,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7483,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7508,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7509,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7544,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7545,27): error TS8024: JSDoc '@param' tag has name 'comparator', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7679,23): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7680,23): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7786,23): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/lodash.js(7787,39): error TS8024: JSDoc '@param' tag has name 'indexes', but there is no parameter with that name.
+node_modules/lodash/lodash.js(7296,17): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(8145,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(8145,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/lodash.js(8178,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(8178,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8295,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8303,46): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(8317,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8318,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8334,46): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(8347,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8348,27): error TS8024: JSDoc '@param' tag has name 'comparator', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8361,46): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(8518,23): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8519,23): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8543,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8566,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8567,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8596,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8597,27): error TS8024: JSDoc '@param' tag has name 'comparator', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8622,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8679,27): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8680,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(8797,39): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
+node_modules/lodash/lodash.js(8303,46): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/lodash.js(8334,46): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/lodash.js(8361,46): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
 node_modules/lodash/lodash.js(8822,55): error TS2339: Property 'thru' does not exist on type '{ __wrapped__: any; __actions__: never[] | undefined; __chain__: boolean | undefined; __index__: ...'.
-node_modules/lodash/lodash.js(9057,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9058,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
 node_modules/lodash/lodash.js(9093,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(9093,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9177,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9178,27): error TS8024: JSDoc '@param' tag has name 'predicate', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9179,25): error TS8024: JSDoc '@param' tag has name 'fromIndex', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9214,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9215,27): error TS8024: JSDoc '@param' tag has name 'predicate', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9216,25): error TS8024: JSDoc '@param' tag has name 'fromIndex', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9373,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9374,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
 node_modules/lodash/lodash.js(9407,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(9407,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9446,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9447,39): error TS8024: JSDoc '@param' tag has name 'path', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9449,23): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9480,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9481,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
+node_modules/lodash/lodash.js(9432,12): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(9433,55): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/lodash.js(9563,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(9563,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9587,9): error TS2322: Type 'string[][]' is not assignable to type 'string[]'.
-  Type 'string[]' is not assignable to type 'string'.
-node_modules/lodash/lodash.js(9602,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9603,27): error TS8024: JSDoc '@param' tag has name 'predicate', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9673,14): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[], iteratee: Function, accumulator?: any, initAccum?: boolean) => any) | ((collecti...' has no compatible call signatures.
+node_modules/lodash/lodash.js(9587,9): error TS2322: Type 'string[][]' is not assignable to type 'string[] | undefined'.
+  Type 'string[][]' is not assignable to type 'string[]'.
+    Type 'string[]' is not assignable to type 'string'.
+node_modules/lodash/lodash.js(9589,38): error TS2345: Argument of type 'any[] | string[] | Function[] | any[][] | undefined' is not assignable to parameter of type 'any[] | string[] | Function[]'.
+  Type 'undefined' is not assignable to type 'any[] | string[] | Function[]'.
+node_modules/lodash/lodash.js(9673,14): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[] | undefined, iteratee: Function, accumulator?: any, initAccum?: boolean | undefin...' has no compatible call signatures.
 node_modules/lodash/lodash.js(9702,14): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((collection: any, iteratee: Function, accumulator: any, initAccum: boolean, eachFunc: Function) ...' has no compatible call signatures.
 node_modules/lodash/lodash.js(9773,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(9773,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/lodash.js(9859,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(9859,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9902,30): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/lodash.js(9903,43): error TS8024: JSDoc '@param' tag has name 'iteratees', but there is no parameter with that name.
 node_modules/lodash/lodash.js(10004,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(10004,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10065,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10066,19): error TS8024: JSDoc '@param' tag has name 'thisArg', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10067,23): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
 node_modules/lodash/lodash.js(10092,59): error TS2454: Variable 'holders' is used before being assigned.
-node_modules/lodash/lodash.js(10111,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10112,24): error TS8024: JSDoc '@param' tag has name 'key', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10113,23): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
 node_modules/lodash/lodash.js(10146,57): error TS2454: Variable 'holders' is used before being assigned.
 node_modules/lodash/lodash.js(10167,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(10167,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/lodash.js(10193,14): error TS2339: Property 'placeholder' does not exist on type 'Function'.
-node_modules/lodash/lodash.js(10193,34): error TS2339: Property 'placeholder' does not exist on type '(func: Function, arity?: number, guard: any) => Function'.
+node_modules/lodash/lodash.js(10193,34): error TS2339: Property 'placeholder' does not exist on type '(func: Function, arity?: number | undefined, guard: any) => Function'.
 node_modules/lodash/lodash.js(10212,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(10212,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/lodash.js(10238,14): error TS2339: Property 'placeholder' does not exist on type 'Function'.
-node_modules/lodash/lodash.js(10238,39): error TS2339: Property 'placeholder' does not exist on type '(func: Function, arity?: number, guard: any) => Function'.
-node_modules/lodash/lodash.js(10428,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10429,23): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10450,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10451,24): error TS8024: JSDoc '@param' tag has name 'wait', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10452,23): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10619,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10620,43): error TS8024: JSDoc '@param' tag has name 'transforms', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10675,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10676,23): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10712,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10713,23): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10745,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(10746,38): error TS8024: JSDoc '@param' tag has name 'indexes', but there is no parameter with that name.
+node_modules/lodash/lodash.js(10238,39): error TS2339: Property 'placeholder' does not exist on type '(func: Function, arity?: number | undefined, guard: any) => Function'.
+node_modules/lodash/lodash.js(10313,21): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(10314,31): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(10315,47): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(10316,34): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(10341,27): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(10355,69): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(10834,26): error TS2538: Type 'undefined' cannot be used as an index type.
+node_modules/lodash/lodash.js(10896,32): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(10897,34): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(10899,35): error TS2345: Argument of type '{ 'leading': boolean; 'maxWait': number | undefined; 'trailing': boolean; }' is not assignable to parameter of type '{ leading?: boolean; maxWait?: number; trailing?: boolean; } | undefined'.
+  Type '{ 'leading': boolean; 'maxWait': number | undefined; 'trailing': boolean; }' is not assignable to type '{ leading?: boolean; maxWait?: number; trailing?: boolean; }'.
+    Types of property 'maxWait' are incompatible.
+      Type 'number | undefined' is not assignable to type 'number'.
+        Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/lodash.js(10922,14): error TS2554: Expected 3 arguments, but got 2.
-node_modules/lodash/lodash.js(10960,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
+node_modules/lodash/lodash.js(10960,19): error TS8029: JSDoc '@param' tag has name 'value', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/lodash/lodash.js(11021,31): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/lodash.js(11057,31): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/lodash.js(11079,31): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/lodash.js(11112,31): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(11186,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(11187,19): error TS8024: JSDoc '@param' tag has name 'other', but there is no parameter with that name.
-node_modules/lodash/lodash.js(11211,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(11212,19): error TS8024: JSDoc '@param' tag has name 'other', but there is no parameter with that name.
-node_modules/lodash/lodash.js(11238,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(11261,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(11286,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(11385,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(11404,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
 node_modules/lodash/lodash.js(11523,14): error TS2554: Expected 3-5 arguments, but got 2.
-node_modules/lodash/lodash.js(11774,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12047,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12097,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12160,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12242,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12243,19): error TS8024: JSDoc '@param' tag has name 'other', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12267,19): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12268,19): error TS8024: JSDoc '@param' tag has name 'other', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12566,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12567,28): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12609,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12610,28): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12646,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12647,27): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12648,27): error TS8024: JSDoc '@param' tag has name 'customizer', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12678,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12679,27): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12680,27): error TS8024: JSDoc '@param' tag has name 'customizer', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12705,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12706,39): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12768,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12769,28): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12818,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(12819,28): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13192,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13221,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13222,27): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13256,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13257,30): error TS8024: JSDoc '@param' tag has name 'path', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13258,23): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
 node_modules/lodash/lodash.js(13298,36): error TS2554: Expected 2 arguments, but got 1.
-node_modules/lodash/lodash.js(13412,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13413,28): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13445,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13446,27): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13447,26): error TS8024: JSDoc '@param' tag has name 'customizer', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13477,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13478,39): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
+node_modules/lodash/lodash.js(13354,33): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/lodash/lodash.js(13392,38): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/lodash.js(13500,36): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(13540,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13541,39): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13707,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13733,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(13796,7): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[], iteratee: Function) => any[]) | ((object: any, iteratee: Function) => any)' has no compatible call signatures.
-node_modules/lodash/lodash.js(14117,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
+node_modules/lodash/lodash.js(13581,16): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/lodash/lodash.js(13796,7): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[] | undefined, iteratee: Function) => any[]) | ((object: any, iteratee: Function) =...' has no compatible call signatures.
+node_modules/lodash/lodash.js(13797,16): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/lodash/lodash.js(13974,9): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/lodash.js(14174,48): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
 node_modules/lodash/lodash.js(14245,43): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
-node_modules/lodash/lodash.js(14279,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lodash.js(14303,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lodash.js(14327,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
 node_modules/lodash/lodash.js(14458,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(14458,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/lodash.js(14486,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(14486,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(14518,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lodash.js(14519,31): error TS8024: JSDoc '@param' tag has name 'pattern', but there is no parameter with that name.
-node_modules/lodash/lodash.js(14520,33): error TS8024: JSDoc '@param' tag has name 'replacement', but there is no parameter with that name.
-node_modules/lodash/lodash.js(14542,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lodash.js(14607,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
+node_modules/lodash/lodash.js(14520,33): error TS8029: JSDoc '@param' tag has name 'replacement', but there is no parameter with that name. It would match 'arguments' if it had an array type.
+node_modules/lodash/lodash.js(14582,56): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(14692,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(14692,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/lodash.js(14773,38): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(14780,25): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(14785,10): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(14788,10): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(14793,25): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(14802,19): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(14827,22): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(14877,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
 node_modules/lodash/lodash.js(14902,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
 node_modules/lodash/lodash.js(14928,14): error TS1003: Identifier expected.
@@ -793,55 +639,26 @@ node_modules/lodash/lodash.js(14966,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(14966,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/lodash.js(14999,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(14999,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/lodash.js(15065,40): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(15066,30): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/lodash.js(15067,34): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(15083,20): error TS2454: Variable 'strSymbols' is used before being assigned.
 node_modules/lodash/lodash.js(15090,11): error TS2454: Variable 'strSymbols' is used before being assigned.
 node_modules/lodash/lodash.js(15138,41): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
-node_modules/lodash/lodash.js(15149,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15173,25): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
 node_modules/lodash/lodash.js(15194,14): error TS1003: Identifier expected.
 node_modules/lodash/lodash.js(15194,14): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15224,26): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15225,23): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15256,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15257,38): error TS8024: JSDoc '@param' tag has name 'methodNames', but there is no parameter with that name.
 node_modules/lodash/lodash.js(15356,45): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(15417,43): error TS8024: JSDoc '@param' tag has name 'funcs', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15440,43): error TS8024: JSDoc '@param' tag has name 'funcs', but there is no parameter with that name.
 node_modules/lodash/lodash.js(15518,78): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/lodash.js(15550,44): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/lodash.js(15580,34): error TS2345: Argument of type 'string | any[]' is not assignable to parameter of type 'string'.
   Type 'any[]' is not assignable to type 'string'.
 node_modules/lodash/lodash.js(15580,60): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/lodash.js(15591,30): error TS8024: JSDoc '@param' tag has name 'path', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15592,23): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15622,24): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15623,23): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
+node_modules/lodash/lodash.js(15689,53): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/lodash.js(15706,65): error TS2345: Argument of type 'IArguments' is not assignable to parameter of type 'any[]'.
-node_modules/lodash/lodash.js(15785,43): error TS8024: JSDoc '@param' tag has name 'iteratees', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15805,43): error TS8024: JSDoc '@param' tag has name 'predicates', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15831,43): error TS8024: JSDoc '@param' tag has name 'predicates', but there is no parameter with that name.
+node_modules/lodash/lodash.js(15773,30): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/lodash.js(15872,41): error TS2345: Argument of type 'string | symbol' is not assignable to parameter of type 'string'.
   Type 'symbol' is not assignable to type 'string'.
-node_modules/lodash/lodash.js(15915,25): error TS8024: JSDoc '@param' tag has name 'start', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15916,24): error TS8024: JSDoc '@param' tag has name 'end', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15917,25): error TS8024: JSDoc '@param' tag has name 'step', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15953,25): error TS8024: JSDoc '@param' tag has name 'start', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15954,24): error TS8024: JSDoc '@param' tag has name 'end', but there is no parameter with that name.
-node_modules/lodash/lodash.js(15955,25): error TS8024: JSDoc '@param' tag has name 'step', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16170,24): error TS8024: JSDoc '@param' tag has name 'augend', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16171,24): error TS8024: JSDoc '@param' tag has name 'addend', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16189,24): error TS8024: JSDoc '@param' tag has name 'number', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16190,25): error TS8024: JSDoc '@param' tag has name 'precision', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16212,24): error TS8024: JSDoc '@param' tag has name 'dividend', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16213,24): error TS8024: JSDoc '@param' tag has name 'divisor', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16231,24): error TS8024: JSDoc '@param' tag has name 'number', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16232,25): error TS8024: JSDoc '@param' tag has name 'precision', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16405,24): error TS8024: JSDoc '@param' tag has name 'multiplier', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16406,24): error TS8024: JSDoc '@param' tag has name 'multiplicand', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16424,24): error TS8024: JSDoc '@param' tag has name 'number', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16425,25): error TS8024: JSDoc '@param' tag has name 'precision', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16447,24): error TS8024: JSDoc '@param' tag has name 'minuend', but there is no parameter with that name.
-node_modules/lodash/lodash.js(16448,24): error TS8024: JSDoc '@param' tag has name 'subtrahend', but there is no parameter with that name.
 node_modules/lodash/lodash.js(16914,19): error TS2339: Property 'filter' does not exist on type '{ __wrapped__: any; __actions__: never[] | undefined; __dir__: number | undefined; __filtered__: ...'.
 node_modules/lodash/lodash.js(16918,19): error TS2339: Property 'filter' does not exist on type '{ __wrapped__: any; __actions__: never[] | undefined; __dir__: number | undefined; __filtered__: ...'.
 node_modules/lodash/lodash.js(16935,19): error TS2339: Property 'filter' does not exist on type '{ __wrapped__: any; __actions__: never[] | undefined; __dir__: number | undefined; __filtered__: ...'.
@@ -858,111 +675,52 @@ node_modules/lodash/lodash.js(17073,45): error TS2304: Cannot find name 'define'
 node_modules/lodash/lodash.js(17073,71): error TS2304: Cannot find name 'define'.
 node_modules/lodash/lodash.js(17082,5): error TS2304: Cannot find name 'define'.
 node_modules/lodash/lodash.js(17089,30): error TS2339: Property '_' does not exist on type '{ (value: any): any; templateSettings: any; prototype: any; after: (n: number, func: Function) =>...'.
-node_modules/lodash/lowerCase.js(10,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lowerFirst.js(10,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/lt.js(11,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lt.js(12,15): error TS8024: JSDoc '@param' tag has name 'other', but there is no parameter with that name.
-node_modules/lodash/lte.js(10,15): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
-node_modules/lodash/lte.js(11,15): error TS8024: JSDoc '@param' tag has name 'other', but there is no parameter with that name.
 node_modules/lodash/map.js(50,27): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/mapKeys.js(28,14): error TS2554: Expected 0-1 arguments, but got 2.
+node_modules/lodash/mapKeys.js(31,29): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/mapValues.js(35,14): error TS2554: Expected 0-1 arguments, but got 2.
+node_modules/lodash/mapValues.js(38,34): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/matches.js(36,40): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/matchesProperty.js(34,30): error TS2345: Argument of type 'string | any[]' is not assignable to parameter of type 'string'.
   Type 'any[]' is not assignable to type 'string'.
 node_modules/lodash/matchesProperty.js(34,56): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/maxBy.js(30,27): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/meanBy.js(28,26): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/merge.js(19,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/merge.js(20,24): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/mergeWith.js(17,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/mergeWith.js(18,23): error TS8024: JSDoc '@param' tag has name 'sources', but there is no parameter with that name.
-node_modules/lodash/mergeWith.js(19,22): error TS8024: JSDoc '@param' tag has name 'customizer', but there is no parameter with that name.
-node_modules/lodash/method.js(12,26): error TS8024: JSDoc '@param' tag has name 'path', but there is no parameter with that name.
-node_modules/lodash/method.js(13,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
-node_modules/lodash/methodOf.js(13,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/methodOf.js(14,19): error TS8024: JSDoc '@param' tag has name 'args', but there is no parameter with that name.
 node_modules/lodash/minBy.js(30,27): error TS2554: Expected 0-1 arguments, but got 2.
+node_modules/lodash/mixin.js(49,49): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/mixin.js(66,61): error TS2345: Argument of type 'IArguments' is not assignable to parameter of type 'any[]'.
-node_modules/lodash/multiply.js(10,20): error TS8024: JSDoc '@param' tag has name 'multiplier', but there is no parameter with that name.
-node_modules/lodash/multiply.js(11,20): error TS8024: JSDoc '@param' tag has name 'multiplicand', but there is no parameter with that name.
-node_modules/lodash/omit.js(25,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/omit.js(26,35): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
+node_modules/lodash/nthArg.js(28,26): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/omit.js(48,32): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 node_modules/lodash/orderBy.js(18,10): error TS1003: Identifier expected.
 node_modules/lodash/orderBy.js(18,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/orderBy.js(40,3): error TS2322: Type 'string[] | undefined' is not assignable to type 'string[]'.
-  Type 'undefined' is not assignable to type 'string[]'.
-node_modules/lodash/over.js(12,39): error TS8024: JSDoc '@param' tag has name 'iteratees', but there is no parameter with that name.
-node_modules/lodash/overArgs.js(20,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/overArgs.js(21,39): error TS8024: JSDoc '@param' tag has name 'transforms', but there is no parameter with that name.
-node_modules/lodash/overEvery.js(12,39): error TS8024: JSDoc '@param' tag has name 'predicates', but there is no parameter with that name.
-node_modules/lodash/overSome.js(12,39): error TS8024: JSDoc '@param' tag has name 'predicates', but there is no parameter with that name.
 node_modules/lodash/parseInt.js(24,10): error TS1003: Identifier expected.
 node_modules/lodash/parseInt.js(24,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/partial.js(24,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/partial.js(25,19): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
 node_modules/lodash/partial.js(48,9): error TS2339: Property 'placeholder' does not exist on type 'Function'.
-node_modules/lodash/partialRight.js(23,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/partialRight.js(24,19): error TS8024: JSDoc '@param' tag has name 'partials', but there is no parameter with that name.
 node_modules/lodash/partialRight.js(47,14): error TS2339: Property 'placeholder' does not exist on type 'Function'.
-node_modules/lodash/partition.js(13,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/partition.js(14,23): error TS8024: JSDoc '@param' tag has name 'predicate', but there is no parameter with that name.
-node_modules/lodash/pick.js(11,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/pick.js(12,35): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
+node_modules/lodash/pickBy.js(33,12): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/property.js(29,37): error TS2345: Argument of type 'string | symbol' is not assignable to parameter of type 'string'.
   Type 'symbol' is not assignable to type 'string'.
-node_modules/lodash/pull.js(16,19): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/pull.js(17,19): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
 node_modules/lodash/pullAllBy.js(29,34): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/pullAllWith.js(28,34): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'.
-node_modules/lodash/pullAt.js(18,19): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/pullAt.js(19,35): error TS8024: JSDoc '@param' tag has name 'indexes', but there is no parameter with that name.
-node_modules/lodash/random.js(45,5): error TS2322: Type 'undefined' is not assignable to type 'number'.
-node_modules/lodash/random.js(45,13): error TS2322: Type 'undefined' is not assignable to type 'boolean'.
-node_modules/lodash/random.js(50,7): error TS2322: Type 'undefined' is not assignable to type 'number'.
-node_modules/lodash/random.js(54,7): error TS2322: Type 'undefined' is not assignable to type 'number'.
-node_modules/lodash/range.js(16,21): error TS8024: JSDoc '@param' tag has name 'start', but there is no parameter with that name.
-node_modules/lodash/range.js(17,20): error TS8024: JSDoc '@param' tag has name 'end', but there is no parameter with that name.
-node_modules/lodash/range.js(18,21): error TS8024: JSDoc '@param' tag has name 'step', but there is no parameter with that name.
-node_modules/lodash/rangeRight.js(11,21): error TS8024: JSDoc '@param' tag has name 'start', but there is no parameter with that name.
-node_modules/lodash/rangeRight.js(12,20): error TS8024: JSDoc '@param' tag has name 'end', but there is no parameter with that name.
-node_modules/lodash/rangeRight.js(13,21): error TS8024: JSDoc '@param' tag has name 'step', but there is no parameter with that name.
-node_modules/lodash/rearg.js(17,22): error TS8024: JSDoc '@param' tag has name 'func', but there is no parameter with that name.
-node_modules/lodash/rearg.js(18,34): error TS8024: JSDoc '@param' tag has name 'indexes', but there is no parameter with that name.
-node_modules/lodash/rearg.js(30,55): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'any[]'.
-node_modules/lodash/reduce.js(48,10): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[], iteratee: Function, accumulator?: any, initAccum?: boolean) => any) | ((collecti...' has no compatible call signatures.
+node_modules/lodash/reduce.js(48,10): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[] | undefined, iteratee: Function, accumulator?: any, initAccum?: boolean | undefin...' has no compatible call signatures.
 node_modules/lodash/reduce.js(48,27): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/reduceRight.js(33,10): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[], iteratee: Function, accumulator?: any, initAccum?: boolean) => any) | ((collecti...' has no compatible call signatures.
+node_modules/lodash/reduceRight.js(33,10): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[] | undefined, iteratee: Function, accumulator?: any, initAccum?: boolean | undefin...' has no compatible call signatures.
 node_modules/lodash/reduceRight.js(33,27): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/reject.js(43,34): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/remove.js(41,15): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/repeat.js(15,10): error TS1003: Identifier expected.
 node_modules/lodash/repeat.js(15,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/replace.js(13,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/replace.js(14,27): error TS8024: JSDoc '@param' tag has name 'pattern', but there is no parameter with that name.
-node_modules/lodash/replace.js(15,29): error TS8024: JSDoc '@param' tag has name 'replacement', but there is no parameter with that name.
-node_modules/lodash/round.js(10,20): error TS8024: JSDoc '@param' tag has name 'number', but there is no parameter with that name.
-node_modules/lodash/round.js(11,21): error TS8024: JSDoc '@param' tag has name 'precision', but there is no parameter with that name.
+node_modules/lodash/replace.js(15,29): error TS8029: JSDoc '@param' tag has name 'replacement', but there is no parameter with that name. It would match 'arguments' if it had an array type.
 node_modules/lodash/sampleSize.js(17,10): error TS1003: Identifier expected.
 node_modules/lodash/sampleSize.js(17,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/setWith.js(28,3): error TS2322: Type 'Function | undefined' is not assignable to type 'Function'.
-  Type 'undefined' is not assignable to type 'Function'.
-node_modules/lodash/snakeCase.js(11,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
 node_modules/lodash/some.js(18,10): error TS1003: Identifier expected.
 node_modules/lodash/some.js(18,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/some.js(46,5): error TS2322: Type 'undefined' is not assignable to type 'Function'.
 node_modules/lodash/some.js(48,27): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/sortBy.js(16,26): error TS8024: JSDoc '@param' tag has name 'collection', but there is no parameter with that name.
-node_modules/lodash/sortBy.js(17,39): error TS8024: JSDoc '@param' tag has name 'iteratees', but there is no parameter with that name.
 node_modules/lodash/sortedIndexBy.js(30,42): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/sortedLastIndexBy.js(30,42): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/sortedUniqBy.js(22,29): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/split.js(33,5): error TS2322: Type 'undefined' is not assignable to type 'string | RegExp'.
-node_modules/lodash/split.js(33,17): error TS2322: Type 'undefined' is not assignable to type 'number'.
-node_modules/lodash/startCase.js(12,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/subtract.js(10,20): error TS8024: JSDoc '@param' tag has name 'minuend', but there is no parameter with that name.
-node_modules/lodash/subtract.js(11,20): error TS8024: JSDoc '@param' tag has name 'subtrahend', but there is no parameter with that name.
+node_modules/lodash/spread.js(53,22): error TS2538: Type 'undefined' cannot be used as an index type.
 node_modules/lodash/sumBy.js(29,22): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/take.js(13,10): error TS1003: Identifier expected.
 node_modules/lodash/take.js(13,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
@@ -972,62 +730,53 @@ node_modules/lodash/takeRightWhile.js(41,24): error TS2554: Expected 0-1 argumen
 node_modules/lodash/takeWhile.js(41,24): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/template.js(65,10): error TS1003: Identifier expected.
 node_modules/lodash/template.js(65,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/template.js(141,5): error TS2322: Type 'undefined' is not assignable to type '{ escape?: RegExp; evaluate?: RegExp; imports?: any; interpolate?: RegExp; sourceURL?: string; va...'.
+node_modules/lodash/template.js(146,34): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/template.js(153,21): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/template.js(158,6): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/template.js(161,6): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/template.js(165,34): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/template.js(171,15): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/template.js(196,18): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/template.js(225,21): error TS2345: Argument of type 'any[]' is not assignable to parameter of type 'string'.
-node_modules/lodash/templateSettings.js(63,12): error TS2322: Type '{ [x: string]: any; 'escape': (string?: string) => string; }' is not assignable to type 'Function'.
+node_modules/lodash/templateSettings.js(63,12): error TS2322: Type '{ [x: string]: any; 'escape': (string?: string | undefined) => string; }' is not assignable to type 'Function'.
   Object literal may only specify known properties, and ''escape'' does not exist in type 'Function'.
+node_modules/lodash/throttle.js(59,28): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/throttle.js(60,30): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/throttle.js(62,31): error TS2345: Argument of type '{ 'leading': boolean; 'maxWait': number | undefined; 'trailing': boolean; }' is not assignable to parameter of type '{ leading?: boolean; maxWait?: number; trailing?: boolean; } | undefined'.
+  Type '{ 'leading': boolean; 'maxWait': number | undefined; 'trailing': boolean; }' is not assignable to type '{ leading?: boolean; maxWait?: number; trailing?: boolean; }'.
+    Types of property 'maxWait' are incompatible.
+      Type 'number | undefined' is not assignable to type 'number'.
+        Type 'undefined' is not assignable to type 'number'.
 node_modules/lodash/toLower.js(11,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/toPairs.js(14,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
-node_modules/lodash/toPairsIn.js(14,20): error TS8024: JSDoc '@param' tag has name 'object', but there is no parameter with that name.
 node_modules/lodash/toUpper.js(11,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
 node_modules/lodash/transform.js(46,14): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/transform.js(59,3): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[], iteratee: Function) => any[]) | ((object: any, iteratee: Function) => any)' has no compatible call signatures.
+node_modules/lodash/transform.js(59,3): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((array?: any[] | undefined, iteratee: Function) => any[]) | ((object: any, iteratee: Function) =...' has no compatible call signatures.
+node_modules/lodash/transform.js(60,12): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/trim.js(20,10): error TS1003: Identifier expected.
 node_modules/lodash/trim.js(20,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/trimEnd.js(19,10): error TS1003: Identifier expected.
 node_modules/lodash/trimEnd.js(19,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/trimStart.js(19,10): error TS1003: Identifier expected.
 node_modules/lodash/trimStart.js(19,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/truncate.js(60,36): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/truncate.js(61,26): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/truncate.js(62,30): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/truncate.js(78,16): error TS2454: Variable 'strSymbols' is used before being assigned.
 node_modules/lodash/truncate.js(85,7): error TS2454: Variable 'strSymbols' is used before being assigned.
 node_modules/lodash/unary.js(19,10): error TS2554: Expected 3 arguments, but got 2.
 node_modules/lodash/unescape.js(30,37): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
-node_modules/lodash/union.js(15,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/union.js(23,42): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/unionBy.js(19,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/unionBy.js(20,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
-node_modules/lodash/unionBy.js(36,42): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
+node_modules/lodash/union.js(23,42): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
+node_modules/lodash/unionBy.js(36,42): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
 node_modules/lodash/unionBy.js(36,68): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/unionWith.js(17,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/unionWith.js(18,23): error TS8024: JSDoc '@param' tag has name 'comparator', but there is no parameter with that name.
-node_modules/lodash/unionWith.js(31,42): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean'.
-node_modules/lodash/unionWith.js(31,68): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'.
+node_modules/lodash/unionWith.js(31,42): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
+  Type '(value: any) => boolean' is not assignable to type 'false'.
 node_modules/lodash/uniqBy.js(28,52): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/uniqWith.js(24,3): error TS2322: Type 'Function | undefined' is not assignable to type 'Function'.
-  Type 'undefined' is not assignable to type 'Function'.
-node_modules/lodash/uniqWith.js(25,52): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'.
-node_modules/lodash/updateWith.js(29,3): error TS2322: Type 'Function | undefined' is not assignable to type 'Function'.
-  Type 'undefined' is not assignable to type 'Function'.
-node_modules/lodash/upperCase.js(10,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/upperFirst.js(10,21): error TS8024: JSDoc '@param' tag has name 'string', but there is no parameter with that name.
-node_modules/lodash/without.js(16,19): error TS8024: JSDoc '@param' tag has name 'array', but there is no parameter with that name.
-node_modules/lodash/without.js(17,19): error TS8024: JSDoc '@param' tag has name 'values', but there is no parameter with that name.
 node_modules/lodash/words.js(15,10): error TS1003: Identifier expected.
 node_modules/lodash/words.js(15,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/words.js(27,3): error TS2322: Type 'string | RegExp | undefined' is not assignable to type 'string | RegExp'.
-  Type 'undefined' is not assignable to type 'string | RegExp'.
-node_modules/lodash/wrapperAt.js(15,35): error TS8024: JSDoc '@param' tag has name 'paths', but there is no parameter with that name.
 node_modules/lodash/wrapperAt.js(40,51): error TS2339: Property 'thru' does not exist on type '{ __wrapped__: any; __actions__: never[] | undefined; __chain__: boolean | undefined; __index__: ...'.
-node_modules/lodash/xor.js(16,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/xorBy.js(19,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/xorBy.js(20,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
 node_modules/lodash/xorBy.js(36,58): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/xorWith.js(17,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/xorWith.js(18,23): error TS8024: JSDoc '@param' tag has name 'comparator', but there is no parameter with that name.
-node_modules/lodash/xorWith.js(31,58): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Function'.
-node_modules/lodash/zip.js(13,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/zipWith.js(13,23): error TS8024: JSDoc '@param' tag has name 'arrays', but there is no parameter with that name.
-node_modules/lodash/zipWith.js(14,23): error TS8024: JSDoc '@param' tag has name 'iteratee', but there is no parameter with that name.
 
 
 

--- a/tests/baselines/reference/user/uglify-js.log
+++ b/tests/baselines/reference/user/uglify-js.log
@@ -6,72 +6,72 @@ node_modules/uglify-js/lib/ast.js(858,5): error TS2322: Type '{ [x: string]: any
   Object literal may only specify known properties, but '_visit' does not exist in type 'TreeWalker'. Did you mean to write 'visit'?
 node_modules/uglify-js/lib/compress.js(186,27): error TS2554: Expected 0 arguments, but got 1.
 node_modules/uglify-js/lib/compress.js(474,26): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(745,18): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(988,38): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
-node_modules/uglify-js/lib/compress.js(1097,53): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
-node_modules/uglify-js/lib/compress.js(1137,112): error TS2532: Object is possibly 'undefined'.
-node_modules/uglify-js/lib/compress.js(1138,29): error TS2532: Object is possibly 'undefined'.
-node_modules/uglify-js/lib/compress.js(1147,87): error TS2322: Type 'false' is not assignable to type 'number'.
-node_modules/uglify-js/lib/compress.js(1155,29): error TS2322: Type 'false' is not assignable to type 'never'.
-node_modules/uglify-js/lib/compress.js(1208,38): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(1301,38): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
-node_modules/uglify-js/lib/compress.js(1393,27): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(1407,26): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(1821,44): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(1999,19): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(2237,27): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(2735,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
-  Type 'string[]' provides no match for the signature '(): boolean'.
-node_modules/uglify-js/lib/compress.js(2737,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
-node_modules/uglify-js/lib/compress.js(2739,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
-node_modules/uglify-js/lib/compress.js(2741,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
+node_modules/uglify-js/lib/compress.js(754,18): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(996,38): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
+node_modules/uglify-js/lib/compress.js(1105,53): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
+node_modules/uglify-js/lib/compress.js(1145,112): error TS2532: Object is possibly 'undefined'.
+node_modules/uglify-js/lib/compress.js(1146,29): error TS2532: Object is possibly 'undefined'.
+node_modules/uglify-js/lib/compress.js(1155,87): error TS2322: Type 'false' is not assignable to type 'number'.
+node_modules/uglify-js/lib/compress.js(1163,29): error TS2322: Type 'false' is not assignable to type 'never'.
+node_modules/uglify-js/lib/compress.js(1216,38): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(1309,38): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
+node_modules/uglify-js/lib/compress.js(1401,27): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(1415,26): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(1829,44): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(2007,19): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(2245,27): error TS2554: Expected 0 arguments, but got 1.
 node_modules/uglify-js/lib/compress.js(2743,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
+  Type 'string[]' provides no match for the signature '(): boolean'.
 node_modules/uglify-js/lib/compress.js(2745,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
-node_modules/uglify-js/lib/compress.js(2747,16): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(2974,23): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(2987,33): error TS2322: Type '"f"' is not assignable to type 'boolean'.
-node_modules/uglify-js/lib/compress.js(3122,18): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3132,33): error TS2339: Property 'add' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3136,32): error TS2339: Property 'add' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3142,40): error TS2339: Property 'add' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3151,41): error TS2339: Property 'add' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3168,14): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3170,40): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3178,33): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
-node_modules/uglify-js/lib/compress.js(3252,63): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3420,23): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3437,36): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
-node_modules/uglify-js/lib/compress.js(3443,38): error TS2339: Property 'set' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3447,40): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
-node_modules/uglify-js/lib/compress.js(3472,22): error TS2339: Property 'each' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3476,30): error TS2339: Property 'del' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3481,30): error TS2339: Property 'set' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3492,41): error TS2339: Property 'has' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3494,48): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3506,41): error TS2339: Property 'has' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3508,48): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3591,21): error TS2403: Subsequent variable declarations must have the same type.  Variable 'defs' must be of type 'typeof Dictionary', but here has type 'any'.
-node_modules/uglify-js/lib/compress.js(3593,36): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3610,22): error TS2339: Property 'set' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/compress.js(3630,17): error TS2447: The '|=' operator is not allowed for boolean types. Consider using '||' instead.
-node_modules/uglify-js/lib/compress.js(3655,30): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3806,22): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(4070,17): error TS2403: Subsequent variable declarations must have the same type.  Variable 'body' must be of type 'any[]', but here has type 'any'.
-node_modules/uglify-js/lib/compress.js(4154,22): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(4482,30): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(4489,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'code' must be of type 'string', but here has type '{ [x: string]: any; get: () => string; toString: () => string; indent: () => void; indentation: (...'.
-node_modules/uglify-js/lib/compress.js(4493,36): error TS2532: Object is possibly 'undefined'.
-node_modules/uglify-js/lib/compress.js(4498,41): error TS2339: Property 'get' does not exist on type 'string'.
-node_modules/uglify-js/lib/compress.js(4968,18): error TS2454: Variable 'is_strict_comparison' is used before being assigned.
-node_modules/uglify-js/lib/compress.js(5424,32): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(5484,24): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(5556,24): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(5562,26): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(5917,43): error TS2454: Variable 'property' is used before being assigned.
-node_modules/uglify-js/lib/compress.js(5931,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'value' must be of type 'number', but here has type 'any'.
-node_modules/uglify-js/lib/compress.js(5934,46): error TS2339: Property 'has_side_effects' does not exist on type 'number'.
-node_modules/uglify-js/lib/compress.js(5941,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'value' must be of type 'number', but here has type 'any'.
-node_modules/uglify-js/lib/compress.js(5994,19): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(2747,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
+node_modules/uglify-js/lib/compress.js(2749,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
+node_modules/uglify-js/lib/compress.js(2751,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
+node_modules/uglify-js/lib/compress.js(2753,13): error TS2322: Type 'string[]' is not assignable to type '() => boolean'.
+node_modules/uglify-js/lib/compress.js(2755,16): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(2982,23): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(2995,33): error TS2322: Type '"f"' is not assignable to type 'boolean'.
+node_modules/uglify-js/lib/compress.js(3132,18): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3142,33): error TS2339: Property 'add' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3146,32): error TS2339: Property 'add' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3152,40): error TS2339: Property 'add' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3161,41): error TS2339: Property 'add' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3178,14): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3180,40): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3188,33): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
+node_modules/uglify-js/lib/compress.js(3262,63): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3451,23): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3468,36): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
+node_modules/uglify-js/lib/compress.js(3474,38): error TS2339: Property 'set' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3478,40): error TS2339: Property 'parent' does not exist on type '{ before: any; after: any; }'.
+node_modules/uglify-js/lib/compress.js(3503,22): error TS2339: Property 'each' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3507,30): error TS2339: Property 'del' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3512,30): error TS2339: Property 'set' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3523,41): error TS2339: Property 'has' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3525,48): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3537,41): error TS2339: Property 'has' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3539,48): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3622,21): error TS2403: Subsequent variable declarations must have the same type.  Variable 'defs' must be of type 'typeof Dictionary', but here has type 'any'.
+node_modules/uglify-js/lib/compress.js(3624,36): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3641,22): error TS2339: Property 'set' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/compress.js(3661,17): error TS2447: The '|=' operator is not allowed for boolean types. Consider using '||' instead.
+node_modules/uglify-js/lib/compress.js(3686,30): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3837,22): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(4101,17): error TS2403: Subsequent variable declarations must have the same type.  Variable 'body' must be of type 'any[]', but here has type 'any'.
+node_modules/uglify-js/lib/compress.js(4185,22): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(4513,30): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(4520,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'code' must be of type 'string', but here has type '{ [x: string]: any; get: () => string; toString: () => string; indent: () => void; indentation: (...'.
+node_modules/uglify-js/lib/compress.js(4524,36): error TS2532: Object is possibly 'undefined'.
+node_modules/uglify-js/lib/compress.js(4529,41): error TS2339: Property 'get' does not exist on type 'string'.
+node_modules/uglify-js/lib/compress.js(4999,18): error TS2454: Variable 'is_strict_comparison' is used before being assigned.
+node_modules/uglify-js/lib/compress.js(5455,32): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(5515,24): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(5587,24): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(5593,26): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(5948,43): error TS2454: Variable 'property' is used before being assigned.
+node_modules/uglify-js/lib/compress.js(5962,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'value' must be of type 'number', but here has type 'any'.
+node_modules/uglify-js/lib/compress.js(5965,46): error TS2339: Property 'has_side_effects' does not exist on type 'number'.
+node_modules/uglify-js/lib/compress.js(5972,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'value' must be of type 'number', but here has type 'any'.
+node_modules/uglify-js/lib/compress.js(6025,19): error TS2554: Expected 0 arguments, but got 1.
 node_modules/uglify-js/lib/minify.js(148,75): error TS2339: Property 'compress' does not exist on type '{ options: any; pure_funcs: any; top_retain: any; toplevel: { [x: string]: any; funcs: any; vars:...'.
 node_modules/uglify-js/lib/output.js(213,29): error TS2339: Property 'token' does not exist on type 'never'.
 node_modules/uglify-js/lib/output.js(214,29): error TS2339: Property 'line' does not exist on type 'never'.
@@ -93,9 +93,9 @@ node_modules/uglify-js/lib/output.js(241,33): error TS2339: Property 'col' does 
 node_modules/uglify-js/lib/output.js(332,27): error TS2345: Argument of type '{ token: any; name: any; line: number; col: number; }' is not assignable to parameter of type 'never'.
 node_modules/uglify-js/lib/output.js(471,22): error TS2554: Expected 0 arguments, but got 1.
 node_modules/uglify-js/lib/output.js(765,23): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/output.js(1176,29): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/output.js(1246,37): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'String' has no compatible call signatures.
-node_modules/uglify-js/lib/output.js(1358,20): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'String' has no compatible call signatures.
+node_modules/uglify-js/lib/output.js(1177,29): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/output.js(1247,37): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'String' has no compatible call signatures.
+node_modules/uglify-js/lib/output.js(1359,20): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'String' has no compatible call signatures.
 node_modules/uglify-js/lib/parse.js(53,1): error TS2322: Type 'Function' is not assignable to type 'string'.
 node_modules/uglify-js/lib/parse.js(54,1): error TS2322: Type 'Function' is not assignable to type 'string'.
 node_modules/uglify-js/lib/parse.js(55,1): error TS2322: Type 'Function' is not assignable to type 'string'.
@@ -164,32 +164,32 @@ node_modules/uglify-js/lib/propmangle.js(62,45): error TS2339: Property 'prototy
 node_modules/uglify-js/lib/propmangle.js(75,14): error TS2554: Expected 0 arguments, but got 1.
 node_modules/uglify-js/lib/propmangle.js(85,15): error TS2554: Expected 0 arguments, but got 1.
 node_modules/uglify-js/lib/propmangle.js(139,14): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/scope.js(110,14): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/scope.js(114,13): error TS2531: Object is possibly 'null'.
-node_modules/uglify-js/lib/scope.js(134,24): error TS2339: Property 'has' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/scope.js(137,20): error TS2339: Property 'set' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/scope.js(139,20): error TS2339: Property 'del' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/scope.js(143,42): error TS2339: Property 'parent_scope' does not exist on type 'never'.
-node_modules/uglify-js/lib/scope.js(144,19): error TS2339: Property 'uses_with' does not exist on type 'never'.
-node_modules/uglify-js/lib/scope.js(169,27): error TS2531: Object is possibly 'null'.
-node_modules/uglify-js/lib/scope.js(177,13): error TS2531: Object is possibly 'null'.
-node_modules/uglify-js/lib/scope.js(180,30): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
-node_modules/uglify-js/lib/scope.js(193,14): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/scope.js(230,19): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/scope.js(435,14): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/scope.js(488,15): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/scope.js(507,12): error TS2339: Property 'reset' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(508,12): error TS2339: Property 'sort' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(513,15): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/scope.js(548,12): error TS2339: Property 'reset' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(553,24): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(556,28): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(562,16): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(566,12): error TS2339: Property 'sort' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(570,20): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(593,12): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(601,12): error TS2339: Property 'sort' does not exist on type '(num: any) => string'.
-node_modules/uglify-js/lib/scope.js(604,12): error TS2339: Property 'reset' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(105,14): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/scope.js(109,13): error TS2531: Object is possibly 'null'.
+node_modules/uglify-js/lib/scope.js(129,24): error TS2339: Property 'has' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/scope.js(132,20): error TS2339: Property 'set' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/scope.js(134,20): error TS2339: Property 'del' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/scope.js(138,42): error TS2339: Property 'parent_scope' does not exist on type 'never'.
+node_modules/uglify-js/lib/scope.js(139,19): error TS2339: Property 'uses_with' does not exist on type 'never'.
+node_modules/uglify-js/lib/scope.js(164,27): error TS2531: Object is possibly 'null'.
+node_modules/uglify-js/lib/scope.js(172,13): error TS2531: Object is possibly 'null'.
+node_modules/uglify-js/lib/scope.js(175,30): error TS2339: Property 'get' does not exist on type 'typeof Dictionary'.
+node_modules/uglify-js/lib/scope.js(188,14): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/scope.js(225,19): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/scope.js(433,14): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/scope.js(486,15): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/scope.js(505,12): error TS2339: Property 'reset' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(506,12): error TS2339: Property 'sort' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(511,15): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/scope.js(546,12): error TS2339: Property 'reset' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(551,24): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(554,28): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(560,16): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(564,12): error TS2339: Property 'sort' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(568,20): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(591,12): error TS2339: Property 'consider' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(599,12): error TS2339: Property 'sort' does not exist on type '(num: any) => string'.
+node_modules/uglify-js/lib/scope.js(602,12): error TS2339: Property 'reset' does not exist on type '(num: any) => string'.
 node_modules/uglify-js/lib/sourcemap.js(56,25): error TS2304: Cannot find name 'MOZ_SourceMap'.
 node_modules/uglify-js/lib/sourcemap.js(60,40): error TS2304: Cannot find name 'MOZ_SourceMap'.
 node_modules/uglify-js/tools/exit.js(2,12): error TS2454: Variable 'process' is used before being assigned.

--- a/tests/baselines/reference/user/util.log
+++ b/tests/baselines/reference/user/util.log
@@ -56,8 +56,6 @@ node_modules/util/util.js(55,20): error TS2555: Expected at least 2 arguments, b
 node_modules/util/util.js(73,15): error TS2339: Property 'noDeprecation' does not exist on type 'Process'.
 node_modules/util/util.js(80,19): error TS2339: Property 'throwDeprecation' does not exist on type 'Process'.
 node_modules/util/util.js(82,26): error TS2339: Property 'traceDeprecation' does not exist on type 'Process'.
-node_modules/util/util.js(566,22): error TS8024: JSDoc '@param' tag has name 'ctor', but there is no parameter with that name.
-node_modules/util/util.js(568,22): error TS8024: JSDoc '@param' tag has name 'superCtor', but there is no parameter with that name.
 
 
 


### PR DESCRIPTION
From #22510 and #22514, which remove lots of bogus `@param` errors and add lots of `Object is possibly undefined` errors, respectively. Looks like overall 400 fewer errors.

There are quite a few effects of the correct addition of undefined to types based on postfix= in jsdoc, actually.