### PR TITLE
Options which have category Diagnostics.Advanced_Options do not work with `--init`

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1346,7 +1346,7 @@ namespace ts {
             const categorizedOptions = createMultiMap<CommandLineOption>();
             for (const option of optionDeclarations) {
                 const { category } = option;
-                if (category !== undefined && category !== Diagnostics.Command_line_Options && category !== Diagnostics.Advanced_Options) {
+                if (category !== undefined && category !== Diagnostics.Command_line_Options) {
                     categorizedOptions.add(getLocaleSpecificMessage(category), option);
                 }
             }


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes  #22957 
