### PR TITLE
Handle ts-only declaration export aliases in system transformer

### DIFF
--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -916,7 +916,7 @@ namespace ts {
             else {
                 const original = getOriginalNode(node);
                 if (isModuleOrEnumDeclaration(original)) {
-                    return appendExportsOfDeclaration(statements, original);
+                    return append(appendExportsOfDeclaration(statements, original), node);
                 }
             }
 

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -913,6 +913,12 @@ namespace ts {
                 delete deferredExports[id];
                 return append(statements, node);
             }
+            else {
+                const original = getOriginalNode(node);
+                if (isModuleOrEnumDeclaration(original)) {
+                    return appendExportsOfDeclaration(statements, original);
+                }
+            }
 
             return node;
         }

--- a/tests/baselines/reference/systemNamespaceAliasEmit.js
+++ b/tests/baselines/reference/systemNamespaceAliasEmit.js
@@ -1,0 +1,34 @@
+//// [systemNamespaceAliasEmit.ts]
+namespace ns {
+    const value = 1;
+}
+
+enum AnEnum {
+    ONE,
+    TWO
+}
+
+export {ns, AnEnum, ns as FooBar, AnEnum as BarEnum};
+
+//// [systemNamespaceAliasEmit.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var ns, AnEnum;
+    return {
+        setters: [],
+        execute: function () {
+            (function (ns) {
+                var value = 1;
+            })(ns || (ns = {}));
+            exports_1("ns", ns);
+            exports_1("FooBar", ns);
+            (function (AnEnum) {
+                AnEnum[AnEnum["ONE"] = 0] = "ONE";
+                AnEnum[AnEnum["TWO"] = 1] = "TWO";
+            })(AnEnum || (AnEnum = {}));
+            exports_1("AnEnum", AnEnum);
+            exports_1("BarEnum", AnEnum);
+        }
+    };
+});

--- a/tests/baselines/reference/systemNamespaceAliasEmit.symbols
+++ b/tests/baselines/reference/systemNamespaceAliasEmit.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/systemNamespaceAliasEmit.ts ===
+namespace ns {
+>ns : Symbol(ns, Decl(systemNamespaceAliasEmit.ts, 0, 0))
+
+    const value = 1;
+>value : Symbol(value, Decl(systemNamespaceAliasEmit.ts, 1, 9))
+}
+
+enum AnEnum {
+>AnEnum : Symbol(AnEnum, Decl(systemNamespaceAliasEmit.ts, 2, 1))
+
+    ONE,
+>ONE : Symbol(BarEnum.ONE, Decl(systemNamespaceAliasEmit.ts, 4, 13))
+
+    TWO
+>TWO : Symbol(BarEnum.TWO, Decl(systemNamespaceAliasEmit.ts, 5, 8))
+}
+
+export {ns, AnEnum, ns as FooBar, AnEnum as BarEnum};
+>ns : Symbol(ns, Decl(systemNamespaceAliasEmit.ts, 9, 8))
+>AnEnum : Symbol(AnEnum, Decl(systemNamespaceAliasEmit.ts, 9, 11))
+>ns : Symbol(FooBar, Decl(systemNamespaceAliasEmit.ts, 9, 19))
+>FooBar : Symbol(FooBar, Decl(systemNamespaceAliasEmit.ts, 9, 19))
+>AnEnum : Symbol(BarEnum, Decl(systemNamespaceAliasEmit.ts, 9, 33))
+>BarEnum : Symbol(BarEnum, Decl(systemNamespaceAliasEmit.ts, 9, 33))
+

--- a/tests/baselines/reference/systemNamespaceAliasEmit.types
+++ b/tests/baselines/reference/systemNamespaceAliasEmit.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/systemNamespaceAliasEmit.ts ===
+namespace ns {
+>ns : typeof ns
+
+    const value = 1;
+>value : 1
+>1 : 1
+}
+
+enum AnEnum {
+>AnEnum : AnEnum
+
+    ONE,
+>ONE : AnEnum.ONE
+
+    TWO
+>TWO : AnEnum.TWO
+}
+
+export {ns, AnEnum, ns as FooBar, AnEnum as BarEnum};
+>ns : typeof ns
+>AnEnum : typeof AnEnum
+>ns : typeof ns
+>FooBar : typeof ns
+>AnEnum : typeof AnEnum
+>BarEnum : typeof AnEnum
+

--- a/tests/cases/compiler/systemNamespaceAliasEmit.ts
+++ b/tests/cases/compiler/systemNamespaceAliasEmit.ts
@@ -1,0 +1,11 @@
+// @module: system
+namespace ns {
+    const value = 1;
+}
+
+enum AnEnum {
+    ONE,
+    TWO
+}
+
+export {ns, AnEnum, ns as FooBar, AnEnum as BarEnum};


### PR DESCRIPTION
Fixes #15074.

Enums and namespaces without an export modifier are transformed to an IIFE in `ts.ts` with an accompanying end-of-declaration marker, whereas when they are exported directly they are a variable statement instead, which was visited and had its exports collected. Since the transform elides export declarations (and relies on export marking during the walk of other nodes instead), it would never check the IIFEs for exports (since they're not directly exportable). We still want to avoid collecting exports during the visit of expression statements, however, since a merged enum/namespace is _also_ transpiled to one (and we don't want to duplicate the export for both the end of merge marker and the end of declaration marker); so instead we check for enums and namespaces when we transform an end of declaration marker and inject the missing exports at that time if we haven't already collected them.
