### PR TITLE
Two JSdoc parsing fixes

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2204,14 +2204,14 @@ namespace ts {
         }
 
         function parseJSDocAllType(postFixEquals: boolean): JSDocAllType | JSDocOptionalType {
-            const result = finishNode(createNode(SyntaxKind.JSDocAllType)) as JSDocAllType;
+            const result = createNode(SyntaxKind.JSDocAllType) as JSDocAllType;
             if (postFixEquals) {
                 return createJSDocPostfixType(SyntaxKind.JSDocOptionalType, result) as JSDocOptionalType;
             }
             else {
                 nextToken();
-                return result;
             }
+            return finishNode(result);
         }
 
         function parseJSDocNonNullableType(): TypeNode {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2203,10 +2203,15 @@ namespace ts {
             return finishNode(node);
         }
 
-        function parseJSDocAllType(): JSDocAllType {
-            const result = createNode(SyntaxKind.JSDocAllType) as JSDocAllType;
-            nextToken();
-            return finishNode(result);
+        function parseJSDocAllType(postFixEquals: boolean): JSDocAllType  | JSDocOptionalType {
+            const result = finishNode(createNode(SyntaxKind.JSDocAllType)) as JSDocAllType;
+            if (postFixEquals) {
+                return createJSDocPostfixType(SyntaxKind.JSDocOptionalType, result) as JSDocOptionalType;
+            }
+            else {
+                nextToken();
+                return result;
+            }
         }
 
         function parseJSDocNonNullableType(): TypeNode {
@@ -2740,7 +2745,9 @@ namespace ts {
                     // If these are followed by a dot, then parse these out as a dotted type reference instead.
                     return tryParse(parseKeywordAndNoDot) || parseTypeReference();
                 case SyntaxKind.AsteriskToken:
-                    return parseJSDocAllType();
+                    return parseJSDocAllType(/*postfixEquals*/ false);
+                case SyntaxKind.AsteriskEqualsToken:
+                    return parseJSDocAllType(/*postfixEquals*/ true);
                 case SyntaxKind.QuestionToken:
                     return parseJSDocUnknownOrNullableType();
                 case SyntaxKind.FunctionKeyword:

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2203,7 +2203,7 @@ namespace ts {
             return finishNode(node);
         }
 
-        function parseJSDocAllType(postFixEquals: boolean): JSDocAllType  | JSDocOptionalType {
+        function parseJSDocAllType(postFixEquals: boolean): JSDocAllType | JSDocOptionalType {
             const result = finishNode(createNode(SyntaxKind.JSDocAllType)) as JSDocAllType;
             if (postFixEquals) {
                 return createJSDocPostfixType(SyntaxKind.JSDocOptionalType, result) as JSDocOptionalType;
@@ -6503,6 +6503,10 @@ namespace ts {
                 }
 
                 function parseBracketNameInPropertyAndParamTag(): { name: EntityName, isBracketed: boolean } {
+                    if (token() === SyntaxKind.NoSubstitutionTemplateLiteral) {
+                        // a markdown-quoted name: `arg` is not legal jsdoc, but occurs in the wild
+                        return { name: createIdentifier(/*isIdentifier*/ true), isBracketed: false };
+                    }
                     // Looking for something like '[foo]', 'foo', '[foo.bar]' or 'foo.bar'
                     const isBracketed = parseOptional(SyntaxKind.OpenBracketToken);
                     const name = parseJSDocEntityName();

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1975,7 +1975,7 @@ namespace ts {
                 case CharacterCodes.dot:
                     return token = SyntaxKind.DotToken;
                 case CharacterCodes.backtick:
-                    while(pos < end && text.charCodeAt(pos) !== CharacterCodes.backtick) {
+                    while (pos < end && text.charCodeAt(pos) !== CharacterCodes.backtick) {
                         pos++;
                     }
                     tokenValue = text.substring(tokenPos + 1, pos);

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1974,6 +1974,13 @@ namespace ts {
                     return token = SyntaxKind.CommaToken;
                 case CharacterCodes.dot:
                     return token = SyntaxKind.DotToken;
+                case CharacterCodes.backtick:
+                    while(pos < end && text.charCodeAt(pos) !== CharacterCodes.backtick) {
+                        pos++;
+                    }
+                    tokenValue = text.substring(tokenPos + 1, pos);
+                    pos++;
+                    return token = SyntaxKind.NoSubstitutionTemplateLiteral;
             }
 
             if (isIdentifierStart(ch, ScriptTarget.Latest)) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -73,6 +73,7 @@ namespace ts {
         | SyntaxKind.CommaToken
         | SyntaxKind.DotToken
         | SyntaxKind.Identifier
+        | SyntaxKind.NoSubstitutionTemplateLiteral
         | SyntaxKind.Unknown;
 
     export type JsxTokenSyntaxKind =
@@ -84,7 +85,7 @@ namespace ts {
         | SyntaxKind.OpenBraceToken
         | SyntaxKind.LessThanToken;
 
-    // token > SyntaxKind.Identifer => token is a keyword
+    // token > SyntaxKind.Identifier => token is a keyword
     // Also, If you add a new SyntaxKind be sure to keep the `Markers` section at the bottom in sync
     export const enum SyntaxKind {
         Unknown,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -59,7 +59,7 @@ declare namespace ts {
         pos: number;
         end: number;
     }
-    type JsDocSyntaxKind = SyntaxKind.EndOfFileToken | SyntaxKind.WhitespaceTrivia | SyntaxKind.AtToken | SyntaxKind.NewLineTrivia | SyntaxKind.AsteriskToken | SyntaxKind.OpenBraceToken | SyntaxKind.CloseBraceToken | SyntaxKind.LessThanToken | SyntaxKind.OpenBracketToken | SyntaxKind.CloseBracketToken | SyntaxKind.EqualsToken | SyntaxKind.CommaToken | SyntaxKind.DotToken | SyntaxKind.Identifier | SyntaxKind.Unknown;
+    type JsDocSyntaxKind = SyntaxKind.EndOfFileToken | SyntaxKind.WhitespaceTrivia | SyntaxKind.AtToken | SyntaxKind.NewLineTrivia | SyntaxKind.AsteriskToken | SyntaxKind.OpenBraceToken | SyntaxKind.CloseBraceToken | SyntaxKind.LessThanToken | SyntaxKind.OpenBracketToken | SyntaxKind.CloseBracketToken | SyntaxKind.EqualsToken | SyntaxKind.CommaToken | SyntaxKind.DotToken | SyntaxKind.Identifier | SyntaxKind.NoSubstitutionTemplateLiteral | SyntaxKind.Unknown;
     type JsxTokenSyntaxKind = SyntaxKind.LessThanSlashToken | SyntaxKind.EndOfFileToken | SyntaxKind.ConflictMarkerTrivia | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.OpenBraceToken | SyntaxKind.LessThanToken;
     enum SyntaxKind {
         Unknown = 0,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -59,7 +59,7 @@ declare namespace ts {
         pos: number;
         end: number;
     }
-    type JsDocSyntaxKind = SyntaxKind.EndOfFileToken | SyntaxKind.WhitespaceTrivia | SyntaxKind.AtToken | SyntaxKind.NewLineTrivia | SyntaxKind.AsteriskToken | SyntaxKind.OpenBraceToken | SyntaxKind.CloseBraceToken | SyntaxKind.LessThanToken | SyntaxKind.OpenBracketToken | SyntaxKind.CloseBracketToken | SyntaxKind.EqualsToken | SyntaxKind.CommaToken | SyntaxKind.DotToken | SyntaxKind.Identifier | SyntaxKind.Unknown;
+    type JsDocSyntaxKind = SyntaxKind.EndOfFileToken | SyntaxKind.WhitespaceTrivia | SyntaxKind.AtToken | SyntaxKind.NewLineTrivia | SyntaxKind.AsteriskToken | SyntaxKind.OpenBraceToken | SyntaxKind.CloseBraceToken | SyntaxKind.LessThanToken | SyntaxKind.OpenBracketToken | SyntaxKind.CloseBracketToken | SyntaxKind.EqualsToken | SyntaxKind.CommaToken | SyntaxKind.DotToken | SyntaxKind.Identifier | SyntaxKind.NoSubstitutionTemplateLiteral | SyntaxKind.Unknown;
     type JsxTokenSyntaxKind = SyntaxKind.LessThanSlashToken | SyntaxKind.EndOfFileToken | SyntaxKind.ConflictMarkerTrivia | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.OpenBraceToken | SyntaxKind.LessThanToken;
     enum SyntaxKind {
         Unknown = 0,

--- a/tests/baselines/reference/jsdocParseBackquotedParamName.symbols
+++ b/tests/baselines/reference/jsdocParseBackquotedParamName.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/**
+ * @param {string=} `args`
+ * @param `bwarg` {?number?}
+ */
+function f(args, bwarg) {
+>f : Symbol(f, Decl(a.js, 0, 0))
+>args : Symbol(args, Decl(a.js, 4, 11))
+>bwarg : Symbol(bwarg, Decl(a.js, 4, 16))
+}
+
+=== tests/cases/conformance/jsdoc/ts.ts ===
+/**
+ * @param `arg` - this is fine
+ */
+function g(arg: string) {
+>g : Symbol(g, Decl(ts.ts, 0, 0))
+>arg : Symbol(arg, Decl(ts.ts, 3, 11))
+}
+

--- a/tests/baselines/reference/jsdocParseBackquotedParamName.types
+++ b/tests/baselines/reference/jsdocParseBackquotedParamName.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/**
+ * @param {string=} `args`
+ * @param `bwarg` {?number?}
+ */
+function f(args, bwarg) {
+>f : (args?: string | undefined, bwarg: number | null) => void
+>args : string | undefined
+>bwarg : number | null
+}
+
+=== tests/cases/conformance/jsdoc/ts.ts ===
+/**
+ * @param `arg` - this is fine
+ */
+function g(arg: string) {
+>g : (arg: string) => void
+>arg : string
+}
+

--- a/tests/baselines/reference/jsdocParseStarEquals.symbols
+++ b/tests/baselines/reference/jsdocParseStarEquals.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/** @param {...*=} args
+    @return {*=} */
+function f(...args) {
+>f : Symbol(f, Decl(a.js, 0, 0))
+>args : Symbol(args, Decl(a.js, 2, 11))
+
+    return null
+}
+

--- a/tests/baselines/reference/jsdocParseStarEquals.symbols
+++ b/tests/baselines/reference/jsdocParseStarEquals.symbols
@@ -8,3 +8,7 @@ function f(...args) {
     return null
 }
 
+/** @type *= */
+var x;
+>x : Symbol(x, Decl(a.js, 7, 3))
+

--- a/tests/baselines/reference/jsdocParseStarEquals.types
+++ b/tests/baselines/reference/jsdocParseStarEquals.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/** @param {...*=} args
+    @return {*=} */
+function f(...args) {
+>f : (...args: any[]) => any
+>args : any[]
+
+    return null
+>null : null
+}
+

--- a/tests/baselines/reference/jsdocParseStarEquals.types
+++ b/tests/baselines/reference/jsdocParseStarEquals.types
@@ -9,3 +9,7 @@ function f(...args) {
 >null : null
 }
 
+/** @type *= */
+var x;
+>x : any
+

--- a/tests/cases/conformance/jsdoc/jsdocParseBackquotedParamName.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParseBackquotedParamName.ts
@@ -1,0 +1,20 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @strict: true
+// @Filename: a.js
+
+/**
+ * @param {string=} `args`
+ * @param `bwarg` {?number?}
+ */
+function f(args, bwarg) {
+}
+
+// @Filename: ts.ts
+
+/**
+ * @param `arg` - this is fine
+ */
+function g(arg: string) {
+}

--- a/tests/cases/conformance/jsdoc/jsdocParseStarEquals.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParseStarEquals.ts
@@ -9,3 +9,6 @@
 function f(...args) {
     return null
 }
+
+/** @type *= */
+var x;

--- a/tests/cases/conformance/jsdoc/jsdocParseStarEquals.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParseStarEquals.ts
@@ -1,0 +1,11 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @strict: true
+// @Filename: a.js
+
+/** @param {...*=} args
+    @return {*=} */
+function f(...args) {
+    return null
+}


### PR DESCRIPTION
1. Correctly parse `*=`. Previously `parseNonArrayType` missed it because the scanner produces a single AsteriskEqualsToken for it.
2. Allow non-standard use of backticks around names in `@param` tags. For example:

```ts
/** @param {number} `a` some kind of number */
function f(a) { ... }
```

Fixes #22413