### PR TITLE
Revert assertion addition

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8021,8 +8021,7 @@ namespace ts {
         function getLiteralTypeFromPropertyName(prop: Symbol) {
             const links = getSymbolLinks(getLateBoundSymbol(prop));
             if (!links.nameType) {
-                if (links.target && links.target !== unknownSymbol && links.target !== resolvingSymbol) {
-                    Debug.assert(links.target.escapedName === prop.escapedName || links.target.escapedName === InternalSymbolName.Computed, "Target symbol and symbol do not have the same name");
+                if (links.target && links.target !== unknownSymbol && links.target !== resolvingSymbol && links.target.escapedName === prop.escapedName) {
                     links.nameType = getLiteralTypeFromPropertyName(links.target);
                 }
                 else {


### PR DESCRIPTION
It's just not true - alias symbol targets can be named whatever 🤷‍♂️  (but we can still only reuse the target's cached type if the name is the same.)

Fixes a test in our RWC suite.