### PR TITLE
Make region outlining more sensitive to CRLF

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -33,7 +33,7 @@ namespace ts.OutliningElementsCollector {
             const currentLineStart = lineStarts[i];
             const lineEnd = i + 1 === lineStarts.length ? sourceFile.getEnd() : lineStarts[i + 1] - 1;
             const lineText = sourceFile.text.substring(currentLineStart, lineEnd);
-            const result = lineText.match(/^\s*\/\/\s*#(end)?region(?:\s+(.*))?$/);
+            const result = lineText.match(/^\s*\/\/\s*#(end)?region(?:\s+(.*))?(?:\r)?$/);
             if (!result || isInComment(sourceFile, currentLineStart)) {
                 continue;
             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #22440 
Previously the regex for detecting the start and end of folding regions failed on CRLF.
This change makes it properly handle lines that use CRLF. No change to tests because fourslash is generally insensitive to line endings (cf. @RyanCavanaugh).
