### PR TITLE
Make nodebuilder only preserve parameter modifiers for constructors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3379,7 +3379,8 @@ namespace ts {
                 else {
                     typeParameters = signature.typeParameters && signature.typeParameters.map(parameter => typeParameterToDeclaration(parameter, context));
                 }
-                const parameters = signature.parameters.map(parameter => symbolToParameterDeclaration(parameter, context));
+
+                const parameters = signature.parameters.map(parameter => symbolToParameterDeclaration(parameter, context, kind === SyntaxKind.Constructor));
                 if (signature.thisParameter) {
                     const thisParameter = symbolToParameterDeclaration(signature.thisParameter, context);
                     parameters.unshift(thisParameter);
@@ -3419,7 +3420,7 @@ namespace ts {
                 return createTypeParameterDeclaration(name, constraintNode, defaultParameterNode);
             }
 
-            function symbolToParameterDeclaration(parameterSymbol: Symbol, context: NodeBuilderContext): ParameterDeclaration {
+            function symbolToParameterDeclaration(parameterSymbol: Symbol, context: NodeBuilderContext, preserveModifierFlags?: boolean): ParameterDeclaration {
                 const parameterDeclaration = getDeclarationOfKind<ParameterDeclaration>(parameterSymbol, SyntaxKind.Parameter);
                 Debug.assert(!!parameterDeclaration || isTransientSymbol(parameterSymbol) && !!parameterSymbol.isRestParameter);
 
@@ -3429,7 +3430,7 @@ namespace ts {
                 }
                 const parameterTypeNode = typeToTypeNodeHelper(parameterType, context);
 
-                const modifiers = !(context.flags & NodeBuilderFlags.OmitParameterModifiers) && parameterDeclaration && parameterDeclaration.modifiers && parameterDeclaration.modifiers.map(getSynthesizedClone);
+                const modifiers = !(context.flags & NodeBuilderFlags.OmitParameterModifiers) && preserveModifierFlags && parameterDeclaration && parameterDeclaration.modifiers && parameterDeclaration.modifiers.map(getSynthesizedClone);
                 const dotDotDotToken = !parameterDeclaration || isRestParameter(parameterDeclaration) ? createToken(SyntaxKind.DotDotDotToken) : undefined;
                 const name = parameterDeclaration
                     ? parameterDeclaration.name ?

--- a/tests/baselines/reference/ArrowFunctionExpression1.types
+++ b/tests/baselines/reference/ArrowFunctionExpression1.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/ArrowFunctionExpression1.ts ===
 var v = (public x: string) => { };
->v : (public x: string) => void
->(public x: string) => { } : (public x: string) => void
+>v : (x: string) => void
+>(public x: string) => { } : (x: string) => void
 >x : string
 

--- a/tests/baselines/reference/ParameterList4.types
+++ b/tests/baselines/reference/ParameterList4.types
@@ -1,5 +1,5 @@
 === tests/cases/compiler/ParameterList4.ts ===
 function F(public A) {
->F : (public A: any) => void
+>F : (A: any) => void
 >A : any
 }

--- a/tests/baselines/reference/ParameterList5.types
+++ b/tests/baselines/reference/ParameterList5.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/ParameterList5.ts ===
 function A(): (public B) => C {
->A : () => (public B: any) => any
+>A : () => (B: any) => any
 >B : any
 >C : No type information available!
 }

--- a/tests/baselines/reference/ParameterList6.types
+++ b/tests/baselines/reference/ParameterList6.types
@@ -3,7 +3,7 @@ class C {
 >C : C
 
   constructor(C: (public A) => any) {
->C : (public A: any) => any
+>C : (A: any) => any
 >A : any
   }
 }

--- a/tests/baselines/reference/anonymousClassDeclarationDoesntPrintWithReadonly.js
+++ b/tests/baselines/reference/anonymousClassDeclarationDoesntPrintWithReadonly.js
@@ -1,0 +1,51 @@
+//// [anonymousClassDeclarationDoesntPrintWithReadonly.ts]
+export class X {
+    constructor(readonly a: number) { }
+}
+
+export function y() {
+    return class extends X { }
+}
+
+//// [anonymousClassDeclarationDoesntPrintWithReadonly.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+var X = /** @class */ (function () {
+    function X(a) {
+        this.a = a;
+    }
+    return X;
+}());
+exports.X = X;
+function y() {
+    return /** @class */ (function (_super) {
+        __extends(class_1, _super);
+        function class_1() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        return class_1;
+    }(X));
+}
+exports.y = y;
+
+
+//// [anonymousClassDeclarationDoesntPrintWithReadonly.d.ts]
+export declare class X {
+    readonly a: number;
+    constructor(a: number);
+}
+export declare function y(): {
+    new (a: number): {
+        readonly a: number;
+    };
+};

--- a/tests/baselines/reference/anonymousClassDeclarationDoesntPrintWithReadonly.symbols
+++ b/tests/baselines/reference/anonymousClassDeclarationDoesntPrintWithReadonly.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts ===
+export class X {
+>X : Symbol(X, Decl(anonymousClassDeclarationDoesntPrintWithReadonly.ts, 0, 0))
+
+    constructor(readonly a: number) { }
+>a : Symbol(X.a, Decl(anonymousClassDeclarationDoesntPrintWithReadonly.ts, 1, 16))
+}
+
+export function y() {
+>y : Symbol(y, Decl(anonymousClassDeclarationDoesntPrintWithReadonly.ts, 2, 1))
+
+    return class extends X { }
+>X : Symbol(X, Decl(anonymousClassDeclarationDoesntPrintWithReadonly.ts, 0, 0))
+}

--- a/tests/baselines/reference/anonymousClassDeclarationDoesntPrintWithReadonly.types
+++ b/tests/baselines/reference/anonymousClassDeclarationDoesntPrintWithReadonly.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts ===
+export class X {
+>X : X
+
+    constructor(readonly a: number) { }
+>a : number
+}
+
+export function y() {
+>y : () => typeof (Anonymous class)
+
+    return class extends X { }
+>class extends X { } : typeof (Anonymous class)
+>X : X
+}

--- a/tests/baselines/reference/callSignaturesWithAccessibilityModifiersOnParameters.types
+++ b/tests/baselines/reference/callSignaturesWithAccessibilityModifiersOnParameters.types
@@ -2,32 +2,32 @@
 // Call signature parameters do not allow accessibility modifiers
 
 function foo(public x, private y) { }
->foo : (public x: any, private y: any) => void
+>foo : (x: any, y: any) => void
 >x : any
 >y : any
 
 var f = function foo(public x, private y) { }
->f : (public x: any, private y: any) => void
->function foo(public x, private y) { } : (public x: any, private y: any) => void
->foo : (public x: any, private y: any) => void
+>f : (x: any, y: any) => void
+>function foo(public x, private y) { } : (x: any, y: any) => void
+>foo : (x: any, y: any) => void
 >x : any
 >y : any
 
 var f2 = function (public x, private y) { }
->f2 : (public x: any, private y: any) => void
->function (public x, private y) { } : (public x: any, private y: any) => void
+>f2 : (x: any, y: any) => void
+>function (public x, private y) { } : (x: any, y: any) => void
 >x : any
 >y : any
 
 var f3 = (x, private y) => { }
->f3 : (x: any, private y: any) => void
->(x, private y) => { } : (x: any, private y: any) => void
+>f3 : (x: any, y: any) => void
+>(x, private y) => { } : (x: any, y: any) => void
 >x : any
 >y : any
 
 var f4 = <T>(public x: T, y: T) => { }
->f4 : <T>(public x: T, y: T) => void
-><T>(public x: T, y: T) => { } : <T>(public x: T, y: T) => void
+>f4 : <T>(x: T, y: T) => void
+><T>(public x: T, y: T) => { } : <T>(x: T, y: T) => void
 >T : T
 >x : T
 >T : T
@@ -35,32 +35,32 @@ var f4 = <T>(public x: T, y: T) => { }
 >T : T
 
 function foo2(private x: string, public y: number) { }
->foo2 : (private x: string, public y: number) => void
+>foo2 : (x: string, y: number) => void
 >x : string
 >y : number
 
 var f5 = function foo(private x: string, public y: number) { }
->f5 : (private x: string, public y: number) => void
->function foo(private x: string, public y: number) { } : (private x: string, public y: number) => void
->foo : (private x: string, public y: number) => void
+>f5 : (x: string, y: number) => void
+>function foo(private x: string, public y: number) { } : (x: string, y: number) => void
+>foo : (x: string, y: number) => void
 >x : string
 >y : number
 
 var f6 = function (private x: string, public y: number) { }
->f6 : (private x: string, public y: number) => void
->function (private x: string, public y: number) { } : (private x: string, public y: number) => void
+>f6 : (x: string, y: number) => void
+>function (private x: string, public y: number) { } : (x: string, y: number) => void
 >x : string
 >y : number
 
 var f7 = (private x: string, public y: number) => { }
->f7 : (private x: string, public y: number) => void
->(private x: string, public y: number) => { } : (private x: string, public y: number) => void
+>f7 : (x: string, y: number) => void
+>(private x: string, public y: number) => { } : (x: string, y: number) => void
 >x : string
 >y : number
 
 var f8 = <T>(private x: T, public y: T) => { }
->f8 : <T>(private x: T, public y: T) => void
-><T>(private x: T, public y: T) => { } : <T>(private x: T, public y: T) => void
+>f8 : <T>(x: T, y: T) => void
+><T>(private x: T, public y: T) => { } : <T>(x: T, y: T) => void
 >T : T
 >x : T
 >T : T
@@ -71,17 +71,17 @@ class C {
 >C : C
 
     foo(public x, private y) { }
->foo : (public x: any, private y: any) => void
+>foo : (x: any, y: any) => void
 >x : any
 >y : any
 
     foo2(public x: number, private y: string) { }
->foo2 : (public x: number, private y: string) => void
+>foo2 : (x: number, y: string) => void
 >x : number
 >y : string
 
     foo3<T>(public x: T, private y: T) { }
->foo3 : <T>(public x: T, private y: T) => void
+>foo3 : <T>(x: T, y: T) => void
 >T : T
 >x : T
 >T : T
@@ -101,17 +101,17 @@ interface I {
 >y : number
 
     foo(private x, public y);
->foo : { (private x: any, public y: any): any; (public x: number, y: string): any; }
+>foo : { (x: any, y: any): any; (x: number, y: string): any; }
 >x : any
 >y : any
 
     foo(public x: number, y: string);
->foo : { (private x: any, public y: any): any; (public x: number, y: string): any; }
+>foo : { (x: any, y: any): any; (x: number, y: string): any; }
 >x : number
 >y : string
 
     foo3<T>(x: T, private y: T);
->foo3 : <T>(x: T, private y: T) => any
+>foo3 : <T>(x: T, y: T) => any
 >T : T
 >x : T
 >T : T
@@ -120,39 +120,39 @@ interface I {
 }
 
 var a: {
->a : { foo(public x: any, private y: any): any; foo2(private x: number, public y: string): any; }
+>a : { foo(x: any, y: any): any; foo2(x: number, y: string): any; }
 
     foo(public x, private y);
->foo : (public x: any, private y: any) => any
+>foo : (x: any, y: any) => any
 >x : any
 >y : any
 
     foo2(private x: number, public y: string);
->foo2 : (private x: number, public y: string) => any
+>foo2 : (x: number, y: string) => any
 >x : number
 >y : string
 
 };
 
 var b = {
->b : { foo(public x: any, y: any): void; a: (x: number, private y: string) => void; b: <T>(public x: T, private y: T) => void; }
->{    foo(public x, y) { },    a: function foo(x: number, private y: string) { },    b: <T>(public x: T, private y: T) => { }} : { foo(public x: any, y: any): void; a: (x: number, private y: string) => void; b: <T>(public x: T, private y: T) => void; }
+>b : { foo(x: any, y: any): void; a: (x: number, y: string) => void; b: <T>(x: T, y: T) => void; }
+>{    foo(public x, y) { },    a: function foo(x: number, private y: string) { },    b: <T>(public x: T, private y: T) => { }} : { foo(x: any, y: any): void; a: (x: number, y: string) => void; b: <T>(x: T, y: T) => void; }
 
     foo(public x, y) { },
->foo : (public x: any, y: any) => void
+>foo : (x: any, y: any) => void
 >x : any
 >y : any
 
     a: function foo(x: number, private y: string) { },
->a : (x: number, private y: string) => void
->function foo(x: number, private y: string) { } : (x: number, private y: string) => void
->foo : (x: number, private y: string) => void
+>a : (x: number, y: string) => void
+>function foo(x: number, private y: string) { } : (x: number, y: string) => void
+>foo : (x: number, y: string) => void
 >x : number
 >y : string
 
     b: <T>(public x: T, private y: T) => { }
->b : <T>(public x: T, private y: T) => void
-><T>(public x: T, private y: T) => { } : <T>(public x: T, private y: T) => void
+>b : <T>(x: T, y: T) => void
+><T>(public x: T, private y: T) => { } : <T>(x: T, y: T) => void
 >T : T
 >x : T
 >T : T

--- a/tests/baselines/reference/constructSignatureWithAccessibilityModifiersOnParameters.types
+++ b/tests/baselines/reference/constructSignatureWithAccessibilityModifiersOnParameters.types
@@ -38,14 +38,14 @@ interface I2 {
 }
 
 var a: {
->a : new (public x: any) => any
+>a : new (x: any) => any
 
     new (public x);
 >x : any
 }
 
 var b: {
->b : new (private x: any) => any
+>b : new (x: any) => any
 
     new (private x);
 >x : any

--- a/tests/baselines/reference/constructSignatureWithAccessibilityModifiersOnParameters2.types
+++ b/tests/baselines/reference/constructSignatureWithAccessibilityModifiersOnParameters2.types
@@ -54,7 +54,7 @@ interface I2 {
 }
 
 var a: {
->a : { new (public x: any): any; new (public y: any): any; }
+>a : { new (x: any): any; new (y: any): any; }
 
     new (public x);
 >x : any
@@ -64,7 +64,7 @@ var a: {
 }
 
 var b: {
->b : { new (private x: any): any; new (private y: any): any; }
+>b : { new (x: any): any; new (y: any): any; }
 
     new (private x);
 >x : any

--- a/tests/baselines/reference/parameterPropertyOutsideConstructor.types
+++ b/tests/baselines/reference/parameterPropertyOutsideConstructor.types
@@ -3,7 +3,7 @@ class C {
 >C : C
 
     foo(public x) {
->foo : (public x: any) => void
+>foo : (x: any) => void
 >x : any
     }
 }

--- a/tests/baselines/reference/parserArrowFunctionExpression1.types
+++ b/tests/baselines/reference/parserArrowFunctionExpression1.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression1.ts ===
 var v = (public x: string) => { };
->v : (public x: string) => void
->(public x: string) => { } : (public x: string) => void
+>v : (x: string) => void
+>(public x: string) => { } : (x: string) => void
 >x : string
 

--- a/tests/baselines/reference/parserParameterList4.types
+++ b/tests/baselines/reference/parserParameterList4.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList4.ts ===
 function F(public A) {
->F : (public A: any) => void
+>F : (A: any) => void
 >A : any
 }

--- a/tests/baselines/reference/parserParameterList5.types
+++ b/tests/baselines/reference/parserParameterList5.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList5.ts ===
 function A(): (public B) => C {
->A : () => (public B: any) => any
+>A : () => (B: any) => any
 >B : any
 >C : No type information available!
 }

--- a/tests/baselines/reference/parserParameterList6.types
+++ b/tests/baselines/reference/parserParameterList6.types
@@ -3,7 +3,7 @@ class C {
 >C : C
 
   constructor(C: (public A) => any) {
->C : (public A: any) => any
+>C : (A: any) => any
 >A : any
   }
 }

--- a/tests/baselines/reference/readonlyInAmbientClass.types
+++ b/tests/baselines/reference/readonlyInAmbientClass.types
@@ -6,6 +6,6 @@ declare class C{
 >x : number
 
 	method(readonly x: number);
->method : (readonly x: number) => any
+>method : (x: number) => any
 >x : number
 }

--- a/tests/baselines/reference/readonlyInNonPropertyParameters.types
+++ b/tests/baselines/reference/readonlyInNonPropertyParameters.types
@@ -4,7 +4,7 @@ class X {
 >X : X
 
 	method(readonly x: number) {}
->method : (readonly x: number) => void
+>method : (x: number) => void
 >x : number
 
 	set x(readonly value: number) {}
@@ -12,7 +12,7 @@ class X {
 >value : number
 }
 (readonly x) => 0;
->(readonly x) => 0 : (readonly x: any) => number
+>(readonly x) => 0 : (x: any) => number
 >x : any
 >0 : 0
 

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.types
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.types
@@ -725,7 +725,7 @@ function notFirst(a: number, this: C): number { return this.n; }
 
 ///// parse errors /////
 function modifiers(async this: C): number { return this.n; }
->modifiers : (async : any, this: C) => number
+>modifiers : (: any, this: C) => number
 > : any
 >this : C
 >C : C

--- a/tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts
+++ b/tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts
@@ -1,0 +1,8 @@
+// @declaration: true
+export class X {
+    constructor(readonly a: number) { }
+}
+
+export function y() {
+    return class extends X { }
+}


### PR DESCRIPTION
Fixes #21954
