### PR TITLE
Fix issue #22923

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16405,12 +16405,18 @@ namespace ts {
                     }
                 }
             }
-            const suggestion = getSuggestionForNonexistentProperty(propNode, containingType);
-            if (suggestion !== undefined) {
-                errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, declarationNameToString(propNode), typeToString(containingType), suggestion);
+            const promisedType = getPromisedTypeOfPromise(containingType);
+            if (promisedType && getPropertyOfType(promisedType, propNode.escapedText)) {
+                errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_forget_to_use_await, declarationNameToString(propNode), typeToString(containingType));
             }
             else {
-                errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1, declarationNameToString(propNode), typeToString(containingType));
+                const suggestion = getSuggestionForNonexistentProperty(propNode, containingType);
+                if (suggestion !== undefined) {
+                    errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, declarationNameToString(propNode), typeToString(containingType), suggestion);
+                }
+                else {
+                    errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1, declarationNameToString(propNode), typeToString(containingType));
+                }
             }
             diagnostics.add(createDiagnosticForNodeFromMessageChain(propNode, errorInfo));
         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2000,7 +2000,10 @@
         "category": "Error",
         "code": 2569
     },
-
+    "Property '{0}' does not exist on type '{1}'. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2570
+    },
     "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",
         "code": 2600

--- a/tests/baselines/reference/nonexistentPropertyAvailableOnPromisedType.errors.txt
+++ b/tests/baselines/reference/nonexistentPropertyAvailableOnPromisedType.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/nonexistentPropertyAvailableOnPromisedType.ts(2,7): error TS2570: Property 'toLowerCase' does not exist on type 'Promise<string>'. Did you forget to use 'await'?
+
+
+==== tests/cases/compiler/nonexistentPropertyAvailableOnPromisedType.ts (1 errors) ====
+    function f(x: Promise<string>) {
+        x.toLowerCase();
+          ~~~~~~~~~~~
+!!! error TS2570: Property 'toLowerCase' does not exist on type 'Promise<string>'. Did you forget to use 'await'?
+    }
+    

--- a/tests/baselines/reference/nonexistentPropertyAvailableOnPromisedType.js
+++ b/tests/baselines/reference/nonexistentPropertyAvailableOnPromisedType.js
@@ -1,0 +1,10 @@
+//// [nonexistentPropertyAvailableOnPromisedType.ts]
+function f(x: Promise<string>) {
+    x.toLowerCase();
+}
+
+
+//// [nonexistentPropertyAvailableOnPromisedType.js]
+function f(x) {
+    x.toLowerCase();
+}

--- a/tests/baselines/reference/nonexistentPropertyAvailableOnPromisedType.symbols
+++ b/tests/baselines/reference/nonexistentPropertyAvailableOnPromisedType.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/nonexistentPropertyAvailableOnPromisedType.ts ===
+function f(x: Promise<string>) {
+>f : Symbol(f, Decl(nonexistentPropertyAvailableOnPromisedType.ts, 0, 0))
+>x : Symbol(x, Decl(nonexistentPropertyAvailableOnPromisedType.ts, 0, 11))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --))
+
+    x.toLowerCase();
+>x : Symbol(x, Decl(nonexistentPropertyAvailableOnPromisedType.ts, 0, 11))
+}
+

--- a/tests/baselines/reference/nonexistentPropertyAvailableOnPromisedType.types
+++ b/tests/baselines/reference/nonexistentPropertyAvailableOnPromisedType.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/nonexistentPropertyAvailableOnPromisedType.ts ===
+function f(x: Promise<string>) {
+>f : (x: Promise<string>) => void
+>x : Promise<string>
+>Promise : Promise<T>
+
+    x.toLowerCase();
+>x.toLowerCase() : any
+>x.toLowerCase : any
+>x : Promise<string>
+>toLowerCase : any
+}
+

--- a/tests/baselines/reference/nonexistentPropertyOnUnion.errors.txt
+++ b/tests/baselines/reference/nonexistentPropertyOnUnion.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/nonexistentPropertyOnUnion.ts(2,7): error TS2339: Property 'toLowerCase' does not exist on type 'string | Promise<string>'.
+  Property 'toLowerCase' does not exist on type 'Promise<string>'.
+
+
+==== tests/cases/compiler/nonexistentPropertyOnUnion.ts (1 errors) ====
+    function f(x: string | Promise<string>) {
+        x.toLowerCase();
+          ~~~~~~~~~~~
+!!! error TS2339: Property 'toLowerCase' does not exist on type 'string | Promise<string>'.
+!!! error TS2339:   Property 'toLowerCase' does not exist on type 'Promise<string>'.
+    }
+    

--- a/tests/baselines/reference/nonexistentPropertyOnUnion.js
+++ b/tests/baselines/reference/nonexistentPropertyOnUnion.js
@@ -1,0 +1,10 @@
+//// [nonexistentPropertyOnUnion.ts]
+function f(x: string | Promise<string>) {
+    x.toLowerCase();
+}
+
+
+//// [nonexistentPropertyOnUnion.js]
+function f(x) {
+    x.toLowerCase();
+}

--- a/tests/baselines/reference/nonexistentPropertyOnUnion.symbols
+++ b/tests/baselines/reference/nonexistentPropertyOnUnion.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/nonexistentPropertyOnUnion.ts ===
+function f(x: string | Promise<string>) {
+>f : Symbol(f, Decl(nonexistentPropertyOnUnion.ts, 0, 0))
+>x : Symbol(x, Decl(nonexistentPropertyOnUnion.ts, 0, 11))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --))
+
+    x.toLowerCase();
+>x : Symbol(x, Decl(nonexistentPropertyOnUnion.ts, 0, 11))
+}
+

--- a/tests/baselines/reference/nonexistentPropertyOnUnion.types
+++ b/tests/baselines/reference/nonexistentPropertyOnUnion.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/nonexistentPropertyOnUnion.ts ===
+function f(x: string | Promise<string>) {
+>f : (x: string | Promise<string>) => void
+>x : string | Promise<string>
+>Promise : Promise<T>
+
+    x.toLowerCase();
+>x.toLowerCase() : any
+>x.toLowerCase : any
+>x : string | Promise<string>
+>toLowerCase : any
+}
+

--- a/tests/baselines/reference/nonexistentPropertyUnavailableOnPromisedType.errors.txt
+++ b/tests/baselines/reference/nonexistentPropertyUnavailableOnPromisedType.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts(2,7): error TS2339: Property 'toLowerCase' does not exist on type 'Promise<number>'.
+
+
+==== tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts (1 errors) ====
+    function f(x: Promise<number>) {
+        x.toLowerCase();
+          ~~~~~~~~~~~
+!!! error TS2339: Property 'toLowerCase' does not exist on type 'Promise<number>'.
+    }
+    

--- a/tests/baselines/reference/nonexistentPropertyUnavailableOnPromisedType.js
+++ b/tests/baselines/reference/nonexistentPropertyUnavailableOnPromisedType.js
@@ -1,0 +1,10 @@
+//// [nonexistentPropertyUnavailableOnPromisedType.ts]
+function f(x: Promise<number>) {
+    x.toLowerCase();
+}
+
+
+//// [nonexistentPropertyUnavailableOnPromisedType.js]
+function f(x) {
+    x.toLowerCase();
+}

--- a/tests/baselines/reference/nonexistentPropertyUnavailableOnPromisedType.symbols
+++ b/tests/baselines/reference/nonexistentPropertyUnavailableOnPromisedType.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts ===
+function f(x: Promise<number>) {
+>f : Symbol(f, Decl(nonexistentPropertyUnavailableOnPromisedType.ts, 0, 0))
+>x : Symbol(x, Decl(nonexistentPropertyUnavailableOnPromisedType.ts, 0, 11))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --))
+
+    x.toLowerCase();
+>x : Symbol(x, Decl(nonexistentPropertyUnavailableOnPromisedType.ts, 0, 11))
+}
+

--- a/tests/baselines/reference/nonexistentPropertyUnavailableOnPromisedType.types
+++ b/tests/baselines/reference/nonexistentPropertyUnavailableOnPromisedType.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts ===
+function f(x: Promise<number>) {
+>f : (x: Promise<number>) => void
+>x : Promise<number>
+>Promise : Promise<T>
+
+    x.toLowerCase();
+>x.toLowerCase() : any
+>x.toLowerCase : any
+>x : Promise<number>
+>toLowerCase : any
+}
+

--- a/tests/cases/compiler/nonexistentPropertyAvailableOnPromisedType.ts
+++ b/tests/cases/compiler/nonexistentPropertyAvailableOnPromisedType.ts
@@ -1,0 +1,3 @@
+function f(x: Promise<string>) {
+    x.toLowerCase();
+}

--- a/tests/cases/compiler/nonexistentPropertyOnUnion.ts
+++ b/tests/cases/compiler/nonexistentPropertyOnUnion.ts
@@ -1,0 +1,3 @@
+function f(x: string | Promise<string>) {
+    x.toLowerCase();
+}

--- a/tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts
+++ b/tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts
@@ -1,0 +1,3 @@
+function f(x: Promise<number>) {
+    x.toLowerCase();
+}


### PR DESCRIPTION
Fixes #22923

I'm still not sure that `isPromiseLike` should use `isReferenceToType` or something more smart (e.g. `getPromisedTypeOfPromise` to resolve actual types)