### PR TITLE
Improve behaviour of `...` inside JSDoc functions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24550,9 +24550,7 @@ namespace ts {
                 }
             }
             if (isParameter(parent) && isJSDocFunctionType(parent.parent)) {
-                if (last(parent.parent.parameters) === parent) {
-                    return createArrayType(type);
-                }
+                return createArrayType(type);
             }
             return addOptionality(type);
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24495,8 +24495,15 @@ namespace ts {
             checkJSDocTypeIsInJsFile(node);
             checkSourceElement(node.type);
 
-            // Only legal location is in the *last* parameter tag.
+            // Only legal location is in the *last* parameter tag or last parameter of a JSDoc function.
             const { parent } = node;
+            if (isParameter(node.parent) && isJSDocFunctionType(parent.parent)) {
+                if (last(parent.parent.parameters) !== parent) {
+                    error(node, Diagnostics.A_rest_parameter_must_be_last_in_a_parameter_list);
+                }
+                return;
+            }
+
             if (!isJSDocTypeExpression(parent)) {
                 error(node, Diagnostics.JSDoc_may_only_appear_in_the_last_parameter_of_a_signature);
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24497,7 +24497,7 @@ namespace ts {
 
             // Only legal location is in the *last* parameter tag or last parameter of a JSDoc function.
             const { parent } = node;
-            if (isParameter(node.parent) && isJSDocFunctionType(parent.parent)) {
+            if (isParameter(parent) && isJSDocFunctionType(parent.parent)) {
                 if (last(parent.parent.parameters) !== parent) {
                     error(node, Diagnostics.A_rest_parameter_must_be_last_in_a_parameter_list);
                 }
@@ -24547,6 +24547,11 @@ namespace ts {
                         symbol && lastParamDeclaration.symbol === symbol && isRestParameter(lastParamDeclaration)) {
                         return createArrayType(type);
                     }
+                }
+            }
+            if (isParameter(parent) && isJSDocFunctionType(parent.parent)) {
+                if (last(parent.parent.parameters) === parent) {
+                    return createArrayType(type);
                 }
             }
             return addOptionality(type);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1861,7 +1861,7 @@ namespace ts {
     }
 
     export function isRestParameter(node: ParameterDeclaration): boolean {
-        return node.dotDotDotToken !== undefined;
+        return node.dotDotDotToken !== undefined || node.type && node.type.kind === SyntaxKind.JSDocVariadicType;
     }
 
     export const enum AssignmentKind {

--- a/tests/baselines/reference/jsdocParseDotDotDotInJSDocFunction.symbols
+++ b/tests/baselines/reference/jsdocParseDotDotDotInJSDocFunction.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+// from bcryptjs
+/** @param {function(...[*])} callback */
+function g(callback) {
+>g : Symbol(g, Decl(a.js, 0, 0))
+>callback : Symbol(callback, Decl(a.js, 2, 11))
+
+    callback([1], [2], [3])
+>callback : Symbol(callback, Decl(a.js, 2, 11))
+}
+
+/**
+ * @type {!function(...number):string}
+ * @inner
+ */
+var stringFromCharCode = String.fromCharCode;
+>stringFromCharCode : Symbol(stringFromCharCode, Decl(a.js, 10, 3))
+>String.fromCharCode : Symbol(StringConstructor.fromCharCode, Decl(lib.d.ts, --, --))
+>String : Symbol(String, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>fromCharCode : Symbol(StringConstructor.fromCharCode, Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/jsdocParseDotDotDotInJSDocFunction.types
+++ b/tests/baselines/reference/jsdocParseDotDotDotInJSDocFunction.types
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+// from bcryptjs
+/** @param {function(...[*])} callback */
+function g(callback) {
+>g : (callback: (...arg0: [any][]) => any) => void
+>callback : (...arg0: [any][]) => any
+
+    callback([1], [2], [3])
+>callback([1], [2], [3]) : any
+>callback : (...arg0: [any][]) => any
+>[1] : [number]
+>1 : 1
+>[2] : [number]
+>2 : 2
+>[3] : [number]
+>3 : 3
+}
+
+/**
+ * @type {!function(...number):string}
+ * @inner
+ */
+var stringFromCharCode = String.fromCharCode;
+>stringFromCharCode : (...arg0: number[]) => string
+>String.fromCharCode : (...codes: number[]) => string
+>String : StringConstructor
+>fromCharCode : (...codes: number[]) => string
+

--- a/tests/cases/conformance/jsdoc/jsdocParseDotDotDotInJSDocFunction.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParseDotDotDotInJSDocFunction.ts
@@ -1,0 +1,17 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @strict: true
+// @Filename: a.js
+
+// from bcryptjs
+/** @param {function(...[*])} callback */
+function g(callback) {
+    callback([1], [2], [3])
+}
+
+/**
+ * @type {!function(...number):string}
+ * @inner
+ */
+var stringFromCharCode = String.fromCharCode;


### PR DESCRIPTION
1. No error for `...type` when it is the last parameter of a jsdoc `function()` type.
2. `...type` is marked as a rest parameter.
3. `...type` results in `type[]` inside a jsdoc function type.

Fixes #22508