### PR TITLE
Stop printing two spaces between heritage clauses

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5161,7 +5161,7 @@ namespace ts {
         VariableDeclarationList = CommaDelimited | SpaceBetweenSiblings | SingleLine,
         SingleLineFunctionBodyStatements = SingleLine | SpaceBetweenSiblings | SpaceBetweenBraces,
         MultiLineFunctionBodyStatements = MultiLine,
-        ClassHeritageClauses = SingleLine | SpaceBetweenSiblings,
+        ClassHeritageClauses = SingleLine,
         ClassMembers = Indented | MultiLine,
         InterfaceMembers = Indented | MultiLine,
         EnumMembers = CommaDelimited | Indented | MultiLine,

--- a/src/harness/unittests/printer.ts
+++ b/src/harness/unittests/printer.ts
@@ -64,7 +64,7 @@ namespace ts {
             printsCorrectly("regularExpressionLiteral", {}, printer => printer.printFile(createSourceFile("source.ts", "let regex = /abc/;", ScriptTarget.ES2017)));
 
             printsCorrectly("classHeritageClauses", {}, printer => printer.printFile(createSourceFile(
-                "source.ts", 
+                "source.ts",
                 `class A extends B implements C implements D {}`,
                 ScriptTarget.ES2017
             )));

--- a/src/harness/unittests/printer.ts
+++ b/src/harness/unittests/printer.ts
@@ -62,6 +62,12 @@ namespace ts {
 
             // github #18071
             printsCorrectly("regularExpressionLiteral", {}, printer => printer.printFile(createSourceFile("source.ts", "let regex = /abc/;", ScriptTarget.ES2017)));
+
+            printsCorrectly("classHeritageClauses", {}, printer => printer.printFile(createSourceFile(
+                "source.ts", 
+                `class A extends B implements C implements D {}`,
+                ScriptTarget.ES2017
+            )));
         });
 
         describe("printBundle", () => {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2823,7 +2823,7 @@ declare namespace ts {
         VariableDeclarationList = 272,
         SingleLineFunctionBodyStatements = 384,
         MultiLineFunctionBodyStatements = 1,
-        ClassHeritageClauses = 256,
+        ClassHeritageClauses = 0,
         ClassMembers = 65,
         InterfaceMembers = 65,
         EnumMembers = 81,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2823,7 +2823,7 @@ declare namespace ts {
         VariableDeclarationList = 272,
         SingleLineFunctionBodyStatements = 384,
         MultiLineFunctionBodyStatements = 1,
-        ClassHeritageClauses = 256,
+        ClassHeritageClauses = 0,
         ClassMembers = 65,
         InterfaceMembers = 65,
         EnumMembers = 81,

--- a/tests/baselines/reference/declFileGenericType2.js
+++ b/tests/baselines/reference/declFileGenericType2.js
@@ -117,7 +117,7 @@ declare module templa.dom.mvc {
     }
 }
 declare module templa.dom.mvc {
-    class AbstractElementController<ModelType extends templa.mvc.IModel> extends templa.mvc.AbstractController<ModelType>  implements IElementController<ModelType> {
+    class AbstractElementController<ModelType extends templa.mvc.IModel> extends templa.mvc.AbstractController<ModelType> implements IElementController<ModelType> {
         constructor();
     }
 }

--- a/tests/baselines/reference/printerApi/printsFileCorrectly.classHeritageClauses.js
+++ b/tests/baselines/reference/printerApi/printsFileCorrectly.classHeritageClauses.js
@@ -1,0 +1,2 @@
+class A extends B implements C implements D {
+}


### PR DESCRIPTION
We noticed this when we swapped to using the emitter for declaration output.