### PR TITLE
Add support for ReadonlyArray to Array.isArray

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1253,7 +1253,7 @@ interface ArrayConstructor {
     (arrayLength?: number): any[];
     <T>(arrayLength: number): T[];
     <T>(...items: T[]): T[];
-    isArray(arg: any): arg is Array<any>;
+    isArray(arg: any): arg is ReadonlyArray<any>;
     readonly prototype: Array<any>;
 }
 

--- a/tests/baselines/reference/fixSignatureCaching.types
+++ b/tests/baselines/reference/fixSignatureCaching.types
@@ -1109,9 +1109,9 @@ define(function () {
 >Array : ArrayConstructor
 
         Array.isArray : function (value) { return Object.prototype.toString.call(value) === '[object Array]'; };
->Array.isArray : (arg: any) => arg is any[]
+>Array.isArray : (arg: any) => arg is ReadonlyArray<any>
 >Array : ArrayConstructor
->isArray : (arg: any) => arg is any[]
+>isArray : (arg: any) => arg is ReadonlyArray<any>
 >function (value) { return Object.prototype.toString.call(value) === '[object Array]'; } : (value: any) => boolean
 >value : any
 >Object.prototype.toString.call(value) === '[object Array]' : boolean

--- a/tests/baselines/reference/isArray.errors.txt
+++ b/tests/baselines/reference/isArray.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/compiler/isArray.ts(7,11): error TS2322: Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/isArray.ts(17,11): error TS2322: Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/isArray.ts(18,24): error TS2339: Property 'push' does not exist on type 'ReadonlyArray<number>'.
+
+
+==== tests/cases/compiler/isArray.ts (3 errors) ====
+    var maybeArray: number | number[];
+    
+    
+    if (Array.isArray(maybeArray)) {
+        maybeArray.length; // OK
+        maybeArray.push(0); // OK
+        const str: string = maybeArray[0]; // Expect error
+              ~~~
+!!! error TS2322: Type 'number' is not assignable to type 'string'.
+    }
+    else {
+        maybeArray.toFixed(); // OK
+    }
+    
+    var maybeReadonlyArray: number | ReadonlyArray<number>;
+    if (Array.isArray(maybeReadonlyArray)) {
+        maybeReadonlyArray.length; // OK
+        const num = maybeReadonlyArray[0]; // OK, expect typeof num = number
+        const str: string = maybeReadonlyArray[0]; // Expect error
+              ~~~
+!!! error TS2322: Type 'number' is not assignable to type 'string'.
+        maybeReadonlyArray.push(0); // Expect error
+                           ~~~~
+!!! error TS2339: Property 'push' does not exist on type 'ReadonlyArray<number>'.
+    } else {
+        maybeReadonlyArray.toFixed();
+    }

--- a/tests/baselines/reference/isArray.js
+++ b/tests/baselines/reference/isArray.js
@@ -4,16 +4,40 @@ var maybeArray: number | number[];
 
 if (Array.isArray(maybeArray)) {
     maybeArray.length; // OK
+    maybeArray.push(0); // OK
+    const str: string = maybeArray[0]; // Expect error
 }
 else {
     maybeArray.toFixed(); // OK
+}
+
+var maybeReadonlyArray: number | ReadonlyArray<number>;
+if (Array.isArray(maybeReadonlyArray)) {
+    maybeReadonlyArray.length; // OK
+    const num = maybeReadonlyArray[0]; // OK, expect typeof num = number
+    const str: string = maybeReadonlyArray[0]; // Expect error
+    maybeReadonlyArray.push(0); // Expect error
+} else {
+    maybeReadonlyArray.toFixed();
 }
 
 //// [isArray.js]
 var maybeArray;
 if (Array.isArray(maybeArray)) {
     maybeArray.length; // OK
+    maybeArray.push(0); // OK
+    var str = maybeArray[0]; // Expect error
 }
 else {
     maybeArray.toFixed(); // OK
+}
+var maybeReadonlyArray;
+if (Array.isArray(maybeReadonlyArray)) {
+    maybeReadonlyArray.length; // OK
+    var num = maybeReadonlyArray[0]; // OK, expect typeof num = number
+    var str = maybeReadonlyArray[0]; // Expect error
+    maybeReadonlyArray.push(0); // Expect error
+}
+else {
+    maybeReadonlyArray.toFixed();
 }

--- a/tests/baselines/reference/isArray.symbols
+++ b/tests/baselines/reference/isArray.symbols
@@ -13,10 +13,52 @@ if (Array.isArray(maybeArray)) {
 >maybeArray.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
 >maybeArray : Symbol(maybeArray, Decl(isArray.ts, 0, 3))
 >length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+
+    maybeArray.push(0); // OK
+>maybeArray.push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+>maybeArray : Symbol(maybeArray, Decl(isArray.ts, 0, 3))
+>push : Symbol(Array.push, Decl(lib.d.ts, --, --))
+
+    const str: string = maybeArray[0]; // Expect error
+>str : Symbol(str, Decl(isArray.ts, 6, 9))
+>maybeArray : Symbol(maybeArray, Decl(isArray.ts, 0, 3))
 }
 else {
     maybeArray.toFixed(); // OK
 >maybeArray.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 >maybeArray : Symbol(maybeArray, Decl(isArray.ts, 0, 3))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+}
+
+var maybeReadonlyArray: number | ReadonlyArray<number>;
+>maybeReadonlyArray : Symbol(maybeReadonlyArray, Decl(isArray.ts, 12, 3))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.d.ts, --, --))
+
+if (Array.isArray(maybeReadonlyArray)) {
+>Array.isArray : Symbol(ArrayConstructor.isArray, Decl(lib.d.ts, --, --))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>isArray : Symbol(ArrayConstructor.isArray, Decl(lib.d.ts, --, --))
+>maybeReadonlyArray : Symbol(maybeReadonlyArray, Decl(isArray.ts, 12, 3))
+
+    maybeReadonlyArray.length; // OK
+>maybeReadonlyArray.length : Symbol(ReadonlyArray.length, Decl(lib.d.ts, --, --))
+>maybeReadonlyArray : Symbol(maybeReadonlyArray, Decl(isArray.ts, 12, 3))
+>length : Symbol(ReadonlyArray.length, Decl(lib.d.ts, --, --))
+
+    const num = maybeReadonlyArray[0]; // OK, expect typeof num = number
+>num : Symbol(num, Decl(isArray.ts, 15, 9))
+>maybeReadonlyArray : Symbol(maybeReadonlyArray, Decl(isArray.ts, 12, 3))
+
+    const str: string = maybeReadonlyArray[0]; // Expect error
+>str : Symbol(str, Decl(isArray.ts, 16, 9))
+>maybeReadonlyArray : Symbol(maybeReadonlyArray, Decl(isArray.ts, 12, 3))
+
+    maybeReadonlyArray.push(0); // Expect error
+>maybeReadonlyArray : Symbol(maybeReadonlyArray, Decl(isArray.ts, 12, 3))
+
+} else {
+    maybeReadonlyArray.toFixed();
+>maybeReadonlyArray.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>maybeReadonlyArray : Symbol(maybeReadonlyArray, Decl(isArray.ts, 12, 3))
 >toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 }

--- a/tests/baselines/reference/isArray.types
+++ b/tests/baselines/reference/isArray.types
@@ -5,20 +5,76 @@ var maybeArray: number | number[];
 
 if (Array.isArray(maybeArray)) {
 >Array.isArray(maybeArray) : boolean
->Array.isArray : (arg: any) => arg is any[]
+>Array.isArray : (arg: any) => arg is ReadonlyArray<any>
 >Array : ArrayConstructor
->isArray : (arg: any) => arg is any[]
+>isArray : (arg: any) => arg is ReadonlyArray<any>
 >maybeArray : number | number[]
 
     maybeArray.length; // OK
 >maybeArray.length : number
 >maybeArray : number[]
 >length : number
+
+    maybeArray.push(0); // OK
+>maybeArray.push(0) : number
+>maybeArray.push : (...items: number[]) => number
+>maybeArray : number[]
+>push : (...items: number[]) => number
+>0 : 0
+
+    const str: string = maybeArray[0]; // Expect error
+>str : string
+>maybeArray[0] : number
+>maybeArray : number[]
+>0 : 0
 }
 else {
     maybeArray.toFixed(); // OK
 >maybeArray.toFixed() : string
 >maybeArray.toFixed : (fractionDigits?: number) => string
 >maybeArray : number
+>toFixed : (fractionDigits?: number) => string
+}
+
+var maybeReadonlyArray: number | ReadonlyArray<number>;
+>maybeReadonlyArray : number | ReadonlyArray<number>
+>ReadonlyArray : ReadonlyArray<T>
+
+if (Array.isArray(maybeReadonlyArray)) {
+>Array.isArray(maybeReadonlyArray) : boolean
+>Array.isArray : (arg: any) => arg is ReadonlyArray<any>
+>Array : ArrayConstructor
+>isArray : (arg: any) => arg is ReadonlyArray<any>
+>maybeReadonlyArray : number | ReadonlyArray<number>
+
+    maybeReadonlyArray.length; // OK
+>maybeReadonlyArray.length : number
+>maybeReadonlyArray : ReadonlyArray<number>
+>length : number
+
+    const num = maybeReadonlyArray[0]; // OK, expect typeof num = number
+>num : number
+>maybeReadonlyArray[0] : number
+>maybeReadonlyArray : ReadonlyArray<number>
+>0 : 0
+
+    const str: string = maybeReadonlyArray[0]; // Expect error
+>str : string
+>maybeReadonlyArray[0] : number
+>maybeReadonlyArray : ReadonlyArray<number>
+>0 : 0
+
+    maybeReadonlyArray.push(0); // Expect error
+>maybeReadonlyArray.push(0) : any
+>maybeReadonlyArray.push : any
+>maybeReadonlyArray : ReadonlyArray<number>
+>push : any
+>0 : 0
+
+} else {
+    maybeReadonlyArray.toFixed();
+>maybeReadonlyArray.toFixed() : string
+>maybeReadonlyArray.toFixed : (fractionDigits?: number) => string
+>maybeReadonlyArray : number
 >toFixed : (fractionDigits?: number) => string
 }

--- a/tests/baselines/reference/malformedTags.types
+++ b/tests/baselines/reference/malformedTags.types
@@ -6,7 +6,7 @@
  */
 var isArray = Array.isArray;
 >isArray : Function
->Array.isArray : (arg: any) => arg is any[]
+>Array.isArray : (arg: any) => arg is ReadonlyArray<any>
 >Array : ArrayConstructor
->isArray : (arg: any) => arg is any[]
+>isArray : (arg: any) => arg is ReadonlyArray<any>
 

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -3131,27 +3131,27 @@ module Harness {
 >identifier : any
 
             public normalizeToArray(arg: any) {
->normalizeToArray : (arg: any) => any[]
+>normalizeToArray : (arg: any) => ReadonlyArray<any>
 >arg : any
 
                 if ((Array.isArray && Array.isArray(arg)) || arg instanceof Array)
 >(Array.isArray && Array.isArray(arg)) || arg instanceof Array : boolean
 >(Array.isArray && Array.isArray(arg)) : boolean
 >Array.isArray && Array.isArray(arg) : boolean
->Array.isArray : (arg: any) => arg is any[]
+>Array.isArray : (arg: any) => arg is ReadonlyArray<any>
 >Array : ArrayConstructor
->isArray : (arg: any) => arg is any[]
+>isArray : (arg: any) => arg is ReadonlyArray<any>
 >Array.isArray(arg) : boolean
->Array.isArray : (arg: any) => arg is any[]
+>Array.isArray : (arg: any) => arg is ReadonlyArray<any>
 >Array : ArrayConstructor
->isArray : (arg: any) => arg is any[]
+>isArray : (arg: any) => arg is ReadonlyArray<any>
 >arg : any
 >arg instanceof Array : boolean
 >arg : any
 >Array : ArrayConstructor
 
                     return arg;
->arg : any[]
+>arg : ReadonlyArray<any>
 
                 return [arg];
 >[arg] : any[]
@@ -3311,12 +3311,12 @@ module Harness {
 >others : any
 
                 others = this.normalizeToArray(others);
->others = this.normalizeToArray(others) : any[]
+>others = this.normalizeToArray(others) : ReadonlyArray<any>
 >others : any
->this.normalizeToArray(others) : any[]
->this.normalizeToArray : (arg: any) => any[]
+>this.normalizeToArray(others) : ReadonlyArray<any>
+>this.normalizeToArray : (arg: any) => ReadonlyArray<any>
 >this : this
->normalizeToArray : (arg: any) => any[]
+>normalizeToArray : (arg: any) => ReadonlyArray<any>
 >others : any
 
                 for (var i = 0; i < others.length; i++) {
@@ -3365,12 +3365,12 @@ module Harness {
 >others : any
 
                 others = this.normalizeToArray(others);
->others = this.normalizeToArray(others) : any[]
+>others = this.normalizeToArray(others) : ReadonlyArray<any>
 >others : any
->this.normalizeToArray(others) : any[]
->this.normalizeToArray : (arg: any) => any[]
+>this.normalizeToArray(others) : ReadonlyArray<any>
+>this.normalizeToArray : (arg: any) => ReadonlyArray<any>
 >this : this
->normalizeToArray : (arg: any) => any[]
+>normalizeToArray : (arg: any) => ReadonlyArray<any>
 >others : any
 
                 for (var i = 0; i < others.length; i++) {
@@ -3521,12 +3521,12 @@ module Harness {
 >others : any
 
                 others = this.normalizeToArray(others);
->others = this.normalizeToArray(others) : any[]
+>others = this.normalizeToArray(others) : ReadonlyArray<any>
 >others : any
->this.normalizeToArray(others) : any[]
->this.normalizeToArray : (arg: any) => any[]
+>this.normalizeToArray(others) : ReadonlyArray<any>
+>this.normalizeToArray : (arg: any) => ReadonlyArray<any>
 >this : this
->normalizeToArray : (arg: any) => any[]
+>normalizeToArray : (arg: any) => ReadonlyArray<any>
 >others : any
 
                 for (var i = 0; i < others.length; i++) {
@@ -3577,12 +3577,12 @@ module Harness {
 >others : any
 
                 others = this.normalizeToArray(others);
->others = this.normalizeToArray(others) : any[]
+>others = this.normalizeToArray(others) : ReadonlyArray<any>
 >others : any
->this.normalizeToArray(others) : any[]
->this.normalizeToArray : (arg: any) => any[]
+>this.normalizeToArray(others) : ReadonlyArray<any>
+>this.normalizeToArray : (arg: any) => ReadonlyArray<any>
 >this : this
->normalizeToArray : (arg: any) => any[]
+>normalizeToArray : (arg: any) => ReadonlyArray<any>
 >others : any
 
                 for (var i = 0; i < others.length; i++) {

--- a/tests/baselines/reference/partiallyDiscriminantedUnions.types
+++ b/tests/baselines/reference/partiallyDiscriminantedUnions.types
@@ -96,9 +96,9 @@ function isShape(s : Shapes): s is Shape {
     return !Array.isArray(s);
 >!Array.isArray(s) : boolean
 >Array.isArray(s) : boolean
->Array.isArray : (arg: any) => arg is any[]
+>Array.isArray : (arg: any) => arg is ReadonlyArray<any>
 >Array : ArrayConstructor
->isArray : (arg: any) => arg is any[]
+>isArray : (arg: any) => arg is ReadonlyArray<any>
 >s : Shapes
 }
 

--- a/tests/cases/compiler/isArray.ts
+++ b/tests/cases/compiler/isArray.ts
@@ -3,7 +3,19 @@ var maybeArray: number | number[];
 
 if (Array.isArray(maybeArray)) {
     maybeArray.length; // OK
+    maybeArray.push(0); // OK
+    const str: string = maybeArray[0]; // Expect error
 }
 else {
     maybeArray.toFixed(); // OK
+}
+
+var maybeReadonlyArray: number | ReadonlyArray<number>;
+if (Array.isArray(maybeReadonlyArray)) {
+    maybeReadonlyArray.length; // OK
+    const num = maybeReadonlyArray[0]; // OK, expect typeof num = number
+    const str: string = maybeReadonlyArray[0]; // Expect error
+    maybeReadonlyArray.push(0); // Expect error
+} else {
+    maybeReadonlyArray.toFixed();
 }


### PR DESCRIPTION
Fixes #17002

This makes the `Array.isArray` test assert that the argument is `ReadonlyArray` instead of `Array`. This actually works well as the compiler preserves the `Array`-ness if the input could have been a full `Array` instead of just a `ReadonlyArray`; as demonstrated by the test.

This is arguably a breaking change if the argument actually is `any` and the user was expecting to get a mutable array from the output; but blindly mutating some `any` just because it passes `Array.isArray` sounds like a terrible idea so I think it's a good break.