### PR TITLE
Forward typesMapLocation from Session from ProjectService

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -354,7 +354,8 @@ namespace ts.server {
                 eventHandler: this.eventHandler,
                 globalPlugins: opts.globalPlugins,
                 pluginProbeLocations: opts.pluginProbeLocations,
-                allowLocalPluginLoads: opts.allowLocalPluginLoads
+                allowLocalPluginLoads: opts.allowLocalPluginLoads,
+                typesMapLocation: this.typingsInstaller.typesMapLocation
             };
             this.projectService = new ProjectService(settings);
             this.gcTimer = new GcTimer(this.host, /*delay*/ 7000, this.logger);

--- a/src/server/typingsCache.ts
+++ b/src/server/typingsCache.ts
@@ -14,6 +14,7 @@ namespace ts.server {
         attach(projectService: ProjectService): void;
         onProjectClosed(p: Project): void;
         readonly globalTypingsCacheLocation: string;
+        readonly typesMapLocation?: string;
     }
 
     export const nullTypingsInstaller: ITypingsInstaller = {


### PR DESCRIPTION
When a new ProjectService is created from a new Session, the
typesMapLocation of the typingsInstaller is not forwarded to the the
ProjectService, and results in the error message
`Provided types map file "/path/to/typesMap.json" doesn't exist`

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #22607 
