### PR TITLE
Fix conditional type variance

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10205,10 +10205,13 @@ namespace ts {
                             if (result = isRelatedTo(getTrueTypeFromConditionalType(<ConditionalType>source), getTrueTypeFromConditionalType(<ConditionalType>target), reportErrors)) {
                                 result &= isRelatedTo(getFalseTypeFromConditionalType(<ConditionalType>source), getFalseTypeFromConditionalType(<ConditionalType>target), reportErrors);
                             }
-                            if (result) {
-                                errorInfo = saveErrorInfo;
-                                return result;
-                            }
+                        }
+                        else {
+                            result = isRelatedTo(getDefaultConstraintOfConditionalType(<ConditionalType>source), getDefaultConstraintOfConditionalType(<ConditionalType>target), reportErrors);
+                        }
+                        if (result) {
+                            errorInfo = saveErrorInfo;
+                            return result;
                         }
                     }
                     else if (relation !== definitelyAssignableRelation) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10200,18 +10200,18 @@ namespace ts {
                 }
                 else if (source.flags & TypeFlags.Conditional) {
                     if (target.flags & TypeFlags.Conditional) {
-                        if (isTypeIdenticalTo((<ConditionalType>source).checkType, (<ConditionalType>target).checkType) &&
-                            isTypeIdenticalTo((<ConditionalType>source).extendsType, (<ConditionalType>target).extendsType)) {
+                        // Two conditional types 'T1 extends U1 ? X1 : Y1' and 'T2 extends U2 ? X2 : Y2' are related if
+                        // one of T1 and T2 is related to the other, U1 and U2 are identical types, X1 is related to X2,
+                        // and Y1 is related to Y2.
+                        if (isTypeIdenticalTo((<ConditionalType>source).extendsType, (<ConditionalType>target).extendsType) &&
+                            (isRelatedTo((<ConditionalType>source).checkType, (<ConditionalType>target).checkType) || isRelatedTo((<ConditionalType>target).checkType, (<ConditionalType>source).checkType))) {
                             if (result = isRelatedTo(getTrueTypeFromConditionalType(<ConditionalType>source), getTrueTypeFromConditionalType(<ConditionalType>target), reportErrors)) {
                                 result &= isRelatedTo(getFalseTypeFromConditionalType(<ConditionalType>source), getFalseTypeFromConditionalType(<ConditionalType>target), reportErrors);
                             }
-                        }
-                        else {
-                            result = isRelatedTo(getDefaultConstraintOfConditionalType(<ConditionalType>source), getDefaultConstraintOfConditionalType(<ConditionalType>target), reportErrors);
-                        }
-                        if (result) {
-                            errorInfo = saveErrorInfo;
-                            return result;
+                            if (result) {
+                                errorInfo = saveErrorInfo;
+                                return result;
+                            }
                         }
                     }
                     else if (relation !== definitelyAssignableRelation) {

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -1,13 +1,15 @@
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(19,5): error TS2322: Type 'Covariant<A>' is not assignable to type 'Covariant<B>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(15,5): error TS2322: Type 'Covariant<A>' is not assignable to type 'Covariant<B>'.
   Type 'A' is not assignable to type 'B'.
-    Property 'b' is missing in type 'A'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(23,5): error TS2322: Type 'Contravariant<B>' is not assignable to type 'Contravariant<A>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(19,5): error TS2322: Type 'Contravariant<B>' is not assignable to type 'Contravariant<A>'.
   Type 'A' is not assignable to type 'B'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(28,5): error TS2322: Type 'Invariant<B>' is not assignable to type 'Invariant<A>'.
-  Type 'A' is not assignable to type 'B'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(29,5): error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(24,5): error TS2322: Type 'Invariant<B>' is not assignable to type 'Invariant<A>'.
   Types of property 'foo' are incompatible.
-    Type 'A' is not assignable to type 'B'.
+    Type 'B extends string ? keyof B : B' is not assignable to type 'A extends string ? keyof A : A'.
+      Type 'keyof B' is not assignable to type 'keyof A'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(25,5): error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
+  Types of property 'foo' are incompatible.
+    Type 'A extends string ? keyof A : A' is not assignable to type 'B extends string ? keyof B : B'.
+      Type 'A' is not assignable to type 'B'.
 
 
 ==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (4 errors) ====
@@ -23,20 +25,15 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(29,5): error TS23
         foo: T extends string ? keyof T : T;
     }
     
-    interface A { a: string }
-    interface B extends A { b: string }
-    
-    
-    function f1(a: Covariant<A>, b: Covariant<B>) {
+    function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
         a = b;
         b = a;  // Error
         ~
 !!! error TS2322: Type 'Covariant<A>' is not assignable to type 'Covariant<B>'.
 !!! error TS2322:   Type 'A' is not assignable to type 'B'.
-!!! error TS2322:     Property 'b' is missing in type 'A'.
     }
     
-    function f2(a: Contravariant<A>, b: Contravariant<B>) {
+    function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
         a = b;  // Error
         ~
 !!! error TS2322: Type 'Contravariant<B>' is not assignable to type 'Contravariant<A>'.
@@ -44,16 +41,19 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(29,5): error TS23
         b = a;
     }
     
-    function f3(a: Invariant<A>, b: Invariant<B>) {
+    function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
         a = b;  // Error
         ~
 !!! error TS2322: Type 'Invariant<B>' is not assignable to type 'Invariant<A>'.
-!!! error TS2322:   Type 'A' is not assignable to type 'B'.
+!!! error TS2322:   Types of property 'foo' are incompatible.
+!!! error TS2322:     Type 'B extends string ? keyof B : B' is not assignable to type 'A extends string ? keyof A : A'.
+!!! error TS2322:       Type 'keyof B' is not assignable to type 'keyof A'.
         b = a;  // Error
         ~
 !!! error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
 !!! error TS2322:   Types of property 'foo' are incompatible.
-!!! error TS2322:     Type 'A' is not assignable to type 'B'.
+!!! error TS2322:     Type 'A extends string ? keyof A : A' is not assignable to type 'B extends string ? keyof B : B'.
+!!! error TS2322:       Type 'A' is not assignable to type 'B'.
     }
     
     // Repros from #22860

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -1,0 +1,90 @@
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(19,5): error TS2322: Type 'Covariant<A>' is not assignable to type 'Covariant<B>'.
+  Type 'A' is not assignable to type 'B'.
+    Property 'b' is missing in type 'A'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(23,5): error TS2322: Type 'Contravariant<B>' is not assignable to type 'Contravariant<A>'.
+  Type 'A' is not assignable to type 'B'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(28,5): error TS2322: Type 'Invariant<B>' is not assignable to type 'Invariant<A>'.
+  Type 'A' is not assignable to type 'B'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(29,5): error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
+  Types of property 'foo' are incompatible.
+    Type 'A' is not assignable to type 'B'.
+
+
+==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (4 errors) ====
+    interface Covariant<T> {
+        foo: T extends string ? T : number;
+    }
+    
+    interface Contravariant<T> {
+        foo: T extends string ? keyof T : number;
+    }
+    
+    interface Invariant<T> {
+        foo: T extends string ? keyof T : T;
+    }
+    
+    interface A { a: string }
+    interface B extends A { b: string }
+    
+    
+    function f1(a: Covariant<A>, b: Covariant<B>) {
+        a = b;
+        b = a;  // Error
+        ~
+!!! error TS2322: Type 'Covariant<A>' is not assignable to type 'Covariant<B>'.
+!!! error TS2322:   Type 'A' is not assignable to type 'B'.
+!!! error TS2322:     Property 'b' is missing in type 'A'.
+    }
+    
+    function f2(a: Contravariant<A>, b: Contravariant<B>) {
+        a = b;  // Error
+        ~
+!!! error TS2322: Type 'Contravariant<B>' is not assignable to type 'Contravariant<A>'.
+!!! error TS2322:   Type 'A' is not assignable to type 'B'.
+        b = a;
+    }
+    
+    function f3(a: Invariant<A>, b: Invariant<B>) {
+        a = b;  // Error
+        ~
+!!! error TS2322: Type 'Invariant<B>' is not assignable to type 'Invariant<A>'.
+!!! error TS2322:   Type 'A' is not assignable to type 'B'.
+        b = a;  // Error
+        ~
+!!! error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
+!!! error TS2322:   Types of property 'foo' are incompatible.
+!!! error TS2322:     Type 'A' is not assignable to type 'B'.
+    }
+    
+    // Repros from #22860
+    
+    class Opt<T> {
+        toVector(): Vector<T> {
+            return <any>undefined;
+        }
+    }
+    
+    interface Seq<T> {
+        tail(): Opt<Seq<T>>;
+    }
+    
+    class Vector<T> implements Seq<T> {
+        tail(): Opt<Vector<T>> {
+            return <any>undefined;
+        }
+        partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
+        partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
+        partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
+            return <any>undefined;
+        }
+    }
+    
+    interface A1<T> {
+        bat: B1<A1<T>>;
+    }
+    
+    interface B1<T> extends A1<T> {
+        bat: B1<B1<T>>;
+        boom: T extends any ? true : true
+    }
+    

--- a/tests/baselines/reference/conditionalTypes2.js
+++ b/tests/baselines/reference/conditionalTypes2.js
@@ -1,0 +1,138 @@
+//// [conditionalTypes2.ts]
+interface Covariant<T> {
+    foo: T extends string ? T : number;
+}
+
+interface Contravariant<T> {
+    foo: T extends string ? keyof T : number;
+}
+
+interface Invariant<T> {
+    foo: T extends string ? keyof T : T;
+}
+
+interface A { a: string }
+interface B extends A { b: string }
+
+
+function f1(a: Covariant<A>, b: Covariant<B>) {
+    a = b;
+    b = a;  // Error
+}
+
+function f2(a: Contravariant<A>, b: Contravariant<B>) {
+    a = b;  // Error
+    b = a;
+}
+
+function f3(a: Invariant<A>, b: Invariant<B>) {
+    a = b;  // Error
+    b = a;  // Error
+}
+
+// Repros from #22860
+
+class Opt<T> {
+    toVector(): Vector<T> {
+        return <any>undefined;
+    }
+}
+
+interface Seq<T> {
+    tail(): Opt<Seq<T>>;
+}
+
+class Vector<T> implements Seq<T> {
+    tail(): Opt<Vector<T>> {
+        return <any>undefined;
+    }
+    partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
+    partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
+    partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
+        return <any>undefined;
+    }
+}
+
+interface A1<T> {
+    bat: B1<A1<T>>;
+}
+
+interface B1<T> extends A1<T> {
+    bat: B1<B1<T>>;
+    boom: T extends any ? true : true
+}
+
+
+//// [conditionalTypes2.js]
+"use strict";
+function f1(a, b) {
+    a = b;
+    b = a; // Error
+}
+function f2(a, b) {
+    a = b; // Error
+    b = a;
+}
+function f3(a, b) {
+    a = b; // Error
+    b = a; // Error
+}
+// Repros from #22860
+var Opt = /** @class */ (function () {
+    function Opt() {
+    }
+    Opt.prototype.toVector = function () {
+        return undefined;
+    };
+    return Opt;
+}());
+var Vector = /** @class */ (function () {
+    function Vector() {
+    }
+    Vector.prototype.tail = function () {
+        return undefined;
+    };
+    Vector.prototype.partition2 = function (predicate) {
+        return undefined;
+    };
+    return Vector;
+}());
+
+
+//// [conditionalTypes2.d.ts]
+interface Covariant<T> {
+    foo: T extends string ? T : number;
+}
+interface Contravariant<T> {
+    foo: T extends string ? keyof T : number;
+}
+interface Invariant<T> {
+    foo: T extends string ? keyof T : T;
+}
+interface A {
+    a: string;
+}
+interface B extends A {
+    b: string;
+}
+declare function f1(a: Covariant<A>, b: Covariant<B>): void;
+declare function f2(a: Contravariant<A>, b: Contravariant<B>): void;
+declare function f3(a: Invariant<A>, b: Invariant<B>): void;
+declare class Opt<T> {
+    toVector(): Vector<T>;
+}
+interface Seq<T> {
+    tail(): Opt<Seq<T>>;
+}
+declare class Vector<T> implements Seq<T> {
+    tail(): Opt<Vector<T>>;
+    partition2<U extends T>(predicate: (v: T) => v is U): [Vector<U>, Vector<Exclude<T, U>>];
+    partition2(predicate: (x: T) => boolean): [Vector<T>, Vector<T>];
+}
+interface A1<T> {
+    bat: B1<A1<T>>;
+}
+interface B1<T> extends A1<T> {
+    bat: B1<B1<T>>;
+    boom: T extends any ? true : true;
+}

--- a/tests/baselines/reference/conditionalTypes2.js
+++ b/tests/baselines/reference/conditionalTypes2.js
@@ -11,21 +11,17 @@ interface Invariant<T> {
     foo: T extends string ? keyof T : T;
 }
 
-interface A { a: string }
-interface B extends A { b: string }
-
-
-function f1(a: Covariant<A>, b: Covariant<B>) {
+function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
     a = b;
     b = a;  // Error
 }
 
-function f2(a: Contravariant<A>, b: Contravariant<B>) {
+function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
     a = b;  // Error
     b = a;
 }
 
-function f3(a: Invariant<A>, b: Invariant<B>) {
+function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
     a = b;  // Error
     b = a;  // Error
 }
@@ -109,15 +105,9 @@ interface Contravariant<T> {
 interface Invariant<T> {
     foo: T extends string ? keyof T : T;
 }
-interface A {
-    a: string;
-}
-interface B extends A {
-    b: string;
-}
-declare function f1(a: Covariant<A>, b: Covariant<B>): void;
-declare function f2(a: Contravariant<A>, b: Contravariant<B>): void;
-declare function f3(a: Invariant<A>, b: Invariant<B>): void;
+declare function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>): void;
+declare function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>): void;
+declare function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>): void;
 declare class Opt<T> {
     toVector(): Vector<T>;
 }

--- a/tests/baselines/reference/conditionalTypes2.symbols
+++ b/tests/baselines/reference/conditionalTypes2.symbols
@@ -30,80 +30,79 @@ interface Invariant<T> {
 >T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
 }
 
-interface A { a: string }
->A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
->a : Symbol(A.a, Decl(conditionalTypes2.ts, 12, 13))
-
-interface B extends A { b: string }
->B : Symbol(B, Decl(conditionalTypes2.ts, 12, 25))
->A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
->b : Symbol(B.b, Decl(conditionalTypes2.ts, 13, 23))
-
-
-function f1(a: Covariant<A>, b: Covariant<B>) {
->f1 : Symbol(f1, Decl(conditionalTypes2.ts, 13, 35))
->a : Symbol(a, Decl(conditionalTypes2.ts, 16, 12))
+function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
+>f1 : Symbol(f1, Decl(conditionalTypes2.ts, 10, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 12, 12))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 12, 14))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 12, 12))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 12, 28))
 >Covariant : Symbol(Covariant, Decl(conditionalTypes2.ts, 0, 0))
->A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
->b : Symbol(b, Decl(conditionalTypes2.ts, 16, 28))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 12, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 12, 44))
 >Covariant : Symbol(Covariant, Decl(conditionalTypes2.ts, 0, 0))
->B : Symbol(B, Decl(conditionalTypes2.ts, 12, 25))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 12, 14))
 
     a = b;
->a : Symbol(a, Decl(conditionalTypes2.ts, 16, 12))
->b : Symbol(b, Decl(conditionalTypes2.ts, 16, 28))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 12, 28))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 12, 44))
 
     b = a;  // Error
->b : Symbol(b, Decl(conditionalTypes2.ts, 16, 28))
->a : Symbol(a, Decl(conditionalTypes2.ts, 16, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 12, 44))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 12, 28))
 }
 
-function f2(a: Contravariant<A>, b: Contravariant<B>) {
->f2 : Symbol(f2, Decl(conditionalTypes2.ts, 19, 1))
->a : Symbol(a, Decl(conditionalTypes2.ts, 21, 12))
+function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
+>f2 : Symbol(f2, Decl(conditionalTypes2.ts, 15, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 17, 12))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 17, 14))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 17, 12))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 17, 28))
 >Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 2, 1))
->A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
->b : Symbol(b, Decl(conditionalTypes2.ts, 21, 32))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 17, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 17, 48))
 >Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 2, 1))
->B : Symbol(B, Decl(conditionalTypes2.ts, 12, 25))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 17, 14))
 
     a = b;  // Error
->a : Symbol(a, Decl(conditionalTypes2.ts, 21, 12))
->b : Symbol(b, Decl(conditionalTypes2.ts, 21, 32))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 17, 28))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 17, 48))
 
     b = a;
->b : Symbol(b, Decl(conditionalTypes2.ts, 21, 32))
->a : Symbol(a, Decl(conditionalTypes2.ts, 21, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 17, 48))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 17, 28))
 }
 
-function f3(a: Invariant<A>, b: Invariant<B>) {
->f3 : Symbol(f3, Decl(conditionalTypes2.ts, 24, 1))
->a : Symbol(a, Decl(conditionalTypes2.ts, 26, 12))
+function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
+>f3 : Symbol(f3, Decl(conditionalTypes2.ts, 20, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 22, 12))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 22, 14))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 22, 12))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 22, 28))
 >Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 6, 1))
->A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
->b : Symbol(b, Decl(conditionalTypes2.ts, 26, 28))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 22, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 22, 44))
 >Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 6, 1))
->B : Symbol(B, Decl(conditionalTypes2.ts, 12, 25))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 22, 14))
 
     a = b;  // Error
->a : Symbol(a, Decl(conditionalTypes2.ts, 26, 12))
->b : Symbol(b, Decl(conditionalTypes2.ts, 26, 28))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 22, 28))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 22, 44))
 
     b = a;  // Error
->b : Symbol(b, Decl(conditionalTypes2.ts, 26, 28))
->a : Symbol(a, Decl(conditionalTypes2.ts, 26, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 22, 44))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 22, 28))
 }
 
 // Repros from #22860
 
 class Opt<T> {
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 29, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 33, 10))
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 25, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 29, 10))
 
     toVector(): Vector<T> {
->toVector : Symbol(Opt.toVector, Decl(conditionalTypes2.ts, 33, 14))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 33, 10))
+>toVector : Symbol(Opt.toVector, Decl(conditionalTypes2.ts, 29, 14))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 29, 10))
 
         return <any>undefined;
 >undefined : Symbol(undefined)
@@ -111,67 +110,67 @@ class Opt<T> {
 }
 
 interface Seq<T> {
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 14))
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 33, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 35, 14))
 
     tail(): Opt<Seq<T>>;
->tail : Symbol(Seq.tail, Decl(conditionalTypes2.ts, 39, 18))
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 29, 1))
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 14))
+>tail : Symbol(Seq.tail, Decl(conditionalTypes2.ts, 35, 18))
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 25, 1))
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 33, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 35, 14))
 }
 
 class Vector<T> implements Seq<T> {
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 33, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
 
     tail(): Opt<Vector<T>> {
->tail : Symbol(Vector.tail, Decl(conditionalTypes2.ts, 43, 35))
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 29, 1))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>tail : Symbol(Vector.tail, Decl(conditionalTypes2.ts, 39, 35))
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 25, 1))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
 
         return <any>undefined;
 >undefined : Symbol(undefined)
     }
     partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 46, 5), Decl(conditionalTypes2.ts, 47, 88), Decl(conditionalTypes2.ts, 48, 64))
->U : Symbol(U, Decl(conditionalTypes2.ts, 47, 15))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 47, 28))
->v : Symbol(v, Decl(conditionalTypes2.ts, 47, 39))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
->v : Symbol(v, Decl(conditionalTypes2.ts, 47, 39))
->U : Symbol(U, Decl(conditionalTypes2.ts, 47, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
->U : Symbol(U, Decl(conditionalTypes2.ts, 47, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 42, 5), Decl(conditionalTypes2.ts, 43, 88), Decl(conditionalTypes2.ts, 44, 64))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 43, 15))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 43, 28))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 43, 39))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 43, 39))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 43, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 43, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
 >Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
->U : Symbol(U, Decl(conditionalTypes2.ts, 47, 15))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 43, 15))
 
     partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 46, 5), Decl(conditionalTypes2.ts, 47, 88), Decl(conditionalTypes2.ts, 48, 64))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 48, 15))
->x : Symbol(x, Decl(conditionalTypes2.ts, 48, 26))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 42, 5), Decl(conditionalTypes2.ts, 43, 88), Decl(conditionalTypes2.ts, 44, 64))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 44, 15))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 44, 26))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
 
     partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 46, 5), Decl(conditionalTypes2.ts, 47, 88), Decl(conditionalTypes2.ts, 48, 64))
->U : Symbol(U, Decl(conditionalTypes2.ts, 49, 15))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 49, 28))
->v : Symbol(v, Decl(conditionalTypes2.ts, 49, 39))
->T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
->U : Symbol(U, Decl(conditionalTypes2.ts, 49, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 42, 5), Decl(conditionalTypes2.ts, 43, 88), Decl(conditionalTypes2.ts, 44, 64))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 45, 15))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 45, 28))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 45, 39))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 45, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
 
         return <any>undefined;
 >undefined : Symbol(undefined)
@@ -179,30 +178,30 @@ class Vector<T> implements Seq<T> {
 }
 
 interface A1<T> {
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 52, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 48, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 50, 13))
 
     bat: B1<A1<T>>;
->bat : Symbol(A1.bat, Decl(conditionalTypes2.ts, 54, 17))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 56, 1))
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 52, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
+>bat : Symbol(A1.bat, Decl(conditionalTypes2.ts, 50, 17))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 52, 1))
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 48, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 50, 13))
 }
 
 interface B1<T> extends A1<T> {
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 56, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 58, 13))
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 52, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 58, 13))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 52, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 48, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
 
     bat: B1<B1<T>>;
->bat : Symbol(B1.bat, Decl(conditionalTypes2.ts, 58, 31))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 56, 1))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 56, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 58, 13))
+>bat : Symbol(B1.bat, Decl(conditionalTypes2.ts, 54, 31))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 52, 1))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 52, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
 
     boom: T extends any ? true : true
->boom : Symbol(B1.boom, Decl(conditionalTypes2.ts, 59, 19))
->T : Symbol(T, Decl(conditionalTypes2.ts, 58, 13))
+>boom : Symbol(B1.boom, Decl(conditionalTypes2.ts, 55, 19))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
 }
 

--- a/tests/baselines/reference/conditionalTypes2.symbols
+++ b/tests/baselines/reference/conditionalTypes2.symbols
@@ -1,0 +1,208 @@
+=== tests/cases/conformance/types/conditional/conditionalTypes2.ts ===
+interface Covariant<T> {
+>Covariant : Symbol(Covariant, Decl(conditionalTypes2.ts, 0, 0))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 0, 20))
+
+    foo: T extends string ? T : number;
+>foo : Symbol(Covariant.foo, Decl(conditionalTypes2.ts, 0, 24))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 0, 20))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 0, 20))
+}
+
+interface Contravariant<T> {
+>Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 2, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 4, 24))
+
+    foo: T extends string ? keyof T : number;
+>foo : Symbol(Contravariant.foo, Decl(conditionalTypes2.ts, 4, 28))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 4, 24))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 4, 24))
+}
+
+interface Invariant<T> {
+>Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 6, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
+
+    foo: T extends string ? keyof T : T;
+>foo : Symbol(Invariant.foo, Decl(conditionalTypes2.ts, 8, 24))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
+}
+
+interface A { a: string }
+>A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
+>a : Symbol(A.a, Decl(conditionalTypes2.ts, 12, 13))
+
+interface B extends A { b: string }
+>B : Symbol(B, Decl(conditionalTypes2.ts, 12, 25))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
+>b : Symbol(B.b, Decl(conditionalTypes2.ts, 13, 23))
+
+
+function f1(a: Covariant<A>, b: Covariant<B>) {
+>f1 : Symbol(f1, Decl(conditionalTypes2.ts, 13, 35))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 16, 12))
+>Covariant : Symbol(Covariant, Decl(conditionalTypes2.ts, 0, 0))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 16, 28))
+>Covariant : Symbol(Covariant, Decl(conditionalTypes2.ts, 0, 0))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 12, 25))
+
+    a = b;
+>a : Symbol(a, Decl(conditionalTypes2.ts, 16, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 16, 28))
+
+    b = a;  // Error
+>b : Symbol(b, Decl(conditionalTypes2.ts, 16, 28))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 16, 12))
+}
+
+function f2(a: Contravariant<A>, b: Contravariant<B>) {
+>f2 : Symbol(f2, Decl(conditionalTypes2.ts, 19, 1))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 21, 12))
+>Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 2, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 21, 32))
+>Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 2, 1))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 12, 25))
+
+    a = b;  // Error
+>a : Symbol(a, Decl(conditionalTypes2.ts, 21, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 21, 32))
+
+    b = a;
+>b : Symbol(b, Decl(conditionalTypes2.ts, 21, 32))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 21, 12))
+}
+
+function f3(a: Invariant<A>, b: Invariant<B>) {
+>f3 : Symbol(f3, Decl(conditionalTypes2.ts, 24, 1))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 26, 12))
+>Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 6, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 10, 1))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 26, 28))
+>Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 6, 1))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 12, 25))
+
+    a = b;  // Error
+>a : Symbol(a, Decl(conditionalTypes2.ts, 26, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 26, 28))
+
+    b = a;  // Error
+>b : Symbol(b, Decl(conditionalTypes2.ts, 26, 28))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 26, 12))
+}
+
+// Repros from #22860
+
+class Opt<T> {
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 29, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 33, 10))
+
+    toVector(): Vector<T> {
+>toVector : Symbol(Opt.toVector, Decl(conditionalTypes2.ts, 33, 14))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 33, 10))
+
+        return <any>undefined;
+>undefined : Symbol(undefined)
+    }
+}
+
+interface Seq<T> {
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 14))
+
+    tail(): Opt<Seq<T>>;
+>tail : Symbol(Seq.tail, Decl(conditionalTypes2.ts, 39, 18))
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 29, 1))
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 14))
+}
+
+class Vector<T> implements Seq<T> {
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+
+    tail(): Opt<Vector<T>> {
+>tail : Symbol(Vector.tail, Decl(conditionalTypes2.ts, 43, 35))
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 29, 1))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+
+        return <any>undefined;
+>undefined : Symbol(undefined)
+    }
+    partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 46, 5), Decl(conditionalTypes2.ts, 47, 88), Decl(conditionalTypes2.ts, 48, 64))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 47, 15))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 47, 28))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 47, 39))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 47, 39))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 47, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 47, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 47, 15))
+
+    partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 46, 5), Decl(conditionalTypes2.ts, 47, 88), Decl(conditionalTypes2.ts, 48, 64))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 48, 15))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 48, 26))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+
+    partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 46, 5), Decl(conditionalTypes2.ts, 47, 88), Decl(conditionalTypes2.ts, 48, 64))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 49, 15))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 49, 28))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 49, 39))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 43, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 49, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 41, 1))
+
+        return <any>undefined;
+>undefined : Symbol(undefined)
+    }
+}
+
+interface A1<T> {
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 52, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
+
+    bat: B1<A1<T>>;
+>bat : Symbol(A1.bat, Decl(conditionalTypes2.ts, 54, 17))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 56, 1))
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 52, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
+}
+
+interface B1<T> extends A1<T> {
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 56, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 58, 13))
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 52, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 58, 13))
+
+    bat: B1<B1<T>>;
+>bat : Symbol(B1.bat, Decl(conditionalTypes2.ts, 58, 31))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 56, 1))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 56, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 58, 13))
+
+    boom: T extends any ? true : true
+>boom : Symbol(B1.boom, Decl(conditionalTypes2.ts, 59, 19))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 58, 13))
+}
+

--- a/tests/baselines/reference/conditionalTypes2.types
+++ b/tests/baselines/reference/conditionalTypes2.types
@@ -1,0 +1,219 @@
+=== tests/cases/conformance/types/conditional/conditionalTypes2.ts ===
+interface Covariant<T> {
+>Covariant : Covariant<T>
+>T : T
+
+    foo: T extends string ? T : number;
+>foo : T extends string ? T : number
+>T : T
+>T : T
+}
+
+interface Contravariant<T> {
+>Contravariant : Contravariant<T>
+>T : T
+
+    foo: T extends string ? keyof T : number;
+>foo : T extends string ? keyof T : number
+>T : T
+>T : T
+}
+
+interface Invariant<T> {
+>Invariant : Invariant<T>
+>T : T
+
+    foo: T extends string ? keyof T : T;
+>foo : T extends string ? keyof T : T
+>T : T
+>T : T
+>T : T
+}
+
+interface A { a: string }
+>A : A
+>a : string
+
+interface B extends A { b: string }
+>B : B
+>A : A
+>b : string
+
+
+function f1(a: Covariant<A>, b: Covariant<B>) {
+>f1 : (a: Covariant<A>, b: Covariant<B>) => void
+>a : Covariant<A>
+>Covariant : Covariant<T>
+>A : A
+>b : Covariant<B>
+>Covariant : Covariant<T>
+>B : B
+
+    a = b;
+>a = b : Covariant<B>
+>a : Covariant<A>
+>b : Covariant<B>
+
+    b = a;  // Error
+>b = a : Covariant<A>
+>b : Covariant<B>
+>a : Covariant<A>
+}
+
+function f2(a: Contravariant<A>, b: Contravariant<B>) {
+>f2 : (a: Contravariant<A>, b: Contravariant<B>) => void
+>a : Contravariant<A>
+>Contravariant : Contravariant<T>
+>A : A
+>b : Contravariant<B>
+>Contravariant : Contravariant<T>
+>B : B
+
+    a = b;  // Error
+>a = b : Contravariant<B>
+>a : Contravariant<A>
+>b : Contravariant<B>
+
+    b = a;
+>b = a : Contravariant<A>
+>b : Contravariant<B>
+>a : Contravariant<A>
+}
+
+function f3(a: Invariant<A>, b: Invariant<B>) {
+>f3 : (a: Invariant<A>, b: Invariant<B>) => void
+>a : Invariant<A>
+>Invariant : Invariant<T>
+>A : A
+>b : Invariant<B>
+>Invariant : Invariant<T>
+>B : B
+
+    a = b;  // Error
+>a = b : Invariant<B>
+>a : Invariant<A>
+>b : Invariant<B>
+
+    b = a;  // Error
+>b = a : Invariant<A>
+>b : Invariant<B>
+>a : Invariant<A>
+}
+
+// Repros from #22860
+
+class Opt<T> {
+>Opt : Opt<T>
+>T : T
+
+    toVector(): Vector<T> {
+>toVector : () => Vector<T>
+>Vector : Vector<T>
+>T : T
+
+        return <any>undefined;
+><any>undefined : any
+>undefined : undefined
+    }
+}
+
+interface Seq<T> {
+>Seq : Seq<T>
+>T : T
+
+    tail(): Opt<Seq<T>>;
+>tail : () => Opt<Seq<T>>
+>Opt : Opt<T>
+>Seq : Seq<T>
+>T : T
+}
+
+class Vector<T> implements Seq<T> {
+>Vector : Vector<T>
+>T : T
+>Seq : Seq<T>
+>T : T
+
+    tail(): Opt<Vector<T>> {
+>tail : () => Opt<Vector<T>>
+>Opt : Opt<T>
+>Vector : Vector<T>
+>T : T
+
+        return <any>undefined;
+><any>undefined : any
+>undefined : undefined
+    }
+    partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
+>partition2 : { <U extends T>(predicate: (v: T) => v is U): [Vector<U>, Vector<Exclude<T, U>>]; (predicate: (x: T) => boolean): [Vector<T>, Vector<T>]; }
+>U : U
+>T : T
+>predicate : (v: T) => v is U
+>v : T
+>T : T
+>v : any
+>U : U
+>Vector : Vector<T>
+>U : U
+>Vector : Vector<T>
+>Exclude : Exclude<T, U>
+>T : T
+>U : U
+
+    partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
+>partition2 : { <U extends T>(predicate: (v: T) => v is U): [Vector<U>, Vector<Exclude<T, U>>]; (predicate: (x: T) => boolean): [Vector<T>, Vector<T>]; }
+>predicate : (x: T) => boolean
+>x : T
+>T : T
+>Vector : Vector<T>
+>T : T
+>Vector : Vector<T>
+>T : T
+
+    partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
+>partition2 : { <U extends T>(predicate: (v: T) => v is U): [Vector<U>, Vector<Exclude<T, U>>]; (predicate: (x: T) => boolean): [Vector<T>, Vector<T>]; }
+>U : U
+>T : T
+>predicate : (v: T) => boolean
+>v : T
+>T : T
+>Vector : Vector<T>
+>U : U
+>Vector : Vector<T>
+
+        return <any>undefined;
+><any>undefined : any
+>undefined : undefined
+    }
+}
+
+interface A1<T> {
+>A1 : A1<T>
+>T : T
+
+    bat: B1<A1<T>>;
+>bat : B1<A1<T>>
+>B1 : B1<T>
+>A1 : A1<T>
+>T : T
+}
+
+interface B1<T> extends A1<T> {
+>B1 : B1<T>
+>T : T
+>A1 : A1<T>
+>T : T
+
+    bat: B1<B1<T>>;
+>bat : B1<B1<T>>
+>B1 : B1<T>
+>B1 : B1<T>
+>T : T
+
+    boom: T extends any ? true : true
+>boom : T extends any ? true : true
+>T : T
+>true : true
+>true : true
+}
+

--- a/tests/baselines/reference/conditionalTypes2.types
+++ b/tests/baselines/reference/conditionalTypes2.types
@@ -30,18 +30,11 @@ interface Invariant<T> {
 >T : T
 }
 
-interface A { a: string }
+function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
+>f1 : <A, B extends A>(a: Covariant<A>, b: Covariant<B>) => void
 >A : A
->a : string
-
-interface B extends A { b: string }
 >B : B
 >A : A
->b : string
-
-
-function f1(a: Covariant<A>, b: Covariant<B>) {
->f1 : (a: Covariant<A>, b: Covariant<B>) => void
 >a : Covariant<A>
 >Covariant : Covariant<T>
 >A : A
@@ -60,8 +53,11 @@ function f1(a: Covariant<A>, b: Covariant<B>) {
 >a : Covariant<A>
 }
 
-function f2(a: Contravariant<A>, b: Contravariant<B>) {
->f2 : (a: Contravariant<A>, b: Contravariant<B>) => void
+function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
+>f2 : <A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) => void
+>A : A
+>B : B
+>A : A
 >a : Contravariant<A>
 >Contravariant : Contravariant<T>
 >A : A
@@ -80,8 +76,11 @@ function f2(a: Contravariant<A>, b: Contravariant<B>) {
 >a : Contravariant<A>
 }
 
-function f3(a: Invariant<A>, b: Invariant<B>) {
->f3 : (a: Invariant<A>, b: Invariant<B>) => void
+function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
+>f3 : <A, B extends A>(a: Invariant<A>, b: Invariant<B>) => void
+>A : A
+>B : B
+>A : A
 >a : Invariant<A>
 >Invariant : Invariant<T>
 >A : A

--- a/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes2.ts
@@ -13,21 +13,17 @@ interface Invariant<T> {
     foo: T extends string ? keyof T : T;
 }
 
-interface A { a: string }
-interface B extends A { b: string }
-
-
-function f1(a: Covariant<A>, b: Covariant<B>) {
+function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
     a = b;
     b = a;  // Error
 }
 
-function f2(a: Contravariant<A>, b: Contravariant<B>) {
+function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
     a = b;  // Error
     b = a;
 }
 
-function f3(a: Invariant<A>, b: Invariant<B>) {
+function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
     a = b;  // Error
     b = a;  // Error
 }

--- a/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes2.ts
@@ -34,18 +34,18 @@ function f3(a: Invariant<A>, b: Invariant<B>) {
 
 // Repros from #22860
 
-export class Option<T> {
+class Opt<T> {
     toVector(): Vector<T> {
         return <any>undefined;
     }
 }
 
 interface Seq<T> {
-    tail(): Option<Seq<T>>;
+    tail(): Opt<Seq<T>>;
 }
 
 class Vector<T> implements Seq<T> {
-    tail(): Option<Vector<T>> {
+    tail(): Opt<Vector<T>> {
         return <any>undefined;
     }
     partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];

--- a/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes2.ts
@@ -1,0 +1,65 @@
+// @strict: true
+// @declaration: true
+
+interface Covariant<T> {
+    foo: T extends string ? T : number;
+}
+
+interface Contravariant<T> {
+    foo: T extends string ? keyof T : number;
+}
+
+interface Invariant<T> {
+    foo: T extends string ? keyof T : T;
+}
+
+interface A { a: string }
+interface B extends A { b: string }
+
+
+function f1(a: Covariant<A>, b: Covariant<B>) {
+    a = b;
+    b = a;  // Error
+}
+
+function f2(a: Contravariant<A>, b: Contravariant<B>) {
+    a = b;  // Error
+    b = a;
+}
+
+function f3(a: Invariant<A>, b: Invariant<B>) {
+    a = b;  // Error
+    b = a;  // Error
+}
+
+// Repros from #22860
+
+export class Option<T> {
+    toVector(): Vector<T> {
+        return <any>undefined;
+    }
+}
+
+interface Seq<T> {
+    tail(): Option<Seq<T>>;
+}
+
+class Vector<T> implements Seq<T> {
+    tail(): Option<Vector<T>> {
+        return <any>undefined;
+    }
+    partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
+    partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
+    partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
+        return <any>undefined;
+    }
+}
+
+interface A1<T> {
+    bat: B1<A1<T>>;
+}
+
+interface B1<T> extends A1<T> {
+    bat: B1<B1<T>>;
+    boom: T extends any ? true : true
+}


### PR DESCRIPTION
This PR adds a missing type relationship for conditional types: Two conditional types `T1 extends U1 ? X1 : Y1` and `T2 extends U2 ? X2 : Y2` are related if

* one or both of `T1` and `T2` is related to the other,
* `U1` and `U2` are identical types,
* `X1` is related to `X2`, and
* `Y1` is related to `Y2`.

Fixes #22860.