### PR TITLE
Add base for es2019 and add Intl.getCanonicalLocales method

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -150,6 +150,12 @@ const es2018LibrarySource = [
 const es2018LibrarySourceMap = es2018LibrarySource.map(source =>
     ({ target: "lib." + source, sources: ["header.d.ts", source] }));
 
+const es2019LibrarySource = [
+    "es2019.intl.d.ts"
+];
+const es2019LibrarySourceMap = es2019LibrarySource.map(source =>
+    ({ target: "lib." + source, sources: ["header.d.ts", source] }));
+
 const esnextLibrarySource = [
     "esnext.asynciterable.d.ts",
     "esnext.array.d.ts"
@@ -173,6 +179,7 @@ const librarySourceMap = [
     { target: "lib.es2016.d.ts", sources: ["header.d.ts", "es2016.d.ts"] },
     { target: "lib.es2017.d.ts", sources: ["header.d.ts", "es2017.d.ts"] },
     { target: "lib.es2018.d.ts", sources: ["header.d.ts", "es2018.d.ts"] },
+    { target: "lib.es2019.d.ts", sources: ["header.d.ts", "es2019.d.ts"] },
     { target: "lib.esnext.d.ts", sources: ["header.d.ts", "esnext.d.ts"] },
 
     // JavaScript + all host library
@@ -181,8 +188,9 @@ const librarySourceMap = [
     { target: "lib.es2016.full.d.ts", sources: ["header.d.ts", "es2016.d.ts"].concat(hostsLibrarySources, "dom.iterable.d.ts") },
     { target: "lib.es2017.full.d.ts", sources: ["header.d.ts", "es2017.d.ts"].concat(hostsLibrarySources, "dom.iterable.d.ts") },
     { target: "lib.es2018.full.d.ts", sources: ["header.d.ts", "es2018.d.ts"].concat(hostsLibrarySources, "dom.iterable.d.ts") },
+    { target: "lib.es2019.full.d.ts", sources: ["header.d.ts", "es2019.d.ts"].concat(hostsLibrarySources, "dom.iterable.d.ts") },
     { target: "lib.esnext.full.d.ts", sources: ["header.d.ts", "esnext.d.ts"].concat(hostsLibrarySources, "dom.iterable.d.ts") },
-].concat(es2015LibrarySourceMap, es2016LibrarySourceMap, es2017LibrarySourceMap, es2018LibrarySourceMap, esnextLibrarySourceMap);
+].concat(es2015LibrarySourceMap, es2016LibrarySourceMap, es2017LibrarySourceMap, es2018LibrarySourceMap, es2019LibrarySourceMap, esnextLibrarySourceMap);
 
 const libraryTargets = librarySourceMap.map(f =>
     path.join(builtLocalDirectory, f.target));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "typescript",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -63,9 +63,9 @@
             }
         },
         "@types/chai": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.0.tgz",
-            "integrity": "sha512-OuYBlXWHYthxIudMXMeQr92f6D97YoT9CUYCRb0BEP4OavC95jNcczjjr4Ob3H5E1IqlWqwj+leUZPSeth27Qw==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.2.tgz",
+            "integrity": "sha512-D8uQwKYUw2KESkorZ27ykzXgvkDJYXVEihGklgfp5I4HUP8D6IxtcdLTMB1emjQiWzV7WZ5ihm1cxIzVwjoleQ==",
             "dev": true
         },
         "@types/convert-source-map": {
@@ -80,7 +80,7 @@
             "integrity": "sha512-18mSs54BvzV8+TTQxt0ancig6tsuPZySnhp3cQkWFFDmDMavU4pmWwR+bHHqRBWODYqpzIzVkqKLuk/fP6yypQ==",
             "dev": true,
             "requires": {
-                "@types/glob": "5.0.34"
+                "@types/glob": "5.0.35"
             }
         },
         "@types/events": {
@@ -90,9 +90,9 @@
             "dev": true
         },
         "@types/glob": {
-            "version": "5.0.34",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
-            "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
+            "version": "5.0.35",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+            "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
             "dev": true,
             "requires": {
                 "@types/events": "1.1.0",
@@ -189,9 +189,9 @@
             }
         },
         "@types/mocha": {
-            "version": "2.2.46",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.46.tgz",
-            "integrity": "sha512-fwTTP5QLf4xHMkv7ovcKvmlLWX3GrxCa5DRQDOilVyYGCp+arZTAQJCy7/4GKezzYJjfWMpB/Cy4e8nrc9XioA==",
+            "version": "2.2.48",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+            "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
             "dev": true
         },
         "@types/node": {
@@ -207,13 +207,13 @@
             "dev": true,
             "requires": {
                 "@types/node": "8.5.5",
-                "@types/q": "1.0.6"
+                "@types/q": "1.0.7"
             }
         },
         "@types/q": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.6.tgz",
-            "integrity": "sha512-LSx7jkcXoXWB+kkfwG5zc9Okbgn51BrjLMtKwbmnqfQlCGttTnTxvDVwQanHxkK6CLKb9yEfxQ1ID6pqDpeURw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.7.tgz",
+            "integrity": "sha512-0WS7XU7sXzQ7J1nbnMKKYdjrrFoO3YtZYgUzeV8JFXffPnHfvSJQleR70I8BOAsOm14i4dyaAZ3YzqIl1YhkXQ==",
             "dev": true
         },
         "@types/run-sequence": {
@@ -225,18 +225,6 @@
                 "@types/gulp": "3.8.36",
                 "@types/node": "8.5.5"
             }
-        },
-        "@types/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-            "dev": true
-        },
-        "@types/strip-json-comments": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-            "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-            "dev": true
         },
         "@types/through2": {
             "version": "2.0.33",
@@ -315,6 +303,15 @@
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
             "dev": true
         },
+        "ansi-colors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+            "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
         "ansi-cyan": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
@@ -348,20 +345,20 @@
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
             "dev": true
         },
-        "ansi-styles": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-            "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-            "dev": true,
-            "requires": {
-                "color-convert": "1.9.1"
-            }
-        },
         "ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
             "dev": true
+        },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "1.0.0"
+            }
         },
         "archy": {
             "version": "1.0.0",
@@ -646,16 +643,10 @@
                 "resolve": "1.1.7"
             }
         },
-        "browser-stdout": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-            "dev": true
-        },
         "browserify": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/browserify/-/browserify-15.0.0.tgz",
-            "integrity": "sha512-dERxjzl4yacUzaB4XVVXDFFHARzDr6tLRhjqpE/NJUv0SkS3QVmZKiYTiKEQZhQ2HygCL02FUzSS5r3sY/SlTg==",
+            "version": "16.1.1",
+            "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.1.1.tgz",
+            "integrity": "sha512-iSH21jK0+IApV8YHOfmGt1qsGd74oflQ1Ko/28JOkWLFNBngAQfKb6WYIJ9CufH8vycqKX1sYU3y7ZrVhwevAg==",
             "dev": true,
             "requires": {
                 "JSONStream": "1.3.2",
@@ -665,15 +656,15 @@
                 "browserify-zlib": "0.2.0",
                 "buffer": "5.0.8",
                 "cached-path-relative": "1.0.1",
-                "concat-stream": "1.5.2",
+                "concat-stream": "1.6.1",
                 "console-browserify": "1.1.0",
                 "constants-browserify": "1.0.0",
                 "crypto-browserify": "3.12.0",
                 "defined": "1.0.0",
                 "deps-sort": "2.0.0",
-                "domain-browser": "1.1.7",
+                "domain-browser": "1.2.0",
                 "duplexer2": "0.1.4",
-                "events": "1.1.1",
+                "events": "2.0.0",
                 "glob": "7.1.2",
                 "has": "1.0.1",
                 "htmlescape": "1.1.1",
@@ -681,7 +672,8 @@
                 "inherits": "2.0.3",
                 "insert-module-globals": "7.0.1",
                 "labeled-stream-splicer": "2.0.0",
-                "module-deps": "5.0.1",
+                "mkdirp": "0.5.1",
+                "module-deps": "6.0.0",
                 "os-browserify": "0.3.0",
                 "parents": "1.0.1",
                 "path-browserify": "0.0.0",
@@ -700,11 +692,76 @@
                 "syntax-error": "1.3.0",
                 "through2": "2.0.3",
                 "timers-browserify": "1.4.2",
-                "tty-browserify": "0.0.0",
+                "tty-browserify": "0.0.1",
                 "url": "0.11.0",
                 "util": "0.10.3",
                 "vm-browserify": "0.0.4",
                 "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "concat-stream": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+                    "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.3",
+                        "typedarray": "0.0.6"
+                    }
+                },
+                "domain-browser": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+                    "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+                    "dev": true
+                },
+                "events": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/events/-/events-2.0.0.tgz",
+                    "integrity": "sha512-r/M5YkNg9zwI8QbSf7tsDWWJvO3PGwZXyG7GpFAxtMASnHL2eblFd7iHiGPtyGKKFPZ59S63NeX10Ws6WqGDcg==",
+                    "dev": true
+                },
+                "module-deps": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.0.0.tgz",
+                    "integrity": "sha512-BKsMhJJENEM4dTgqq2MDTTHXRHcNUFegoAwlG4HO4VMdUyMcJDKgfgI+MOv6tR5Iv8G3MKZFgsSiyP3ZoosRMw==",
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "1.3.2",
+                        "browser-resolve": "1.11.2",
+                        "cached-path-relative": "1.0.1",
+                        "concat-stream": "1.6.1",
+                        "defined": "1.0.0",
+                        "detective": "5.0.2",
+                        "duplexer2": "0.1.4",
+                        "inherits": "2.0.3",
+                        "parents": "1.0.1",
+                        "readable-stream": "2.3.3",
+                        "resolve": "1.6.0",
+                        "stream-combiner2": "1.1.1",
+                        "subarg": "1.0.0",
+                        "through2": "2.0.3",
+                        "xtend": "4.0.1"
+                    },
+                    "dependencies": {
+                        "resolve": {
+                            "version": "1.6.0",
+                            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+                            "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+                            "dev": true,
+                            "requires": {
+                                "path-parse": "1.0.5"
+                            }
+                        }
+                    }
+                },
+                "tty-browserify": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+                    "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+                    "dev": true
+                }
             }
         },
         "browserify-aes": {
@@ -793,6 +850,12 @@
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
             "dev": true
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
         "buffer-xor": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -876,14 +939,40 @@
             }
         },
         "chalk": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-            "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+            "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "4.5.0"
+                "supports-color": "5.3.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
             }
         },
         "check-error": {
@@ -1368,6 +1457,16 @@
                 "clone": "1.0.3"
             }
         },
+        "define-properties": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+            "dev": true,
+            "requires": {
+                "foreach": "2.0.5",
+                "object-keys": "1.0.11"
+            }
+        },
         "define-property": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
@@ -1473,12 +1572,6 @@
                 "randombytes": "2.0.5"
             }
         },
-        "domain-browser": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-            "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
-            "dev": true
-        },
         "duplexer2": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -1486,29 +1579,6 @@
             "dev": true,
             "requires": {
                 "readable-stream": "2.3.3"
-            }
-        },
-        "duplexify": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-            "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "1.4.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
-            },
-            "dependencies": {
-                "end-of-stream": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-                    "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-                    "dev": true,
-                    "requires": {
-                        "once": "1.4.0"
-                    }
-                }
             }
         },
         "elliptic": {
@@ -1654,12 +1724,6 @@
                 "es5-ext": "0.10.37"
             }
         },
-        "events": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-            "dev": true
-        },
         "evp_bytestokey": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -1753,57 +1817,6 @@
                 }
             }
         },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "2.2.3"
-            },
-            "dependencies": {
-                "fill-range": {
-                    "version": "2.2.3",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "1.1.7",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.6.1"
-                    }
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    }
-                },
-                "isobject": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                    "dev": true,
-                    "requires": {
-                        "isarray": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
-            }
-        },
         "expand-tilde": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -1879,12 +1892,6 @@
                 }
             }
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
         "fill-range": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1940,6 +1947,16 @@
             "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
             "dev": true
         },
+        "flush-write-stream": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+            "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1955,6 +1972,12 @@
                 "for-in": "1.0.2"
             }
         },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+            "dev": true
+        },
         "fragment-cache": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -1962,6 +1985,24 @@
             "dev": true,
             "requires": {
                 "map-cache": "0.2.2"
+            }
+        },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "through2": "2.0.3"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
+                }
             }
         },
         "fs.realpath": {
@@ -2009,42 +2050,6 @@
                 "minimatch": "3.0.4",
                 "once": "1.4.0",
                 "path-is-absolute": "1.0.1"
-            }
-        },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
             }
         },
         "glob-parent": {
@@ -2310,13 +2315,11 @@
             }
         },
         "gulp-clone": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/gulp-clone/-/gulp-clone-1.1.1.tgz",
-            "integrity": "sha512-+9z6YKyup0pxL1nD9Hw5WjC29d280dsGkegagzt4xKAOvroyzZlA8Bs9MYs2WSSFIDqmcftMUVN/oentgBv69A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/gulp-clone/-/gulp-clone-2.0.1.tgz",
+            "integrity": "sha512-SLg/KsHBbinR/pCX3PF5l1YlR28hLp0X+bcpf77PtMJ6zvAQ5kRjtCPV5Wt1wHXsXWZN0eTUZ15R8ZYpi/CdCA==",
             "dev": true,
             "requires": {
-                "chai": "4.1.2",
-                "mocha": "4.1.0",
                 "plugin-error": "0.1.2",
                 "through2": "2.0.3"
             }
@@ -2423,145 +2426,74 @@
             }
         },
         "gulp-sourcemaps": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.3.tgz",
-            "integrity": "sha1-EbAz91n5CeCl8Vt730esKcxU76Q=",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz",
+            "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
             "dev": true,
             "requires": {
                 "@gulp-sourcemaps/identity-map": "1.0.1",
                 "@gulp-sourcemaps/map-sources": "1.0.0",
-                "acorn": "5.3.0",
+                "acorn": "5.5.3",
                 "convert-source-map": "1.5.1",
                 "css": "2.2.1",
                 "debug-fabulous": "1.0.0",
                 "detect-newline": "2.1.0",
                 "graceful-fs": "4.1.11",
-                "source-map": "0.5.7",
+                "source-map": "0.6.1",
                 "strip-bom-string": "1.0.0",
                 "through2": "2.0.3"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-                    "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
                     "dev": true
                 },
                 "graceful-fs": {
                     "version": "4.1.11",
                     "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
                     "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
             }
         },
         "gulp-typescript": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.3.tgz",
-            "integrity": "sha512-Np2sJXgtDUwIAoMtlJ9uXsVmpu1FWXlKZw164hLuo56uJa7qo5W2KZ0yAYiYH/HUsaz5L0O2toMOcLIokpFCPg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-4.0.1.tgz",
+            "integrity": "sha512-BGdaBC1R4SJosXEkkEieeZ21qCZHnfSV78k7zzDljqAxvzDeGRTUqF4geckVclKEeiS3EYOBwNlxoHjJtn20vg==",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "source-map": "0.5.7",
+                "ansi-colors": "1.1.0",
+                "plugin-error": "0.1.2",
+                "source-map": "0.6.1",
                 "through2": "2.0.3",
-                "vinyl-fs": "2.4.4"
+                "vinyl": "2.1.0",
+                "vinyl-fs": "3.0.2"
             },
             "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "1.1.0"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "0.1.1"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
                 "glob-stream": {
-                    "version": "5.3.5",
-                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-                    "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+                    "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
                     "dev": true,
                     "requires": {
                         "extend": "3.0.1",
-                        "glob": "5.0.15",
+                        "glob": "7.1.2",
                         "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
+                        "is-negated-glob": "1.0.0",
+                        "ordered-read-streams": "1.0.1",
+                        "pumpify": "1.4.0",
+                        "readable-stream": "2.3.3",
+                        "remove-trailing-separator": "1.1.0",
+                        "to-absolute-glob": "2.0.2",
                         "unique-stream": "2.2.1"
-                    },
-                    "dependencies": {
-                        "readable-stream": {
-                            "version": "1.0.34",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                            "dev": true,
-                            "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
-                            }
-                        },
-                        "through2": {
-                            "version": "0.6.5",
-                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                            "dev": true,
-                            "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
-                            }
-                        }
                     }
                 },
                 "graceful-fs": {
@@ -2570,38 +2502,10 @@
                     "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                     "dev": true
                 },
-                "gulp-sourcemaps": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-                    "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-                    "dev": true,
-                    "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
-                    }
-                },
-                "is-extglob": {
+                "is-valid-glob": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+                    "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
                     "dev": true
                 },
                 "json-stable-stringify": {
@@ -2613,59 +2517,29 @@
                         "jsonify": "0.0.0"
                     }
                 },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
-                    }
-                },
                 "ordered-read-streams": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-                    "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+                    "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
                         "readable-stream": "2.3.3"
                     }
                 },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                "to-absolute-glob": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+                    "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-absolute": "1.0.0",
+                        "is-negated-glob": "1.0.0"
                     }
                 },
                 "unique-stream": {
@@ -2678,40 +2552,29 @@
                         "through2-filter": "2.0.0"
                     }
                 },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                },
                 "vinyl-fs": {
-                    "version": "2.4.4",
-                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-                    "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.2.tgz",
+                    "integrity": "sha512-AUSFda1OukBwuLPBTbyuO4IRWgfXmqC4UTW0f8xrCa8Hkv9oyIU+NSqBlgfOLZRoUt7cHdo75hKQghCywpIyIw==",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.5.1",
-                        "glob-stream": "5.3.5",
+                        "fs-mkdirp-stream": "1.0.0",
+                        "glob-stream": "6.1.0",
                         "graceful-fs": "4.1.11",
-                        "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
+                        "is-valid-glob": "1.0.0",
                         "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
+                        "lead": "1.0.0",
+                        "object.assign": "4.1.0",
+                        "pumpify": "1.4.0",
                         "readable-stream": "2.3.3",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
+                        "remove-bom-buffer": "3.0.0",
+                        "remove-bom-stream": "1.2.0",
+                        "resolve-options": "1.1.0",
                         "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "to-through": "2.0.0",
+                        "value-or-function": "3.0.0",
+                        "vinyl": "2.1.0",
+                        "vinyl-sourcemap": "1.1.0"
                     }
                 }
             }
@@ -2856,6 +2719,12 @@
             "requires": {
                 "sparkles": "1.0.0"
             }
+        },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -3056,21 +2925,6 @@
                 "kind-of": "6.0.2"
             }
         },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "2.0.0"
-            }
-        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3091,6 +2945,12 @@
             "requires": {
                 "is-extglob": "2.1.1"
             }
+        },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
         },
         "is-number": {
             "version": "3.0.0",
@@ -3154,18 +3014,6 @@
                 "isobject": "3.0.1"
             }
         },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
-        },
         "is-promise": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -3181,12 +3029,6 @@
                 "is-unc-path": "1.0.0"
             }
         },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
-        },
         "is-unc-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -3200,12 +3042,6 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
-        },
-        "is-valid-glob": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
             "dev": true
         },
         "is-windows": {
@@ -3422,6 +3258,15 @@
                 "readable-stream": "2.3.3"
             }
         },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "1.0.2"
+            }
+        },
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3536,12 +3381,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
-        },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
             "dev": true
         },
         "lodash.keys": {
@@ -3694,19 +3533,10 @@
                 "timers-ext": "0.1.2"
             }
         },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.3"
-            }
-        },
         "merge2": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.0.tgz",
-            "integrity": "sha1-D4ghUdmIsfPQdYlFQE+nPuWSPT8=",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
+            "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
             "dev": true
         },
         "micromatch": {
@@ -3806,15 +3636,15 @@
             }
         },
         "mocha": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-            "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz",
+            "integrity": "sha512-nMOpAPFosU1B4Ix1jdhx5e3q7XO55ic5a8cgYvW27CequcEY+BabS0kUVL1Cw1V5PuVHZWeNRWFLmEPexo79VA==",
             "dev": true,
             "requires": {
-                "browser-stdout": "1.3.0",
+                "browser-stdout": "1.3.1",
                 "commander": "2.11.0",
                 "debug": "3.1.0",
-                "diff": "3.3.1",
+                "diff": "3.5.0",
                 "escape-string-regexp": "1.0.5",
                 "glob": "7.1.2",
                 "growl": "1.10.3",
@@ -3823,6 +3653,12 @@
                 "supports-color": "4.4.0"
             },
             "dependencies": {
+                "browser-stdout": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+                    "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+                    "dev": true
+                },
                 "debug": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -3831,6 +3667,12 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "diff": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "4.4.0",
@@ -3848,42 +3690,6 @@
             "resolved": "https://registry.npmjs.org/mocha-fivemat-progress-reporter/-/mocha-fivemat-progress-reporter-0.1.0.tgz",
             "integrity": "sha1-zK/w4ckc9Vf+d+B535lUuRt0d1Y=",
             "dev": true
-        },
-        "module-deps": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-5.0.1.tgz",
-            "integrity": "sha512-sigq/hm/L+Z5IGi1DDl0x2ptkw7S86aFh213QhPLD8v9Opv90IHzKIuWJrRa5bJ77DVKHco2CfIEuThcT/vDJA==",
-            "dev": true,
-            "requires": {
-                "JSONStream": "1.3.2",
-                "browser-resolve": "1.11.2",
-                "cached-path-relative": "1.0.1",
-                "concat-stream": "1.6.0",
-                "defined": "1.0.0",
-                "detective": "5.0.2",
-                "duplexer2": "0.1.4",
-                "inherits": "2.0.3",
-                "parents": "1.0.1",
-                "readable-stream": "2.3.3",
-                "resolve": "1.1.7",
-                "stream-combiner2": "1.1.1",
-                "subarg": "1.0.0",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
-            },
-            "dependencies": {
-                "concat-stream": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-                    "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.3",
-                        "typedarray": "0.0.6"
-                    }
-                }
-            }
         },
         "ms": {
             "version": "2.0.0",
@@ -3992,6 +3798,15 @@
                 "remove-trailing-separator": "1.1.0"
             }
         },
+        "now-and-later": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+            "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4066,6 +3881,12 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+            "dev": true
+        },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -4073,6 +3894,18 @@
             "dev": true,
             "requires": {
                 "isobject": "3.0.1"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.0.11"
             }
         },
         "object.defaults": {
@@ -4095,27 +3928,6 @@
             "requires": {
                 "for-own": "1.0.0",
                 "make-iterator": "1.0.0"
-            }
-        },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
-            },
-            "dependencies": {
-                "for-own": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-                    "dev": true,
-                    "requires": {
-                        "for-in": "1.0.2"
-                    }
-                }
             }
         },
         "object.pick": {
@@ -4246,35 +4058,6 @@
                 "is-absolute": "1.0.0",
                 "map-cache": "0.2.2",
                 "path-root": "0.1.1"
-            }
-        },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
             }
         },
         "parse-passwd": {
@@ -4444,12 +4227,6 @@
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
-        },
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -4481,6 +4258,61 @@
                 "randombytes": "2.0.5"
             }
         },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+            },
+            "dependencies": {
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                    "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0"
+                    }
+                }
+            }
+        },
+        "pumpify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+            "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.5.4",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
+            },
+            "dependencies": {
+                "duplexify": {
+                    "version": "3.5.4",
+                    "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+                    "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.3",
+                        "stream-shift": "1.0.0"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                    "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0"
+                    }
+                }
+            }
+        },
         "punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -4504,27 +4336,6 @@
             "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
             "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
             "dev": true
-        },
-        "randomatic": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-            "dev": true,
-            "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
-            }
         },
         "randombytes": {
             "version": "2.0.5",
@@ -4578,15 +4389,6 @@
                 "resolve": "1.1.7"
             }
         },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "0.1.3"
-            }
-        },
         "regex-not": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
@@ -4594,6 +4396,27 @@
             "dev": true,
             "requires": {
                 "extend-shallow": "2.0.1"
+            }
+        },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "1.1.6",
+                "is-utf8": "0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "3.0.0",
+                "safe-buffer": "5.1.1",
+                "through2": "2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -4634,6 +4457,15 @@
             "requires": {
                 "expand-tilde": "2.0.2",
                 "global-modules": "1.0.0"
+            }
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "3.0.0"
             }
         },
         "resolve-url": {
@@ -4959,9 +4791,9 @@
             }
         },
         "source-map-support": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-            "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
+            "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
             "dev": true,
             "requires": {
                 "source-map": "0.6.1"
@@ -5228,37 +5060,10 @@
                 "is-utf8": "0.2.1"
             }
         },
-        "strip-bom-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "dev": true,
-            "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
-            },
-            "dependencies": {
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "0.2.1"
-                    }
-                }
-            }
-        },
         "strip-bom-string": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
             "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
-            "dev": true
-        },
-        "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
         },
         "subarg": {
@@ -5268,15 +5073,6 @@
             "dev": true,
             "requires": {
                 "minimist": "1.2.0"
-            }
-        },
-        "supports-color": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-            "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-            "dev": true,
-            "requires": {
-                "has-flag": "2.0.0"
             }
         },
         "syntax-error": {
@@ -5346,15 +5142,6 @@
             "requires": {
                 "es5-ext": "0.10.37",
                 "next-tick": "1.0.0"
-            }
-        },
-        "to-absolute-glob": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-            "dev": true,
-            "requires": {
-                "extend-shallow": "2.0.1"
             }
         },
         "to-arraybuffer": {
@@ -5472,6 +5259,15 @@
                 "repeat-string": "1.6.1"
             }
         },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "2.0.3"
+            }
+        },
         "travis-fold": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/travis-fold/-/travis-fold-0.1.2.tgz",
@@ -5479,52 +5275,19 @@
             "dev": true
         },
         "ts-node": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
-            "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.1.tgz",
+            "integrity": "sha512-XK7QmDcNHVmZkVtkiwNDWiERRHPyU8nBqZB1+iv2UhOG0q3RQ9HsZ2CMqISlFbxjrYFGfG2mX7bW4dAyxBVzUw==",
             "dev": true,
             "requires": {
                 "arrify": "1.0.1",
-                "chalk": "2.3.0",
+                "chalk": "2.3.2",
                 "diff": "3.3.1",
                 "make-error": "1.3.2",
                 "minimist": "1.2.0",
                 "mkdirp": "0.5.1",
-                "source-map-support": "0.5.0",
-                "tsconfig": "7.0.0",
-                "v8flags": "3.0.1",
+                "source-map-support": "0.5.4",
                 "yn": "2.0.0"
-            },
-            "dependencies": {
-                "v8flags": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
-                    "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
-                    "dev": true,
-                    "requires": {
-                        "homedir-polyfill": "1.0.1"
-                    }
-                }
-            }
-        },
-        "tsconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-            "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-            "dev": true,
-            "requires": {
-                "@types/strip-bom": "3.0.0",
-                "@types/strip-json-comments": "0.0.30",
-                "strip-bom": "3.0.0",
-                "strip-json-comments": "2.0.1"
-            },
-            "dependencies": {
-                "strip-bom": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-                    "dev": true
-                }
             }
         },
         "tslib": {
@@ -5534,37 +5297,44 @@
             "dev": true
         },
         "tslint": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
-            "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
+            "version": "5.9.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+            "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
             "dev": true,
             "requires": {
                 "babel-code-frame": "6.26.0",
                 "builtin-modules": "1.1.1",
-                "chalk": "2.3.0",
-                "commander": "2.11.0",
+                "chalk": "2.3.2",
+                "commander": "2.15.1",
                 "diff": "3.3.1",
                 "glob": "7.1.2",
+                "js-yaml": "3.10.0",
                 "minimatch": "3.0.4",
-                "resolve": "1.5.0",
-                "semver": "5.4.1",
+                "resolve": "1.6.0",
+                "semver": "5.5.0",
                 "tslib": "1.8.1",
                 "tsutils": "2.16.0"
             },
             "dependencies": {
+                "commander": {
+                    "version": "2.15.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+                    "dev": true
+                },
                 "resolve": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-                    "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+                    "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
                     "dev": true,
                     "requires": {
                         "path-parse": "1.0.5"
                     }
                 },
                 "semver": {
-                    "version": "5.4.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
                     "dev": true
                 }
             }
@@ -5577,12 +5347,6 @@
             "requires": {
                 "tslib": "1.8.1"
             }
-        },
-        "tty-browserify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-            "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-            "dev": true
         },
         "type-check": {
             "version": "0.3.2",
@@ -5606,9 +5370,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.7.0-dev.20180108",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20180108.tgz",
-            "integrity": "sha512-ZlggGsch8Y2d0LqAlCYGRzm/gdm2bqSpb4rdthY+YvpPsQqFixT0tU8sgjeRibMXW9hbS2Hz6kibS8L2oUKWfQ==",
+            "version": "2.8.0-dev.20180320",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.0-dev.20180320.tgz",
+            "integrity": "sha512-rvTiAsXzIeZpifulDClAJsD6CgsaLIj/BhnO259Uxs/zjvtDz7PG6Ai6X9c3xpfnU3S5O7TnCX7xq0cdDUDGYw==",
             "dev": true
         },
         "uglify-js": {
@@ -5861,10 +5625,10 @@
                 "user-home": "1.1.1"
             }
         },
-        "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
             "dev": true
         },
         "vinyl": {
@@ -5966,6 +5730,29 @@
                         "clone": "0.2.0",
                         "clone-stats": "0.0.1"
                     }
+                }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "1.0.2",
+                "convert-source-map": "1.5.1",
+                "graceful-fs": "4.1.11",
+                "normalize-path": "2.1.1",
+                "now-and-later": "2.0.0",
+                "remove-bom-buffer": "3.0.0",
+                "vinyl": "2.1.0"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
                 }
             }
         },

--- a/src/lib/es2019.d.ts
+++ b/src/lib/es2019.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="lib.es2018.d.ts" />
+/// <reference path="lib.es2019.intl.d.ts" />

--- a/src/lib/es2019.intl.d.ts
+++ b/src/lib/es2019.intl.d.ts
@@ -1,0 +1,3 @@
+declare namespace Intl {
+    function getCanonicalLocales(locales: string | string[]): string[];
+}

--- a/src/lib/esnext.d.ts
+++ b/src/lib/esnext.d.ts
@@ -1,3 +1,3 @@
-/// <reference path="lib.es2018.d.ts" />
+/// <reference path="lib.es2019.d.ts" />
 /// <reference path="lib.esnext.asynciterable.d.ts" />
 /// <reference path="lib.esnext.array.d.ts" />


### PR DESCRIPTION
This adds base for ES2019 and adds `Intl.getCanonicalLocales` method as defined here:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales
- https://tc39.github.io/ecma402/#sec-intl.getcanonicallocales
