### PR TITLE
For import fix, for "foo/index" module, use "foo" as default export name, not "index"

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -802,21 +802,22 @@ namespace ts.codefix {
     }
 
     export function moduleSymbolToValidIdentifier(moduleSymbol: Symbol, target: ScriptTarget): string {
-        return moduleSpecifierToValidIdentifier(removeFileExtension(getBaseFileName(moduleSymbol.name)), target);
+        return moduleSpecifierToValidIdentifier(removeFileExtension(stripQuotes(moduleSymbol.name)), target);
     }
 
     export function moduleSpecifierToValidIdentifier(moduleSpecifier: string, target: ScriptTarget): string {
+        const baseName = getBaseFileName(removeSuffix(moduleSpecifier, "/index"));
         let res = "";
         let lastCharWasValid = true;
-        const firstCharCode = moduleSpecifier.charCodeAt(0);
+        const firstCharCode = baseName.charCodeAt(0);
         if (isIdentifierStart(firstCharCode, target)) {
             res += String.fromCharCode(firstCharCode);
         }
         else {
             lastCharWasValid = false;
         }
-        for (let i = 1; i < moduleSpecifier.length; i++) {
-            const ch = moduleSpecifier.charCodeAt(i);
+        for (let i = 1; i < baseName.length; i++) {
+            const ch = baseName.charCodeAt(i);
             const isValid = isIdentifierPart(ch, target);
             if (isValid) {
                 let char = String.fromCharCode(ch);

--- a/tests/cases/fourslash/importNameCodeFixDefaultExport3.ts
+++ b/tests/cases/fourslash/importNameCodeFixDefaultExport3.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /foo-bar/index.ts
+////export default 0;
+
+// @Filename: /b.ts
+////[|foo/**/Bar|]
+
+goTo.file("/b.ts");
+verify.importFixAtPosition([`import fooBar from "./foo-bar";
+
+fooBar`]);


### PR DESCRIPTION
Fixes #22447