### PR TITLE
Include arrow functions as javascript initializers

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1542,7 +1542,9 @@ namespace ts {
             const e = skipParentheses(initializer.expression);
             return e.kind === SyntaxKind.FunctionExpression || e.kind === SyntaxKind.ArrowFunction ? initializer : undefined;
         }
-        if (initializer.kind === SyntaxKind.FunctionExpression || initializer.kind === SyntaxKind.ClassExpression) {
+        if (initializer.kind === SyntaxKind.FunctionExpression ||
+            initializer.kind === SyntaxKind.ClassExpression ||
+            initializer.kind === SyntaxKind.ArrowFunction) {
             return initializer as Expression;
         }
         if (isObjectLiteralExpression(initializer) && (initializer.properties.length === 0 || isPrototypeAssignment)) {

--- a/tests/baselines/reference/typeFromPropertyAssignment19.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment19.symbols
@@ -24,17 +24,17 @@ exports = module.exports = C
 >exports : Symbol("tests/cases/conformance/salsa/semver", Decl(semver.js, 0, 0))
 >module : Symbol(export=, Decl(semver.js, 1, 9))
 >exports : Symbol(export=, Decl(semver.js, 1, 9))
->C : Symbol(C, Decl(semver.js, 2, 16))
+>C : Symbol(C, Decl(semver.js, 2, 16), Decl(semver.js, 1, 28))
 
 C.f = n => n + 1
 >C.f : Symbol(C.f, Decl(semver.js, 1, 28))
->C : Symbol(C, Decl(semver.js, 2, 16))
+>C : Symbol(C, Decl(semver.js, 2, 16), Decl(semver.js, 1, 28))
 >f : Symbol(C.f, Decl(semver.js, 1, 28))
 >n : Symbol(n, Decl(semver.js, 2, 5))
 >n : Symbol(n, Decl(semver.js, 2, 5))
 
 function C() {
->C : Symbol(C, Decl(semver.js, 2, 16))
+>C : Symbol(C, Decl(semver.js, 2, 16), Decl(semver.js, 1, 28))
 
     this.p = 1
 >p : Symbol(C.p, Decl(semver.js, 3, 14))

--- a/tests/baselines/reference/typeFromPropertyAssignment19.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment19.types
@@ -1,8 +1,8 @@
 === tests/cases/conformance/salsa/index.js ===
 /// <reference path='./types.d.ts'/>
 const C = require("./semver")
->C : { (): void; f: (n: any) => any; }
->require("./semver") : { (): void; f: (n: any) => any; }
+>C : typeof C
+>require("./semver") : typeof C
 >require : any
 >"./semver" : "./semver"
 
@@ -10,7 +10,7 @@ var two = C.f(1)
 >two : any
 >C.f(1) : any
 >C.f : (n: any) => any
->C : { (): void; f: (n: any) => any; }
+>C : typeof C
 >f : (n: any) => any
 >1 : 1
 
@@ -24,18 +24,18 @@ declare var module: any;
 === tests/cases/conformance/salsa/semver.js ===
 /// <reference path='./types.d.ts'/>
 exports = module.exports = C
->exports = module.exports = C : { (): void; f: (n: any) => any; }
+>exports = module.exports = C : typeof C
 >exports : any
->module.exports = C : { (): void; f: (n: any) => any; }
+>module.exports = C : typeof C
 >module.exports : any
 >module : any
 >exports : any
->C : { (): void; f: (n: any) => any; }
+>C : typeof C
 
 C.f = n => n + 1
 >C.f = n => n + 1 : (n: any) => any
 >C.f : (n: any) => any
->C : { (): void; f: (n: any) => any; }
+>C : typeof C
 >f : (n: any) => any
 >n => n + 1 : (n: any) => any
 >n : any
@@ -44,7 +44,7 @@ C.f = n => n + 1
 >1 : 1
 
 function C() {
->C : { (): void; f: (n: any) => any; }
+>C : typeof C
 
     this.p = 1
 >this.p = 1 : 1

--- a/tests/baselines/reference/typeFromPropertyAssignment23.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment23.symbols
@@ -1,24 +1,42 @@
 === tests/cases/conformance/salsa/a.js ===
-class Ex {
->Ex : Symbol(Ex, Decl(a.js, 0, 0))
+class B {
+>B : Symbol(B, Decl(a.js, 0, 0))
 
+    constructor () {
+        this.n = 1
+>this.n : Symbol(B.n, Decl(a.js, 1, 20))
+>this : Symbol(B, Decl(a.js, 0, 0))
+>n : Symbol(B.n, Decl(a.js, 1, 20))
+    }
     foo() {
->foo : Symbol(Ex.foo, Decl(a.js, 0, 10))
+>foo : Symbol(B.foo, Decl(a.js, 3, 5))
     }
 }
 
-class MyClass extends Ex {
->MyClass : Symbol(MyClass, Decl(a.js, 3, 1))
->Ex : Symbol(Ex, Decl(a.js, 0, 0))
-
-}
+class C extends B { }
+>C : Symbol(C, Decl(a.js, 6, 1))
+>B : Symbol(B, Decl(a.js, 0, 0))
 
 // this override should be fine (even if it's a little odd)
-MyClass.prototype.foo = function() {
->MyClass.prototype.foo : Symbol(MyClass.foo, Decl(a.js, 7, 1))
->MyClass.prototype : Symbol(MyClass.foo, Decl(a.js, 7, 1))
->MyClass : Symbol(MyClass, Decl(a.js, 3, 1))
->prototype : Symbol(MyClass.prototype)
->foo : Symbol(MyClass.foo, Decl(a.js, 7, 1))
+C.prototype.foo = function() {
+>C.prototype.foo : Symbol(C.foo, Decl(a.js, 8, 21))
+>C.prototype : Symbol(C.foo, Decl(a.js, 8, 21))
+>C : Symbol(C, Decl(a.js, 6, 1))
+>prototype : Symbol(C.prototype)
+>foo : Symbol(C.foo, Decl(a.js, 8, 21))
+}
+
+class D extends B { }
+>D : Symbol(D, Decl(a.js, 12, 1))
+>B : Symbol(B, Decl(a.js, 0, 0))
+
+D.prototype.foo = () =>  {
+>D.prototype.foo : Symbol(D.foo, Decl(a.js, 14, 21))
+>D.prototype : Symbol(D.foo, Decl(a.js, 14, 21))
+>D : Symbol(D, Decl(a.js, 12, 1))
+>prototype : Symbol(D.prototype)
+>foo : Symbol(D.foo, Decl(a.js, 14, 21))
+
+    this.n = 'not checked, so no error'
 }
 

--- a/tests/baselines/reference/typeFromPropertyAssignment23.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment23.types
@@ -1,26 +1,53 @@
 === tests/cases/conformance/salsa/a.js ===
-class Ex {
->Ex : Ex
+class B {
+>B : B
 
+    constructor () {
+        this.n = 1
+>this.n = 1 : 1
+>this.n : number
+>this : this
+>n : number
+>1 : 1
+    }
     foo() {
 >foo : () => void
     }
 }
 
-class MyClass extends Ex {
->MyClass : MyClass
->Ex : Ex
-
-}
+class C extends B { }
+>C : C
+>B : B
 
 // this override should be fine (even if it's a little odd)
-MyClass.prototype.foo = function() {
->MyClass.prototype.foo = function() {} : () => void
->MyClass.prototype.foo : () => void
->MyClass.prototype : MyClass
->MyClass : typeof MyClass
->prototype : MyClass
+C.prototype.foo = function() {
+>C.prototype.foo = function() {} : () => void
+>C.prototype.foo : () => void
+>C.prototype : C
+>C : typeof C
+>prototype : C
 >foo : () => void
 >function() {} : () => void
+}
+
+class D extends B { }
+>D : D
+>B : B
+
+D.prototype.foo = () =>  {
+>D.prototype.foo = () =>  {    this.n = 'not checked, so no error'} : () => void
+>D.prototype.foo : () => void
+>D.prototype : D
+>D : typeof D
+>prototype : D
+>foo : () => void
+>() =>  {    this.n = 'not checked, so no error'} : () => void
+
+    this.n = 'not checked, so no error'
+>this.n = 'not checked, so no error' : "not checked, so no error"
+>this.n : any
+>this : any
+>n : any
+>'not checked, so no error' : "not checked, so no error"
 }
 

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment23.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment23.ts
@@ -1,17 +1,22 @@
 // @noEmit: true
-// @strict: true
 // @checkJs: true
 // @allowJs: true
 // @Filename: a.js
-class Ex {
+class B {
+    constructor () {
+        this.n = 1
+    }
     foo() {
     }
 }
 
-class MyClass extends Ex {
-
-}
+class C extends B { }
 
 // this override should be fine (even if it's a little odd)
-MyClass.prototype.foo = function() {
+C.prototype.foo = function() {
+}
+
+class D extends B { }
+D.prototype.foo = () =>  {
+    this.n = 'not checked, so no error'
 }


### PR DESCRIPTION
This means that they are treated as valid js containers, methods, etc. These kind of 'methods' are present in at least webpack and clear-require, even though they can't access `this`.

Fixes a variant of #22895 
Fixes part of #22637

Note that recognising arrow functions as methods is good for understanding existing code, but bad in that it doesn't prevent JS authors from writing possibly buggy new code.

I think the right thing is to prefer understanding existing code, since we hope people with write new code in Typescript. They will, at least, have years of experience lowering their expectations of the correctness of any new Javascript that they write.