### PR TITLE
Improve binding and jsdoc of chained special js assignments

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2445,8 +2445,8 @@ namespace ts {
         function bindPropertyAssignment(name: EntityNameExpression, propertyAccess: PropertyAccessEntityNameExpression, isPrototypeProperty: boolean) {
             let symbol = getJSInitializerSymbolFromName(name);
             const isToplevelNamespaceableInitializer = isBinaryExpression(propertyAccess.parent)
-                ? propertyAccess.parent.parent.parent.kind === SyntaxKind.SourceFile &&
-                    !!getJavascriptInitializer(propertyAccess.parent.right, isPrototypeAccess(propertyAccess.parent.left))
+                ? followBinaryParent(propertyAccess.parent).parent.kind === SyntaxKind.SourceFile &&
+                    !!getJavascriptInitializer(followBinaryRight(propertyAccess.parent), isPrototypeAccess(propertyAccess.parent.left))
                 : propertyAccess.parent.parent.kind === SyntaxKind.SourceFile;
             if (!isPrototypeProperty && (!symbol || !(symbol.flags & SymbolFlags.Namespace)) && isToplevelNamespaceableInitializer) {
                 // make symbols or add declarations for intermediate containers
@@ -2476,6 +2476,13 @@ namespace ts {
             const symbolFlags = SymbolFlags.Property | (isToplevelNamespaceableInitializer ? SymbolFlags.JSContainer : 0);
             const symbolExcludes = SymbolFlags.PropertyExcludes & ~(isToplevelNamespaceableInitializer ? SymbolFlags.JSContainer : 0);
             declareSymbol(symbolTable, symbol, propertyAccess, symbolFlags, symbolExcludes);
+        }
+
+        function followBinaryParent(expr: BinaryExpression) {
+            while (isBinaryExpression(expr.parent)) {
+                expr = expr.parent;
+            }
+            return expr.parent;
         }
 
         function lookupSymbolForPropertyAccess(node: EntityNameExpression, lookupContainer: Node = container): Symbol | undefined {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2445,8 +2445,8 @@ namespace ts {
         function bindPropertyAssignment(name: EntityNameExpression, propertyAccess: PropertyAccessEntityNameExpression, isPrototypeProperty: boolean) {
             let symbol = getJSInitializerSymbolFromName(name);
             const isToplevelNamespaceableInitializer = isBinaryExpression(propertyAccess.parent)
-                ? followBinaryParent(propertyAccess.parent).parent.kind === SyntaxKind.SourceFile &&
-                    !!getJavascriptInitializer(followBinaryRight(propertyAccess.parent), isPrototypeAccess(propertyAccess.parent.left))
+                ? getParentOfBinaryExpression(propertyAccess.parent).parent.kind === SyntaxKind.SourceFile &&
+                    !!getJavascriptInitializer(getInitializerOfBinaryExpression(propertyAccess.parent), isPrototypeAccess(propertyAccess.parent.left))
                 : propertyAccess.parent.parent.kind === SyntaxKind.SourceFile;
             if (!isPrototypeProperty && (!symbol || !(symbol.flags & SymbolFlags.Namespace)) && isToplevelNamespaceableInitializer) {
                 // make symbols or add declarations for intermediate containers
@@ -2478,7 +2478,7 @@ namespace ts {
             declareSymbol(symbolTable, symbol, propertyAccess, symbolFlags, symbolExcludes);
         }
 
-        function followBinaryParent(expr: BinaryExpression) {
+        function getParentOfBinaryExpression(expr: BinaryExpression) {
             while (isBinaryExpression(expr.parent)) {
                 expr = expr.parent;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18206,11 +18206,10 @@ namespace ts {
             while (parent && parent.kind === SyntaxKind.PropertyAccessExpression) {
                 parent = parent.parent;
             }
-            return parent && isBinaryExpression(parent) &&
-                isPrototypeAccess(parent.left) &&
-                parent.operatorToken.kind === SyntaxKind.EqualsToken &&
-                isObjectLiteralExpression(parent.right) &&
-                parent.right;
+            if (parent && isBinaryExpression(parent) && isPrototypeAccess(parent.left) && parent.operatorToken.kind === SyntaxKind.EqualsToken) {
+                const right = followBinaryRight(parent);
+                return isObjectLiteralExpression(right) && right;
+            }
         }
 
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18207,7 +18207,7 @@ namespace ts {
                 parent = parent.parent;
             }
             if (parent && isBinaryExpression(parent) && isPrototypeAccess(parent.left) && parent.operatorToken.kind === SyntaxKind.EqualsToken) {
-                const right = followBinaryRight(parent);
+                const right = getInitializerOfBinaryExpression(parent);
                 return isObjectLiteralExpression(right) && right;
             }
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1629,7 +1629,7 @@ namespace ts {
             return SpecialPropertyAssignmentKind.ModuleExports;
         }
         else if (isEntityNameExpression(lhs.expression)) {
-            if (lhs.name.escapedText === "prototype" && isObjectLiteralExpression(expr.right)) {
+            if (lhs.name.escapedText === "prototype" && isObjectLiteralExpression(followBinaryRight(expr))) {
                 // F.prototype = { ... }
                 return SpecialPropertyAssignmentKind.Prototype;
             }
@@ -1654,6 +1654,13 @@ namespace ts {
         }
 
         return SpecialPropertyAssignmentKind.None;
+    }
+
+    export function followBinaryRight(expr: BinaryExpression) {
+        while (isBinaryExpression(expr.right)) {
+            expr = expr.right;
+        }
+        return expr.right;
     }
 
     export function isPrototypePropertyAssignment(node: Node): boolean {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1779,7 +1779,11 @@ namespace ts {
 
         function getJSDocCommentsAndTagsWorker(node: Node): void {
             const parent = node.parent;
-            if (parent && (parent.kind === SyntaxKind.PropertyAssignment || parent.kind === SyntaxKind.PropertyDeclaration || getNestedModuleDeclaration(parent))) {
+            if (parent &&
+                (parent.kind === SyntaxKind.PropertyAssignment ||
+                 parent.kind === SyntaxKind.PropertyDeclaration ||
+                 isBinaryExpression(parent) && getSpecialPropertyAssignmentKind(parent) !== SpecialPropertyAssignmentKind.None ||
+                 getNestedModuleDeclaration(parent))) {
                 getJSDocCommentsAndTagsWorker(parent);
             }
             // Try to recognize this pattern when node is initializer of variable declaration and JSDoc comments are on containing variable statement.

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1629,7 +1629,7 @@ namespace ts {
             return SpecialPropertyAssignmentKind.ModuleExports;
         }
         else if (isEntityNameExpression(lhs.expression)) {
-            if (lhs.name.escapedText === "prototype" && isObjectLiteralExpression(followBinaryRight(expr))) {
+            if (lhs.name.escapedText === "prototype" && isObjectLiteralExpression(getInitializerOfBinaryExpression(expr))) {
                 // F.prototype = { ... }
                 return SpecialPropertyAssignmentKind.Prototype;
             }
@@ -1656,7 +1656,7 @@ namespace ts {
         return SpecialPropertyAssignmentKind.None;
     }
 
-    export function followBinaryRight(expr: BinaryExpression) {
+    export function getInitializerOfBinaryExpression(expr: BinaryExpression) {
         while (isBinaryExpression(expr.right)) {
             expr = expr.right;
         }

--- a/tests/baselines/reference/chainedPrototypeAssignment.errors.txt
+++ b/tests/baselines/reference/chainedPrototypeAssignment.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/conformance/salsa/use.js(5,5): error TS2345: Argument of type '"nope"' is not assignable to parameter of type 'number'.
+tests/cases/conformance/salsa/use.js(6,5): error TS2345: Argument of type '"not really"' is not assignable to parameter of type 'number'.
+
+
+==== tests/cases/conformance/salsa/use.js (2 errors) ====
+    /// <reference path='./types.d.ts'/>
+    var mod = require('./mod');
+    var a = new mod.A()
+    var b = new mod.B()
+    a.m('nope')
+        ~~~~~~
+!!! error TS2345: Argument of type '"nope"' is not assignable to parameter of type 'number'.
+    b.m('not really')
+        ~~~~~~~~~~~~
+!!! error TS2345: Argument of type '"not really"' is not assignable to parameter of type 'number'.
+    
+==== tests/cases/conformance/salsa/types.d.ts (0 errors) ====
+    declare function require(name: string): any;
+    declare var exports: any;
+==== tests/cases/conformance/salsa/mod.js (0 errors) ====
+    /// <reference path='./types.d.ts'/>
+    var A = function() {
+        this.a = 1
+    }
+    var B = function() {
+        this.b = 2
+    }
+    exports.A = A
+    exports.B = B
+    A.prototype = B.prototype = {
+        /** @param {number} n */
+        m(n) {
+            return n + 1
+        }
+    }
+    

--- a/tests/baselines/reference/chainedPrototypeAssignment.symbols
+++ b/tests/baselines/reference/chainedPrototypeAssignment.symbols
@@ -1,0 +1,81 @@
+=== tests/cases/conformance/salsa/use.js ===
+/// <reference path='./types.d.ts'/>
+var mod = require('./mod');
+>mod : Symbol(mod, Decl(use.js, 1, 3))
+>require : Symbol(require, Decl(types.d.ts, 0, 0))
+>'./mod' : Symbol("tests/cases/conformance/salsa/mod", Decl(mod.js, 0, 0))
+
+var a = new mod.A()
+>a : Symbol(a, Decl(use.js, 2, 3))
+>mod.A : Symbol(A, Decl(mod.js, 6, 1))
+>mod : Symbol(mod, Decl(use.js, 1, 3))
+>A : Symbol(A, Decl(mod.js, 6, 1))
+
+var b = new mod.B()
+>b : Symbol(b, Decl(use.js, 3, 3))
+>mod.B : Symbol(B, Decl(mod.js, 7, 13))
+>mod : Symbol(mod, Decl(use.js, 1, 3))
+>B : Symbol(B, Decl(mod.js, 7, 13))
+
+a.m('nope')
+>a.m : Symbol(m, Decl(mod.js, 9, 29))
+>a : Symbol(a, Decl(use.js, 2, 3))
+>m : Symbol(m, Decl(mod.js, 9, 29))
+
+b.m('not really')
+>b.m : Symbol(m, Decl(mod.js, 9, 29))
+>b : Symbol(b, Decl(use.js, 3, 3))
+>m : Symbol(m, Decl(mod.js, 9, 29))
+
+=== tests/cases/conformance/salsa/types.d.ts ===
+declare function require(name: string): any;
+>require : Symbol(require, Decl(types.d.ts, 0, 0))
+>name : Symbol(name, Decl(types.d.ts, 0, 25))
+
+declare var exports: any;
+>exports : Symbol(exports, Decl(types.d.ts, 1, 11))
+
+=== tests/cases/conformance/salsa/mod.js ===
+/// <reference path='./types.d.ts'/>
+var A = function() {
+>A : Symbol(A, Decl(mod.js, 1, 3), Decl(mod.js, 8, 13))
+
+    this.a = 1
+>a : Symbol(A.a, Decl(mod.js, 1, 20))
+}
+var B = function() {
+>B : Symbol(B, Decl(mod.js, 4, 3), Decl(mod.js, 9, 13))
+
+    this.b = 2
+>b : Symbol(B.b, Decl(mod.js, 4, 20))
+}
+exports.A = A
+>exports.A : Symbol(A, Decl(mod.js, 6, 1))
+>exports : Symbol(A, Decl(mod.js, 6, 1))
+>A : Symbol(A, Decl(mod.js, 6, 1))
+>A : Symbol(A, Decl(mod.js, 1, 3), Decl(mod.js, 8, 13))
+
+exports.B = B
+>exports.B : Symbol(B, Decl(mod.js, 7, 13))
+>exports : Symbol(B, Decl(mod.js, 7, 13))
+>B : Symbol(B, Decl(mod.js, 7, 13))
+>B : Symbol(B, Decl(mod.js, 4, 3), Decl(mod.js, 9, 13))
+
+A.prototype = B.prototype = {
+>A.prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>A : Symbol(A, Decl(mod.js, 1, 3), Decl(mod.js, 8, 13))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>B.prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mod.js, 4, 3), Decl(mod.js, 9, 13))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+
+    /** @param {number} n */
+    m(n) {
+>m : Symbol(m, Decl(mod.js, 9, 29))
+>n : Symbol(n, Decl(mod.js, 11, 6))
+
+        return n + 1
+>n : Symbol(n, Decl(mod.js, 11, 6))
+    }
+}
+

--- a/tests/baselines/reference/chainedPrototypeAssignment.types
+++ b/tests/baselines/reference/chainedPrototypeAssignment.types
@@ -1,0 +1,105 @@
+=== tests/cases/conformance/salsa/use.js ===
+/// <reference path='./types.d.ts'/>
+var mod = require('./mod');
+>mod : typeof "tests/cases/conformance/salsa/mod"
+>require('./mod') : typeof "tests/cases/conformance/salsa/mod"
+>require : (name: string) => any
+>'./mod' : "./mod"
+
+var a = new mod.A()
+>a : { a: number; } & { [x: string]: any; m(n: number): number; }
+>new mod.A() : { a: number; } & { [x: string]: any; m(n: number): number; }
+>mod.A : () => void
+>mod : typeof "tests/cases/conformance/salsa/mod"
+>A : () => void
+
+var b = new mod.B()
+>b : { b: number; } & { [x: string]: any; m(n: number): number; }
+>new mod.B() : { b: number; } & { [x: string]: any; m(n: number): number; }
+>mod.B : () => void
+>mod : typeof "tests/cases/conformance/salsa/mod"
+>B : () => void
+
+a.m('nope')
+>a.m('nope') : number
+>a.m : (n: number) => number
+>a : { a: number; } & { [x: string]: any; m(n: number): number; }
+>m : (n: number) => number
+>'nope' : "nope"
+
+b.m('not really')
+>b.m('not really') : number
+>b.m : (n: number) => number
+>b : { b: number; } & { [x: string]: any; m(n: number): number; }
+>m : (n: number) => number
+>'not really' : "not really"
+
+=== tests/cases/conformance/salsa/types.d.ts ===
+declare function require(name: string): any;
+>require : (name: string) => any
+>name : string
+
+declare var exports: any;
+>exports : any
+
+=== tests/cases/conformance/salsa/mod.js ===
+/// <reference path='./types.d.ts'/>
+var A = function() {
+>A : () => void
+>function() {    this.a = 1} : () => void
+
+    this.a = 1
+>this.a = 1 : 1
+>this.a : any
+>this : any
+>a : any
+>1 : 1
+}
+var B = function() {
+>B : () => void
+>function() {    this.b = 2} : () => void
+
+    this.b = 2
+>this.b = 2 : 2
+>this.b : any
+>this : any
+>b : any
+>2 : 2
+}
+exports.A = A
+>exports.A = A : () => void
+>exports.A : () => void
+>exports : typeof "tests/cases/conformance/salsa/mod"
+>A : () => void
+>A : () => void
+
+exports.B = B
+>exports.B = B : () => void
+>exports.B : () => void
+>exports : typeof "tests/cases/conformance/salsa/mod"
+>B : () => void
+>B : () => void
+
+A.prototype = B.prototype = {
+>A.prototype = B.prototype = {    /** @param {number} n */    m(n) {        return n + 1    }} : { [x: string]: any; m(n: number): number; }
+>A.prototype : any
+>A : () => void
+>prototype : any
+>B.prototype = {    /** @param {number} n */    m(n) {        return n + 1    }} : { [x: string]: any; m(n: number): number; }
+>B.prototype : any
+>B : () => void
+>prototype : any
+>{    /** @param {number} n */    m(n) {        return n + 1    }} : { [x: string]: any; m(n: number): number; }
+
+    /** @param {number} n */
+    m(n) {
+>m : (n: number) => number
+>n : number
+
+        return n + 1
+>n + 1 : number
+>n : number
+>1 : 1
+    }
+}
+

--- a/tests/baselines/reference/jsdocTypeFromChainedAssignment.errors.txt
+++ b/tests/baselines/reference/jsdocTypeFromChainedAssignment.errors.txt
@@ -1,0 +1,41 @@
+tests/cases/conformance/jsdoc/a.js(12,21): error TS2339: Property 'x' does not exist on type 'typeof A'.
+tests/cases/conformance/jsdoc/a.js(15,5): error TS2345: Argument of type '"no"' is not assignable to parameter of type 'number'.
+tests/cases/conformance/jsdoc/a.js(16,5): error TS2345: Argument of type '"not really"' is not assignable to parameter of type 'number'.
+tests/cases/conformance/jsdoc/a.js(17,5): error TS2345: Argument of type '"still no"' is not assignable to parameter of type 'number'.
+tests/cases/conformance/jsdoc/a.js(18,5): error TS2345: Argument of type '"not here either"' is not assignable to parameter of type 'number'.
+tests/cases/conformance/jsdoc/a.js(19,1): error TS2322: Type '10' is not assignable to type '1'.
+
+
+==== tests/cases/conformance/jsdoc/a.js (6 errors) ====
+    function A () {
+        this.x = 1
+        /** @type {1} */
+        this.first = this.second = 1
+    }
+    /** @param {number} n */
+    A.prototype.y = A.prototype.z = function f(n) {
+        return n + this.x
+    }
+    /** @param {number} m */
+    A.s = A.t = function g(m) {
+        return m + this.x
+                        ~
+!!! error TS2339: Property 'x' does not exist on type 'typeof A'.
+    }
+    var a = new A()
+    a.y('no') // error
+        ~~~~
+!!! error TS2345: Argument of type '"no"' is not assignable to parameter of type 'number'.
+    a.z('not really') // error
+        ~~~~~~~~~~~~
+!!! error TS2345: Argument of type '"not really"' is not assignable to parameter of type 'number'.
+    A.s('still no') // error
+        ~~~~~~~~~~
+!!! error TS2345: Argument of type '"still no"' is not assignable to parameter of type 'number'.
+    A.t('not here either') // error
+        ~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '"not here either"' is not assignable to parameter of type 'number'.
+    a.first = 10 // error: '10' isn't assignable to '1'
+    ~~~~~~~
+!!! error TS2322: Type '10' is not assignable to type '1'.
+    

--- a/tests/baselines/reference/jsdocTypeFromChainedAssignment.symbols
+++ b/tests/baselines/reference/jsdocTypeFromChainedAssignment.symbols
@@ -1,0 +1,75 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+function A () {
+>A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+
+    this.x = 1
+>x : Symbol(A.x, Decl(a.js, 0, 15))
+
+    /** @type {1} */
+    this.first = this.second = 1
+>first : Symbol(A.first, Decl(a.js, 1, 14))
+>second : Symbol(A.second, Decl(a.js, 3, 16))
+}
+/** @param {number} n */
+A.prototype.y = A.prototype.z = function f(n) {
+>A.prototype : Symbol(A.y, Decl(a.js, 4, 1))
+>A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>y : Symbol(A.y, Decl(a.js, 4, 1))
+>A.prototype : Symbol(A.z, Decl(a.js, 6, 15))
+>A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>z : Symbol(A.z, Decl(a.js, 6, 15))
+>f : Symbol(f, Decl(a.js, 6, 31))
+>n : Symbol(n, Decl(a.js, 6, 43))
+
+    return n + this.x
+>n : Symbol(n, Decl(a.js, 6, 43))
+>this.x : Symbol(A.x, Decl(a.js, 0, 15))
+>this : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+>x : Symbol(A.x, Decl(a.js, 0, 15))
+}
+/** @param {number} m */
+A.s = A.t = function g(m) {
+>A.s : Symbol(A.s, Decl(a.js, 8, 1))
+>A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+>s : Symbol(A.s, Decl(a.js, 8, 1))
+>A.t : Symbol(A.t, Decl(a.js, 10, 5))
+>A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+>t : Symbol(A.t, Decl(a.js, 10, 5))
+>g : Symbol(g, Decl(a.js, 10, 11))
+>m : Symbol(m, Decl(a.js, 10, 23))
+
+    return m + this.x
+>m : Symbol(m, Decl(a.js, 10, 23))
+>this : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+}
+var a = new A()
+>a : Symbol(a, Decl(a.js, 13, 3))
+>A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+
+a.y('no') // error
+>a.y : Symbol(A.y, Decl(a.js, 4, 1))
+>a : Symbol(a, Decl(a.js, 13, 3))
+>y : Symbol(A.y, Decl(a.js, 4, 1))
+
+a.z('not really') // error
+>a.z : Symbol(A.z, Decl(a.js, 6, 15))
+>a : Symbol(a, Decl(a.js, 13, 3))
+>z : Symbol(A.z, Decl(a.js, 6, 15))
+
+A.s('still no') // error
+>A.s : Symbol(A.s, Decl(a.js, 8, 1))
+>A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+>s : Symbol(A.s, Decl(a.js, 8, 1))
+
+A.t('not here either') // error
+>A.t : Symbol(A.t, Decl(a.js, 10, 5))
+>A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
+>t : Symbol(A.t, Decl(a.js, 10, 5))
+
+a.first = 10 // error: '10' isn't assignable to '1'
+>a.first : Symbol(A.first, Decl(a.js, 1, 14))
+>a : Symbol(a, Decl(a.js, 13, 3))
+>first : Symbol(A.first, Decl(a.js, 1, 14))
+

--- a/tests/baselines/reference/jsdocTypeFromChainedAssignment.types
+++ b/tests/baselines/reference/jsdocTypeFromChainedAssignment.types
@@ -1,0 +1,109 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+function A () {
+>A : typeof A
+
+    this.x = 1
+>this.x = 1 : 1
+>this.x : any
+>this : any
+>x : any
+>1 : 1
+
+    /** @type {1} */
+    this.first = this.second = 1
+>this.first = this.second = 1 : 1
+>this.first : any
+>this : any
+>first : any
+>this.second = 1 : 1
+>this.second : any
+>this : any
+>second : any
+>1 : 1
+}
+/** @param {number} n */
+A.prototype.y = A.prototype.z = function f(n) {
+>A.prototype.y = A.prototype.z = function f(n) {    return n + this.x} : (n: number) => number
+>A.prototype.y : any
+>A.prototype : any
+>A : typeof A
+>prototype : any
+>y : any
+>A.prototype.z = function f(n) {    return n + this.x} : (n: number) => number
+>A.prototype.z : any
+>A.prototype : any
+>A : typeof A
+>prototype : any
+>z : any
+>function f(n) {    return n + this.x} : (n: number) => number
+>f : (n: number) => number
+>n : number
+
+    return n + this.x
+>n + this.x : number
+>n : number
+>this.x : number
+>this : typeof A
+>x : number
+}
+/** @param {number} m */
+A.s = A.t = function g(m) {
+>A.s = A.t = function g(m) {    return m + this.x} : (m: number) => any
+>A.s : (m: number) => any
+>A : typeof A
+>s : (m: number) => any
+>A.t = function g(m) {    return m + this.x} : (m: number) => any
+>A.t : (m: number) => any
+>A : typeof A
+>t : (m: number) => any
+>function g(m) {    return m + this.x} : (m: number) => any
+>g : (m: number) => any
+>m : number
+
+    return m + this.x
+>m + this.x : any
+>m : number
+>this.x : any
+>this : typeof A
+>x : any
+}
+var a = new A()
+>a : typeof A
+>new A() : typeof A
+>A : typeof A
+
+a.y('no') // error
+>a.y('no') : number
+>a.y : (n: number) => number
+>a : typeof A
+>y : (n: number) => number
+>'no' : "no"
+
+a.z('not really') // error
+>a.z('not really') : number
+>a.z : (n: number) => number
+>a : typeof A
+>z : (n: number) => number
+>'not really' : "not really"
+
+A.s('still no') // error
+>A.s('still no') : any
+>A.s : (m: number) => any
+>A : typeof A
+>s : (m: number) => any
+>'still no' : "still no"
+
+A.t('not here either') // error
+>A.t('not here either') : any
+>A.t : (m: number) => any
+>A : typeof A
+>t : (m: number) => any
+>'not here either' : "not here either"
+
+a.first = 10 // error: '10' isn't assignable to '1'
+>a.first = 10 : 10
+>a.first : 1
+>a : typeof A
+>first : 1
+>10 : 10
+

--- a/tests/baselines/reference/jsdocTypeFromChainedAssignment2.errors.txt
+++ b/tests/baselines/reference/jsdocTypeFromChainedAssignment2.errors.txt
@@ -1,0 +1,38 @@
+tests/cases/conformance/jsdoc/use.js(3,7): error TS2345: Argument of type '"no"' is not assignable to parameter of type 'number'.
+tests/cases/conformance/jsdoc/use.js(4,7): error TS2345: Argument of type '"also no"' is not assignable to parameter of type 'number'.
+tests/cases/conformance/jsdoc/use.js(5,7): error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
+tests/cases/conformance/jsdoc/use.js(6,7): error TS2345: Argument of type '1' is not assignable to parameter of type 'string'.
+
+
+==== tests/cases/conformance/jsdoc/use.js (4 errors) ====
+    /// <reference path='./types.d.ts'/>
+    var mod = require('./mod');
+    mod.f('no')
+          ~~~~
+!!! error TS2345: Argument of type '"no"' is not assignable to parameter of type 'number'.
+    mod.g('also no')
+          ~~~~~~~~~
+!!! error TS2345: Argument of type '"also no"' is not assignable to parameter of type 'number'.
+    mod.h(0)
+          ~
+!!! error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
+    mod.i(1)
+          ~
+!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'string'.
+    
+==== tests/cases/conformance/jsdoc/types.d.ts (0 errors) ====
+    declare function require(name: string): any;
+    declare var exports: any;
+    declare var module: { exports: any };
+==== tests/cases/conformance/jsdoc/mod.js (0 errors) ====
+    /// <reference path='./types.d.ts'/>
+    
+    /** @param {number} n */
+    exports.f = exports.g = function fg(n) {
+        return n + 1
+    }
+    /** @param {string} mom */
+    module.exports.h = module.exports.i = function hi(mom) {
+        return `hi, ${mom}!`;
+    }
+    

--- a/tests/baselines/reference/jsdocTypeFromChainedAssignment2.symbols
+++ b/tests/baselines/reference/jsdocTypeFromChainedAssignment2.symbols
@@ -1,0 +1,73 @@
+=== tests/cases/conformance/jsdoc/use.js ===
+/// <reference path='./types.d.ts'/>
+var mod = require('./mod');
+>mod : Symbol(mod, Decl(use.js, 1, 3))
+>require : Symbol(require, Decl(types.d.ts, 0, 0))
+>'./mod' : Symbol("tests/cases/conformance/jsdoc/mod", Decl(mod.js, 0, 0))
+
+mod.f('no')
+>mod.f : Symbol(f, Decl(mod.js, 0, 0))
+>mod : Symbol(mod, Decl(use.js, 1, 3))
+>f : Symbol(f, Decl(mod.js, 0, 0))
+
+mod.g('also no')
+>mod.g : Symbol(g, Decl(mod.js, 3, 11))
+>mod : Symbol(mod, Decl(use.js, 1, 3))
+>g : Symbol(g, Decl(mod.js, 3, 11))
+
+mod.h(0)
+>mod.h : Symbol(h, Decl(mod.js, 5, 1))
+>mod : Symbol(mod, Decl(use.js, 1, 3))
+>h : Symbol(h, Decl(mod.js, 5, 1))
+
+mod.i(1)
+>mod.i : Symbol(i, Decl(mod.js, 7, 18))
+>mod : Symbol(mod, Decl(use.js, 1, 3))
+>i : Symbol(i, Decl(mod.js, 7, 18))
+
+=== tests/cases/conformance/jsdoc/types.d.ts ===
+declare function require(name: string): any;
+>require : Symbol(require, Decl(types.d.ts, 0, 0))
+>name : Symbol(name, Decl(types.d.ts, 0, 25))
+
+declare var exports: any;
+>exports : Symbol(exports, Decl(types.d.ts, 1, 11))
+
+declare var module: { exports: any };
+>module : Symbol(module, Decl(types.d.ts, 2, 11))
+>exports : Symbol(exports, Decl(types.d.ts, 2, 21))
+
+=== tests/cases/conformance/jsdoc/mod.js ===
+/// <reference path='./types.d.ts'/>
+
+/** @param {number} n */
+exports.f = exports.g = function fg(n) {
+>exports.f : Symbol(f, Decl(mod.js, 0, 0))
+>exports : Symbol(f, Decl(mod.js, 0, 0))
+>f : Symbol(f, Decl(mod.js, 0, 0))
+>exports.g : Symbol(g, Decl(mod.js, 3, 11))
+>exports : Symbol(g, Decl(mod.js, 3, 11))
+>g : Symbol(g, Decl(mod.js, 3, 11))
+>fg : Symbol(fg, Decl(mod.js, 3, 23))
+>n : Symbol(n, Decl(mod.js, 3, 36))
+
+    return n + 1
+>n : Symbol(n, Decl(mod.js, 3, 36))
+}
+/** @param {string} mom */
+module.exports.h = module.exports.i = function hi(mom) {
+>module.exports : Symbol(h, Decl(mod.js, 5, 1))
+>module : Symbol(module, Decl(types.d.ts, 2, 11))
+>exports : Symbol(exports, Decl(types.d.ts, 2, 21))
+>h : Symbol(h, Decl(mod.js, 5, 1))
+>module.exports : Symbol(i, Decl(mod.js, 7, 18))
+>module : Symbol(module, Decl(types.d.ts, 2, 11))
+>exports : Symbol(exports, Decl(types.d.ts, 2, 21))
+>i : Symbol(i, Decl(mod.js, 7, 18))
+>hi : Symbol(hi, Decl(mod.js, 7, 37))
+>mom : Symbol(mom, Decl(mod.js, 7, 50))
+
+    return `hi, ${mom}!`;
+>mom : Symbol(mom, Decl(mod.js, 7, 50))
+}
+

--- a/tests/baselines/reference/jsdocTypeFromChainedAssignment2.types
+++ b/tests/baselines/reference/jsdocTypeFromChainedAssignment2.types
@@ -1,0 +1,93 @@
+=== tests/cases/conformance/jsdoc/use.js ===
+/// <reference path='./types.d.ts'/>
+var mod = require('./mod');
+>mod : typeof "tests/cases/conformance/jsdoc/mod"
+>require('./mod') : typeof "tests/cases/conformance/jsdoc/mod"
+>require : (name: string) => any
+>'./mod' : "./mod"
+
+mod.f('no')
+>mod.f('no') : number
+>mod.f : (n: number) => number
+>mod : typeof "tests/cases/conformance/jsdoc/mod"
+>f : (n: number) => number
+>'no' : "no"
+
+mod.g('also no')
+>mod.g('also no') : number
+>mod.g : (n: number) => number
+>mod : typeof "tests/cases/conformance/jsdoc/mod"
+>g : (n: number) => number
+>'also no' : "also no"
+
+mod.h(0)
+>mod.h(0) : string
+>mod.h : (mom: string) => string
+>mod : typeof "tests/cases/conformance/jsdoc/mod"
+>h : (mom: string) => string
+>0 : 0
+
+mod.i(1)
+>mod.i(1) : string
+>mod.i : (mom: string) => string
+>mod : typeof "tests/cases/conformance/jsdoc/mod"
+>i : (mom: string) => string
+>1 : 1
+
+=== tests/cases/conformance/jsdoc/types.d.ts ===
+declare function require(name: string): any;
+>require : (name: string) => any
+>name : string
+
+declare var exports: any;
+>exports : any
+
+declare var module: { exports: any };
+>module : { exports: any; }
+>exports : any
+
+=== tests/cases/conformance/jsdoc/mod.js ===
+/// <reference path='./types.d.ts'/>
+
+/** @param {number} n */
+exports.f = exports.g = function fg(n) {
+>exports.f = exports.g = function fg(n) {    return n + 1} : (n: number) => number
+>exports.f : (n: number) => number
+>exports : typeof "tests/cases/conformance/jsdoc/mod"
+>f : (n: number) => number
+>exports.g = function fg(n) {    return n + 1} : (n: number) => number
+>exports.g : (n: number) => number
+>exports : typeof "tests/cases/conformance/jsdoc/mod"
+>g : (n: number) => number
+>function fg(n) {    return n + 1} : (n: number) => number
+>fg : (n: number) => number
+>n : number
+
+    return n + 1
+>n + 1 : number
+>n : number
+>1 : 1
+}
+/** @param {string} mom */
+module.exports.h = module.exports.i = function hi(mom) {
+>module.exports.h = module.exports.i = function hi(mom) {    return `hi, ${mom}!`;} : (mom: string) => string
+>module.exports.h : any
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>h : any
+>module.exports.i = function hi(mom) {    return `hi, ${mom}!`;} : (mom: string) => string
+>module.exports.i : any
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>i : any
+>function hi(mom) {    return `hi, ${mom}!`;} : (mom: string) => string
+>hi : (mom: string) => string
+>mom : string
+
+    return `hi, ${mom}!`;
+>`hi, ${mom}!` : string
+>mom : string
+}
+

--- a/tests/baselines/reference/typeFromPropertyAssignment10.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment10.symbols
@@ -1,21 +1,21 @@
 === tests/cases/conformance/salsa/module.js ===
 var Outer = Outer || {};
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 
 Outer.app = Outer.app || {};
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 
 === tests/cases/conformance/salsa/someview.js ===
 Outer.app.SomeView = (function () {
 >Outer.app.SomeView : Symbol(Outer.app.SomeView, Decl(someview.js, 0, 0))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >SomeView : Symbol(Outer.app.SomeView, Decl(someview.js, 0, 0))
 
@@ -32,7 +32,7 @@ Outer.app.SomeView = (function () {
 Outer.app.Inner = class {
 >Outer.app.Inner : Symbol(Outer.app.Inner, Decl(someview.js, 5, 5))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >Inner : Symbol(Outer.app.Inner, Decl(someview.js, 5, 5))
 
@@ -48,7 +48,7 @@ var example = new Outer.app.Inner();
 >example : Symbol(example, Decl(someview.js, 12, 3))
 >Outer.app.Inner : Symbol(Outer.app.Inner, Decl(someview.js, 5, 5))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >Inner : Symbol(Outer.app.Inner, Decl(someview.js, 5, 5))
 
@@ -61,7 +61,7 @@ example.y;
 Outer.app.statische = function (k) {
 >Outer.app.statische : Symbol(Outer.app.statische, Decl(someview.js, 13, 10))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >statische : Symbol(Outer.app.statische, Decl(someview.js, 13, 10))
 >k : Symbol(k, Decl(someview.js, 15, 32))
@@ -74,7 +74,7 @@ Outer.app.statische = function (k) {
 Outer.app.Application = (function () {
 >Outer.app.Application : Symbol(app.Application, Decl(application.js, 0, 0))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >Application : Symbol(app.Application, Decl(application.js, 0, 0))
 
@@ -92,7 +92,7 @@ Outer.app.Application = (function () {
 >me : Symbol(me, Decl(application.js, 7, 11))
 >Outer.app.SomeView : Symbol(Outer.app.SomeView, Decl(someview.js, 0, 0))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >SomeView : Symbol(Outer.app.SomeView, Decl(someview.js, 0, 0))
 
@@ -106,7 +106,7 @@ var app = new Outer.app.Application();
 >app : Symbol(app, Decl(main.js, 0, 3))
 >Outer.app.Application : Symbol(app.Application, Decl(application.js, 0, 0))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >Application : Symbol(app.Application, Decl(application.js, 0, 0))
 
@@ -114,7 +114,7 @@ var inner = new Outer.app.Inner();
 >inner : Symbol(inner, Decl(main.js, 1, 3))
 >Outer.app.Inner : Symbol(Outer.app.Inner, Decl(someview.js, 5, 5))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >Inner : Symbol(Outer.app.Inner, Decl(someview.js, 5, 5))
 
@@ -135,7 +135,7 @@ x.y;
 Outer.app.statische(101); // Infinity, duh
 >Outer.app.statische : Symbol(Outer.app.statische, Decl(someview.js, 13, 10))
 >Outer.app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
->Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
+>Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 24), Decl(someview.js, 0, 0), Decl(application.js, 0, 0))
 >app : Symbol(app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(application.js, 0, 6))
 >statische : Symbol(Outer.app.statische, Decl(someview.js, 13, 10))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment8.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment8.symbols
@@ -1,20 +1,20 @@
 === tests/cases/conformance/salsa/a.js ===
 var my = my || {};
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 1, 22))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 1, 22))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 1, 22))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 1, 22))
 
 my.app = my.app || {};
 >my.app : Symbol(app, Decl(a.js, 0, 18), Decl(a.js, 3, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 1, 22))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 1, 22))
 >app : Symbol(app, Decl(a.js, 0, 18), Decl(a.js, 3, 3))
 >my.app : Symbol(app, Decl(a.js, 0, 18), Decl(a.js, 3, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 1, 22))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 1, 22))
 >app : Symbol(app, Decl(a.js, 0, 18), Decl(a.js, 3, 3))
 
 my.app.Application = (function () {
 >my.app.Application : Symbol(Application, Decl(a.js, 1, 22))
 >my.app : Symbol(app, Decl(a.js, 0, 18), Decl(a.js, 3, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 1, 22))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 1, 22))
 >app : Symbol(app, Decl(a.js, 0, 18), Decl(a.js, 3, 3))
 >Application : Symbol(Application, Decl(a.js, 1, 22))
 
@@ -30,27 +30,27 @@ return Application;
 my.app.Application()
 >my.app.Application : Symbol(Application, Decl(a.js, 1, 22))
 >my.app : Symbol(app, Decl(a.js, 0, 18), Decl(a.js, 3, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 1, 22))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 1, 22))
 >app : Symbol(app, Decl(a.js, 0, 18), Decl(a.js, 3, 3))
 >Application : Symbol(Application, Decl(a.js, 1, 22))
 
 === tests/cases/conformance/salsa/b.js ===
 var min = window.min || {};
->min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 1, 24))
+>min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 0, 27), Decl(b.js, 1, 24))
 >window : Symbol(window, Decl(lib.dom.d.ts, --, --))
 
 min.app = min.app || {};
 >min.app : Symbol(app, Decl(b.js, 0, 27), Decl(b.js, 3, 4))
->min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 1, 24))
+>min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 0, 27), Decl(b.js, 1, 24))
 >app : Symbol(app, Decl(b.js, 0, 27), Decl(b.js, 3, 4))
 >min.app : Symbol(app, Decl(b.js, 0, 27), Decl(b.js, 3, 4))
->min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 1, 24))
+>min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 0, 27), Decl(b.js, 1, 24))
 >app : Symbol(app, Decl(b.js, 0, 27), Decl(b.js, 3, 4))
 
 min.app.Application = (function () {
 >min.app.Application : Symbol(Application, Decl(b.js, 1, 24))
 >min.app : Symbol(app, Decl(b.js, 0, 27), Decl(b.js, 3, 4))
->min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 1, 24))
+>min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 0, 27), Decl(b.js, 1, 24))
 >app : Symbol(app, Decl(b.js, 0, 27), Decl(b.js, 3, 4))
 >Application : Symbol(Application, Decl(b.js, 1, 24))
 
@@ -66,7 +66,7 @@ return Application;
 min.app.Application()
 >min.app.Application : Symbol(Application, Decl(b.js, 1, 24))
 >min.app : Symbol(app, Decl(b.js, 0, 27), Decl(b.js, 3, 4))
->min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 1, 24))
+>min : Symbol(min, Decl(b.js, 0, 3), Decl(b.js, 0, 27), Decl(b.js, 1, 24))
 >app : Symbol(app, Decl(b.js, 0, 27), Decl(b.js, 3, 4))
 >Application : Symbol(Application, Decl(b.js, 1, 24))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment9.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment9.symbols
@@ -1,12 +1,12 @@
 === tests/cases/conformance/salsa/a.js ===
 var my = my || {};
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
 
 /** @param {number} n */
 my.method = function(n) {
 >my.method : Symbol(method, Decl(a.js, 0, 18))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
 >method : Symbol(method, Decl(a.js, 0, 18))
 >n : Symbol(n, Decl(a.js, 2, 21))
 
@@ -15,27 +15,27 @@ my.method = function(n) {
 }
 my.number = 1;
 >my.number : Symbol(number, Decl(a.js, 4, 1))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
 >number : Symbol(number, Decl(a.js, 4, 1))
 
 my.object = {};
 >my.object : Symbol(object, Decl(a.js, 5, 14))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
 >object : Symbol(object, Decl(a.js, 5, 14))
 
 my.predicate = my.predicate || {};
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 
 my.predicate.query = function () {
 >my.predicate.query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
 
     var me = this;
@@ -49,17 +49,17 @@ my.predicate.query = function () {
 var q = new my.predicate.query();
 >q : Symbol(q, Decl(a.js, 12, 3))
 >my.predicate.query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
 
 my.predicate.query.another = function () {
 >my.predicate.query.another : Symbol((Anonymous function).another, Decl(a.js, 12, 33))
 >my.predicate.query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
 >another : Symbol((Anonymous function).another, Decl(a.js, 12, 33))
 
@@ -68,9 +68,9 @@ my.predicate.query.another = function () {
 my.predicate.query.result = 'none'
 >my.predicate.query.result : Symbol((Anonymous function).result, Decl(a.js, 15, 1))
 >my.predicate.query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
 >result : Symbol((Anonymous function).result, Decl(a.js, 15, 1))
 
@@ -79,14 +79,14 @@ my.predicate.query.result = 'none'
  */
 my.predicate.sort = my.predicate.sort || function (first, second) {
 >my.predicate.sort : Symbol(sort, Decl(a.js, 16, 34))
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >sort : Symbol(sort, Decl(a.js, 16, 34))
 >my.predicate.sort : Symbol(sort, Decl(a.js, 16, 34))
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >sort : Symbol(sort, Decl(a.js, 16, 34))
 >first : Symbol(first, Decl(a.js, 20, 51))
 >second : Symbol(second, Decl(a.js, 20, 57))
@@ -99,9 +99,9 @@ my.predicate.sort = my.predicate.sort || function (first, second) {
 }
 my.predicate.type = class {
 >my.predicate.type : Symbol(type, Decl(a.js, 22, 1))
->my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
->my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 7, 34), Decl(a.js, 12, 33) ... and 1 more)
->predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 23, 3))
+>my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
+>my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
+>predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >type : Symbol(type, Decl(a.js, 22, 1))
 
     m() { return 101; }
@@ -111,22 +111,22 @@ my.predicate.type = class {
 
 // global-ish prefixes
 var min = window.min || {};
->min : Symbol(min, Decl(a.js, 29, 3))
+>min : Symbol(min, Decl(a.js, 29, 3), Decl(a.js, 29, 27), Decl(a.js, 30, 44), Decl(a.js, 31, 50))
 
 min.nest = this.min.nest || function () { };
->min.nest : Symbol(nest, Decl(a.js, 29, 27))
->min : Symbol(min, Decl(a.js, 29, 3))
->nest : Symbol(nest, Decl(a.js, 29, 27))
+>min.nest : Symbol(nest, Decl(a.js, 29, 27), Decl(a.js, 31, 4))
+>min : Symbol(min, Decl(a.js, 29, 3), Decl(a.js, 29, 27), Decl(a.js, 30, 44), Decl(a.js, 31, 50))
+>nest : Symbol(nest, Decl(a.js, 29, 27), Decl(a.js, 31, 4))
 
 min.nest.other = self.min.nest.other || class { };
 >min.nest.other : Symbol((Anonymous function).other, Decl(a.js, 30, 44))
->min.nest : Symbol(nest, Decl(a.js, 29, 27))
->min : Symbol(min, Decl(a.js, 29, 3))
->nest : Symbol(nest, Decl(a.js, 29, 27))
+>min.nest : Symbol(nest, Decl(a.js, 29, 27), Decl(a.js, 31, 4))
+>min : Symbol(min, Decl(a.js, 29, 3), Decl(a.js, 29, 27), Decl(a.js, 30, 44), Decl(a.js, 31, 50))
+>nest : Symbol(nest, Decl(a.js, 29, 27), Decl(a.js, 31, 4))
 >other : Symbol((Anonymous function).other, Decl(a.js, 30, 44))
 
 min.property = global.min.property || {};
 >min.property : Symbol(property, Decl(a.js, 31, 50))
->min : Symbol(min, Decl(a.js, 29, 3))
+>min : Symbol(min, Decl(a.js, 29, 3), Decl(a.js, 29, 27), Decl(a.js, 30, 44), Decl(a.js, 31, 50))
 >property : Symbol(property, Decl(a.js, 31, 50))
 

--- a/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment.ts
@@ -1,0 +1,24 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @noImplicitAny: true
+// @Filename: a.js
+function A () {
+    this.x = 1
+    /** @type {1} */
+    this.first = this.second = 1
+}
+/** @param {number} n */
+A.prototype.y = A.prototype.z = function f(n) {
+    return n + this.x
+}
+/** @param {number} m */
+A.s = A.t = function g(m) {
+    return m + this.x
+}
+var a = new A()
+a.y('no') // error
+a.z('not really') // error
+A.s('still no') // error
+A.t('not here either') // error
+a.first = 10 // error: '10' isn't assignable to '1'

--- a/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment2.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment2.ts
@@ -1,0 +1,27 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @noImplicitAny: true
+// @Filename: types.d.ts
+declare function require(name: string): any;
+declare var exports: any;
+declare var module: { exports: any };
+// @Filename: mod.js
+/// <reference path='./types.d.ts'/>
+
+/** @param {number} n */
+exports.f = exports.g = function fg(n) {
+    return n + 1
+}
+/** @param {string} mom */
+module.exports.h = module.exports.i = function hi(mom) {
+    return `hi, ${mom}!`;
+}
+
+// @Filename: use.js
+/// <reference path='./types.d.ts'/>
+var mod = require('./mod');
+mod.f('no')
+mod.g('also no')
+mod.h(0)
+mod.i(1)

--- a/tests/cases/conformance/salsa/chainedPrototypeAssignment.ts
+++ b/tests/cases/conformance/salsa/chainedPrototypeAssignment.ts
@@ -1,0 +1,31 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @noImplicitAny: true
+// @Filename: types.d.ts
+declare function require(name: string): any;
+declare var exports: any;
+// @Filename: mod.js
+/// <reference path='./types.d.ts'/>
+var A = function() {
+    this.a = 1
+}
+var B = function() {
+    this.b = 2
+}
+exports.A = A
+exports.B = B
+A.prototype = B.prototype = {
+    /** @param {number} n */
+    m(n) {
+        return n + 1
+    }
+}
+
+// @Filename: use.js
+/// <reference path='./types.d.ts'/>
+var mod = require('./mod');
+var a = new mod.A()
+var b = new mod.B()
+a.m('nope')
+b.m('not really')


### PR DESCRIPTION
Chained prototype assignments now bind correctly:

```js
function A() { }
function B() { }
A.prototype = B.prototype = {
  method() { }
}
```

JSDoc on chained special JS assignments now contributes to the type correctly:

```js
/** @param {number} m */
A.prototype.rm = A.prototype.remove = function(m) {
}
```

Fixes #22434
I don't think there's a bug for broken chained prototype assignments, since I discovered it while fixing jsdoc of chained special assignments.

A couple of notes:
1. Special assignments don't contextually type their initialisers by the jsdoc. So there's no good test of jsdoc on prototype assignment, because object literals don't reach up to the containing declaration for jsdoc the way that functions do:

```js
/** @type {{ a: 1 }} */
A.prototype = { a: 1 } // sorry, a: number still, you have to annotate a directly
```
2. The printed type of constructor functions that have static assignments is `typeof A`. This is not right because it's also printed for the type of instances too. I'll fix this with my next PR, where I will address correct printing of constructor functions, as well as the name of function expressions in variable declartions.

```js
function A() {
  this.a = 1
}
A.x = 1
A // shows A: typeof A instead of { () => void; x: number }
var a = new A();
a // shows a: typeof A, which is incorrect
```