### PR TITLE
Dont follow aliases when looking for default exported symbol declarations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1741,8 +1741,8 @@ namespace ts {
             // Declaration files (and ambient modules)
             if (!file || file.isDeclarationFile) {
                 // Definitely cannot have a synthetic default if they have a syntactic default member specified
-                const defaultExportSymbol = resolveExportByName(moduleSymbol, InternalSymbolName.Default, dontResolveAlias);
-                if (defaultExportSymbol && defaultExportSymbol.valueDeclaration && isSyntacticDefault(defaultExportSymbol.valueDeclaration)) {
+                const defaultExportSymbol = resolveExportByName(moduleSymbol, InternalSymbolName.Default, /*dontResolveAlias*/ true); // Dont resolve alias because we want the immediately exported symbol's declaration
+                if (defaultExportSymbol && some(defaultExportSymbol.declarations, isSyntacticDefault)) {
                     return false;
                 }
                 // It _might_ still be incorrect to assume there is no __esModule marker on the import at runtime, even if there is no `default` member

--- a/tests/baselines/reference/systemDefaultImportCallable.js
+++ b/tests/baselines/reference/systemDefaultImportCallable.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/systemDefaultImportCallable.ts] ////
+
+//// [core-js.d.ts]
+declare module core {
+    var String: {
+        repeat(text: string, count: number): string;
+    };
+}
+declare module "core-js/fn/string/repeat" {
+    var repeat: typeof core.String.repeat;
+    export default repeat;
+}
+//// [greeter.ts]
+import repeat from "core-js/fn/string/repeat";
+
+const _: string = repeat(new Date().toUTCString() + " ", 2);
+
+//// [greeter.js]
+System.register(["core-js/fn/string/repeat"], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var repeat_1, _;
+    return {
+        setters: [
+            function (repeat_1_1) {
+                repeat_1 = repeat_1_1;
+            }
+        ],
+        execute: function () {
+            _ = repeat_1["default"](new Date().toUTCString() + " ", 2);
+        }
+    };
+});

--- a/tests/baselines/reference/systemDefaultImportCallable.symbols
+++ b/tests/baselines/reference/systemDefaultImportCallable.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/core-js.d.ts ===
+declare module core {
+>core : Symbol(core, Decl(core-js.d.ts, 0, 0))
+
+    var String: {
+>String : Symbol(String, Decl(core-js.d.ts, 1, 7))
+
+        repeat(text: string, count: number): string;
+>repeat : Symbol(repeat, Decl(core-js.d.ts, 1, 17))
+>text : Symbol(text, Decl(core-js.d.ts, 2, 15))
+>count : Symbol(count, Decl(core-js.d.ts, 2, 28))
+
+    };
+}
+declare module "core-js/fn/string/repeat" {
+>"core-js/fn/string/repeat" : Symbol("core-js/fn/string/repeat", Decl(core-js.d.ts, 4, 1))
+
+    var repeat: typeof core.String.repeat;
+>repeat : Symbol(repeat, Decl(core-js.d.ts, 6, 7))
+>core.String.repeat : Symbol(repeat, Decl(core-js.d.ts, 1, 17))
+>core.String : Symbol(core.String, Decl(core-js.d.ts, 1, 7))
+>core : Symbol(core, Decl(core-js.d.ts, 0, 0))
+>String : Symbol(core.String, Decl(core-js.d.ts, 1, 7))
+>repeat : Symbol(repeat, Decl(core-js.d.ts, 1, 17))
+
+    export default repeat;
+>repeat : Symbol(repeat, Decl(core-js.d.ts, 6, 7))
+}
+=== tests/cases/compiler/greeter.ts ===
+import repeat from "core-js/fn/string/repeat";
+>repeat : Symbol(repeat, Decl(greeter.ts, 0, 6))
+
+const _: string = repeat(new Date().toUTCString() + " ", 2);
+>_ : Symbol(_, Decl(greeter.ts, 2, 5))
+>repeat : Symbol(repeat, Decl(greeter.ts, 0, 6))
+>new Date().toUTCString : Symbol(Date.toUTCString, Decl(lib.d.ts, --, --))
+>Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>toUTCString : Symbol(Date.toUTCString, Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/systemDefaultImportCallable.types
+++ b/tests/baselines/reference/systemDefaultImportCallable.types
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/core-js.d.ts ===
+declare module core {
+>core : typeof core
+
+    var String: {
+>String : { repeat(text: string, count: number): string; }
+
+        repeat(text: string, count: number): string;
+>repeat : (text: string, count: number) => string
+>text : string
+>count : number
+
+    };
+}
+declare module "core-js/fn/string/repeat" {
+>"core-js/fn/string/repeat" : typeof "core-js/fn/string/repeat"
+
+    var repeat: typeof core.String.repeat;
+>repeat : (text: string, count: number) => string
+>core.String.repeat : (text: string, count: number) => string
+>core.String : { repeat(text: string, count: number): string; }
+>core : typeof core
+>String : { repeat(text: string, count: number): string; }
+>repeat : (text: string, count: number) => string
+
+    export default repeat;
+>repeat : (text: string, count: number) => string
+}
+=== tests/cases/compiler/greeter.ts ===
+import repeat from "core-js/fn/string/repeat";
+>repeat : (text: string, count: number) => string
+
+const _: string = repeat(new Date().toUTCString() + " ", 2);
+>_ : string
+>repeat(new Date().toUTCString() + " ", 2) : string
+>repeat : (text: string, count: number) => string
+>new Date().toUTCString() + " " : string
+>new Date().toUTCString() : string
+>new Date().toUTCString : () => string
+>new Date() : Date
+>Date : DateConstructor
+>toUTCString : () => string
+>" " : " "
+>2 : 2
+

--- a/tests/cases/compiler/systemDefaultImportCallable.ts
+++ b/tests/cases/compiler/systemDefaultImportCallable.ts
@@ -1,0 +1,15 @@
+// @module: system
+// @filename: core-js.d.ts
+declare module core {
+    var String: {
+        repeat(text: string, count: number): string;
+    };
+}
+declare module "core-js/fn/string/repeat" {
+    var repeat: typeof core.String.repeat;
+    export default repeat;
+}
+// @filename: greeter.ts
+import repeat from "core-js/fn/string/repeat";
+
+const _: string = repeat(new Date().toUTCString() + " ", 2);


### PR DESCRIPTION
Followup to https://github.com/Microsoft/TypeScript/pull/22814 that fixes the failing RWC test we have.