### PR TITLE
Revert change to `canUseEvents` in `IoSessionOptions`

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -511,7 +511,7 @@ namespace ts.server {
                 byteLength: Buffer.byteLength,
                 hrtime: process.hrtime,
                 logger,
-                canUseEvents: eventPort !== undefined,
+                canUseEvents: true,
                 globalPlugins,
                 pluginProbeLocations,
                 allowLocalPluginLoads,


### PR DESCRIPTION
Fixes #22790 (tested in a local build with vscode)
In #22591 this was changed from hardcoded `true` to `eventPort !== undefined`.