### PR TITLE
Ensure TSS_LOG handles paths with spaces

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -598,7 +598,9 @@ namespace ts.server {
             if (option && value) {
                 switch (option) {
                     case "-file":
-                        logEnv.file = getLogPath(args, i);
+                        const logPathAndNumberOfExtraParts = getLogPath(args, i + 1);
+                        logEnv.file = logPathAndNumberOfExtraParts[0];
+                        i += logPathAndNumberOfExtraParts[1];
                         break;
                     case "-level":
                         const level = getLogLevel(value);
@@ -616,17 +618,19 @@ namespace ts.server {
         return logEnv;
     }
 
-    function getLogPath(args: string[], initialIndex: number) {
-        let pathStart = args[initialIndex + 1];
+    function getLogPath(args: string[], initialIndex: number): [string, number] {
+        let pathStart = args[initialIndex];
+        let extraPartCounter = 0;
         if (pathStart.charCodeAt(0) === CharacterCodes.doubleQuote &&
             pathStart.charCodeAt(pathStart.length - 1) !== CharacterCodes.doubleQuote) {
-            for (let i = initialIndex + 2; i < args.length; i++) {
+            for (let i = initialIndex + 1; i < args.length; i++) {
                 pathStart += " ";
                 pathStart += args[i];
+                extraPartCounter++;
                 if (pathStart.charCodeAt(pathStart.length - 1) === CharacterCodes.doubleQuote) break;
             }
         }
-        return stripQuotes(pathStart);
+        return [stripQuotes(pathStart), extraPartCounter];
     }
 
     function getLogLevel(level: string) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -594,13 +594,12 @@ namespace ts.server {
         const len = args.length - 1;
         for (let i = 0; i < len; i += 2) {
             const option = args[i];
-            const value = args[i + 1];
+            const { value, extraPartCounter } = getEntireValue(i + 1);
+            i += extraPartCounter;
             if (option && value) {
                 switch (option) {
                     case "-file":
-                        const { logPath, extraPartCounter } = getLogPath(i + 1);
-                        logEnv.file = logPath;
-                        i += extraPartCounter;
+                        logEnv.file = value;
                         break;
                     case "-level":
                         const level = getLogLevel(value);
@@ -617,7 +616,7 @@ namespace ts.server {
         }
         return logEnv;
 
-        function getLogPath(initialIndex: number) {
+        function getEntireValue(initialIndex: number) {
             let pathStart = args[initialIndex];
             let extraPartCounter = 0;
             if (pathStart.charCodeAt(0) === CharacterCodes.doubleQuote &&
@@ -629,7 +628,7 @@ namespace ts.server {
                     if (pathStart.charCodeAt(pathStart.length - 1) === CharacterCodes.doubleQuote) break;
                 }
             }
-            return { logPath: stripQuotes(pathStart), extraPartCounter };
+            return { value: stripQuotes(pathStart), extraPartCounter };
         }
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -598,7 +598,7 @@ namespace ts.server {
             if (option && value) {
                 switch (option) {
                     case "-file":
-                        const { logPath, extraPartCounter } = getLogPath(args, i + 1);
+                        const { logPath, extraPartCounter } = getLogPath(i + 1);
                         logEnv.file = logPath;
                         i += extraPartCounter;
                         break;
@@ -616,21 +616,21 @@ namespace ts.server {
             }
         }
         return logEnv;
-    }
 
-    function getLogPath(args: string[], initialIndex: number) {
-        let pathStart = args[initialIndex];
-        let extraPartCounter = 0;
-        if (pathStart.charCodeAt(0) === CharacterCodes.doubleQuote &&
-            pathStart.charCodeAt(pathStart.length - 1) !== CharacterCodes.doubleQuote) {
-            for (let i = initialIndex + 1; i < args.length; i++) {
-                pathStart += " ";
-                pathStart += args[i];
-                extraPartCounter++;
-                if (pathStart.charCodeAt(pathStart.length - 1) === CharacterCodes.doubleQuote) break;
+        function getLogPath(initialIndex: number) {
+            let pathStart = args[initialIndex];
+            let extraPartCounter = 0;
+            if (pathStart.charCodeAt(0) === CharacterCodes.doubleQuote &&
+                pathStart.charCodeAt(pathStart.length - 1) !== CharacterCodes.doubleQuote) {
+                for (let i = initialIndex + 1; i < args.length; i++) {
+                    pathStart += " ";
+                    pathStart += args[i];
+                    extraPartCounter++;
+                    if (pathStart.charCodeAt(pathStart.length - 1) === CharacterCodes.doubleQuote) break;
+                }
             }
+            return { logPath: stripQuotes(pathStart), extraPartCounter };
         }
-        return { logPath: stripQuotes(pathStart), extraPartCounter };
     }
 
     function getLogLevel(level: string) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -598,9 +598,9 @@ namespace ts.server {
             if (option && value) {
                 switch (option) {
                     case "-file":
-                        const logPathAndNumberOfExtraParts = getLogPath(args, i + 1);
-                        logEnv.file = logPathAndNumberOfExtraParts[0];
-                        i += logPathAndNumberOfExtraParts[1];
+                        const { logPath, extraPartCounter } = getLogPath(args, i + 1);
+                        logEnv.file = logPath;
+                        i += extraPartCounter;
                         break;
                     case "-level":
                         const level = getLogLevel(value);
@@ -618,7 +618,7 @@ namespace ts.server {
         return logEnv;
     }
 
-    function getLogPath(args: string[], initialIndex: number): [string, number] {
+    function getLogPath(args: string[], initialIndex: number) {
         let pathStart = args[initialIndex];
         let extraPartCounter = 0;
         if (pathStart.charCodeAt(0) === CharacterCodes.doubleQuote &&
@@ -630,7 +630,7 @@ namespace ts.server {
                 if (pathStart.charCodeAt(pathStart.length - 1) === CharacterCodes.doubleQuote) break;
             }
         }
-        return [stripQuotes(pathStart), extraPartCounter];
+        return { logPath: stripQuotes(pathStart), extraPartCounter };
     }
 
     function getLogLevel(level: string) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -618,7 +618,7 @@ namespace ts.server {
 
     function getLogPath(args: string[], initialIndex: number) {
         let pathStart = args[initialIndex + 1];
-        if (pathStart.charCodeAt(0) === CharacterCodes.doubleQuote && 
+        if (pathStart.charCodeAt(0) === CharacterCodes.doubleQuote &&
             pathStart.charCodeAt(pathStart.length - 1) !== CharacterCodes.doubleQuote) {
             for (let i = initialIndex + 2; i < args.length; i++) {
                 pathStart += " ";

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -598,7 +598,7 @@ namespace ts.server {
             if (option && value) {
                 switch (option) {
                     case "-file":
-                        logEnv.file = stripQuotes(value);
+                        logEnv.file = getLogPath(args, i);
                         break;
                     case "-level":
                         const level = getLogLevel(value);
@@ -614,6 +614,19 @@ namespace ts.server {
             }
         }
         return logEnv;
+    }
+
+    function getLogPath(args: string[], initialIndex: number) {
+        let pathStart = args[initialIndex + 1];
+        if (pathStart.charCodeAt(0) === CharacterCodes.doubleQuote && 
+            pathStart.charCodeAt(pathStart.length - 1) !== CharacterCodes.doubleQuote) {
+            for (let i = initialIndex + 2; i < args.length; i++) {
+                pathStart += " ";
+                pathStart += args[i];
+                if (pathStart.charCodeAt(pathStart.length - 1) === CharacterCodes.doubleQuote) break;
+            }
+        }
+        return stripQuotes(pathStart);
     }
 
     function getLogLevel(level: string) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Currently, if the file path provided to the "TSS_LOG" environment variable has spaces in it, we fail to handle it and no log is generated. This change handles spaces when the file path is surrounded by double quotes.