### PR TITLE
Add 'getNameFromPropertyName' helper

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1561,22 +1561,10 @@ namespace ts.FindAllReferences.Core {
         }
     }
 
-    function getNameFromObjectLiteralElement(node: ObjectLiteralElement): string {
-        if (node.name.kind === SyntaxKind.ComputedPropertyName) {
-            const nameExpression = node.name.expression;
-            // treat computed property names where expression is string/numeric literal as just string/numeric literal
-            if (isStringOrNumericLiteral(nameExpression)) {
-                return nameExpression.text;
-            }
-            return undefined;
-        }
-        return getTextOfIdentifierOrLiteral(node.name);
-    }
-
     /** Gets all symbols for one property. Does not get symbols for every property. */
     function getPropertySymbolsFromContextualType(node: ObjectLiteralElement, checker: TypeChecker): ReadonlyArray<Symbol> {
         const contextualType = checker.getContextualType(<ObjectLiteralExpression>node.parent);
-        const name = getNameFromObjectLiteralElement(node);
+        const name = getNameFromPropertyName(node.name);
         const symbol = contextualType && name && contextualType.getProperty(name);
         return symbol ? [symbol] :
             contextualType && contextualType.flags & TypeFlags.Union ? mapDefined((<UnionType>contextualType).types, t => t.getProperty(name)) : emptyArray;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -653,8 +653,8 @@ namespace ts {
 
             function getDeclarationName(declaration: Declaration) {
                 const name = getNameOfDeclaration(declaration);
-                return name && (isPropertyNameLiteral(name) ? getTextOfIdentifierOrLiteral(name) :
-                    name.kind === SyntaxKind.ComputedPropertyName && isPropertyAccessExpression(name.expression) ? name.expression.name.text : undefined);
+                return name && (isComputedPropertyName(name) && isPropertyAccessExpression(name.expression) ? name.expression.name.text
+                    : isPropertyName(name) ? getNameFromPropertyName(name) : undefined);
             }
 
             function visit(node: Node): void {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1220,6 +1220,13 @@ namespace ts {
     export function skipConstraint(type: Type): Type {
         return type.flags & TypeFlags.TypeParameter ? type.getConstraint() : type;
     }
+
+    export function getNameFromPropertyName(name: PropertyName): string | undefined {
+        return name.kind === SyntaxKind.ComputedPropertyName
+            // treat computed property names where expression is string/numeric literal as just string/numeric literal
+            ? isStringOrNumericLiteral(name.expression) ? name.expression.text : undefined
+            : getTextOfIdentifierOrLiteral(name);
+    }
 }
 
 // Display-part writer helpers

--- a/tests/cases/fourslash/navigateToQuoted.ts
+++ b/tests/cases/fourslash/navigateToQuoted.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+// @noLib: true
+
+////class C {
+////    ["foo-bar"]() {}
+////    ["foo bar"]() {}
+////}
+
+verify.navigationItemsListContains("foo-bar", "method", "foo-bar", "exact", undefined, "C");
+// TODO: GH#23035
+// verify.navigationItemsListContains("foo bar", "method", "foo bar", "exact", undefined, "C");

--- a/tests/cases/fourslash/navigateToSymbolIterator.ts
+++ b/tests/cases/fourslash/navigateToSymbolIterator.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////class C {
+////    [Symbol.iterator]() {}
+////}
+
+verify.navigationItemsListContains("iterator", "method", "iterator", "exact", undefined, "C");


### PR DESCRIPTION
* First, I was attempting to reduce duplicate code between `getNameFromObjectLiteralElement` and `getDeclarationName`.
* This mostly works, but I also noticed a feature of `getDeclarationName` where for `[Symbol.iterator]` we would make `iterator` be the name. This seems sensible enough (no other way to navigate to it), but we weren't testing this feature before.
* This PR also adds support for navigation to quoted names as a side-effect, but it doesn't work for names with spaces (#23035)