### PR TITLE
Remove unused properties from patternMatcher

### DIFF
--- a/src/harness/unittests/services/patternMatcher.ts
+++ b/src/harness/unittests/services/patternMatcher.ts
@@ -127,7 +127,6 @@ describe("PatternMatcher", () => {
 
             assert.equal(ts.PatternMatchKind.camelCase, match.kind);
             assert.equal(true, match.isCaseSensitive);
-            assertInRange(match.camelCaseWeight, 1, 1 << 30);
         });
 
         it("PreferCaseSensitiveCamelCaseMatchPartialPattern", () => {
@@ -235,30 +234,6 @@ describe("PatternMatcher", () => {
 
             assert.equal(ts.PatternMatchKind.camelCase, match.kind);
             assert.equal(false, match.isCaseSensitive);
-        });
-
-        it("PreferCaseSensitiveRelativeWeights1", () => {
-            const match1 = getFirstMatch("FogBarBaz", "FB");
-            const match2 = getFirstMatch("FooFlobBaz", "FB");
-
-            // We should prefer something that starts at the beginning if possible
-            assertInRange(match1.camelCaseWeight, match2.camelCaseWeight + 1, 1 << 30);
-        });
-
-        it("PreferCaseSensitiveRelativeWeights2", () => {
-            const match1 = getFirstMatch("BazBarFooFooFoo", "FFF");
-            const match2 = getFirstMatch("BazFogBarFooFoo", "FFF");
-
-            // Contiguous things should also be preferred
-            assertInRange(match1.camelCaseWeight, match2.camelCaseWeight + 1, 1 << 30);
-        });
-
-        it("PreferCaseSensitiveRelativeWeights3", () => {
-            const match1 = getFirstMatch("FogBarFooFoo", "FFF");
-            const match2 = getFirstMatch("BarFooFooFoo", "FFF");
-
-            // The weight of being first should be greater than the weight of being contiguous
-            assertInRange(match1.camelCaseWeight, match2.camelCaseWeight + 1, 1 << 30);
         });
 
         it("AllLowerPattern1", () => {
@@ -505,11 +480,6 @@ describe("PatternMatcher", () => {
         for (let i = 0; i < array1.length; i++) {
             assert.equal(array1[i], array2[i]);
         }
-    }
-
-    function assertInRange(val: number, low: number, high: number) {
-        assert.isTrue(val >= low);
-        assert.isTrue(val <= high);
     }
 
     function verifyBreakIntoCharacterSpans(original: string, ...parts: string[]): void {

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -57,7 +57,7 @@ namespace ts.NavigateTo {
             }
 
             const matchKind = bestMatchKind(containerMatches);
-            const isCaseSensitive = allMatchesAreCaseSensitive(containerMatches);
+            const isCaseSensitive = matches.every(m => m.isCaseSensitive);
             rawItems.push({ name, fileName, matchKind, isCaseSensitive, declaration });
         }
     }
@@ -73,19 +73,6 @@ namespace ts.NavigateTo {
             default:
                 return true;
         }
-    }
-
-    function allMatchesAreCaseSensitive(matches: ReadonlyArray<PatternMatch>): boolean {
-        Debug.assert(matches.length > 0);
-
-        // This is a case sensitive match, only if all the submatches were case sensitive.
-        for (const match of matches) {
-            if (!match.isCaseSensitive) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     function tryAddSingleDeclarationName(declaration: Declaration, containers: string[]): boolean {


### PR DESCRIPTION
`patternMatcher` is only used in `navigateTo`. These two unused properties seem intended for comparing two matches to get a best match, but we don't actually do that -- we just use the matches for the `kind` and `isCaseSensitive` properties, and then we only care about the minimum kind over all matches and whether every match was case sensitive, and don't really care about individual matches. It's possible that we could ferry more information along and make `compareNavigateToItems` more complex, but don't know if that would be worth the trouble.