### PR TITLE
Rename index types to keyof

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3015,9 +3015,9 @@ namespace ts {
                     // The type is an object literal type.
                     return createAnonymousTypeNode(<ObjectType>type);
                 }
-                if (type.flags & TypeFlags.Index) {
-                    const indexedType = (<IndexType>type).type;
-                    const indexTypeNode = typeToTypeNodeHelper(indexedType, context);
+                if (type.flags & TypeFlags.Keyof) {
+                    const keyType = (<KeyofType>type).type;
+                    const indexTypeNode = typeToTypeNodeHelper(keyType, context);
                     return createTypeOperatorNode(indexTypeNode);
                 }
                 if (type.flags & TypeFlags.IndexedAccess) {
@@ -4150,8 +4150,8 @@ namespace ts {
             // A variable declared in a for..in statement is of type string, or of type keyof T when the
             // right hand expression is of a type parameter type.
             if (isVariableDeclaration(declaration) && declaration.parent.parent.kind === SyntaxKind.ForInStatement) {
-                const indexType = getIndexType(checkNonNullExpression(declaration.parent.parent.expression));
-                return indexType.flags & (TypeFlags.TypeParameter | TypeFlags.Index) ? indexType : stringType;
+                const indexType = getKeyofType(checkNonNullExpression(declaration.parent.parent.expression));
+                return indexType.flags & (TypeFlags.TypeParameter | TypeFlags.Keyof) ? indexType : stringType;
             }
 
             if (isVariableDeclaration(declaration) && declaration.parent.parent.kind === SyntaxKind.ForOfStatement) {
@@ -5955,7 +5955,7 @@ namespace ts {
                 // if the key type is a 'keyof X', obtain 'keyof C' where C is the base constraint of X.
                 // Finally, iterate over the constituents of the resulting iteration type.
                 const keyType = constraintType.flags & TypeFlags.InstantiableNonPrimitive ? getApparentType(constraintType) : constraintType;
-                const iterationType = keyType.flags & TypeFlags.Index ? getIndexType(getApparentType((<IndexType>keyType).type)) : keyType;
+                const iterationType = keyType.flags & TypeFlags.Keyof ? getKeyofType(getApparentType((<KeyofType>keyType).type)) : keyType;
                 forEachType(iterationType, addMemberForKeyType);
             }
             setStructuredTypeMembers(type, members, emptyArray, emptyArray, stringIndexInfo, undefined);
@@ -6036,7 +6036,7 @@ namespace ts {
                     const declaredType = <MappedType>getTypeFromMappedTypeNode(type.declaration);
                     const constraint = getConstraintTypeFromMappedType(declaredType);
                     const extendedConstraint = constraint && constraint.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(<TypeParameter>constraint) : constraint;
-                    type.modifiersType = extendedConstraint && extendedConstraint.flags & TypeFlags.Index ? instantiateType((<IndexType>extendedConstraint).type, type.mapper || identityMapper) : emptyObjectType;
+                    type.modifiersType = extendedConstraint && extendedConstraint.flags & TypeFlags.Keyof ? instantiateType((<KeyofType>extendedConstraint).type, type.mapper || identityMapper) : emptyObjectType;
                 }
             }
             return type.modifiersType;
@@ -6227,7 +6227,7 @@ namespace ts {
 
         function getBaseConstraintOfType(type: Type): Type {
             const constraint = getBaseConstraintOfInstantiableNonPrimitiveUnionOrIntersection(type);
-            if (!constraint && type.flags & TypeFlags.Index) {
+            if (!constraint && type.flags & TypeFlags.Keyof) {
                 return stringType;
             }
             return constraint;
@@ -6291,7 +6291,7 @@ namespace ts {
                         t.flags & TypeFlags.Intersection && baseTypes.length ? getIntersectionType(baseTypes) :
                             undefined;
                 }
-                if (t.flags & TypeFlags.Index) {
+                if (t.flags & TypeFlags.Keyof) {
                     return stringType;
                 }
                 if (t.flags & TypeFlags.IndexedAccess) {
@@ -8011,11 +8011,11 @@ namespace ts {
         }
 
         function getIndexTypeForGenericType(type: InstantiableType | UnionOrIntersectionType) {
-            if (!type.resolvedIndexType) {
-                type.resolvedIndexType = <IndexType>createType(TypeFlags.Index);
-                type.resolvedIndexType.type = type;
+            if (!type.resolvedKeyofType) {
+                type.resolvedKeyofType = <KeyofType>createType(TypeFlags.Keyof);
+                type.resolvedKeyofType.type = type;
             }
-            return type.resolvedIndexType;
+            return type.resolvedKeyofType;
         }
 
         function getLiteralTypeFromPropertyName(prop: Symbol) {
@@ -8038,8 +8038,8 @@ namespace ts {
             return getUnionType(map(getPropertiesOfType(type), getLiteralTypeFromPropertyName));
         }
 
-        function getIndexType(type: Type): Type {
-            return type.flags & TypeFlags.Intersection ? getUnionType(map((<IntersectionType>type).types, t => getIndexType(t))) :
+        function getKeyofType(type: Type): Type {
+            return type.flags & TypeFlags.Intersection ? getUnionType(map((<IntersectionType>type).types, t => getKeyofType(t))) :
                 maybeTypeOfKind(type, TypeFlags.InstantiableNonPrimitive) ? getIndexTypeForGenericType(<InstantiableType | UnionOrIntersectionType>type) :
                 getObjectFlags(type) & ObjectFlags.Mapped ? getConstraintTypeFromMappedType(<MappedType>type) :
                 type === wildcardType ? wildcardType :
@@ -8048,7 +8048,7 @@ namespace ts {
         }
 
         function getIndexTypeOrString(type: Type): Type {
-            const indexType = getIndexType(type);
+            const indexType = getKeyofType(type);
             return indexType.flags & TypeFlags.Never ? stringType : indexType;
         }
 
@@ -8057,7 +8057,7 @@ namespace ts {
             if (!links.resolvedType) {
                 switch (node.operator) {
                     case SyntaxKind.KeyOfKeyword:
-                        links.resolvedType = getIndexType(getTypeFromTypeNode(node.type));
+                        links.resolvedType = getKeyofType(getTypeFromTypeNode(node.type));
                         break;
                     case SyntaxKind.UniqueKeyword:
                         links.resolvedType = node.type.kind === SyntaxKind.SymbolKeyword
@@ -8144,7 +8144,7 @@ namespace ts {
         }
 
         function isGenericIndexType(type: Type): boolean {
-            return maybeTypeOfKind(type, TypeFlags.InstantiableNonPrimitive | TypeFlags.Index);
+            return maybeTypeOfKind(type, TypeFlags.InstantiableNonPrimitive | TypeFlags.Keyof);
         }
 
         // Return true if the given type is a non-generic object type with a string index signature and no
@@ -8938,8 +8938,8 @@ namespace ts {
             // homomorphic mapped types we leave primitive types alone. For example, when T is instantiated to a
             // union type A | undefined, we produce { [P in keyof A]: X } | undefined.
             const constraintType = getConstraintTypeFromMappedType(type);
-            if (constraintType.flags & TypeFlags.Index) {
-                const typeVariable = (<IndexType>constraintType).type;
+            if (constraintType.flags & TypeFlags.Keyof) {
+                const typeVariable = (<KeyofType>constraintType).type;
                 if (typeVariable.flags & TypeFlags.TypeParameter) {
                     const mappedTypeVariable = instantiateType(typeVariable, mapper);
                     if (typeVariable !== mappedTypeVariable) {
@@ -9036,8 +9036,8 @@ namespace ts {
                     const newTypes = instantiateTypes(types, mapper);
                     return newTypes !== types ? getIntersectionType(newTypes, type.aliasSymbol, instantiateTypes(type.aliasTypeArguments, mapper)) : type;
                 }
-                if (type.flags & TypeFlags.Index) {
-                    return getIndexType(instantiateType((<IndexType>type).type, mapper));
+                if (type.flags & TypeFlags.Keyof) {
+                    return getKeyofType(instantiateType((<KeyofType>type).type, mapper));
                 }
                 if (type.flags & TypeFlags.IndexedAccess) {
                     return getIndexedAccessType(instantiateType((<IndexedAccessType>type).objectType, mapper), instantiateType((<IndexedAccessType>type).indexType, mapper));
@@ -9778,8 +9778,8 @@ namespace ts {
                         }
                     }
                 }
-                if (flags & TypeFlags.Index) {
-                    return isRelatedTo((<IndexType>source).type, (<IndexType>target).type, /*reportErrors*/ false);
+                if (flags & TypeFlags.Keyof) {
+                    return isRelatedTo((<KeyofType>source).type, (<KeyofType>target).type, /*reportErrors*/ false);
                 }
                 if (flags & TypeFlags.IndexedAccess) {
                     if (result = isRelatedTo((<IndexedAccessType>source).objectType, (<IndexedAccessType>target).objectType, /*reportErrors*/ false)) {
@@ -10089,7 +10089,7 @@ namespace ts {
                 const saveErrorInfo = errorInfo;
                 if (target.flags & TypeFlags.TypeParameter) {
                     // A source type { [P in keyof T]: X } is related to a target type T if X is related to T[P].
-                    if (getObjectFlags(source) & ObjectFlags.Mapped && getConstraintTypeFromMappedType(<MappedType>source) === getIndexType(target)) {
+                    if (getObjectFlags(source) & ObjectFlags.Mapped && getConstraintTypeFromMappedType(<MappedType>source) === getKeyofType(target)) {
                         if (!(getMappedTypeModifiers(<MappedType>source) & MappedTypeModifiers.IncludeOptional)) {
                             const templateType = getTemplateTypeFromMappedType(<MappedType>source);
                             const indexedAccessType = getIndexedAccessType(target, getTypeParameterFromMappedType(<MappedType>source));
@@ -10099,18 +10099,18 @@ namespace ts {
                         }
                     }
                 }
-                else if (target.flags & TypeFlags.Index) {
+                else if (target.flags & TypeFlags.Keyof) {
                     // A keyof S is related to a keyof T if T is related to S.
-                    if (source.flags & TypeFlags.Index) {
-                        if (result = isRelatedTo((<IndexType>target).type, (<IndexType>source).type, /*reportErrors*/ false)) {
+                    if (source.flags & TypeFlags.Keyof) {
+                        if (result = isRelatedTo((<KeyofType>target).type, (<KeyofType>source).type, /*reportErrors*/ false)) {
                             return result;
                         }
                     }
                     // A type S is assignable to keyof T if S is assignable to keyof C, where C is the
                     // constraint of T.
-                    const constraint = getConstraintForRelation((<IndexType>target).type);
+                    const constraint = getConstraintForRelation((<KeyofType>target).type);
                     if (constraint) {
-                        if (result = isRelatedTo(source, getIndexType(constraint), reportErrors)) {
+                        if (result = isRelatedTo(source, getKeyofType(constraint), reportErrors)) {
                             return result;
                         }
                     }
@@ -10136,7 +10136,7 @@ namespace ts {
                         return Ternary.True;
                     }
                     // A source type T is related to a target type { [P in keyof T]: X } if T[P] is related to X.
-                    if (!isGenericMappedType(source) && getConstraintTypeFromMappedType(target) === getIndexType(source)) {
+                    if (!isGenericMappedType(source) && getConstraintTypeFromMappedType(target) === getKeyofType(source)) {
                         const indexedAccessType = getIndexedAccessType(source, getTypeParameterFromMappedType(target));
                         const templateType = getTemplateTypeFromMappedType(target);
                         if (result = isRelatedTo(indexedAccessType, templateType, reportErrors)) {
@@ -11567,7 +11567,7 @@ namespace ts {
         }
 
         function inferReverseMappedType(sourceType: Type, target: MappedType): Type {
-            const typeParameter = <TypeParameter>getIndexedAccessType((<IndexType>getConstraintTypeFromMappedType(target)).type, getTypeParameterFromMappedType(target));
+            const typeParameter = <TypeParameter>getIndexedAccessType((<KeyofType>getConstraintTypeFromMappedType(target)).type, getTypeParameterFromMappedType(target));
             const templateType = getTemplateTypeFromMappedType(target);
             const inference = createInferenceInfo(typeParameter);
             inferTypes([inference], sourceType, templateType);
@@ -11711,15 +11711,15 @@ namespace ts {
                         }
                     }
                 }
-                else if (source.flags & TypeFlags.Index && target.flags & TypeFlags.Index) {
+                else if (source.flags & TypeFlags.Keyof && target.flags & TypeFlags.Keyof) {
                     contravariant = !contravariant;
-                    inferFromTypes((<IndexType>source).type, (<IndexType>target).type);
+                    inferFromTypes((<KeyofType>source).type, (<KeyofType>target).type);
                     contravariant = !contravariant;
                 }
-                else if ((isLiteralType(source) || source.flags & TypeFlags.String) && target.flags & TypeFlags.Index) {
+                else if ((isLiteralType(source) || source.flags & TypeFlags.String) && target.flags & TypeFlags.Keyof) {
                     const empty = createEmptyObjectTypeFromStringLiteral(source);
                     contravariant = !contravariant;
-                    inferFromTypes(empty, (target as IndexType).type);
+                    inferFromTypes(empty, (target as KeyofType).type);
                     contravariant = !contravariant;
                 }
                 else if (source.flags & TypeFlags.IndexedAccess && target.flags & TypeFlags.IndexedAccess) {
@@ -11826,12 +11826,12 @@ namespace ts {
                 }
                 if (getObjectFlags(target) & ObjectFlags.Mapped) {
                     const constraintType = getConstraintTypeFromMappedType(<MappedType>target);
-                    if (constraintType.flags & TypeFlags.Index) {
+                    if (constraintType.flags & TypeFlags.Keyof) {
                         // We're inferring from some source type S to a homomorphic mapped type { [P in keyof T]: X },
                         // where T is a type variable. Use inferTypeForHomomorphicMappedType to infer a suitable source
                         // type and then make a secondary inference from that type to T. We make a secondary inference
                         // such that direct inferences to T get priority over inferences to Partial<T>, for example.
-                        const inference = getInferenceInfoForType((<IndexType>constraintType).type);
+                        const inference = getInferenceInfoForType((<KeyofType>constraintType).type);
                         if (inference && !inference.isFixed) {
                             const inferredType = inferTypeForHomomorphicMappedType(source, <MappedType>target);
                             if (inferredType) {
@@ -11848,7 +11848,7 @@ namespace ts {
                         // parameter. Infer from 'keyof S' to T and infer from a union of each property type in S to X.
                         const savePriority = priority;
                         priority |= InferencePriority.MappedTypeConstraint;
-                        inferFromTypes(getIndexType(source), constraintType);
+                        inferFromTypes(getKeyofType(source), constraintType);
                         priority = savePriority;
                         inferFromTypes(getUnionType(map(getPropertiesOfType(source), getTypeOfSymbol)), getTemplateTypeFromMappedType(<MappedType>target));
                         return;
@@ -11944,7 +11944,7 @@ namespace ts {
 
         function hasPrimitiveConstraint(type: TypeParameter): boolean {
             const constraint = getConstraintOfTypeParameter(type);
-            return constraint && maybeTypeOfKind(constraint, TypeFlags.Primitive | TypeFlags.Index);
+            return constraint && maybeTypeOfKind(constraint, TypeFlags.Primitive | TypeFlags.Keyof);
         }
 
         function isObjectLiteralType(type: Type) {
@@ -19618,7 +19618,7 @@ namespace ts {
                 }
                 // If the contextual type is a literal of a particular primitive type, we consider this a
                 // literal context for all literals of that primitive type.
-                return contextualType.flags & (TypeFlags.StringLiteral | TypeFlags.Index) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
+                return contextualType.flags & (TypeFlags.StringLiteral | TypeFlags.Keyof) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
                     contextualType.flags & TypeFlags.NumberLiteral && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral) ||
                     contextualType.flags & TypeFlags.BooleanLiteral && maybeTypeOfKind(candidateType, TypeFlags.BooleanLiteral) ||
                     contextualType.flags & TypeFlags.UniqueESSymbol && maybeTypeOfKind(candidateType, TypeFlags.UniqueESSymbol);
@@ -20541,7 +20541,7 @@ namespace ts {
             // Check if the index type is assignable to 'keyof T' for the object type.
             const objectType = (<IndexedAccessType>type).objectType;
             const indexType = (<IndexedAccessType>type).indexType;
-            if (isTypeAssignableTo(indexType, getIndexType(objectType))) {
+            if (isTypeAssignableTo(indexType, getKeyofType(objectType))) {
                 if (accessNode.kind === SyntaxKind.ElementAccessExpression && isAssignmentTarget(accessNode) &&
                     getObjectFlags(objectType) & ObjectFlags.Mapped && getMappedTypeModifiers(<MappedType>objectType) & MappedTypeModifiers.IncludeReadonly) {
                     error(accessNode, Diagnostics.Index_signature_in_type_0_only_permits_reading, typeToString(objectType));

--- a/src/compiler/symbolWalker.ts
+++ b/src/compiler/symbolWalker.ts
@@ -79,8 +79,8 @@ namespace ts {
                 if (type.flags & TypeFlags.UnionOrIntersection) {
                     visitUnionOrIntersectionType(type as UnionOrIntersectionType);
                 }
-                if (type.flags & TypeFlags.Index) {
-                    visitIndexType(type as IndexType);
+                if (type.flags & TypeFlags.Keyof) {
+                    visitIndexType(type as KeyofType);
                 }
                 if (type.flags & TypeFlags.IndexedAccess) {
                     visitIndexedAccessType(type as IndexedAccessType);
@@ -100,7 +100,7 @@ namespace ts {
                 forEach(type.types, visitType);
             }
 
-            function visitIndexType(type: IndexType): void {
+            function visitIndexType(type: KeyofType): void {
                 visitType(type.type);
             }
 

--- a/src/compiler/symbolWalker.ts
+++ b/src/compiler/symbolWalker.ts
@@ -80,7 +80,7 @@ namespace ts {
                     visitUnionOrIntersectionType(type as UnionOrIntersectionType);
                 }
                 if (type.flags & TypeFlags.Keyof) {
-                    visitIndexType(type as KeyofType);
+                    visitKeyofType(type as KeyofType);
                 }
                 if (type.flags & TypeFlags.IndexedAccess) {
                     visitIndexedAccessType(type as IndexedAccessType);
@@ -100,7 +100,7 @@ namespace ts {
                 forEach(type.types, visitType);
             }
 
-            function visitIndexType(type: KeyofType): void {
+            function visitKeyofType(type: KeyofType): void {
                 visitType(type.type);
             }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3528,7 +3528,9 @@ namespace ts {
         Object                  = 1 << 16,  // Object type
         Union                   = 1 << 17,  // Union (T | U)
         Intersection            = 1 << 18,  // Intersection (T & U)
-        Index                   = 1 << 19,  // keyof T
+        Keyof                   = 1 << 19,  // keyof T
+        /** @deprecated */
+        Index                   = Keyof,
         IndexedAccess           = 1 << 20,  // T[K]
         Conditional             = 1 << 21,  // T extends U ? X : Y
         Substitution            = 1 << 22,  // Type parameter substitution
@@ -3558,7 +3560,7 @@ namespace ts {
         Intrinsic = Any | String | Number | Boolean | BooleanLiteral | ESSymbol | Void | Undefined | Null | Never | NonPrimitive,
         /* @internal */
         Primitive = String | Number | Boolean | Enum | EnumLiteral | ESSymbol | Void | Undefined | Null | Literal | UniqueESSymbol,
-        StringLike = String | StringLiteral | Index,
+        StringLike = String | StringLiteral | Keyof,
         NumberLike = Number | NumberLiteral | Enum,
         BooleanLike = Boolean | BooleanLiteral,
         EnumLike = Enum | EnumLiteral,
@@ -3567,7 +3569,7 @@ namespace ts {
         StructuredType = Object | Union | Intersection,
         TypeVariable = TypeParameter | IndexedAccess,
         InstantiableNonPrimitive = TypeVariable | Conditional | Substitution,
-        InstantiablePrimitive = Index,
+        InstantiablePrimitive = Keyof,
         Instantiable = InstantiableNonPrimitive | InstantiablePrimitive,
         StructuredOrInstantiable = StructuredType | Instantiable,
 
@@ -3713,7 +3715,7 @@ namespace ts {
         /* @internal */
         resolvedProperties: Symbol[];
         /* @internal */
-        resolvedIndexType: IndexType;
+        resolvedKeyofType: KeyofType;
         /* @internal */
         resolvedBaseConstraint: Type;
         /* @internal */
@@ -3800,7 +3802,7 @@ namespace ts {
         /* @internal */
         resolvedBaseConstraint?: Type;
         /* @internal */
-        resolvedIndexType?: IndexType;
+        resolvedKeyofType?: KeyofType;
     }
 
     // Type parameters (TypeFlags.TypeParameter)
@@ -3828,10 +3830,12 @@ namespace ts {
         constraint?: Type;
     }
 
-    // keyof T types (TypeFlags.Index)
-    export interface IndexType extends InstantiableType {
+    // keyof T types (TypeFlags.Keyof)
+    export interface KeyofType extends InstantiableType {
         type: InstantiableType | UnionOrIntersectionType;
     }
+    /** @deprecated */
+    export type IndexType = KeyofType;
 
     export interface ConditionalRoot {
         node: ConditionalTypeNode;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2071,6 +2071,8 @@ declare namespace ts {
         Object = 65536,
         Union = 131072,
         Intersection = 262144,
+        Keyof = 524288,
+        /** @deprecated */
         Index = 524288,
         IndexedAccess = 1048576,
         Conditional = 2097152,
@@ -2191,9 +2193,11 @@ declare namespace ts {
         indexType: Type;
         constraint?: Type;
     }
-    interface IndexType extends InstantiableType {
+    interface KeyofType extends InstantiableType {
         type: InstantiableType | UnionOrIntersectionType;
     }
+    /** @deprecated */
+    type IndexType = KeyofType;
     interface ConditionalRoot {
         node: ConditionalTypeNode;
         checkType: Type;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2071,6 +2071,8 @@ declare namespace ts {
         Object = 65536,
         Union = 131072,
         Intersection = 262144,
+        Keyof = 524288,
+        /** @deprecated */
         Index = 524288,
         IndexedAccess = 1048576,
         Conditional = 2097152,
@@ -2191,9 +2193,11 @@ declare namespace ts {
         indexType: Type;
         constraint?: Type;
     }
-    interface IndexType extends InstantiableType {
+    interface KeyofType extends InstantiableType {
         type: InstantiableType | UnionOrIntersectionType;
     }
+    /** @deprecated */
+    type IndexType = KeyofType;
     interface ConditionalRoot {
         node: ConditionalTypeNode;
         checkType: Type;


### PR DESCRIPTION
"Index type" is a bad name for keyof types in our code base. It's fine for a spec, but inside the source:
1. Both "index type" and the variable name indexType also means (a) the index type of an indexed access type (b) the type of an index signature (if any).
2. Comments *never* use "index type" to refer to keyof types. They always say "keyof T".

The second point indicates that nobody actually thinks of these types as IndexTypes, but KeyofTypes. So I changed the name. I added aliases to the old names so that the public interface won't break.

Note that I ran all tests *before* adding the deprecated aliases, so our own code base doesn't use IndexType anywhere.