### PR TITLE
Fix indexed access in conditional type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7349,13 +7349,24 @@ namespace ts {
             return result;
         }
 
+        function isUnaryTupleTypeNode(node: TypeNode) {
+            return node.kind === SyntaxKind.TupleType && (<TupleTypeNode>node).elementTypes.length === 1;
+        }
+
+        function getImpliedConstraint(typeVariable: TypeVariable, checkNode: TypeNode, extendsNode: TypeNode): Type {
+            return isUnaryTupleTypeNode(checkNode) && isUnaryTupleTypeNode(extendsNode) ? getImpliedConstraint(typeVariable, (<TupleTypeNode>checkNode).elementTypes[0], (<TupleTypeNode>extendsNode).elementTypes[0]) :
+                getActualTypeVariable(getTypeFromTypeNode(checkNode)) === typeVariable ? getTypeFromTypeNode(extendsNode) :
+                undefined;
+        }
+
         function getConstrainedTypeVariable(typeVariable: TypeVariable, node: Node) {
             let constraints: Type[];
             while (isPartOfTypeNode(node)) {
                 const parent = node.parent;
                 if (parent.kind === SyntaxKind.ConditionalType && node === (<ConditionalTypeNode>parent).trueType) {
-                    if (getActualTypeVariable(getTypeFromTypeNode((<ConditionalTypeNode>parent).checkType)) === typeVariable) {
-                        constraints = append(constraints, getTypeFromTypeNode((<ConditionalTypeNode>parent).extendsType));
+                    const constraint = getImpliedConstraint(typeVariable, (<ConditionalTypeNode>parent).checkType, (<ConditionalTypeNode>parent).extendsType);
+                    if (constraint) {
+                        constraints = append(constraints, constraint);
                     }
                 }
                 node = parent;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3033,7 +3033,7 @@ namespace ts {
                     return createConditionalTypeNode(checkTypeNode, extendsTypeNode, trueTypeNode, falseTypeNode);
                 }
                 if (type.flags & TypeFlags.Substitution) {
-                    return typeToTypeNodeHelper((<SubstitutionType>type).typeParameter, context);
+                    return typeToTypeNodeHelper((<SubstitutionType>type).typeVariable, context);
                 }
 
                 Debug.fail("Should be unreachable.");
@@ -7303,7 +7303,7 @@ namespace ts {
             const res = tryGetDeclaredTypeOfSymbol(symbol);
             if (res) {
                 return checkNoTypeArguments(node, symbol) ?
-                    res.flags & TypeFlags.TypeParameter ? getConstrainedTypeParameter(<TypeParameter>res, node) : res :
+                    res.flags & TypeFlags.TypeParameter ? getConstrainedTypeVariable(<TypeParameter>res, node) : res :
                     unknownType;
             }
 
@@ -7342,25 +7342,25 @@ namespace ts {
             }
         }
 
-        function getSubstitutionType(typeParameter: TypeParameter, substitute: Type) {
+        function getSubstitutionType(typeVariable: TypeVariable, substitute: Type) {
             const result = <SubstitutionType>createType(TypeFlags.Substitution);
-            result.typeParameter = typeParameter;
+            result.typeVariable = typeVariable;
             result.substitute = substitute;
             return result;
         }
 
-        function getConstrainedTypeParameter(typeParameter: TypeParameter, node: Node) {
+        function getConstrainedTypeVariable(typeVariable: TypeVariable, node: Node) {
             let constraints: Type[];
             while (isPartOfTypeNode(node)) {
                 const parent = node.parent;
                 if (parent.kind === SyntaxKind.ConditionalType && node === (<ConditionalTypeNode>parent).trueType) {
-                    if (getTypeFromTypeNode((<ConditionalTypeNode>parent).checkType) === typeParameter) {
+                    if (getActualTypeVariable(getTypeFromTypeNode((<ConditionalTypeNode>parent).checkType)) === typeVariable) {
                         constraints = append(constraints, getTypeFromTypeNode((<ConditionalTypeNode>parent).extendsType));
                     }
                 }
                 node = parent;
             }
-            return constraints ? getSubstitutionType(typeParameter, getIntersectionType(append(constraints, typeParameter))) : typeParameter;
+            return constraints ? getSubstitutionType(typeVariable, getIntersectionType(append(constraints, typeVariable))) : typeVariable;
         }
 
         function isJSDocTypeReference(node: TypeReferenceType): node is TypeReferenceNode {
@@ -8256,7 +8256,13 @@ namespace ts {
         function getTypeFromIndexedAccessTypeNode(node: IndexedAccessTypeNode) {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
-                links.resolvedType = getIndexedAccessType(getTypeFromTypeNode(node.objectType), getTypeFromTypeNode(node.indexType), node);
+                const objectType = getTypeFromTypeNode(node.objectType);
+                const indexType = getTypeFromTypeNode(node.indexType);
+                const resolved = getIndexedAccessType(objectType, indexType, node);
+                links.resolvedType = resolved.flags & TypeFlags.IndexedAccess &&
+                    (<IndexedAccessType>resolved).objectType === objectType &&
+                    (<IndexedAccessType>resolved).indexType === indexType ?
+                    getConstrainedTypeVariable(<IndexedAccessType>resolved, node) : resolved;
             }
             return links.resolvedType;
         }
@@ -8276,8 +8282,8 @@ namespace ts {
             return links.resolvedType;
         }
 
-        function getActualTypeParameter(type: Type) {
-            return type.flags & TypeFlags.Substitution ? (<SubstitutionType>type).typeParameter : type;
+        function getActualTypeVariable(type: Type) {
+            return type.flags & TypeFlags.Substitution ? (<SubstitutionType>type).typeVariable : type;
         }
 
         function getConditionalType(root: ConditionalRoot, mapper: TypeMapper): Type {
@@ -8321,7 +8327,7 @@ namespace ts {
                 }
             }
             // Return a deferred type for a check that is neither definitely true nor definitely false
-            const erasedCheckType = getActualTypeParameter(checkType);
+            const erasedCheckType = getActualTypeVariable(checkType);
             const result = <ConditionalType>createType(TypeFlags.Conditional);
             result.root = root;
             result.checkType = erasedCheckType;
@@ -9041,7 +9047,7 @@ namespace ts {
                     return getConditionalTypeInstantiation(<ConditionalType>type, combineTypeMappers((<ConditionalType>type).mapper, mapper));
                 }
                 if (type.flags & TypeFlags.Substitution) {
-                    return mapper((<SubstitutionType>type).typeParameter);
+                    return instantiateType((<SubstitutionType>type).typeVariable, mapper);
                 }
             }
             return type;
@@ -9647,10 +9653,10 @@ namespace ts {
                     target = (<LiteralType>target).regularType;
                 }
                 if (source.flags & TypeFlags.Substitution) {
-                    source = relation === definitelyAssignableRelation ? (<SubstitutionType>source).typeParameter : (<SubstitutionType>source).substitute;
+                    source = relation === definitelyAssignableRelation ? (<SubstitutionType>source).typeVariable : (<SubstitutionType>source).substitute;
                 }
                 if (target.flags & TypeFlags.Substitution) {
-                    target = (<SubstitutionType>target).typeParameter;
+                    target = (<SubstitutionType>target).typeVariable;
                 }
 
                 // both types are the same - covers 'they are the same primitive type or both are Any' or the same type parameter cases

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3844,6 +3844,8 @@ namespace ts {
         constraint?: Type;
     }
 
+    export type TypeVariable = TypeParameter | IndexedAccessType;
+
     // keyof T types (TypeFlags.Index)
     export interface IndexType extends InstantiableType {
         type: InstantiableType | UnionOrIntersectionType;
@@ -3875,14 +3877,14 @@ namespace ts {
     }
 
     // Type parameter substitution (TypeFlags.Substitution)
-    // Substitution types are created for type parameter references that occur in the true branch
-    // of a conditional type. For example, in 'T extends string ? Foo<T> : Bar<T>', the reference to
-    // T in Foo<T> is resolved as a substitution type that substitutes 'string & T' for T. Thus, if
-    // Foo has a 'string' constraint on its type parameter, T will satisfy it. Substitution types
-    // disappear upon instantiation (just like type parameters).
+    // Substitution types are created for type parameters or indexed access types that occur in the
+    // true branch of a conditional type. For example, in 'T extends string ? Foo<T> : Bar<T>', the
+    // reference to T in Foo<T> is resolved as a substitution type that substitutes 'string & T' for T.
+    // Thus, if Foo has a 'string' constraint on its type parameter, T will satisfy it. Substitution
+    // types disappear upon instantiation (just like type parameters).
     export interface SubstitutionType extends InstantiableType {
-        typeParameter: TypeParameter;  // Target type parameter
-        substitute: Type;              // Type to substitute for type parameter
+        typeVariable: TypeVariable;  // Target type variable
+        substitute: Type;            // Type to substitute for type parameter
     }
 
     export const enum SignatureKind {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2192,6 +2192,7 @@ declare namespace ts {
         indexType: Type;
         constraint?: Type;
     }
+    type TypeVariable = TypeParameter | IndexedAccessType;
     interface IndexType extends InstantiableType {
         type: InstantiableType | UnionOrIntersectionType;
     }
@@ -2216,7 +2217,7 @@ declare namespace ts {
         resolvedFalseType?: Type;
     }
     interface SubstitutionType extends InstantiableType {
-        typeParameter: TypeParameter;
+        typeVariable: TypeVariable;
         substitute: Type;
     }
     enum SignatureKind {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2192,6 +2192,7 @@ declare namespace ts {
         indexType: Type;
         constraint?: Type;
     }
+    type TypeVariable = TypeParameter | IndexedAccessType;
     interface IndexType extends InstantiableType {
         type: InstantiableType | UnionOrIntersectionType;
     }
@@ -2216,7 +2217,7 @@ declare namespace ts {
         resolvedFalseType?: Type;
     }
     interface SubstitutionType extends InstantiableType {
-        typeParameter: TypeParameter;
+        typeVariable: TypeVariable;
         substitute: Type;
     }
     enum SignatureKind {

--- a/tests/baselines/reference/conditionalTypes1.errors.txt
+++ b/tests/baselines/reference/conditionalTypes1.errors.txt
@@ -64,8 +64,8 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(159,5): error TS2
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(160,5): error TS2322: Type 'T' is not assignable to type 'ZeroOf<T>'.
   Type 'string | number' is not assignable to type 'ZeroOf<T>'.
     Type 'string' is not assignable to type 'ZeroOf<T>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(254,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'z' must be of type 'T1', but here has type 'Foo<T & U>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(279,43): error TS2322: Type 'T95<U>' is not assignable to type 'T94<U>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(255,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'z' must be of type 'T1', but here has type 'Foo<T & U>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(280,43): error TS2322: Type 'T95<U>' is not assignable to type 'T94<U>'.
   Type 'boolean' is not assignable to type 'true'.
 
 
@@ -321,6 +321,7 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(279,43): error TS
     type T35<T extends { a: string, b: number }> = T[];
     type T36<T> = T extends { a: string } ? T extends { b: number } ? T35<T> : never : never;
     type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never : never;
+    type T38<T> = [T] extends [{ a: string }] ? [T] extends [{ b: number }] ? T35<T> : never : never;
     
     type Extends<T, U> = T extends U ? true : false;
     type If<C extends boolean, T, F> = C extends true ? T : F;

--- a/tests/baselines/reference/conditionalTypes1.errors.txt
+++ b/tests/baselines/reference/conditionalTypes1.errors.txt
@@ -64,8 +64,8 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(159,5): error TS2
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(160,5): error TS2322: Type 'T' is not assignable to type 'ZeroOf<T>'.
   Type 'string | number' is not assignable to type 'ZeroOf<T>'.
     Type 'string' is not assignable to type 'ZeroOf<T>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(250,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'z' must be of type 'T1', but here has type 'Foo<T & U>'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(275,43): error TS2322: Type 'T95<U>' is not assignable to type 'T94<U>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(254,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'z' must be of type 'T1', but here has type 'Foo<T & U>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(279,43): error TS2322: Type 'T95<U>' is not assignable to type 'T94<U>'.
   Type 'boolean' is not assignable to type 'true'.
 
 
@@ -318,6 +318,10 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(275,43): error TS
 !!! error TS2322:     Type 'string' is not assignable to type 'ZeroOf<T>'.
     }
     
+    type T35<T extends { a: string, b: number }> = T[];
+    type T36<T> = T extends { a: string } ? T extends { b: number } ? T35<T> : never : never;
+    type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never : never;
+    
     type Extends<T, U> = T extends U ? true : false;
     type If<C extends boolean, T, F> = C extends true ? T : F;
     type Not<C extends boolean> = If<C, false, true>;
@@ -477,4 +481,15 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(275,43): error TS
     
     type Test1 = NonFooKeys1<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
     type Test2 = NonFooKeys2<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
+    
+    // Repro from #21729
+    
+    interface Foo2 { foo: string; }
+    interface Bar2 { bar: string; }
+    type FooBar = Foo2 | Bar2;
+    declare interface ExtractFooBar<FB extends FooBar> { }
+    
+    type Extracted<Struct> = {
+        [K in keyof Struct]: Struct[K] extends FooBar ? ExtractFooBar<Struct[K]> : Struct[K];
+    }
     

--- a/tests/baselines/reference/conditionalTypes1.js
+++ b/tests/baselines/reference/conditionalTypes1.js
@@ -164,6 +164,7 @@ function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
 type T35<T extends { a: string, b: number }> = T[];
 type T36<T> = T extends { a: string } ? T extends { b: number } ? T35<T> : never : never;
 type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never : never;
+type T38<T> = [T] extends [{ a: string }] ? [T] extends [{ b: number }] ? T35<T> : never : never;
 
 type Extends<T, U> = T extends U ? true : false;
 type If<C extends boolean, T, F> = C extends true ? T : F;
@@ -546,6 +547,11 @@ declare type T37<T> = T extends {
 } ? T extends {
     a: string;
 } ? T35<T> : never : never;
+declare type T38<T> = [T] extends [{
+    a: string;
+}] ? [T] extends [{
+    b: number;
+}] ? T35<T> : never : never;
 declare type Extends<T, U> = T extends U ? true : false;
 declare type If<C extends boolean, T, F> = C extends true ? T : F;
 declare type Not<C extends boolean> = If<C, false, true>;

--- a/tests/baselines/reference/conditionalTypes1.js
+++ b/tests/baselines/reference/conditionalTypes1.js
@@ -161,6 +161,10 @@ function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
     y = x;  // Error
 }
 
+type T35<T extends { a: string, b: number }> = T[];
+type T36<T> = T extends { a: string } ? T extends { b: number } ? T35<T> : never : never;
+type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never : never;
+
 type Extends<T, U> = T extends U ? true : false;
 type If<C extends boolean, T, F> = C extends true ? T : F;
 type Not<C extends boolean> = If<C, false, true>;
@@ -315,6 +319,17 @@ type NonFooKeys2<T extends object> = Exclude<keyof T, 'foo'>;
 
 type Test1 = NonFooKeys1<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
 type Test2 = NonFooKeys2<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
+
+// Repro from #21729
+
+interface Foo2 { foo: string; }
+interface Bar2 { bar: string; }
+type FooBar = Foo2 | Bar2;
+declare interface ExtractFooBar<FB extends FooBar> { }
+
+type Extracted<Struct> = {
+    [K in keyof Struct]: Struct[K] extends FooBar ? ExtractFooBar<Struct[K]> : Struct[K];
+}
 
 
 //// [conditionalTypes1.js]
@@ -517,6 +532,20 @@ declare type ZeroOf<T extends number | string | boolean> = T extends number ? 0 
 declare function zeroOf<T extends number | string | boolean>(value: T): ZeroOf<T>;
 declare function f20<T extends string>(n: number, b: boolean, x: number | boolean, y: T): void;
 declare function f21<T extends number | string>(x: T, y: ZeroOf<T>): void;
+declare type T35<T extends {
+    a: string;
+    b: number;
+}> = T[];
+declare type T36<T> = T extends {
+    a: string;
+} ? T extends {
+    b: number;
+} ? T35<T> : never : never;
+declare type T37<T> = T extends {
+    b: number;
+} ? T extends {
+    a: string;
+} ? T35<T> : never : never;
 declare type Extends<T, U> = T extends U ? true : false;
 declare type If<C extends boolean, T, F> = C extends true ? T : F;
 declare type Not<C extends boolean> = If<C, false, true>;
@@ -624,3 +653,15 @@ declare type Test2 = NonFooKeys2<{
     bar: 2;
     baz: 3;
 }>;
+interface Foo2 {
+    foo: string;
+}
+interface Bar2 {
+    bar: string;
+}
+declare type FooBar = Foo2 | Bar2;
+declare interface ExtractFooBar<FB extends FooBar> {
+}
+declare type Extracted<Struct> = {
+    [K in keyof Struct]: Struct[K] extends FooBar ? ExtractFooBar<Struct[K]> : Struct[K];
+};

--- a/tests/baselines/reference/conditionalTypes1.symbols
+++ b/tests/baselines/reference/conditionalTypes1.symbols
@@ -612,608 +612,672 @@ function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
 >x : Symbol(x, Decl(conditionalTypes1.ts, 155, 40))
 }
 
+type T35<T extends { a: string, b: number }> = T[];
+>T35 : Symbol(T35, Decl(conditionalTypes1.ts, 160, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 162, 9))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 162, 20))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 162, 31))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 162, 9))
+
+type T36<T> = T extends { a: string } ? T extends { b: number } ? T35<T> : never : never;
+>T36 : Symbol(T36, Decl(conditionalTypes1.ts, 162, 51))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 163, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 163, 9))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 163, 25))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 163, 9))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 163, 51))
+>T35 : Symbol(T35, Decl(conditionalTypes1.ts, 160, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 163, 9))
+
+type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never : never;
+>T37 : Symbol(T37, Decl(conditionalTypes1.ts, 163, 89))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 164, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 164, 9))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 164, 25))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 164, 9))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 164, 51))
+>T35 : Symbol(T35, Decl(conditionalTypes1.ts, 160, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 164, 9))
+
 type Extends<T, U> = T extends U ? true : false;
->Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 160, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 162, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 162, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 162, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 162, 15))
+>Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 164, 89))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 166, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 166, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 166, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 166, 15))
 
 type If<C extends boolean, T, F> = C extends true ? T : F;
->If : Symbol(If, Decl(conditionalTypes1.ts, 162, 48))
->C : Symbol(C, Decl(conditionalTypes1.ts, 163, 8))
->T : Symbol(T, Decl(conditionalTypes1.ts, 163, 26))
->F : Symbol(F, Decl(conditionalTypes1.ts, 163, 29))
->C : Symbol(C, Decl(conditionalTypes1.ts, 163, 8))
->T : Symbol(T, Decl(conditionalTypes1.ts, 163, 26))
->F : Symbol(F, Decl(conditionalTypes1.ts, 163, 29))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 167, 8))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 167, 26))
+>F : Symbol(F, Decl(conditionalTypes1.ts, 167, 29))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 167, 8))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 167, 26))
+>F : Symbol(F, Decl(conditionalTypes1.ts, 167, 29))
 
 type Not<C extends boolean> = If<C, false, true>;
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 163, 58))
->C : Symbol(C, Decl(conditionalTypes1.ts, 164, 9))
->If : Symbol(If, Decl(conditionalTypes1.ts, 162, 48))
->C : Symbol(C, Decl(conditionalTypes1.ts, 164, 9))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 168, 9))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 168, 9))
 
 type And<A extends boolean, B extends boolean> = If<A, B, false>;
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
->A : Symbol(A, Decl(conditionalTypes1.ts, 165, 9))
->B : Symbol(B, Decl(conditionalTypes1.ts, 165, 27))
->If : Symbol(If, Decl(conditionalTypes1.ts, 162, 48))
->A : Symbol(A, Decl(conditionalTypes1.ts, 165, 9))
->B : Symbol(B, Decl(conditionalTypes1.ts, 165, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 169, 9))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 169, 27))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 169, 9))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 169, 27))
 
 type Or<A extends boolean, B extends boolean> = If<A, true, B>;
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
->A : Symbol(A, Decl(conditionalTypes1.ts, 166, 8))
->B : Symbol(B, Decl(conditionalTypes1.ts, 166, 26))
->If : Symbol(If, Decl(conditionalTypes1.ts, 162, 48))
->A : Symbol(A, Decl(conditionalTypes1.ts, 166, 8))
->B : Symbol(B, Decl(conditionalTypes1.ts, 166, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 170, 8))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 170, 26))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 170, 8))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 170, 26))
 
 type IsString<T> = Extends<T, string>;
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 166, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 168, 14))
->Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 160, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 168, 14))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 172, 14))
+>Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 164, 89))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 172, 14))
 
 type Q1 = IsString<number>;  // false
->Q1 : Symbol(Q1, Decl(conditionalTypes1.ts, 168, 38))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 166, 63))
+>Q1 : Symbol(Q1, Decl(conditionalTypes1.ts, 172, 38))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
 
 type Q2 = IsString<"abc">;  // true
->Q2 : Symbol(Q2, Decl(conditionalTypes1.ts, 170, 27))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 166, 63))
+>Q2 : Symbol(Q2, Decl(conditionalTypes1.ts, 174, 27))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
 
 type Q3 = IsString<any>;  // boolean
->Q3 : Symbol(Q3, Decl(conditionalTypes1.ts, 171, 26))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 166, 63))
+>Q3 : Symbol(Q3, Decl(conditionalTypes1.ts, 175, 26))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
 
 type Q4 = IsString<never>;  // never
->Q4 : Symbol(Q4, Decl(conditionalTypes1.ts, 172, 24))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 166, 63))
+>Q4 : Symbol(Q4, Decl(conditionalTypes1.ts, 176, 24))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
 
 type N1 = Not<false>;  // true
->N1 : Symbol(N1, Decl(conditionalTypes1.ts, 173, 26))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 163, 58))
+>N1 : Symbol(N1, Decl(conditionalTypes1.ts, 177, 26))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
 
 type N2 = Not<true>;  // false
->N2 : Symbol(N2, Decl(conditionalTypes1.ts, 175, 21))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 163, 58))
+>N2 : Symbol(N2, Decl(conditionalTypes1.ts, 179, 21))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
 
 type N3 = Not<boolean>;  // boolean
->N3 : Symbol(N3, Decl(conditionalTypes1.ts, 176, 20))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 163, 58))
+>N3 : Symbol(N3, Decl(conditionalTypes1.ts, 180, 20))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
 
 type A1 = And<false, false>;  // false
->A1 : Symbol(A1, Decl(conditionalTypes1.ts, 177, 23))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A1 : Symbol(A1, Decl(conditionalTypes1.ts, 181, 23))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A2 = And<false, true>;  // false
->A2 : Symbol(A2, Decl(conditionalTypes1.ts, 179, 28))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A2 : Symbol(A2, Decl(conditionalTypes1.ts, 183, 28))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A3 = And<true, false>;  // false
->A3 : Symbol(A3, Decl(conditionalTypes1.ts, 180, 27))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A3 : Symbol(A3, Decl(conditionalTypes1.ts, 184, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A4 = And<true, true>;  // true
->A4 : Symbol(A4, Decl(conditionalTypes1.ts, 181, 27))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A4 : Symbol(A4, Decl(conditionalTypes1.ts, 185, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A5 = And<boolean, false>;  // false
->A5 : Symbol(A5, Decl(conditionalTypes1.ts, 182, 26))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A5 : Symbol(A5, Decl(conditionalTypes1.ts, 186, 26))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A6 = And<false, boolean>;  // false
->A6 : Symbol(A6, Decl(conditionalTypes1.ts, 183, 30))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A6 : Symbol(A6, Decl(conditionalTypes1.ts, 187, 30))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A7 = And<boolean, true>;  // boolean
->A7 : Symbol(A7, Decl(conditionalTypes1.ts, 184, 30))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A7 : Symbol(A7, Decl(conditionalTypes1.ts, 188, 30))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A8 = And<true, boolean>;  // boolean
->A8 : Symbol(A8, Decl(conditionalTypes1.ts, 185, 29))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A8 : Symbol(A8, Decl(conditionalTypes1.ts, 189, 29))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type A9 = And<boolean, boolean>;  // boolean
->A9 : Symbol(A9, Decl(conditionalTypes1.ts, 186, 29))
->And : Symbol(And, Decl(conditionalTypes1.ts, 164, 49))
+>A9 : Symbol(A9, Decl(conditionalTypes1.ts, 190, 29))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
 
 type O1 = Or<false, false>;  // false
->O1 : Symbol(O1, Decl(conditionalTypes1.ts, 187, 32))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O1 : Symbol(O1, Decl(conditionalTypes1.ts, 191, 32))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O2 = Or<false, true>;  // true
->O2 : Symbol(O2, Decl(conditionalTypes1.ts, 189, 27))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O2 : Symbol(O2, Decl(conditionalTypes1.ts, 193, 27))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O3 = Or<true, false>;  // true
->O3 : Symbol(O3, Decl(conditionalTypes1.ts, 190, 26))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O3 : Symbol(O3, Decl(conditionalTypes1.ts, 194, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O4 = Or<true, true>;  // true
->O4 : Symbol(O4, Decl(conditionalTypes1.ts, 191, 26))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O4 : Symbol(O4, Decl(conditionalTypes1.ts, 195, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O5 = Or<boolean, false>;  // boolean
->O5 : Symbol(O5, Decl(conditionalTypes1.ts, 192, 25))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O5 : Symbol(O5, Decl(conditionalTypes1.ts, 196, 25))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O6 = Or<false, boolean>;  // boolean
->O6 : Symbol(O6, Decl(conditionalTypes1.ts, 193, 29))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O6 : Symbol(O6, Decl(conditionalTypes1.ts, 197, 29))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O7 = Or<boolean, true>;  // true
->O7 : Symbol(O7, Decl(conditionalTypes1.ts, 194, 29))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O7 : Symbol(O7, Decl(conditionalTypes1.ts, 198, 29))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O8 = Or<true, boolean>;  // true
->O8 : Symbol(O8, Decl(conditionalTypes1.ts, 195, 28))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O8 : Symbol(O8, Decl(conditionalTypes1.ts, 199, 28))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type O9 = Or<boolean, boolean>;  // boolean
->O9 : Symbol(O9, Decl(conditionalTypes1.ts, 196, 28))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 165, 65))
+>O9 : Symbol(O9, Decl(conditionalTypes1.ts, 200, 28))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
 
 type T40 = never extends never ? true : false;  // true
->T40 : Symbol(T40, Decl(conditionalTypes1.ts, 197, 31))
+>T40 : Symbol(T40, Decl(conditionalTypes1.ts, 201, 31))
 
 type T41 = number extends never ? true : false;  // false
->T41 : Symbol(T41, Decl(conditionalTypes1.ts, 199, 46))
+>T41 : Symbol(T41, Decl(conditionalTypes1.ts, 203, 46))
 
 type T42 = never extends number ? true : false;  // true
->T42 : Symbol(T42, Decl(conditionalTypes1.ts, 200, 47))
+>T42 : Symbol(T42, Decl(conditionalTypes1.ts, 204, 47))
 
 type IsNever<T> = [T] extends [never] ? true : false;
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 201, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 203, 13))
->T : Symbol(T, Decl(conditionalTypes1.ts, 203, 13))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 207, 13))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 207, 13))
 
 type T50 = IsNever<never>;  // true
->T50 : Symbol(T50, Decl(conditionalTypes1.ts, 203, 53))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 201, 47))
+>T50 : Symbol(T50, Decl(conditionalTypes1.ts, 207, 53))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
 
 type T51 = IsNever<number>;  // false
->T51 : Symbol(T51, Decl(conditionalTypes1.ts, 205, 26))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 201, 47))
+>T51 : Symbol(T51, Decl(conditionalTypes1.ts, 209, 26))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
 
 type T52 = IsNever<any>;  // false
->T52 : Symbol(T52, Decl(conditionalTypes1.ts, 206, 27))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 201, 47))
+>T52 : Symbol(T52, Decl(conditionalTypes1.ts, 210, 27))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
 
 // Repros from #21664
 
 type Eq<T, U> = T extends U ? U extends T ? true : false : false;
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 207, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 211, 8))
->U : Symbol(U, Decl(conditionalTypes1.ts, 211, 10))
->T : Symbol(T, Decl(conditionalTypes1.ts, 211, 8))
->U : Symbol(U, Decl(conditionalTypes1.ts, 211, 10))
->U : Symbol(U, Decl(conditionalTypes1.ts, 211, 10))
->T : Symbol(T, Decl(conditionalTypes1.ts, 211, 8))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
 
 type T60 = Eq<true, true>;  // true
->T60 : Symbol(T60, Decl(conditionalTypes1.ts, 211, 65))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 207, 24))
+>T60 : Symbol(T60, Decl(conditionalTypes1.ts, 215, 65))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
 
 type T61 = Eq<true, false>;  // false
->T61 : Symbol(T61, Decl(conditionalTypes1.ts, 212, 26))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 207, 24))
+>T61 : Symbol(T61, Decl(conditionalTypes1.ts, 216, 26))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
 
 type T62 = Eq<false, true>;  // false
->T62 : Symbol(T62, Decl(conditionalTypes1.ts, 213, 27))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 207, 24))
+>T62 : Symbol(T62, Decl(conditionalTypes1.ts, 217, 27))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
 
 type T63 = Eq<false, false>;  // true
->T63 : Symbol(T63, Decl(conditionalTypes1.ts, 214, 27))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 207, 24))
+>T63 : Symbol(T63, Decl(conditionalTypes1.ts, 218, 27))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
 
 type Eq1<T, U> = Eq<T, U> extends false ? false : true;
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 215, 28))
->T : Symbol(T, Decl(conditionalTypes1.ts, 217, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 217, 11))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 207, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 217, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 217, 11))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 221, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 221, 11))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 221, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 221, 11))
 
 type T70 = Eq1<true, true>;  // true
->T70 : Symbol(T70, Decl(conditionalTypes1.ts, 217, 55))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 215, 28))
+>T70 : Symbol(T70, Decl(conditionalTypes1.ts, 221, 55))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
 
 type T71 = Eq1<true, false>;  // false
->T71 : Symbol(T71, Decl(conditionalTypes1.ts, 218, 27))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 215, 28))
+>T71 : Symbol(T71, Decl(conditionalTypes1.ts, 222, 27))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
 
 type T72 = Eq1<false, true>;  // false
->T72 : Symbol(T72, Decl(conditionalTypes1.ts, 219, 28))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 215, 28))
+>T72 : Symbol(T72, Decl(conditionalTypes1.ts, 223, 28))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
 
 type T73 = Eq1<false, false>;  // true
->T73 : Symbol(T73, Decl(conditionalTypes1.ts, 220, 28))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 215, 28))
+>T73 : Symbol(T73, Decl(conditionalTypes1.ts, 224, 28))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
 
 type Eq2<T, U> = Eq<T, U> extends true ? true : false;
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 221, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 223, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 223, 11))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 207, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 223, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 223, 11))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 227, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 227, 11))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 227, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 227, 11))
 
 type T80 = Eq2<true, true>;  // true
->T80 : Symbol(T80, Decl(conditionalTypes1.ts, 223, 54))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 221, 29))
+>T80 : Symbol(T80, Decl(conditionalTypes1.ts, 227, 54))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
 
 type T81 = Eq2<true, false>;  // false
->T81 : Symbol(T81, Decl(conditionalTypes1.ts, 224, 27))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 221, 29))
+>T81 : Symbol(T81, Decl(conditionalTypes1.ts, 228, 27))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
 
 type T82 = Eq2<false, true>;  // false
->T82 : Symbol(T82, Decl(conditionalTypes1.ts, 225, 28))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 221, 29))
+>T82 : Symbol(T82, Decl(conditionalTypes1.ts, 229, 28))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
 
 type T83 = Eq2<false, false>;  // true
->T83 : Symbol(T83, Decl(conditionalTypes1.ts, 226, 28))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 221, 29))
+>T83 : Symbol(T83, Decl(conditionalTypes1.ts, 230, 28))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
 
 // Repro from #21756
 
 type Foo<T> = T extends string ? boolean : number;
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 227, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 231, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 231, 9))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 235, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 235, 9))
 
 type Bar<T> = T extends string ? boolean : number;
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 231, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 232, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 232, 9))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 236, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 236, 9))
 
 const convert = <U>(value: Foo<U>): Bar<U> => value;
->convert : Symbol(convert, Decl(conditionalTypes1.ts, 233, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 233, 17))
->value : Symbol(value, Decl(conditionalTypes1.ts, 233, 20))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 227, 29))
->U : Symbol(U, Decl(conditionalTypes1.ts, 233, 17))
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 231, 50))
->U : Symbol(U, Decl(conditionalTypes1.ts, 233, 17))
->value : Symbol(value, Decl(conditionalTypes1.ts, 233, 20))
+>convert : Symbol(convert, Decl(conditionalTypes1.ts, 237, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 237, 20))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 237, 20))
 
 type Baz<T> = Foo<T>;
->Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 233, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 9))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 227, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 9))
+>Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 237, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 239, 9))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 239, 9))
 
 const convert2 = <T>(value: Foo<T>): Baz<T> => value;
->convert2 : Symbol(convert2, Decl(conditionalTypes1.ts, 236, 5))
->T : Symbol(T, Decl(conditionalTypes1.ts, 236, 18))
->value : Symbol(value, Decl(conditionalTypes1.ts, 236, 21))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 227, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 236, 18))
->Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 233, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 236, 18))
->value : Symbol(value, Decl(conditionalTypes1.ts, 236, 21))
+>convert2 : Symbol(convert2, Decl(conditionalTypes1.ts, 240, 5))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 240, 21))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
+>Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 237, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 240, 21))
 
 function f31<T>() {
->f31 : Symbol(f31, Decl(conditionalTypes1.ts, 236, 53))
->T : Symbol(T, Decl(conditionalTypes1.ts, 238, 13))
+>f31 : Symbol(f31, Decl(conditionalTypes1.ts, 240, 53))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
 
     type T1 = T extends string ? boolean : number;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 238, 19))
->T : Symbol(T, Decl(conditionalTypes1.ts, 238, 13))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 19))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
 
     type T2 = T extends string ? boolean : number;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 239, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 238, 13))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
 
     var x: T1;
->x : Symbol(x, Decl(conditionalTypes1.ts, 241, 7), Decl(conditionalTypes1.ts, 242, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 238, 19))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 19))
 
     var x: T2;
->x : Symbol(x, Decl(conditionalTypes1.ts, 241, 7), Decl(conditionalTypes1.ts, 242, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 239, 50))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 50))
 }
 
 function f32<T, U>() {
->f32 : Symbol(f32, Decl(conditionalTypes1.ts, 243, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 245, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 245, 15))
+>f32 : Symbol(f32, Decl(conditionalTypes1.ts, 247, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
 
     type T1 = T & U extends string ? boolean : number;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 245, 22))
->T : Symbol(T, Decl(conditionalTypes1.ts, 245, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 245, 15))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
 
     type T2 = Foo<T & U>;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 246, 54))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 227, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 245, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 245, 15))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 54))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
 
     var z: T1;
->z : Symbol(z, Decl(conditionalTypes1.ts, 248, 7), Decl(conditionalTypes1.ts, 249, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 245, 22))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
 
     var z: T2;  // Error, T2 is distributive, T1 isn't
->z : Symbol(z, Decl(conditionalTypes1.ts, 248, 7), Decl(conditionalTypes1.ts, 249, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 246, 54))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 54))
 }
 
 function f33<T, U>() {
->f33 : Symbol(f33, Decl(conditionalTypes1.ts, 250, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 252, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 252, 15))
+>f33 : Symbol(f33, Decl(conditionalTypes1.ts, 254, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
 
     type T1 = Foo<T & U>;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 252, 22))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 227, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 252, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 252, 15))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 256, 22))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
 
     type T2 = Bar<T & U>;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 253, 25))
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 231, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 252, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 252, 15))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 257, 25))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
 
     var z: T1;
->z : Symbol(z, Decl(conditionalTypes1.ts, 255, 7), Decl(conditionalTypes1.ts, 256, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 252, 22))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 259, 7), Decl(conditionalTypes1.ts, 260, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 256, 22))
 
     var z: T2;
->z : Symbol(z, Decl(conditionalTypes1.ts, 255, 7), Decl(conditionalTypes1.ts, 256, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 253, 25))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 259, 7), Decl(conditionalTypes1.ts, 260, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 257, 25))
 }
 
 // Repro from #21823
 
 type T90<T> = T extends 0 ? 0 : () => 0;
->T90 : Symbol(T90, Decl(conditionalTypes1.ts, 257, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 261, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 261, 9))
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 265, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 265, 9))
 
 type T91<T> = T extends 0 ? 0 : () => 0;
->T91 : Symbol(T91, Decl(conditionalTypes1.ts, 261, 40))
->T : Symbol(T, Decl(conditionalTypes1.ts, 262, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 262, 9))
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
 
 const f40 = <U>(a: T90<U>): T91<U> => a;
->f40 : Symbol(f40, Decl(conditionalTypes1.ts, 263, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 263, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 263, 16))
->T90 : Symbol(T90, Decl(conditionalTypes1.ts, 257, 1))
->U : Symbol(U, Decl(conditionalTypes1.ts, 263, 13))
->T91 : Symbol(T91, Decl(conditionalTypes1.ts, 261, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 263, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 263, 16))
+>f40 : Symbol(f40, Decl(conditionalTypes1.ts, 267, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 267, 16))
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 267, 16))
 
 const f41 = <U>(a: T91<U>): T90<U> => a;
->f41 : Symbol(f41, Decl(conditionalTypes1.ts, 264, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 264, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 264, 16))
->T91 : Symbol(T91, Decl(conditionalTypes1.ts, 261, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 264, 13))
->T90 : Symbol(T90, Decl(conditionalTypes1.ts, 257, 1))
->U : Symbol(U, Decl(conditionalTypes1.ts, 264, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 264, 16))
+>f41 : Symbol(f41, Decl(conditionalTypes1.ts, 268, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
 
 type T92<T> = T extends () => 0 ? () => 1 : () => 2;
->T92 : Symbol(T92, Decl(conditionalTypes1.ts, 264, 40))
->T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 270, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 270, 9))
 
 type T93<T> = T extends () => 0 ? () => 1 : () => 2;
->T93 : Symbol(T93, Decl(conditionalTypes1.ts, 266, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 267, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 267, 9))
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
 
 const f42 = <U>(a: T92<U>): T93<U> => a;
->f42 : Symbol(f42, Decl(conditionalTypes1.ts, 268, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
->T92 : Symbol(T92, Decl(conditionalTypes1.ts, 264, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
->T93 : Symbol(T93, Decl(conditionalTypes1.ts, 266, 52))
->U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
+>f42 : Symbol(f42, Decl(conditionalTypes1.ts, 272, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 272, 16))
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 272, 16))
 
 const f43 = <U>(a: T93<U>): T92<U> => a;
->f43 : Symbol(f43, Decl(conditionalTypes1.ts, 269, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 269, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 269, 16))
->T93 : Symbol(T93, Decl(conditionalTypes1.ts, 266, 52))
->U : Symbol(U, Decl(conditionalTypes1.ts, 269, 13))
->T92 : Symbol(T92, Decl(conditionalTypes1.ts, 264, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 269, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 269, 16))
+>f43 : Symbol(f43, Decl(conditionalTypes1.ts, 273, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 273, 16))
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 273, 16))
 
 type T94<T> = T extends string ? true : 42;
->T94 : Symbol(T94, Decl(conditionalTypes1.ts, 269, 40))
->T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 275, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 275, 9))
 
 type T95<T> = T extends string ? boolean : number;
->T95 : Symbol(T95, Decl(conditionalTypes1.ts, 271, 43))
->T : Symbol(T, Decl(conditionalTypes1.ts, 272, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 272, 9))
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 276, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 276, 9))
 
 const f44 = <U>(value: T94<U>): T95<U> => value;
->f44 : Symbol(f44, Decl(conditionalTypes1.ts, 273, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
->value : Symbol(value, Decl(conditionalTypes1.ts, 273, 16))
->T94 : Symbol(T94, Decl(conditionalTypes1.ts, 269, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
->T95 : Symbol(T95, Decl(conditionalTypes1.ts, 271, 43))
->U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
->value : Symbol(value, Decl(conditionalTypes1.ts, 273, 16))
+>f44 : Symbol(f44, Decl(conditionalTypes1.ts, 277, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 277, 16))
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 277, 16))
 
 const f45 = <U>(value: T95<U>): T94<U> => value;  // Error
->f45 : Symbol(f45, Decl(conditionalTypes1.ts, 274, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 274, 13))
->value : Symbol(value, Decl(conditionalTypes1.ts, 274, 16))
->T95 : Symbol(T95, Decl(conditionalTypes1.ts, 271, 43))
->U : Symbol(U, Decl(conditionalTypes1.ts, 274, 13))
->T94 : Symbol(T94, Decl(conditionalTypes1.ts, 269, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 274, 13))
->value : Symbol(value, Decl(conditionalTypes1.ts, 274, 16))
+>f45 : Symbol(f45, Decl(conditionalTypes1.ts, 278, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 278, 16))
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 278, 16))
 
 // Repro from #21863
 
 function f50() {
->f50 : Symbol(f50, Decl(conditionalTypes1.ts, 274, 48))
+>f50 : Symbol(f50, Decl(conditionalTypes1.ts, 278, 48))
 
     type Eq<T, U> = T extends U ? U extends T ? true : false : false;
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 278, 16))
->T : Symbol(T, Decl(conditionalTypes1.ts, 279, 12))
->U : Symbol(U, Decl(conditionalTypes1.ts, 279, 14))
->T : Symbol(T, Decl(conditionalTypes1.ts, 279, 12))
->U : Symbol(U, Decl(conditionalTypes1.ts, 279, 14))
->U : Symbol(U, Decl(conditionalTypes1.ts, 279, 14))
->T : Symbol(T, Decl(conditionalTypes1.ts, 279, 12))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 282, 16))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 283, 12))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 283, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 283, 12))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 283, 14))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 283, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 283, 12))
 
     type If<S, T, U> = S extends false ? U : T;
->If : Symbol(If, Decl(conditionalTypes1.ts, 279, 69))
->S : Symbol(S, Decl(conditionalTypes1.ts, 280, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 280, 14))
->U : Symbol(U, Decl(conditionalTypes1.ts, 280, 17))
->S : Symbol(S, Decl(conditionalTypes1.ts, 280, 12))
->U : Symbol(U, Decl(conditionalTypes1.ts, 280, 17))
->T : Symbol(T, Decl(conditionalTypes1.ts, 280, 14))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 283, 69))
+>S : Symbol(S, Decl(conditionalTypes1.ts, 284, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 284, 14))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 284, 17))
+>S : Symbol(S, Decl(conditionalTypes1.ts, 284, 12))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 284, 17))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 284, 14))
 
     type Omit<T extends object> = { [P in keyof T]: If<Eq<T[P], never>, never, P>; }[keyof T];
->Omit : Symbol(Omit, Decl(conditionalTypes1.ts, 280, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 281, 14))
->P : Symbol(P, Decl(conditionalTypes1.ts, 281, 37))
->T : Symbol(T, Decl(conditionalTypes1.ts, 281, 14))
->If : Symbol(If, Decl(conditionalTypes1.ts, 279, 69))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 278, 16))
->T : Symbol(T, Decl(conditionalTypes1.ts, 281, 14))
->P : Symbol(P, Decl(conditionalTypes1.ts, 281, 37))
->P : Symbol(P, Decl(conditionalTypes1.ts, 281, 37))
->T : Symbol(T, Decl(conditionalTypes1.ts, 281, 14))
+>Omit : Symbol(Omit, Decl(conditionalTypes1.ts, 284, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 285, 37))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 283, 69))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 282, 16))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 285, 37))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 285, 37))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
 
     type Omit2<T extends object, U = never> = { [P in keyof T]: If<Eq<T[P], U>, never, P>; }[keyof T];
->Omit2 : Symbol(Omit2, Decl(conditionalTypes1.ts, 281, 94))
->T : Symbol(T, Decl(conditionalTypes1.ts, 282, 15))
->U : Symbol(U, Decl(conditionalTypes1.ts, 282, 32))
->P : Symbol(P, Decl(conditionalTypes1.ts, 282, 49))
->T : Symbol(T, Decl(conditionalTypes1.ts, 282, 15))
->If : Symbol(If, Decl(conditionalTypes1.ts, 279, 69))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 278, 16))
->T : Symbol(T, Decl(conditionalTypes1.ts, 282, 15))
->P : Symbol(P, Decl(conditionalTypes1.ts, 282, 49))
->U : Symbol(U, Decl(conditionalTypes1.ts, 282, 32))
->P : Symbol(P, Decl(conditionalTypes1.ts, 282, 49))
->T : Symbol(T, Decl(conditionalTypes1.ts, 282, 15))
+>Omit2 : Symbol(Omit2, Decl(conditionalTypes1.ts, 285, 94))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 286, 15))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 286, 32))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 286, 49))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 286, 15))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 283, 69))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 282, 16))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 286, 15))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 286, 49))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 286, 32))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 286, 49))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 286, 15))
 
     type A = Omit<{ a: void; b: never; }>;  // 'a'
->A : Symbol(A, Decl(conditionalTypes1.ts, 282, 102))
->Omit : Symbol(Omit, Decl(conditionalTypes1.ts, 280, 47))
->a : Symbol(a, Decl(conditionalTypes1.ts, 283, 19))
->b : Symbol(b, Decl(conditionalTypes1.ts, 283, 28))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 286, 102))
+>Omit : Symbol(Omit, Decl(conditionalTypes1.ts, 284, 47))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 287, 19))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 287, 28))
 
     type B = Omit2<{ a: void; b: never; }>;  // 'a'
->B : Symbol(B, Decl(conditionalTypes1.ts, 283, 42))
->Omit2 : Symbol(Omit2, Decl(conditionalTypes1.ts, 281, 94))
->a : Symbol(a, Decl(conditionalTypes1.ts, 284, 20))
->b : Symbol(b, Decl(conditionalTypes1.ts, 284, 29))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 287, 42))
+>Omit2 : Symbol(Omit2, Decl(conditionalTypes1.ts, 285, 94))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 288, 20))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 288, 29))
 }
 
 // Repro from #21862
 
 type OldDiff<T extends string, U extends string> = (
->OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 285, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 289, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 289, 30))
+>OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 289, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 293, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 293, 30))
 
     & { [P in T]: P; }
->P : Symbol(P, Decl(conditionalTypes1.ts, 290, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 289, 13))
->P : Symbol(P, Decl(conditionalTypes1.ts, 290, 9))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 294, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 293, 13))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 294, 9))
 
     & { [P in U]: never; }
->P : Symbol(P, Decl(conditionalTypes1.ts, 291, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 289, 30))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 295, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 293, 30))
 
     & { [x: string]: never; }
->x : Symbol(x, Decl(conditionalTypes1.ts, 292, 9))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 296, 9))
 
 )[T];
->T : Symbol(T, Decl(conditionalTypes1.ts, 289, 13))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 293, 13))
 
 type NewDiff<T, U> = T extends U ? never : T;
->NewDiff : Symbol(NewDiff, Decl(conditionalTypes1.ts, 293, 5))
->T : Symbol(T, Decl(conditionalTypes1.ts, 294, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 294, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 294, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 294, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 294, 13))
+>NewDiff : Symbol(NewDiff, Decl(conditionalTypes1.ts, 297, 5))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 298, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 298, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 298, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 298, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 298, 13))
 
 interface A {
->A : Symbol(A, Decl(conditionalTypes1.ts, 294, 45))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
 
     a: 'a';
->a : Symbol(A.a, Decl(conditionalTypes1.ts, 295, 13))
+>a : Symbol(A.a, Decl(conditionalTypes1.ts, 299, 13))
 }
 interface B1 extends A {
->B1 : Symbol(B1, Decl(conditionalTypes1.ts, 297, 1))
->A : Symbol(A, Decl(conditionalTypes1.ts, 294, 45))
+>B1 : Symbol(B1, Decl(conditionalTypes1.ts, 301, 1))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
 
     b: 'b';
->b : Symbol(B1.b, Decl(conditionalTypes1.ts, 298, 24))
+>b : Symbol(B1.b, Decl(conditionalTypes1.ts, 302, 24))
 
     c: OldDiff<keyof this, keyof A>;
->c : Symbol(B1.c, Decl(conditionalTypes1.ts, 299, 11))
->OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 285, 1))
->A : Symbol(A, Decl(conditionalTypes1.ts, 294, 45))
+>c : Symbol(B1.c, Decl(conditionalTypes1.ts, 303, 11))
+>OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 289, 1))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
 }
 interface B2 extends A {
->B2 : Symbol(B2, Decl(conditionalTypes1.ts, 301, 1))
->A : Symbol(A, Decl(conditionalTypes1.ts, 294, 45))
+>B2 : Symbol(B2, Decl(conditionalTypes1.ts, 305, 1))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
 
     b: 'b';
->b : Symbol(B2.b, Decl(conditionalTypes1.ts, 302, 24))
+>b : Symbol(B2.b, Decl(conditionalTypes1.ts, 306, 24))
 
     c: NewDiff<keyof this, keyof A>;
->c : Symbol(B2.c, Decl(conditionalTypes1.ts, 303, 11))
->NewDiff : Symbol(NewDiff, Decl(conditionalTypes1.ts, 293, 5))
->A : Symbol(A, Decl(conditionalTypes1.ts, 294, 45))
+>c : Symbol(B2.c, Decl(conditionalTypes1.ts, 307, 11))
+>NewDiff : Symbol(NewDiff, Decl(conditionalTypes1.ts, 297, 5))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
 }
 type c1 = B1['c']; // 'c' | 'b'
->c1 : Symbol(c1, Decl(conditionalTypes1.ts, 305, 1))
->B1 : Symbol(B1, Decl(conditionalTypes1.ts, 297, 1))
+>c1 : Symbol(c1, Decl(conditionalTypes1.ts, 309, 1))
+>B1 : Symbol(B1, Decl(conditionalTypes1.ts, 301, 1))
 
 type c2 = B2['c']; // 'c' | 'b'
->c2 : Symbol(c2, Decl(conditionalTypes1.ts, 306, 18))
->B2 : Symbol(B2, Decl(conditionalTypes1.ts, 301, 1))
+>c2 : Symbol(c2, Decl(conditionalTypes1.ts, 310, 18))
+>B2 : Symbol(B2, Decl(conditionalTypes1.ts, 305, 1))
 
 // Repro from #21929
 
 type NonFooKeys1<T extends object> = OldDiff<keyof T, 'foo'>;
->NonFooKeys1 : Symbol(NonFooKeys1, Decl(conditionalTypes1.ts, 307, 18))
->T : Symbol(T, Decl(conditionalTypes1.ts, 311, 17))
->OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 285, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 311, 17))
+>NonFooKeys1 : Symbol(NonFooKeys1, Decl(conditionalTypes1.ts, 311, 18))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 315, 17))
+>OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 289, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 315, 17))
 
 type NonFooKeys2<T extends object> = Exclude<keyof T, 'foo'>;
->NonFooKeys2 : Symbol(NonFooKeys2, Decl(conditionalTypes1.ts, 311, 61))
->T : Symbol(T, Decl(conditionalTypes1.ts, 312, 17))
+>NonFooKeys2 : Symbol(NonFooKeys2, Decl(conditionalTypes1.ts, 315, 61))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 316, 17))
 >Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes1.ts, 312, 17))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 316, 17))
 
 type Test1 = NonFooKeys1<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
->Test1 : Symbol(Test1, Decl(conditionalTypes1.ts, 312, 61))
->NonFooKeys1 : Symbol(NonFooKeys1, Decl(conditionalTypes1.ts, 307, 18))
->foo : Symbol(foo, Decl(conditionalTypes1.ts, 314, 26))
->bar : Symbol(bar, Decl(conditionalTypes1.ts, 314, 33))
->baz : Symbol(baz, Decl(conditionalTypes1.ts, 314, 41))
+>Test1 : Symbol(Test1, Decl(conditionalTypes1.ts, 316, 61))
+>NonFooKeys1 : Symbol(NonFooKeys1, Decl(conditionalTypes1.ts, 311, 18))
+>foo : Symbol(foo, Decl(conditionalTypes1.ts, 318, 26))
+>bar : Symbol(bar, Decl(conditionalTypes1.ts, 318, 33))
+>baz : Symbol(baz, Decl(conditionalTypes1.ts, 318, 41))
 
 type Test2 = NonFooKeys2<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
->Test2 : Symbol(Test2, Decl(conditionalTypes1.ts, 314, 51))
->NonFooKeys2 : Symbol(NonFooKeys2, Decl(conditionalTypes1.ts, 311, 61))
->foo : Symbol(foo, Decl(conditionalTypes1.ts, 315, 26))
->bar : Symbol(bar, Decl(conditionalTypes1.ts, 315, 33))
->baz : Symbol(baz, Decl(conditionalTypes1.ts, 315, 41))
+>Test2 : Symbol(Test2, Decl(conditionalTypes1.ts, 318, 51))
+>NonFooKeys2 : Symbol(NonFooKeys2, Decl(conditionalTypes1.ts, 315, 61))
+>foo : Symbol(foo, Decl(conditionalTypes1.ts, 319, 26))
+>bar : Symbol(bar, Decl(conditionalTypes1.ts, 319, 33))
+>baz : Symbol(baz, Decl(conditionalTypes1.ts, 319, 41))
+
+// Repro from #21729
+
+interface Foo2 { foo: string; }
+>Foo2 : Symbol(Foo2, Decl(conditionalTypes1.ts, 319, 51))
+>foo : Symbol(Foo2.foo, Decl(conditionalTypes1.ts, 323, 16))
+
+interface Bar2 { bar: string; }
+>Bar2 : Symbol(Bar2, Decl(conditionalTypes1.ts, 323, 31))
+>bar : Symbol(Bar2.bar, Decl(conditionalTypes1.ts, 324, 16))
+
+type FooBar = Foo2 | Bar2;
+>FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 324, 31))
+>Foo2 : Symbol(Foo2, Decl(conditionalTypes1.ts, 319, 51))
+>Bar2 : Symbol(Bar2, Decl(conditionalTypes1.ts, 323, 31))
+
+declare interface ExtractFooBar<FB extends FooBar> { }
+>ExtractFooBar : Symbol(ExtractFooBar, Decl(conditionalTypes1.ts, 325, 26))
+>FB : Symbol(FB, Decl(conditionalTypes1.ts, 326, 32))
+>FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 324, 31))
+
+type Extracted<Struct> = {
+>Extracted : Symbol(Extracted, Decl(conditionalTypes1.ts, 326, 54))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
+
+    [K in keyof Struct]: Struct[K] extends FooBar ? ExtractFooBar<Struct[K]> : Struct[K];
+>K : Symbol(K, Decl(conditionalTypes1.ts, 329, 5))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 329, 5))
+>FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 324, 31))
+>ExtractFooBar : Symbol(ExtractFooBar, Decl(conditionalTypes1.ts, 325, 26))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 329, 5))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 329, 5))
+}
 

--- a/tests/baselines/reference/conditionalTypes1.symbols
+++ b/tests/baselines/reference/conditionalTypes1.symbols
@@ -639,645 +639,655 @@ type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never
 >T35 : Symbol(T35, Decl(conditionalTypes1.ts, 160, 1))
 >T : Symbol(T, Decl(conditionalTypes1.ts, 164, 9))
 
+type T38<T> = [T] extends [{ a: string }] ? [T] extends [{ b: number }] ? T35<T> : never : never;
+>T38 : Symbol(T38, Decl(conditionalTypes1.ts, 164, 89))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 165, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 165, 9))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 165, 28))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 165, 9))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 165, 58))
+>T35 : Symbol(T35, Decl(conditionalTypes1.ts, 160, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 165, 9))
+
 type Extends<T, U> = T extends U ? true : false;
->Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 164, 89))
->T : Symbol(T, Decl(conditionalTypes1.ts, 166, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 166, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 166, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 166, 15))
+>Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 165, 97))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 167, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 167, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 167, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 167, 15))
 
 type If<C extends boolean, T, F> = C extends true ? T : F;
->If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
->C : Symbol(C, Decl(conditionalTypes1.ts, 167, 8))
->T : Symbol(T, Decl(conditionalTypes1.ts, 167, 26))
->F : Symbol(F, Decl(conditionalTypes1.ts, 167, 29))
->C : Symbol(C, Decl(conditionalTypes1.ts, 167, 8))
->T : Symbol(T, Decl(conditionalTypes1.ts, 167, 26))
->F : Symbol(F, Decl(conditionalTypes1.ts, 167, 29))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 167, 48))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 168, 8))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 168, 26))
+>F : Symbol(F, Decl(conditionalTypes1.ts, 168, 29))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 168, 8))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 168, 26))
+>F : Symbol(F, Decl(conditionalTypes1.ts, 168, 29))
 
 type Not<C extends boolean> = If<C, false, true>;
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
->C : Symbol(C, Decl(conditionalTypes1.ts, 168, 9))
->If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
->C : Symbol(C, Decl(conditionalTypes1.ts, 168, 9))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 168, 58))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 169, 9))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 167, 48))
+>C : Symbol(C, Decl(conditionalTypes1.ts, 169, 9))
 
 type And<A extends boolean, B extends boolean> = If<A, B, false>;
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
->A : Symbol(A, Decl(conditionalTypes1.ts, 169, 9))
->B : Symbol(B, Decl(conditionalTypes1.ts, 169, 27))
->If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
->A : Symbol(A, Decl(conditionalTypes1.ts, 169, 9))
->B : Symbol(B, Decl(conditionalTypes1.ts, 169, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 170, 9))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 170, 27))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 167, 48))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 170, 9))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 170, 27))
 
 type Or<A extends boolean, B extends boolean> = If<A, true, B>;
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
->A : Symbol(A, Decl(conditionalTypes1.ts, 170, 8))
->B : Symbol(B, Decl(conditionalTypes1.ts, 170, 26))
->If : Symbol(If, Decl(conditionalTypes1.ts, 166, 48))
->A : Symbol(A, Decl(conditionalTypes1.ts, 170, 8))
->B : Symbol(B, Decl(conditionalTypes1.ts, 170, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 171, 8))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 171, 26))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 167, 48))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 171, 8))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 171, 26))
 
 type IsString<T> = Extends<T, string>;
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
->T : Symbol(T, Decl(conditionalTypes1.ts, 172, 14))
->Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 164, 89))
->T : Symbol(T, Decl(conditionalTypes1.ts, 172, 14))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 171, 63))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 173, 14))
+>Extends : Symbol(Extends, Decl(conditionalTypes1.ts, 165, 97))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 173, 14))
 
 type Q1 = IsString<number>;  // false
->Q1 : Symbol(Q1, Decl(conditionalTypes1.ts, 172, 38))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
+>Q1 : Symbol(Q1, Decl(conditionalTypes1.ts, 173, 38))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 171, 63))
 
 type Q2 = IsString<"abc">;  // true
->Q2 : Symbol(Q2, Decl(conditionalTypes1.ts, 174, 27))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
+>Q2 : Symbol(Q2, Decl(conditionalTypes1.ts, 175, 27))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 171, 63))
 
 type Q3 = IsString<any>;  // boolean
->Q3 : Symbol(Q3, Decl(conditionalTypes1.ts, 175, 26))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
+>Q3 : Symbol(Q3, Decl(conditionalTypes1.ts, 176, 26))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 171, 63))
 
 type Q4 = IsString<never>;  // never
->Q4 : Symbol(Q4, Decl(conditionalTypes1.ts, 176, 24))
->IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 170, 63))
+>Q4 : Symbol(Q4, Decl(conditionalTypes1.ts, 177, 24))
+>IsString : Symbol(IsString, Decl(conditionalTypes1.ts, 171, 63))
 
 type N1 = Not<false>;  // true
->N1 : Symbol(N1, Decl(conditionalTypes1.ts, 177, 26))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
+>N1 : Symbol(N1, Decl(conditionalTypes1.ts, 178, 26))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 168, 58))
 
 type N2 = Not<true>;  // false
->N2 : Symbol(N2, Decl(conditionalTypes1.ts, 179, 21))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
+>N2 : Symbol(N2, Decl(conditionalTypes1.ts, 180, 21))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 168, 58))
 
 type N3 = Not<boolean>;  // boolean
->N3 : Symbol(N3, Decl(conditionalTypes1.ts, 180, 20))
->Not : Symbol(Not, Decl(conditionalTypes1.ts, 167, 58))
+>N3 : Symbol(N3, Decl(conditionalTypes1.ts, 181, 20))
+>Not : Symbol(Not, Decl(conditionalTypes1.ts, 168, 58))
 
 type A1 = And<false, false>;  // false
->A1 : Symbol(A1, Decl(conditionalTypes1.ts, 181, 23))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A1 : Symbol(A1, Decl(conditionalTypes1.ts, 182, 23))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type A2 = And<false, true>;  // false
->A2 : Symbol(A2, Decl(conditionalTypes1.ts, 183, 28))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A2 : Symbol(A2, Decl(conditionalTypes1.ts, 184, 28))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type A3 = And<true, false>;  // false
->A3 : Symbol(A3, Decl(conditionalTypes1.ts, 184, 27))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A3 : Symbol(A3, Decl(conditionalTypes1.ts, 185, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type A4 = And<true, true>;  // true
->A4 : Symbol(A4, Decl(conditionalTypes1.ts, 185, 27))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A4 : Symbol(A4, Decl(conditionalTypes1.ts, 186, 27))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type A5 = And<boolean, false>;  // false
->A5 : Symbol(A5, Decl(conditionalTypes1.ts, 186, 26))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A5 : Symbol(A5, Decl(conditionalTypes1.ts, 187, 26))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type A6 = And<false, boolean>;  // false
->A6 : Symbol(A6, Decl(conditionalTypes1.ts, 187, 30))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A6 : Symbol(A6, Decl(conditionalTypes1.ts, 188, 30))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type A7 = And<boolean, true>;  // boolean
->A7 : Symbol(A7, Decl(conditionalTypes1.ts, 188, 30))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A7 : Symbol(A7, Decl(conditionalTypes1.ts, 189, 30))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type A8 = And<true, boolean>;  // boolean
->A8 : Symbol(A8, Decl(conditionalTypes1.ts, 189, 29))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A8 : Symbol(A8, Decl(conditionalTypes1.ts, 190, 29))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type A9 = And<boolean, boolean>;  // boolean
->A9 : Symbol(A9, Decl(conditionalTypes1.ts, 190, 29))
->And : Symbol(And, Decl(conditionalTypes1.ts, 168, 49))
+>A9 : Symbol(A9, Decl(conditionalTypes1.ts, 191, 29))
+>And : Symbol(And, Decl(conditionalTypes1.ts, 169, 49))
 
 type O1 = Or<false, false>;  // false
->O1 : Symbol(O1, Decl(conditionalTypes1.ts, 191, 32))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O1 : Symbol(O1, Decl(conditionalTypes1.ts, 192, 32))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type O2 = Or<false, true>;  // true
->O2 : Symbol(O2, Decl(conditionalTypes1.ts, 193, 27))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O2 : Symbol(O2, Decl(conditionalTypes1.ts, 194, 27))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type O3 = Or<true, false>;  // true
->O3 : Symbol(O3, Decl(conditionalTypes1.ts, 194, 26))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O3 : Symbol(O3, Decl(conditionalTypes1.ts, 195, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type O4 = Or<true, true>;  // true
->O4 : Symbol(O4, Decl(conditionalTypes1.ts, 195, 26))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O4 : Symbol(O4, Decl(conditionalTypes1.ts, 196, 26))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type O5 = Or<boolean, false>;  // boolean
->O5 : Symbol(O5, Decl(conditionalTypes1.ts, 196, 25))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O5 : Symbol(O5, Decl(conditionalTypes1.ts, 197, 25))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type O6 = Or<false, boolean>;  // boolean
->O6 : Symbol(O6, Decl(conditionalTypes1.ts, 197, 29))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O6 : Symbol(O6, Decl(conditionalTypes1.ts, 198, 29))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type O7 = Or<boolean, true>;  // true
->O7 : Symbol(O7, Decl(conditionalTypes1.ts, 198, 29))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O7 : Symbol(O7, Decl(conditionalTypes1.ts, 199, 29))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type O8 = Or<true, boolean>;  // true
->O8 : Symbol(O8, Decl(conditionalTypes1.ts, 199, 28))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O8 : Symbol(O8, Decl(conditionalTypes1.ts, 200, 28))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type O9 = Or<boolean, boolean>;  // boolean
->O9 : Symbol(O9, Decl(conditionalTypes1.ts, 200, 28))
->Or : Symbol(Or, Decl(conditionalTypes1.ts, 169, 65))
+>O9 : Symbol(O9, Decl(conditionalTypes1.ts, 201, 28))
+>Or : Symbol(Or, Decl(conditionalTypes1.ts, 170, 65))
 
 type T40 = never extends never ? true : false;  // true
->T40 : Symbol(T40, Decl(conditionalTypes1.ts, 201, 31))
+>T40 : Symbol(T40, Decl(conditionalTypes1.ts, 202, 31))
 
 type T41 = number extends never ? true : false;  // false
->T41 : Symbol(T41, Decl(conditionalTypes1.ts, 203, 46))
+>T41 : Symbol(T41, Decl(conditionalTypes1.ts, 204, 46))
 
 type T42 = never extends number ? true : false;  // true
->T42 : Symbol(T42, Decl(conditionalTypes1.ts, 204, 47))
+>T42 : Symbol(T42, Decl(conditionalTypes1.ts, 205, 47))
 
 type IsNever<T> = [T] extends [never] ? true : false;
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 207, 13))
->T : Symbol(T, Decl(conditionalTypes1.ts, 207, 13))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 206, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 208, 13))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 208, 13))
 
 type T50 = IsNever<never>;  // true
->T50 : Symbol(T50, Decl(conditionalTypes1.ts, 207, 53))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
+>T50 : Symbol(T50, Decl(conditionalTypes1.ts, 208, 53))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 206, 47))
 
 type T51 = IsNever<number>;  // false
->T51 : Symbol(T51, Decl(conditionalTypes1.ts, 209, 26))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
+>T51 : Symbol(T51, Decl(conditionalTypes1.ts, 210, 26))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 206, 47))
 
 type T52 = IsNever<any>;  // false
->T52 : Symbol(T52, Decl(conditionalTypes1.ts, 210, 27))
->IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 205, 47))
+>T52 : Symbol(T52, Decl(conditionalTypes1.ts, 211, 27))
+>IsNever : Symbol(IsNever, Decl(conditionalTypes1.ts, 206, 47))
 
 // Repros from #21664
 
 type Eq<T, U> = T extends U ? U extends T ? true : false : false;
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
->U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
->T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
->U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
->U : Symbol(U, Decl(conditionalTypes1.ts, 215, 10))
->T : Symbol(T, Decl(conditionalTypes1.ts, 215, 8))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 212, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 216, 8))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 216, 10))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 216, 8))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 216, 10))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 216, 10))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 216, 8))
 
 type T60 = Eq<true, true>;  // true
->T60 : Symbol(T60, Decl(conditionalTypes1.ts, 215, 65))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T60 : Symbol(T60, Decl(conditionalTypes1.ts, 216, 65))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 212, 24))
 
 type T61 = Eq<true, false>;  // false
->T61 : Symbol(T61, Decl(conditionalTypes1.ts, 216, 26))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T61 : Symbol(T61, Decl(conditionalTypes1.ts, 217, 26))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 212, 24))
 
 type T62 = Eq<false, true>;  // false
->T62 : Symbol(T62, Decl(conditionalTypes1.ts, 217, 27))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T62 : Symbol(T62, Decl(conditionalTypes1.ts, 218, 27))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 212, 24))
 
 type T63 = Eq<false, false>;  // true
->T63 : Symbol(T63, Decl(conditionalTypes1.ts, 218, 27))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
+>T63 : Symbol(T63, Decl(conditionalTypes1.ts, 219, 27))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 212, 24))
 
 type Eq1<T, U> = Eq<T, U> extends false ? false : true;
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
->T : Symbol(T, Decl(conditionalTypes1.ts, 221, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 221, 11))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 221, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 221, 11))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 220, 28))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 222, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 222, 11))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 212, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 222, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 222, 11))
 
 type T70 = Eq1<true, true>;  // true
->T70 : Symbol(T70, Decl(conditionalTypes1.ts, 221, 55))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
+>T70 : Symbol(T70, Decl(conditionalTypes1.ts, 222, 55))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 220, 28))
 
 type T71 = Eq1<true, false>;  // false
->T71 : Symbol(T71, Decl(conditionalTypes1.ts, 222, 27))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
+>T71 : Symbol(T71, Decl(conditionalTypes1.ts, 223, 27))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 220, 28))
 
 type T72 = Eq1<false, true>;  // false
->T72 : Symbol(T72, Decl(conditionalTypes1.ts, 223, 28))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
+>T72 : Symbol(T72, Decl(conditionalTypes1.ts, 224, 28))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 220, 28))
 
 type T73 = Eq1<false, false>;  // true
->T73 : Symbol(T73, Decl(conditionalTypes1.ts, 224, 28))
->Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 219, 28))
+>T73 : Symbol(T73, Decl(conditionalTypes1.ts, 225, 28))
+>Eq1 : Symbol(Eq1, Decl(conditionalTypes1.ts, 220, 28))
 
 type Eq2<T, U> = Eq<T, U> extends true ? true : false;
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 227, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 227, 11))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 211, 24))
->T : Symbol(T, Decl(conditionalTypes1.ts, 227, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 227, 11))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 226, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 228, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 228, 11))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 212, 24))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 228, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 228, 11))
 
 type T80 = Eq2<true, true>;  // true
->T80 : Symbol(T80, Decl(conditionalTypes1.ts, 227, 54))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
+>T80 : Symbol(T80, Decl(conditionalTypes1.ts, 228, 54))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 226, 29))
 
 type T81 = Eq2<true, false>;  // false
->T81 : Symbol(T81, Decl(conditionalTypes1.ts, 228, 27))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
+>T81 : Symbol(T81, Decl(conditionalTypes1.ts, 229, 27))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 226, 29))
 
 type T82 = Eq2<false, true>;  // false
->T82 : Symbol(T82, Decl(conditionalTypes1.ts, 229, 28))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
+>T82 : Symbol(T82, Decl(conditionalTypes1.ts, 230, 28))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 226, 29))
 
 type T83 = Eq2<false, false>;  // true
->T83 : Symbol(T83, Decl(conditionalTypes1.ts, 230, 28))
->Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 225, 29))
+>T83 : Symbol(T83, Decl(conditionalTypes1.ts, 231, 28))
+>Eq2 : Symbol(Eq2, Decl(conditionalTypes1.ts, 226, 29))
 
 // Repro from #21756
 
 type Foo<T> = T extends string ? boolean : number;
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 235, 9))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 232, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 236, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 236, 9))
 
 type Bar<T> = T extends string ? boolean : number;
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 236, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 236, 9))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 236, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 237, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 237, 9))
 
 const convert = <U>(value: Foo<U>): Bar<U> => value;
->convert : Symbol(convert, Decl(conditionalTypes1.ts, 237, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
->value : Symbol(value, Decl(conditionalTypes1.ts, 237, 20))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
->U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
->U : Symbol(U, Decl(conditionalTypes1.ts, 237, 17))
->value : Symbol(value, Decl(conditionalTypes1.ts, 237, 20))
+>convert : Symbol(convert, Decl(conditionalTypes1.ts, 238, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 238, 17))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 238, 20))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 232, 29))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 238, 17))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 236, 50))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 238, 17))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 238, 20))
 
 type Baz<T> = Foo<T>;
->Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 237, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 239, 9))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 239, 9))
+>Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 238, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 240, 9))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 232, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 240, 9))
 
 const convert2 = <T>(value: Foo<T>): Baz<T> => value;
->convert2 : Symbol(convert2, Decl(conditionalTypes1.ts, 240, 5))
->T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
->value : Symbol(value, Decl(conditionalTypes1.ts, 240, 21))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
->Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 237, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 240, 18))
->value : Symbol(value, Decl(conditionalTypes1.ts, 240, 21))
+>convert2 : Symbol(convert2, Decl(conditionalTypes1.ts, 241, 5))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 241, 18))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 241, 21))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 232, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 241, 18))
+>Baz : Symbol(Baz, Decl(conditionalTypes1.ts, 238, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 241, 18))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 241, 21))
 
 function f31<T>() {
->f31 : Symbol(f31, Decl(conditionalTypes1.ts, 240, 53))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
+>f31 : Symbol(f31, Decl(conditionalTypes1.ts, 241, 53))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 243, 13))
 
     type T1 = T extends string ? boolean : number;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 19))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 243, 19))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 243, 13))
 
     type T2 = T extends string ? boolean : number;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 242, 13))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 244, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 243, 13))
 
     var x: T1;
->x : Symbol(x, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 242, 19))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 246, 7), Decl(conditionalTypes1.ts, 247, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 243, 19))
 
     var x: T2;
->x : Symbol(x, Decl(conditionalTypes1.ts, 245, 7), Decl(conditionalTypes1.ts, 246, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 243, 50))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 246, 7), Decl(conditionalTypes1.ts, 247, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 244, 50))
 }
 
 function f32<T, U>() {
->f32 : Symbol(f32, Decl(conditionalTypes1.ts, 247, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>f32 : Symbol(f32, Decl(conditionalTypes1.ts, 248, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 250, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 250, 15))
 
     type T1 = T & U extends string ? boolean : number;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 250, 22))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 250, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 250, 15))
 
     type T2 = Foo<T & U>;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 54))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 249, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 249, 15))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 251, 54))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 232, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 250, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 250, 15))
 
     var z: T1;
->z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 249, 22))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 253, 7), Decl(conditionalTypes1.ts, 254, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 250, 22))
 
     var z: T2;  // Error, T2 is distributive, T1 isn't
->z : Symbol(z, Decl(conditionalTypes1.ts, 252, 7), Decl(conditionalTypes1.ts, 253, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 250, 54))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 253, 7), Decl(conditionalTypes1.ts, 254, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 251, 54))
 }
 
 function f33<T, U>() {
->f33 : Symbol(f33, Decl(conditionalTypes1.ts, 254, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
+>f33 : Symbol(f33, Decl(conditionalTypes1.ts, 255, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 257, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 257, 15))
 
     type T1 = Foo<T & U>;
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 256, 22))
->Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 231, 29))
->T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 257, 22))
+>Foo : Symbol(Foo, Decl(conditionalTypes1.ts, 232, 29))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 257, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 257, 15))
 
     type T2 = Bar<T & U>;
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 257, 25))
->Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 235, 50))
->T : Symbol(T, Decl(conditionalTypes1.ts, 256, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 256, 15))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 258, 25))
+>Bar : Symbol(Bar, Decl(conditionalTypes1.ts, 236, 50))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 257, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 257, 15))
 
     var z: T1;
->z : Symbol(z, Decl(conditionalTypes1.ts, 259, 7), Decl(conditionalTypes1.ts, 260, 7))
->T1 : Symbol(T1, Decl(conditionalTypes1.ts, 256, 22))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 260, 7), Decl(conditionalTypes1.ts, 261, 7))
+>T1 : Symbol(T1, Decl(conditionalTypes1.ts, 257, 22))
 
     var z: T2;
->z : Symbol(z, Decl(conditionalTypes1.ts, 259, 7), Decl(conditionalTypes1.ts, 260, 7))
->T2 : Symbol(T2, Decl(conditionalTypes1.ts, 257, 25))
+>z : Symbol(z, Decl(conditionalTypes1.ts, 260, 7), Decl(conditionalTypes1.ts, 261, 7))
+>T2 : Symbol(T2, Decl(conditionalTypes1.ts, 258, 25))
 }
 
 // Repro from #21823
 
 type T90<T> = T extends 0 ? 0 : () => 0;
->T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 265, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 265, 9))
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 262, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
 
 type T91<T> = T extends 0 ? 0 : () => 0;
->T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
->T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 266, 9))
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 266, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 267, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 267, 9))
 
 const f40 = <U>(a: T90<U>): T91<U> => a;
->f40 : Symbol(f40, Decl(conditionalTypes1.ts, 267, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 267, 16))
->T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
->U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
->T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 267, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 267, 16))
+>f40 : Symbol(f40, Decl(conditionalTypes1.ts, 268, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 262, 1))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 266, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
 
 const f41 = <U>(a: T91<U>): T90<U> => a;
->f41 : Symbol(f41, Decl(conditionalTypes1.ts, 268, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
->T91 : Symbol(T91, Decl(conditionalTypes1.ts, 265, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
->T90 : Symbol(T90, Decl(conditionalTypes1.ts, 261, 1))
->U : Symbol(U, Decl(conditionalTypes1.ts, 268, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 268, 16))
+>f41 : Symbol(f41, Decl(conditionalTypes1.ts, 269, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 269, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 269, 16))
+>T91 : Symbol(T91, Decl(conditionalTypes1.ts, 266, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 269, 13))
+>T90 : Symbol(T90, Decl(conditionalTypes1.ts, 262, 1))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 269, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 269, 16))
 
 type T92<T> = T extends () => 0 ? () => 1 : () => 2;
->T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
->T : Symbol(T, Decl(conditionalTypes1.ts, 270, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 270, 9))
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 269, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
 
 type T93<T> = T extends () => 0 ? () => 1 : () => 2;
->T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
->T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 271, 9))
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 271, 52))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 272, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 272, 9))
 
 const f42 = <U>(a: T92<U>): T93<U> => a;
->f42 : Symbol(f42, Decl(conditionalTypes1.ts, 272, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 272, 16))
->T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
->T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
->U : Symbol(U, Decl(conditionalTypes1.ts, 272, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 272, 16))
+>f42 : Symbol(f42, Decl(conditionalTypes1.ts, 273, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 273, 16))
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 269, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 271, 52))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 273, 16))
 
 const f43 = <U>(a: T93<U>): T92<U> => a;
->f43 : Symbol(f43, Decl(conditionalTypes1.ts, 273, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 273, 16))
->T93 : Symbol(T93, Decl(conditionalTypes1.ts, 270, 52))
->U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
->T92 : Symbol(T92, Decl(conditionalTypes1.ts, 268, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 273, 13))
->a : Symbol(a, Decl(conditionalTypes1.ts, 273, 16))
+>f43 : Symbol(f43, Decl(conditionalTypes1.ts, 274, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 274, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 274, 16))
+>T93 : Symbol(T93, Decl(conditionalTypes1.ts, 271, 52))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 274, 13))
+>T92 : Symbol(T92, Decl(conditionalTypes1.ts, 269, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 274, 13))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 274, 16))
 
 type T94<T> = T extends string ? true : 42;
->T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
->T : Symbol(T, Decl(conditionalTypes1.ts, 275, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 275, 9))
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 274, 40))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 276, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 276, 9))
 
 type T95<T> = T extends string ? boolean : number;
->T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
->T : Symbol(T, Decl(conditionalTypes1.ts, 276, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 276, 9))
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 276, 43))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 277, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 277, 9))
 
 const f44 = <U>(value: T94<U>): T95<U> => value;
->f44 : Symbol(f44, Decl(conditionalTypes1.ts, 277, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
->value : Symbol(value, Decl(conditionalTypes1.ts, 277, 16))
->T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
->T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
->U : Symbol(U, Decl(conditionalTypes1.ts, 277, 13))
->value : Symbol(value, Decl(conditionalTypes1.ts, 277, 16))
+>f44 : Symbol(f44, Decl(conditionalTypes1.ts, 278, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 278, 16))
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 274, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 276, 43))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 278, 16))
 
 const f45 = <U>(value: T95<U>): T94<U> => value;  // Error
->f45 : Symbol(f45, Decl(conditionalTypes1.ts, 278, 5))
->U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
->value : Symbol(value, Decl(conditionalTypes1.ts, 278, 16))
->T95 : Symbol(T95, Decl(conditionalTypes1.ts, 275, 43))
->U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
->T94 : Symbol(T94, Decl(conditionalTypes1.ts, 273, 40))
->U : Symbol(U, Decl(conditionalTypes1.ts, 278, 13))
->value : Symbol(value, Decl(conditionalTypes1.ts, 278, 16))
+>f45 : Symbol(f45, Decl(conditionalTypes1.ts, 279, 5))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 279, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 279, 16))
+>T95 : Symbol(T95, Decl(conditionalTypes1.ts, 276, 43))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 279, 13))
+>T94 : Symbol(T94, Decl(conditionalTypes1.ts, 274, 40))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 279, 13))
+>value : Symbol(value, Decl(conditionalTypes1.ts, 279, 16))
 
 // Repro from #21863
 
 function f50() {
->f50 : Symbol(f50, Decl(conditionalTypes1.ts, 278, 48))
+>f50 : Symbol(f50, Decl(conditionalTypes1.ts, 279, 48))
 
     type Eq<T, U> = T extends U ? U extends T ? true : false : false;
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 282, 16))
->T : Symbol(T, Decl(conditionalTypes1.ts, 283, 12))
->U : Symbol(U, Decl(conditionalTypes1.ts, 283, 14))
->T : Symbol(T, Decl(conditionalTypes1.ts, 283, 12))
->U : Symbol(U, Decl(conditionalTypes1.ts, 283, 14))
->U : Symbol(U, Decl(conditionalTypes1.ts, 283, 14))
->T : Symbol(T, Decl(conditionalTypes1.ts, 283, 12))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 283, 16))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 284, 12))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 284, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 284, 12))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 284, 14))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 284, 14))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 284, 12))
 
     type If<S, T, U> = S extends false ? U : T;
->If : Symbol(If, Decl(conditionalTypes1.ts, 283, 69))
->S : Symbol(S, Decl(conditionalTypes1.ts, 284, 12))
->T : Symbol(T, Decl(conditionalTypes1.ts, 284, 14))
->U : Symbol(U, Decl(conditionalTypes1.ts, 284, 17))
->S : Symbol(S, Decl(conditionalTypes1.ts, 284, 12))
->U : Symbol(U, Decl(conditionalTypes1.ts, 284, 17))
->T : Symbol(T, Decl(conditionalTypes1.ts, 284, 14))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 284, 69))
+>S : Symbol(S, Decl(conditionalTypes1.ts, 285, 12))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 285, 17))
+>S : Symbol(S, Decl(conditionalTypes1.ts, 285, 12))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 285, 17))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
 
     type Omit<T extends object> = { [P in keyof T]: If<Eq<T[P], never>, never, P>; }[keyof T];
->Omit : Symbol(Omit, Decl(conditionalTypes1.ts, 284, 47))
->T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
->P : Symbol(P, Decl(conditionalTypes1.ts, 285, 37))
->T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
->If : Symbol(If, Decl(conditionalTypes1.ts, 283, 69))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 282, 16))
->T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
->P : Symbol(P, Decl(conditionalTypes1.ts, 285, 37))
->P : Symbol(P, Decl(conditionalTypes1.ts, 285, 37))
->T : Symbol(T, Decl(conditionalTypes1.ts, 285, 14))
+>Omit : Symbol(Omit, Decl(conditionalTypes1.ts, 285, 47))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 286, 14))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 286, 37))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 286, 14))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 284, 69))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 283, 16))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 286, 14))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 286, 37))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 286, 37))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 286, 14))
 
     type Omit2<T extends object, U = never> = { [P in keyof T]: If<Eq<T[P], U>, never, P>; }[keyof T];
->Omit2 : Symbol(Omit2, Decl(conditionalTypes1.ts, 285, 94))
->T : Symbol(T, Decl(conditionalTypes1.ts, 286, 15))
->U : Symbol(U, Decl(conditionalTypes1.ts, 286, 32))
->P : Symbol(P, Decl(conditionalTypes1.ts, 286, 49))
->T : Symbol(T, Decl(conditionalTypes1.ts, 286, 15))
->If : Symbol(If, Decl(conditionalTypes1.ts, 283, 69))
->Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 282, 16))
->T : Symbol(T, Decl(conditionalTypes1.ts, 286, 15))
->P : Symbol(P, Decl(conditionalTypes1.ts, 286, 49))
->U : Symbol(U, Decl(conditionalTypes1.ts, 286, 32))
->P : Symbol(P, Decl(conditionalTypes1.ts, 286, 49))
->T : Symbol(T, Decl(conditionalTypes1.ts, 286, 15))
+>Omit2 : Symbol(Omit2, Decl(conditionalTypes1.ts, 286, 94))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 287, 15))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 287, 32))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 287, 49))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 287, 15))
+>If : Symbol(If, Decl(conditionalTypes1.ts, 284, 69))
+>Eq : Symbol(Eq, Decl(conditionalTypes1.ts, 283, 16))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 287, 15))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 287, 49))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 287, 32))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 287, 49))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 287, 15))
 
     type A = Omit<{ a: void; b: never; }>;  // 'a'
->A : Symbol(A, Decl(conditionalTypes1.ts, 286, 102))
->Omit : Symbol(Omit, Decl(conditionalTypes1.ts, 284, 47))
->a : Symbol(a, Decl(conditionalTypes1.ts, 287, 19))
->b : Symbol(b, Decl(conditionalTypes1.ts, 287, 28))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 287, 102))
+>Omit : Symbol(Omit, Decl(conditionalTypes1.ts, 285, 47))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 288, 19))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 288, 28))
 
     type B = Omit2<{ a: void; b: never; }>;  // 'a'
->B : Symbol(B, Decl(conditionalTypes1.ts, 287, 42))
->Omit2 : Symbol(Omit2, Decl(conditionalTypes1.ts, 285, 94))
->a : Symbol(a, Decl(conditionalTypes1.ts, 288, 20))
->b : Symbol(b, Decl(conditionalTypes1.ts, 288, 29))
+>B : Symbol(B, Decl(conditionalTypes1.ts, 288, 42))
+>Omit2 : Symbol(Omit2, Decl(conditionalTypes1.ts, 286, 94))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 289, 20))
+>b : Symbol(b, Decl(conditionalTypes1.ts, 289, 29))
 }
 
 // Repro from #21862
 
 type OldDiff<T extends string, U extends string> = (
->OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 289, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 293, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 293, 30))
+>OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 290, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 294, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 294, 30))
 
     & { [P in T]: P; }
->P : Symbol(P, Decl(conditionalTypes1.ts, 294, 9))
->T : Symbol(T, Decl(conditionalTypes1.ts, 293, 13))
->P : Symbol(P, Decl(conditionalTypes1.ts, 294, 9))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 295, 9))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 294, 13))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 295, 9))
 
     & { [P in U]: never; }
->P : Symbol(P, Decl(conditionalTypes1.ts, 295, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 293, 30))
+>P : Symbol(P, Decl(conditionalTypes1.ts, 296, 9))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 294, 30))
 
     & { [x: string]: never; }
->x : Symbol(x, Decl(conditionalTypes1.ts, 296, 9))
+>x : Symbol(x, Decl(conditionalTypes1.ts, 297, 9))
 
 )[T];
->T : Symbol(T, Decl(conditionalTypes1.ts, 293, 13))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 294, 13))
 
 type NewDiff<T, U> = T extends U ? never : T;
->NewDiff : Symbol(NewDiff, Decl(conditionalTypes1.ts, 297, 5))
->T : Symbol(T, Decl(conditionalTypes1.ts, 298, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 298, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 298, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 298, 15))
->T : Symbol(T, Decl(conditionalTypes1.ts, 298, 13))
+>NewDiff : Symbol(NewDiff, Decl(conditionalTypes1.ts, 298, 5))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 299, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 299, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 299, 13))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 299, 15))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 299, 13))
 
 interface A {
->A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 299, 45))
 
     a: 'a';
->a : Symbol(A.a, Decl(conditionalTypes1.ts, 299, 13))
+>a : Symbol(A.a, Decl(conditionalTypes1.ts, 300, 13))
 }
 interface B1 extends A {
->B1 : Symbol(B1, Decl(conditionalTypes1.ts, 301, 1))
->A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
+>B1 : Symbol(B1, Decl(conditionalTypes1.ts, 302, 1))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 299, 45))
 
     b: 'b';
->b : Symbol(B1.b, Decl(conditionalTypes1.ts, 302, 24))
+>b : Symbol(B1.b, Decl(conditionalTypes1.ts, 303, 24))
 
     c: OldDiff<keyof this, keyof A>;
->c : Symbol(B1.c, Decl(conditionalTypes1.ts, 303, 11))
->OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 289, 1))
->A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
+>c : Symbol(B1.c, Decl(conditionalTypes1.ts, 304, 11))
+>OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 290, 1))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 299, 45))
 }
 interface B2 extends A {
->B2 : Symbol(B2, Decl(conditionalTypes1.ts, 305, 1))
->A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
+>B2 : Symbol(B2, Decl(conditionalTypes1.ts, 306, 1))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 299, 45))
 
     b: 'b';
->b : Symbol(B2.b, Decl(conditionalTypes1.ts, 306, 24))
+>b : Symbol(B2.b, Decl(conditionalTypes1.ts, 307, 24))
 
     c: NewDiff<keyof this, keyof A>;
->c : Symbol(B2.c, Decl(conditionalTypes1.ts, 307, 11))
->NewDiff : Symbol(NewDiff, Decl(conditionalTypes1.ts, 297, 5))
->A : Symbol(A, Decl(conditionalTypes1.ts, 298, 45))
+>c : Symbol(B2.c, Decl(conditionalTypes1.ts, 308, 11))
+>NewDiff : Symbol(NewDiff, Decl(conditionalTypes1.ts, 298, 5))
+>A : Symbol(A, Decl(conditionalTypes1.ts, 299, 45))
 }
 type c1 = B1['c']; // 'c' | 'b'
->c1 : Symbol(c1, Decl(conditionalTypes1.ts, 309, 1))
->B1 : Symbol(B1, Decl(conditionalTypes1.ts, 301, 1))
+>c1 : Symbol(c1, Decl(conditionalTypes1.ts, 310, 1))
+>B1 : Symbol(B1, Decl(conditionalTypes1.ts, 302, 1))
 
 type c2 = B2['c']; // 'c' | 'b'
->c2 : Symbol(c2, Decl(conditionalTypes1.ts, 310, 18))
->B2 : Symbol(B2, Decl(conditionalTypes1.ts, 305, 1))
+>c2 : Symbol(c2, Decl(conditionalTypes1.ts, 311, 18))
+>B2 : Symbol(B2, Decl(conditionalTypes1.ts, 306, 1))
 
 // Repro from #21929
 
 type NonFooKeys1<T extends object> = OldDiff<keyof T, 'foo'>;
->NonFooKeys1 : Symbol(NonFooKeys1, Decl(conditionalTypes1.ts, 311, 18))
->T : Symbol(T, Decl(conditionalTypes1.ts, 315, 17))
->OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 289, 1))
->T : Symbol(T, Decl(conditionalTypes1.ts, 315, 17))
+>NonFooKeys1 : Symbol(NonFooKeys1, Decl(conditionalTypes1.ts, 312, 18))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 316, 17))
+>OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 290, 1))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 316, 17))
 
 type NonFooKeys2<T extends object> = Exclude<keyof T, 'foo'>;
->NonFooKeys2 : Symbol(NonFooKeys2, Decl(conditionalTypes1.ts, 315, 61))
->T : Symbol(T, Decl(conditionalTypes1.ts, 316, 17))
+>NonFooKeys2 : Symbol(NonFooKeys2, Decl(conditionalTypes1.ts, 316, 61))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 317, 17))
 >Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes1.ts, 316, 17))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 317, 17))
 
 type Test1 = NonFooKeys1<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
->Test1 : Symbol(Test1, Decl(conditionalTypes1.ts, 316, 61))
->NonFooKeys1 : Symbol(NonFooKeys1, Decl(conditionalTypes1.ts, 311, 18))
->foo : Symbol(foo, Decl(conditionalTypes1.ts, 318, 26))
->bar : Symbol(bar, Decl(conditionalTypes1.ts, 318, 33))
->baz : Symbol(baz, Decl(conditionalTypes1.ts, 318, 41))
-
-type Test2 = NonFooKeys2<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
->Test2 : Symbol(Test2, Decl(conditionalTypes1.ts, 318, 51))
->NonFooKeys2 : Symbol(NonFooKeys2, Decl(conditionalTypes1.ts, 315, 61))
+>Test1 : Symbol(Test1, Decl(conditionalTypes1.ts, 317, 61))
+>NonFooKeys1 : Symbol(NonFooKeys1, Decl(conditionalTypes1.ts, 312, 18))
 >foo : Symbol(foo, Decl(conditionalTypes1.ts, 319, 26))
 >bar : Symbol(bar, Decl(conditionalTypes1.ts, 319, 33))
 >baz : Symbol(baz, Decl(conditionalTypes1.ts, 319, 41))
 
+type Test2 = NonFooKeys2<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
+>Test2 : Symbol(Test2, Decl(conditionalTypes1.ts, 319, 51))
+>NonFooKeys2 : Symbol(NonFooKeys2, Decl(conditionalTypes1.ts, 316, 61))
+>foo : Symbol(foo, Decl(conditionalTypes1.ts, 320, 26))
+>bar : Symbol(bar, Decl(conditionalTypes1.ts, 320, 33))
+>baz : Symbol(baz, Decl(conditionalTypes1.ts, 320, 41))
+
 // Repro from #21729
 
 interface Foo2 { foo: string; }
->Foo2 : Symbol(Foo2, Decl(conditionalTypes1.ts, 319, 51))
->foo : Symbol(Foo2.foo, Decl(conditionalTypes1.ts, 323, 16))
+>Foo2 : Symbol(Foo2, Decl(conditionalTypes1.ts, 320, 51))
+>foo : Symbol(Foo2.foo, Decl(conditionalTypes1.ts, 324, 16))
 
 interface Bar2 { bar: string; }
->Bar2 : Symbol(Bar2, Decl(conditionalTypes1.ts, 323, 31))
->bar : Symbol(Bar2.bar, Decl(conditionalTypes1.ts, 324, 16))
+>Bar2 : Symbol(Bar2, Decl(conditionalTypes1.ts, 324, 31))
+>bar : Symbol(Bar2.bar, Decl(conditionalTypes1.ts, 325, 16))
 
 type FooBar = Foo2 | Bar2;
->FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 324, 31))
->Foo2 : Symbol(Foo2, Decl(conditionalTypes1.ts, 319, 51))
->Bar2 : Symbol(Bar2, Decl(conditionalTypes1.ts, 323, 31))
+>FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 325, 31))
+>Foo2 : Symbol(Foo2, Decl(conditionalTypes1.ts, 320, 51))
+>Bar2 : Symbol(Bar2, Decl(conditionalTypes1.ts, 324, 31))
 
 declare interface ExtractFooBar<FB extends FooBar> { }
->ExtractFooBar : Symbol(ExtractFooBar, Decl(conditionalTypes1.ts, 325, 26))
->FB : Symbol(FB, Decl(conditionalTypes1.ts, 326, 32))
->FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 324, 31))
+>ExtractFooBar : Symbol(ExtractFooBar, Decl(conditionalTypes1.ts, 326, 26))
+>FB : Symbol(FB, Decl(conditionalTypes1.ts, 327, 32))
+>FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 325, 31))
 
 type Extracted<Struct> = {
->Extracted : Symbol(Extracted, Decl(conditionalTypes1.ts, 326, 54))
->Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
+>Extracted : Symbol(Extracted, Decl(conditionalTypes1.ts, 327, 54))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 329, 15))
 
     [K in keyof Struct]: Struct[K] extends FooBar ? ExtractFooBar<Struct[K]> : Struct[K];
->K : Symbol(K, Decl(conditionalTypes1.ts, 329, 5))
->Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
->Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
->K : Symbol(K, Decl(conditionalTypes1.ts, 329, 5))
->FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 324, 31))
->ExtractFooBar : Symbol(ExtractFooBar, Decl(conditionalTypes1.ts, 325, 26))
->Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
->K : Symbol(K, Decl(conditionalTypes1.ts, 329, 5))
->Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 328, 15))
->K : Symbol(K, Decl(conditionalTypes1.ts, 329, 5))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 330, 5))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 329, 15))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 329, 15))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 330, 5))
+>FooBar : Symbol(FooBar, Decl(conditionalTypes1.ts, 325, 31))
+>ExtractFooBar : Symbol(ExtractFooBar, Decl(conditionalTypes1.ts, 326, 26))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 329, 15))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 330, 5))
+>Struct : Symbol(Struct, Decl(conditionalTypes1.ts, 329, 15))
+>K : Symbol(K, Decl(conditionalTypes1.ts, 330, 5))
 }
 

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -678,6 +678,33 @@ function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
 >x : T
 }
 
+type T35<T extends { a: string, b: number }> = T[];
+>T35 : T[]
+>T : T
+>a : string
+>b : number
+>T : T
+
+type T36<T> = T extends { a: string } ? T extends { b: number } ? T35<T> : never : never;
+>T36 : T36<T>
+>T : T
+>T : T
+>a : string
+>T : T
+>b : number
+>T35 : T[]
+>T : T
+
+type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never : never;
+>T37 : T37<T>
+>T : T
+>T : T
+>b : number
+>T : T
+>a : string
+>T35 : T[]
+>T : T
+
 type Extends<T, U> = T extends U ? true : false;
 >Extends : Extends<T, U>
 >T : T
@@ -1369,4 +1396,41 @@ type Test2 = NonFooKeys2<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
 >foo : 1
 >bar : 2
 >baz : 3
+
+// Repro from #21729
+
+interface Foo2 { foo: string; }
+>Foo2 : Foo2
+>foo : string
+
+interface Bar2 { bar: string; }
+>Bar2 : Bar2
+>bar : string
+
+type FooBar = Foo2 | Bar2;
+>FooBar : FooBar
+>Foo2 : Foo2
+>Bar2 : Bar2
+
+declare interface ExtractFooBar<FB extends FooBar> { }
+>ExtractFooBar : ExtractFooBar<FB>
+>FB : FB
+>FooBar : FooBar
+
+type Extracted<Struct> = {
+>Extracted : Extracted<Struct>
+>Struct : Struct
+
+    [K in keyof Struct]: Struct[K] extends FooBar ? ExtractFooBar<Struct[K]> : Struct[K];
+>K : K
+>Struct : Struct
+>Struct : Struct
+>K : K
+>FooBar : FooBar
+>ExtractFooBar : ExtractFooBar<FB>
+>Struct : Struct
+>K : K
+>Struct : Struct
+>K : K
+}
 

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -705,6 +705,16 @@ type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never
 >T35 : T[]
 >T : T
 
+type T38<T> = [T] extends [{ a: string }] ? [T] extends [{ b: number }] ? T35<T> : never : never;
+>T38 : T38<T>
+>T : T
+>T : T
+>a : string
+>T : T
+>b : number
+>T35 : T[]
+>T : T
+
 type Extends<T, U> = T extends U ? true : false;
 >Extends : Extends<T, U>
 >T : T

--- a/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes1.ts
@@ -163,6 +163,10 @@ function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
     y = x;  // Error
 }
 
+type T35<T extends { a: string, b: number }> = T[];
+type T36<T> = T extends { a: string } ? T extends { b: number } ? T35<T> : never : never;
+type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never : never;
+
 type Extends<T, U> = T extends U ? true : false;
 type If<C extends boolean, T, F> = C extends true ? T : F;
 type Not<C extends boolean> = If<C, false, true>;
@@ -317,3 +321,14 @@ type NonFooKeys2<T extends object> = Exclude<keyof T, 'foo'>;
 
 type Test1 = NonFooKeys1<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
 type Test2 = NonFooKeys2<{foo: 1, bar: 2, baz: 3}>;  // "bar" | "baz"
+
+// Repro from #21729
+
+interface Foo2 { foo: string; }
+interface Bar2 { bar: string; }
+type FooBar = Foo2 | Bar2;
+declare interface ExtractFooBar<FB extends FooBar> { }
+
+type Extracted<Struct> = {
+    [K in keyof Struct]: Struct[K] extends FooBar ? ExtractFooBar<Struct[K]> : Struct[K];
+}

--- a/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes1.ts
@@ -166,6 +166,7 @@ function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
 type T35<T extends { a: string, b: number }> = T[];
 type T36<T> = T extends { a: string } ? T extends { b: number } ? T35<T> : never : never;
 type T37<T> = T extends { b: number } ? T extends { a: string } ? T35<T> : never : never;
+type T38<T> = [T] extends [{ a: string }] ? [T] extends [{ b: number }] ? T35<T> : never : never;
 
 type Extends<T, U> = T extends U ? true : false;
 type If<C extends boolean, T, F> = C extends true ? T : F;


### PR DESCRIPTION
With this PR, when the checked type in a conditional type is an indexed access type, we now add an implicit constraint to the type in the true branch.

Also, this PR fixes an issue where implicit constraints are not combined in nested conditional types.

Fixes #21729.