### PR TITLE
Fix type when annotated with a JSDoc function type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6700,7 +6700,6 @@ namespace ts {
                 const iife = getImmediatelyInvokedFunctionExpression(declaration);
                 const isJSConstructSignature = isJSDocConstructSignature(declaration);
                 const isUntypedSignatureInJSFile = !iife &&
-                    !isJSConstructSignature &&
                     isInJavaScriptFile(declaration) &&
                     declaration.kind !== SyntaxKind.FunctionType &&
                     declaration.kind !== SyntaxKind.ConstructorType &&

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6701,9 +6701,7 @@ namespace ts {
                 const isJSConstructSignature = isJSDocConstructSignature(declaration);
                 const isUntypedSignatureInJSFile = !iife &&
                     isInJavaScriptFile(declaration) &&
-                    declaration.kind !== SyntaxKind.FunctionType &&
-                    declaration.kind !== SyntaxKind.ConstructorType &&
-                    declaration.kind !== SyntaxKind.JSDocFunctionType &&
+                    isValueSignatureDeclaration(declaration) &&
                     !hasJSDocParameterTags(declaration) &&
                     !getJSDocType(declaration);
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9130,7 +9130,8 @@ namespace ts {
         }
 
         function isContextSensitiveFunctionOrObjectLiteralMethod(func: Node): func is FunctionExpression | ArrowFunction | MethodDeclaration {
-            return (isFunctionExpressionOrArrowFunction(func) || isObjectLiteralMethod(func)) && isContextSensitiveFunctionLikeDeclaration(func);
+            return (isInJavaScriptFile(func) && isFunctionDeclaration(func) || isFunctionExpressionOrArrowFunction(func) || isObjectLiteralMethod(func)) &&
+                isContextSensitiveFunctionLikeDeclaration(func);
         }
 
         function getTypeWithoutSignatures(type: Type): Type {
@@ -14198,49 +14199,49 @@ namespace ts {
         // Return contextual type of parameter or undefined if no contextual type is available
         function getContextuallyTypedParameterType(parameter: ParameterDeclaration): Type | undefined {
             const func = parameter.parent;
-            if (isContextSensitiveFunctionOrObjectLiteralMethod(func)) {
-                const iife = getImmediatelyInvokedFunctionExpression(func);
-                if (iife && iife.arguments) {
-                    const indexOfParameter = func.parameters.indexOf(parameter);
-                    if (parameter.dotDotDotToken) {
-                        const restTypes: Type[] = [];
-                        for (let i = indexOfParameter; i < iife.arguments.length; i++) {
-                            restTypes.push(getWidenedLiteralType(checkExpression(iife.arguments[i])));
-                        }
-                        return restTypes.length ? createArrayType(getUnionType(restTypes)) : undefined;
+            if (!isContextSensitiveFunctionOrObjectLiteralMethod(func)) {
+                return undefined;
+            }
+            const iife = getImmediatelyInvokedFunctionExpression(func);
+            if (iife && iife.arguments) {
+                const indexOfParameter = func.parameters.indexOf(parameter);
+                if (parameter.dotDotDotToken) {
+                    const restTypes: Type[] = [];
+                    for (let i = indexOfParameter; i < iife.arguments.length; i++) {
+                        restTypes.push(getWidenedLiteralType(checkExpression(iife.arguments[i])));
                     }
-                    const links = getNodeLinks(iife);
-                    const cached = links.resolvedSignature;
-                    links.resolvedSignature = anySignature;
-                    const type = indexOfParameter < iife.arguments.length ?
-                        getWidenedLiteralType(checkExpression(iife.arguments[indexOfParameter])) :
-                        parameter.initializer ? undefined : undefinedWideningType;
-                    links.resolvedSignature = cached;
-                    return type;
+                    return restTypes.length ? createArrayType(getUnionType(restTypes)) : undefined;
                 }
-                const contextualSignature = getContextualSignature(func);
-                if (contextualSignature) {
-                    const funcHasRestParameters = hasRestParameter(func);
-                    const len = func.parameters.length - (funcHasRestParameters ? 1 : 0);
-                    let indexOfParameter = func.parameters.indexOf(parameter);
-                    if (getThisParameter(func) !== undefined && !contextualSignature.thisParameter) {
-                        Debug.assert(indexOfParameter !== 0); // Otherwise we should not have called `getContextuallyTypedParameterType`.
-                        indexOfParameter -= 1;
-                    }
+                const links = getNodeLinks(iife);
+                const cached = links.resolvedSignature;
+                links.resolvedSignature = anySignature;
+                const type = indexOfParameter < iife.arguments.length ?
+                    getWidenedLiteralType(checkExpression(iife.arguments[indexOfParameter])) :
+                    parameter.initializer ? undefined : undefinedWideningType;
+                links.resolvedSignature = cached;
+                return type;
+            }
+            const contextualSignature = getContextualSignature(func);
+            if (contextualSignature) {
+                const funcHasRestParameters = hasRestParameter(func);
+                const len = func.parameters.length - (funcHasRestParameters ? 1 : 0);
+                let indexOfParameter = func.parameters.indexOf(parameter);
+                if (getThisParameter(func) !== undefined && !contextualSignature.thisParameter) {
+                    Debug.assert(indexOfParameter !== 0); // Otherwise we should not have called `getContextuallyTypedParameterType`.
+                    indexOfParameter -= 1;
+                }
 
-                    if (indexOfParameter < len) {
-                        return getTypeAtPosition(contextualSignature, indexOfParameter);
-                    }
+                if (indexOfParameter < len) {
+                    return getTypeAtPosition(contextualSignature, indexOfParameter);
+                }
 
-                    // If last parameter is contextually rest parameter get its type
-                    if (funcHasRestParameters &&
-                        indexOfParameter === (func.parameters.length - 1) &&
-                        isRestParameterIndex(contextualSignature, func.parameters.length - 1)) {
-                        return getTypeOfSymbol(lastOrUndefined(contextualSignature.parameters));
-                    }
+                // If last parameter is contextually rest parameter get its type
+                if (funcHasRestParameters &&
+                    indexOfParameter === (func.parameters.length - 1) &&
+                    isRestParameterIndex(contextualSignature, func.parameters.length - 1)) {
+                    return getTypeOfSymbol(lastOrUndefined(contextualSignature.parameters));
                 }
             }
-            return undefined;
         }
 
         // In a variable, parameter or property declaration with a type annotation,
@@ -14803,7 +14804,16 @@ namespace ts {
         // union type of return types from these signatures
         function getContextualSignature(node: FunctionExpression | ArrowFunction | MethodDeclaration): Signature {
             Debug.assert(node.kind !== SyntaxKind.MethodDeclaration || isObjectLiteralMethod(node));
-            const type = getContextualTypeForFunctionLikeDeclaration(node);
+            let type: Type;
+            if (isInJavaScriptFile(node)) {
+                const jsdoc = getJSDocType(node);
+                if (jsdoc) {
+                    type = getTypeFromTypeNode(jsdoc);
+                }
+            }
+            if (!type) {
+                type = getContextualTypeForFunctionLikeDeclaration(node);
+            }
             if (!type) {
                 return undefined;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6699,7 +6699,13 @@ namespace ts {
                 let hasThisParameter: boolean;
                 const iife = getImmediatelyInvokedFunctionExpression(declaration);
                 const isJSConstructSignature = isJSDocConstructSignature(declaration);
-                const isUntypedSignatureInJSFile = !iife && !isJSConstructSignature && isInJavaScriptFile(declaration) && !hasJSDocParameterTags(declaration);
+                const isUntypedSignatureInJSFile = !iife &&
+                    !isJSConstructSignature &&
+                    isInJavaScriptFile(declaration) &&
+                    declaration.kind !== SyntaxKind.FunctionType &&
+                    declaration.kind !== SyntaxKind.JSDocFunctionType &&
+                    !hasJSDocParameterTags(declaration) &&
+                    !getJSDocType(declaration);
 
                 // If this is a JSDoc construct signature, then skip the first parameter in the
                 // parameter list.  The first parameter represents the return type of the construct

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6703,6 +6703,7 @@ namespace ts {
                     !isJSConstructSignature &&
                     isInJavaScriptFile(declaration) &&
                     declaration.kind !== SyntaxKind.FunctionType &&
+                    declaration.kind !== SyntaxKind.ConstructorType &&
                     declaration.kind !== SyntaxKind.JSDocFunctionType &&
                     !hasJSDocParameterTags(declaration) &&
                     !getJSDocType(declaration);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4510,6 +4510,15 @@ namespace ts {
         let tag: JSDocTypeTag | JSDocParameterTag | undefined = getFirstJSDocTag(node, isJSDocTypeTag);
         if (!tag && isParameter(node)) {
             tag = find(getJSDocParameterTags(node), tag => !!tag.typeExpression);
+            if (!tag && isFunctionLike(node.parent)) {
+                const typeTag = getJSDocTypeTag(node.parent);
+                if (typeTag && typeTag.typeExpression && isFunctionLike(typeTag.typeExpression.type)) {
+                    const i = node.parent.parameters.indexOf(node);
+                    if (i > -1) {
+                        return typeTag.typeExpression.type.parameters[i].type;
+                    }
+                }
+            }
         }
 
         return tag && tag.typeExpression && tag.typeExpression.type;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1958,6 +1958,18 @@ namespace ts {
         return false;
     }
 
+    export type ValueSignatureDeclaration =
+        | FunctionDeclaration
+        | MethodDeclaration
+        | ConstructorDeclaration
+        | AccessorDeclaration
+        | FunctionExpression
+        | ArrowFunction;
+
+    export function isValueSignatureDeclaration(node: Node): node is ValueSignatureDeclaration {
+        return isFunctionExpression(node) || isArrowFunction(node) || isMethodOrAccessor(node) || isFunctionDeclaration(node) || isConstructorDeclaration(node);
+    }
+
     function walkUp(node: Node, kind: SyntaxKind) {
         while (node && node.kind === kind) {
             node = node.parent;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4510,15 +4510,6 @@ namespace ts {
         let tag: JSDocTypeTag | JSDocParameterTag | undefined = getFirstJSDocTag(node, isJSDocTypeTag);
         if (!tag && isParameter(node)) {
             tag = find(getJSDocParameterTags(node), tag => !!tag.typeExpression);
-            if (!tag && isFunctionLike(node.parent)) {
-                const typeTag = getJSDocTypeTag(node.parent);
-                if (typeTag && typeTag.typeExpression && isFunctionLike(typeTag.typeExpression.type)) {
-                    const i = node.parent.parameters.indexOf(node);
-                    if (i > -1) {
-                        return typeTag.typeExpression.type.parameters[i].type;
-                    }
-                }
-            }
         }
 
         return tag && tag.typeExpression && tag.typeExpression.type;

--- a/tests/baselines/reference/checkJsdocTypeTagOnObjectProperty1.types
+++ b/tests/baselines/reference/checkJsdocTypeTagOnObjectProperty1.types
@@ -20,12 +20,12 @@ const obj = {
 
   /** @type {function(number): number} */
   method1(n1) {
->method1 : (n1: any) => any
->n1 : any
+>method1 : (n1: number) => number
+>n1 : number
 
       return n1 + 42;
->n1 + 42 : any
->n1 : any
+>n1 + 42 : number
+>n1 : number
 >42 : 42
 
   },
@@ -44,10 +44,10 @@ const obj = {
   /** @type {function(number): number} */
   arrowFunc: (num) => num + 42
 >arrowFunc : (arg0: number) => number
->(num) => num + 42 : (num: any) => any
->num : any
->num + 42 : any
->num : any
+>(num) => num + 42 : (num: number) => number
+>num : number
+>num + 42 : number
+>num : number
 >42 : 42
 }
 obj.foo = 'string'

--- a/tests/baselines/reference/checkJsdocTypeTagOnObjectProperty2.errors.txt
+++ b/tests/baselines/reference/checkJsdocTypeTagOnObjectProperty2.errors.txt
@@ -1,11 +1,9 @@
 tests/cases/conformance/jsdoc/0.js(5,3): error TS2322: Type 'number' is not assignable to type 'string | undefined'.
-tests/cases/conformance/jsdoc/0.js(7,3): error TS2322: Type '(n1: any) => string' is not assignable to type '(arg0: number) => number'.
+tests/cases/conformance/jsdoc/0.js(7,3): error TS2322: Type '(n1: number) => string' is not assignable to type '(arg0: number) => number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsdoc/0.js(11,3): error TS2322: Type '(n1: any) => string' is not assignable to type '(arg0: number) => number'.
+tests/cases/conformance/jsdoc/0.js(11,3): error TS2322: Type '(n1: number) => string' is not assignable to type '(arg0: number) => number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsdoc/0.js(13,3): error TS2322: Type '(num?: string) => string' is not assignable to type '(arg0: number) => number'.
-  Types of parameters 'num' and 'arg0' are incompatible.
-    Type 'number' is not assignable to type 'string | undefined'.
+tests/cases/conformance/jsdoc/0.js(13,15): error TS2322: Type '"0"' is not assignable to type 'number'.
 tests/cases/conformance/jsdoc/0.js(15,3): error TS2322: Type 'undefined' is not assignable to type 'string'.
 tests/cases/conformance/jsdoc/0.js(19,5): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsdoc/0.js(22,22): error TS2345: Argument of type '"0"' is not assignable to parameter of type 'number'.
@@ -22,21 +20,19 @@ tests/cases/conformance/jsdoc/0.js(22,22): error TS2345: Argument of type '"0"' 
       /** @type {function(number): number} */
       method1(n1) {
       ~~~~~~~
-!!! error TS2322: Type '(n1: any) => string' is not assignable to type '(arg0: number) => number'.
+!!! error TS2322: Type '(n1: number) => string' is not assignable to type '(arg0: number) => number'.
 !!! error TS2322:   Type 'string' is not assignable to type 'number'.
           return "42";
       },
       /** @type {function(number): number} */
       method2: (n1) => "lol",
       ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '(n1: any) => string' is not assignable to type '(arg0: number) => number'.
+!!! error TS2322: Type '(n1: number) => string' is not assignable to type '(arg0: number) => number'.
 !!! error TS2322:   Type 'string' is not assignable to type 'number'.
       /** @type {function(number): number} */
       arrowFunc: (num="0") => num + 42,
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '(num?: string) => string' is not assignable to type '(arg0: number) => number'.
-!!! error TS2322:   Types of parameters 'num' and 'arg0' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string | undefined'.
+                  ~~~~~~~
+!!! error TS2322: Type '"0"' is not assignable to type 'number'.
       /** @type {string} */
       lol
       ~~~

--- a/tests/baselines/reference/checkJsdocTypeTagOnObjectProperty2.types
+++ b/tests/baselines/reference/checkJsdocTypeTagOnObjectProperty2.types
@@ -14,8 +14,8 @@ const obj = {
 
   /** @type {function(number): number} */
   method1(n1) {
->method1 : (n1: any) => string
->n1 : any
+>method1 : (n1: number) => string
+>n1 : number
 
       return "42";
 >"42" : "42"
@@ -24,18 +24,18 @@ const obj = {
   /** @type {function(number): number} */
   method2: (n1) => "lol",
 >method2 : (arg0: number) => number
->(n1) => "lol" : (n1: any) => string
->n1 : any
+>(n1) => "lol" : (n1: number) => string
+>n1 : number
 >"lol" : "lol"
 
   /** @type {function(number): number} */
   arrowFunc: (num="0") => num + 42,
 >arrowFunc : (arg0: number) => number
->(num="0") => num + 42 : (num?: string) => string
->num : string
+>(num="0") => num + 42 : (num?: number) => number
+>num : number
 >"0" : "0"
->num + 42 : string
->num : string
+>num + 42 : number
+>num : number
 >42 : 42
 
   /** @type {string} */

--- a/tests/baselines/reference/jsdocTypeTag.js
+++ b/tests/baselines/reference/jsdocTypeTag.js
@@ -64,6 +64,9 @@ var Func;
 /** @type {(s: string) => number} */
 var f;
 
+/** @type {new (s: string) => { s: string }} */
+var ctor;
+
 //// [b.ts]
 var S: string;
 var s: string;
@@ -86,6 +89,7 @@ var Obj: any;
 var obj: any;
 var Func: Function;
 var f: (s: string) => number;
+var ctor: new (s: string) => { s: string };
 
 
 //// [a.js]
@@ -131,6 +135,8 @@ var obj;
 var Func;
 /** @type {(s: string) => number} */
 var f;
+/** @type {new (s: string) => { s: string }} */
+var ctor;
 //// [b.js]
 var S;
 var s;
@@ -153,3 +159,4 @@ var Obj;
 var obj;
 var Func;
 var f;
+var ctor;

--- a/tests/baselines/reference/jsdocTypeTag.js
+++ b/tests/baselines/reference/jsdocTypeTag.js
@@ -61,6 +61,9 @@ var obj;
 /** @type {Function} */
 var Func;
 
+/** @type {(s: string) => number} */
+var f;
+
 //// [b.ts]
 var S: string;
 var s: string;
@@ -82,6 +85,7 @@ var nullable: number | null;
 var Obj: any;
 var obj: any;
 var Func: Function;
+var f: (s: string) => number;
 
 
 //// [a.js]
@@ -125,6 +129,8 @@ var Obj;
 var obj;
 /** @type {Function} */
 var Func;
+/** @type {(s: string) => number} */
+var f;
 //// [b.js]
 var S;
 var s;
@@ -146,3 +152,4 @@ var nullable;
 var Obj;
 var obj;
 var Func;
+var f;

--- a/tests/baselines/reference/jsdocTypeTag.symbols
+++ b/tests/baselines/reference/jsdocTypeTag.symbols
@@ -83,6 +83,10 @@ var Func;
 var f;
 >f : Symbol(f, Decl(a.js, 61, 3), Decl(b.ts, 20, 3))
 
+/** @type {new (s: string) => { s: string }} */
+var ctor;
+>ctor : Symbol(ctor, Decl(a.js, 64, 3), Decl(b.ts, 21, 3))
+
 === tests/cases/conformance/jsdoc/b.ts ===
 var S: string;
 >S : Symbol(S, Decl(a.js, 1, 3), Decl(b.ts, 0, 3))
@@ -150,4 +154,9 @@ var Func: Function;
 var f: (s: string) => number;
 >f : Symbol(f, Decl(a.js, 61, 3), Decl(b.ts, 20, 3))
 >s : Symbol(s, Decl(b.ts, 20, 8))
+
+var ctor: new (s: string) => { s: string };
+>ctor : Symbol(ctor, Decl(a.js, 64, 3), Decl(b.ts, 21, 3))
+>s : Symbol(s, Decl(b.ts, 21, 15))
+>s : Symbol(s, Decl(b.ts, 21, 30))
 

--- a/tests/baselines/reference/jsdocTypeTag.symbols
+++ b/tests/baselines/reference/jsdocTypeTag.symbols
@@ -79,6 +79,10 @@ var obj;
 var Func;
 >Func : Symbol(Func, Decl(a.js, 58, 3), Decl(b.ts, 19, 3))
 
+/** @type {(s: string) => number} */
+var f;
+>f : Symbol(f, Decl(a.js, 61, 3), Decl(b.ts, 20, 3))
+
 === tests/cases/conformance/jsdoc/b.ts ===
 var S: string;
 >S : Symbol(S, Decl(a.js, 1, 3), Decl(b.ts, 0, 3))
@@ -142,4 +146,8 @@ var obj: any;
 var Func: Function;
 >Func : Symbol(Func, Decl(a.js, 58, 3), Decl(b.ts, 19, 3))
 >Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+var f: (s: string) => number;
+>f : Symbol(f, Decl(a.js, 61, 3), Decl(b.ts, 20, 3))
+>s : Symbol(s, Decl(b.ts, 20, 8))
 

--- a/tests/baselines/reference/jsdocTypeTag.types
+++ b/tests/baselines/reference/jsdocTypeTag.types
@@ -83,6 +83,10 @@ var Func;
 var f;
 >f : (s: string) => number
 
+/** @type {new (s: string) => { s: string }} */
+var ctor;
+>ctor : new (s: string) => { s: string; }
+
 === tests/cases/conformance/jsdoc/b.ts ===
 var S: string;
 >S : string
@@ -152,5 +156,10 @@ var Func: Function;
 
 var f: (s: string) => number;
 >f : (s: string) => number
+>s : string
+
+var ctor: new (s: string) => { s: string };
+>ctor : new (s: string) => { s: string; }
+>s : string
 >s : string
 

--- a/tests/baselines/reference/jsdocTypeTag.types
+++ b/tests/baselines/reference/jsdocTypeTag.types
@@ -79,6 +79,10 @@ var obj;
 var Func;
 >Func : Function
 
+/** @type {(s: string) => number} */
+var f;
+>f : (s: string) => number
+
 === tests/cases/conformance/jsdoc/b.ts ===
 var S: string;
 >S : string
@@ -145,4 +149,8 @@ var obj: any;
 var Func: Function;
 >Func : Function
 >Function : Function
+
+var f: (s: string) => number;
+>f : (s: string) => number
+>s : string
 

--- a/tests/baselines/reference/jsdocTypeTagParameterType.errors.txt
+++ b/tests/baselines/reference/jsdocTypeTagParameterType.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/conformance/jsdoc/a.js(3,5): error TS2322: Type '1' is not assignable to type 'string'.
+tests/cases/conformance/jsdoc/a.js(7,5): error TS2322: Type '1' is not assignable to type 'string'.
+
+
+==== tests/cases/conformance/jsdoc/a.js (2 errors) ====
+    /** @type {function(string): void} */
+    const f = (value) => {
+        value = 1 // should error
+        ~~~~~
+!!! error TS2322: Type '1' is not assignable to type 'string'.
+    };
+    /** @type {(s: string) => void} */
+    function g(s) {
+        s = 1 // Should error
+        ~
+!!! error TS2322: Type '1' is not assignable to type 'string'.
+    }
+    

--- a/tests/baselines/reference/jsdocTypeTagParameterType.symbols
+++ b/tests/baselines/reference/jsdocTypeTagParameterType.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/** @type {function(string): void} */
+const f = (value) => {
+>f : Symbol(f, Decl(a.js, 1, 5))
+>value : Symbol(value, Decl(a.js, 1, 11))
+
+    value = 1 // should error
+>value : Symbol(value, Decl(a.js, 1, 11))
+
+};
+/** @type {(s: string) => void} */
+function g(s) {
+>g : Symbol(g, Decl(a.js, 3, 2))
+>s : Symbol(s, Decl(a.js, 5, 11))
+
+    s = 1 // Should error
+>s : Symbol(s, Decl(a.js, 5, 11))
+}
+

--- a/tests/baselines/reference/jsdocTypeTagParameterType.types
+++ b/tests/baselines/reference/jsdocTypeTagParameterType.types
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/** @type {function(string): void} */
+const f = (value) => {
+>f : (arg0: string) => void
+>(value) => {    value = 1 // should error} : (value: string) => void
+>value : string
+
+    value = 1 // should error
+>value = 1 : 1
+>value : string
+>1 : 1
+
+};
+/** @type {(s: string) => void} */
+function g(s) {
+>g : (s: string) => void
+>s : string
+
+    s = 1 // Should error
+>s = 1 : 1
+>s : string
+>1 : 1
+}
+

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.errors.txt
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/conformance/jsdoc/a.js(8,1): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/jsdoc/a.js(9,1): error TS2554: Expected 1 arguments, but got 0.
+
+
+==== tests/cases/conformance/jsdoc/a.js (2 errors) ====
+    /** @type {function(string): void} */
+    const f = (value) => {
+    };
+    /** @type {(s: string) => void} */
+    function g(s) {
+    }
+    
+    f() // should error
+    ~~~
+!!! error TS2554: Expected 1 arguments, but got 0.
+    g() // should error
+    ~~~
+!!! error TS2554: Expected 1 arguments, but got 0.
+    

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.errors.txt
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.errors.txt
@@ -1,19 +1,29 @@
-tests/cases/conformance/jsdoc/a.js(8,1): error TS2554: Expected 1 arguments, but got 0.
-tests/cases/conformance/jsdoc/a.js(9,1): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/jsdoc/a.js(8,12): error TS7006: Parameter 's' implicitly has an 'any' type.
+tests/cases/conformance/jsdoc/a.js(11,1): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/jsdoc/a.js(12,1): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/jsdoc/a.js(13,1): error TS2554: Expected 1 arguments, but got 0.
 
 
-==== tests/cases/conformance/jsdoc/a.js (2 errors) ====
+==== tests/cases/conformance/jsdoc/a.js (4 errors) ====
     /** @type {function(string): void} */
     const f = (value) => {
     };
     /** @type {(s: string) => void} */
     function g(s) {
     }
+    /** @type {{(s: string): void}} */
+    function h(s) {
+               ~
+!!! error TS7006: Parameter 's' implicitly has an 'any' type.
+    }
     
     f() // should error
     ~~~
 !!! error TS2554: Expected 1 arguments, but got 0.
     g() // should error
+    ~~~
+!!! error TS2554: Expected 1 arguments, but got 0.
+    h()
     ~~~
 !!! error TS2554: Expected 1 arguments, but got 0.
     

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.errors.txt
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.errors.txt
@@ -1,10 +1,9 @@
-tests/cases/conformance/jsdoc/a.js(8,12): error TS7006: Parameter 's' implicitly has an 'any' type.
 tests/cases/conformance/jsdoc/a.js(11,1): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/conformance/jsdoc/a.js(12,1): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/conformance/jsdoc/a.js(13,1): error TS2554: Expected 1 arguments, but got 0.
 
 
-==== tests/cases/conformance/jsdoc/a.js (4 errors) ====
+==== tests/cases/conformance/jsdoc/a.js (3 errors) ====
     /** @type {function(string): void} */
     const f = (value) => {
     };
@@ -13,8 +12,6 @@ tests/cases/conformance/jsdoc/a.js(13,1): error TS2554: Expected 1 arguments, bu
     }
     /** @type {{(s: string): void}} */
     function h(s) {
-               ~
-!!! error TS7006: Parameter 's' implicitly has an 'any' type.
     }
     
     f() // should error

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.symbols
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.symbols
@@ -10,10 +10,18 @@ function g(s) {
 >g : Symbol(g, Decl(a.js, 2, 2))
 >s : Symbol(s, Decl(a.js, 4, 11))
 }
+/** @type {{(s: string): void}} */
+function h(s) {
+>h : Symbol(h, Decl(a.js, 5, 1))
+>s : Symbol(s, Decl(a.js, 7, 11))
+}
 
 f() // should error
 >f : Symbol(f, Decl(a.js, 1, 5))
 
 g() // should error
 >g : Symbol(g, Decl(a.js, 2, 2))
+
+h()
+>h : Symbol(h, Decl(a.js, 5, 1))
 

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.symbols
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/** @type {function(string): void} */
+const f = (value) => {
+>f : Symbol(f, Decl(a.js, 1, 5))
+>value : Symbol(value, Decl(a.js, 1, 11))
+
+};
+/** @type {(s: string) => void} */
+function g(s) {
+>g : Symbol(g, Decl(a.js, 2, 2))
+>s : Symbol(s, Decl(a.js, 4, 11))
+}
+
+f() // should error
+>f : Symbol(f, Decl(a.js, 1, 5))
+
+g() // should error
+>g : Symbol(g, Decl(a.js, 2, 2))
+

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.types
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.types
@@ -11,6 +11,11 @@ function g(s) {
 >g : (s: string) => void
 >s : string
 }
+/** @type {{(s: string): void}} */
+function h(s) {
+>h : (s: any) => void
+>s : any
+}
 
 f() // should error
 >f() : void
@@ -19,4 +24,8 @@ f() // should error
 g() // should error
 >g() : void
 >g : (s: string) => void
+
+h()
+>h() : void
+>h : (s: any) => void
 

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.types
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.types
@@ -13,8 +13,8 @@ function g(s) {
 }
 /** @type {{(s: string): void}} */
 function h(s) {
->h : (s: any) => void
->s : any
+>h : (s: string) => void
+>s : string
 }
 
 f() // should error
@@ -27,5 +27,5 @@ g() // should error
 
 h()
 >h() : void
->h : (s: any) => void
+>h : (s: string) => void
 

--- a/tests/baselines/reference/jsdocTypeTagRequiredParameters.types
+++ b/tests/baselines/reference/jsdocTypeTagRequiredParameters.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/** @type {function(string): void} */
+const f = (value) => {
+>f : (arg0: string) => void
+>(value) => {} : (value: string) => void
+>value : string
+
+};
+/** @type {(s: string) => void} */
+function g(s) {
+>g : (s: string) => void
+>s : string
+}
+
+f() // should error
+>f() : void
+>f : (arg0: string) => void
+
+g() // should error
+>g() : void
+>g : (s: string) => void
+

--- a/tests/cases/conformance/jsdoc/jsdocTypeTag.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeTag.ts
@@ -63,6 +63,9 @@ var obj;
 /** @type {Function} */
 var Func;
 
+/** @type {(s: string) => number} */
+var f;
+
 // @filename: b.ts
 var S: string;
 var s: string;
@@ -84,3 +87,4 @@ var nullable: number | null;
 var Obj: any;
 var obj: any;
 var Func: Function;
+var f: (s: string) => number;

--- a/tests/cases/conformance/jsdoc/jsdocTypeTag.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeTag.ts
@@ -66,6 +66,9 @@ var Func;
 /** @type {(s: string) => number} */
 var f;
 
+/** @type {new (s: string) => { s: string }} */
+var ctor;
+
 // @filename: b.ts
 var S: string;
 var s: string;
@@ -88,3 +91,4 @@ var Obj: any;
 var obj: any;
 var Func: Function;
 var f: (s: string) => number;
+var ctor: new (s: string) => { s: string };

--- a/tests/cases/conformance/jsdoc/jsdocTypeTagParameterType.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeTagParameterType.ts
@@ -1,0 +1,15 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @strict: true
+// @noImplicitAny: true
+// @Filename: a.js
+
+/** @type {function(string): void} */
+const f = (value) => {
+    value = 1 // should error
+};
+/** @type {(s: string) => void} */
+function g(s) {
+    s = 1 // Should error
+}

--- a/tests/cases/conformance/jsdoc/jsdocTypeTagRequiredParameters.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeTagRequiredParameters.ts
@@ -1,0 +1,16 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @strict: true
+// @noImplicitAny: true
+// @Filename: a.js
+
+/** @type {function(string): void} */
+const f = (value) => {
+};
+/** @type {(s: string) => void} */
+function g(s) {
+}
+
+f() // should error
+g() // should error

--- a/tests/cases/conformance/jsdoc/jsdocTypeTagRequiredParameters.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeTagRequiredParameters.ts
@@ -11,6 +11,10 @@ const f = (value) => {
 /** @type {(s: string) => void} */
 function g(s) {
 }
+/** @type {{(s: string): void}} */
+function h(s) {
+}
 
 f() // should error
 g() // should error
+h()

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc16.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc16.ts
@@ -5,6 +5,7 @@
 
 verify.codeFix({
     description: "Annotate with type from JSDoc",
+    index: 0,
     newFileContent:
 `/** @type {function(*, ...number, ...boolean): void} */
 var x: (arg0: any, arg1: number[], ...rest: boolean[]) => void = (x, ys, ...zs) => { };`,


### PR DESCRIPTION
Previously,
1. A variable annotated with a JSDoc function type would not require all its parameters to be provided. This should only apply to functions without a type annotation.
2. A parameter in a function with a JSDoc function type annotation would still have the type 'any'.
3. Two `var` declarations in a Typescript and Javascript file, respectively, would error even when they had identical function types.

Fixes #22080

I don't think there are bugs filed for (2) or (3).
