### PR TITLE
Don't allow to iterate over 'never'

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22619,7 +22619,12 @@ namespace ts {
          * we want to get the iterated type of an iterable for ES2015 or later, or the iterated type
          * of a iterable (if defined globally) or element type of an array like for ES2015 or earlier.
          */
-        function getIteratedTypeOrElementType(inputType: Type, errorNode: Node, allowStringInput: boolean, allowAsyncIterables: boolean, checkAssignability: boolean): Type {
+        function getIteratedTypeOrElementType(inputType: Type, errorNode: Node, allowStringInput: boolean, allowAsyncIterables: boolean, checkAssignability: boolean): Type | undefined {
+            if (inputType === neverType) {
+                reportTypeNotIterableError(errorNode, allowAsyncIterables);
+                return undefined;
+            }
+
             const uplevelIteration = languageVersion >= ScriptTarget.ES2015;
             const downlevelIteration = !uplevelIteration && compilerOptions.downlevelIteration;
 
@@ -22786,11 +22791,8 @@ namespace ts {
                 const signatures = methodType && getSignaturesOfType(methodType, SignatureKind.Call);
                 if (!some(signatures)) {
                     if (errorNode) {
-                        error(errorNode,
-                            allowAsyncIterables
-                                ? Diagnostics.Type_must_have_a_Symbol_asyncIterator_method_that_returns_an_async_iterator
-                                : Diagnostics.Type_must_have_a_Symbol_iterator_method_that_returns_an_iterator);
                         // only report on the first error
+                        reportTypeNotIterableError(errorNode, allowAsyncIterables);
                         errorNode = undefined;
                     }
                     return undefined;
@@ -22811,6 +22813,12 @@ namespace ts {
                     ? typeAsIterable.iteratedTypeOfAsyncIterable = iteratedType
                     : typeAsIterable.iteratedTypeOfIterable = iteratedType;
             }
+        }
+
+        function reportTypeNotIterableError(errorNode: Node, allowAsyncIterables: boolean): void {
+            error(errorNode, allowAsyncIterables
+                ? Diagnostics.Type_must_have_a_Symbol_asyncIterator_method_that_returns_an_async_iterator
+                : Diagnostics.Type_must_have_a_Symbol_iterator_method_that_returns_an_iterator);
         }
 
         /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22621,7 +22621,7 @@ namespace ts {
          */
         function getIteratedTypeOrElementType(inputType: Type, errorNode: Node, allowStringInput: boolean, allowAsyncIterables: boolean, checkAssignability: boolean): Type | undefined {
             if (inputType === neverType) {
-                reportTypeNotIterableError(errorNode, allowAsyncIterables);
+                reportTypeNotIterableError(errorNode, inputType, allowAsyncIterables);
                 return undefined;
             }
 
@@ -22792,7 +22792,7 @@ namespace ts {
                 if (!some(signatures)) {
                     if (errorNode) {
                         // only report on the first error
-                        reportTypeNotIterableError(errorNode, allowAsyncIterables);
+                        reportTypeNotIterableError(errorNode, type, allowAsyncIterables);
                         errorNode = undefined;
                     }
                     return undefined;
@@ -22815,10 +22815,10 @@ namespace ts {
             }
         }
 
-        function reportTypeNotIterableError(errorNode: Node, allowAsyncIterables: boolean): void {
+        function reportTypeNotIterableError(errorNode: Node, type: Type, allowAsyncIterables: boolean): void {
             error(errorNode, allowAsyncIterables
-                ? Diagnostics.Type_must_have_a_Symbol_asyncIterator_method_that_returns_an_async_iterator
-                : Diagnostics.Type_must_have_a_Symbol_iterator_method_that_returns_an_iterator);
+                ? Diagnostics.Type_0_must_have_a_Symbol_asyncIterator_method_that_returns_an_async_iterator
+                : Diagnostics.Type_0_must_have_a_Symbol_iterator_method_that_returns_an_iterator, typeToString(type));
         }
 
         /**

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1668,7 +1668,7 @@
         "category": "Error",
         "code": 2487
     },
-    "Type must have a '[Symbol.iterator]()' method that returns an iterator.": {
+    "Type '{0}' must have a '[Symbol.iterator]()' method that returns an iterator.": {
         "category": "Error",
         "code": 2488
     },
@@ -1732,7 +1732,7 @@
         "category": "Error",
         "code": 2503
     },
-    "Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.": {
+    "Type '{0}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.": {
         "category": "Error",
         "code": 2504
     },

--- a/tests/baselines/reference/YieldExpression6_es6.errors.txt
+++ b/tests/baselines/reference/YieldExpression6_es6.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/es6/yieldExpressions/YieldExpression6_es6.ts(2,9): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/yieldExpressions/YieldExpression6_es6.ts(2,9): error TS2488: Type '() => any' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/yieldExpressions/YieldExpression6_es6.ts (1 errors) ====
     function* foo() {
       yield*foo
             ~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type '() => any' must have a '[Symbol.iterator]()' method that returns an iterator.
     }

--- a/tests/baselines/reference/YieldExpression6_es6.types
+++ b/tests/baselines/reference/YieldExpression6_es6.types
@@ -1,8 +1,8 @@
 === tests/cases/conformance/es6/yieldExpressions/YieldExpression6_es6.ts ===
 function* foo() {
->foo : () => IterableIterator<any>
+>foo : () => any
 
   yield*foo
 >yield*foo : any
->foo : () => IterableIterator<any>
+>foo : () => any
 }

--- a/tests/baselines/reference/for-of14.errors.txt
+++ b/tests/baselines/reference/for-of14.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/for-ofStatements/for-of14.ts(8,11): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/for-ofStatements/for-of14.ts(8,11): error TS2488: Type 'StringIterator' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/for-ofStatements/for-of14.ts (1 errors) ====
@@ -11,4 +11,4 @@ tests/cases/conformance/es6/for-ofStatements/for-of14.ts(8,11): error TS2488: Ty
     var v: string;
     for (v of new StringIterator) { } // Should fail because the iterator is not iterable
               ~~~~~~~~~~~~~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'StringIterator' must have a '[Symbol.iterator]()' method that returns an iterator.

--- a/tests/baselines/reference/generatorTypeCheck21.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck21.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck21.ts(5,13): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck21.ts(5,13): error TS2488: Type 'Bar' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck21.ts (1 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck21.ts(5,13): erro
         yield;
         yield * new Bar;
                 ~~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'Bar' must have a '[Symbol.iterator]()' method that returns an iterator.
     }

--- a/tests/baselines/reference/iterableArrayPattern21.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern21.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/destructuring/iterableArrayPattern21.ts(1,5): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/destructuring/iterableArrayPattern21.ts(1,5): error TS2488: Type '{ 0: string; 1: boolean; }' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/destructuring/iterableArrayPattern21.ts (1 errors) ====
     var [a, b] = { 0: "", 1: true };
         ~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type '{ 0: string; 1: boolean; }' must have a '[Symbol.iterator]()' method that returns an iterator.

--- a/tests/baselines/reference/iterableArrayPattern22.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern22.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/destructuring/iterableArrayPattern22.ts(1,5): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/destructuring/iterableArrayPattern22.ts(1,5): error TS2488: Type '{ 0: string; 1: boolean; }' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/destructuring/iterableArrayPattern22.ts (1 errors) ====
     var [...a] = { 0: "", 1: true };
         ~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type '{ 0: string; 1: boolean; }' must have a '[Symbol.iterator]()' method that returns an iterator.

--- a/tests/baselines/reference/iterableArrayPattern23.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern23.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts(2,1): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts(2,1): error TS2488: Type '{ 0: string; 1: true; }' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts (1 errors) ====
     var a: string, b: boolean;
     [a, b] = { 0: "", 1: true };
     ~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type '{ 0: string; 1: true; }' must have a '[Symbol.iterator]()' method that returns an iterator.

--- a/tests/baselines/reference/iterableArrayPattern24.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern24.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts(2,1): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts(2,1): error TS2488: Type '{ 0: string; 1: true; }' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts (1 errors) ====
     var a: string, b: boolean[];
     [a, ...b] = { 0: "", 1: true };
     ~~~~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type '{ 0: string; 1: true; }' must have a '[Symbol.iterator]()' method that returns an iterator.

--- a/tests/baselines/reference/iteratorSpreadInArray8.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInArray8.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/spread/iteratorSpreadInArray8.ts(10,17): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/spread/iteratorSpreadInArray8.ts(10,17): error TS2488: Type 'SymbolIterator' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/spread/iteratorSpreadInArray8.ts (1 errors) ====
@@ -13,4 +13,4 @@ tests/cases/conformance/es6/spread/iteratorSpreadInArray8.ts(10,17): error TS248
     
     var array = [...new SymbolIterator];
                     ~~~~~~~~~~~~~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'SymbolIterator' must have a '[Symbol.iterator]()' method that returns an iterator.

--- a/tests/baselines/reference/neverTypeErrors1.errors.txt
+++ b/tests/baselines/reference/neverTypeErrors1.errors.txt
@@ -8,9 +8,10 @@ tests/cases/conformance/types/never/neverTypeErrors1.ts(9,5): error TS2349: Cann
 tests/cases/conformance/types/never/neverTypeErrors1.ts(13,5): error TS2322: Type 'undefined' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors1.ts(17,5): error TS2322: Type '1' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors1.ts(20,16): error TS2534: A function returning 'never' cannot have a reachable end point.
+tests/cases/conformance/types/never/neverTypeErrors1.ts(23,17): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
-==== tests/cases/conformance/types/never/neverTypeErrors1.ts (10 errors) ====
+==== tests/cases/conformance/types/never/neverTypeErrors1.ts (11 errors) ====
     function f1() {
         let x: never;
         x = 1;
@@ -52,3 +53,8 @@ tests/cases/conformance/types/never/neverTypeErrors1.ts(20,16): error TS2534: A 
                    ~~~~~
 !!! error TS2534: A function returning 'never' cannot have a reachable end point.
     }
+    
+    for (const n of f4()) {}
+                    ~~~~
+!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+    

--- a/tests/baselines/reference/neverTypeErrors1.errors.txt
+++ b/tests/baselines/reference/neverTypeErrors1.errors.txt
@@ -8,7 +8,7 @@ tests/cases/conformance/types/never/neverTypeErrors1.ts(9,5): error TS2349: Cann
 tests/cases/conformance/types/never/neverTypeErrors1.ts(13,5): error TS2322: Type 'undefined' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors1.ts(17,5): error TS2322: Type '1' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors1.ts(20,16): error TS2534: A function returning 'never' cannot have a reachable end point.
-tests/cases/conformance/types/never/neverTypeErrors1.ts(23,17): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/types/never/neverTypeErrors1.ts(23,17): error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/types/never/neverTypeErrors1.ts (11 errors) ====
@@ -56,5 +56,5 @@ tests/cases/conformance/types/never/neverTypeErrors1.ts(23,17): error TS2488: Ty
     
     for (const n of f4()) {}
                     ~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
     

--- a/tests/baselines/reference/neverTypeErrors1.js
+++ b/tests/baselines/reference/neverTypeErrors1.js
@@ -21,6 +21,9 @@ function f3(): never {
 function f4(): never {
 }
 
+for (const n of f4()) {}
+
+
 //// [neverTypeErrors1.js]
 function f1() {
     var x;
@@ -39,4 +42,7 @@ function f3() {
     return 1;
 }
 function f4() {
+}
+for (var _i = 0, _a = f4(); _i < _a.length; _i++) {
+    var n = _a[_i];
 }

--- a/tests/baselines/reference/neverTypeErrors1.symbols
+++ b/tests/baselines/reference/neverTypeErrors1.symbols
@@ -43,3 +43,8 @@ function f3(): never {
 function f4(): never {
 >f4 : Symbol(f4, Decl(neverTypeErrors1.ts, 17, 1))
 }
+
+for (const n of f4()) {}
+>n : Symbol(n, Decl(neverTypeErrors1.ts, 22, 10))
+>f4 : Symbol(f4, Decl(neverTypeErrors1.ts, 17, 1))
+

--- a/tests/baselines/reference/neverTypeErrors1.types
+++ b/tests/baselines/reference/neverTypeErrors1.types
@@ -56,3 +56,9 @@ function f3(): never {
 function f4(): never {
 >f4 : () => never
 }
+
+for (const n of f4()) {}
+>n : any
+>f4() : never
+>f4 : () => never
+

--- a/tests/baselines/reference/neverTypeErrors2.errors.txt
+++ b/tests/baselines/reference/neverTypeErrors2.errors.txt
@@ -8,7 +8,7 @@ tests/cases/conformance/types/never/neverTypeErrors2.ts(9,5): error TS2349: Cann
 tests/cases/conformance/types/never/neverTypeErrors2.ts(13,5): error TS2322: Type 'undefined' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors2.ts(17,5): error TS2322: Type '1' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors2.ts(20,16): error TS2534: A function returning 'never' cannot have a reachable end point.
-tests/cases/conformance/types/never/neverTypeErrors2.ts(23,17): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/types/never/neverTypeErrors2.ts(23,17): error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/types/never/neverTypeErrors2.ts (11 errors) ====
@@ -56,5 +56,5 @@ tests/cases/conformance/types/never/neverTypeErrors2.ts(23,17): error TS2488: Ty
     
     for (const n of f4()) {}
                     ~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.
     

--- a/tests/baselines/reference/neverTypeErrors2.errors.txt
+++ b/tests/baselines/reference/neverTypeErrors2.errors.txt
@@ -8,9 +8,10 @@ tests/cases/conformance/types/never/neverTypeErrors2.ts(9,5): error TS2349: Cann
 tests/cases/conformance/types/never/neverTypeErrors2.ts(13,5): error TS2322: Type 'undefined' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors2.ts(17,5): error TS2322: Type '1' is not assignable to type 'never'.
 tests/cases/conformance/types/never/neverTypeErrors2.ts(20,16): error TS2534: A function returning 'never' cannot have a reachable end point.
+tests/cases/conformance/types/never/neverTypeErrors2.ts(23,17): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
-==== tests/cases/conformance/types/never/neverTypeErrors2.ts (10 errors) ====
+==== tests/cases/conformance/types/never/neverTypeErrors2.ts (11 errors) ====
     function f1() {
         let x: never;
         x = 1;
@@ -52,3 +53,8 @@ tests/cases/conformance/types/never/neverTypeErrors2.ts(20,16): error TS2534: A 
                    ~~~~~
 !!! error TS2534: A function returning 'never' cannot have a reachable end point.
     }
+    
+    for (const n of f4()) {}
+                    ~~~~
+!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+    

--- a/tests/baselines/reference/neverTypeErrors2.js
+++ b/tests/baselines/reference/neverTypeErrors2.js
@@ -21,6 +21,9 @@ function f3(): never {
 function f4(): never {
 }
 
+for (const n of f4()) {}
+
+
 //// [neverTypeErrors2.js]
 function f1() {
     var x;
@@ -39,4 +42,7 @@ function f3() {
     return 1;
 }
 function f4() {
+}
+for (var _i = 0, _a = f4(); _i < _a.length; _i++) {
+    var n = _a[_i];
 }

--- a/tests/baselines/reference/neverTypeErrors2.symbols
+++ b/tests/baselines/reference/neverTypeErrors2.symbols
@@ -43,3 +43,8 @@ function f3(): never {
 function f4(): never {
 >f4 : Symbol(f4, Decl(neverTypeErrors2.ts, 17, 1))
 }
+
+for (const n of f4()) {}
+>n : Symbol(n, Decl(neverTypeErrors2.ts, 22, 10))
+>f4 : Symbol(f4, Decl(neverTypeErrors2.ts, 17, 1))
+

--- a/tests/baselines/reference/neverTypeErrors2.types
+++ b/tests/baselines/reference/neverTypeErrors2.types
@@ -56,3 +56,9 @@ function f3(): never {
 function f4(): never {
 >f4 : () => never
 }
+
+for (const n of f4()) {}
+>n : any
+>f4() : never
+>f4 : () => never
+

--- a/tests/baselines/reference/types.asyncGenerators.esnext.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.esnext.2.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(2,12): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(8,12): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(2,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(8,12): error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(10,7): error TS2322: Type '() => AsyncIterableIterator<string>' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncIterableIterator<string>' is not assignable to type 'AsyncIterableIterator<number>'.
     Type 'string' is not assignable to type 'number'.
@@ -45,14 +45,14 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(
     Type '(value?: any) => Promise<IteratorResult<any>>' is not assignable to type '(value?: any) => IteratorResult<number>'.
       Type 'Promise<IteratorResult<any>>' is not assignable to type 'IteratorResult<number>'.
         Property 'done' is missing in type 'Promise<IteratorResult<any>>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(74,12): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(74,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 
 
 ==== tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts (24 errors) ====
     async function * inferReturnType1() {
         yield* {};
                ~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
     }
     async function * inferReturnType2() {
         yield* inferReturnType2();
@@ -60,7 +60,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(
     async function * inferReturnType3() {
         yield* Promise.resolve([1, 2]);
                ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
     }
     const assignability1: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
@@ -194,5 +194,5 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(
     async function * yieldStar() {
         yield* {};
                ~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
     }

--- a/tests/baselines/reference/types.forAwait.esnext.2.errors.txt
+++ b/tests/baselines/reference/types.forAwait.esnext.2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(6,27): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(8,21): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(6,27): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(8,21): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(10,16): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(12,16): error TS2322: Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(14,21): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
-tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(16,15): error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(14,21): error TS2488: Type 'AsyncIterable<number>' must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(16,15): error TS2488: Type 'AsyncIterable<number>' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts (6 errors) ====
@@ -14,11 +14,11 @@ tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(16,15): error 
         let z: string;
         for await (const x of {}) {
                               ~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
         }
         for await (y of {}) {
                         ~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
         }
         for await (z of asyncIterable) {
                    ~
@@ -30,10 +30,10 @@ tests/cases/conformance/types/forAwait/types.forAwait.esnext.2.ts(16,15): error 
         }
         for (const x of asyncIterable) {
                         ~~~~~~~~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'AsyncIterable<number>' must have a '[Symbol.iterator]()' method that returns an iterator.
         }
         for (y of asyncIterable) {
                   ~~~~~~~~~~~~~
-!!! error TS2488: Type must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'AsyncIterable<number>' must have a '[Symbol.iterator]()' method that returns an iterator.
         }
     }

--- a/tests/baselines/reference/types.forAwait.esnext.3.errors.txt
+++ b/tests/baselines/reference/types.forAwait.esnext.3.errors.txt
@@ -1,8 +1,8 @@
 error TS2318: Cannot find global type 'AsyncIterableIterator'.
-tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(3,27): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(5,21): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(10,27): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(12,21): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(3,27): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(5,21): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(10,27): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(12,21): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 
 
 !!! error TS2318: Cannot find global type 'AsyncIterableIterator'.
@@ -11,21 +11,21 @@ tests/cases/conformance/types/forAwait/types.forAwait.esnext.3.ts(12,21): error 
         let y: number;
         for await (const x of {}) {
                               ~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
         }
         for await (y of {}) {
                         ~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
         }
     }
     async function* f2() {
         let y: number;
         for await (const x of {}) {
                               ~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
         }
         for await (y of {}) {
                         ~~
-!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
         }
     }

--- a/tests/cases/conformance/types/never/neverTypeErrors1.ts
+++ b/tests/cases/conformance/types/never/neverTypeErrors1.ts
@@ -19,3 +19,5 @@ function f3(): never {
 
 function f4(): never {
 }
+
+for (const n of f4()) {}

--- a/tests/cases/conformance/types/never/neverTypeErrors2.ts
+++ b/tests/cases/conformance/types/never/neverTypeErrors2.ts
@@ -21,3 +21,5 @@ function f3(): never {
 
 function f4(): never {
 }
+
+for (const n of f4()) {}


### PR DESCRIPTION
Currently the following has no compile error:
```ts
function f(stringOrStrings: string | string) {
    if (typeof stringOrStrings !== "string") {
        for (const s of stringOrStrings) {
            s.twoUpprKaze();
        }
    }
}
```
I meant `string | string[]`. The problem would be solved if `never` weren't considered iterable.