### PR TITLE
Mark js-assignment functions' symbols as methods

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2473,8 +2473,10 @@ namespace ts {
                 (symbol.exports || (symbol.exports = createSymbolTable()));
 
             // Declare the method/property
-            const symbolFlags = SymbolFlags.Property | (isToplevelNamespaceableInitializer ? SymbolFlags.JSContainer : 0);
-            const symbolExcludes = SymbolFlags.PropertyExcludes & ~(isToplevelNamespaceableInitializer ? SymbolFlags.JSContainer : 0);
+            const jsContainerFlag = isToplevelNamespaceableInitializer ? SymbolFlags.JSContainer : 0;
+            const isMethod = isFunctionLikeDeclaration(getAssignedJavascriptInitializer(propertyAccess));
+            const symbolFlags = (isMethod ? SymbolFlags.Method : SymbolFlags.Property) | jsContainerFlag;
+            const symbolExcludes = (isMethod ? SymbolFlags.MethodExcludes : SymbolFlags.PropertyExcludes) & ~jsContainerFlag;
             declareSymbol(symbolTable, symbol, propertyAccess, symbolFlags, symbolExcludes);
         }
 

--- a/src/services/codefixes/convertFunctionToEs6Class.ts
+++ b/src/services/codefixes/convertFunctionToEs6Class.ts
@@ -99,8 +99,8 @@ namespace ts.codefix {
             }
 
             function createClassElement(symbol: Symbol, modifiers: Modifier[]): ClassElement {
-                // both properties and methods are bound as property symbols
-                if (!(symbol.flags & SymbolFlags.Property)) {
+                // Right now the only thing we can convert are function expressions, which are marked as methods
+                if (!(symbol.flags & SymbolFlags.Method)) {
                     return;
                 }
 

--- a/tests/baselines/reference/constructorFunctions2.types
+++ b/tests/baselines/reference/constructorFunctions2.types
@@ -40,23 +40,23 @@ B.prototype.m = function() { this.x = 2; }
 >function() { this.x = 2; } : () => void
 >this.x = 2 : 2
 >this.x : number
->this : { id: number; m: () => void; x: number; }
+>this : { id: number; m(): void; x: number; }
 >x : number
 >2 : 2
 
 const b = new B();
->b : { id: number; m: () => void; x: number; }
->new B() : { id: number; m: () => void; x: number; }
+>b : { id: number; m(): void; x: number; }
+>new B() : { id: number; m(): void; x: number; }
 >B : () => void
 
 b.id;
 >b.id : number
->b : { id: number; m: () => void; x: number; }
+>b : { id: number; m(): void; x: number; }
 >id : number
 
 b.x;
 >b.x : number
->b : { id: number; m: () => void; x: number; }
+>b : { id: number; m(): void; x: number; }
 >x : number
 
 === tests/cases/conformance/salsa/other.js ===

--- a/tests/baselines/reference/constructorFunctionsStrict.types
+++ b/tests/baselines/reference/constructorFunctionsStrict.types
@@ -23,27 +23,27 @@ C.prototype.m = function() {
     this.y = 12
 >this.y = 12 : 12
 >this.y : number | undefined
->this : { x: number; m: () => void; y: number | undefined; }
+>this : { x: number; m(): void; y: number | undefined; }
 >y : number | undefined
 >12 : 12
 }
 var c = new C(1)
->c : { x: number; m: () => void; y: number | undefined; }
->new C(1) : { x: number; m: () => void; y: number | undefined; }
+>c : { x: number; m(): void; y: number | undefined; }
+>new C(1) : { x: number; m(): void; y: number | undefined; }
 >C : (x: number) => void
 >1 : 1
 
 c.x = undefined // should error
 >c.x = undefined : undefined
 >c.x : number
->c : { x: number; m: () => void; y: number | undefined; }
+>c : { x: number; m(): void; y: number | undefined; }
 >x : number
 >undefined : undefined
 
 c.y = undefined // ok
 >c.y = undefined : undefined
 >c.y : number | undefined
->c : { x: number; m: () => void; y: number | undefined; }
+>c : { x: number; m(): void; y: number | undefined; }
 >y : number | undefined
 >undefined : undefined
 

--- a/tests/baselines/reference/inferringClassMembersFromAssignments2.types
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments2.types
@@ -11,7 +11,7 @@ OOOrder.prototype.m = function () {
     this.p = 1
 >this.p = 1 : 1
 >this.p : number
->this : { x: number; m: () => void; p: number; }
+>this : { x: number; m(): void; p: number; }
 >p : number
 >1 : 1
 }

--- a/tests/baselines/reference/jsContainerMergeTsDeclaration.types
+++ b/tests/baselines/reference/jsContainerMergeTsDeclaration.types
@@ -1,20 +1,20 @@
 === tests/cases/conformance/salsa/a.js ===
 var /*1*/x = function foo() {
->x : { (): void; a: () => void; }
->function foo() {} : { (): void; a: () => void; }
->foo : { (): void; a: () => void; }
+>x : { (): void; a(): void; }
+>function foo() {} : { (): void; a(): void; }
+>foo : { (): void; a(): void; }
 }
 x.a = function bar() {
 >x.a = function bar() {} : () => void
 >x.a : () => void
->x : { (): void; a: () => void; }
+>x : { (): void; a(): void; }
 >a : () => void
 >function bar() {} : () => void
 >bar : () => void
 }
 === tests/cases/conformance/salsa/b.ts ===
 var x = function () {
->x : { (): void; a: () => void; }
+>x : { (): void; a(): void; }
 >function () {    return 1;}() : number
 >function () {    return 1;} : () => number
 

--- a/tests/baselines/reference/methodsReturningThis.types
+++ b/tests/baselines/reference/methodsReturningThis.types
@@ -14,80 +14,80 @@ Class.prototype.containsError = function () { return this.notPresent; };
 >containsError : any
 >function () { return this.notPresent; } : () => any
 >this.notPresent : any
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >notPresent : any
 
 // lots of methods that return this, which caused out-of-memory in #9527
 Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; };
->Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => { containsError: () => any; m1: any; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m1 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m1 : any
->function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => { containsError: () => any; m1: any; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >a : any
 >b : any
 >c : any
 >d : any
 >tx : any
 >ty : any
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 Class.prototype.m2 = function (x, y) { return this; };
->Class.prototype.m2 = function (x, y) { return this; } : (x: any, y: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: any; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m2 = function (x, y) { return this; } : (x: any, y: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m2 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m2 : any
->function (x, y) { return this; } : (x: any, y: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: any; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>function (x, y) { return this; } : (x: any, y: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >x : any
 >y : any
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 Class.prototype.m3 = function (x, y) { return this; };
->Class.prototype.m3 = function (x, y) { return this; } : (x: any, y: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: any; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m3 = function (x, y) { return this; } : (x: any, y: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m3 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m3 : any
->function (x, y) { return this; } : (x: any, y: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: any; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>function (x, y) { return this; } : (x: any, y: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >x : any
 >y : any
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 Class.prototype.m4 = function (angle) { return this; };
->Class.prototype.m4 = function (angle) { return this; } : (angle: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: any; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m4 = function (angle) { return this; } : (angle: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m4 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m4 : any
->function (angle) { return this; } : (angle: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: any; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>function (angle) { return this; } : (angle: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >angle : any
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 Class.prototype.m5 = function (matrix) { return this; };
->Class.prototype.m5 = function (matrix) { return this; } : (matrix: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: any; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m5 = function (matrix) { return this; } : (matrix: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m5 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m5 : any
->function (matrix) { return this; } : (matrix: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: any; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>function (matrix) { return this; } : (matrix: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >matrix : any
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; };
->Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: any; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m6 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m6 : any
->function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: any; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >x : any
 >y : any
 >pivotX : any
@@ -97,37 +97,37 @@ Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, s
 >rotation : any
 >skewX : any
 >skewY : any
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 Class.prototype.m7 = function(matrix) { return this; };
->Class.prototype.m7 = function(matrix) { return this; } : (matrix: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: any; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m7 = function(matrix) { return this; } : (matrix: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m7 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m7 : any
->function(matrix) { return this; } : (matrix: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: any; m8: () => typeof Class; m9: () => typeof Class; }
+>function(matrix) { return this; } : (matrix: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >matrix : any
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 Class.prototype.m8 = function() { return this; };
->Class.prototype.m8 = function() { return this; } : () => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: any; m9: () => typeof Class; }
+>Class.prototype.m8 = function() { return this; } : () => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m8 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m8 : any
->function() { return this; } : () => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: any; m9: () => typeof Class; }
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>function() { return this; } : () => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 Class.prototype.m9 = function () { return this; };
->Class.prototype.m9 = function () { return this; } : () => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: any; }
+>Class.prototype.m9 = function () { return this; } : () => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 >Class.prototype.m9 : any
 >Class.prototype : any
 >Class : () => void
 >prototype : any
 >m9 : any
->function () { return this; } : () => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: any; }
->this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>function () { return this; } : () => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
 
 

--- a/tests/baselines/reference/multipleDeclarations.symbols
+++ b/tests/baselines/reference/multipleDeclarations.symbols
@@ -3,13 +3,13 @@ function C() {
 >C : Symbol(C, Decl(input.js, 0, 0))
 
     this.m = null;
->m : Symbol(C.m, Decl(input.js, 0, 14), Decl(input.js, 2, 1))
+>m : Symbol(C.m, Decl(input.js, 0, 14))
 }
 C.prototype.m = function() {
->C.prototype : Symbol(C.m, Decl(input.js, 0, 14), Decl(input.js, 2, 1))
+>C.prototype : Symbol(C.m, Decl(input.js, 2, 1))
 >C : Symbol(C, Decl(input.js, 0, 0))
 >prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
->m : Symbol(C.m, Decl(input.js, 0, 14), Decl(input.js, 2, 1))
+>m : Symbol(C.m, Decl(input.js, 2, 1))
 
     this.nothing();
 >this : Symbol(C, Decl(input.js, 0, 0))

--- a/tests/baselines/reference/multipleDeclarations.types
+++ b/tests/baselines/reference/multipleDeclarations.types
@@ -21,7 +21,7 @@ C.prototype.m = function() {
     this.nothing();
 >this.nothing() : any
 >this.nothing : any
->this : { m: () => void; }
+>this : { m: any; }
 >nothing : any
 }
 class X {

--- a/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.types
+++ b/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.types
@@ -15,39 +15,39 @@ function MyClass() {
  * @returns {MyClass}
  */
 MyClass.prototype.optionalParam = function(required, notRequired) {
->MyClass.prototype.optionalParam = function(required, notRequired) {    return this;} : (required: string, notRequired?: string) => { prop: any; optionalParam: any; }
+>MyClass.prototype.optionalParam = function(required, notRequired) {    return this;} : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
 >MyClass.prototype.optionalParam : any
 >MyClass.prototype : any
 >MyClass : () => void
 >prototype : any
 >optionalParam : any
->function(required, notRequired) {    return this;} : (required: string, notRequired?: string) => { prop: any; optionalParam: any; }
+>function(required, notRequired) {    return this;} : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
 >required : string
 >notRequired : string
 
     return this;
->this : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
+>this : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
 
 };
 let pInst = new MyClass();
->pInst : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
->new MyClass() : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
+>pInst : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>new MyClass() : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
 >MyClass : () => void
 
 let c1 = pInst.optionalParam('hello')
->c1 : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
->pInst.optionalParam('hello') : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
->pInst.optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam: any; }
->pInst : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
->optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam: any; }
+>c1 : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>pInst.optionalParam('hello') : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>pInst.optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>pInst : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
 >'hello' : "hello"
 
 let c2 = pInst.optionalParam('hello', null)
->c2 : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
->pInst.optionalParam('hello', null) : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
->pInst.optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam: any; }
->pInst : { prop: any; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
->optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam: any; }
+>c2 : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>pInst.optionalParam('hello', null) : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>pInst.optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>pInst : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
 >'hello' : "hello"
 >null : null
 

--- a/tests/baselines/reference/typeFromJSConstructor.types
+++ b/tests/baselines/reference/typeFromJSConstructor.types
@@ -60,35 +60,35 @@ Installer.prototype.first = function () {
     this.arg = 'hi' // error
 >this.arg = 'hi' : "hi"
 >this.arg : number
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >arg : number
 >'hi' : "hi"
 
     this.unknown = 'hi' // ok
 >this.unknown = 'hi' : "hi"
 >this.unknown : string | boolean | null
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >unknown : string | boolean | null
 >'hi' : "hi"
 
     this.newProperty = 1 // ok: number | boolean
 >this.newProperty = 1 : 1
 >this.newProperty : number | boolean | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >newProperty : number | boolean | undefined
 >1 : 1
 
     this.twice = undefined // ok
 >this.twice = undefined : undefined
 >this.twice : string | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >twice : string | undefined
 >undefined : undefined
 
     this.twice = 'hi' // ok
 >this.twice = 'hi' : "hi"
 >this.twice : string | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >twice : string | undefined
 >'hi' : "hi"
 }
@@ -104,35 +104,35 @@ Installer.prototype.second = function () {
     this.arg = false // error
 >this.arg = false : false
 >this.arg : number
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >arg : number
 >false : false
 
     this.unknown = false // ok
 >this.unknown = false : false
 >this.unknown : string | boolean | null
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >unknown : string | boolean | null
 >false : false
 
     this.newProperty = false // ok
 >this.newProperty = false : false
 >this.newProperty : number | boolean | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >newProperty : number | boolean | undefined
 >false : false
 
     this.twice = null // error
 >this.twice = null : null
 >this.twice : string | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >twice : string | undefined
 >null : null
 
     this.twice = false // error
 >this.twice = false : false
 >this.twice : string | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >twice : string | undefined
 >false : false
 
@@ -140,7 +140,7 @@ Installer.prototype.second = function () {
 >this.twices.push(1) : number
 >this.twices.push : (...items: any[]) => number
 >this.twices : any[] | null
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >twices : any[] | null
 >push : (...items: any[]) => number
 >1 : 1
@@ -148,7 +148,7 @@ Installer.prototype.second = function () {
     if (this.twices != null) {
 >this.twices != null : boolean
 >this.twices : any[] | null
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >twices : any[] | null
 >null : null
 
@@ -156,7 +156,7 @@ Installer.prototype.second = function () {
 >this.twices.push('hi') : number
 >this.twices.push : (...items: any[]) => number
 >this.twices : any[]
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first: () => void; newProperty: number | boolean | undefined; second: () => void; }
+>this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
 >twices : any[]
 >push : (...items: any[]) => number
 >'hi' : "hi"

--- a/tests/baselines/reference/typeFromPropertyAssignment13.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment13.types
@@ -1,12 +1,12 @@
 === tests/cases/conformance/salsa/module.js ===
 var Outer = {}
->Outer : { [x: string]: any; Inner: () => void; }
->{} : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
+>{} : { [x: string]: any; Inner(): void; }
 
 Outer.Inner = function() {}
 >Outer.Inner = function() {} : () => void
 >Outer.Inner : () => void
->Outer : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
 >Inner : () => void
 >function() {} : () => void
 
@@ -14,7 +14,7 @@ Outer.Inner.prototype = {
 >Outer.Inner.prototype = {    m() { },    i: 1} : { [x: string]: any; m(): void; i: number; }
 >Outer.Inner.prototype : any
 >Outer.Inner : () => void
->Outer : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
 >Inner : () => void
 >prototype : any
 >{    m() { },    i: 1} : { [x: string]: any; m(): void; i: number; }
@@ -32,7 +32,7 @@ Outer.Inner.prototype.j = 2
 >Outer.Inner.prototype.j : any
 >Outer.Inner.prototype : any
 >Outer.Inner : () => void
->Outer : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
 >Inner : () => void
 >prototype : any
 >j : any
@@ -43,7 +43,7 @@ Outer.Inner.prototype.k;
 >Outer.Inner.prototype.k : any
 >Outer.Inner.prototype : any
 >Outer.Inner : () => void
->Outer : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
 >Inner : () => void
 >prototype : any
 >k : any
@@ -52,7 +52,7 @@ var inner = new Outer.Inner()
 >inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
 >new Outer.Inner() : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
 >Outer.Inner : () => void
->Outer : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
 >Inner : () => void
 
 inner.m()

--- a/tests/baselines/reference/typeFromPropertyAssignment16.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment16.types
@@ -1,12 +1,12 @@
 === tests/cases/conformance/salsa/a.js ===
 var Outer = {};
->Outer : { [x: string]: any; Inner: () => void; }
->{} : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
+>{} : { [x: string]: any; Inner(): void; }
 
 Outer.Inner = function () {}
 >Outer.Inner = function () {} : () => void
 >Outer.Inner : () => void
->Outer : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
 >Inner : () => void
 >function () {} : () => void
 
@@ -14,7 +14,7 @@ Outer.Inner.prototype = {
 >Outer.Inner.prototype = {    x: 1,    m() { }} : { [x: string]: any; x: number; m(): void; }
 >Outer.Inner.prototype : any
 >Outer.Inner : () => void
->Outer : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
 >Inner : () => void
 >prototype : any
 >{    x: 1,    m() { }} : { [x: string]: any; x: number; m(): void; }
@@ -46,7 +46,7 @@ var inno = new Outer.Inner()
 >inno : { [x: string]: any; x: number; m(): void; }
 >new Outer.Inner() : { [x: string]: any; x: number; m(): void; }
 >Outer.Inner : () => void
->Outer : { [x: string]: any; Inner: () => void; }
+>Outer : { [x: string]: any; Inner(): void; }
 >Inner : () => void
 
 inno.x

--- a/tests/baselines/reference/typeFromPropertyAssignment20.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment20.types
@@ -39,7 +39,7 @@
                 this._trampolineEnabled = false;
 >this._trampolineEnabled = false : false
 >this._trampolineEnabled : boolean
->this : { _trampolineEnabled: boolean; disableTrampolineIfNecessary: (b: any) => void; }
+>this : { _trampolineEnabled: boolean; disableTrampolineIfNecessary(b: any): void; }
 >_trampolineEnabled : boolean
 >false : false
             }

--- a/tests/baselines/reference/typeFromPropertyAssignment22.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment22.types
@@ -27,29 +27,29 @@ Installer.prototype.loadArgMetadata = function (next) {
         this.args = 'hi'
 >this.args = 'hi' : "hi"
 >this.args : number
->this : { args: number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>this : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
 >args : number
 >'hi' : "hi"
 
         this.newProperty = 1
 >this.newProperty = 1 : 1
 >this.newProperty : number | undefined
->this : { args: number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>this : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
 >newProperty : number | undefined
 >1 : 1
     }
 }
 var i = new Installer()
->i : { args: number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
->new Installer() : { args: number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>i : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
+>new Installer() : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
 >Installer : () => void
 
 i.newProperty = i.args // ok, number ==> number | undefined
 >i.newProperty = i.args : number
 >i.newProperty : number | undefined
->i : { args: number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>i : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
 >newProperty : number | undefined
 >i.args : number
->i : { args: number; loadArgMetadata: (next: any) => void; newProperty: number | undefined; }
+>i : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
 >args : number
 

--- a/tests/baselines/reference/typeFromPropertyAssignment7.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment7.types
@@ -1,12 +1,12 @@
 === tests/cases/conformance/salsa/a.js ===
 var obj = {};
->obj : { [x: string]: any; method: (hunch: any) => boolean; }
->{} : { [x: string]: any; method: (hunch: any) => boolean; }
+>obj : { [x: string]: any; method(hunch: any): boolean; }
+>{} : { [x: string]: any; method(hunch: any): boolean; }
 
 obj.method = function (hunch) {
 >obj.method = function (hunch) {    return true;} : (hunch: any) => boolean
 >obj.method : (hunch: any) => boolean
->obj : { [x: string]: any; method: (hunch: any) => boolean; }
+>obj : { [x: string]: any; method(hunch: any): boolean; }
 >method : (hunch: any) => boolean
 >function (hunch) {    return true;} : (hunch: any) => boolean
 >hunch : any
@@ -18,6 +18,6 @@ var b = obj.method();
 >b : boolean
 >obj.method() : boolean
 >obj.method : (hunch: any) => boolean
->obj : { [x: string]: any; method: (hunch: any) => boolean; }
+>obj : { [x: string]: any; method(hunch: any): boolean; }
 >method : (hunch: any) => boolean
 

--- a/tests/baselines/reference/typeFromPropertyAssignment9.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment9.types
@@ -1,15 +1,15 @@
 === tests/cases/conformance/salsa/a.js ===
 var my = my || {};
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->my || {} : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->{} : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>my || {} : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>{} : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
 
 /** @param {number} n */
 my.method = function(n) {
 >my.method = function(n) {    return n + 1;} : (n: number) => number
 >my.method : (n: number) => number
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
 >method : (n: number) => number
 >function(n) {    return n + 1;} : (n: number) => number
 >n : number
@@ -22,45 +22,45 @@ my.method = function(n) {
 my.number = 1;
 >my.number = 1 : 1
 >my.number : number
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
 >number : number
 >1 : 1
 
 my.object = {};
 >my.object = {} : { [x: string]: any; }
 >my.object : { [x: string]: any; }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
 >object : { [x: string]: any; }
 >{} : { [x: string]: any; }
 
 my.predicate = my.predicate || {};
->my.predicate = my.predicate || {} : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my.predicate || {} : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->{} : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
+>my.predicate = my.predicate || {} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate || {} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>{} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
 
 my.predicate.query = function () {
->my.predicate.query = function () {    var me = this;    me.property = false;} : { (): void; another: () => number; result: string; }
->my.predicate.query : { (): void; another: () => number; result: string; }
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->query : { (): void; another: () => number; result: string; }
->function () {    var me = this;    me.property = false;} : { (): void; another: () => number; result: string; }
+>my.predicate.query = function () {    var me = this;    me.property = false;} : { (): void; another(): number; result: string; }
+>my.predicate.query : { (): void; another(): number; result: string; }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>query : { (): void; another(): number; result: string; }
+>function () {    var me = this;    me.property = false;} : { (): void; another(): number; result: string; }
 
     var me = this;
->me : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->this : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
+>me : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>this : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
 
     me.property = false;
 >me.property = false : false
 >me.property : any
->me : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
+>me : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
 >property : any
 >false : false
 
@@ -68,20 +68,20 @@ my.predicate.query = function () {
 var q = new my.predicate.query();
 >q : any
 >new my.predicate.query() : any
->my.predicate.query : { (): void; another: () => number; result: string; }
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->query : { (): void; another: () => number; result: string; }
+>my.predicate.query : { (): void; another(): number; result: string; }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>query : { (): void; another(): number; result: string; }
 
 my.predicate.query.another = function () {
 >my.predicate.query.another = function () {    return 1;} : () => number
 >my.predicate.query.another : () => number
->my.predicate.query : { (): void; another: () => number; result: string; }
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->query : { (): void; another: () => number; result: string; }
+>my.predicate.query : { (): void; another(): number; result: string; }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>query : { (): void; another(): number; result: string; }
 >another : () => number
 >function () {    return 1;} : () => number
 
@@ -91,11 +91,11 @@ my.predicate.query.another = function () {
 my.predicate.query.result = 'none'
 >my.predicate.query.result = 'none' : "none"
 >my.predicate.query.result : string
->my.predicate.query : { (): void; another: () => number; result: string; }
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->query : { (): void; another: () => number; result: string; }
+>my.predicate.query : { (): void; another(): number; result: string; }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>query : { (): void; another(): number; result: string; }
 >result : string
 >'none' : "none"
 
@@ -105,15 +105,15 @@ my.predicate.query.result = 'none'
 my.predicate.sort = my.predicate.sort || function (first, second) {
 >my.predicate.sort = my.predicate.sort || function (first, second) {    return first > second ? first : second;} : (first: number, second: number) => number
 >my.predicate.sort : (first: number, second: number) => number
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
 >sort : (first: number, second: number) => number
 >my.predicate.sort || function (first, second) {    return first > second ? first : second;} : (first: number, second: number) => number
 >my.predicate.sort : (first: number, second: number) => number
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
 >sort : (first: number, second: number) => number
 >function (first, second) {    return first > second ? first : second;} : (first: number, second: number) => number
 >first : number
@@ -130,9 +130,9 @@ my.predicate.sort = my.predicate.sort || function (first, second) {
 my.predicate.type = class {
 >my.predicate.type = class {    m() { return 101; }} : typeof (Anonymous class)
 >my.predicate.type : typeof (Anonymous class)
->my.predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method: (n: number) => number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another: () => number; result: string; }; sort: (first: number, second: number) => number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
 >type : typeof (Anonymous class)
 >class {    m() { return 101; }} : typeof (Anonymous class)
 

--- a/tests/baselines/reference/typeFromPropertyAssignmentWithExport.types
+++ b/tests/baselines/reference/typeFromPropertyAssignmentWithExport.types
@@ -2,13 +2,13 @@
 // this is a javascript file...
 
 export const Adapter = {};
->Adapter : { [x: string]: any; prop: { [x: string]: any; }; asyncMethod: () => void; }
->{} : { [x: string]: any; prop: { [x: string]: any; }; asyncMethod: () => void; }
+>Adapter : { [x: string]: any; prop: { [x: string]: any; }; asyncMethod(): void; }
+>{} : { [x: string]: any; prop: { [x: string]: any; }; asyncMethod(): void; }
 
 Adapter.prop = {};
 >Adapter.prop = {} : { [x: string]: any; }
 >Adapter.prop : { [x: string]: any; }
->Adapter : { [x: string]: any; prop: { [x: string]: any; }; asyncMethod: () => void; }
+>Adapter : { [x: string]: any; prop: { [x: string]: any; }; asyncMethod(): void; }
 >prop : { [x: string]: any; }
 >{} : { [x: string]: any; }
 
@@ -16,7 +16,7 @@ Adapter.prop = {};
 Adapter.asyncMethod = function() {}
 >Adapter.asyncMethod = function() {} : () => void
 >Adapter.asyncMethod : () => void
->Adapter : { [x: string]: any; prop: { [x: string]: any; }; asyncMethod: () => void; }
+>Adapter : { [x: string]: any; prop: { [x: string]: any; }; asyncMethod(): void; }
 >asyncMethod : () => void
 >function() {} : () => void
 

--- a/tests/cases/fourslash/indirectClassInstantiation.ts
+++ b/tests/cases/fourslash/indirectClassInstantiation.ts
@@ -18,4 +18,4 @@ verify.completionListContains('property');
 edit.backspace();
 
 goTo.marker('b');
-verify.quickInfoIs('(property) class2.blah: () => void');
+verify.quickInfoIs('(method) class2.blah(): void');

--- a/tests/cases/fourslash/javaScriptPrototype1.ts
+++ b/tests/cases/fourslash/javaScriptPrototype1.ts
@@ -22,8 +22,8 @@
 // Members of the class instance
 goTo.marker('1');
 edit.insert('.');
-verify.completionListContains('foo', undefined, undefined, 'property');
-verify.completionListContains('bar', undefined, undefined, 'property');
+verify.completionListContains('foo', undefined, undefined, 'method');
+verify.completionListContains('bar', undefined, undefined, 'method');
 edit.backspace();
 
 // Members of a class method (1)

--- a/tests/cases/fourslash/javaScriptPrototype3.ts
+++ b/tests/cases/fourslash/javaScriptPrototype3.ts
@@ -15,6 +15,6 @@ goTo.marker();
 edit.insert('.');
 
 // Check members of the function
-verify.completionListContains('foo', undefined, undefined, 'property');
-verify.completionListContains('bar', undefined, undefined, 'property');
+verify.completionListContains('foo', undefined, undefined, 'method');
+verify.completionListContains('bar', undefined, undefined, 'method');
 verify.completionListContains('qua', undefined, undefined, 'property');


### PR DESCRIPTION
This is a better fix than #23068 and #22935 because it makes js-assigned functions work more like methods, so they reuse more of the existing method machinery.

This make display more accurate:
1. The functions now print as methods
2. When the type of the function references the class, the type of the function itself is now printed correctly instead of as `any`.

Other benefits:
1. `isMethodLike` no longer needs to have a js special case.
2. The check in convertFunctionToEs6Class makes more sense.

Downsides:
1. Both getTypeOfFunc and getTypeOfVariable need js special cases, as does getSignatureOfSymbol.