### PR TITLE
Handle toplevel this-assignment without crashing

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2362,6 +2362,10 @@ namespace ts {
                     const symbolTable = hasModifier(thisContainer, ModifierFlags.Static) ? containingClass.symbol.exports : containingClass.symbol.members;
                     declareSymbol(symbolTable, containingClass.symbol, node, SymbolFlags.Property, SymbolFlags.None, /*isReplaceableByMethod*/ true);
                     break;
+                case SyntaxKind.SourceFile:
+                    // this.foo assignment in a source file
+                    // Do not bind. It would be nice to support this someday though.
+                    break;
 
                 default:
                     Debug.fail(Debug.showSyntaxKind(thisContainer));

--- a/tests/baselines/reference/topLevelThisAssignment.js
+++ b/tests/baselines/reference/topLevelThisAssignment.js
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/salsa/topLevelThisAssignment.ts] ////
+
+//// [a.js]
+this.a = 10;
+this.a;
+a;
+
+//// [b.js]
+this.a;
+a;
+
+
+//// [output.js]
+this.a = 10;
+this.a;
+a;
+this.a;
+a;

--- a/tests/baselines/reference/topLevelThisAssignment.symbols
+++ b/tests/baselines/reference/topLevelThisAssignment.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/salsa/a.js ===
+this.a = 10;
+No type information for this code.this.a;
+No type information for this code.a;
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/salsa/b.js ===
+this.a;
+No type information for this code.a;
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/topLevelThisAssignment.types
+++ b/tests/baselines/reference/topLevelThisAssignment.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/salsa/a.js ===
+this.a = 10;
+>this.a = 10 : 10
+>this.a : any
+>this : any
+>a : any
+>10 : 10
+
+this.a;
+>this.a : any
+>this : any
+>a : any
+
+a;
+>a : any
+
+=== tests/cases/conformance/salsa/b.js ===
+this.a;
+>this.a : any
+>this : any
+>a : any
+
+a;
+>a : any
+

--- a/tests/cases/conformance/salsa/topLevelThisAssignment.ts
+++ b/tests/cases/conformance/salsa/topLevelThisAssignment.ts
@@ -1,0 +1,10 @@
+// @out: output.js
+// @allowJs: true
+// @Filename: a.js
+this.a = 10;
+this.a;
+a;
+
+// @Filename: b.js
+this.a;
+a;


### PR DESCRIPTION
Do nothing now. Someday we might handle it correctly.

Fixes #22888