### PR TITLE
fix: `CompilerHost.getSourceFile` is being called for odd filenames

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -154,6 +154,7 @@ var harnessSources = harnessCoreSources.concat([
     "transform.ts",
     "customTransforms.ts",
     "programMissingFiles.ts",
+    "programNoParseFalsyFileNames.ts",
     "symbolWalker.ts",
     "languageService.ts",
     "publicApi.ts",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -611,8 +611,9 @@ namespace ts {
             if (!skipDefaultLib) {
                 // If '--lib' is not specified, include default library file according to '--target'
                 // otherwise, using options specified in '--lib' instead of '--target' default library file
-                if (!options.lib) {
-                    processRootFile(getDefaultLibraryFileName(), /*isDefaultLib*/ true);
+                const defaultLibraryFileName = getDefaultLibraryFileName();
+                if (!options.lib && defaultLibraryFileName) {
+                    processRootFile(defaultLibraryFileName, /*isDefaultLib*/ true);
                 }
                 else {
                     forEach(options.lib, libFileName => {
@@ -1117,7 +1118,7 @@ namespace ts {
             // otherwise, using options specified in '--lib' instead of '--target' default library file
             const equalityComparer = host.useCaseSensitiveFileNames() ? equateStringsCaseSensitive : equateStringsCaseInsensitive;
             if (!options.lib) {
-               return equalityComparer(file.fileName, getDefaultLibraryFileName());
+                return equalityComparer(file.fileName, getDefaultLibraryFileName());
             }
             else {
                 return forEach(options.lib, libFileName => equalityComparer(file.fileName, combinePaths(defaultLibraryPath, libFileName)));

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -135,6 +135,7 @@
         "./unittests/telemetry.ts",
         "./unittests/languageService.ts",
         "./unittests/programMissingFiles.ts",
+        "./unittests/programNoParseFalsyFileNames.ts",
         "./unittests/publicApi.ts",
         "./unittests/hostNewLineSupport.ts"
     ]

--- a/src/harness/unittests/programNoParseFalsyFileNames.ts
+++ b/src/harness/unittests/programNoParseFalsyFileNames.ts
@@ -1,0 +1,37 @@
+/// <reference path="..\harness.ts" />
+namespace ts {
+    describe("programNoParseFalsyFileNames", () => {
+        let program: Program;
+
+        beforeEach(() => {
+            const testSource = `
+            class Foo extends HTMLElement {
+                bar: string = 'baz';
+            }`;
+
+            const host: CompilerHost = {
+                getSourceFile: (fileName: string, languageVersion: ScriptTarget, _onError?: (message: string) => void) => {
+                    return fileName === "test.ts" ? createSourceFile(fileName, testSource, languageVersion) : undefined;
+                },
+                getDefaultLibFileName: () => "",
+                writeFile: (_fileName, _content) => { throw new Error("unsupported"); },
+                getCurrentDirectory: () => sys.getCurrentDirectory(),
+                getCanonicalFileName: fileName => sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase(),
+                getNewLine: () => sys.newLine,
+                useCaseSensitiveFileNames: () => sys.useCaseSensitiveFileNames,
+                fileExists: fileName => fileName === "test.ts",
+                readFile: fileName => fileName === "test.ts" ? testSource : undefined,
+                resolveModuleNames: (_moduleNames: string[], _containingFile: string) => { throw new Error("unsupported"); },
+                getDirectories: _path => { throw new Error("unsupported"); },
+            };
+
+            program = createProgram(["test.ts"], { module: ModuleKind.ES2015 }, host);
+        });
+
+        it("should not have missing file paths", () => {
+            assert(program.getSourceFiles().length === 1, "expected 'getSourceFiles' length to be 1");
+            assert(program.getMissingFilePaths().length === 0, "expected 'getMissingFilePaths' length to be 0");
+            assert(program.getFileProcessingDiagnostics().getDiagnostics().length === 0, "expected 'getFileProcessingDiagnostics' length to be 0");
+        });
+    });
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[X] Code is up-to-date with the `master` branch
[X] You've successfully run `jake runtests` locally
[X] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Would love to add some Unit Tests but kinda can't find a way where to test it. If any one is willing to give me pointers on how do you guy usually test this. I'll happily add them

Ignore falsy file names from `getSourceFileFromReferenceWorker`

Closes: #13629
