### PR TITLE
Correctly track thisContainer for this-property-assignments in JS nested containers

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -479,7 +479,7 @@ namespace ts {
             // and block-container.  Then after we pop out of processing the children, we restore
             // these saved values.
             const saveContainer = container;
-            const saveContainerContainer = thisParentContainer;
+            const saveThisContainer = thisParentContainer;
             const savedBlockScopeContainer = blockScopeContainer;
 
             // Depending on what kind of node this is, we may have to adjust the current container
@@ -572,7 +572,7 @@ namespace ts {
             }
 
             container = saveContainer;
-            thisParentContainer = saveContainerContainer;
+            thisParentContainer = saveThisContainer;
             blockScopeContainer = savedBlockScopeContainer;
         }
 

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -479,7 +479,7 @@ namespace ts {
             // and block-container.  Then after we pop out of processing the children, we restore
             // these saved values.
             const saveContainer = container;
-            const saveThisContainer = thisParentContainer;
+            const saveThisParentContainer = thisParentContainer;
             const savedBlockScopeContainer = blockScopeContainer;
 
             // Depending on what kind of node this is, we may have to adjust the current container
@@ -572,7 +572,7 @@ namespace ts {
             }
 
             container = saveContainer;
-            thisParentContainer = saveThisContainer;
+            thisParentContainer = saveThisParentContainer;
             blockScopeContainer = savedBlockScopeContainer;
         }
 

--- a/tests/baselines/reference/typeFromPropertyAssignment20.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment20.symbols
@@ -1,0 +1,49 @@
+=== tests/cases/conformance/salsa/bluebird.js ===
+!function outer (f) { return f }(
+>outer : Symbol(outer, Decl(bluebird.js, 0, 1))
+>f : Symbol(f, Decl(bluebird.js, 0, 17))
+>f : Symbol(f, Decl(bluebird.js, 0, 17))
+
+    function inner () {
+>inner : Symbol(inner, Decl(bluebird.js, 0, 33))
+
+        function Async() {
+>Async : Symbol(Async, Decl(bluebird.js, 1, 23))
+
+            this._trampolineEnabled = true;
+>_trampolineEnabled : Symbol(Async._trampolineEnabled, Decl(bluebird.js, 2, 26), Decl(bluebird.js, 7, 20))
+        }
+
+        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {
+>Async.prototype : Symbol(Async.disableTrampolineIfNecessary, Decl(bluebird.js, 4, 9))
+>Async : Symbol(Async, Decl(bluebird.js, 1, 23))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>disableTrampolineIfNecessary : Symbol(Async.disableTrampolineIfNecessary, Decl(bluebird.js, 4, 9))
+>dtin : Symbol(dtin, Decl(bluebird.js, 6, 54))
+>b : Symbol(b, Decl(bluebird.js, 6, 69))
+
+            if (b) {
+>b : Symbol(b, Decl(bluebird.js, 6, 69))
+
+                this._trampolineEnabled = false;
+>this._trampolineEnabled : Symbol(Async._trampolineEnabled, Decl(bluebird.js, 2, 26), Decl(bluebird.js, 7, 20))
+>this : Symbol(Async, Decl(bluebird.js, 1, 23))
+>_trampolineEnabled : Symbol(Async._trampolineEnabled, Decl(bluebird.js, 2, 26), Decl(bluebird.js, 7, 20))
+            }
+        };
+        var a = new Async()
+>a : Symbol(a, Decl(bluebird.js, 11, 11))
+>Async : Symbol(Async, Decl(bluebird.js, 1, 23))
+
+        a._trampolineEnabled = true;
+>a._trampolineEnabled : Symbol(Async._trampolineEnabled, Decl(bluebird.js, 2, 26), Decl(bluebird.js, 7, 20))
+>a : Symbol(a, Decl(bluebird.js, 11, 11))
+>_trampolineEnabled : Symbol(Async._trampolineEnabled, Decl(bluebird.js, 2, 26), Decl(bluebird.js, 7, 20))
+
+        a.disableTrampolineIfNecessary(false);
+>a.disableTrampolineIfNecessary : Symbol(Async.disableTrampolineIfNecessary, Decl(bluebird.js, 4, 9))
+>a : Symbol(a, Decl(bluebird.js, 11, 11))
+>disableTrampolineIfNecessary : Symbol(Async.disableTrampolineIfNecessary, Decl(bluebird.js, 4, 9))
+
+    })
+

--- a/tests/baselines/reference/typeFromPropertyAssignment20.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment20.symbols
@@ -31,19 +31,5 @@
 >_trampolineEnabled : Symbol(Async._trampolineEnabled, Decl(bluebird.js, 2, 26), Decl(bluebird.js, 7, 20))
             }
         };
-        var a = new Async()
->a : Symbol(a, Decl(bluebird.js, 11, 11))
->Async : Symbol(Async, Decl(bluebird.js, 1, 23))
-
-        a._trampolineEnabled = true;
->a._trampolineEnabled : Symbol(Async._trampolineEnabled, Decl(bluebird.js, 2, 26), Decl(bluebird.js, 7, 20))
->a : Symbol(a, Decl(bluebird.js, 11, 11))
->_trampolineEnabled : Symbol(Async._trampolineEnabled, Decl(bluebird.js, 2, 26), Decl(bluebird.js, 7, 20))
-
-        a.disableTrampolineIfNecessary(false);
->a.disableTrampolineIfNecessary : Symbol(Async.disableTrampolineIfNecessary, Decl(bluebird.js, 4, 9))
->a : Symbol(a, Decl(bluebird.js, 11, 11))
->disableTrampolineIfNecessary : Symbol(Async.disableTrampolineIfNecessary, Decl(bluebird.js, 4, 9))
-
     })
 

--- a/tests/baselines/reference/typeFromPropertyAssignment20.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment20.types
@@ -1,0 +1,67 @@
+=== tests/cases/conformance/salsa/bluebird.js ===
+!function outer (f) { return f }(
+>!function outer (f) { return f }(    function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };        var a = new Async()        a._trampolineEnabled = true;        a.disableTrampolineIfNecessary(false);    }) : boolean
+>function outer (f) { return f }(    function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };        var a = new Async()        a._trampolineEnabled = true;        a.disableTrampolineIfNecessary(false);    }) : () => void
+>function outer (f) { return f } : (f: () => void) => () => void
+>outer : (f: () => void) => () => void
+>f : () => void
+>f : () => void
+
+    function inner () {
+>function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };        var a = new Async()        a._trampolineEnabled = true;        a.disableTrampolineIfNecessary(false);    } : () => void
+>inner : () => void
+
+        function Async() {
+>Async : () => void
+
+            this._trampolineEnabled = true;
+>this._trampolineEnabled = true : true
+>this._trampolineEnabled : any
+>this : any
+>_trampolineEnabled : any
+>true : true
+        }
+
+        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {
+>Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        } : (b: any) => void
+>Async.prototype.disableTrampolineIfNecessary : any
+>Async.prototype : any
+>Async : () => void
+>prototype : any
+>disableTrampolineIfNecessary : any
+>function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        } : (b: any) => void
+>dtin : (b: any) => void
+>b : any
+
+            if (b) {
+>b : any
+
+                this._trampolineEnabled = false;
+>this._trampolineEnabled = false : false
+>this._trampolineEnabled : boolean
+>this : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
+>_trampolineEnabled : boolean
+>false : false
+            }
+        };
+        var a = new Async()
+>a : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
+>new Async() : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
+>Async : () => void
+
+        a._trampolineEnabled = true;
+>a._trampolineEnabled = true : true
+>a._trampolineEnabled : boolean
+>a : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
+>_trampolineEnabled : boolean
+>true : true
+
+        a.disableTrampolineIfNecessary(false);
+>a.disableTrampolineIfNecessary(false) : void
+>a.disableTrampolineIfNecessary : (b: any) => void
+>a : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
+>disableTrampolineIfNecessary : (b: any) => void
+>false : false
+
+    })
+

--- a/tests/baselines/reference/typeFromPropertyAssignment20.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment20.types
@@ -1,14 +1,14 @@
 === tests/cases/conformance/salsa/bluebird.js ===
 !function outer (f) { return f }(
->!function outer (f) { return f }(    function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };        var a = new Async()        a._trampolineEnabled = true;        a.disableTrampolineIfNecessary(false);    }) : boolean
->function outer (f) { return f }(    function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };        var a = new Async()        a._trampolineEnabled = true;        a.disableTrampolineIfNecessary(false);    }) : () => void
+>!function outer (f) { return f }(    function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };    }) : boolean
+>function outer (f) { return f }(    function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };    }) : () => void
 >function outer (f) { return f } : (f: () => void) => () => void
 >outer : (f: () => void) => () => void
 >f : () => void
 >f : () => void
 
     function inner () {
->function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };        var a = new Async()        a._trampolineEnabled = true;        a.disableTrampolineIfNecessary(false);    } : () => void
+>function inner () {        function Async() {            this._trampolineEnabled = true;        }        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        };    } : () => void
 >inner : () => void
 
         function Async() {
@@ -44,24 +44,5 @@
 >false : false
             }
         };
-        var a = new Async()
->a : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
->new Async() : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
->Async : () => void
-
-        a._trampolineEnabled = true;
->a._trampolineEnabled = true : true
->a._trampolineEnabled : boolean
->a : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
->_trampolineEnabled : boolean
->true : true
-
-        a.disableTrampolineIfNecessary(false);
->a.disableTrampolineIfNecessary(false) : void
->a.disableTrampolineIfNecessary : (b: any) => void
->a : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
->disableTrampolineIfNecessary : (b: any) => void
->false : false
-
     })
 

--- a/tests/baselines/reference/typeFromPropertyAssignment21.errors.txt
+++ b/tests/baselines/reference/typeFromPropertyAssignment21.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js(2,1): error TS2304: Cannot find name 'Event'.
+
+
+==== tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js (1 errors) ====
+    // Extend that DOM!
+    Event.prototype.removeChildren = function () {
+    ~~~~~
+!!! error TS2304: Cannot find name 'Event'.
+        this.textContent = 'nope, not going to happen'
+    }
+    

--- a/tests/baselines/reference/typeFromPropertyAssignment21.errors.txt
+++ b/tests/baselines/reference/typeFromPropertyAssignment21.errors.txt
@@ -1,11 +1,14 @@
-tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js(2,1): error TS2304: Cannot find name 'Event'.
+tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js(2,17): error TS2339: Property 'removeChildren' does not exist on type 'Event'.
+tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js(3,10): error TS2339: Property 'textContent' does not exist on type 'Event'.
 
 
-==== tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js (1 errors) ====
-    // Extend that DOM!
+==== tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js (2 errors) ====
+    // Extend that DOM! (doesn't work, but shouldn't crash)
     Event.prototype.removeChildren = function () {
-    ~~~~~
-!!! error TS2304: Cannot find name 'Event'.
+                    ~~~~~~~~~~~~~~
+!!! error TS2339: Property 'removeChildren' does not exist on type 'Event'.
         this.textContent = 'nope, not going to happen'
+             ~~~~~~~~~~~
+!!! error TS2339: Property 'textContent' does not exist on type 'Event'.
     }
     

--- a/tests/baselines/reference/typeFromPropertyAssignment21.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment21.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js ===
+// Extend that DOM!
+No type information for this code.Event.prototype.removeChildren = function () {
+No type information for this code.    this.textContent = 'nope, not going to happen'
+No type information for this code.}
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/typeFromPropertyAssignment21.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment21.symbols
@@ -1,7 +1,11 @@
 === tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js ===
-// Extend that DOM!
-No type information for this code.Event.prototype.removeChildren = function () {
-No type information for this code.    this.textContent = 'nope, not going to happen'
-No type information for this code.}
-No type information for this code.
-No type information for this code.
+// Extend that DOM! (doesn't work, but shouldn't crash)
+Event.prototype.removeChildren = function () {
+>Event.prototype : Symbol(prototype, Decl(lib.dom.d.ts, --, --))
+>Event : Symbol(Event, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>prototype : Symbol(prototype, Decl(lib.dom.d.ts, --, --))
+
+    this.textContent = 'nope, not going to happen'
+>this : Symbol(Event, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/typeFromPropertyAssignment21.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment21.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js ===
+// Extend that DOM!
+Event.prototype.removeChildren = function () {
+>Event.prototype.removeChildren = function () {    this.textContent = 'nope, not going to happen'} : () => void
+>Event.prototype.removeChildren : any
+>Event.prototype : any
+>Event : any
+>prototype : any
+>removeChildren : any
+>function () {    this.textContent = 'nope, not going to happen'} : () => void
+
+    this.textContent = 'nope, not going to happen'
+>this.textContent = 'nope, not going to happen' : "nope, not going to happen"
+>this.textContent : any
+>this : any
+>textContent : any
+>'nope, not going to happen' : "nope, not going to happen"
+}
+

--- a/tests/baselines/reference/typeFromPropertyAssignment21.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment21.types
@@ -1,18 +1,18 @@
 === tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js ===
-// Extend that DOM!
+// Extend that DOM! (doesn't work, but shouldn't crash)
 Event.prototype.removeChildren = function () {
 >Event.prototype.removeChildren = function () {    this.textContent = 'nope, not going to happen'} : () => void
 >Event.prototype.removeChildren : any
->Event.prototype : any
->Event : any
->prototype : any
+>Event.prototype : Event
+>Event : { new (typeArg: string, eventInitDict?: EventInit): Event; prototype: Event; readonly AT_TARGET: number; readonly BUBBLING_PHASE: number; readonly CAPTURING_PHASE: number; readonly NONE: number; }
+>prototype : Event
 >removeChildren : any
 >function () {    this.textContent = 'nope, not going to happen'} : () => void
 
     this.textContent = 'nope, not going to happen'
 >this.textContent = 'nope, not going to happen' : "nope, not going to happen"
 >this.textContent : any
->this : any
+>this : Event
 >textContent : any
 >'nope, not going to happen' : "nope, not going to happen"
 }

--- a/tests/baselines/reference/typeFromPropertyAssignment22.errors.txt
+++ b/tests/baselines/reference/typeFromPropertyAssignment22.errors.txt
@@ -1,0 +1,21 @@
+tests/cases/conformance/salsa/npm-install.js(12,1): error TS2322: Type 'string | number' is not assignable to type 'number | undefined'.
+  Type 'string' is not assignable to type 'number | undefined'.
+
+
+==== tests/cases/conformance/salsa/npm-install.js (1 errors) ====
+    function Installer () {
+        this.args = 0
+    }
+    Installer.prototype.loadArgMetadata = function (next) {
+        // ArrowFunction isn't treated as a this-container
+        (args) => {
+            this.args = 'hi'
+            this.newProperty = 1
+        }
+    }
+    var i = new Installer()
+    i.newProperty = i.args // error, number | string =/> number | undefined
+    ~~~~~~~~~~~~~
+!!! error TS2322: Type 'string | number' is not assignable to type 'number | undefined'.
+!!! error TS2322:   Type 'string' is not assignable to type 'number | undefined'.
+    

--- a/tests/baselines/reference/typeFromPropertyAssignment22.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment22.symbols
@@ -1,14 +1,9 @@
 === tests/cases/conformance/salsa/npm-install.js ===
-function Installer (where, dryrun, args, opts) {
+function Installer () {
 >Installer : Symbol(Installer, Decl(npm-install.js, 0, 0))
->where : Symbol(where, Decl(npm-install.js, 0, 20))
->dryrun : Symbol(dryrun, Decl(npm-install.js, 0, 26))
->args : Symbol(args, Decl(npm-install.js, 0, 34))
->opts : Symbol(opts, Decl(npm-install.js, 0, 40))
 
-  this.args = args
->args : Symbol(Installer.args, Decl(npm-install.js, 0, 48), Decl(npm-install.js, 5, 13))
->args : Symbol(args, Decl(npm-install.js, 0, 34))
+    this.args = 0
+>args : Symbol(Installer.args, Decl(npm-install.js, 0, 23), Decl(npm-install.js, 5, 15))
 }
 Installer.prototype.loadArgMetadata = function (next) {
 >Installer.prototype : Symbol(Installer.loadArgMetadata, Decl(npm-install.js, 2, 1))
@@ -17,20 +12,30 @@ Installer.prototype.loadArgMetadata = function (next) {
 >loadArgMetadata : Symbol(Installer.loadArgMetadata, Decl(npm-install.js, 2, 1))
 >next : Symbol(next, Decl(npm-install.js, 3, 48))
 
-  // ArrowFunction isn't treated as a this-container
-  (args) => {
->args : Symbol(args, Decl(npm-install.js, 5, 3))
+    // ArrowFunction isn't treated as a this-container
+    (args) => {
+>args : Symbol(args, Decl(npm-install.js, 5, 5))
 
-    this.args = args
->this.args : Symbol(Installer.args, Decl(npm-install.js, 0, 48), Decl(npm-install.js, 5, 13))
+        this.args = 'hi'
+>this.args : Symbol(Installer.args, Decl(npm-install.js, 0, 23), Decl(npm-install.js, 5, 15))
 >this : Symbol(Installer, Decl(npm-install.js, 0, 0))
->args : Symbol(Installer.args, Decl(npm-install.js, 0, 48), Decl(npm-install.js, 5, 13))
->args : Symbol(args, Decl(npm-install.js, 5, 3))
+>args : Symbol(Installer.args, Decl(npm-install.js, 0, 23), Decl(npm-install.js, 5, 15))
 
-      this.newProperty = 1
->this.newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 20))
+        this.newProperty = 1
+>this.newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 24))
 >this : Symbol(Installer, Decl(npm-install.js, 0, 0))
->newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 20))
-  }
+>newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 24))
+    }
 }
+var i = new Installer()
+>i : Symbol(i, Decl(npm-install.js, 10, 3))
+>Installer : Symbol(Installer, Decl(npm-install.js, 0, 0))
+
+i.newProperty = i.args // error, number | string =/> number | undefined
+>i.newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 24))
+>i : Symbol(i, Decl(npm-install.js, 10, 3))
+>newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 24))
+>i.args : Symbol(Installer.args, Decl(npm-install.js, 0, 23), Decl(npm-install.js, 5, 15))
+>i : Symbol(i, Decl(npm-install.js, 10, 3))
+>args : Symbol(Installer.args, Decl(npm-install.js, 0, 23), Decl(npm-install.js, 5, 15))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment22.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment22.symbols
@@ -1,0 +1,36 @@
+=== tests/cases/conformance/salsa/npm-install.js ===
+function Installer (where, dryrun, args, opts) {
+>Installer : Symbol(Installer, Decl(npm-install.js, 0, 0))
+>where : Symbol(where, Decl(npm-install.js, 0, 20))
+>dryrun : Symbol(dryrun, Decl(npm-install.js, 0, 26))
+>args : Symbol(args, Decl(npm-install.js, 0, 34))
+>opts : Symbol(opts, Decl(npm-install.js, 0, 40))
+
+  this.args = args
+>args : Symbol(Installer.args, Decl(npm-install.js, 0, 48), Decl(npm-install.js, 5, 13))
+>args : Symbol(args, Decl(npm-install.js, 0, 34))
+}
+Installer.prototype.loadArgMetadata = function (next) {
+>Installer.prototype : Symbol(Installer.loadArgMetadata, Decl(npm-install.js, 2, 1))
+>Installer : Symbol(Installer, Decl(npm-install.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>loadArgMetadata : Symbol(Installer.loadArgMetadata, Decl(npm-install.js, 2, 1))
+>next : Symbol(next, Decl(npm-install.js, 3, 48))
+
+  // ArrowFunction isn't treated as a this-container
+  (args) => {
+>args : Symbol(args, Decl(npm-install.js, 5, 3))
+
+    this.args = args
+>this.args : Symbol(Installer.args, Decl(npm-install.js, 0, 48), Decl(npm-install.js, 5, 13))
+>this : Symbol(Installer, Decl(npm-install.js, 0, 0))
+>args : Symbol(Installer.args, Decl(npm-install.js, 0, 48), Decl(npm-install.js, 5, 13))
+>args : Symbol(args, Decl(npm-install.js, 5, 3))
+
+      this.newProperty = 1
+>this.newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 20))
+>this : Symbol(Installer, Decl(npm-install.js, 0, 0))
+>newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 20))
+  }
+}
+

--- a/tests/baselines/reference/typeFromPropertyAssignment22.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment22.types
@@ -1,0 +1,46 @@
+=== tests/cases/conformance/salsa/npm-install.js ===
+function Installer (where, dryrun, args, opts) {
+>Installer : (where: any, dryrun: any, args: any, opts: any) => void
+>where : any
+>dryrun : any
+>args : any
+>opts : any
+
+  this.args = args
+>this.args = args : any
+>this.args : any
+>this : any
+>args : any
+>args : any
+}
+Installer.prototype.loadArgMetadata = function (next) {
+>Installer.prototype.loadArgMetadata = function (next) {  // ArrowFunction isn't treated as a this-container  (args) => {    this.args = args      this.newProperty = 1  }} : (next: any) => void
+>Installer.prototype.loadArgMetadata : any
+>Installer.prototype : any
+>Installer : (where: any, dryrun: any, args: any, opts: any) => void
+>prototype : any
+>loadArgMetadata : any
+>function (next) {  // ArrowFunction isn't treated as a this-container  (args) => {    this.args = args      this.newProperty = 1  }} : (next: any) => void
+>next : any
+
+  // ArrowFunction isn't treated as a this-container
+  (args) => {
+>(args) => {    this.args = args      this.newProperty = 1  } : (args: any) => void
+>args : any
+
+    this.args = args
+>this.args = args : any
+>this.args : any
+>this : { args: any; loadArgMetadata: (next: any) => void; newProperty: number; }
+>args : any
+>args : any
+
+      this.newProperty = 1
+>this.newProperty = 1 : 1
+>this.newProperty : number
+>this : { args: any; loadArgMetadata: (next: any) => void; newProperty: number; }
+>newProperty : number
+>1 : 1
+  }
+}
+

--- a/tests/baselines/reference/typeFromPropertyAssignment22.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment22.types
@@ -1,46 +1,55 @@
 === tests/cases/conformance/salsa/npm-install.js ===
-function Installer (where, dryrun, args, opts) {
->Installer : (where: any, dryrun: any, args: any, opts: any) => void
->where : any
->dryrun : any
->args : any
->opts : any
+function Installer () {
+>Installer : () => void
 
-  this.args = args
->this.args = args : any
+    this.args = 0
+>this.args = 0 : 0
 >this.args : any
 >this : any
 >args : any
->args : any
+>0 : 0
 }
 Installer.prototype.loadArgMetadata = function (next) {
->Installer.prototype.loadArgMetadata = function (next) {  // ArrowFunction isn't treated as a this-container  (args) => {    this.args = args      this.newProperty = 1  }} : (next: any) => void
+>Installer.prototype.loadArgMetadata = function (next) {    // ArrowFunction isn't treated as a this-container    (args) => {        this.args = 'hi'        this.newProperty = 1    }} : (next: any) => void
 >Installer.prototype.loadArgMetadata : any
 >Installer.prototype : any
->Installer : (where: any, dryrun: any, args: any, opts: any) => void
+>Installer : () => void
 >prototype : any
 >loadArgMetadata : any
->function (next) {  // ArrowFunction isn't treated as a this-container  (args) => {    this.args = args      this.newProperty = 1  }} : (next: any) => void
+>function (next) {    // ArrowFunction isn't treated as a this-container    (args) => {        this.args = 'hi'        this.newProperty = 1    }} : (next: any) => void
 >next : any
 
-  // ArrowFunction isn't treated as a this-container
-  (args) => {
->(args) => {    this.args = args      this.newProperty = 1  } : (args: any) => void
+    // ArrowFunction isn't treated as a this-container
+    (args) => {
+>(args) => {        this.args = 'hi'        this.newProperty = 1    } : (args: any) => void
 >args : any
 
-    this.args = args
->this.args = args : any
->this.args : any
->this : { args: any; loadArgMetadata: (next: any) => void; newProperty: number; }
->args : any
->args : any
+        this.args = 'hi'
+>this.args = 'hi' : "hi"
+>this.args : string | number
+>this : { args: string | number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>args : string | number
+>'hi' : "hi"
 
-      this.newProperty = 1
+        this.newProperty = 1
 >this.newProperty = 1 : 1
->this.newProperty : number
->this : { args: any; loadArgMetadata: (next: any) => void; newProperty: number; }
->newProperty : number
+>this.newProperty : number | undefined
+>this : { args: string | number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>newProperty : number | undefined
 >1 : 1
-  }
+    }
 }
+var i = new Installer()
+>i : { args: string | number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>new Installer() : { args: string | number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>Installer : () => void
+
+i.newProperty = i.args // error, number | string =/> number | undefined
+>i.newProperty = i.args : string | number
+>i.newProperty : number | undefined
+>i : { args: string | number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>newProperty : number | undefined
+>i.args : string | number
+>i : { args: string | number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>args : string | number
 

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment20.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment20.ts
@@ -14,7 +14,4 @@
                 this._trampolineEnabled = false;
             }
         };
-        var a = new Async()
-        a._trampolineEnabled = true;
-        a.disableTrampolineIfNecessary(false);
     })

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment20.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment20.ts
@@ -1,0 +1,20 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: bluebird.js
+
+!function outer (f) { return f }(
+    function inner () {
+        function Async() {
+            this._trampolineEnabled = true;
+        }
+
+        Async.prototype.disableTrampolineIfNecessary = function dtin(b) {
+            if (b) {
+                this._trampolineEnabled = false;
+            }
+        };
+        var a = new Async()
+        a._trampolineEnabled = true;
+        a.disableTrampolineIfNecessary(false);
+    })

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment21.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment21.ts
@@ -1,9 +1,10 @@
 // @allowJs: true
 // @checkJs: true
 // @noEmit: true
+// @lib: dom, es5
 // @Filename: chrome-devtools-DOMExtension.js
 
-// Extend that DOM!
+// Extend that DOM! (doesn't work, but shouldn't crash)
 Event.prototype.removeChildren = function () {
     this.textContent = 'nope, not going to happen'
 }

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment21.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment21.ts
@@ -1,0 +1,9 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: chrome-devtools-DOMExtension.js
+
+// Extend that DOM!
+Event.prototype.removeChildren = function () {
+    this.textContent = 'nope, not going to happen'
+}

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment22.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment22.ts
@@ -1,0 +1,14 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: npm-install.js
+function Installer (where, dryrun, args, opts) {
+  this.args = args
+}
+Installer.prototype.loadArgMetadata = function (next) {
+  // ArrowFunction isn't treated as a this-container
+  (args) => {
+    this.args = args
+      this.newProperty = 1
+  }
+}

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment22.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment22.ts
@@ -1,14 +1,17 @@
 // @allowJs: true
 // @checkJs: true
 // @noEmit: true
+// @strictNullChecks: true
 // @Filename: npm-install.js
-function Installer (where, dryrun, args, opts) {
-  this.args = args
+function Installer () {
+    this.args = 0
 }
 Installer.prototype.loadArgMetadata = function (next) {
-  // ArrowFunction isn't treated as a this-container
-  (args) => {
-    this.args = args
-      this.newProperty = 1
-  }
+    // ArrowFunction isn't treated as a this-container
+    (args) => {
+        this.args = 'hi'
+        this.newProperty = 1
+    }
 }
+var i = new Installer()
+i.newProperty = i.args // error, number | string =/> number | undefined


### PR DESCRIPTION
Previously thisContainer (previously called containerContainer) would update on every block, not just those that could bind `this`.

In addition, if the constructor symbol still can't be found, then no binding happens. This is usually OK because people don't add new properties in methods too often.

Fixes #22774