### PR TITLE
findAllRefs: give entry for union its own definition

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1100,10 +1100,10 @@ namespace FourSlash {
                 references: ranges.map<ts.ReferenceEntry>(r => {
                     const { isWriteAccess = false, isDefinition = false, isInString } = (r.marker && r.marker.data || {}) as { isWriteAccess?: boolean, isDefinition?: boolean, isInString?: true };
                     return {
-                        isWriteAccess,
-                        isDefinition,
                         fileName: r.fileName,
                         textSpan: ts.createTextSpanFromRange(r),
+                        isWriteAccess,
+                        isDefinition,
                         ...(isInString ? { isInString: true } : undefined),
                     };
                 }),
@@ -1119,7 +1119,7 @@ namespace FourSlash {
                 const fullActual = ts.map<ts.ReferencedSymbol, ReferenceGroupJson>(this.findReferencesAtCaret(), ({ definition, references }, i) => {
                     const text = definition.displayParts.map(d => d.text).join("");
                     return {
-                        definition: typeof fullExpected[i].definition === "string" ? text : { text, range: definition.textSpan },
+                        definition: fullExpected.length > i && typeof fullExpected[i].definition === "string" ? text : { text, range: definition.textSpan },
                         references,
                     };
                 });

--- a/tests/cases/fourslash/findAllRefsForComputedProperties.ts
+++ b/tests/cases/fourslash/findAllRefsForComputedProperties.ts
@@ -1,26 +1,25 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface I {
-////    ["[|{| "isDefinition": true |}prop1|]"]: () => void;
+////    [|["[|{| "isDefinition": true |}prop1|]"]|]: () => void;
 ////}
 ////
 ////class C implements I {
-////    ["[|{| "isDefinition": true |}prop1|]"]: any;
+////    [|["[|{| "isDefinition": true |}prop1|]"]|]: any;
 ////}
 ////
 ////var x: I = {
-////    ["[|{| "isDefinition": true |}prop1|]"]: function () { },
+////    [|["[|{| "isDefinition": true |}prop1|]"]|]: function () { },
 ////}
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups(r0, [{ definition: '(property) I["prop1"]: () => void', ranges }]);
-verify.referenceGroups(r1, [
-    { definition: '(property) I["prop1"]: () => void', ranges: [r0, r2] },
-    { definition: '(property) C["prop1"]: any', ranges: [r1] }
+// TODO: GH#22690
+const [r0Big, r0, r1Big, r1, r2Big, r2] = test.ranges();
+verify.referenceGroups([r0, r1], [
+    { definition: { text: '(property) I["prop1"]: () => void', range: r0Big }, ranges: [r0, r2] },
+    { definition: { text: '(property) C["prop1"]: any', range: r1Big }, ranges: [r1] },
 ]);
 verify.referenceGroups(r2, [
-    { definition: '(property) I["prop1"]: () => void', ranges: [r0, r1] },
-    { definition: '(property) ["prop1"]: () => void', ranges: [r2] }
+    { definition: { text: '(property) I["prop1"]: () => void', range: r0Big }, ranges: [r0] },
+    { definition: { text: '(property) C["prop1"]: any', range: r1Big }, ranges: [r1] },
+    { definition: { text: '(property) ["prop1"]: () => void', range: r2Big }, ranges: [r2] },
 ]);
-

--- a/tests/cases/fourslash/findAllRefsForComputedProperties2.ts
+++ b/tests/cases/fourslash/findAllRefsForComputedProperties2.ts
@@ -1,25 +1,25 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface I {
-////    [[|{| "isDefinition": true |}42|]](): void;
+////    [|[[|{| "isDefinition": true |}42|]]|](): void;
 ////}
 ////
 ////class C implements I {
-////    [[|{| "isDefinition": true |}42|]]: any;
+////    [|[[|{| "isDefinition": true |}42|]]|]: any;
 ////}
 ////
 ////var x: I = {
-////    ["[|{| "isDefinition": true |}42|]"]: function () { }
+////    [|["[|{| "isDefinition": true |}42|]"]|]: function () { }
 ////}
 
-const ranges = test.ranges();
-const [r0, r1, r2] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) I[42](): void", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) I[42](): void", ranges: [r0, r2] },
-    { definition:  "(property) C[42]: any", ranges: [r1] }
+// TODO: GH#22690
+const [r0Big, r0, r1Big, r1, r2Big, r2] = test.ranges();
+verify.referenceGroups([r0, r1], [
+    { definition: { text: '(method) I[42](): void', range: r0Big }, ranges: [r0, r2] },
+    { definition: { text: '(property) C[42]: any', range: r1Big }, ranges: [r1] },
 ]);
 verify.referenceGroups(r2, [
-    { definition: "(method) I[42](): void", ranges: [r0, r1] },
-    { definition: '(property) ["42"]: () => void', ranges: [r2] }
+    { definition: { text: '(method) I[42](): void', range: r0Big }, ranges: [r0] },
+    { definition: { text: '(property) C[42]: any', range: r1Big }, ranges: [r1] },
+    { definition: { text: '(property) ["42"]: () => void', range: r2Big }, ranges: [r2] },
 ]);

--- a/tests/cases/fourslash/findAllRefsInClassExpression.ts
+++ b/tests/cases/fourslash/findAllRefsInClassExpression.ts
@@ -5,10 +5,8 @@
 ////   [|{| "isWriteAccess": true, "isDefinition": true |}boom|](){}
 ////}
 
-const ranges = test.ranges();
-const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) I.boom(): void", ranges }]);
-verify.referenceGroups(r1, [
+const [r0, r1] = test.ranges();
+verify.referenceGroups([r0, r1], [
     { definition: "(method) I.boom(): void", ranges: [r0] },
     { definition: "(method) C.boom(): void", ranges: [r1] }
 ]);

--- a/tests/cases/fourslash/findAllRefsInheritedProperties3.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties3.ts
@@ -18,10 +18,22 @@
 //// v.[|propName|];   // r7
 
 const [r0, r1, r2, r3, r4, r5, r6, r7] = test.ranges();
-verify.referenceGroups(r0, [{ definition: "(method) class1.doStuff(): void", ranges: [r0, r4, r6] }]);
-verify.referenceGroups(r1, [{ definition: "(property) class1.propName: string", ranges: [r1, r5, r7] }]);
-verify.referenceGroups(r2, [{ definition: "(method) interface1.doStuff(): void", ranges: [r2, r4, r6] }]);
-verify.referenceGroups(r3, [{ definition: "(property) interface1.propName: string", ranges: [r3, r5, r7] }]);
+verify.referenceGroups(r0, [
+    { definition: "(method) class1.doStuff(): void", ranges: [r0] },
+    { definition: "(method) class2.doStuff(): void", ranges: [r4, r6] },
+]);
+verify.referenceGroups(r1, [
+    { definition: "(property) class1.propName: string", ranges: [r1] },
+    { definition: "(property) class2.propName: string", ranges: [r5, r7] },
+]);
+verify.referenceGroups(r2, [
+    { definition: "(method) interface1.doStuff(): void", ranges: [r2] },
+    { definition: "(method) class2.doStuff(): void", ranges: [r4, r6] },
+]);
+verify.referenceGroups(r3, [
+    { definition: "(property) interface1.propName: string", ranges: [r3] },
+    { definition: "(property) class2.propName: string", ranges: [r5, r7] },
+]);
 verify.referenceGroups([r4, r6], [
     { definition: "(method) class1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface1.doStuff(): void", ranges: [r2] },

--- a/tests/cases/fourslash/findAllRefsParameterPropertyDeclaration_inheritance.ts
+++ b/tests/cases/fourslash/findAllRefsParameterPropertyDeclaration_inheritance.ts
@@ -13,8 +13,9 @@
 
 const [r0, r1, r2, r3] = test.ranges();
 verify.referenceGroups(r0, [
-    { definition: "(property) C.x: string", ranges: [r0, r2, r3] },
+    { definition: "(property) C.x: string", ranges: [r0] },
     { definition: "(parameter) x: string", ranges: [r1] },
+    { definition: "(property) D.x: string", ranges: [r2, r3] },
 ]);
 verify.referenceGroups(r1, [
     { definition: "(property) C.x: string", ranges: [r0] },

--- a/tests/cases/fourslash/findAllRefsRedeclaredPropertyInDerivedInterface.ts
+++ b/tests/cases/fourslash/findAllRefsRedeclaredPropertyInDerivedInterface.ts
@@ -12,15 +12,13 @@
 ////const b: B = { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: 0 };
 
 const [r0, r1, r2, r3] = test.ranges();
-verify.referenceGroups(r0, [
-    { definition: "(property) A.x: string | number", ranges: [r0, r1, r2, r3] },
-]);
-verify.referenceGroups(r1, [
+verify.referenceGroups([r0, r1], [
     { definition: "(property) A.x: string | number", ranges: [r0, r2] },
     { definition: "(property) B.x: number", ranges: [r1, r3] },
 ]);
 verify.referenceGroups(r2, [
-    { definition: "(property) A.x: string | number", ranges: [r0, r1, r3] },
+    { definition: "(property) A.x: string | number", ranges: [r0] },
+    { definition: "(property) B.x: number", ranges: [r1, r3] },
     { definition: "(property) x: number", ranges: [r2] },
 ]);
 verify.referenceGroups(r3, [

--- a/tests/cases/fourslash/findAllRefsRootSymbols.ts
+++ b/tests/cases/fourslash/findAllRefsRootSymbols.ts
@@ -6,11 +6,11 @@
 ////o.[|x|];
 
 const [r0, r1, r2, r3] = test.ranges();
-verify.referenceGroups(r0, [{ definition: "(property) I.x: {}", ranges: [r0, r3] }]);
-verify.referenceGroups(r1, [{ definition: "(property) J.x: {}", ranges: [r1, r3] }]);
-verify.referenceGroups(r2, [{ definition: "(property) x: string", ranges: [r2, r3] }]);
-verify.referenceGroups(r3, [
-	{ definition: "(property) I.x: {}", ranges: [r0, r3] },
-	{ definition: "(property) J.x: {}", ranges: [r1] },
-	{ definition: "(property) x: string", ranges: [r2] },
-]);
+const i = { definition: "(property) I.x: {}", ranges: [r0] };
+const j = { definition: "(property) J.x: {}", ranges: [r1] };
+const anon = { definition: "(property) x: string", ranges: [r2] };
+const intersect = { definition: "(property) x: string & {}", ranges: [r3] };
+verify.referenceGroups(r0, [i, intersect]);
+verify.referenceGroups(r1, [j, intersect]);
+verify.referenceGroups(r2, [anon, intersect]);
+verify.referenceGroups(r3, [i, j, anon, intersect]);

--- a/tests/cases/fourslash/findAllRefsUnionProperty.ts
+++ b/tests/cases/fourslash/findAllRefsUnionProperty.ts
@@ -4,13 +4,16 @@
 ////    | { [|{| "isWriteAccess": true, "isDefinition": true |}type|]: "a" }
 ////    | { [|{| "isWriteAccess": true, "isDefinition": true |}type|]: "b" };
 ////declare const t: T;
-////if (t.[|type|] !== "failure") {
+////if (t.[|type|] === "a") {
+////    t.[|type|];
+////} else {
 ////    t.[|type|];
 ////}
 
 const ranges = test.ranges();
-const [r0, r1, r2, r3] = ranges;
+const [r0, r1, r2, r3, r4] = ranges;
 verify.referenceGroups(ranges, [
-    { definition: '(property) type: "a"', ranges: [r0, r2, r3] }, // TODO: this have type `"a" | "b"`
-    { definition: '(property) type: "b"', ranges: [r1] },
+    { definition: { text: '(property) type: "a"',  range: r0 }, ranges: [r0, r3] },
+    { definition: { text: '(property) type: "b"', range: r1 }, ranges: [r1, r4] },
+    { definition: { text: '(property) type: "a" | "b"', range: r0 }, ranges: [r2] },
 ]);

--- a/tests/cases/fourslash/referencesForClassMembers.ts
+++ b/tests/cases/fourslash/referencesForClassMembers.ts
@@ -16,16 +16,14 @@
 const ranges = test.rangesByText();
 const properties = ranges.get("a");
 const [a0, a1, a2] = properties;
-verify.referenceGroups(a0, [{ definition: "(property) Base.a: number", ranges: properties }]);
-verify.referenceGroups([a1, a2], [
+verify.referenceGroups(properties, [
     { definition: "(property) Base.a: number", ranges: [a0] },
     { definition: "(property) MyClass.a: any", ranges: [a1, a2] }
 ]);
 
 const methods = ranges.get("method");
 const [m0, m1, m2] = methods;
-verify.referenceGroups(m0, [{ definition: "(method) Base.method(): void", ranges: methods }]);
-verify.referenceGroups([m1, m2], [
+verify.referenceGroups(methods, [
     { definition: "(method) Base.method(): void", ranges: [m0] },
     { definition: "(method) MyClass.method(): void", ranges: [m1, m2] }
 ]);

--- a/tests/cases/fourslash/referencesForClassMembersExtendingAbstractClass.ts
+++ b/tests/cases/fourslash/referencesForClassMembersExtendingAbstractClass.ts
@@ -16,16 +16,14 @@
 const ranges = test.rangesByText();
 const properties = ranges.get("a");
 const [a0, a1, a2] = properties;
-verify.referenceGroups(a0, [{ definition: "(property) Base.a: number", ranges: properties }]);
-verify.referenceGroups([a1, a2], [
+verify.referenceGroups(properties, [
     { definition: "(property) Base.a: number", ranges: [a0] },
     { definition: "(property) MyClass.a: any", ranges: [a1, a2] }
 ]);
 
 const methods = ranges.get("method");
 const [m0, m1, m2] = methods;
-verify.referenceGroups(m0, [{ definition: "(method) Base.method(): void", ranges: methods }]);
-verify.referenceGroups([m1, m2], [
+verify.referenceGroups(methods, [
     { definition: "(method) Base.method(): void", ranges: [m0] },
     { definition: "(method) MyClass.method(): void", ranges: [m1, m2] }
 ]);

--- a/tests/cases/fourslash/referencesForClassMembersExtendingGenericClass.ts
+++ b/tests/cases/fourslash/referencesForClassMembersExtendingGenericClass.ts
@@ -16,16 +16,14 @@
 const ranges = test.rangesByText();
 const properties = ranges.get("a");
 const [a0, a1, a2] = properties;
-verify.referenceGroups(a0, [{ definition: "(property) Base<T>.a: this", ranges: properties }]);
-verify.referenceGroups([a1, a2], [
+verify.referenceGroups(properties, [
     { definition: "(property) Base<T>.a: this", ranges: [a0] },
     { definition: "(property) MyClass.a: any", ranges: [a1, a2] }
 ]);
 
 const methods = ranges.get("method");
 const [m0, m1, m2] = methods;
-verify.referenceGroups(m0, [{ definition: "(method) Base<T>.method<U>(a?: T, b?: U): this", ranges: methods }]);
-verify.referenceGroups([m1, m2], [
+verify.referenceGroups(methods, [
     { definition: "(method) Base<T>.method<U>(a?: T, b?: U): this", ranges: [m0] },
     { definition: "(method) MyClass.method(): void", ranges: [m1, m2] }
 ]);

--- a/tests/cases/fourslash/referencesForContextuallyTypedUnionProperties.ts
+++ b/tests/cases/fourslash/referencesForContextuallyTypedUnionProperties.ts
@@ -36,14 +36,29 @@
 
 const all = test.ranges();
 const [aCommon, bCommon, ...unionRefs] = all;
-verify.referenceGroups(aCommon, [{ definition: "(property) A.common: string", ranges: [aCommon, ...unionRefs] }]);
-verify.referenceGroups(bCommon, [{ definition: "(property) B.common: number", ranges: [bCommon, ...unionRefs] }]);
+verify.referenceGroups(aCommon, [
+    { definition: "(property) A.common: string", ranges: [aCommon] },
+    { definition: "(property) common: string | number", ranges: unionRefs },
+]);
+verify.referenceGroups(bCommon, [
+    { definition: "(property) B.common: number", ranges: [bCommon] },
+    { definition: "(property) common: string | number", ranges: unionRefs },
+]);
 
 unionRefs.forEach((unionRef, idx) => {
     const type = unionRef.marker.data.type;
+    const last2 = [
+        { definition: `(property) common: string | number`, ranges: unionRefs.filter(u => u != unionRef) },
+        { definition: `(property) common: ${type}`, ranges: [unionRef] },
+    ];
+    if (idx === 0) {
+        const tmp = last2[0];
+        last2[0] = last2[1];
+        last2[1] = tmp;
+    }
     verify.referenceGroups(unionRef, [
-        { definition: "(property) A.common: string", ranges: all.filter(x => x !== bCommon && x !== unionRef) },
+        { definition: "(property) A.common: string", ranges: [aCommon] },
         { definition: "(property) B.common: number", ranges: [bCommon] },
-        { definition: `(property) common: ${type}`, ranges: [unionRef] }
+        ...last2,
     ]);
 });

--- a/tests/cases/fourslash/referencesForInheritedProperties.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties.ts
@@ -23,12 +23,7 @@
 
 const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) interface1.doStuff(): void", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) interface2.doStuff(): void", ranges: [r1, r2, r3] }
-]);
-verify.referenceGroups([r2, r3], [
+verify.referenceGroups(ranges, [
     { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface2.doStuff(): void", ranges: [r1] },
     { definition: "(method) class1.doStuff(): void", ranges: [r2, r3] }

--- a/tests/cases/fourslash/referencesForInheritedProperties2.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties2.ts
@@ -28,12 +28,7 @@
 
 const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
-verify.referenceGroups(r0, [{ definition: "(method) interface1.doStuff(): void", ranges }]);
-verify.referenceGroups(r1, [
-    { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) interface2.doStuff(): void", ranges: [r1, r2, r3] }
-]);
-verify.referenceGroups([r2, r3], [
+verify.referenceGroups(ranges, [
     { definition: "(method) interface1.doStuff(): void", ranges: [r0] },
     { definition: "(method) interface2.doStuff(): void", ranges: [r1] },
     { definition: "(method) class1.doStuff(): void", ranges: [r2, r3] }

--- a/tests/cases/fourslash/referencesForInheritedProperties5.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties5.ts
@@ -14,15 +14,16 @@
 //// v.[|doStuff|]();
 
 const ranges = test.rangesByText();
-const [m0, m1, m2] = ranges.get("doStuff");
-const [p0, p1, p2] = ranges.get("propName");
-verify.referenceGroups([m0, m2], [{ definition: "(method) interface1.doStuff(): void", ranges: [m0, m1, m2] }]);
-verify.referenceGroups(m1, [
+const methods = ranges.get("doStuff");
+const [m0, m1, m2] = methods;
+verify.referenceGroups(methods, [
     { definition: "(method) interface1.doStuff(): void", ranges: [m0, m2] },
     { definition: "(method) interface2.doStuff(): void", ranges: [m1] }
 ]);
-verify.referenceGroups([p0, p2], [{ definition: "(property) interface1.propName: string", ranges: [p0, p1, p2] }]);
-verify.referenceGroups(p1, [
+
+const props = ranges.get("propName");
+const [p0, p1, p2] = props;
+verify.referenceGroups(props, [
     { definition: "(property) interface1.propName: string", ranges: [p0, p2] },
     { definition: "(property) interface2.propName: string", ranges: [p1] }
 ]);

--- a/tests/cases/fourslash/referencesForInheritedProperties6.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties6.ts
@@ -1,22 +1,18 @@
 ﻿/// <reference path='fourslash.ts'/>
 
-//// class class1 extends class1 {
+////class class1 extends class1 {
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|]() { }
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
-//// }
-//// class class2 extends class1 {
+////}
+////class class2 extends class1 {
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|]() { }
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
-//// }
+////}
 ////
-//// var v: class2;
-//// v.[|propName|];
-//// v.[|doStuff|]();
+////var v: class2;
+////v.[|doStuff|]();
 
-const ranges = test.rangesByText();
-const [m0, m1, m2] = ranges.get("doStuff");
-verify.referenceGroups(m0, [{ definition: "(method) class1.doStuff(): void", ranges: [m0, m1, m2] }]);
-verify.referenceGroups([m1, m2], [
+const ranges = test.ranges();
+const [m0, m1, m2] = ranges;
+verify.referenceGroups(ranges, [
     { definition: "(method) class1.doStuff(): void", ranges: [m0] },
     { definition: "(method) class2.doStuff(): void", ranges: [m1, m2] }
 ]);

--- a/tests/cases/fourslash/referencesForInheritedProperties7.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties7.ts
@@ -18,22 +18,15 @@
 //// v.[|propName|];
 
 const [r0, r1, r2, r3, r4, r5, r6, r7] = test.ranges();
-verify.referenceGroups(r0, [{ definition: "(method) class1.doStuff(): void", ranges: [r0, r4, r6] }]);
-verify.referenceGroups(r1, [{ definition: "(property) class1.propName: string", ranges: [r1, r5, r7] }]);
-verify.referenceGroups(r2, [{ definition: "(method) interface1.doStuff(): void", ranges: [r2, r4, r6] }]);
-verify.referenceGroups(r3, [{ definition: "(property) interface1.propName: string", ranges: [r3, r5, r7] }]);
-verify.referenceGroups(r4, [
-    { definition: "(method) class1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) interface1.doStuff(): void", ranges: [r2] },
-    { definition: "(method) class2.doStuff(): void", ranges: [r4, r6] }
-]);
-verify.referenceGroups([r5, r7], [
-    { definition: "(property) class1.propName: string", ranges: [r1] },
-    { definition: "(property) interface1.propName: string", ranges: [r3] },
-    { definition: "(property) class2.propName: string", ranges: [r5, r7] }
-]);
-verify.referenceGroups(r6, [
-    { definition: "(method) class1.doStuff(): void", ranges: [r0] },
-    { definition: "(method) interface1.doStuff(): void", ranges: [r2] },
-    { definition: "(method) class2.doStuff(): void", ranges: [r4, r6] },
-]);
+const c1DoStuff = { definition: "(method) class1.doStuff(): void", ranges: [r0] };
+const c2DoStuff = { definition: "(method) class2.doStuff(): void", ranges: [r4, r6] };
+const c1PropName = { definition: "(property) class1.propName: string", ranges: [r1] };
+const c2PropName = { definition: "(property) class2.propName: string", ranges: [r5, r7] };
+const iDoStuff = { definition: "(method) interface1.doStuff(): void", ranges: [r2] };
+const iPropName = { definition: "(property) interface1.propName: string", ranges: [r3] };
+verify.referenceGroups(r0, [c1DoStuff, c2DoStuff]);
+verify.referenceGroups(r1, [c1PropName, c2PropName]);
+verify.referenceGroups(r2, [iDoStuff, c2DoStuff]);
+verify.referenceGroups(r3, [iPropName, c2PropName]);
+verify.referenceGroups([r4, r6], [c1DoStuff, iDoStuff, c2DoStuff]);
+verify.referenceGroups([r5, r7], [c1PropName, iPropName, c2PropName]);

--- a/tests/cases/fourslash/referencesForOverrides.ts
+++ b/tests/cases/fourslash/referencesForOverrides.ts
@@ -79,63 +79,39 @@ const ranges = test.rangesByText();
 
 const fooRanges = ranges.get("foo");
 const [foo0, foo1, foo2] = fooRanges;
-verify.referenceGroups(foo0, [{ definition: "(method) SimpleClassTest.Foo.foo(): void", ranges: fooRanges }]);
-verify.referenceGroups([foo1, foo2], [
+verify.referenceGroups(fooRanges, [
     { definition: "(method) SimpleClassTest.Foo.foo(): void", ranges: [foo0] },
-    { definition: "(method) SimpleClassTest.Bar.foo(): void", ranges: [foo1, foo2] }
+    { definition: "(method) SimpleClassTest.Bar.foo(): void", ranges: [foo1, foo2] },
 ]);
 
 const ifooRanges = ranges.get("ifoo");
 const [ifoo0, ifoo1, ifoo2] = ifooRanges;
-verify.referenceGroups(ifoo0, [{ definition: "(method) SimpleInterfaceTest.IFoo.ifoo(): void", ranges: ifooRanges }]);
-verify.referenceGroups([ifoo1, ifoo2], [
+verify.referenceGroups(ifooRanges, [
     { definition: "(method) SimpleInterfaceTest.IFoo.ifoo(): void", ranges: [ifoo0] },
     { definition: "(method) SimpleInterfaceTest.IBar.ifoo(): void", ranges: [ifoo1, ifoo2] }
 ]);
 
 const icfooRanges = ranges.get("icfoo");
 const [icfoo0, icfoo1, icfoo2] = icfooRanges;
-verify.referenceGroups(icfoo0, [{ definition: "(method) SimpleClassInterfaceTest.IFoo.icfoo(): void", ranges: icfooRanges }]);
-verify.referenceGroups([icfoo1, icfoo2], [
+verify.referenceGroups(icfooRanges, [
     { definition: "(method) SimpleClassInterfaceTest.IFoo.icfoo(): void", ranges: [icfoo0] },
     { definition: "(method) SimpleClassInterfaceTest.Bar.icfoo(): void", ranges: [icfoo1, icfoo2] }
 ]);
 
 const fieldRanges = ranges.get("field");
 const [field0, field1, field2, field3, field4, field5] = fieldRanges;
-verify.referenceGroups(field0, [{ definition: "(property) Test.IBase.field: string", ranges: fieldRanges }]);
-verify.referenceGroups(field1, [
-    { definition: "(property) Test.IBase.field: string", ranges: [field0] },
-    { definition: "(property) Test.IBlah.field: string", ranges: fieldRanges.slice(1) }
-]);
-verify.referenceGroups(field2, [
-    { definition: "(property) Test.IBase.field: string", ranges: [field0] },
-    { definition: "(property) Test.IBlah.field: string", ranges: [field1] },
-    { definition: "(property) Test.IBlah2.field: string", ranges: fieldRanges.slice(2) }
-]);
-verify.referenceGroups(field3, [
-    { definition: "(property) Test.IBase.field: string", ranges: [field0] },
-    { definition: "(property) Test.IBlah.field: string", ranges: [field1] },
-    { definition: "(property) Test.IBlah2.field: string", ranges: [field2] },
-    { definition: "(property) Test.Bar.field: string", ranges: fieldRanges.slice(3) }
-]);
-verify.referenceGroups([field4, field5], [
+verify.referenceGroups(fieldRanges, [
     { definition: "(property) Test.IBase.field: string", ranges: [field0] },
     { definition: "(property) Test.IBlah.field: string", ranges: [field1] },
     { definition: "(property) Test.IBlah2.field: string", ranges: [field2] },
     { definition: "(property) Test.Bar.field: string", ranges: [field3] },
-    { definition: "(property) Test.BarBlah.field: string", ranges: fieldRanges.slice(4) }
+    { definition: "(property) Test.BarBlah.field: string", ranges: [field4, field5] },
 ]);
 
 const methodRanges = ranges.get("method");
 const [method0, method1, method2, method3] = methodRanges;
-verify.referenceGroups(method0, [{ definition: "(method) Test.IBase.method(): void", ranges: methodRanges }]);
-verify.referenceGroups(method1, [
-    { definition: "(method) Test.IBase.method(): void", ranges: [method0] },
-    { definition: "(method) Test.IDerived.method(): void", ranges: methodRanges.slice(1) }
-]);
-verify.referenceGroups([method2, method3], [
+verify.referenceGroups(methodRanges, [
     { definition: "(method) Test.IBase.method(): void", ranges: [method0] },
     { definition: "(method) Test.IDerived.method(): void", ranges: [method1] },
-    { definition: "(method) Test.Bar.method(): void", ranges: methodRanges.slice(2) }
+    { definition: "(method) Test.Bar.method(): void", ranges: [method2, method3] },
 ]);

--- a/tests/cases/fourslash/referencesForUnionProperties.ts
+++ b/tests/cases/fourslash/referencesForUnionProperties.ts
@@ -23,14 +23,22 @@
 ////x.common.[|a|];
 
 const [one, base, hasAOrB, x] = test.ranges();
-verify.referenceGroups(one, [{ definition: "(property) a: number", ranges: [one, x] }]);
-verify.referenceGroups(base, [{ definition: "(property) Base.a: string", ranges: [base, hasAOrB, x] }]);
+verify.referenceGroups(one, [
+    { definition: "(property) a: number", ranges: [one] },
+    { definition: "(property) a: string | number", ranges: [x] },
+]);
+verify.referenceGroups(base, [
+    { definition: "(property) Base.a: string", ranges: [base] },
+    { definition: "(property) HasAOrB.a: string", ranges: [hasAOrB, x] },
+]);
 verify.referenceGroups(hasAOrB, [
     { definition: "(property) Base.a: string", ranges: [base] },
-    { definition: "(property) HasAOrB.a: string", ranges: [hasAOrB, x] }
+    { definition: "(property) HasAOrB.a: string", ranges: [hasAOrB] },
+    { definition: "(property) a: string | number", ranges: [x] },
 ]);
 verify.referenceGroups(x, [
-    { definition: "(property) a: number", ranges: [one, x] },
+    { definition: "(property) a: number", ranges: [one] },
     { definition: "(property) Base.a: string", ranges: [base] },
     { definition: "(property) HasAOrB.a: string", ranges: [hasAOrB] },
+    { definition: "(property) a: string | number", ranges: [x] },
 ]);


### PR DESCRIPTION
Fixes #21297

Also gives entries for base classes their own definition.