### PR TITLE
isMethodLike recognises prototype-assignment methods

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16103,7 +16103,7 @@ namespace ts {
         }
 
         function isMethodLike(symbol: Symbol) {
-            return !!(symbol.flags & SymbolFlags.Method || getCheckFlags(symbol) & CheckFlags.SyntheticMethod);
+            return !!(symbol.flags & SymbolFlags.Method || getCheckFlags(symbol) & CheckFlags.SyntheticMethod || isFunctionLikeDeclaration(getAssignedJavascriptInitializer(symbol.valueDeclaration)));
         }
 
         /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16103,7 +16103,9 @@ namespace ts {
         }
 
         function isMethodLike(symbol: Symbol) {
-            return !!(symbol.flags & SymbolFlags.Method || getCheckFlags(symbol) & CheckFlags.SyntheticMethod || isFunctionLikeDeclaration(getAssignedJavascriptInitializer(symbol.valueDeclaration)));
+            return !!(symbol.flags & SymbolFlags.Method ||
+                      getCheckFlags(symbol) & CheckFlags.SyntheticMethod ||
+                      isInJavaScriptFile(symbol.valueDeclaration) && isFunctionLikeDeclaration(getAssignedJavascriptInitializer(symbol.valueDeclaration)));
         }
 
         /**

--- a/tests/baselines/reference/typeFromPropertyAssignment23.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment23.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/salsa/a.js ===
+class Ex {
+>Ex : Symbol(Ex, Decl(a.js, 0, 0))
+
+    foo() {
+>foo : Symbol(Ex.foo, Decl(a.js, 0, 10))
+    }
+}
+
+class MyClass extends Ex {
+>MyClass : Symbol(MyClass, Decl(a.js, 3, 1))
+>Ex : Symbol(Ex, Decl(a.js, 0, 0))
+
+}
+
+// this override should be fine (even if it's a little odd)
+MyClass.prototype.foo = function() {
+>MyClass.prototype.foo : Symbol(MyClass.foo, Decl(a.js, 7, 1))
+>MyClass.prototype : Symbol(MyClass.foo, Decl(a.js, 7, 1))
+>MyClass : Symbol(MyClass, Decl(a.js, 3, 1))
+>prototype : Symbol(MyClass.prototype)
+>foo : Symbol(MyClass.foo, Decl(a.js, 7, 1))
+}
+

--- a/tests/baselines/reference/typeFromPropertyAssignment23.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment23.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/salsa/a.js ===
+class Ex {
+>Ex : Ex
+
+    foo() {
+>foo : () => void
+    }
+}
+
+class MyClass extends Ex {
+>MyClass : MyClass
+>Ex : Ex
+
+}
+
+// this override should be fine (even if it's a little odd)
+MyClass.prototype.foo = function() {
+>MyClass.prototype.foo = function() {} : () => void
+>MyClass.prototype.foo : () => void
+>MyClass.prototype : MyClass
+>MyClass : typeof MyClass
+>prototype : MyClass
+>foo : () => void
+>function() {} : () => void
+}
+

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment23.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment23.ts
@@ -1,0 +1,17 @@
+// @noEmit: true
+// @strict: true
+// @checkJs: true
+// @allowJs: true
+// @Filename: a.js
+class Ex {
+    foo() {
+    }
+}
+
+class MyClass extends Ex {
+
+}
+
+// this override should be fine (even if it's a little odd)
+MyClass.prototype.foo = function() {
+}


### PR DESCRIPTION
Previously it did not. This led to some bogus errors.

Fixes #22895 