### PR TITLE
Move JSX props support check and make syntactic

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14767,7 +14767,7 @@ namespace ts {
             return propsType;
         }
 
-        function getJsxPropsTypeFromClassType(hostClassType: Type, isJs: boolean, context: JsxOpeningLikeElement, reportErrors?: boolean) {
+        function getJsxPropsTypeFromClassType(hostClassType: Type, isJs: boolean, context: JsxOpeningLikeElement, reportErrors: boolean) {
             if (isTypeAny(hostClassType)) {
                 return hostClassType;
             }
@@ -14822,7 +14822,7 @@ namespace ts {
         function getJsxPropsTypeFromConstructSignature(sig: Signature, isJs: boolean, context: JsxOpeningLikeElement) {
             const hostClassType = getReturnTypeOfSignature(sig);
             if (hostClassType) {
-                return getJsxPropsTypeFromClassType(hostClassType, isJs, context);
+                return getJsxPropsTypeFromClassType(hostClassType, isJs, context, /*reportErrors*/ false);
             }
             return getJsxPropsTypeFromCallSignature(sig, context);
         }

--- a/tests/baselines/reference/tsxElementResolution12.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution12.errors.txt
@@ -1,11 +1,13 @@
 tests/cases/conformance/jsx/file.tsx(23,1): error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
+tests/cases/conformance/jsx/file.tsx(23,7): error TS2339: Property 'x' does not exist on type '{}'.
 tests/cases/conformance/jsx/file.tsx(25,1): error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
+tests/cases/conformance/jsx/file.tsx(26,1): error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
 tests/cases/conformance/jsx/file.tsx(33,7): error TS2322: Type '{ x: string; }' is not assignable to type '{ x: number; }'.
   Types of property 'x' are incompatible.
     Type 'string' is not assignable to type 'number'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (5 errors) ====
     declare module JSX {
     	interface Element { }
     	interface ElementAttributesProperty { pr: any; }
@@ -31,11 +33,15 @@ tests/cases/conformance/jsx/file.tsx(33,7): error TS2322: Type '{ x: string; }' 
     <Obj3 x={10} />; // Error
     ~~~~~~~~~~~~~~~
 !!! error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
+          ~~~~~~
+!!! error TS2339: Property 'x' does not exist on type '{}'.
     var attributes: any;
     <Obj3 {...attributes} />; // Error
     ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
     <Obj3 {...{}} />; // OK
+    ~~~~~~~~~~~~~~~~
+!!! error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
     
     interface Obj4type {
     	new(n: string): { x: number; pr: { x: number; } };

--- a/tests/baselines/reference/tsxNoTypeAnnotatedSFC.errors.txt
+++ b/tests/baselines/reference/tsxNoTypeAnnotatedSFC.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx(2,24): error TS2307: Cannot find module 'react'.
+
+
+==== tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx (1 errors) ====
+    // not _actually_ making react available in this test to regression test #22948
+    import * as React from 'react';
+                           ~~~~~~~
+!!! error TS2307: Cannot find module 'react'.
+    
+    const Test123 = () => <div/>;
+    
+    function testComponent(props) {
+        return <Test123 {...props}/>;
+    }

--- a/tests/baselines/reference/tsxNoTypeAnnotatedSFC.js
+++ b/tests/baselines/reference/tsxNoTypeAnnotatedSFC.js
@@ -1,0 +1,19 @@
+//// [tsxNoTypeAnnotatedSFC.tsx]
+// not _actually_ making react available in this test to regression test #22948
+import * as React from 'react';
+
+const Test123 = () => <div/>;
+
+function testComponent(props) {
+    return <Test123 {...props}/>;
+}
+
+//// [tsxNoTypeAnnotatedSFC.jsx]
+"use strict";
+exports.__esModule = true;
+// not _actually_ making react available in this test to regression test #22948
+var React = require("react");
+var Test123 = function () { return <div />; };
+function testComponent(props) {
+    return <Test123 {...props}/>;
+}

--- a/tests/baselines/reference/tsxNoTypeAnnotatedSFC.symbols
+++ b/tests/baselines/reference/tsxNoTypeAnnotatedSFC.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx ===
+// not _actually_ making react available in this test to regression test #22948
+import * as React from 'react';
+>React : Symbol(React, Decl(tsxNoTypeAnnotatedSFC.tsx, 1, 6))
+
+const Test123 = () => <div/>;
+>Test123 : Symbol(Test123, Decl(tsxNoTypeAnnotatedSFC.tsx, 3, 5))
+
+function testComponent(props) {
+>testComponent : Symbol(testComponent, Decl(tsxNoTypeAnnotatedSFC.tsx, 3, 29))
+>props : Symbol(props, Decl(tsxNoTypeAnnotatedSFC.tsx, 5, 23))
+
+    return <Test123 {...props}/>;
+>Test123 : Symbol(Test123, Decl(tsxNoTypeAnnotatedSFC.tsx, 3, 5))
+>props : Symbol(props, Decl(tsxNoTypeAnnotatedSFC.tsx, 5, 23))
+}

--- a/tests/baselines/reference/tsxNoTypeAnnotatedSFC.types
+++ b/tests/baselines/reference/tsxNoTypeAnnotatedSFC.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx ===
+// not _actually_ making react available in this test to regression test #22948
+import * as React from 'react';
+>React : any
+
+const Test123 = () => <div/>;
+>Test123 : () => any
+>() => <div/> : () => any
+><div/> : any
+>div : any
+
+function testComponent(props) {
+>testComponent : (props: any) => any
+>props : any
+
+    return <Test123 {...props}/>;
+><Test123 {...props}/> : any
+>Test123 : () => any
+>props : any
+}

--- a/tests/baselines/reference/tsxSpreadAttributesResolution17.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution17.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/conformance/jsx/file.tsx(18,21): error TS2607: JSX element class does not support attributes because it does not have a 'props' property.
+
+
+==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
+    declare global {
+        namespace JSX {
+            interface Element {}
+            interface ElementAttributesProperty { props: {} }
+        }
+    }
+    declare var React: any;
+    
+    export class Empty extends React.Component<{}, {}> {
+        render() {
+            return <div>Hello</div>;
+        }
+    }
+    
+    declare const obj: { a: number | undefined } | undefined;
+    
+    // OK
+    let unionedSpread = <Empty {...obj} />;
+                        ~~~~~~~~~~~~~~~~~~
+!!! error TS2607: JSX element class does not support attributes because it does not have a 'props' property.
+    

--- a/tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx
+++ b/tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx
@@ -1,0 +1,9 @@
+// @jsx: preserve
+// not _actually_ making react available in this test to regression test #22948
+import * as React from 'react';
+
+const Test123 = () => <div/>;
+
+function testComponent(props) {
+    return <Test123 {...props}/>;
+}


### PR DESCRIPTION
Fixes #22948. We can get `emptyObjectType` out of `resolveCustomJsxElementAttributesType` via `tryGetAllJsxStatelessFunctionAttributesType` via `getApparentType`, so it wan't really a great indicator for tracking the procedural error the comment by the offending check claims it was tracking. Now I've moved the error to where its conditions are initially checked, and perform the check syntactically rather than with types (meaning `<Obj {...{}}/>` will now error if `Obj` does not specify that it has props, which seems sensible) to facilitate this. 