### PR TITLE
Propagate CheckFlags.Late through instantiateSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8843,7 +8843,7 @@ namespace ts {
             }
             // Keep the flags from the symbol we're instantiating.  Mark that is instantiated, and
             // also transient so that we can just store data on it directly.
-            const result = createSymbol(symbol.flags, symbol.escapedName, CheckFlags.Instantiated);
+            const result = createSymbol(symbol.flags, symbol.escapedName, CheckFlags.Instantiated | (getCheckFlags(symbol) & CheckFlags.Late));
             result.declarations = symbol.declarations;
             result.parent = symbol.parent;
             result.target = symbol;

--- a/tests/baselines/reference/declarationEmitPrivateNameCausesError.errors.txt
+++ b/tests/baselines/reference/declarationEmitPrivateNameCausesError.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/file.ts(4,17): error TS4060: Return type of exported function has or is using private name 'IGNORE_EXTRA_VARIABLES'.
+
+
+==== tests/cases/compiler/file.ts (1 errors) ====
+    const IGNORE_EXTRA_VARIABLES = Symbol(); //Notice how this is unexported
+    
+    //This is exported
+    export function ignoreExtraVariables<CtorT extends {new(...args:any[]):{}}> (ctor : CtorT) {
+                    ~~~~~~~~~~~~~~~~~~~~
+!!! error TS4060: Return type of exported function has or is using private name 'IGNORE_EXTRA_VARIABLES'.
+        return class extends ctor {
+            [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used
+        };
+    }

--- a/tests/baselines/reference/declarationEmitPrivateNameCausesError.js
+++ b/tests/baselines/reference/declarationEmitPrivateNameCausesError.js
@@ -1,0 +1,40 @@
+//// [file.ts]
+const IGNORE_EXTRA_VARIABLES = Symbol(); //Notice how this is unexported
+
+//This is exported
+export function ignoreExtraVariables<CtorT extends {new(...args:any[]):{}}> (ctor : CtorT) {
+    return class extends ctor {
+        [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used
+    };
+}
+
+//// [file.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+var IGNORE_EXTRA_VARIABLES = Symbol(); //Notice how this is unexported
+//This is exported
+function ignoreExtraVariables(ctor) {
+    return _a = /** @class */ (function (_super) {
+            __extends(class_1, _super);
+            function class_1() {
+                var _this = _super !== null && _super.apply(this, arguments) || this;
+                _this[_b] = true; //An unexported constant is used
+                return _this;
+            }
+            return class_1;
+        }(ctor)),
+        _b = IGNORE_EXTRA_VARIABLES,
+        _a;
+    var _b, _a;
+}
+exports.ignoreExtraVariables = ignoreExtraVariables;

--- a/tests/baselines/reference/declarationEmitPrivateNameCausesError.symbols
+++ b/tests/baselines/reference/declarationEmitPrivateNameCausesError.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/file.ts ===
+const IGNORE_EXTRA_VARIABLES = Symbol(); //Notice how this is unexported
+>IGNORE_EXTRA_VARIABLES : Symbol(IGNORE_EXTRA_VARIABLES, Decl(file.ts, 0, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+
+//This is exported
+export function ignoreExtraVariables<CtorT extends {new(...args:any[]):{}}> (ctor : CtorT) {
+>ignoreExtraVariables : Symbol(ignoreExtraVariables, Decl(file.ts, 0, 40))
+>CtorT : Symbol(CtorT, Decl(file.ts, 3, 37))
+>args : Symbol(args, Decl(file.ts, 3, 56))
+>ctor : Symbol(ctor, Decl(file.ts, 3, 77))
+>CtorT : Symbol(CtorT, Decl(file.ts, 3, 37))
+
+    return class extends ctor {
+>ctor : Symbol(ctor, Decl(file.ts, 3, 77))
+
+        [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used
+>[IGNORE_EXTRA_VARIABLES] : Symbol((Anonymous class)[IGNORE_EXTRA_VARIABLES], Decl(file.ts, 4, 31))
+>IGNORE_EXTRA_VARIABLES : Symbol(IGNORE_EXTRA_VARIABLES, Decl(file.ts, 0, 5))
+
+    };
+}

--- a/tests/baselines/reference/declarationEmitPrivateNameCausesError.types
+++ b/tests/baselines/reference/declarationEmitPrivateNameCausesError.types
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/file.ts ===
+const IGNORE_EXTRA_VARIABLES = Symbol(); //Notice how this is unexported
+>IGNORE_EXTRA_VARIABLES : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+//This is exported
+export function ignoreExtraVariables<CtorT extends {new(...args:any[]):{}}> (ctor : CtorT) {
+>ignoreExtraVariables : <CtorT extends new (...args: any[]) => {}>(ctor: CtorT) => { new (...args: any[]): (Anonymous class); prototype: ignoreExtraVariables<any>.(Anonymous class); } & CtorT
+>CtorT : CtorT
+>args : any[]
+>ctor : CtorT
+>CtorT : CtorT
+
+    return class extends ctor {
+>class extends ctor {        [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used    } : { new (...args: any[]): (Anonymous class); prototype: ignoreExtraVariables<any>.(Anonymous class); } & CtorT
+>ctor : {}
+
+        [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used
+>[IGNORE_EXTRA_VARIABLES] : boolean
+>IGNORE_EXTRA_VARIABLES : unique symbol
+>true : true
+
+    };
+}

--- a/tests/cases/compiler/declarationEmitPrivateNameCausesError.ts
+++ b/tests/cases/compiler/declarationEmitPrivateNameCausesError.ts
@@ -1,0 +1,11 @@
+// @declaration: true
+// @lib: es6
+// @filename: file.ts
+const IGNORE_EXTRA_VARIABLES = Symbol(); //Notice how this is unexported
+
+//This is exported
+export function ignoreExtraVariables<CtorT extends {new(...args:any[]):{}}> (ctor : CtorT) {
+    return class extends ctor {
+        [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used
+    };
+}


### PR DESCRIPTION
So they they are recognized as having late bound names (and error-checked as such) even once instantiated.

Fixes #21769.
