### PR TITLE
organizeImports: Fix bug in reference-testing for renamed import (#22797)

### DIFF
--- a/src/harness/unittests/organizeImports.ts
+++ b/src/harness/unittests/organizeImports.ts
@@ -197,6 +197,16 @@ export const Other = 1;
                 assert.isEmpty(changes);
             });
 
+            testOrganizeImports("Renamed_used",
+                {
+                    path: "/test.ts",
+                    content: `
+import { F1 as EffOne, F2 as EffTwo } from "lib";
+EffOne();
+`,
+                },
+                libFile);
+
             testOrganizeImports("Simple",
                 {
                     path: "/test.ts",

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -96,7 +96,7 @@ namespace ts.OrganizeImports {
                 }
                 else {
                     // List of named imports
-                    const newElements = namedBindings.elements.filter(e => isDeclarationUsed(e.propertyName || e.name));
+                    const newElements = namedBindings.elements.filter(e => isDeclarationUsed(e.name));
                     if (newElements.length < namedBindings.elements.length) {
                         namedBindings = newElements.length
                             ? updateNamedImports(namedBindings, newElements)

--- a/tests/baselines/reference/organizeImports/Renamed_used.ts
+++ b/tests/baselines/reference/organizeImports/Renamed_used.ts
@@ -1,0 +1,9 @@
+// ==ORIGINAL==
+
+import { F1 as EffOne, F2 as EffTwo } from "lib";
+EffOne();
+
+// ==ORGANIZED==
+
+import { F1 as EffOne } from "lib";
+EffOne();


### PR DESCRIPTION
Port of #22797
Worth porting to 2.8? @DanielRosenwasser @mhegazy 