### PR TITLE
Fix typo in Array Type Literals section of spec

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1706,7 +1706,7 @@ When union, intersection, function, or constructor types are used as array eleme
 
 ```TypeScript
 (string | number)[]  
-(() => string))[]
+(() => string)[]
 ```
 
 Alternatively, array types can be written using the 'Array&lt;T>' notation. For example, the types above are equivalent to


### PR DESCRIPTION
Extra end bracket in 2nd line of 1st example code block under Array Type Literals subsection  (3.8.4) of the spec.

Changed `(() => string))[]` to `(() => string)[]`.