### PR TITLE
Fix cache invalidation

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1118,7 +1118,7 @@ namespace ts {
         const perModuleNameCache = cache && cache.getOrCreateCacheForModuleName(moduleName);
         return forEachAncestorDirectory(normalizeSlashes(directory), ancestorDirectory => {
             if (getBaseFileName(ancestorDirectory) !== "node_modules") {
-                const resolutionFromCache = tryFindNonRelativeModuleNameInCache(perModuleNameCache, moduleName, ancestorDirectory, state.traceEnabled, state.host);
+                const resolutionFromCache = tryFindNonRelativeModuleNameInCache(perModuleNameCache, moduleName, ancestorDirectory, state.traceEnabled, state.host, failedLookupLocations);
                 if (resolutionFromCache) {
                     return resolutionFromCache;
                 }
@@ -1196,12 +1196,13 @@ namespace ts {
             typesPackageName;
     }
 
-    function tryFindNonRelativeModuleNameInCache(cache: PerModuleNameCache | undefined, moduleName: string, containingDirectory: string, traceEnabled: boolean, host: ModuleResolutionHost): SearchResult<Resolved> {
+    function tryFindNonRelativeModuleNameInCache(cache: PerModuleNameCache | undefined, moduleName: string, containingDirectory: string, traceEnabled: boolean, host: ModuleResolutionHost, failedLookupLocations: Push<string>): SearchResult<Resolved> {
         const result = cache && cache.get(containingDirectory);
         if (result) {
             if (traceEnabled) {
                 trace(host, Diagnostics.Resolution_for_module_0_was_found_in_cache_from_location_1, moduleName, containingDirectory);
             }
+            failedLookupLocations.push(...result.failedLookupLocations);
             return { value: result.resolvedModule && { path: result.resolvedModule.resolvedFileName, extension: result.resolvedModule.extension, packageId: result.resolvedModule.packageId } };
         }
     }
@@ -1226,7 +1227,7 @@ namespace ts {
             if (!isExternalModuleNameRelative(moduleName)) {
                 // Climb up parent directories looking for a module.
                 const resolved = forEachAncestorDirectory(containingDirectory, directory => {
-                    const resolutionFromCache = tryFindNonRelativeModuleNameInCache(perModuleNameCache, moduleName, directory, traceEnabled, host);
+                    const resolutionFromCache = tryFindNonRelativeModuleNameInCache(perModuleNameCache, moduleName, directory, traceEnabled, host, failedLookupLocations);
                     if (resolutionFromCache) {
                         return resolutionFromCache;
                     }

--- a/src/harness/unittests/moduleResolution.ts
+++ b/src/harness/unittests/moduleResolution.ts
@@ -16,7 +16,7 @@ namespace ts {
     export function checkResolvedModuleWithFailedLookupLocations(actual: ResolvedModuleWithFailedLookupLocations, expectedResolvedModule: ResolvedModuleFull, expectedFailedLookupLocations: string[]): void {
         assert.isTrue(actual.resolvedModule !== undefined, "module should be resolved");
         checkResolvedModule(actual.resolvedModule, expectedResolvedModule);
-        assert.deepEqual(actual.failedLookupLocations, expectedFailedLookupLocations);
+        assert.deepEqual(actual.failedLookupLocations, expectedFailedLookupLocations, `Failed lookup locations should match - expected has ${expectedFailedLookupLocations.length}, actual has ${actual.failedLookupLocations.length}`);
     }
 
     export function createResolvedModule(resolvedFileName: string, isExternalLibraryImport = false): ResolvedModuleFull {


### PR DESCRIPTION
Fixes #22710 

Let's say you perform two different resolutions:
```
Look for 'express' from /foo/bar
Look for 'express' from /foo/bar/baz
```
The first search generates search paths, also known as "failed lookup locations", like this:
```
/foo/bar/node_modules/express/index.d.ts
/foo/node_modules/express/index.d.ts
/node_modules/express/index.d.ts
```
As well as a bunch of other variants (like the `@types` packages).

During the second search from `/foo/bar/baz`, we look for e.g. `/foo/bar/baz/node_modules/express`. This generates ~10 failed lookup locations.
Then we go up a directory and see that there's a cached module resolution result from `/foo/bar` for the same module. At that point we immediately abort the search.

We attach the failed lookup locations to the file that was looking for them. Because we aborted the search early, we only stored `/foo/bar/baz/node_modules/express` and its variants for the files that were under a subfolder.

Later when `/foo/bar/node_modules/express` *does* exist (as triggered by the file watcher), we scanned over all the source files to see if they need their resolution re-done. Because the files under `/foo/bar/baz` *didn't* record a failed lookup location for this folder, they got skipped during program recomputation.

The fix is to record the failed lookup locations in the cache along with the resolution outcome, and concat the "local" failed lookup locations to those in the cache when reporting the module resolution results.

cc @aozgaa who helped debug this