### PR TITLE
[release-2.8] Do not watch child directories of the sym link folders

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -24,13 +24,13 @@ namespace ts {
      * Make `elements` into a `NodeArray<T>`. If `elements` is `undefined`, returns an empty `NodeArray<T>`.
      */
     export function createNodeArray<T extends Node>(elements?: ReadonlyArray<T>, hasTrailingComma?: boolean): NodeArray<T> {
-        if (elements) {
+        if (!elements || elements === emptyArray) {
+            elements = [];
+        }
+        else {
             if (isNodeArray(elements)) {
                 return elements;
             }
-        }
-        else {
-            elements = [];
         }
 
         const array = <NodeArray<T>>elements;

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -2355,9 +2355,9 @@ declare module "fs" {
                 verifyRenamingFileInSubFolder(TestFSWithWatch.Tsc_WatchDirectory.NonRecursiveWatchDirectory);
             });
 
-            // it("uses non recursive dynamic polling when renaming file in subfolder", () => {
-            //     verifyRenamingFileInSubFolder(TestFSWithWatch.Tsc_WatchDirectory.DynamicPolling);
-            // });
+            it("uses non recursive dynamic polling when renaming file in subfolder", () => {
+                verifyRenamingFileInSubFolder(TestFSWithWatch.Tsc_WatchDirectory.DynamicPolling);
+            });
         });
     });
 }

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -2358,6 +2358,50 @@ declare module "fs" {
             it("uses non recursive dynamic polling when renaming file in subfolder", () => {
                 verifyRenamingFileInSubFolder(TestFSWithWatch.Tsc_WatchDirectory.DynamicPolling);
             });
+
+            it("when there are symlinks to folders in recursive folders", () => {
+                const cwd = "/home/user/projects/myproject";
+                const file1: FileOrFolder = {
+                    path: `${cwd}/src/file.ts`,
+                    content: `import * as a from "a"`
+                };
+                const tsconfig: FileOrFolder = {
+                    path: `${cwd}/tsconfig.json`,
+                    content: `{ "compilerOptions": { "extendedDiagnostics": true, "traceResolution": true }}`
+                };
+                const realA: FileOrFolder = {
+                    path: `${cwd}/node_modules/reala/index.d.ts`,
+                    content: `export {}`
+                };
+                const realB: FileOrFolder = {
+                    path: `${cwd}/node_modules/realb/index.d.ts`,
+                    content: `export {}`
+                };
+                const symLinkA: FileOrFolder = {
+                    path: `${cwd}/node_modules/a`,
+                    symLink: `${cwd}/node_modules/reala`
+                };
+                const symLinkB: FileOrFolder = {
+                    path: `${cwd}/node_modules/b`,
+                    symLink: `${cwd}/node_modules/realb`
+                };
+                const symLinkBInA: FileOrFolder = {
+                    path: `${cwd}/node_modules/reala/node_modules/b`,
+                    symLink: `${cwd}/node_modules/b`
+                };
+                const symLinkAInB: FileOrFolder = {
+                    path: `${cwd}/node_modules/realb/node_modules/a`,
+                    symLink: `${cwd}/node_modules/a`
+                };
+                const files = [file1, tsconfig, realA, realB, symLinkA, symLinkB, symLinkBInA, symLinkAInB];
+                const environmentVariables = createMap<string>();
+                environmentVariables.set("TSC_WATCHDIRECTORY", TestFSWithWatch.Tsc_WatchDirectory.NonRecursiveWatchDirectory);
+                const host = createWatchedSystem(files, { environmentVariables, currentDirectory: cwd });
+                createWatchOfConfigFile("tsconfig.json", host);
+                checkWatchedDirectories(host, emptyArray, /*recursive*/ true);
+                checkWatchedDirectories(host, [cwd, `${cwd}/node_modules`, `${cwd}/node_modules/@types`, `${cwd}/node_modules/reala`, `${cwd}/node_modules/realb`,
+                    `${cwd}/node_modules/reala/node_modules`, `${cwd}/node_modules/realb/node_modules`, `${cwd}/src`], /*recursive*/ false);
+            });
         });
     });
 }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -88,7 +88,7 @@ interface Array<T> {}`
     }
 
     interface Folder extends FSEntry {
-        entries: FSEntry[];
+        entries: SortedArray<FSEntry>;
     }
 
     interface SymLink extends FSEntry {
@@ -512,7 +512,7 @@ interface Array<T> {}`
         }
 
         private addFileOrFolderInFolder(folder: Folder, fileOrDirectory: File | Folder | SymLink, ignoreWatch?: boolean) {
-            folder.entries.push(fileOrDirectory);
+            insertSorted(folder.entries, fileOrDirectory, (a, b) => compareStringsCaseSensitive(getBaseFileName(a.path), getBaseFileName(b.path)));
             folder.modifiedTime = new Date();
             this.fs.set(fileOrDirectory.path, fileOrDirectory);
 
@@ -622,7 +622,7 @@ interface Array<T> {}`
 
         private toFolder(path: string): Folder {
             const folder = this.toFsEntry(path) as Folder;
-            folder.entries = [];
+            folder.entries = [] as SortedArray<FSEntry>;
             return folder;
         }
 

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -314,7 +314,8 @@ interface Array<T> {}`
                     directoryExists: path => this.directoryExists(path),
                     getAccessileSortedChildDirectories: path => this.getDirectories(path),
                     filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
-                    watchDirectory
+                    watchDirectory,
+                    realpath: s => this.realpath(s)
                 });
             }
             else if (tscWatchDirectory === Tsc_WatchDirectory.NonRecursiveWatchDirectory) {
@@ -323,7 +324,8 @@ interface Array<T> {}`
                     directoryExists: path => this.directoryExists(path),
                     getAccessileSortedChildDirectories: path => this.getDirectories(path),
                     filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
-                    watchDirectory
+                    watchDirectory,
+                    realpath: s => this.realpath(s)
                 });
             }
             else if (tscWatchDirectory === Tsc_WatchDirectory.DynamicPolling) {
@@ -333,7 +335,8 @@ interface Array<T> {}`
                     directoryExists: path => this.directoryExists(path),
                     getAccessileSortedChildDirectories: path => this.getDirectories(path),
                     filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
-                    watchDirectory
+                    watchDirectory,
+                    realpath: s => this.realpath(s)
                 });
             }
         }
@@ -649,7 +652,7 @@ interface Array<T> {}`
 
             const realpath = this.realpath(path);
             if (path !== realpath) {
-                return this.getRealFsEntry(isFsEntry, realpath as Path);
+                return this.getRealFsEntry(isFsEntry, this.toPath(realpath));
             }
 
             return undefined;

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -312,7 +312,7 @@ interface Array<T> {}`
                 const watchDirectory: HostWatchDirectory = (directory, cb) => this.watchFile(directory, () => cb(directory), PollingInterval.Medium);
                 this.customRecursiveWatchDirectory = createRecursiveDirectoryWatcher({
                     directoryExists: path => this.directoryExists(path),
-                    getAccessileSortedChildDirectories: path => this.getDirectories(path),
+                    getAccessibleSortedChildDirectories: path => this.getDirectories(path),
                     filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
                     watchDirectory,
                     realpath: s => this.realpath(s)
@@ -322,7 +322,7 @@ interface Array<T> {}`
                 const watchDirectory: HostWatchDirectory = (directory, cb) => this.watchDirectory(directory, fileName => cb(fileName), /*recursive*/ false);
                 this.customRecursiveWatchDirectory = createRecursiveDirectoryWatcher({
                     directoryExists: path => this.directoryExists(path),
-                    getAccessileSortedChildDirectories: path => this.getDirectories(path),
+                    getAccessibleSortedChildDirectories: path => this.getDirectories(path),
                     filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
                     watchDirectory,
                     realpath: s => this.realpath(s)
@@ -333,7 +333,7 @@ interface Array<T> {}`
                 const watchDirectory: HostWatchDirectory = (directory, cb) => watchFile(directory, () => cb(directory), PollingInterval.Medium);
                 this.customRecursiveWatchDirectory = createRecursiveDirectoryWatcher({
                     directoryExists: path => this.directoryExists(path),
-                    getAccessileSortedChildDirectories: path => this.getDirectories(path),
+                    getAccessibleSortedChildDirectories: path => this.getDirectories(path),
                     filePathComparer: this.useCaseSensitiveFileNames ? compareStringsCaseSensitive : compareStringsCaseInsensitive,
                     watchDirectory,
                     realpath: s => this.realpath(s)


### PR DESCRIPTION
Fixes #22668 and maintains same feature set as fs.watch on windows when node supports it.

This ports #22976

I am also porting #22526 and #22450 since these were test changes that helped in reliable testing of tsc-watch test cases.
