### PR TITLE
Improve conditional type constraints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6233,7 +6233,12 @@ namespace ts {
         }
 
         function getDefaultConstraintOfConditionalType(type: ConditionalType) {
-            return getUnionType([getInferredTrueTypeFromConditionalType(type), getFalseTypeFromConditionalType(type)]);
+            if (!type.resolvedDefaultConstraint) {
+                const rootTrueType = type.root.trueType;
+                const rootTrueConstraint = rootTrueType.flags & TypeFlags.Substitution ? (<SubstitutionType>rootTrueType).substitute : rootTrueType;
+                type.resolvedDefaultConstraint = getUnionType([instantiateType(rootTrueConstraint, type.combinedMapper || type.mapper), getFalseTypeFromConditionalType(type)]);
+            }
+            return type.resolvedDefaultConstraint;
         }
 
         function getConstraintOfDistributiveConditionalType(type: ConditionalType): Type {
@@ -6246,7 +6251,10 @@ namespace ts {
                 const constraint = getConstraintOfType(type.checkType);
                 if (constraint) {
                     const mapper = createTypeMapper([<TypeParameter>type.root.checkType], [constraint]);
-                    return getConditionalTypeInstantiation(type, combineTypeMappers(mapper, type.mapper));
+                    const instantiated = getConditionalTypeInstantiation(type, combineTypeMappers(mapper, type.mapper));
+                    if (!(instantiated.flags & TypeFlags.Never)) {
+                        return instantiated;
+                    }
                 }
             }
             return undefined;
@@ -8398,12 +8406,6 @@ namespace ts {
             return type.resolvedFalseType || (type.resolvedFalseType = instantiateType(type.root.falseType, type.mapper));
         }
 
-        function getInferredTrueTypeFromConditionalType(type: ConditionalType) {
-            return type.combinedMapper ?
-                type.resolvedInferredTrueType || (type.resolvedInferredTrueType = instantiateType(type.root.trueType, type.combinedMapper)) :
-                getTrueTypeFromConditionalType(type);
-        }
-
         function getInferTypeParameters(node: ConditionalTypeNode): TypeParameter[] {
             let result: TypeParameter[];
             if (node.locals) {
@@ -8416,13 +8418,25 @@ namespace ts {
             return result;
         }
 
+        function getTopConditionalType(node: Node): ConditionalTypeNode {
+            let result: ConditionalTypeNode;
+            while (node) {
+                if (node.kind === SyntaxKind.ConditionalType) {
+                    result = <ConditionalTypeNode>node;
+                }
+                node = node.parent;
+            }
+            return result;
+        }
+
         function getTypeFromConditionalTypeNode(node: ConditionalTypeNode): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
                 const checkType = getTypeFromTypeNode(node.checkType);
                 const aliasTypeArguments = getAliasTypeArgumentsForTypeNode(node);
                 const allOuterTypeParameters = getOuterTypeParameters(node, /*includeThisTypes*/ true);
-                const outerTypeParameters = aliasTypeArguments ? allOuterTypeParameters : filter(allOuterTypeParameters, tp => isTypeParameterPossiblyReferenced(tp, node));
+                const topNode = getTopConditionalType(node);
+                const outerTypeParameters = aliasTypeArguments ? allOuterTypeParameters : filter(allOuterTypeParameters, tp => isTypeParameterPossiblyReferenced(tp, topNode));
                 const root: ConditionalRoot = {
                     node,
                     checkType,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3878,7 +3878,7 @@ namespace ts {
         resolvedTrueType?: Type;
         resolvedFalseType?: Type;
         /* @internal */
-        resolvedInferredTrueType?: Type;
+        resolvedDefaultConstraint?: Type;
         /* @internal */
         mapper?: TypeMapper;
         /* @internal */

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -10,9 +10,21 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(25,5): error TS23
   Types of property 'foo' are incompatible.
     Type 'A extends string ? keyof A : A' is not assignable to type 'B extends string ? keyof B : B'.
       Type 'A' is not assignable to type 'B'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(73,12): error TS2345: Argument of type 'Extract<Extract<T, Foo>, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+  Type 'Bar & Extract<T, Foo>' is not assignable to type '{ foo: string; bat: string; }'.
+    Property 'bat' is missing in type 'Bar & Foo'.
+      Type 'Extract<Foo & T, Bar>' is not assignable to type '{ foo: string; bat: string; }'.
+        Type 'Bar & Foo & T' is not assignable to type '{ foo: string; bat: string; }'.
+          Property 'bat' is missing in type 'Bar & Foo'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(74,12): error TS2345: Argument of type 'Extract<T, Foo & Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+  Type 'Foo & Bar & T' is not assignable to type '{ foo: string; bat: string; }'.
+    Property 'bat' is missing in type 'Foo & Bar'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2345: Argument of type 'Extract2<T, Foo, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+  Type 'T extends Bar ? T : never' is not assignable to type '{ foo: string; bat: string; }'.
+    Type 'Bar & Foo & T' is not assignable to type '{ foo: string; bat: string; }'.
 
 
-==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (4 errors) ====
+==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (7 errors) ====
     interface Covariant<T> {
         foo: T extends string ? T : number;
     }
@@ -56,6 +68,71 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(25,5): error TS23
 !!! error TS2322:       Type 'A' is not assignable to type 'B'.
     }
     
+    // Extract<T, Function> is a T that is known to be a Function
+    function isFunction<T>(value: T): value is Extract<T, Function> {
+        return typeof value === "function";
+    }
+    
+    function getFunction<T>(item: T) {
+        if (isFunction(item)) {
+            return item;
+        }
+        throw new Error();
+    }
+    
+    function f10<T>(x: T) {
+        if (isFunction(x)) {
+            const f: Function = x;
+            const t: T = x;
+        }
+    }
+    
+    function f11(x: string | (() => string) | undefined) {
+        if (isFunction(x)) {
+            x();
+        }
+    }
+    
+    function f12(x: string | (() => string) | undefined) {
+        const f = getFunction(x);  // () => string
+        f();
+    }
+    
+    type Foo = { foo: string };
+    type Bar = { bar: string };
+    
+    declare function fooBar(x: { foo: string, bar: string }): void;
+    declare function fooBat(x: { foo: string, bat: string }): void;
+    
+    type Extract2<T, U, V> = T extends U ? T extends V ? T : never : never;
+    
+    function f20<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+        fooBar(x);
+        fooBar(y);
+        fooBar(z);
+    }
+    
+    function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+        fooBat(x);  // Error
+               ~
+!!! error TS2345: Argument of type 'Extract<Extract<T, Foo>, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+!!! error TS2345:   Type 'Bar & Extract<T, Foo>' is not assignable to type '{ foo: string; bat: string; }'.
+!!! error TS2345:     Property 'bat' is missing in type 'Bar & Foo'.
+!!! error TS2345:       Type 'Extract<Foo & T, Bar>' is not assignable to type '{ foo: string; bat: string; }'.
+!!! error TS2345:         Type 'Bar & Foo & T' is not assignable to type '{ foo: string; bat: string; }'.
+!!! error TS2345:           Property 'bat' is missing in type 'Bar & Foo'.
+        fooBat(y);  // Error
+               ~
+!!! error TS2345: Argument of type 'Extract<T, Foo & Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+!!! error TS2345:   Type 'Foo & Bar & T' is not assignable to type '{ foo: string; bat: string; }'.
+!!! error TS2345:     Property 'bat' is missing in type 'Foo & Bar'.
+        fooBat(z);  // Error
+               ~
+!!! error TS2345: Argument of type 'Extract2<T, Foo, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+!!! error TS2345:   Type 'T extends Bar ? T : never' is not assignable to type '{ foo: string; bat: string; }'.
+!!! error TS2345:     Type 'Bar & Foo & T' is not assignable to type '{ foo: string; bat: string; }'.
+    }
+    
     // Repros from #22860
     
     class Opt<T> {
@@ -86,5 +163,17 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(25,5): error TS23
     interface B1<T> extends A1<T> {
         bat: B1<B1<T>>;
         boom: T extends any ? true : true
+    }
+    
+    // Repro from #22899
+    
+    declare function toString1(value: object | Function): string ;
+    declare function toString2(value: Function): string ;
+    
+    function foo<T>(value: T) {
+        if (isFunction(value)) {
+            toString1(value);
+            toString2(value);
+        }
     }
     

--- a/tests/baselines/reference/conditionalTypes2.js
+++ b/tests/baselines/reference/conditionalTypes2.js
@@ -26,6 +26,56 @@ function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
     b = a;  // Error
 }
 
+// Extract<T, Function> is a T that is known to be a Function
+function isFunction<T>(value: T): value is Extract<T, Function> {
+    return typeof value === "function";
+}
+
+function getFunction<T>(item: T) {
+    if (isFunction(item)) {
+        return item;
+    }
+    throw new Error();
+}
+
+function f10<T>(x: T) {
+    if (isFunction(x)) {
+        const f: Function = x;
+        const t: T = x;
+    }
+}
+
+function f11(x: string | (() => string) | undefined) {
+    if (isFunction(x)) {
+        x();
+    }
+}
+
+function f12(x: string | (() => string) | undefined) {
+    const f = getFunction(x);  // () => string
+    f();
+}
+
+type Foo = { foo: string };
+type Bar = { bar: string };
+
+declare function fooBar(x: { foo: string, bar: string }): void;
+declare function fooBat(x: { foo: string, bat: string }): void;
+
+type Extract2<T, U, V> = T extends U ? T extends V ? T : never : never;
+
+function f20<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+    fooBar(x);
+    fooBar(y);
+    fooBar(z);
+}
+
+function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+    fooBat(x);  // Error
+    fooBat(y);  // Error
+    fooBat(z);  // Error
+}
+
 // Repros from #22860
 
 class Opt<T> {
@@ -58,6 +108,18 @@ interface B1<T> extends A1<T> {
     boom: T extends any ? true : true
 }
 
+// Repro from #22899
+
+declare function toString1(value: object | Function): string ;
+declare function toString2(value: Function): string ;
+
+function foo<T>(value: T) {
+    if (isFunction(value)) {
+        toString1(value);
+        toString2(value);
+    }
+}
+
 
 //// [conditionalTypes2.js]
 "use strict";
@@ -72,6 +134,41 @@ function f2(a, b) {
 function f3(a, b) {
     a = b; // Error
     b = a; // Error
+}
+// Extract<T, Function> is a T that is known to be a Function
+function isFunction(value) {
+    return typeof value === "function";
+}
+function getFunction(item) {
+    if (isFunction(item)) {
+        return item;
+    }
+    throw new Error();
+}
+function f10(x) {
+    if (isFunction(x)) {
+        var f = x;
+        var t = x;
+    }
+}
+function f11(x) {
+    if (isFunction(x)) {
+        x();
+    }
+}
+function f12(x) {
+    var f = getFunction(x); // () => string
+    f();
+}
+function f20(x, y, z) {
+    fooBar(x);
+    fooBar(y);
+    fooBar(z);
+}
+function f21(x, y, z) {
+    fooBat(x); // Error
+    fooBat(y); // Error
+    fooBat(z); // Error
 }
 // Repros from #22860
 var Opt = /** @class */ (function () {
@@ -93,6 +190,12 @@ var Vector = /** @class */ (function () {
     };
     return Vector;
 }());
+function foo(value) {
+    if (isFunction(value)) {
+        toString1(value);
+        toString2(value);
+    }
+}
 
 
 //// [conditionalTypes2.d.ts]
@@ -108,6 +211,28 @@ interface Invariant<T> {
 declare function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>): void;
 declare function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>): void;
 declare function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>): void;
+declare function isFunction<T>(value: T): value is Extract<T, Function>;
+declare function getFunction<T>(item: T): Extract<T, Function>;
+declare function f10<T>(x: T): void;
+declare function f11(x: string | (() => string) | undefined): void;
+declare function f12(x: string | (() => string) | undefined): void;
+declare type Foo = {
+    foo: string;
+};
+declare type Bar = {
+    bar: string;
+};
+declare function fooBar(x: {
+    foo: string;
+    bar: string;
+}): void;
+declare function fooBat(x: {
+    foo: string;
+    bat: string;
+}): void;
+declare type Extract2<T, U, V> = T extends U ? T extends V ? T : never : never;
+declare function f20<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>): void;
+declare function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>): void;
 declare class Opt<T> {
     toVector(): Vector<T>;
 }
@@ -126,3 +251,6 @@ interface B1<T> extends A1<T> {
     bat: B1<B1<T>>;
     boom: T extends any ? true : true;
 }
+declare function toString1(value: object | Function): string;
+declare function toString2(value: Function): string;
+declare function foo<T>(value: T): void;

--- a/tests/baselines/reference/conditionalTypes2.symbols
+++ b/tests/baselines/reference/conditionalTypes2.symbols
@@ -93,16 +93,193 @@ function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
 >a : Symbol(a, Decl(conditionalTypes2.ts, 22, 28))
 }
 
+// Extract<T, Function> is a T that is known to be a Function
+function isFunction<T>(value: T): value is Extract<T, Function> {
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 28, 20))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 28, 23))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 28, 20))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 28, 23))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 28, 20))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+    return typeof value === "function";
+>value : Symbol(value, Decl(conditionalTypes2.ts, 28, 23))
+}
+
+function getFunction<T>(item: T) {
+>getFunction : Symbol(getFunction, Decl(conditionalTypes2.ts, 30, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 32, 21))
+>item : Symbol(item, Decl(conditionalTypes2.ts, 32, 24))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 32, 21))
+
+    if (isFunction(item)) {
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
+>item : Symbol(item, Decl(conditionalTypes2.ts, 32, 24))
+
+        return item;
+>item : Symbol(item, Decl(conditionalTypes2.ts, 32, 24))
+    }
+    throw new Error();
+>Error : Symbol(Error, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+}
+
+function f10<T>(x: T) {
+>f10 : Symbol(f10, Decl(conditionalTypes2.ts, 37, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 39, 16))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+
+    if (isFunction(x)) {
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 39, 16))
+
+        const f: Function = x;
+>f : Symbol(f, Decl(conditionalTypes2.ts, 41, 13))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 39, 16))
+
+        const t: T = x;
+>t : Symbol(t, Decl(conditionalTypes2.ts, 42, 13))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 39, 16))
+    }
+}
+
+function f11(x: string | (() => string) | undefined) {
+>f11 : Symbol(f11, Decl(conditionalTypes2.ts, 44, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 46, 13))
+
+    if (isFunction(x)) {
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 46, 13))
+
+        x();
+>x : Symbol(x, Decl(conditionalTypes2.ts, 46, 13))
+    }
+}
+
+function f12(x: string | (() => string) | undefined) {
+>f12 : Symbol(f12, Decl(conditionalTypes2.ts, 50, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 52, 13))
+
+    const f = getFunction(x);  // () => string
+>f : Symbol(f, Decl(conditionalTypes2.ts, 53, 9))
+>getFunction : Symbol(getFunction, Decl(conditionalTypes2.ts, 30, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 52, 13))
+
+    f();
+>f : Symbol(f, Decl(conditionalTypes2.ts, 53, 9))
+}
+
+type Foo = { foo: string };
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
+>foo : Symbol(foo, Decl(conditionalTypes2.ts, 57, 12))
+
+type Bar = { bar: string };
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+>bar : Symbol(bar, Decl(conditionalTypes2.ts, 58, 12))
+
+declare function fooBar(x: { foo: string, bar: string }): void;
+>fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 58, 27))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 60, 24))
+>foo : Symbol(foo, Decl(conditionalTypes2.ts, 60, 28))
+>bar : Symbol(bar, Decl(conditionalTypes2.ts, 60, 41))
+
+declare function fooBat(x: { foo: string, bat: string }): void;
+>fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 60, 63))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 61, 24))
+>foo : Symbol(foo, Decl(conditionalTypes2.ts, 61, 28))
+>bat : Symbol(bat, Decl(conditionalTypes2.ts, 61, 41))
+
+type Extract2<T, U, V> = T extends U ? T extends V ? T : never : never;
+>Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 61, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 63, 14))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 63, 16))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 63, 19))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 63, 14))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 63, 16))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 63, 14))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 63, 19))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 63, 14))
+
+function f20<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+>f20 : Symbol(f20, Decl(conditionalTypes2.ts, 63, 71))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 65, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 65, 16))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 65, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 65, 49))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 65, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+>z : Symbol(z, Decl(conditionalTypes2.ts, 65, 75))
+>Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 61, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 65, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+
+    fooBar(x);
+>fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 58, 27))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 65, 16))
+
+    fooBar(y);
+>fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 58, 27))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 65, 49))
+
+    fooBar(z);
+>fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 58, 27))
+>z : Symbol(z, Decl(conditionalTypes2.ts, 65, 75))
+}
+
+function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+>f21 : Symbol(f21, Decl(conditionalTypes2.ts, 69, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 71, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 71, 16))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 71, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 71, 49))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 71, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+>z : Symbol(z, Decl(conditionalTypes2.ts, 71, 75))
+>Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 61, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 71, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+
+    fooBat(x);  // Error
+>fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 60, 63))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 71, 16))
+
+    fooBat(y);  // Error
+>fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 60, 63))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 71, 49))
+
+    fooBat(z);  // Error
+>fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 60, 63))
+>z : Symbol(z, Decl(conditionalTypes2.ts, 71, 75))
+}
+
 // Repros from #22860
 
 class Opt<T> {
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 25, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 29, 10))
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 75, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 79, 10))
 
     toVector(): Vector<T> {
->toVector : Symbol(Opt.toVector, Decl(conditionalTypes2.ts, 29, 14))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 29, 10))
+>toVector : Symbol(Opt.toVector, Decl(conditionalTypes2.ts, 79, 14))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 79, 10))
 
         return <any>undefined;
 >undefined : Symbol(undefined)
@@ -110,67 +287,67 @@ class Opt<T> {
 }
 
 interface Seq<T> {
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 33, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 35, 14))
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 83, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 85, 14))
 
     tail(): Opt<Seq<T>>;
->tail : Symbol(Seq.tail, Decl(conditionalTypes2.ts, 35, 18))
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 25, 1))
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 33, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 35, 14))
+>tail : Symbol(Seq.tail, Decl(conditionalTypes2.ts, 85, 18))
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 75, 1))
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 83, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 85, 14))
 }
 
 class Vector<T> implements Seq<T> {
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 33, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
+>Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 83, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
 
     tail(): Opt<Vector<T>> {
->tail : Symbol(Vector.tail, Decl(conditionalTypes2.ts, 39, 35))
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 25, 1))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>tail : Symbol(Vector.tail, Decl(conditionalTypes2.ts, 89, 35))
+>Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 75, 1))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
 
         return <any>undefined;
 >undefined : Symbol(undefined)
     }
     partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 42, 5), Decl(conditionalTypes2.ts, 43, 88), Decl(conditionalTypes2.ts, 44, 64))
->U : Symbol(U, Decl(conditionalTypes2.ts, 43, 15))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 43, 28))
->v : Symbol(v, Decl(conditionalTypes2.ts, 43, 39))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->v : Symbol(v, Decl(conditionalTypes2.ts, 43, 39))
->U : Symbol(U, Decl(conditionalTypes2.ts, 43, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
->U : Symbol(U, Decl(conditionalTypes2.ts, 43, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 92, 5), Decl(conditionalTypes2.ts, 93, 88), Decl(conditionalTypes2.ts, 94, 64))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 93, 15))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 93, 28))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 93, 39))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 93, 39))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 93, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 93, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
 >Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->U : Symbol(U, Decl(conditionalTypes2.ts, 43, 15))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 93, 15))
 
     partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 42, 5), Decl(conditionalTypes2.ts, 43, 88), Decl(conditionalTypes2.ts, 44, 64))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 44, 15))
->x : Symbol(x, Decl(conditionalTypes2.ts, 44, 26))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 92, 5), Decl(conditionalTypes2.ts, 93, 88), Decl(conditionalTypes2.ts, 94, 64))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 94, 15))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 94, 26))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
 
     partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 42, 5), Decl(conditionalTypes2.ts, 43, 88), Decl(conditionalTypes2.ts, 44, 64))
->U : Symbol(U, Decl(conditionalTypes2.ts, 45, 15))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 45, 28))
->v : Symbol(v, Decl(conditionalTypes2.ts, 45, 39))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
->U : Symbol(U, Decl(conditionalTypes2.ts, 45, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 37, 1))
+>partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 92, 5), Decl(conditionalTypes2.ts, 93, 88), Decl(conditionalTypes2.ts, 94, 64))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 95, 15))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
+>predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 95, 28))
+>v : Symbol(v, Decl(conditionalTypes2.ts, 95, 39))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 95, 15))
+>Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
 
         return <any>undefined;
 >undefined : Symbol(undefined)
@@ -178,30 +355,62 @@ class Vector<T> implements Seq<T> {
 }
 
 interface A1<T> {
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 48, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 50, 13))
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 98, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 100, 13))
 
     bat: B1<A1<T>>;
->bat : Symbol(A1.bat, Decl(conditionalTypes2.ts, 50, 17))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 52, 1))
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 48, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 50, 13))
+>bat : Symbol(A1.bat, Decl(conditionalTypes2.ts, 100, 17))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 102, 1))
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 98, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 100, 13))
 }
 
 interface B1<T> extends A1<T> {
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 52, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 48, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 102, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 104, 13))
+>A1 : Symbol(A1, Decl(conditionalTypes2.ts, 98, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 104, 13))
 
     bat: B1<B1<T>>;
->bat : Symbol(B1.bat, Decl(conditionalTypes2.ts, 54, 31))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 52, 1))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 52, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
+>bat : Symbol(B1.bat, Decl(conditionalTypes2.ts, 104, 31))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 102, 1))
+>B1 : Symbol(B1, Decl(conditionalTypes2.ts, 102, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 104, 13))
 
     boom: T extends any ? true : true
->boom : Symbol(B1.boom, Decl(conditionalTypes2.ts, 55, 19))
->T : Symbol(T, Decl(conditionalTypes2.ts, 54, 13))
+>boom : Symbol(B1.boom, Decl(conditionalTypes2.ts, 105, 19))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 104, 13))
+}
+
+// Repro from #22899
+
+declare function toString1(value: object | Function): string ;
+>toString1 : Symbol(toString1, Decl(conditionalTypes2.ts, 107, 1))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 111, 27))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+declare function toString2(value: Function): string ;
+>toString2 : Symbol(toString2, Decl(conditionalTypes2.ts, 111, 62))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 112, 27))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+function foo<T>(value: T) {
+>foo : Symbol(foo, Decl(conditionalTypes2.ts, 112, 53))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 114, 13))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 114, 16))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 114, 13))
+
+    if (isFunction(value)) {
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 114, 16))
+
+        toString1(value);
+>toString1 : Symbol(toString1, Decl(conditionalTypes2.ts, 107, 1))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 114, 16))
+
+        toString2(value);
+>toString2 : Symbol(toString2, Decl(conditionalTypes2.ts, 111, 62))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 114, 16))
+    }
 }
 

--- a/tests/baselines/reference/conditionalTypes2.types
+++ b/tests/baselines/reference/conditionalTypes2.types
@@ -99,6 +99,199 @@ function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
 >a : Invariant<A>
 }
 
+// Extract<T, Function> is a T that is known to be a Function
+function isFunction<T>(value: T): value is Extract<T, Function> {
+>isFunction : <T>(value: T) => value is Extract<T, Function>
+>T : T
+>value : T
+>T : T
+>value : any
+>Extract : Extract<T, U>
+>T : T
+>Function : Function
+
+    return typeof value === "function";
+>typeof value === "function" : boolean
+>typeof value : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>value : T
+>"function" : "function"
+}
+
+function getFunction<T>(item: T) {
+>getFunction : <T>(item: T) => Extract<T, Function>
+>T : T
+>item : T
+>T : T
+
+    if (isFunction(item)) {
+>isFunction(item) : boolean
+>isFunction : <T>(value: T) => value is Extract<T, Function>
+>item : T
+
+        return item;
+>item : Extract<T, Function>
+    }
+    throw new Error();
+>new Error() : Error
+>Error : ErrorConstructor
+}
+
+function f10<T>(x: T) {
+>f10 : <T>(x: T) => void
+>T : T
+>x : T
+>T : T
+
+    if (isFunction(x)) {
+>isFunction(x) : boolean
+>isFunction : <T>(value: T) => value is Extract<T, Function>
+>x : T
+
+        const f: Function = x;
+>f : Function
+>Function : Function
+>x : Extract<T, Function>
+
+        const t: T = x;
+>t : T
+>T : T
+>x : Extract<T, Function>
+    }
+}
+
+function f11(x: string | (() => string) | undefined) {
+>f11 : (x: string | (() => string) | undefined) => void
+>x : string | (() => string) | undefined
+
+    if (isFunction(x)) {
+>isFunction(x) : boolean
+>isFunction : <T>(value: T) => value is Extract<T, Function>
+>x : string | (() => string) | undefined
+
+        x();
+>x() : string
+>x : () => string
+    }
+}
+
+function f12(x: string | (() => string) | undefined) {
+>f12 : (x: string | (() => string) | undefined) => void
+>x : string | (() => string) | undefined
+
+    const f = getFunction(x);  // () => string
+>f : () => string
+>getFunction(x) : () => string
+>getFunction : <T>(item: T) => Extract<T, Function>
+>x : string | (() => string) | undefined
+
+    f();
+>f() : string
+>f : () => string
+}
+
+type Foo = { foo: string };
+>Foo : Foo
+>foo : string
+
+type Bar = { bar: string };
+>Bar : Bar
+>bar : string
+
+declare function fooBar(x: { foo: string, bar: string }): void;
+>fooBar : (x: { foo: string; bar: string; }) => void
+>x : { foo: string; bar: string; }
+>foo : string
+>bar : string
+
+declare function fooBat(x: { foo: string, bat: string }): void;
+>fooBat : (x: { foo: string; bat: string; }) => void
+>x : { foo: string; bat: string; }
+>foo : string
+>bat : string
+
+type Extract2<T, U, V> = T extends U ? T extends V ? T : never : never;
+>Extract2 : Extract2<T, U, V>
+>T : T
+>U : U
+>V : V
+>T : T
+>U : U
+>T : T
+>V : V
+>T : T
+
+function f20<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+>f20 : <T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) => void
+>T : T
+>x : Extract<Extract<T, Foo>, Bar>
+>Extract : Extract<T, U>
+>Extract : Extract<T, U>
+>T : T
+>Foo : Foo
+>Bar : Bar
+>y : Extract<T, Foo & Bar>
+>Extract : Extract<T, U>
+>T : T
+>Foo : Foo
+>Bar : Bar
+>z : Extract2<T, Foo, Bar>
+>Extract2 : Extract2<T, U, V>
+>T : T
+>Foo : Foo
+>Bar : Bar
+
+    fooBar(x);
+>fooBar(x) : void
+>fooBar : (x: { foo: string; bar: string; }) => void
+>x : Extract<Extract<T, Foo>, Bar>
+
+    fooBar(y);
+>fooBar(y) : void
+>fooBar : (x: { foo: string; bar: string; }) => void
+>y : Extract<T, Foo & Bar>
+
+    fooBar(z);
+>fooBar(z) : void
+>fooBar : (x: { foo: string; bar: string; }) => void
+>z : Extract2<T, Foo, Bar>
+}
+
+function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+>f21 : <T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) => void
+>T : T
+>x : Extract<Extract<T, Foo>, Bar>
+>Extract : Extract<T, U>
+>Extract : Extract<T, U>
+>T : T
+>Foo : Foo
+>Bar : Bar
+>y : Extract<T, Foo & Bar>
+>Extract : Extract<T, U>
+>T : T
+>Foo : Foo
+>Bar : Bar
+>z : Extract2<T, Foo, Bar>
+>Extract2 : Extract2<T, U, V>
+>T : T
+>Foo : Foo
+>Bar : Bar
+
+    fooBat(x);  // Error
+>fooBat(x) : void
+>fooBat : (x: { foo: string; bat: string; }) => void
+>x : Extract<Extract<T, Foo>, Bar>
+
+    fooBat(y);  // Error
+>fooBat(y) : void
+>fooBat : (x: { foo: string; bat: string; }) => void
+>y : Extract<T, Foo & Bar>
+
+    fooBat(z);  // Error
+>fooBat(z) : void
+>fooBat : (x: { foo: string; bat: string; }) => void
+>z : Extract2<T, Foo, Bar>
+}
+
 // Repros from #22860
 
 class Opt<T> {
@@ -214,5 +407,40 @@ interface B1<T> extends A1<T> {
 >T : T
 >true : true
 >true : true
+}
+
+// Repro from #22899
+
+declare function toString1(value: object | Function): string ;
+>toString1 : (value: object | Function) => string
+>value : object | Function
+>Function : Function
+
+declare function toString2(value: Function): string ;
+>toString2 : (value: Function) => string
+>value : Function
+>Function : Function
+
+function foo<T>(value: T) {
+>foo : <T>(value: T) => void
+>T : T
+>value : T
+>T : T
+
+    if (isFunction(value)) {
+>isFunction(value) : boolean
+>isFunction : <T>(value: T) => value is Extract<T, Function>
+>value : T
+
+        toString1(value);
+>toString1(value) : string
+>toString1 : (value: object | Function) => string
+>value : Extract<T, Function>
+
+        toString2(value);
+>toString2(value) : string
+>toString2 : (value: Function) => string
+>value : Extract<T, Function>
+    }
 }
 

--- a/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes2.ts
@@ -28,6 +28,56 @@ function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
     b = a;  // Error
 }
 
+// Extract<T, Function> is a T that is known to be a Function
+function isFunction<T>(value: T): value is Extract<T, Function> {
+    return typeof value === "function";
+}
+
+function getFunction<T>(item: T) {
+    if (isFunction(item)) {
+        return item;
+    }
+    throw new Error();
+}
+
+function f10<T>(x: T) {
+    if (isFunction(x)) {
+        const f: Function = x;
+        const t: T = x;
+    }
+}
+
+function f11(x: string | (() => string) | undefined) {
+    if (isFunction(x)) {
+        x();
+    }
+}
+
+function f12(x: string | (() => string) | undefined) {
+    const f = getFunction(x);  // () => string
+    f();
+}
+
+type Foo = { foo: string };
+type Bar = { bar: string };
+
+declare function fooBar(x: { foo: string, bar: string }): void;
+declare function fooBat(x: { foo: string, bat: string }): void;
+
+type Extract2<T, U, V> = T extends U ? T extends V ? T : never : never;
+
+function f20<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+    fooBar(x);
+    fooBar(y);
+    fooBar(z);
+}
+
+function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
+    fooBat(x);  // Error
+    fooBat(y);  // Error
+    fooBat(z);  // Error
+}
+
 // Repros from #22860
 
 class Opt<T> {
@@ -58,4 +108,16 @@ interface A1<T> {
 interface B1<T> extends A1<T> {
     bat: B1<B1<T>>;
     boom: T extends any ? true : true
+}
+
+// Repro from #22899
+
+declare function toString1(value: object | Function): string ;
+declare function toString2(value: Function): string ;
+
+function foo<T>(value: T) {
+    if (isFunction(value)) {
+        toString1(value);
+        toString2(value);
+    }
 }


### PR DESCRIPTION
This PR improves our reasoning over constraints associated with conditional types. We now consider a conditional type of the form `T extends U ? T : X` to have the constraint `(T & U) | F` (meaning that `T extends U ? T : X` is assignable to anything to which `(T & U) | F` is assignable). Previously we considered the constraint to just be `T | F`, but we now factor in the relationship to `U` that has been proven by the `extends` clause.

With this change the predefined `Extract<T, U>` conditional type effectively becomes a way of representing a type `T` with an additional constraint `U`. Or, in more intuitive terms, a `T` that is also known to be a `U`. For example:

```ts
function isFunction<T>(value: T): value is Extract<T, Function> {
    return typeof value === "function";
}

// Return type is Extract<T, Function>, i.e. a T known to be a Function
function getFunction<T>(item: T) {
    if (isFunction(item)) {
        return item;
    }
    throw new Error();
}

function f1<T>(x: T) {
    if (isFunction(x)) {
        const f: Function = x;  // x is a Function
        const t: T = x;  // and x is a T
    }
}

function f2(x: string | (() => string) | undefined) {
    if (isFunction(x)) {
        x();  // x narrowed to () => string
    }
}

function f3(x: string | (() => string) | undefined) {
    const f = getFunction(x);  // () => string
    f();
}
```

Fixes #22899.