### PR TITLE
Add support for suppressing project events

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -168,11 +168,12 @@ namespace ts.projectSystem {
         readonly session: TestSession;
         readonly service: server.ProjectService;
         readonly host: TestServerHost;
-        constructor(files: FileOrFolder[]) {
+        constructor(files: FileOrFolder[], suppressDiagnosticEvents?: boolean) {
             this.host = createServerHost(files);
             this.session = createSession(this.host, {
                 canUseEvents: true,
                 eventHandler: event => this.events.push(event),
+                suppressDiagnosticEvents,
             });
             this.service = this.session.getProjectService();
         }
@@ -483,6 +484,12 @@ namespace ts.projectSystem {
 
     function checkProjectUpdatedInBackgroundEvent(session: TestSession, openFiles: string[]) {
         checkNthEvent(session, server.toEvent("projectsUpdatedInBackground", { openFiles }), 0, /*isMostRecent*/ true);
+    }
+
+    function checkNoDiagnosticEvents(session: TestSession) {
+        for (const event of session.events) {
+            assert.isFalse(event.event.endsWith("Diag"), JSON.stringify(event));
+        }
     }
 
     function checkNthEvent(session: TestSession, expectedEvent: protocol.Event, index: number, isMostRecent: boolean) {
@@ -4074,6 +4081,63 @@ namespace ts.projectSystem {
             session.clearMessages();
         });
 
+        it("suppressed diagnostic events", () => {
+            const file: FileOrFolder = {
+                path: "/a.ts",
+                content: "1 = 2;",
+            };
+
+            const host = createServerHost([file]);
+            const session = createSession(host, { canUseEvents: true, suppressDiagnosticEvents: true });
+            const service = session.getProjectService();
+
+            session.executeCommandSeq<protocol.OpenRequest>({
+                command: server.CommandNames.Open,
+                arguments: { file: file.path, fileContent: file.content },
+            });
+
+            checkNumberOfProjects(service, { inferredProjects: 1 });
+
+            host.checkTimeoutQueueLength(0);
+            checkNoDiagnosticEvents(session);
+
+            session.clearMessages();
+
+            let expectedSequenceId = session.getNextSeq();
+
+            session.executeCommandSeq<protocol.GeterrRequest>({
+                command: server.CommandNames.Geterr,
+                arguments: {
+                    delay: 0,
+                    files: [file.path],
+                }
+            });
+
+            host.checkTimeoutQueueLength(0);
+            checkNoDiagnosticEvents(session);
+
+            checkCompleteEvent(session, 1, expectedSequenceId);
+
+            session.clearMessages();
+
+            expectedSequenceId = session.getNextSeq();
+
+            session.executeCommandSeq<protocol.GeterrForProjectRequest>({
+                command: server.CommandNames.Geterr,
+                arguments: {
+                    delay: 0,
+                    file: file.path,
+                }
+            });
+
+            host.checkTimeoutQueueLength(0);
+            checkNoDiagnosticEvents(session);
+
+            checkCompleteEvent(session, 1, expectedSequenceId);
+
+            session.clearMessages();
+        });
+
         function createDiagnostic(start: protocol.Location, end: protocol.Location, message: DiagnosticMessage, args: ReadonlyArray<string> = []): protocol.Diagnostic {
             return { start, end, text: formatStringFromArgs(message.message, args), code: message.code, category: diagnosticCategoryName(message), source: undefined };
         }
@@ -4149,7 +4213,7 @@ namespace ts.projectSystem {
             serverEventManager.checkSingleConfigFileDiagEvent(configFile.path, configFile.path);
         });
 
-        it("are not generated when the config file doesnot include file opened and config file has errors", () => {
+        it("are not generated when the config file does not include file opened and config file has errors", () => {
             const file = {
                 path: "/a/b/app.ts",
                 content: "let x = 10"
@@ -4173,7 +4237,26 @@ namespace ts.projectSystem {
             serverEventManager.hasZeroEvent("configFileDiag");
         });
 
-        it("are not generated when the config file doesnot include file opened and doesnt contain any errors", () => {
+        it("are not generated when the config file has errors but suppressDiagnosticEvents is true", () => {
+            const file = {
+                path: "/a/b/app.ts",
+                content: "let x = 10"
+            };
+            const configFile = {
+                path: "/a/b/tsconfig.json",
+                content: `{
+                    "compilerOptions": {
+                        "foo": "bar",
+                        "allowJS": true
+                    }
+                }`
+            };
+            const serverEventManager = new TestServerEventManager([file, configFile], /*suppressDiagnosticEvents*/ true);
+            openFilesForSession([file], serverEventManager.session);
+            serverEventManager.hasZeroEvent("configFileDiag");
+        });
+
+        it("are not generated when the config file does not include file opened and doesnt contain any errors", () => {
             const file = {
                 path: "/a/b/app.ts",
                 content: "let x = 10"

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -305,6 +305,7 @@ namespace ts.server {
         useInferredProjectPerProjectRoot: boolean;
         typingsInstaller: ITypingsInstaller;
         eventHandler?: ProjectServiceEventHandler;
+        suppressDiagnosticEvents?: boolean;
         throttleWaitMilliseconds?: number;
         globalPlugins?: ReadonlyArray<string>;
         pluginProbeLocations?: ReadonlyArray<string>;
@@ -392,6 +393,7 @@ namespace ts.server {
         public readonly typingsInstaller: ITypingsInstaller;
         public readonly throttleWaitMilliseconds?: number;
         private readonly eventHandler?: ProjectServiceEventHandler;
+        private readonly suppressDiagnosticEvents?: boolean;
 
         public readonly globalPlugins: ReadonlyArray<string>;
         public readonly pluginProbeLocations: ReadonlyArray<string>;
@@ -413,6 +415,7 @@ namespace ts.server {
             this.typingsInstaller = opts.typingsInstaller || nullTypingsInstaller;
             this.throttleWaitMilliseconds = opts.throttleWaitMilliseconds;
             this.eventHandler = opts.eventHandler;
+            this.suppressDiagnosticEvents = opts.suppressDiagnosticEvents;
             this.globalPlugins = opts.globalPlugins || emptyArray;
             this.pluginProbeLocations = opts.pluginProbeLocations || emptyArray;
             this.allowLocalPluginLoads = !!opts.allowLocalPluginLoads;
@@ -1598,7 +1601,7 @@ namespace ts.server {
         }
 
         private sendConfigFileDiagEvent(project: ConfiguredProject, triggerFile: NormalizedPath) {
-            if (!this.eventHandler) {
+            if (!this.eventHandler || this.suppressDiagnosticEvents) {
                 return;
             }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -512,6 +512,7 @@ namespace ts.server {
                 hrtime: process.hrtime,
                 logger,
                 canUseEvents: true,
+                suppressDiagnosticEvents,
                 globalPlugins,
                 pluginProbeLocations,
                 allowLocalPluginLoads,
@@ -927,6 +928,7 @@ namespace ts.server {
     const useSingleInferredProject = hasArgument("--useSingleInferredProject");
     const useInferredProjectPerProjectRoot = hasArgument("--useInferredProjectPerProjectRoot");
     const disableAutomaticTypingAcquisition = hasArgument("--disableAutomaticTypingAcquisition");
+    const suppressDiagnosticEvents = hasArgument("--suppressDiagnosticEvents");
     const telemetryEnabled = hasArgument(Arguments.EnableTelemetry);
 
     logger.info(`Starting TS Server`);

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7256,6 +7256,8 @@ declare namespace ts.server {
          */
         canUseEvents: boolean;
         eventHandler?: ProjectServiceEventHandler;
+        /** Has no effect if eventHandler is also specified. */
+        suppressDiagnosticEvents?: boolean;
         throttleWaitMilliseconds?: number;
         globalPlugins?: ReadonlyArray<string>;
         pluginProbeLocations?: ReadonlyArray<string>;
@@ -7274,6 +7276,7 @@ declare namespace ts.server {
         private hrtime;
         protected logger: Logger;
         protected canUseEvents: boolean;
+        private suppressDiagnosticEvents?;
         private eventHandler;
         constructor(opts: SessionOptions);
         private sendRequestCompletedEvent;
@@ -7289,6 +7292,7 @@ declare namespace ts.server {
         private syntacticCheck;
         private infoCheck;
         private sendDiagnosticsEvent;
+        /** It is the caller's responsibility to verify that `!this.suppressDiagnosticEvents`. */
         private updateErrorCheck;
         private cleanProjects;
         private cleanup;
@@ -7817,6 +7821,7 @@ declare namespace ts.server {
         useInferredProjectPerProjectRoot: boolean;
         typingsInstaller: ITypingsInstaller;
         eventHandler?: ProjectServiceEventHandler;
+        suppressDiagnosticEvents?: boolean;
         throttleWaitMilliseconds?: number;
         globalPlugins?: ReadonlyArray<string>;
         pluginProbeLocations?: ReadonlyArray<string>;
@@ -7883,6 +7888,7 @@ declare namespace ts.server {
         readonly typingsInstaller: ITypingsInstaller;
         readonly throttleWaitMilliseconds?: number;
         private readonly eventHandler?;
+        private readonly suppressDiagnosticEvents?;
         readonly globalPlugins: ReadonlyArray<string>;
         readonly pluginProbeLocations: ReadonlyArray<string>;
         readonly allowLocalPluginLoads: boolean;


### PR DESCRIPTION
VS doesn't consume (e.g.) `syntaxDiag` events, so there's no reason to do the work to compute their payloads.