### PR TITLE
Ability to extend static Event interface

### DIFF
--- a/lib/lib.d.ts
+++ b/lib/lib.d.ts
@@ -7847,13 +7847,15 @@ interface Event {
     readonly CAPTURING_PHASE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -3710,13 +3710,15 @@ interface Event {
     readonly CAPTURING_PHASE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/lib/lib.es2016.full.d.ts
+++ b/lib/lib.es2016.full.d.ts
@@ -3713,13 +3713,15 @@ interface Event {
     readonly CAPTURING_PHASE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/lib/lib.es2017.full.d.ts
+++ b/lib/lib.es2017.full.d.ts
@@ -3718,13 +3718,15 @@ interface Event {
     readonly CAPTURING_PHASE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/lib/lib.es2018.full.d.ts
+++ b/lib/lib.es2018.full.d.ts
@@ -3713,13 +3713,15 @@ interface Event {
     readonly CAPTURING_PHASE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/lib/lib.es6.d.ts
+++ b/lib/lib.es6.d.ts
@@ -9558,13 +9558,15 @@ interface Event {
     readonly CAPTURING_PHASE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/lib/lib.esnext.full.d.ts
+++ b/lib/lib.esnext.full.d.ts
@@ -3716,13 +3716,15 @@ interface Event {
     readonly CAPTURING_PHASE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/lib/lib.webworker.d.ts
+++ b/lib/lib.webworker.d.ts
@@ -403,13 +403,15 @@ interface Event {
     readonly CAPTURING_PHASE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -4609,14 +4609,15 @@ interface Event {
     readonly NONE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-    readonly NONE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventListenerObject {
     handleEvent(evt: Event): void;

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -490,14 +490,15 @@ interface Event {
     readonly NONE: number;
 }
 
-declare var Event: {
+interface EventConstructor {
     prototype: Event;
     new(typeArg: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;
-    readonly NONE: number;
-};
+}
+
+declare var Event: EventConstructor;
 
 interface EventListenerObject {
     handleEvent(evt: Event): void;

--- a/tests/baselines/reference/typeFromPropertyAssignment21.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment21.symbols
@@ -1,9 +1,9 @@
 === tests/cases/conformance/salsa/chrome-devtools-DOMExtension.js ===
 // Extend that DOM! (doesn't work, but shouldn't crash)
 Event.prototype.removeChildren = function () {
->Event.prototype : Symbol(prototype, Decl(lib.dom.d.ts, --, --))
+>Event.prototype : Symbol(EventConstructor.prototype, Decl(lib.dom.d.ts, --, --))
 >Event : Symbol(Event, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
->prototype : Symbol(prototype, Decl(lib.dom.d.ts, --, --))
+>prototype : Symbol(EventConstructor.prototype, Decl(lib.dom.d.ts, --, --))
 
     this.textContent = 'nope, not going to happen'
 >this : Symbol(Event, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))

--- a/tests/baselines/reference/typeFromPropertyAssignment21.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment21.types
@@ -4,7 +4,7 @@ Event.prototype.removeChildren = function () {
 >Event.prototype.removeChildren = function () {    this.textContent = 'nope, not going to happen'} : () => void
 >Event.prototype.removeChildren : any
 >Event.prototype : Event
->Event : { new (typeArg: string, eventInitDict?: EventInit): Event; prototype: Event; readonly AT_TARGET: number; readonly BUBBLING_PHASE: number; readonly CAPTURING_PHASE: number; readonly NONE: number; }
+>Event : EventConstructor
 >prototype : Event
 >removeChildren : any
 >function () {    this.textContent = 'nope, not going to happen'} : () => void

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -7110,13 +7110,15 @@ interface Event {
     CAPTURING_PHASE: number;
 }
 
-declare var Event: {
-    prototype: Event;
-    new(type: string, eventInitDict?: EventInit): Event;
-    AT_TARGET: number;
-    BUBBLING_PHASE: number;
-    CAPTURING_PHASE: number;
+interface EventConstructor {
+  prototype: Event;
+  new(type: string, eventInitDict?: EventInit): Event;
+  AT_TARGET: number;
+  BUBBLING_PHASE: number;
+  CAPTURING_PHASE: number;
 }
+
+declare var Event: EventConstructor;
 
 interface EventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;


### PR DESCRIPTION
## Main idea
Moved EventConstructor to separate interface for better extensibility.
Before this patch Event was declared with literal:

```ts 
declare var Event: {
    prototype: Event;
    new(typeArg: string, eventInitDict?: EventInit): Event;
    readonly AT_TARGET: number;
    readonly BUBBLING_PHASE: number;
    readonly CAPTURING_PHASE: number;
};
```

in that case there is no ability to add static properties to Event using declaration merging.

Moved EventConstructor to separate named interface, now anyone can extend it in own project using declaration merging, same idea as ArrayConstructor declaration:

```ts
interface EventConstructor {
    prototype: Event;
    new(typeArg: string, eventInitDict?: EventInit): Event;
    readonly AT_TARGET: number;
    readonly BUBBLING_PHASE: number;
    readonly CAPTURING_PHASE: number;
}

declare var Event: EventConstructor;
```

As far as I know, this change made no side effects for anyone.

## And some additional questions

### 1. Strange changes in dom.generated.d.ts
src\lib\dom.generated.d.ts git shows that 1144 lines added and 1143 removed, but TortoiseGitMerge shows only some lines changed(event declaration). Github shows many lines changed. I`m using Windows 10 may be it is line ending problem, but file is autogenerated, what should i do to make diff clear?

### 2. const vs var

Array declared:

```ts
declare const Array ...
``` 

But Event declared:

```ts
declare var Event ...
```

Should all declarations be const or var?

### 3. Different declarations fo Event in different files

Declaration of Event declared in tests\lib\lib.d.ts:

```ts
declare var Event: {
    prototype: Event;
    new(type: string, eventInitDict?: EventInit): Event;
    AT_TARGET: number;
    BUBBLING_PHASE: number;
    CAPTURING_PHASE: number;
}
```
differs from Event declared in all another d.ts files:

```ts
declare var Event: {
    prototype: Event;
    new(typeArg: string, eventInitDict?: EventInit): Event;
    readonly AT_TARGET: number;
    readonly BUBBLING_PHASE: number;
    readonly CAPTURING_PHASE: number;
};
```

 shoul this declarations be equal? By meaning they are equal now.

### 4. Convert another declarations?

Would it be better to convert all `delare var/const` declarations with literal type to separate named types?

May be some questions better to convert to separate issues for discussion?  



