### PR TITLE
Fix bug: don't return string literal completions if there's no contextual type

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -386,7 +386,7 @@ namespace ts.Completions {
                     //          '/*completion position*/'
                     //      });
                     const type = typeChecker.getContextualType(node.parent.parent);
-                    return { kind: StringLiteralCompletionKind.Properties, symbols: type && type.getApparentProperties() };
+                    return type && { kind: StringLiteralCompletionKind.Properties, symbols: type.getApparentProperties() };
                 }
                 return fromContextualType();
 

--- a/tests/cases/fourslash/completionsStringLiteral_objectProperty.ts
+++ b/tests/cases/fourslash/completionsStringLiteral_objectProperty.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+////const x = { "/**/" };
+
+// We specifically filter out any array-like types.
+// Private members will be excluded by `createUnionOrIntersectionProperty`.
+goTo.marker("");
+verify.completionListIsEmpty();


### PR DESCRIPTION
Fixes #23074
Already fixed in master branch by #22933.