### PR TITLE
Remove unnecessary 'forEachEntry' call

### DIFF
--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -20,7 +20,7 @@ namespace ts.NavigateTo {
                 continue;
             }
 
-            forEachEntry(sourceFile.getNamedDeclarations(), (declarations, name) => {
+            sourceFile.getNamedDeclarations().forEach((declarations, name) => {
                 getItemsFromNamedDeclaration(patternMatcher, name, declarations, checker, sourceFile.fileName, rawItems);
             });
         }


### PR DESCRIPTION
`forEachEntry` looks for a truthy result and returns it, but for void callbacks we should just use `forEach` (as the documentation for `forEachEntry` says).