### PR TITLE
Don't trigger binding in LanguageService.getProgram

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1008,7 +1008,8 @@ namespace FourSlash {
         }
 
         private verifyRange(desc: string, expected: Range, actual: ts.Node) {
-            const actualStart = actual.getStart();
+            const sourceFile = this.getProgram().getSourceFile(expected.fileName);
+            const actualStart = actual.getStart(sourceFile);
             const actualEnd = actual.getEnd();
             if (actualStart !== expected.pos || actualEnd !== expected.end) {
                 this.raiseError(`${desc} should be ${expected.pos}-${expected.end}, got ${actualStart}-${actualEnd}`);

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -174,7 +174,7 @@ namespace ts {
             let entry = bucket.get(path);
             if (!entry) {
                 // Have never seen this file with these settings.  Create a new source file for it.
-                const sourceFile = createLanguageServiceSourceFile(fileName, scriptSnapshot, compilationSettings.target, version, /*setNodeParents*/ false, scriptKind);
+                const sourceFile = createLanguageServiceSourceFile(fileName, scriptSnapshot, compilationSettings.target, version, /*setNodeParents*/ true, scriptKind);
 
                 entry = {
                     sourceFile,

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -174,7 +174,7 @@ namespace ts {
             let entry = bucket.get(path);
             if (!entry) {
                 // Have never seen this file with these settings.  Create a new source file for it.
-                const sourceFile = createLanguageServiceSourceFile(fileName, scriptSnapshot, compilationSettings.target, version, /*setNodeParents*/ true, scriptKind);
+                const sourceFile = createLanguageServiceSourceFile(fileName, scriptSnapshot, compilationSettings.target, version, /*setNodeParents*/ false, scriptKind);
 
                 entry = {
                     sourceFile,

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -855,7 +855,7 @@ namespace ts.refactor.extractSymbol {
                 newNodes.push(createVariableStatement(
                     /*modifiers*/ undefined,
                     createVariableDeclarationList(
-                        [createVariableDeclaration(getSynthesizedDeepClone(variableDeclaration.name), /*type*/ getSynthesizedDeepClone(variableDeclaration.type), /*initializer*/ call)], // TODO (acasey): test binding patterns
+                        [createVariableDeclaration(getSynthesizedDeepClone(variableDeclaration.name), /*type*/ getSynthesizedDeepClone(variableDeclaration.type), /*initializer*/ call)],
                         variableDeclaration.parent.flags)));
             }
             else {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1204,6 +1204,7 @@ namespace ts {
                 const hostProjectVersion = host.getProjectVersion();
                 if (hostProjectVersion) {
                     if (lastProjectVersion === hostProjectVersion && !host.hasChangedAutomaticTypeDirectiveNames) {
+                        bindNodesIfNecessary();
                         return;
                     }
 
@@ -1226,6 +1227,7 @@ namespace ts {
 
             // If the program is already up-to-date, we can reuse it
             if (isProgramUptoDate(program, rootFileNames, hostCache.compilationSettings(), path => hostCache.getVersion(path), fileExists, hasInvalidatedResolution, host.hasChangedAutomaticTypeDirectiveNames)) {
+                bindNodesIfNecessary();
                 return;
             }
 
@@ -1294,12 +1296,14 @@ namespace ts {
             // the course of whatever called `synchronizeHostData`
             sourcemappedFileCache = createSourceFileLikeCache(host);
 
-            if (bindNodes) {
-                // Make sure all the nodes in the program are both bound.
-                program.getTypeChecker();
-            }
-
+            bindNodesIfNecessary();
             return;
+
+            function bindNodesIfNecessary() {
+                if (bindNodes) {
+                    program.getTypeChecker();
+                }
+            }
 
             function fileExists(fileName: string) {
                 const path = toPath(fileName, currentDirectory, getCanonicalFileName);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1198,7 +1198,7 @@ namespace ts {
             return sourceFile;
         }
 
-        function synchronizeHostData(): void {
+        function synchronizeHostData(bindNodes = true): void {
             // perform fast check if host supports it
             if (host.getProjectVersion) {
                 const hostProjectVersion = host.getProjectVersion();
@@ -1294,9 +1294,11 @@ namespace ts {
             // the course of whatever called `synchronizeHostData`
             sourcemappedFileCache = createSourceFileLikeCache(host);
 
-            // Make sure all the nodes in the program are both bound, and have their parent
-            // pointers set property.
-            program.getTypeChecker();
+            if (bindNodes) {
+                // Make sure all the nodes in the program are both bound.
+                program.getTypeChecker();
+            }
+
             return;
 
             function fileExists(fileName: string) {
@@ -1374,7 +1376,7 @@ namespace ts {
         }
 
         function getProgram(): Program {
-            synchronizeHostData();
+            synchronizeHostData(/*bindNodes*/ false);
 
             return program;
         }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -664,7 +664,7 @@ namespace ts {
             }
 
             // find the child that contains 'position'
-            for (const child of current.getChildren()) {
+            for (const child of current.getChildren(sourceFile)) {
                 if (!includeJsDocComment && isJSDocNode(child)) {
                     continue;
                 }


### PR DESCRIPTION
When `LanguageService.getProgram` calls `synchronizeHostData` there's no need for it to call `program.getTypeChecker()`.  First, all callers require syntax tree parent points, so we should just pass `setParentNode` = `true` to `createLanguageServiceSourceFile`.  Second, those callers that require binding already trigger it themselves (by calling `program.getTypeChecker`).