### PR TITLE
Print js-constructor function type names

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3073,7 +3073,7 @@ namespace ts {
                             return symbolToTypeNode(symbol, context, isInstanceType);
                         }
                         // Always use 'typeof T' for type of class, enum, and module objects
-                        if (symbol.flags & SymbolFlags.Class && !getBaseTypeVariableOfClass(symbol) && !(symbol.valueDeclaration.kind === SyntaxKind.ClassExpression && context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral) ||
+                        else if (symbol.flags & SymbolFlags.Class && !getBaseTypeVariableOfClass(symbol) && !(symbol.valueDeclaration.kind === SyntaxKind.ClassExpression && context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral) ||
                             symbol.flags & (SymbolFlags.Enum | SymbolFlags.ValueModule) ||
                             shouldWriteTypeOfFunctionSymbol()) {
                             return symbolToTypeNode(symbol, context, SymbolFlags.Value);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3067,6 +3067,11 @@ namespace ts {
                 function createAnonymousTypeNode(type: ObjectType): TypeNode {
                     const symbol = type.symbol;
                     if (symbol) {
+                        if (isJavaScriptConstructor(symbol.valueDeclaration)) {
+                            // Instance and static types share the same symbol; only add 'typeof' for the static side.
+                            const isInstanceType = type === getInferredClassType(symbol) ? SymbolFlags.Type : SymbolFlags.Value;
+                            return symbolToTypeNode(symbol, context, isInstanceType);
+                        }
                         // Always use 'typeof T' for type of class, enum, and module objects
                         if (symbol.flags & SymbolFlags.Class && !getBaseTypeVariableOfClass(symbol) && !(symbol.valueDeclaration.kind === SyntaxKind.ClassExpression && context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral) ||
                             symbol.flags & (SymbolFlags.Enum | SymbolFlags.ValueModule) ||

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4549,6 +4549,12 @@ namespace ts {
             return undefined;
         }
         switch (declaration.kind) {
+            case SyntaxKind.ClassExpression:
+            case SyntaxKind.FunctionExpression:
+                if (!(declaration as ClassExpression | FunctionExpression).name) {
+                    return getAssignedName(declaration);
+                }
+                break;
             case SyntaxKind.Identifier:
                 return declaration as Identifier;
             case SyntaxKind.JSDocPropertyTag:
@@ -4579,6 +4585,23 @@ namespace ts {
             }
         }
         return (declaration as NamedDeclaration).name;
+    }
+
+    function getAssignedName(node: Node): DeclarationName {
+        if (!node.parent) {
+            return undefined;
+        }
+        else if (isPropertyAssignment(node.parent)) {
+            return node.parent.name;
+        }
+        else if (isBinaryExpression(node.parent) && node === node.parent.right) {
+            if (isIdentifier(node.parent.left)) {
+                return node.parent.left;
+            }
+            else if (isPropertyAccessExpression(node.parent.left)) {
+                return node.parent.left.name;
+            }
+        }
     }
 
     /**

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4591,7 +4591,7 @@ namespace ts {
         if (!node.parent) {
             return undefined;
         }
-        else if (isPropertyAssignment(node.parent)) {
+        else if (isPropertyAssignment(node.parent) || isBindingElement(node.parent)) {
             return node.parent.name;
         }
         else if (isBinaryExpression(node.parent) && node === node.parent.right) {

--- a/tests/baselines/reference/chainedPrototypeAssignment.types
+++ b/tests/baselines/reference/chainedPrototypeAssignment.types
@@ -7,30 +7,30 @@ var mod = require('./mod');
 >'./mod' : "./mod"
 
 var a = new mod.A()
->a : { a: number; } & { [x: string]: any; m(n: number): number; }
->new mod.A() : { a: number; } & { [x: string]: any; m(n: number): number; }
->mod.A : () => void
+>a : A & { [x: string]: any; m(n: number): number; }
+>new mod.A() : A & { [x: string]: any; m(n: number): number; }
+>mod.A : typeof A
 >mod : typeof import("tests/cases/conformance/salsa/mod")
->A : () => void
+>A : typeof A
 
 var b = new mod.B()
->b : { b: number; } & { [x: string]: any; m(n: number): number; }
->new mod.B() : { b: number; } & { [x: string]: any; m(n: number): number; }
->mod.B : () => void
+>b : B & { [x: string]: any; m(n: number): number; }
+>new mod.B() : B & { [x: string]: any; m(n: number): number; }
+>mod.B : typeof B
 >mod : typeof import("tests/cases/conformance/salsa/mod")
->B : () => void
+>B : typeof B
 
 a.m('nope')
 >a.m('nope') : number
 >a.m : (n: number) => number
->a : { a: number; } & { [x: string]: any; m(n: number): number; }
+>a : A & { [x: string]: any; m(n: number): number; }
 >m : (n: number) => number
 >'nope' : "nope"
 
 b.m('not really')
 >b.m('not really') : number
 >b.m : (n: number) => number
->b : { b: number; } & { [x: string]: any; m(n: number): number; }
+>b : B & { [x: string]: any; m(n: number): number; }
 >m : (n: number) => number
 >'not really' : "not really"
 
@@ -45,8 +45,8 @@ declare var exports: any;
 === tests/cases/conformance/salsa/mod.js ===
 /// <reference path='./types.d.ts'/>
 var A = function() {
->A : () => void
->function() {    this.a = 1} : () => void
+>A : typeof A
+>function() {    this.a = 1} : typeof A
 
     this.a = 1
 >this.a = 1 : 1
@@ -56,8 +56,8 @@ var A = function() {
 >1 : 1
 }
 var B = function() {
->B : () => void
->function() {    this.b = 2} : () => void
+>B : typeof B
+>function() {    this.b = 2} : typeof B
 
     this.b = 2
 >this.b = 2 : 2
@@ -67,27 +67,27 @@ var B = function() {
 >2 : 2
 }
 exports.A = A
->exports.A = A : () => void
->exports.A : () => void
+>exports.A = A : typeof A
+>exports.A : typeof A
 >exports : typeof import("tests/cases/conformance/salsa/mod")
->A : () => void
->A : () => void
+>A : typeof A
+>A : typeof A
 
 exports.B = B
->exports.B = B : () => void
->exports.B : () => void
+>exports.B = B : typeof B
+>exports.B : typeof B
 >exports : typeof import("tests/cases/conformance/salsa/mod")
->B : () => void
->B : () => void
+>B : typeof B
+>B : typeof B
 
 A.prototype = B.prototype = {
 >A.prototype = B.prototype = {    /** @param {number} n */    m(n) {        return n + 1    }} : { [x: string]: any; m(n: number): number; }
 >A.prototype : any
->A : () => void
+>A : typeof A
 >prototype : any
 >B.prototype = {    /** @param {number} n */    m(n) {        return n + 1    }} : { [x: string]: any; m(n: number): number; }
 >B.prototype : any
->B : () => void
+>B : typeof B
 >prototype : any
 >{    /** @param {number} n */    m(n) {        return n + 1    }} : { [x: string]: any; m(n: number): number; }
 

--- a/tests/baselines/reference/classExpressionNames.symbols
+++ b/tests/baselines/reference/classExpressionNames.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/ts.ts ===
+var o = {
+>o : Symbol(o, Decl(ts.ts, 0, 3))
+
+    C: class {
+>C : Symbol(C, Decl(ts.ts, 0, 9))
+    }
+}
+var oc = new o.C()
+>oc : Symbol(oc, Decl(ts.ts, 4, 3))
+>o.C : Symbol(C, Decl(ts.ts, 0, 9))
+>o : Symbol(o, Decl(ts.ts, 0, 3))
+>C : Symbol(C, Decl(ts.ts, 0, 9))
+
+var V = class {
+>V : Symbol(V, Decl(ts.ts, 6, 3))
+}
+var v = new V()
+>v : Symbol(v, Decl(ts.ts, 8, 3))
+>V : Symbol(V, Decl(ts.ts, 6, 3))
+
+var A;
+>A : Symbol(A, Decl(ts.ts, 10, 3))
+
+A = class {
+>A : Symbol(A, Decl(ts.ts, 10, 3))
+}
+var a = new A()
+>a : Symbol(a, Decl(ts.ts, 13, 3))
+>A : Symbol(A, Decl(ts.ts, 10, 3))
+

--- a/tests/baselines/reference/classExpressionNames.symbols
+++ b/tests/baselines/reference/classExpressionNames.symbols
@@ -29,3 +29,15 @@ var a = new A()
 >a : Symbol(a, Decl(ts.ts, 13, 3))
 >A : Symbol(A, Decl(ts.ts, 10, 3))
 
+const {
+    B = class { }
+>B : Symbol(B, Decl(ts.ts, 15, 7))
+
+} = ({ B: undefined });
+>B : Symbol(B, Decl(ts.ts, 17, 6))
+>undefined : Symbol(undefined)
+
+var b = new B();
+>b : Symbol(b, Decl(ts.ts, 18, 3))
+>B : Symbol(B, Decl(ts.ts, 15, 7))
+

--- a/tests/baselines/reference/classExpressionNames.types
+++ b/tests/baselines/reference/classExpressionNames.types
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/ts.ts ===
+var o = {
+>o : { C: typeof C; }
+>{    C: class {    }} : { C: typeof C; }
+
+    C: class {
+>C : typeof C
+>class {    } : typeof C
+    }
+}
+var oc = new o.C()
+>oc : C
+>new o.C() : C
+>o.C : typeof C
+>o : { C: typeof C; }
+>C : typeof C
+
+var V = class {
+>V : typeof V
+>class {} : typeof V
+}
+var v = new V()
+>v : V
+>new V() : V
+>V : typeof V
+
+var A;
+>A : any
+
+A = class {
+>A = class {} : typeof A
+>A : any
+>class {} : typeof A
+}
+var a = new A()
+>a : A
+>new A() : A
+>A : typeof A
+

--- a/tests/baselines/reference/classExpressionNames.types
+++ b/tests/baselines/reference/classExpressionNames.types
@@ -37,3 +37,19 @@ var a = new A()
 >new A() : A
 >A : typeof A
 
+const {
+    B = class { }
+>B : typeof B
+>class { } : typeof B
+
+} = ({ B: undefined });
+>({ B: undefined }) : { B?: undefined; }
+>{ B: undefined } : { B?: undefined; }
+>B : undefined
+>undefined : undefined
+
+var b = new B();
+>b : B
+>new B() : B
+>B : typeof B
+

--- a/tests/baselines/reference/commonjsAccessExports.symbols
+++ b/tests/baselines/reference/commonjsAccessExports.symbols
@@ -18,7 +18,7 @@ exports.x;
 >Cls : Symbol(Cls, Decl(a.js, 4, 1))
 
         this.x = 0;
->x : Symbol((Anonymous function).x, Decl(a.js, 6, 30))
+>x : Symbol(Cls.x, Decl(a.js, 6, 30))
     }
 }
 

--- a/tests/baselines/reference/commonjsAccessExports.types
+++ b/tests/baselines/reference/commonjsAccessExports.types
@@ -15,11 +15,11 @@ exports.x;
 {
     // 'exports' does not provide a contextual type to a function-class
     exports.Cls = function() {
->exports.Cls = function() {        this.x = 0;    } : () => void
->exports.Cls : () => void
+>exports.Cls = function() {        this.x = 0;    } : typeof (Anonymous function)
+>exports.Cls : typeof (Anonymous function)
 >exports : typeof import("/a")
->Cls : () => void
->function() {        this.x = 0;    } : () => void
+>Cls : typeof (Anonymous function)
+>function() {        this.x = 0;    } : typeof (Anonymous function)
 
         this.x = 0;
 >this.x = 0 : 0
@@ -31,9 +31,9 @@ exports.x;
 }
 
 const instance = new exports.Cls();
->instance : { x: number; }
->new exports.Cls() : { x: number; }
->exports.Cls : () => void
+>instance : (Anonymous function)
+>new exports.Cls() : (Anonymous function)
+>exports.Cls : typeof (Anonymous function)
 >exports : typeof import("/a")
->Cls : () => void
+>Cls : typeof (Anonymous function)
 

--- a/tests/baselines/reference/commonjsAccessExports.types
+++ b/tests/baselines/reference/commonjsAccessExports.types
@@ -15,11 +15,11 @@ exports.x;
 {
     // 'exports' does not provide a contextual type to a function-class
     exports.Cls = function() {
->exports.Cls = function() {        this.x = 0;    } : typeof (Anonymous function)
->exports.Cls : typeof (Anonymous function)
+>exports.Cls = function() {        this.x = 0;    } : typeof Cls
+>exports.Cls : typeof Cls
 >exports : typeof import("/a")
->Cls : typeof (Anonymous function)
->function() {        this.x = 0;    } : typeof (Anonymous function)
+>Cls : typeof Cls
+>function() {        this.x = 0;    } : typeof Cls
 
         this.x = 0;
 >this.x = 0 : 0
@@ -31,9 +31,9 @@ exports.x;
 }
 
 const instance = new exports.Cls();
->instance : (Anonymous function)
->new exports.Cls() : (Anonymous function)
->exports.Cls : typeof (Anonymous function)
+>instance : Cls
+>new exports.Cls() : Cls
+>exports.Cls : typeof Cls
 >exports : typeof import("/a")
->Cls : typeof (Anonymous function)
+>Cls : typeof Cls
 

--- a/tests/baselines/reference/constructorFunctions.types
+++ b/tests/baselines/reference/constructorFunctions.types
@@ -129,12 +129,12 @@ var c5_v2;
 >c5_v2 : any
 
 c5_v2 = class { };
->c5_v2 = class { } : typeof (Anonymous class)
+>c5_v2 = class { } : typeof c5_v2
 >c5_v2 : any
->class { } : typeof (Anonymous class)
+>class { } : typeof c5_v2
 
 new c5_v2();
->new c5_v2() : (Anonymous class)
->c5_v2 : typeof (Anonymous class)
+>new c5_v2() : c5_v2
+>c5_v2 : typeof c5_v2
 
 

--- a/tests/baselines/reference/constructorFunctions.types
+++ b/tests/baselines/reference/constructorFunctions.types
@@ -1,15 +1,15 @@
 === tests/cases/conformance/salsa/index.js ===
 function C1() {
->C1 : () => typeof C1
+>C1 : typeof C1
 
     if (!(this instanceof C1)) return new C1();
 >!(this instanceof C1) : boolean
 >(this instanceof C1) : boolean
 >this instanceof C1 : boolean
 >this : any
->C1 : () => typeof C1
->new C1() : { x: number; }
->C1 : () => typeof C1
+>C1 : typeof C1
+>new C1() : C1
+>C1 : typeof C1
 
     this.x = 1;
 >this.x = 1 : 1
@@ -20,27 +20,27 @@ function C1() {
 }
 
 const c1_v1 = C1();
->c1_v1 : { x: number; }
->C1() : { x: number; }
->C1 : () => typeof C1
+>c1_v1 : C1
+>C1() : C1
+>C1 : typeof C1
 
 const c1_v2 = new C1();
->c1_v2 : { x: number; }
->new C1() : { x: number; }
->C1 : () => typeof C1
+>c1_v2 : C1
+>new C1() : C1
+>C1 : typeof C1
 
 var C2 = function () {
->C2 : () => any
->function () {    if (!(this instanceof C2)) return new C2();    this.x = 1;} : () => any
+>C2 : typeof C2
+>function () {    if (!(this instanceof C2)) return new C2();    this.x = 1;} : typeof C2
 
     if (!(this instanceof C2)) return new C2();
 >!(this instanceof C2) : boolean
 >(this instanceof C2) : boolean
 >this instanceof C2 : boolean
 >this : any
->C2 : () => any
->new C2() : { x: number; }
->C2 : () => any
+>C2 : typeof C2
+>new C2() : C2
+>C2 : typeof C2
 
     this.x = 1;
 >this.x = 1 : 1
@@ -52,65 +52,65 @@ var C2 = function () {
 };
 
 const c2_v1 = C2();
->c2_v1 : { x: number; }
->C2() : { x: number; }
->C2 : () => any
+>c2_v1 : C2
+>C2() : C2
+>C2 : typeof C2
 
 const c2_v2 = new C2();
->c2_v2 : { x: number; }
->new C2() : { x: number; }
->C2 : () => any
+>c2_v2 : C2
+>new C2() : C2
+>C2 : typeof C2
 
 /** @class */
 function C3() {
->C3 : () => typeof C3
+>C3 : typeof C3
 
     if (!(this instanceof C3)) return new C3();
 >!(this instanceof C3) : boolean
 >(this instanceof C3) : boolean
 >this instanceof C3 : boolean
 >this : any
->C3 : () => typeof C3
->new C3() : {}
->C3 : () => typeof C3
+>C3 : typeof C3
+>new C3() : C3
+>C3 : typeof C3
 
 };
 
 const c3_v1 = C3();
->c3_v1 : {}
->C3() : {}
->C3 : () => typeof C3
+>c3_v1 : C3
+>C3() : C3
+>C3 : typeof C3
 
 const c3_v2 = new C3();
->c3_v2 : {}
->new C3() : {}
->C3 : () => typeof C3
+>c3_v2 : C3
+>new C3() : C3
+>C3 : typeof C3
 
 /** @class */
 var C4 = function () {
->C4 : () => any
->function () {    if (!(this instanceof C4)) return new C4();} : () => any
+>C4 : typeof C4
+>function () {    if (!(this instanceof C4)) return new C4();} : typeof C4
 
     if (!(this instanceof C4)) return new C4();
 >!(this instanceof C4) : boolean
 >(this instanceof C4) : boolean
 >this instanceof C4 : boolean
 >this : any
->C4 : () => any
->new C4() : {}
->C4 : () => any
+>C4 : typeof C4
+>new C4() : C4
+>C4 : typeof C4
 
 };
 
 const c4_v1 = C4();
->c4_v1 : {}
->C4() : {}
->C4 : () => any
+>c4_v1 : C4
+>C4() : C4
+>C4 : typeof C4
 
 const c4_v2 = new C4();
->c4_v2 : {}
->new C4() : {}
->C4 : () => any
+>c4_v2 : C4
+>new C4() : C4
+>C4 : typeof C4
 
 var c5_v1;
 >c5_v1 : any

--- a/tests/baselines/reference/constructorFunctions2.types
+++ b/tests/baselines/reference/constructorFunctions2.types
@@ -9,21 +9,21 @@ declare var module: any, exports: any;
 
 === tests/cases/conformance/salsa/index.js ===
 const A = require("./other");
->A : () => void
->require("./other") : () => void
+>A : typeof A
+>require("./other") : typeof A
 >require : (id: string) => any
 >"./other" : "./other"
 
 const a = new A().id;
 >a : number
 >new A().id : number
->new A() : { id: number; }
->A : () => void
+>new A() : A
+>A : typeof A
 >id : number
 
 const B = function() { this.id = 1; }
->B : () => void
->function() { this.id = 1; } : () => void
+>B : typeof B
+>function() { this.id = 1; } : typeof B
 >this.id = 1 : 1
 >this.id : any
 >this : any
@@ -34,34 +34,34 @@ B.prototype.m = function() { this.x = 2; }
 >B.prototype.m = function() { this.x = 2; } : () => void
 >B.prototype.m : any
 >B.prototype : any
->B : () => void
+>B : typeof B
 >prototype : any
 >m : any
 >function() { this.x = 2; } : () => void
 >this.x = 2 : 2
 >this.x : number
->this : { id: number; m(): void; x: number; }
+>this : B
 >x : number
 >2 : 2
 
 const b = new B();
->b : { id: number; m(): void; x: number; }
->new B() : { id: number; m(): void; x: number; }
->B : () => void
+>b : B
+>new B() : B
+>B : typeof B
 
 b.id;
 >b.id : number
->b : { id: number; m(): void; x: number; }
+>b : B
 >id : number
 
 b.x;
 >b.x : number
->b : { id: number; m(): void; x: number; }
+>b : B
 >x : number
 
 === tests/cases/conformance/salsa/other.js ===
 function A() { this.id = 1; }
->A : () => void
+>A : typeof A
 >this.id = 1 : 1
 >this.id : any
 >this : any
@@ -69,9 +69,9 @@ function A() { this.id = 1; }
 >1 : 1
 
 module.exports = A;
->module.exports = A : () => void
+>module.exports = A : typeof A
 >module.exports : any
 >module : any
 >exports : any
->A : () => void
+>A : typeof A
 

--- a/tests/baselines/reference/constructorFunctions3.symbols
+++ b/tests/baselines/reference/constructorFunctions3.symbols
@@ -1,0 +1,94 @@
+=== tests/cases/conformance/salsa/a.js ===
+function Instance() {
+>Instance : Symbol(Instance, Decl(a.js, 0, 0))
+
+    this.i = 'simple'
+>i : Symbol(Instance.i, Decl(a.js, 0, 21))
+}
+var i = new Instance();
+>i : Symbol(i, Decl(a.js, 3, 3))
+>Instance : Symbol(Instance, Decl(a.js, 0, 0))
+
+Instance;
+>Instance : Symbol(Instance, Decl(a.js, 0, 0))
+
+i;
+>i : Symbol(i, Decl(a.js, 3, 3))
+
+function StaticToo() {
+>StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2))
+
+    this.i = 'more complex'
+>i : Symbol(StaticToo.i, Decl(a.js, 7, 22))
+}
+StaticToo.property = 'yep'
+>StaticToo.property : Symbol(StaticToo.property, Decl(a.js, 9, 1))
+>StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2))
+>property : Symbol(StaticToo.property, Decl(a.js, 9, 1))
+
+var s = new StaticToo();
+>s : Symbol(s, Decl(a.js, 11, 3))
+>StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2))
+
+s;
+>s : Symbol(s, Decl(a.js, 11, 3))
+
+StaticToo;
+>StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2))
+
+// Both!
+function A () {
+>A : Symbol(A, Decl(a.js, 13, 10), Decl(a.js, 24, 1))
+
+    this.x = 1
+>x : Symbol(A.x, Decl(a.js, 16, 15))
+
+    /** @type {1} */
+    this.second = 1
+>second : Symbol(A.second, Decl(a.js, 17, 14))
+}
+/** @param {number} n */
+A.prototype.z = function f(n) {
+>A.prototype : Symbol(A.z, Decl(a.js, 20, 1))
+>A : Symbol(A, Decl(a.js, 13, 10), Decl(a.js, 24, 1))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>z : Symbol(A.z, Decl(a.js, 20, 1))
+>f : Symbol(f, Decl(a.js, 22, 15))
+>n : Symbol(n, Decl(a.js, 22, 27))
+
+    return n + this.x
+>n : Symbol(n, Decl(a.js, 22, 27))
+>this.x : Symbol(A.x, Decl(a.js, 16, 15))
+>this : Symbol(A, Decl(a.js, 13, 10), Decl(a.js, 24, 1))
+>x : Symbol(A.x, Decl(a.js, 16, 15))
+}
+/** @param {number} m */
+A.t = function g(m) {
+>A.t : Symbol(A.t, Decl(a.js, 24, 1))
+>A : Symbol(A, Decl(a.js, 13, 10), Decl(a.js, 24, 1))
+>t : Symbol(A.t, Decl(a.js, 24, 1))
+>g : Symbol(g, Decl(a.js, 26, 5))
+>m : Symbol(m, Decl(a.js, 26, 17))
+
+    return m + 1
+>m : Symbol(m, Decl(a.js, 26, 17))
+}
+var a = new A()
+>a : Symbol(a, Decl(a.js, 29, 3))
+>A : Symbol(A, Decl(a.js, 13, 10), Decl(a.js, 24, 1))
+
+a.z(3)
+>a.z : Symbol(A.z, Decl(a.js, 20, 1))
+>a : Symbol(a, Decl(a.js, 29, 3))
+>z : Symbol(A.z, Decl(a.js, 20, 1))
+
+A.t(2)
+>A.t : Symbol(A.t, Decl(a.js, 24, 1))
+>A : Symbol(A, Decl(a.js, 13, 10), Decl(a.js, 24, 1))
+>t : Symbol(A.t, Decl(a.js, 24, 1))
+
+a.second = 1
+>a.second : Symbol(A.second, Decl(a.js, 17, 14))
+>a : Symbol(a, Decl(a.js, 29, 3))
+>second : Symbol(A.second, Decl(a.js, 17, 14))
+

--- a/tests/baselines/reference/constructorFunctions3.types
+++ b/tests/baselines/reference/constructorFunctions3.types
@@ -1,0 +1,129 @@
+=== tests/cases/conformance/salsa/a.js ===
+function Instance() {
+>Instance : typeof Instance
+
+    this.i = 'simple'
+>this.i = 'simple' : "simple"
+>this.i : any
+>this : any
+>i : any
+>'simple' : "simple"
+}
+var i = new Instance();
+>i : Instance
+>new Instance() : Instance
+>Instance : typeof Instance
+
+Instance;
+>Instance : typeof Instance
+
+i;
+>i : Instance
+
+function StaticToo() {
+>StaticToo : typeof StaticToo
+
+    this.i = 'more complex'
+>this.i = 'more complex' : "more complex"
+>this.i : any
+>this : any
+>i : any
+>'more complex' : "more complex"
+}
+StaticToo.property = 'yep'
+>StaticToo.property = 'yep' : "yep"
+>StaticToo.property : string
+>StaticToo : typeof StaticToo
+>property : string
+>'yep' : "yep"
+
+var s = new StaticToo();
+>s : StaticToo
+>new StaticToo() : StaticToo
+>StaticToo : typeof StaticToo
+
+s;
+>s : StaticToo
+
+StaticToo;
+>StaticToo : typeof StaticToo
+
+// Both!
+function A () {
+>A : typeof A
+
+    this.x = 1
+>this.x = 1 : 1
+>this.x : any
+>this : any
+>x : any
+>1 : 1
+
+    /** @type {1} */
+    this.second = 1
+>this.second = 1 : 1
+>this.second : any
+>this : any
+>second : any
+>1 : 1
+}
+/** @param {number} n */
+A.prototype.z = function f(n) {
+>A.prototype.z = function f(n) {    return n + this.x} : (n: number) => number
+>A.prototype.z : any
+>A.prototype : any
+>A : typeof A
+>prototype : any
+>z : any
+>function f(n) {    return n + this.x} : (n: number) => number
+>f : (n: number) => number
+>n : number
+
+    return n + this.x
+>n + this.x : number
+>n : number
+>this.x : number
+>this : A
+>x : number
+}
+/** @param {number} m */
+A.t = function g(m) {
+>A.t = function g(m) {    return m + 1} : (m: number) => number
+>A.t : (m: number) => number
+>A : typeof A
+>t : (m: number) => number
+>function g(m) {    return m + 1} : (m: number) => number
+>g : (m: number) => number
+>m : number
+
+    return m + 1
+>m + 1 : number
+>m : number
+>1 : 1
+}
+var a = new A()
+>a : A
+>new A() : A
+>A : typeof A
+
+a.z(3)
+>a.z(3) : number
+>a.z : (n: number) => number
+>a : A
+>z : (n: number) => number
+>3 : 3
+
+A.t(2)
+>A.t(2) : number
+>A.t : (m: number) => number
+>A : typeof A
+>t : (m: number) => number
+>2 : 2
+
+a.second = 1
+>a.second = 1 : 1
+>a.second : 1
+>a : A
+>second : 1
+>1 : 1
+

--- a/tests/baselines/reference/constructorFunctionsStrict.types
+++ b/tests/baselines/reference/constructorFunctionsStrict.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/salsa/a.js ===
 /** @param {number} x */
 function C(x) {
->C : (x: number) => void
+>C : typeof C
 >x : number
 
     this.x = x
@@ -15,7 +15,7 @@ C.prototype.m = function() {
 >C.prototype.m = function() {    this.y = 12} : () => void
 >C.prototype.m : any
 >C.prototype : any
->C : (x: number) => void
+>C : typeof C
 >prototype : any
 >m : any
 >function() {    this.y = 12} : () => void
@@ -23,33 +23,33 @@ C.prototype.m = function() {
     this.y = 12
 >this.y = 12 : 12
 >this.y : number | undefined
->this : { x: number; m(): void; y: number | undefined; }
+>this : C
 >y : number | undefined
 >12 : 12
 }
 var c = new C(1)
->c : { x: number; m(): void; y: number | undefined; }
->new C(1) : { x: number; m(): void; y: number | undefined; }
->C : (x: number) => void
+>c : C
+>new C(1) : C
+>C : typeof C
 >1 : 1
 
 c.x = undefined // should error
 >c.x = undefined : undefined
 >c.x : number
->c : { x: number; m(): void; y: number | undefined; }
+>c : C
 >x : number
 >undefined : undefined
 
 c.y = undefined // ok
 >c.y = undefined : undefined
 >c.y : number | undefined
->c : { x: number; m(): void; y: number | undefined; }
+>c : C
 >y : number | undefined
 >undefined : undefined
 
 /** @param {number} x */
 function A(x) {
->A : (x: number) => typeof A
+>A : typeof A
 >x : number
 
     if (!(this instanceof A)) {
@@ -57,11 +57,11 @@ function A(x) {
 >(this instanceof A) : boolean
 >this instanceof A : boolean
 >this : any
->A : (x: number) => typeof A
+>A : typeof A
 
         return new A(x)
->new A(x) : { x: number; }
->A : (x: number) => typeof A
+>new A(x) : A
+>A : typeof A
 >x : number
     }
     this.x = x
@@ -72,23 +72,23 @@ function A(x) {
 >x : number
 }
 var k = A(1)
->k : { x: number; }
->A(1) : { x: number; }
->A : (x: number) => typeof A
+>k : A
+>A(1) : A
+>A : typeof A
 >1 : 1
 
 var j = new A(2)
->j : { x: number; }
->new A(2) : { x: number; }
->A : (x: number) => typeof A
+>j : A
+>new A(2) : A
+>A : typeof A
 >2 : 2
 
 k.x === j.x
 >k.x === j.x : boolean
 >k.x : number
->k : { x: number; }
+>k : A
 >x : number
 >j.x : number
->j : { x: number; }
+>j : A
 >x : number
 

--- a/tests/baselines/reference/exportNestedNamespaces.symbols
+++ b/tests/baselines/reference/exportNestedNamespaces.symbols
@@ -13,7 +13,7 @@ exports.n.K = function () {
 
     this.x = 10;
 >this : Symbol(__object, Decl(mod.js, 0, 11), Decl(mod.js, 1, 8))
->x : Symbol((Anonymous function).x, Decl(mod.js, 1, 27))
+>x : Symbol(K.x, Decl(mod.js, 1, 27))
 }
 exports.Classic = class {
 >exports.Classic : Symbol(Classic, Decl(mod.js, 3, 1))
@@ -22,9 +22,9 @@ exports.Classic = class {
 
     constructor() {
         this.p = 1
->this.p : Symbol((Anonymous class).p, Decl(mod.js, 5, 19))
->this : Symbol((Anonymous class), Decl(mod.js, 4, 17))
->p : Symbol((Anonymous class).p, Decl(mod.js, 5, 19))
+>this.p : Symbol(Classic.p, Decl(mod.js, 5, 19))
+>this : Symbol(Classic, Decl(mod.js, 4, 17))
+>p : Symbol(Classic.p, Decl(mod.js, 5, 19))
     }
 }
 
@@ -41,9 +41,9 @@ var k = new s.n.K()
 >K : Symbol(K, Decl(mod.js, 0, 15))
 
 k.x
->k.x : Symbol((Anonymous function).x, Decl(mod.js, 1, 27))
+>k.x : Symbol(K.x, Decl(mod.js, 1, 27))
 >k : Symbol(k, Decl(use.js, 2, 3))
->x : Symbol((Anonymous function).x, Decl(mod.js, 1, 27))
+>x : Symbol(K.x, Decl(mod.js, 1, 27))
 
 var classic = new s.Classic()
 >classic : Symbol(classic, Decl(use.js, 4, 3))
@@ -60,14 +60,14 @@ function f(c, classic) {
 >classic : Symbol(classic, Decl(use.js, 9, 13))
 
     c.x
->c.x : Symbol((Anonymous function).x, Decl(mod.js, 1, 27))
+>c.x : Symbol(K.x, Decl(mod.js, 1, 27))
 >c : Symbol(c, Decl(use.js, 9, 11))
->x : Symbol((Anonymous function).x, Decl(mod.js, 1, 27))
+>x : Symbol(K.x, Decl(mod.js, 1, 27))
 
     classic.p
->classic.p : Symbol((Anonymous class).p, Decl(mod.js, 5, 19))
+>classic.p : Symbol(Classic.p, Decl(mod.js, 5, 19))
 >classic : Symbol(classic, Decl(use.js, 9, 13))
->p : Symbol((Anonymous class).p, Decl(mod.js, 5, 19))
+>p : Symbol(Classic.p, Decl(mod.js, 5, 19))
 }
 
 

--- a/tests/baselines/reference/exportNestedNamespaces.types
+++ b/tests/baselines/reference/exportNestedNamespaces.types
@@ -7,13 +7,13 @@ exports.n = {};
 >{} : typeof __object
 
 exports.n.K = function () {
->exports.n.K = function () {    this.x = 10;} : () => void
->exports.n.K : () => void
+>exports.n.K = function () {    this.x = 10;} : typeof (Anonymous function)
+>exports.n.K : typeof (Anonymous function)
 >exports.n : typeof __object
 >exports : typeof import("tests/cases/conformance/salsa/mod")
 >n : typeof __object
->K : () => void
->function () {    this.x = 10;} : () => void
+>K : typeof (Anonymous function)
+>function () {    this.x = 10;} : typeof (Anonymous function)
 
     this.x = 10;
 >this.x = 10 : 10
@@ -44,17 +44,17 @@ import * as s from './mod'
 >s : typeof s
 
 var k = new s.n.K()
->k : { x: number; }
->new s.n.K() : { x: number; }
->s.n.K : () => void
+>k : (Anonymous function)
+>new s.n.K() : (Anonymous function)
+>s.n.K : typeof (Anonymous function)
 >s.n : typeof __object
 >s : typeof s
 >n : typeof __object
->K : () => void
+>K : typeof (Anonymous function)
 
 k.x
 >k.x : number
->k : { x: number; }
+>k : (Anonymous function)
 >x : number
 
 var classic = new s.Classic()
@@ -68,13 +68,13 @@ var classic = new s.Classic()
 /** @param {s.n.K} c
     @param {s.Classic} classic */
 function f(c, classic) {
->f : (c: { x: number; }, classic: (Anonymous class)) => void
->c : { x: number; }
+>f : (c: (Anonymous function), classic: (Anonymous class)) => void
+>c : (Anonymous function)
 >classic : (Anonymous class)
 
     c.x
 >c.x : number
->c : { x: number; }
+>c : (Anonymous function)
 >x : number
 
     classic.p

--- a/tests/baselines/reference/exportNestedNamespaces.types
+++ b/tests/baselines/reference/exportNestedNamespaces.types
@@ -7,13 +7,13 @@ exports.n = {};
 >{} : typeof __object
 
 exports.n.K = function () {
->exports.n.K = function () {    this.x = 10;} : typeof (Anonymous function)
->exports.n.K : typeof (Anonymous function)
+>exports.n.K = function () {    this.x = 10;} : typeof K
+>exports.n.K : typeof K
 >exports.n : typeof __object
 >exports : typeof import("tests/cases/conformance/salsa/mod")
 >n : typeof __object
->K : typeof (Anonymous function)
->function () {    this.x = 10;} : typeof (Anonymous function)
+>K : typeof K
+>function () {    this.x = 10;} : typeof K
 
     this.x = 10;
 >this.x = 10 : 10
@@ -23,11 +23,11 @@ exports.n.K = function () {
 >10 : 10
 }
 exports.Classic = class {
->exports.Classic = class {    constructor() {        this.p = 1    }} : typeof (Anonymous class)
->exports.Classic : typeof (Anonymous class)
+>exports.Classic = class {    constructor() {        this.p = 1    }} : typeof Classic
+>exports.Classic : typeof Classic
 >exports : typeof import("tests/cases/conformance/salsa/mod")
->Classic : typeof (Anonymous class)
->class {    constructor() {        this.p = 1    }} : typeof (Anonymous class)
+>Classic : typeof Classic
+>class {    constructor() {        this.p = 1    }} : typeof Classic
 
     constructor() {
         this.p = 1
@@ -44,42 +44,42 @@ import * as s from './mod'
 >s : typeof s
 
 var k = new s.n.K()
->k : (Anonymous function)
->new s.n.K() : (Anonymous function)
->s.n.K : typeof (Anonymous function)
+>k : K
+>new s.n.K() : K
+>s.n.K : typeof K
 >s.n : typeof __object
 >s : typeof s
 >n : typeof __object
->K : typeof (Anonymous function)
+>K : typeof K
 
 k.x
 >k.x : number
->k : (Anonymous function)
+>k : K
 >x : number
 
 var classic = new s.Classic()
->classic : (Anonymous class)
->new s.Classic() : (Anonymous class)
->s.Classic : typeof (Anonymous class)
+>classic : Classic
+>new s.Classic() : Classic
+>s.Classic : typeof Classic
 >s : typeof s
->Classic : typeof (Anonymous class)
+>Classic : typeof Classic
 
 
 /** @param {s.n.K} c
     @param {s.Classic} classic */
 function f(c, classic) {
->f : (c: (Anonymous function), classic: (Anonymous class)) => void
->c : (Anonymous function)
->classic : (Anonymous class)
+>f : (c: K, classic: Classic) => void
+>c : K
+>classic : Classic
 
     c.x
 >c.x : number
->c : (Anonymous function)
+>c : K
 >x : number
 
     classic.p
 >classic.p : number
->classic : (Anonymous class)
+>classic : Classic
 >p : number
 }
 

--- a/tests/baselines/reference/functionExpressionNames.symbols
+++ b/tests/baselines/reference/functionExpressionNames.symbols
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/b.js ===
+exports.E = function() {
+>exports.E : Symbol(E, Decl(b.js, 0, 0))
+>exports : Symbol(E, Decl(b.js, 0, 0))
+>E : Symbol(E, Decl(b.js, 0, 0))
+
+    this.e = 'exported'
+>e : Symbol(E.e, Decl(b.js, 0, 24))
+}
+var e = new exports.E();
+>e : Symbol(e, Decl(b.js, 3, 3))
+>exports.E : Symbol(E, Decl(b.js, 0, 0))
+>exports : Symbol("tests/cases/compiler/b", Decl(b.js, 0, 0))
+>E : Symbol(E, Decl(b.js, 0, 0))
+
+var o = {
+>o : Symbol(o, Decl(b.js, 5, 3))
+
+    C: function () {
+>C : Symbol(C, Decl(b.js, 5, 9))
+
+        this.c = 'nested object'
+>this : Symbol(o, Decl(b.js, 5, 7))
+>c : Symbol(C.c, Decl(b.js, 6, 20))
+    }
+}
+var og = new o.C();
+>og : Symbol(og, Decl(b.js, 10, 3))
+>o.C : Symbol(C, Decl(b.js, 5, 9))
+>o : Symbol(o, Decl(b.js, 5, 3))
+>C : Symbol(C, Decl(b.js, 5, 9))
+
+var V = function () {
+>V : Symbol(V, Decl(b.js, 12, 3))
+
+    this.v = 'simple'
+>v : Symbol(V.v, Decl(b.js, 12, 21))
+}
+var v = new V();
+>v : Symbol(v, Decl(b.js, 15, 3))
+>V : Symbol(V, Decl(b.js, 12, 3))
+
+var A;
+>A : Symbol(A, Decl(b.js, 17, 3))
+
+A = function () {
+>A : Symbol(A, Decl(b.js, 17, 3))
+
+    this.a = 'assignment'
+>a : Symbol(A.a, Decl(b.js, 18, 17))
+}
+var a = new A();
+>a : Symbol(a, Decl(b.js, 21, 3))
+>A : Symbol(A, Decl(b.js, 17, 3))
+

--- a/tests/baselines/reference/functionExpressionNames.symbols
+++ b/tests/baselines/reference/functionExpressionNames.symbols
@@ -53,3 +53,18 @@ var a = new A();
 >a : Symbol(a, Decl(b.js, 21, 3))
 >A : Symbol(A, Decl(b.js, 17, 3))
 
+const {
+    B = function() {
+>B : Symbol(B, Decl(b.js, 23, 7))
+
+        this.b = 'binding pattern'
+>b : Symbol(B.b, Decl(b.js, 24, 20))
+    }
+} = { B: undefined };
+>B : Symbol(B, Decl(b.js, 27, 5))
+>undefined : Symbol(undefined)
+
+var b = new B();
+>b : Symbol(b, Decl(b.js, 28, 3))
+>B : Symbol(B, Decl(b.js, 23, 7))
+

--- a/tests/baselines/reference/functionExpressionNames.types
+++ b/tests/baselines/reference/functionExpressionNames.types
@@ -79,3 +79,25 @@ var a = new A();
 >new A() : A
 >A : typeof A
 
+const {
+    B = function() {
+>B : typeof B
+>function() {        this.b = 'binding pattern'    } : typeof B
+
+        this.b = 'binding pattern'
+>this.b = 'binding pattern' : "binding pattern"
+>this.b : any
+>this : any
+>b : any
+>'binding pattern' : "binding pattern"
+    }
+} = { B: undefined };
+>{ B: undefined } : { B?: undefined; }
+>B : undefined
+>undefined : undefined
+
+var b = new B();
+>b : B
+>new B() : B
+>B : typeof B
+

--- a/tests/baselines/reference/functionExpressionNames.types
+++ b/tests/baselines/reference/functionExpressionNames.types
@@ -1,0 +1,81 @@
+=== tests/cases/compiler/b.js ===
+exports.E = function() {
+>exports.E = function() {    this.e = 'exported'} : typeof E
+>exports.E : typeof E
+>exports : typeof import("tests/cases/compiler/b")
+>E : typeof E
+>function() {    this.e = 'exported'} : typeof E
+
+    this.e = 'exported'
+>this.e = 'exported' : "exported"
+>this.e : any
+>this : any
+>e : any
+>'exported' : "exported"
+}
+var e = new exports.E();
+>e : E
+>new exports.E() : E
+>exports.E : typeof E
+>exports : typeof import("tests/cases/compiler/b")
+>E : typeof E
+
+var o = {
+>o : { [x: string]: any; C: typeof C; }
+>{    C: function () {        this.c = 'nested object'    }} : { [x: string]: any; C: typeof C; }
+
+    C: function () {
+>C : typeof C
+>function () {        this.c = 'nested object'    } : typeof C
+
+        this.c = 'nested object'
+>this.c = 'nested object' : "nested object"
+>this.c : any
+>this : { [x: string]: any; C: typeof C; }
+>c : any
+>'nested object' : "nested object"
+    }
+}
+var og = new o.C();
+>og : C
+>new o.C() : C
+>o.C : typeof C
+>o : { [x: string]: any; C: typeof C; }
+>C : typeof C
+
+var V = function () {
+>V : typeof V
+>function () {    this.v = 'simple'} : typeof V
+
+    this.v = 'simple'
+>this.v = 'simple' : "simple"
+>this.v : any
+>this : any
+>v : any
+>'simple' : "simple"
+}
+var v = new V();
+>v : V
+>new V() : V
+>V : typeof V
+
+var A;
+>A : any
+
+A = function () {
+>A = function () {    this.a = 'assignment'} : typeof A
+>A : any
+>function () {    this.a = 'assignment'} : typeof A
+
+    this.a = 'assignment'
+>this.a = 'assignment' : "assignment"
+>this.a : any
+>this : any
+>a : any
+>'assignment' : "assignment"
+}
+var a = new A();
+>a : A
+>new A() : A
+>A : typeof A
+

--- a/tests/baselines/reference/inferringClassMembersFromAssignments2.types
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments2.types
@@ -3,7 +3,7 @@ OOOrder.prototype.m = function () {
 >OOOrder.prototype.m = function () {    this.p = 1} : () => void
 >OOOrder.prototype.m : any
 >OOOrder.prototype : any
->OOOrder : () => void
+>OOOrder : typeof OOOrder
 >prototype : any
 >m : any
 >function () {    this.p = 1} : () => void
@@ -11,12 +11,12 @@ OOOrder.prototype.m = function () {
     this.p = 1
 >this.p = 1 : 1
 >this.p : number
->this : { x: number; m(): void; p: number; }
+>this : OOOrder
 >p : number
 >1 : 1
 }
 function OOOrder() {
->OOOrder : () => void
+>OOOrder : typeof OOOrder
 
     this.x = 1
 >this.x = 1 : 1

--- a/tests/baselines/reference/jsdocTypeFromChainedAssignment.types
+++ b/tests/baselines/reference/jsdocTypeFromChainedAssignment.types
@@ -43,7 +43,7 @@ A.prototype.y = A.prototype.z = function f(n) {
 >n + this.x : number
 >n : number
 >this.x : number
->this : typeof A
+>this : A
 >x : number
 }
 /** @param {number} m */
@@ -68,21 +68,21 @@ A.s = A.t = function g(m) {
 >x : any
 }
 var a = new A()
->a : typeof A
->new A() : typeof A
+>a : A
+>new A() : A
 >A : typeof A
 
 a.y('no') // error
 >a.y('no') : number
 >a.y : (n: number) => number
->a : typeof A
+>a : A
 >y : (n: number) => number
 >'no' : "no"
 
 a.z('not really') // error
 >a.z('not really') : number
 >a.z : (n: number) => number
->a : typeof A
+>a : A
 >z : (n: number) => number
 >'not really' : "not really"
 
@@ -103,7 +103,7 @@ A.t('not here either') // error
 a.first = 10 // error: '10' isn't assignable to '1'
 >a.first = 10 : 10
 >a.first : 1
->a : typeof A
+>a : A
 >first : 1
 >10 : 10
 

--- a/tests/baselines/reference/jsdocTypeTagCast.errors.txt
+++ b/tests/baselines/reference/jsdocTypeTagCast.errors.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/jsdoc/b.js(51,17): error TS2352: Type 'SomeDerived' cann
   Property 'q' is missing in type 'SomeDerived'.
 tests/cases/conformance/jsdoc/b.js(52,17): error TS2352: Type 'SomeBase' cannot be converted to type 'SomeOther'.
   Property 'q' is missing in type 'SomeBase'.
-tests/cases/conformance/jsdoc/b.js(58,1): error TS2322: Type '{ p: string | number; }' is not assignable to type 'SomeBase'.
+tests/cases/conformance/jsdoc/b.js(58,1): error TS2322: Type 'SomeFakeClass' is not assignable to type 'SomeBase'.
   Types of property 'p' are incompatible.
     Type 'string | number' is not assignable to type 'number'.
       Type 'string' is not assignable to type 'number'.
@@ -97,7 +97,7 @@ tests/cases/conformance/jsdoc/b.js(67,8): error TS2454: Variable 'numOrStr' is u
     
     someBase = someFakeClass; // Error
     ~~~~~~~~
-!!! error TS2322: Type '{ p: string | number; }' is not assignable to type 'SomeBase'.
+!!! error TS2322: Type 'SomeFakeClass' is not assignable to type 'SomeBase'.
 !!! error TS2322:   Types of property 'p' are incompatible.
 !!! error TS2322:     Type 'string | number' is not assignable to type 'number'.
 !!! error TS2322:       Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/jsdocTypeTagCast.types
+++ b/tests/baselines/reference/jsdocTypeTagCast.types
@@ -80,7 +80,7 @@ class SomeOther {
 }
 
 function SomeFakeClass() {
->SomeFakeClass : () => void
+>SomeFakeClass : typeof SomeFakeClass
 
     /** @type {string|number} */
     this.p = "bar";
@@ -108,9 +108,9 @@ var someOther = new SomeOther();
 >SomeOther : typeof SomeOther
 
 var someFakeClass = new SomeFakeClass();
->someFakeClass : { p: string | number; }
->new SomeFakeClass() : { p: string | number; }
->SomeFakeClass : () => void
+>someFakeClass : SomeFakeClass
+>new SomeFakeClass() : SomeFakeClass
+>SomeFakeClass : typeof SomeFakeClass
 
 someBase = /** @type {SomeBase} */(someDerived);
 >someBase = /** @type {SomeBase} */(someDerived) : SomeBase
@@ -168,24 +168,24 @@ someOther = /** @type {SomeOther} */(someOther);
 
 someFakeClass = someBase;
 >someFakeClass = someBase : SomeBase
->someFakeClass : { p: string | number; }
+>someFakeClass : SomeFakeClass
 >someBase : SomeBase
 
 someFakeClass = someDerived;
 >someFakeClass = someDerived : SomeDerived
->someFakeClass : { p: string | number; }
+>someFakeClass : SomeFakeClass
 >someDerived : SomeDerived
 
 someBase = someFakeClass; // Error
->someBase = someFakeClass : { p: string | number; }
+>someBase = someFakeClass : SomeFakeClass
 >someBase : SomeBase
->someFakeClass : { p: string | number; }
+>someFakeClass : SomeFakeClass
 
 someBase = /** @type {SomeBase} */(someFakeClass);
 >someBase = /** @type {SomeBase} */(someFakeClass) : SomeBase
 >someBase : SomeBase
 >(someFakeClass) : SomeBase
->someFakeClass : { p: string | number; }
+>someFakeClass : SomeFakeClass
 
 // Type assertion cannot be a type-predicate type
 /** @type {number | string} */

--- a/tests/baselines/reference/methodsReturningThis.types
+++ b/tests/baselines/reference/methodsReturningThis.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/input.js ===
 function Class()
->Class : () => void
+>Class : typeof Class
 {
 }
 
@@ -9,85 +9,85 @@ Class.prototype.containsError = function () { return this.notPresent; };
 >Class.prototype.containsError = function () { return this.notPresent; } : () => any
 >Class.prototype.containsError : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >containsError : any
 >function () { return this.notPresent; } : () => any
 >this.notPresent : any
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : Class
 >notPresent : any
 
 // lots of methods that return this, which caused out-of-memory in #9527
 Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; };
->Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => Class
 >Class.prototype.m1 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m1 : any
->function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => Class
 >a : any
 >b : any
 >c : any
 >d : any
 >tx : any
 >ty : any
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : Class
 
 Class.prototype.m2 = function (x, y) { return this; };
->Class.prototype.m2 = function (x, y) { return this; } : (x: any, y: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m2 = function (x, y) { return this; } : (x: any, y: any) => Class
 >Class.prototype.m2 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m2 : any
->function (x, y) { return this; } : (x: any, y: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function (x, y) { return this; } : (x: any, y: any) => Class
 >x : any
 >y : any
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : Class
 
 Class.prototype.m3 = function (x, y) { return this; };
->Class.prototype.m3 = function (x, y) { return this; } : (x: any, y: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m3 = function (x, y) { return this; } : (x: any, y: any) => Class
 >Class.prototype.m3 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m3 : any
->function (x, y) { return this; } : (x: any, y: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function (x, y) { return this; } : (x: any, y: any) => Class
 >x : any
 >y : any
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : Class
 
 Class.prototype.m4 = function (angle) { return this; };
->Class.prototype.m4 = function (angle) { return this; } : (angle: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m4 = function (angle) { return this; } : (angle: any) => Class
 >Class.prototype.m4 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m4 : any
->function (angle) { return this; } : (angle: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function (angle) { return this; } : (angle: any) => Class
 >angle : any
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : Class
 
 Class.prototype.m5 = function (matrix) { return this; };
->Class.prototype.m5 = function (matrix) { return this; } : (matrix: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m5 = function (matrix) { return this; } : (matrix: any) => Class
 >Class.prototype.m5 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m5 : any
->function (matrix) { return this; } : (matrix: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function (matrix) { return this; } : (matrix: any) => Class
 >matrix : any
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : Class
 
 Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; };
->Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => Class
 >Class.prototype.m6 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m6 : any
->function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => Class
 >x : any
 >y : any
 >pivotX : any
@@ -97,37 +97,37 @@ Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, s
 >rotation : any
 >skewX : any
 >skewY : any
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : Class
 
 Class.prototype.m7 = function(matrix) { return this; };
->Class.prototype.m7 = function(matrix) { return this; } : (matrix: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m7 = function(matrix) { return this; } : (matrix: any) => Class
 >Class.prototype.m7 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m7 : any
->function(matrix) { return this; } : (matrix: any) => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function(matrix) { return this; } : (matrix: any) => Class
 >matrix : any
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>this : Class
 
 Class.prototype.m8 = function() { return this; };
->Class.prototype.m8 = function() { return this; } : () => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m8 = function() { return this; } : () => Class
 >Class.prototype.m8 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m8 : any
->function() { return this; } : () => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function() { return this; } : () => Class
+>this : Class
 
 Class.prototype.m9 = function () { return this; };
->Class.prototype.m9 = function () { return this; } : () => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>Class.prototype.m9 = function () { return this; } : () => Class
 >Class.prototype.m9 : any
 >Class.prototype : any
->Class : () => void
+>Class : typeof Class
 >prototype : any
 >m9 : any
->function () { return this; } : () => { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
->this : { containsError(): any; m1(a: any, b: any, c: any, d: any, tx: any, ty: any): typeof Class; m2(x: any, y: any): typeof Class; m3(x: any, y: any): typeof Class; m4(angle: any): typeof Class; m5(matrix: any): typeof Class; m6(x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any): typeof Class; m7(matrix: any): typeof Class; m8(): typeof Class; m9(): typeof Class; }
+>function () { return this; } : () => Class
+>this : Class
 
 

--- a/tests/baselines/reference/moduleExportNestedNamespaces.symbols
+++ b/tests/baselines/reference/moduleExportNestedNamespaces.symbols
@@ -17,9 +17,9 @@ module.exports.Classic = class {
 
     constructor() {
         this.p = 1
->this.p : Symbol((Anonymous class).p, Decl(mod.js, 5, 19))
->this : Symbol((Anonymous class), Decl(mod.js, 4, 24))
->p : Symbol((Anonymous class).p, Decl(mod.js, 5, 19))
+>this.p : Symbol(Classic.p, Decl(mod.js, 5, 19))
+>this : Symbol(Classic, Decl(mod.js, 4, 24))
+>p : Symbol(Classic.p, Decl(mod.js, 5, 19))
     }
 }
 
@@ -60,8 +60,8 @@ function f(c, classic) {
 >x : Symbol(C.x, Decl(mod.js, 1, 35))
 
     classic.p
->classic.p : Symbol((Anonymous class).p, Decl(mod.js, 5, 19))
+>classic.p : Symbol(Classic.p, Decl(mod.js, 5, 19))
 >classic : Symbol(classic, Decl(use.js, 9, 13))
->p : Symbol((Anonymous class).p, Decl(mod.js, 5, 19))
+>p : Symbol(Classic.p, Decl(mod.js, 5, 19))
 }
 

--- a/tests/baselines/reference/moduleExportNestedNamespaces.types
+++ b/tests/baselines/reference/moduleExportNestedNamespaces.types
@@ -28,13 +28,13 @@ module.exports.n.K = function C() {
 >10 : 10
 }
 module.exports.Classic = class {
->module.exports.Classic = class {    constructor() {        this.p = 1    }} : typeof (Anonymous class)
+>module.exports.Classic = class {    constructor() {        this.p = 1    }} : typeof Classic
 >module.exports.Classic : any
 >module.exports : any
 >module : any
 >exports : any
 >Classic : any
->class {    constructor() {        this.p = 1    }} : typeof (Anonymous class)
+>class {    constructor() {        this.p = 1    }} : typeof Classic
 
     constructor() {
         this.p = 1
@@ -65,19 +65,19 @@ k.x
 >x : number
 
 var classic = new s.Classic()
->classic : (Anonymous class)
->new s.Classic() : (Anonymous class)
->s.Classic : typeof (Anonymous class)
+>classic : Classic
+>new s.Classic() : Classic
+>s.Classic : typeof Classic
 >s : typeof s
->Classic : typeof (Anonymous class)
+>Classic : typeof Classic
 
 
 /** @param {s.n.K} c
     @param {s.Classic} classic */
 function f(c, classic) {
->f : (c: C, classic: (Anonymous class)) => void
+>f : (c: C, classic: Classic) => void
 >c : C
->classic : (Anonymous class)
+>classic : Classic
 
     c.x
 >c.x : number
@@ -86,7 +86,7 @@ function f(c, classic) {
 
     classic.p
 >classic.p : number
->classic : (Anonymous class)
+>classic : Classic
 >p : number
 }
 

--- a/tests/baselines/reference/moduleExportNestedNamespaces.types
+++ b/tests/baselines/reference/moduleExportNestedNamespaces.types
@@ -9,7 +9,7 @@ module.exports.n = {};
 >{} : typeof __object
 
 module.exports.n.K = function C() {
->module.exports.n.K = function C() {    this.x = 10;} : () => void
+>module.exports.n.K = function C() {    this.x = 10;} : typeof C
 >module.exports.n.K : any
 >module.exports.n : any
 >module.exports : any
@@ -17,8 +17,8 @@ module.exports.n.K = function C() {
 >exports : any
 >n : any
 >K : any
->function C() {    this.x = 10;} : () => void
->C : () => void
+>function C() {    this.x = 10;} : typeof C
+>C : typeof C
 
     this.x = 10;
 >this.x = 10 : 10
@@ -51,17 +51,17 @@ import * as s from './mod'
 >s : typeof s
 
 var k = new s.n.K()
->k : { x: number; }
->new s.n.K() : { x: number; }
->s.n.K : () => void
+>k : C
+>new s.n.K() : C
+>s.n.K : typeof C
 >s.n : typeof __object
 >s : typeof s
 >n : typeof __object
->K : () => void
+>K : typeof C
 
 k.x
 >k.x : number
->k : { x: number; }
+>k : C
 >x : number
 
 var classic = new s.Classic()
@@ -75,13 +75,13 @@ var classic = new s.Classic()
 /** @param {s.n.K} c
     @param {s.Classic} classic */
 function f(c, classic) {
->f : (c: { x: number; }, classic: (Anonymous class)) => void
->c : { x: number; }
+>f : (c: C, classic: (Anonymous class)) => void
+>c : C
 >classic : (Anonymous class)
 
     c.x
 >c.x : number
->c : { x: number; }
+>c : C
 >x : number
 
     classic.p

--- a/tests/baselines/reference/multipleDeclarations.types
+++ b/tests/baselines/reference/multipleDeclarations.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/input.js ===
 function C() {
->C : () => void
+>C : typeof C
 
     this.m = null;
 >this.m = null : null
@@ -13,7 +13,7 @@ C.prototype.m = function() {
 >C.prototype.m = function() {    this.nothing();} : () => void
 >C.prototype.m : any
 >C.prototype : any
->C : () => void
+>C : typeof C
 >prototype : any
 >m : any
 >function() {    this.nothing();} : () => void
@@ -21,7 +21,7 @@ C.prototype.m = function() {
     this.nothing();
 >this.nothing() : any
 >this.nothing : any
->this : { m: any; }
+>this : C
 >nothing : any
 }
 class X {

--- a/tests/baselines/reference/newTarget.es5.js
+++ b/tests/baselines/reference/newTarget.es5.js
@@ -75,5 +75,5 @@ var f2 = function _b() {
     var j = function () { return _newTarget; };
 };
 var O = {
-    k: function _c() { var _newTarget = this && this instanceof _c ? this.constructor : void 0; return _newTarget; }
+    k: function k() { var _newTarget = this && this instanceof k ? this.constructor : void 0; return _newTarget; }
 };

--- a/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.types
+++ b/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/jsDocOptionality.js ===
 function MyClass() {
->MyClass : () => void
+>MyClass : typeof MyClass
 
   this.prop = null;
 >this.prop = null : null
@@ -15,39 +15,39 @@ function MyClass() {
  * @returns {MyClass}
  */
 MyClass.prototype.optionalParam = function(required, notRequired) {
->MyClass.prototype.optionalParam = function(required, notRequired) {    return this;} : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>MyClass.prototype.optionalParam = function(required, notRequired) {    return this;} : (required: string, notRequired?: string) => MyClass
 >MyClass.prototype.optionalParam : any
 >MyClass.prototype : any
->MyClass : () => void
+>MyClass : typeof MyClass
 >prototype : any
 >optionalParam : any
->function(required, notRequired) {    return this;} : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>function(required, notRequired) {    return this;} : (required: string, notRequired?: string) => MyClass
 >required : string
 >notRequired : string
 
     return this;
->this : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>this : MyClass
 
 };
 let pInst = new MyClass();
->pInst : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->new MyClass() : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->MyClass : () => void
+>pInst : MyClass
+>new MyClass() : MyClass
+>MyClass : typeof MyClass
 
 let c1 = pInst.optionalParam('hello')
->c1 : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->pInst.optionalParam('hello') : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->pInst.optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->pInst : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>c1 : MyClass
+>pInst.optionalParam('hello') : MyClass
+>pInst.optionalParam : (required: string, notRequired?: string) => MyClass
+>pInst : MyClass
+>optionalParam : (required: string, notRequired?: string) => MyClass
 >'hello' : "hello"
 
 let c2 = pInst.optionalParam('hello', null)
->c2 : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->pInst.optionalParam('hello', null) : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->pInst.optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->pInst : { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
->optionalParam : (required: string, notRequired?: string) => { prop: any; optionalParam(required: string, notRequired?: string): typeof MyClass; }
+>c2 : MyClass
+>pInst.optionalParam('hello', null) : MyClass
+>pInst.optionalParam : (required: string, notRequired?: string) => MyClass
+>pInst : MyClass
+>optionalParam : (required: string, notRequired?: string) => MyClass
 >'hello' : "hello"
 >null : null
 

--- a/tests/baselines/reference/typeFromJSConstructor.types
+++ b/tests/baselines/reference/typeFromJSConstructor.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/a.js ===
 function Installer () {
->Installer : () => void
+>Installer : typeof Installer
 
     // arg: number
     this.arg = 0
@@ -52,7 +52,7 @@ Installer.prototype.first = function () {
 >Installer.prototype.first = function () {    this.arg = 'hi' // error    this.unknown = 'hi' // ok    this.newProperty = 1 // ok: number | boolean    this.twice = undefined // ok    this.twice = 'hi' // ok} : () => void
 >Installer.prototype.first : any
 >Installer.prototype : any
->Installer : () => void
+>Installer : typeof Installer
 >prototype : any
 >first : any
 >function () {    this.arg = 'hi' // error    this.unknown = 'hi' // ok    this.newProperty = 1 // ok: number | boolean    this.twice = undefined // ok    this.twice = 'hi' // ok} : () => void
@@ -60,35 +60,35 @@ Installer.prototype.first = function () {
     this.arg = 'hi' // error
 >this.arg = 'hi' : "hi"
 >this.arg : number
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >arg : number
 >'hi' : "hi"
 
     this.unknown = 'hi' // ok
 >this.unknown = 'hi' : "hi"
 >this.unknown : string | boolean | null
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >unknown : string | boolean | null
 >'hi' : "hi"
 
     this.newProperty = 1 // ok: number | boolean
 >this.newProperty = 1 : 1
 >this.newProperty : number | boolean | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >newProperty : number | boolean | undefined
 >1 : 1
 
     this.twice = undefined // ok
 >this.twice = undefined : undefined
 >this.twice : string | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >twice : string | undefined
 >undefined : undefined
 
     this.twice = 'hi' // ok
 >this.twice = 'hi' : "hi"
 >this.twice : string | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >twice : string | undefined
 >'hi' : "hi"
 }
@@ -96,7 +96,7 @@ Installer.prototype.second = function () {
 >Installer.prototype.second = function () {    this.arg = false // error    this.unknown = false // ok    this.newProperty = false // ok    this.twice = null // error    this.twice = false // error    this.twices.push(1) // error: Object is possibly null    if (this.twices != null) {        this.twices.push('hi')    }} : () => void
 >Installer.prototype.second : any
 >Installer.prototype : any
->Installer : () => void
+>Installer : typeof Installer
 >prototype : any
 >second : any
 >function () {    this.arg = false // error    this.unknown = false // ok    this.newProperty = false // ok    this.twice = null // error    this.twice = false // error    this.twices.push(1) // error: Object is possibly null    if (this.twices != null) {        this.twices.push('hi')    }} : () => void
@@ -104,35 +104,35 @@ Installer.prototype.second = function () {
     this.arg = false // error
 >this.arg = false : false
 >this.arg : number
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >arg : number
 >false : false
 
     this.unknown = false // ok
 >this.unknown = false : false
 >this.unknown : string | boolean | null
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >unknown : string | boolean | null
 >false : false
 
     this.newProperty = false // ok
 >this.newProperty = false : false
 >this.newProperty : number | boolean | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >newProperty : number | boolean | undefined
 >false : false
 
     this.twice = null // error
 >this.twice = null : null
 >this.twice : string | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >twice : string | undefined
 >null : null
 
     this.twice = false // error
 >this.twice = false : false
 >this.twice : string | undefined
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >twice : string | undefined
 >false : false
 
@@ -140,7 +140,7 @@ Installer.prototype.second = function () {
 >this.twices.push(1) : number
 >this.twices.push : (...items: any[]) => number
 >this.twices : any[] | null
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >twices : any[] | null
 >push : (...items: any[]) => number
 >1 : 1
@@ -148,7 +148,7 @@ Installer.prototype.second = function () {
     if (this.twices != null) {
 >this.twices != null : boolean
 >this.twices : any[] | null
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >twices : any[] | null
 >null : null
 
@@ -156,7 +156,7 @@ Installer.prototype.second = function () {
 >this.twices.push('hi') : number
 >this.twices.push : (...items: any[]) => number
 >this.twices : any[]
->this : { arg: number; unknown: string | boolean | null; twice: string | undefined; twices: any[] | null; first(): void; newProperty: number | boolean | undefined; second(): void; }
+>this : Installer
 >twices : any[]
 >push : (...items: any[]) => number
 >'hi' : "hi"

--- a/tests/baselines/reference/typeFromJSInitializer.types
+++ b/tests/baselines/reference/typeFromJSInitializer.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/a.js ===
 function A () {
->A : () => void
+>A : typeof A
 
     // should get any on this-assignments in constructor
     this.unknown = null
@@ -25,63 +25,63 @@ function A () {
 >[] : never[]
 }
 var a = new A()
->a : { unknown: any; unknowable: any; empty: any[]; }
->new A() : { unknown: any; unknowable: any; empty: any[]; }
->A : () => void
+>a : A
+>new A() : A
+>A : typeof A
 
 a.unknown = 1
 >a.unknown = 1 : 1
 >a.unknown : any
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >unknown : any
 >1 : 1
 
 a.unknown = true
 >a.unknown = true : true
 >a.unknown : any
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >unknown : any
 >true : true
 
 a.unknown = {}
 >a.unknown = {} : { [x: string]: any; }
 >a.unknown : any
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >unknown : any
 >{} : { [x: string]: any; }
 
 a.unknown = 'hi'
 >a.unknown = 'hi' : "hi"
 >a.unknown : any
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >unknown : any
 >'hi' : "hi"
 
 a.unknowable = 1
 >a.unknowable = 1 : 1
 >a.unknowable : any
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >unknowable : any
 >1 : 1
 
 a.unknowable = true
 >a.unknowable = true : true
 >a.unknowable : any
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >unknowable : any
 >true : true
 
 a.unknowable = {}
 >a.unknowable = {} : { [x: string]: any; }
 >a.unknowable : any
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >unknowable : any
 >{} : { [x: string]: any; }
 
 a.unknowable = 'hi'
 >a.unknowable = 'hi' : "hi"
 >a.unknowable : any
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >unknowable : any
 >'hi' : "hi"
 
@@ -89,7 +89,7 @@ a.empty.push(1)
 >a.empty.push(1) : number
 >a.empty.push : (...items: any[]) => number
 >a.empty : any[]
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >empty : any[]
 >push : (...items: any[]) => number
 >1 : 1
@@ -98,7 +98,7 @@ a.empty.push(true)
 >a.empty.push(true) : number
 >a.empty.push : (...items: any[]) => number
 >a.empty : any[]
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >empty : any[]
 >push : (...items: any[]) => number
 >true : true
@@ -107,7 +107,7 @@ a.empty.push({})
 >a.empty.push({}) : number
 >a.empty.push : (...items: any[]) => number
 >a.empty : any[]
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >empty : any[]
 >push : (...items: any[]) => number
 >{} : {}
@@ -116,7 +116,7 @@ a.empty.push('hi')
 >a.empty.push('hi') : number
 >a.empty.push : (...items: any[]) => number
 >a.empty : any[]
->a : { unknown: any; unknowable: any; empty: any[]; }
+>a : A
 >empty : any[]
 >push : (...items: any[]) => number
 >'hi' : "hi"

--- a/tests/baselines/reference/typeFromParamTagForFunction.symbols
+++ b/tests/baselines/reference/typeFromParamTagForFunction.symbols
@@ -14,7 +14,7 @@ exports.A = function () {
 >A : Symbol(A, Decl(a-ext.js, 0, 0))
 
     this.x = 1;
->x : Symbol((Anonymous function).x, Decl(a-ext.js, 0, 25))
+>x : Symbol(A.x, Decl(a-ext.js, 0, 25))
 
 };
 
@@ -28,9 +28,9 @@ const { A } = require("./a-ext");
 function a(p) { p.x; }
 >a : Symbol(a, Decl(a.js, 0, 33))
 >p : Symbol(p, Decl(a.js, 3, 11))
->p.x : Symbol((Anonymous function).x, Decl(a-ext.js, 0, 25))
+>p.x : Symbol(A.x, Decl(a-ext.js, 0, 25))
 >p : Symbol(p, Decl(a.js, 3, 11))
->x : Symbol((Anonymous function).x, Decl(a-ext.js, 0, 25))
+>x : Symbol(A.x, Decl(a-ext.js, 0, 25))
 
 === tests/cases/conformance/salsa/b-ext.js ===
 exports.B = class {
@@ -40,9 +40,9 @@ exports.B = class {
 
     constructor() {
         this.x = 1;
->this.x : Symbol((Anonymous class).x, Decl(b-ext.js, 1, 19))
->this : Symbol((Anonymous class), Decl(b-ext.js, 0, 11))
->x : Symbol((Anonymous class).x, Decl(b-ext.js, 1, 19))
+>this.x : Symbol(B.x, Decl(b-ext.js, 1, 19))
+>this : Symbol(B, Decl(b-ext.js, 0, 11))
+>x : Symbol(B.x, Decl(b-ext.js, 1, 19))
     }
 };
 
@@ -56,9 +56,9 @@ const { B } = require("./b-ext");
 function b(p) { p.x; }
 >b : Symbol(b, Decl(b.js, 0, 33))
 >p : Symbol(p, Decl(b.js, 3, 11))
->p.x : Symbol((Anonymous class).x, Decl(b-ext.js, 1, 19))
+>p.x : Symbol(B.x, Decl(b-ext.js, 1, 19))
 >p : Symbol(p, Decl(b.js, 3, 11))
->x : Symbol((Anonymous class).x, Decl(b-ext.js, 1, 19))
+>x : Symbol(B.x, Decl(b-ext.js, 1, 19))
 
 === tests/cases/conformance/salsa/c-ext.js ===
 export function C() {

--- a/tests/baselines/reference/typeFromParamTagForFunction.types
+++ b/tests/baselines/reference/typeFromParamTagForFunction.types
@@ -9,11 +9,11 @@ declare var module: any, exports: any;
 
 === tests/cases/conformance/salsa/a-ext.js ===
 exports.A = function () {
->exports.A = function () {    this.x = 1;} : () => void
->exports.A : () => void
+>exports.A = function () {    this.x = 1;} : typeof (Anonymous function)
+>exports.A : typeof (Anonymous function)
 >exports : typeof import("tests/cases/conformance/salsa/a-ext")
->A : () => void
->function () {    this.x = 1;} : () => void
+>A : typeof (Anonymous function)
+>function () {    this.x = 1;} : typeof (Anonymous function)
 
     this.x = 1;
 >this.x = 1 : 1
@@ -26,17 +26,17 @@ exports.A = function () {
 
 === tests/cases/conformance/salsa/a.js ===
 const { A } = require("./a-ext");
->A : () => void
+>A : typeof (Anonymous function)
 >require("./a-ext") : typeof import("tests/cases/conformance/salsa/a-ext")
 >require : (id: string) => any
 >"./a-ext" : "./a-ext"
 
 /** @param {A} p */
 function a(p) { p.x; }
->a : (p: { x: number; }) => void
->p : { x: number; }
+>a : (p: (Anonymous function)) => void
+>p : (Anonymous function)
 >p.x : number
->p : { x: number; }
+>p : (Anonymous function)
 >x : number
 
 === tests/cases/conformance/salsa/b-ext.js ===
@@ -74,7 +74,7 @@ function b(p) { p.x; }
 
 === tests/cases/conformance/salsa/c-ext.js ===
 export function C() {
->C : () => void
+>C : typeof C
 
     this.x = 1;
 >this.x = 1 : 1
@@ -86,23 +86,23 @@ export function C() {
 
 === tests/cases/conformance/salsa/c.js ===
 const { C } = require("./c-ext");
->C : () => void
+>C : typeof C
 >require("./c-ext") : typeof import("tests/cases/conformance/salsa/c-ext")
 >require : (id: string) => any
 >"./c-ext" : "./c-ext"
 
 /** @param {C} p */
 function c(p) { p.x; }
->c : (p: { x: number; }) => void
->p : { x: number; }
+>c : (p: C) => void
+>p : C
 >p.x : number
->p : { x: number; }
+>p : C
 >x : number
 
 === tests/cases/conformance/salsa/d-ext.js ===
 export var D = function() {
->D : () => void
->function() {    this.x = 1;} : () => void
+>D : typeof D
+>function() {    this.x = 1;} : typeof D
 
     this.x = 1;
 >this.x = 1 : 1
@@ -115,17 +115,17 @@ export var D = function() {
 
 === tests/cases/conformance/salsa/d.js ===
 const { D } = require("./d-ext");
->D : () => void
+>D : typeof D
 >require("./d-ext") : typeof import("tests/cases/conformance/salsa/d-ext")
 >require : (id: string) => any
 >"./d-ext" : "./d-ext"
 
 /** @param {D} p */
 function d(p) { p.x; }
->d : (p: { x: number; }) => void
->p : { x: number; }
+>d : (p: D) => void
+>p : D
 >p.x : number
->p : { x: number; }
+>p : D
 >x : number
 
 === tests/cases/conformance/salsa/e-ext.js ===
@@ -159,8 +159,8 @@ function e(p) { p.x; }
 
 === tests/cases/conformance/salsa/f.js ===
 var F = function () {
->F : () => void
->function () {    this.x = 1;} : () => void
+>F : typeof F
+>function () {    this.x = 1;} : typeof F
 
     this.x = 1;
 >this.x = 1 : 1
@@ -173,15 +173,15 @@ var F = function () {
 
 /** @param {F} p */
 function f(p) { p.x; }
->f : (p: { x: number; }) => void
->p : { x: number; }
+>f : (p: F) => void
+>p : F
 >p.x : number
->p : { x: number; }
+>p : F
 >x : number
 
 === tests/cases/conformance/salsa/g.js ===
 function G() {
->G : () => void
+>G : typeof G
 
     this.x = 1;
 >this.x = 1 : 1
@@ -193,10 +193,10 @@ function G() {
 
 /** @param {G} p */
 function g(p) { p.x; }
->g : (p: { x: number; }) => void
->p : { x: number; }
+>g : (p: G) => void
+>p : G
 >p.x : number
->p : { x: number; }
+>p : G
 >x : number
 
 === tests/cases/conformance/salsa/h.js ===

--- a/tests/baselines/reference/typeFromParamTagForFunction.types
+++ b/tests/baselines/reference/typeFromParamTagForFunction.types
@@ -9,11 +9,11 @@ declare var module: any, exports: any;
 
 === tests/cases/conformance/salsa/a-ext.js ===
 exports.A = function () {
->exports.A = function () {    this.x = 1;} : typeof (Anonymous function)
->exports.A : typeof (Anonymous function)
+>exports.A = function () {    this.x = 1;} : typeof A
+>exports.A : typeof A
 >exports : typeof import("tests/cases/conformance/salsa/a-ext")
->A : typeof (Anonymous function)
->function () {    this.x = 1;} : typeof (Anonymous function)
+>A : typeof A
+>function () {    this.x = 1;} : typeof A
 
     this.x = 1;
 >this.x = 1 : 1
@@ -26,26 +26,26 @@ exports.A = function () {
 
 === tests/cases/conformance/salsa/a.js ===
 const { A } = require("./a-ext");
->A : typeof (Anonymous function)
+>A : typeof A
 >require("./a-ext") : typeof import("tests/cases/conformance/salsa/a-ext")
 >require : (id: string) => any
 >"./a-ext" : "./a-ext"
 
 /** @param {A} p */
 function a(p) { p.x; }
->a : (p: (Anonymous function)) => void
->p : (Anonymous function)
+>a : (p: A) => void
+>p : A
 >p.x : number
->p : (Anonymous function)
+>p : A
 >x : number
 
 === tests/cases/conformance/salsa/b-ext.js ===
 exports.B = class {
->exports.B = class {    constructor() {        this.x = 1;    }} : typeof (Anonymous class)
->exports.B : typeof (Anonymous class)
+>exports.B = class {    constructor() {        this.x = 1;    }} : typeof B
+>exports.B : typeof B
 >exports : typeof import("tests/cases/conformance/salsa/b-ext")
->B : typeof (Anonymous class)
->class {    constructor() {        this.x = 1;    }} : typeof (Anonymous class)
+>B : typeof B
+>class {    constructor() {        this.x = 1;    }} : typeof B
 
     constructor() {
         this.x = 1;
@@ -59,17 +59,17 @@ exports.B = class {
 
 === tests/cases/conformance/salsa/b.js ===
 const { B } = require("./b-ext");
->B : typeof (Anonymous class)
+>B : typeof B
 >require("./b-ext") : typeof import("tests/cases/conformance/salsa/b-ext")
 >require : (id: string) => any
 >"./b-ext" : "./b-ext"
 
 /** @param {B} p */
 function b(p) { p.x; }
->b : (p: (Anonymous class)) => void
->p : (Anonymous class)
+>b : (p: B) => void
+>p : B
 >p.x : number
->p : (Anonymous class)
+>p : B
 >x : number
 
 === tests/cases/conformance/salsa/c-ext.js ===

--- a/tests/baselines/reference/typeFromPropertyAssignment10.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment10.symbols
@@ -39,9 +39,9 @@ Outer.app.Inner = class {
     constructor() {
         /** @type {number} */
         this.y = 12;
->this.y : Symbol((Anonymous class).y, Decl(someview.js, 7, 19))
->this : Symbol((Anonymous class), Decl(someview.js, 6, 17))
->y : Symbol((Anonymous class).y, Decl(someview.js, 7, 19))
+>this.y : Symbol(Inner.y, Decl(someview.js, 7, 19))
+>this : Symbol(Inner, Decl(someview.js, 6, 17))
+>y : Symbol(Inner.y, Decl(someview.js, 7, 19))
     }
 }
 var example = new Outer.app.Inner();
@@ -53,9 +53,9 @@ var example = new Outer.app.Inner();
 >Inner : Symbol(Outer.app.Inner, Decl(someview.js, 5, 5))
 
 example.y;
->example.y : Symbol((Anonymous class).y, Decl(someview.js, 7, 19))
+>example.y : Symbol(Inner.y, Decl(someview.js, 7, 19))
 >example : Symbol(example, Decl(someview.js, 12, 3))
->y : Symbol((Anonymous class).y, Decl(someview.js, 7, 19))
+>y : Symbol(Inner.y, Decl(someview.js, 7, 19))
 
 /** @param {number} k */
 Outer.app.statische = function (k) {
@@ -119,18 +119,18 @@ var inner = new Outer.app.Inner();
 >Inner : Symbol(Outer.app.Inner, Decl(someview.js, 5, 5))
 
 inner.y;
->inner.y : Symbol((Anonymous class).y, Decl(someview.js, 7, 19))
+>inner.y : Symbol(Inner.y, Decl(someview.js, 7, 19))
 >inner : Symbol(inner, Decl(main.js, 1, 3))
->y : Symbol((Anonymous class).y, Decl(someview.js, 7, 19))
+>y : Symbol(Inner.y, Decl(someview.js, 7, 19))
 
 /** @type {Outer.app.Inner} */
 var x;
 >x : Symbol(x, Decl(main.js, 4, 3))
 
 x.y;
->x.y : Symbol((Anonymous class).y, Decl(someview.js, 7, 19))
+>x.y : Symbol(Inner.y, Decl(someview.js, 7, 19))
 >x : Symbol(x, Decl(main.js, 4, 3))
->y : Symbol((Anonymous class).y, Decl(someview.js, 7, 19))
+>y : Symbol(Inner.y, Decl(someview.js, 7, 19))
 
 Outer.app.statische(101); // Infinity, duh
 >Outer.app.statische : Symbol(Outer.app.statische, Decl(someview.js, 13, 10))

--- a/tests/baselines/reference/typeFromPropertyAssignment10.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment10.types
@@ -41,13 +41,13 @@ Outer.app.SomeView = (function () {
 
 })();
 Outer.app.Inner = class {
->Outer.app.Inner = class {    constructor() {        /** @type {number} */        this.y = 12;    }} : typeof (Anonymous class)
->Outer.app.Inner : typeof (Anonymous class)
+>Outer.app.Inner = class {    constructor() {        /** @type {number} */        this.y = 12;    }} : typeof Inner
+>Outer.app.Inner : typeof Inner
 >Outer.app : typeof __object
 >Outer : typeof __object
 >app : typeof __object
->Inner : typeof (Anonymous class)
->class {    constructor() {        /** @type {number} */        this.y = 12;    }} : typeof (Anonymous class)
+>Inner : typeof Inner
+>class {    constructor() {        /** @type {number} */        this.y = 12;    }} : typeof Inner
 
     constructor() {
         /** @type {number} */
@@ -60,17 +60,17 @@ Outer.app.Inner = class {
     }
 }
 var example = new Outer.app.Inner();
->example : (Anonymous class)
->new Outer.app.Inner() : (Anonymous class)
->Outer.app.Inner : typeof (Anonymous class)
+>example : Inner
+>new Outer.app.Inner() : Inner
+>Outer.app.Inner : typeof Inner
 >Outer.app : typeof __object
 >Outer : typeof __object
 >app : typeof __object
->Inner : typeof (Anonymous class)
+>Inner : typeof Inner
 
 example.y;
 >example.y : number
->example : (Anonymous class)
+>example : Inner
 >y : number
 
 /** @param {number} k */
@@ -141,26 +141,26 @@ var app = new Outer.app.Application();
 >Application : () => void
 
 var inner = new Outer.app.Inner();
->inner : (Anonymous class)
->new Outer.app.Inner() : (Anonymous class)
->Outer.app.Inner : typeof (Anonymous class)
+>inner : Inner
+>new Outer.app.Inner() : Inner
+>Outer.app.Inner : typeof Inner
 >Outer.app : typeof __object
 >Outer : typeof __object
 >app : typeof __object
->Inner : typeof (Anonymous class)
+>Inner : typeof Inner
 
 inner.y;
 >inner.y : number
->inner : (Anonymous class)
+>inner : Inner
 >y : number
 
 /** @type {Outer.app.Inner} */
 var x;
->x : (Anonymous class)
+>x : Inner
 
 x.y;
 >x.y : number
->x : (Anonymous class)
+>x : Inner
 >y : number
 
 Outer.app.statische(101); // Infinity, duh

--- a/tests/baselines/reference/typeFromPropertyAssignment11.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment11.types
@@ -1,12 +1,12 @@
 === tests/cases/conformance/salsa/module.js ===
 var Inner = function() {}
->Inner : () => void
->function() {} : () => void
+>Inner : typeof Inner
+>function() {} : typeof Inner
 
 Inner.prototype = {
 >Inner.prototype = {    m() { },    i: 1} : { [x: string]: any; m(): void; i: number; }
 >Inner.prototype : any
->Inner : () => void
+>Inner : typeof Inner
 >prototype : any
 >{    m() { },    i: 1} : { [x: string]: any; m(): void; i: number; }
 
@@ -22,7 +22,7 @@ Inner.prototype.j = 2
 >Inner.prototype.j = 2 : 2
 >Inner.prototype.j : any
 >Inner.prototype : any
->Inner : () => void
+>Inner : typeof Inner
 >prototype : any
 >j : any
 >2 : 2
@@ -31,33 +31,33 @@ Inner.prototype.j = 2
 Inner.prototype.k;
 >Inner.prototype.k : any
 >Inner.prototype : any
->Inner : () => void
+>Inner : typeof Inner
 >prototype : any
 >k : any
 
 var inner = new Inner()
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
->new Inner() : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
->Inner : () => void
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
+>new Inner() : Inner & { [x: string]: any; m(): void; i: number; }
+>Inner : typeof Inner
 
 inner.m()
 >inner.m() : void
 >inner.m : () => void
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
 >m : () => void
 
 inner.i
 >inner.i : number
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
 >i : number
 
 inner.j
 >inner.j : number
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
 >j : number
 
 inner.k
 >inner.k : string
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
 >k : string
 

--- a/tests/baselines/reference/typeFromPropertyAssignment12.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment12.symbols
@@ -28,8 +28,8 @@ var pos = new Outer.Pos(1, 'x');
 >Pos : Symbol(Outer.Pos, Decl(usage.js, 0, 0))
 
 pos.line;
->pos.line : Symbol((Anonymous function).line, Decl(usage.js, 1, 35))
+>pos.line : Symbol(Pos.line, Decl(usage.js, 1, 35))
 >pos : Symbol(pos, Decl(usage.js, 4, 3))
->line : Symbol((Anonymous function).line, Decl(usage.js, 1, 35))
+>line : Symbol(Pos.line, Decl(usage.js, 1, 35))
 
 

--- a/tests/baselines/reference/typeFromPropertyAssignment12.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment12.types
@@ -8,11 +8,11 @@ var Outer = function(element, config) {};
 === tests/cases/conformance/salsa/usage.js ===
 /** @constructor */
 Outer.Pos = function (line, ch) {};
->Outer.Pos = function (line, ch) {} : (line: any, ch: any) => void
->Outer.Pos : (line: any, ch: any) => void
+>Outer.Pos = function (line, ch) {} : typeof (Anonymous function)
+>Outer.Pos : typeof (Anonymous function)
 >Outer : typeof Outer
->Pos : (line: any, ch: any) => void
->function (line, ch) {} : (line: any, ch: any) => void
+>Pos : typeof (Anonymous function)
+>function (line, ch) {} : typeof (Anonymous function)
 >line : any
 >ch : any
 
@@ -20,24 +20,24 @@ Outer.Pos = function (line, ch) {};
 Outer.Pos.prototype.line;
 >Outer.Pos.prototype.line : any
 >Outer.Pos.prototype : any
->Outer.Pos : (line: any, ch: any) => void
+>Outer.Pos : typeof (Anonymous function)
 >Outer : typeof Outer
->Pos : (line: any, ch: any) => void
+>Pos : typeof (Anonymous function)
 >prototype : any
 >line : any
 
 var pos = new Outer.Pos(1, 'x');
->pos : { line: number; }
->new Outer.Pos(1, 'x') : { line: number; }
->Outer.Pos : (line: any, ch: any) => void
+>pos : (Anonymous function)
+>new Outer.Pos(1, 'x') : (Anonymous function)
+>Outer.Pos : typeof (Anonymous function)
 >Outer : typeof Outer
->Pos : (line: any, ch: any) => void
+>Pos : typeof (Anonymous function)
 >1 : 1
 >'x' : "x"
 
 pos.line;
 >pos.line : number
->pos : { line: number; }
+>pos : (Anonymous function)
 >line : number
 
 

--- a/tests/baselines/reference/typeFromPropertyAssignment12.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment12.types
@@ -8,11 +8,11 @@ var Outer = function(element, config) {};
 === tests/cases/conformance/salsa/usage.js ===
 /** @constructor */
 Outer.Pos = function (line, ch) {};
->Outer.Pos = function (line, ch) {} : typeof (Anonymous function)
->Outer.Pos : typeof (Anonymous function)
+>Outer.Pos = function (line, ch) {} : typeof Pos
+>Outer.Pos : typeof Pos
 >Outer : typeof Outer
->Pos : typeof (Anonymous function)
->function (line, ch) {} : typeof (Anonymous function)
+>Pos : typeof Pos
+>function (line, ch) {} : typeof Pos
 >line : any
 >ch : any
 
@@ -20,24 +20,24 @@ Outer.Pos = function (line, ch) {};
 Outer.Pos.prototype.line;
 >Outer.Pos.prototype.line : any
 >Outer.Pos.prototype : any
->Outer.Pos : typeof (Anonymous function)
+>Outer.Pos : typeof Pos
 >Outer : typeof Outer
->Pos : typeof (Anonymous function)
+>Pos : typeof Pos
 >prototype : any
 >line : any
 
 var pos = new Outer.Pos(1, 'x');
->pos : (Anonymous function)
->new Outer.Pos(1, 'x') : (Anonymous function)
->Outer.Pos : typeof (Anonymous function)
+>pos : Pos
+>new Outer.Pos(1, 'x') : Pos
+>Outer.Pos : typeof Pos
 >Outer : typeof Outer
->Pos : typeof (Anonymous function)
+>Pos : typeof Pos
 >1 : 1
 >'x' : "x"
 
 pos.line;
 >pos.line : number
->pos : (Anonymous function)
+>pos : Pos
 >line : number
 
 

--- a/tests/baselines/reference/typeFromPropertyAssignment13.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment13.symbols
@@ -22,12 +22,12 @@ Outer.Inner.prototype = {
 }
 // incremental assignments still work
 Outer.Inner.prototype.j = 2
->Outer.Inner.prototype : Symbol((Anonymous function).j, Decl(module.js, 5, 1))
+>Outer.Inner.prototype : Symbol(Inner.j, Decl(module.js, 5, 1))
 >Outer.Inner : Symbol(Inner, Decl(module.js, 0, 14), Decl(module.js, 2, 6))
 >Outer : Symbol(Outer, Decl(module.js, 0, 3), Decl(module.js, 0, 14), Decl(module.js, 1, 27))
 >Inner : Symbol(Inner, Decl(module.js, 0, 14), Decl(module.js, 2, 6))
 >prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
->j : Symbol((Anonymous function).j, Decl(module.js, 5, 1))
+>j : Symbol(Inner.j, Decl(module.js, 5, 1))
 
 /** @type {string} */
 Outer.Inner.prototype.k;
@@ -54,12 +54,12 @@ inner.i
 >i : Symbol(i, Decl(module.js, 3, 12))
 
 inner.j
->inner.j : Symbol((Anonymous function).j, Decl(module.js, 5, 1))
+>inner.j : Symbol(Inner.j, Decl(module.js, 5, 1))
 >inner : Symbol(inner, Decl(module.js, 10, 3))
->j : Symbol((Anonymous function).j, Decl(module.js, 5, 1))
+>j : Symbol(Inner.j, Decl(module.js, 5, 1))
 
 inner.k
->inner.k : Symbol((Anonymous function).k, Decl(module.js, 7, 27))
+>inner.k : Symbol(Inner.k, Decl(module.js, 7, 27))
 >inner : Symbol(inner, Decl(module.js, 10, 3))
->k : Symbol((Anonymous function).k, Decl(module.js, 7, 27))
+>k : Symbol(Inner.k, Decl(module.js, 7, 27))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment13.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment13.types
@@ -4,18 +4,18 @@ var Outer = {}
 >{} : { [x: string]: any; Inner(): void; }
 
 Outer.Inner = function() {}
->Outer.Inner = function() {} : typeof (Anonymous function)
->Outer.Inner : typeof (Anonymous function)
+>Outer.Inner = function() {} : typeof Inner
+>Outer.Inner : typeof Inner
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : typeof (Anonymous function)
->function() {} : typeof (Anonymous function)
+>Inner : typeof Inner
+>function() {} : typeof Inner
 
 Outer.Inner.prototype = {
 >Outer.Inner.prototype = {    m() { },    i: 1} : { [x: string]: any; m(): void; i: number; }
 >Outer.Inner.prototype : any
->Outer.Inner : typeof (Anonymous function)
+>Outer.Inner : typeof Inner
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : typeof (Anonymous function)
+>Inner : typeof Inner
 >prototype : any
 >{    m() { },    i: 1} : { [x: string]: any; m(): void; i: number; }
 
@@ -31,9 +31,9 @@ Outer.Inner.prototype.j = 2
 >Outer.Inner.prototype.j = 2 : 2
 >Outer.Inner.prototype.j : any
 >Outer.Inner.prototype : any
->Outer.Inner : typeof (Anonymous function)
+>Outer.Inner : typeof Inner
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : typeof (Anonymous function)
+>Inner : typeof Inner
 >prototype : any
 >j : any
 >2 : 2
@@ -42,37 +42,37 @@ Outer.Inner.prototype.j = 2
 Outer.Inner.prototype.k;
 >Outer.Inner.prototype.k : any
 >Outer.Inner.prototype : any
->Outer.Inner : typeof (Anonymous function)
+>Outer.Inner : typeof Inner
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : typeof (Anonymous function)
+>Inner : typeof Inner
 >prototype : any
 >k : any
 
 var inner = new Outer.Inner()
->inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
->new Outer.Inner() : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
->Outer.Inner : typeof (Anonymous function)
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
+>new Outer.Inner() : Inner & { [x: string]: any; m(): void; i: number; }
+>Outer.Inner : typeof Inner
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : typeof (Anonymous function)
+>Inner : typeof Inner
 
 inner.m()
 >inner.m() : void
 >inner.m : () => void
->inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
 >m : () => void
 
 inner.i
 >inner.i : number
->inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
 >i : number
 
 inner.j
 >inner.j : number
->inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
 >j : number
 
 inner.k
 >inner.k : string
->inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
+>inner : Inner & { [x: string]: any; m(): void; i: number; }
 >k : string
 

--- a/tests/baselines/reference/typeFromPropertyAssignment13.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment13.types
@@ -4,18 +4,18 @@ var Outer = {}
 >{} : { [x: string]: any; Inner(): void; }
 
 Outer.Inner = function() {}
->Outer.Inner = function() {} : () => void
->Outer.Inner : () => void
+>Outer.Inner = function() {} : typeof (Anonymous function)
+>Outer.Inner : typeof (Anonymous function)
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : () => void
->function() {} : () => void
+>Inner : typeof (Anonymous function)
+>function() {} : typeof (Anonymous function)
 
 Outer.Inner.prototype = {
 >Outer.Inner.prototype = {    m() { },    i: 1} : { [x: string]: any; m(): void; i: number; }
 >Outer.Inner.prototype : any
->Outer.Inner : () => void
+>Outer.Inner : typeof (Anonymous function)
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : () => void
+>Inner : typeof (Anonymous function)
 >prototype : any
 >{    m() { },    i: 1} : { [x: string]: any; m(): void; i: number; }
 
@@ -31,9 +31,9 @@ Outer.Inner.prototype.j = 2
 >Outer.Inner.prototype.j = 2 : 2
 >Outer.Inner.prototype.j : any
 >Outer.Inner.prototype : any
->Outer.Inner : () => void
+>Outer.Inner : typeof (Anonymous function)
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : () => void
+>Inner : typeof (Anonymous function)
 >prototype : any
 >j : any
 >2 : 2
@@ -42,37 +42,37 @@ Outer.Inner.prototype.j = 2
 Outer.Inner.prototype.k;
 >Outer.Inner.prototype.k : any
 >Outer.Inner.prototype : any
->Outer.Inner : () => void
+>Outer.Inner : typeof (Anonymous function)
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : () => void
+>Inner : typeof (Anonymous function)
 >prototype : any
 >k : any
 
 var inner = new Outer.Inner()
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
->new Outer.Inner() : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
->Outer.Inner : () => void
+>inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
+>new Outer.Inner() : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
+>Outer.Inner : typeof (Anonymous function)
 >Outer : { [x: string]: any; Inner(): void; }
->Inner : () => void
+>Inner : typeof (Anonymous function)
 
 inner.m()
 >inner.m() : void
 >inner.m : () => void
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
+>inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
 >m : () => void
 
 inner.i
 >inner.i : number
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
+>inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
 >i : number
 
 inner.j
 >inner.j : number
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
+>inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
 >j : number
 
 inner.k
 >inner.k : string
->inner : { j: number; k: string; } & { [x: string]: any; m(): void; i: number; }
+>inner : (Anonymous function) & { [x: string]: any; m(): void; i: number; }
 >k : string
 

--- a/tests/baselines/reference/typeFromPropertyAssignment15.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment15.symbols
@@ -9,12 +9,12 @@ Outer.Inner = class {
 
     constructor() {
         this.x = 1
->this.x : Symbol((Anonymous class).x, Decl(a.js, 3, 19))
->this : Symbol((Anonymous class), Decl(a.js, 2, 13))
->x : Symbol((Anonymous class).x, Decl(a.js, 3, 19))
+>this.x : Symbol(Inner.x, Decl(a.js, 3, 19))
+>this : Symbol(Inner, Decl(a.js, 2, 13))
+>x : Symbol(Inner.x, Decl(a.js, 3, 19))
     }
     m() { }
->m : Symbol((Anonymous class).m, Decl(a.js, 5, 5))
+>m : Symbol(Inner.m, Decl(a.js, 5, 5))
 }
 
 /** @type {Outer.Inner} */
@@ -22,14 +22,14 @@ var inner
 >inner : Symbol(inner, Decl(a.js, 10, 3))
 
 inner.x
->inner.x : Symbol((Anonymous class).x, Decl(a.js, 3, 19))
+>inner.x : Symbol(Inner.x, Decl(a.js, 3, 19))
 >inner : Symbol(inner, Decl(a.js, 10, 3))
->x : Symbol((Anonymous class).x, Decl(a.js, 3, 19))
+>x : Symbol(Inner.x, Decl(a.js, 3, 19))
 
 inner.m()
->inner.m : Symbol((Anonymous class).m, Decl(a.js, 5, 5))
+>inner.m : Symbol(Inner.m, Decl(a.js, 5, 5))
 >inner : Symbol(inner, Decl(a.js, 10, 3))
->m : Symbol((Anonymous class).m, Decl(a.js, 5, 5))
+>m : Symbol(Inner.m, Decl(a.js, 5, 5))
 
 var inno = new Outer.Inner()
 >inno : Symbol(inno, Decl(a.js, 13, 3))
@@ -38,12 +38,12 @@ var inno = new Outer.Inner()
 >Inner : Symbol(Inner, Decl(a.js, 0, 15))
 
 inno.x
->inno.x : Symbol((Anonymous class).x, Decl(a.js, 3, 19))
+>inno.x : Symbol(Inner.x, Decl(a.js, 3, 19))
 >inno : Symbol(inno, Decl(a.js, 13, 3))
->x : Symbol((Anonymous class).x, Decl(a.js, 3, 19))
+>x : Symbol(Inner.x, Decl(a.js, 3, 19))
 
 inno.m()
->inno.m : Symbol((Anonymous class).m, Decl(a.js, 5, 5))
+>inno.m : Symbol(Inner.m, Decl(a.js, 5, 5))
 >inno : Symbol(inno, Decl(a.js, 13, 3))
->m : Symbol((Anonymous class).m, Decl(a.js, 5, 5))
+>m : Symbol(Inner.m, Decl(a.js, 5, 5))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment15.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment15.types
@@ -1,14 +1,14 @@
 === tests/cases/conformance/salsa/a.js ===
 var Outer = {};
->Outer : { [x: string]: any; Inner: typeof (Anonymous class); }
->{} : { [x: string]: any; Inner: typeof (Anonymous class); }
+>Outer : { [x: string]: any; Inner: typeof Inner; }
+>{} : { [x: string]: any; Inner: typeof Inner; }
 
 Outer.Inner = class {
->Outer.Inner = class {    constructor() {        this.x = 1    }    m() { }} : typeof (Anonymous class)
->Outer.Inner : typeof (Anonymous class)
->Outer : { [x: string]: any; Inner: typeof (Anonymous class); }
->Inner : typeof (Anonymous class)
->class {    constructor() {        this.x = 1    }    m() { }} : typeof (Anonymous class)
+>Outer.Inner = class {    constructor() {        this.x = 1    }    m() { }} : typeof Inner
+>Outer.Inner : typeof Inner
+>Outer : { [x: string]: any; Inner: typeof Inner; }
+>Inner : typeof Inner
+>class {    constructor() {        this.x = 1    }    m() { }} : typeof Inner
 
     constructor() {
         this.x = 1
@@ -24,34 +24,34 @@ Outer.Inner = class {
 
 /** @type {Outer.Inner} */
 var inner
->inner : (Anonymous class)
+>inner : Inner
 
 inner.x
 >inner.x : number
->inner : (Anonymous class)
+>inner : Inner
 >x : number
 
 inner.m()
 >inner.m() : void
 >inner.m : () => void
->inner : (Anonymous class)
+>inner : Inner
 >m : () => void
 
 var inno = new Outer.Inner()
->inno : (Anonymous class)
->new Outer.Inner() : (Anonymous class)
->Outer.Inner : typeof (Anonymous class)
->Outer : { [x: string]: any; Inner: typeof (Anonymous class); }
->Inner : typeof (Anonymous class)
+>inno : Inner
+>new Outer.Inner() : Inner
+>Outer.Inner : typeof Inner
+>Outer : { [x: string]: any; Inner: typeof Inner; }
+>Inner : typeof Inner
 
 inno.x
 >inno.x : number
->inno : (Anonymous class)
+>inno : Inner
 >x : number
 
 inno.m()
 >inno.m() : void
 >inno.m : () => void
->inno : (Anonymous class)
+>inno : Inner
 >m : () => void
 

--- a/tests/baselines/reference/typeFromPropertyAssignment17.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment17.types
@@ -15,8 +15,8 @@ mini.M.defaults()
 >defaults : (def: any) => any
 
 var m = new mini.M()
->m : typeof M
->new mini.M() : typeof M
+>m : M
+>new mini.M() : M
 >mini.M : typeof M
 >mini : { (): void; M: typeof M; filter: () => void; }
 >M : typeof M
@@ -24,7 +24,7 @@ var m = new mini.M()
 m.m()
 >m.m() : void
 >m.m : () => void
->m : typeof M
+>m : M
 >m : () => void
 
 mini.filter()

--- a/tests/baselines/reference/typeFromPropertyAssignment2.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment2.types
@@ -28,11 +28,11 @@ Outer.Inner = class I {
 }
 /** @type {Outer} */
 var ok
->ok : typeof Outer
+>ok : Outer
 
 ok.y
 >ok.y : number
->ok : typeof Outer
+>ok : Outer
 >y : number
 
 /** @type {Outer.Inner} */

--- a/tests/baselines/reference/typeFromPropertyAssignment20.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment20.types
@@ -12,7 +12,7 @@
 >inner : () => void
 
         function Async() {
->Async : () => void
+>Async : typeof Async
 
             this._trampolineEnabled = true;
 >this._trampolineEnabled = true : true
@@ -26,7 +26,7 @@
 >Async.prototype.disableTrampolineIfNecessary = function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        } : (b: any) => void
 >Async.prototype.disableTrampolineIfNecessary : any
 >Async.prototype : any
->Async : () => void
+>Async : typeof Async
 >prototype : any
 >disableTrampolineIfNecessary : any
 >function dtin(b) {            if (b) {                this._trampolineEnabled = false;            }        } : (b: any) => void
@@ -39,7 +39,7 @@
                 this._trampolineEnabled = false;
 >this._trampolineEnabled = false : false
 >this._trampolineEnabled : boolean
->this : { _trampolineEnabled: boolean; disableTrampolineIfNecessary(b: any): void; }
+>this : Async
 >_trampolineEnabled : boolean
 >false : false
             }

--- a/tests/baselines/reference/typeFromPropertyAssignment22.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment22.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/npm-install.js ===
 function Installer () {
->Installer : () => void
+>Installer : typeof Installer
 
     this.args = 0
 >this.args = 0 : 0
@@ -13,7 +13,7 @@ Installer.prototype.loadArgMetadata = function (next) {
 >Installer.prototype.loadArgMetadata = function (next) {    // ArrowFunction isn't treated as a this-container    (args) => {        this.args = 'hi'        this.newProperty = 1    }} : (next: any) => void
 >Installer.prototype.loadArgMetadata : any
 >Installer.prototype : any
->Installer : () => void
+>Installer : typeof Installer
 >prototype : any
 >loadArgMetadata : any
 >function (next) {    // ArrowFunction isn't treated as a this-container    (args) => {        this.args = 'hi'        this.newProperty = 1    }} : (next: any) => void
@@ -27,29 +27,29 @@ Installer.prototype.loadArgMetadata = function (next) {
         this.args = 'hi'
 >this.args = 'hi' : "hi"
 >this.args : number
->this : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
+>this : Installer
 >args : number
 >'hi' : "hi"
 
         this.newProperty = 1
 >this.newProperty = 1 : 1
 >this.newProperty : number | undefined
->this : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
+>this : Installer
 >newProperty : number | undefined
 >1 : 1
     }
 }
 var i = new Installer()
->i : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
->new Installer() : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
->Installer : () => void
+>i : Installer
+>new Installer() : Installer
+>Installer : typeof Installer
 
 i.newProperty = i.args // ok, number ==> number | undefined
 >i.newProperty = i.args : number
 >i.newProperty : number | undefined
->i : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
+>i : Installer
 >newProperty : number | undefined
 >i.args : number
->i : { args: number; loadArgMetadata(next: any): void; newProperty: number | undefined; }
+>i : Installer
 >args : number
 

--- a/tests/baselines/reference/typeFromPropertyAssignment3.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment3.types
@@ -1,8 +1,8 @@
 === tests/cases/conformance/salsa/a.js ===
 var Outer = function O() {
->Outer : { (): void; Inner: typeof I; }
->function O() {    this.y = 2} : { (): void; Inner: typeof I; }
->O : { (): void; Inner: typeof I; }
+>Outer : typeof O
+>function O() {    this.y = 2} : typeof O
+>O : typeof O
 
     this.y = 2
 >this.y = 2 : 2
@@ -14,7 +14,7 @@ var Outer = function O() {
 Outer.Inner = class I {
 >Outer.Inner = class I {    constructor() {        this.x = 1    }} : typeof I
 >Outer.Inner : typeof I
->Outer : { (): void; Inner: typeof I; }
+>Outer : typeof O
 >Inner : typeof I
 >class I {    constructor() {        this.x = 1    }} : typeof I
 >I : typeof I
@@ -30,11 +30,11 @@ Outer.Inner = class I {
 }
 /** @type {Outer} */
 var ja
->ja : { y: number; }
+>ja : O
 
 ja.y
 >ja.y : number
->ja : { y: number; }
+>ja : O
 >y : number
 
 /** @type {Outer.Inner} */

--- a/tests/baselines/reference/typeFromPropertyAssignment4.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment4.symbols
@@ -11,9 +11,9 @@ Outer.Inner = class {
     constructor() {
         /** @type {number} */
         this.y = 12
->this.y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
->this : Symbol((Anonymous class), Decl(a.js, 0, 13))
->y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>this.y : Symbol(Inner.y, Decl(a.js, 1, 19))
+>this : Symbol(Inner, Decl(a.js, 0, 13))
+>y : Symbol(Inner.y, Decl(a.js, 1, 19))
     }
 }
 
@@ -22,9 +22,9 @@ var local
 >local : Symbol(local, Decl(a.js, 8, 3))
 
 local.y
->local.y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>local.y : Symbol(Inner.y, Decl(a.js, 1, 19))
 >local : Symbol(local, Decl(a.js, 8, 3))
->y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>y : Symbol(Inner.y, Decl(a.js, 1, 19))
 
 var inner = new Outer.Inner()
 >inner : Symbol(inner, Decl(a.js, 10, 3))
@@ -33,9 +33,9 @@ var inner = new Outer.Inner()
 >Inner : Symbol(Outer.Inner, Decl(a.js, 0, 0))
 
 inner.y
->inner.y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>inner.y : Symbol(Inner.y, Decl(a.js, 1, 19))
 >inner : Symbol(inner, Decl(a.js, 10, 3))
->y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>y : Symbol(Inner.y, Decl(a.js, 1, 19))
 
 === tests/cases/conformance/salsa/b.js ===
 /** @type {Outer.Inner} */
@@ -43,9 +43,9 @@ var x
 >x : Symbol(x, Decl(b.js, 1, 3))
 
 x.y
->x.y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>x.y : Symbol(Inner.y, Decl(a.js, 1, 19))
 >x : Symbol(x, Decl(b.js, 1, 3))
->y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>y : Symbol(Inner.y, Decl(a.js, 1, 19))
 
 var z = new Outer.Inner()
 >z : Symbol(z, Decl(b.js, 3, 3))
@@ -54,7 +54,7 @@ var z = new Outer.Inner()
 >Inner : Symbol(Outer.Inner, Decl(a.js, 0, 0))
 
 z.y
->z.y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>z.y : Symbol(Inner.y, Decl(a.js, 1, 19))
 >z : Symbol(z, Decl(b.js, 3, 3))
->y : Symbol((Anonymous class).y, Decl(a.js, 1, 19))
+>y : Symbol(Inner.y, Decl(a.js, 1, 19))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment4.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment4.types
@@ -5,11 +5,11 @@ var Outer = {};
 
 === tests/cases/conformance/salsa/a.js ===
 Outer.Inner = class {
->Outer.Inner = class {    constructor() {        /** @type {number} */        this.y = 12    }} : typeof (Anonymous class)
->Outer.Inner : typeof (Anonymous class)
+>Outer.Inner = class {    constructor() {        /** @type {number} */        this.y = 12    }} : typeof Inner
+>Outer.Inner : typeof Inner
 >Outer : typeof Outer
->Inner : typeof (Anonymous class)
->class {    constructor() {        /** @type {number} */        this.y = 12    }} : typeof (Anonymous class)
+>Inner : typeof Inner
+>class {    constructor() {        /** @type {number} */        this.y = 12    }} : typeof Inner
 
     constructor() {
         /** @type {number} */
@@ -24,44 +24,44 @@ Outer.Inner = class {
 
 /** @type {Outer.Inner} */
 var local
->local : (Anonymous class)
+>local : Inner
 
 local.y
 >local.y : number
->local : (Anonymous class)
+>local : Inner
 >y : number
 
 var inner = new Outer.Inner()
->inner : (Anonymous class)
->new Outer.Inner() : (Anonymous class)
->Outer.Inner : typeof (Anonymous class)
+>inner : Inner
+>new Outer.Inner() : Inner
+>Outer.Inner : typeof Inner
 >Outer : typeof Outer
->Inner : typeof (Anonymous class)
+>Inner : typeof Inner
 
 inner.y
 >inner.y : number
->inner : (Anonymous class)
+>inner : Inner
 >y : number
 
 === tests/cases/conformance/salsa/b.js ===
 /** @type {Outer.Inner} */
 var x
->x : (Anonymous class)
+>x : Inner
 
 x.y
 >x.y : number
->x : (Anonymous class)
+>x : Inner
 >y : number
 
 var z = new Outer.Inner()
->z : (Anonymous class)
->new Outer.Inner() : (Anonymous class)
->Outer.Inner : typeof (Anonymous class)
+>z : Inner
+>new Outer.Inner() : Inner
+>Outer.Inner : typeof Inner
 >Outer : typeof Outer
->Inner : typeof (Anonymous class)
+>Inner : typeof Inner
 
 z.y
 >z.y : number
->z : (Anonymous class)
+>z : Inner
 >y : number
 

--- a/tests/baselines/reference/typeFromPropertyAssignment9.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment9.symbols
@@ -55,24 +55,24 @@ var q = new my.predicate.query();
 >query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
 
 my.predicate.query.another = function () {
->my.predicate.query.another : Symbol((Anonymous function).another, Decl(a.js, 12, 33))
+>my.predicate.query.another : Symbol(query.another, Decl(a.js, 12, 33))
 >my.predicate.query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
 >my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
 >predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
->another : Symbol((Anonymous function).another, Decl(a.js, 12, 33))
+>another : Symbol(query.another, Decl(a.js, 12, 33))
 
     return 1;
 }
 my.predicate.query.result = 'none'
->my.predicate.query.result : Symbol((Anonymous function).result, Decl(a.js, 15, 1))
+>my.predicate.query.result : Symbol(query.result, Decl(a.js, 15, 1))
 >my.predicate.query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
 >my.predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >my : Symbol(my, Decl(a.js, 0, 3), Decl(a.js, 0, 18), Decl(a.js, 5, 14), Decl(a.js, 6, 15), Decl(a.js, 7, 34) ... and 3 more)
 >predicate : Symbol(predicate, Decl(a.js, 6, 15), Decl(a.js, 8, 3), Decl(a.js, 13, 3), Decl(a.js, 20, 3), Decl(a.js, 23, 3))
 >query : Symbol(query, Decl(a.js, 7, 34), Decl(a.js, 13, 13))
->result : Symbol((Anonymous function).result, Decl(a.js, 15, 1))
+>result : Symbol(query.result, Decl(a.js, 15, 1))
 
 /** @param {number} first
  *  @param {number} second
@@ -105,7 +105,7 @@ my.predicate.type = class {
 >type : Symbol(type, Decl(a.js, 22, 1))
 
     m() { return 101; }
->m : Symbol((Anonymous class).m, Decl(a.js, 23, 27))
+>m : Symbol(type.m, Decl(a.js, 23, 27))
 }
 
 
@@ -119,11 +119,11 @@ min.nest = this.min.nest || function () { };
 >nest : Symbol(nest, Decl(a.js, 29, 27), Decl(a.js, 31, 4))
 
 min.nest.other = self.min.nest.other || class { };
->min.nest.other : Symbol((Anonymous function).other, Decl(a.js, 30, 44))
+>min.nest.other : Symbol(nest.other, Decl(a.js, 30, 44))
 >min.nest : Symbol(nest, Decl(a.js, 29, 27), Decl(a.js, 31, 4))
 >min : Symbol(min, Decl(a.js, 29, 3), Decl(a.js, 29, 27), Decl(a.js, 30, 44), Decl(a.js, 31, 50))
 >nest : Symbol(nest, Decl(a.js, 29, 27), Decl(a.js, 31, 4))
->other : Symbol((Anonymous function).other, Decl(a.js, 30, 44))
+>other : Symbol(nest.other, Decl(a.js, 30, 44))
 
 min.property = global.min.property || {};
 >min.property : Symbol(property, Decl(a.js, 31, 50))

--- a/tests/baselines/reference/typeFromPropertyAssignment9.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment9.types
@@ -1,15 +1,15 @@
 === tests/cases/conformance/salsa/a.js ===
 var my = my || {};
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->my || {} : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->{} : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>my || {} : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>{} : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
 
 /** @param {number} n */
 my.method = function(n) {
 >my.method = function(n) {    return n + 1;} : (n: number) => number
 >my.method : (n: number) => number
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
 >method : (n: number) => number
 >function(n) {    return n + 1;} : (n: number) => number
 >n : number
@@ -22,45 +22,45 @@ my.method = function(n) {
 my.number = 1;
 >my.number = 1 : 1
 >my.number : number
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
 >number : number
 >1 : 1
 
 my.object = {};
 >my.object = {} : { [x: string]: any; }
 >my.object : { [x: string]: any; }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
 >object : { [x: string]: any; }
 >{} : { [x: string]: any; }
 
 my.predicate = my.predicate || {};
->my.predicate = my.predicate || {} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my.predicate || {} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->{} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate = my.predicate || {} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my.predicate || {} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>{} : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 
 my.predicate.query = function () {
 >my.predicate.query = function () {    var me = this;    me.property = false;} : { (): void; another(): number; result: string; }
 >my.predicate.query : { (): void; another(): number; result: string; }
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 >query : { (): void; another(): number; result: string; }
 >function () {    var me = this;    me.property = false;} : { (): void; another(): number; result: string; }
 
     var me = this;
->me : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->this : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>me : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>this : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 
     me.property = false;
 >me.property = false : false
 >me.property : any
->me : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>me : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 >property : any
 >false : false
 
@@ -69,18 +69,18 @@ var q = new my.predicate.query();
 >q : any
 >new my.predicate.query() : any
 >my.predicate.query : { (): void; another(): number; result: string; }
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 >query : { (): void; another(): number; result: string; }
 
 my.predicate.query.another = function () {
 >my.predicate.query.another = function () {    return 1;} : () => number
 >my.predicate.query.another : () => number
 >my.predicate.query : { (): void; another(): number; result: string; }
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 >query : { (): void; another(): number; result: string; }
 >another : () => number
 >function () {    return 1;} : () => number
@@ -92,9 +92,9 @@ my.predicate.query.result = 'none'
 >my.predicate.query.result = 'none' : "none"
 >my.predicate.query.result : string
 >my.predicate.query : { (): void; another(): number; result: string; }
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 >query : { (): void; another(): number; result: string; }
 >result : string
 >'none' : "none"
@@ -105,15 +105,15 @@ my.predicate.query.result = 'none'
 my.predicate.sort = my.predicate.sort || function (first, second) {
 >my.predicate.sort = my.predicate.sort || function (first, second) {    return first > second ? first : second;} : (first: number, second: number) => number
 >my.predicate.sort : (first: number, second: number) => number
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 >sort : (first: number, second: number) => number
 >my.predicate.sort || function (first, second) {    return first > second ? first : second;} : (first: number, second: number) => number
 >my.predicate.sort : (first: number, second: number) => number
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
 >sort : (first: number, second: number) => number
 >function (first, second) {    return first > second ? first : second;} : (first: number, second: number) => number
 >first : number
@@ -128,13 +128,13 @@ my.predicate.sort = my.predicate.sort || function (first, second) {
 >second : number
 }
 my.predicate.type = class {
->my.predicate.type = class {    m() { return 101; }} : typeof (Anonymous class)
->my.predicate.type : typeof (Anonymous class)
->my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }; }
->predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof (Anonymous class); }
->type : typeof (Anonymous class)
->class {    m() { return 101; }} : typeof (Anonymous class)
+>my.predicate.type = class {    m() { return 101; }} : typeof type
+>my.predicate.type : typeof type
+>my.predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>my : { [x: string]: any; method(n: number): number; number: number; object: { [x: string]: any; }; predicate: { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }; }
+>predicate : { [x: string]: any; query: { (): void; another(): number; result: string; }; sort(first: number, second: number): number; type: typeof type; }
+>type : typeof type
+>class {    m() { return 101; }} : typeof type
 
     m() { return 101; }
 >m : () => number
@@ -144,34 +144,34 @@ my.predicate.type = class {
 
 // global-ish prefixes
 var min = window.min || {};
->min : { [x: string]: any; nest: { (): void; other: typeof (Anonymous class); }; property: { [x: string]: any; }; }
+>min : { [x: string]: any; nest: { (): void; other: typeof other; }; property: { [x: string]: any; }; }
 >window.min || {} : any
 >window.min : any
 >window : any
 >min : any
->{} : { [x: string]: any; nest: { (): void; other: typeof (Anonymous class); }; property: { [x: string]: any; }; }
+>{} : { [x: string]: any; nest: { (): void; other: typeof other; }; property: { [x: string]: any; }; }
 
 min.nest = this.min.nest || function () { };
->min.nest = this.min.nest || function () { } : { (): void; other: typeof (Anonymous class); }
->min.nest : { (): void; other: typeof (Anonymous class); }
->min : { [x: string]: any; nest: { (): void; other: typeof (Anonymous class); }; property: { [x: string]: any; }; }
->nest : { (): void; other: typeof (Anonymous class); }
->this.min.nest || function () { } : { (): void; other: typeof (Anonymous class); }
+>min.nest = this.min.nest || function () { } : { (): void; other: typeof other; }
+>min.nest : { (): void; other: typeof other; }
+>min : { [x: string]: any; nest: { (): void; other: typeof other; }; property: { [x: string]: any; }; }
+>nest : { (): void; other: typeof other; }
+>this.min.nest || function () { } : { (): void; other: typeof other; }
 >this.min.nest : any
 >this.min : any
 >this : any
 >min : any
 >nest : any
->function () { } : { (): void; other: typeof (Anonymous class); }
+>function () { } : { (): void; other: typeof other; }
 
 min.nest.other = self.min.nest.other || class { };
->min.nest.other = self.min.nest.other || class { } : typeof (Anonymous class)
->min.nest.other : typeof (Anonymous class)
->min.nest : { (): void; other: typeof (Anonymous class); }
->min : { [x: string]: any; nest: { (): void; other: typeof (Anonymous class); }; property: { [x: string]: any; }; }
->nest : { (): void; other: typeof (Anonymous class); }
->other : typeof (Anonymous class)
->self.min.nest.other || class { } : typeof (Anonymous class)
+>min.nest.other = self.min.nest.other || class { } : typeof other
+>min.nest.other : typeof other
+>min.nest : { (): void; other: typeof other; }
+>min : { [x: string]: any; nest: { (): void; other: typeof other; }; property: { [x: string]: any; }; }
+>nest : { (): void; other: typeof other; }
+>other : typeof other
+>self.min.nest.other || class { } : typeof other
 >self.min.nest.other : any
 >self.min.nest : any
 >self.min : any
@@ -179,12 +179,12 @@ min.nest.other = self.min.nest.other || class { };
 >min : any
 >nest : any
 >other : any
->class { } : typeof (Anonymous class)
+>class { } : typeof other
 
 min.property = global.min.property || {};
 >min.property = global.min.property || {} : { [x: string]: any; }
 >min.property : { [x: string]: any; }
->min : { [x: string]: any; nest: { (): void; other: typeof (Anonymous class); }; property: { [x: string]: any; }; }
+>min : { [x: string]: any; nest: { (): void; other: typeof other; }; property: { [x: string]: any; }; }
 >property : { [x: string]: any; }
 >global.min.property || {} : { [x: string]: any; }
 >global.min.property : any

--- a/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.types
+++ b/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.types
@@ -8,35 +8,35 @@ Common.Item = class I {}
 >I : typeof I
 
 Common.Object = class extends Common.Item {}
->Common.Object = class extends Common.Item {} : typeof (Anonymous class)
->Common.Object : typeof (Anonymous class)
+>Common.Object = class extends Common.Item {} : typeof Object
+>Common.Object : typeof Object
 >Common : typeof Common
->Object : typeof (Anonymous class)
->class extends Common.Item {} : typeof (Anonymous class)
+>Object : typeof Object
+>class extends Common.Item {} : typeof Object
 >Common.Item : I
 >Common : typeof Common
 >Item : typeof I
 
 Workspace.Object = class extends Common.Object {}
->Workspace.Object = class extends Common.Object {} : typeof (Anonymous class)
->Workspace.Object : typeof (Anonymous class)
+>Workspace.Object = class extends Common.Object {} : typeof Object
+>Workspace.Object : typeof Object
 >Workspace : typeof Workspace
->Object : typeof (Anonymous class)
->class extends Common.Object {} : typeof (Anonymous class)
->Common.Object : (Anonymous class)
+>Object : typeof Object
+>class extends Common.Object {} : typeof Object
+>Common.Object : Object
 >Common : typeof Common
->Object : typeof (Anonymous class)
+>Object : typeof Object
 
 /** @type {Workspace.Object} */
 var am;
->am : (Anonymous class)
+>am : Object
 
 === tests/cases/conformance/salsa/roots.js ===
 var Common = {};
 >Common : typeof Common
->{} : { [x: string]: any; Item: typeof I; Object: typeof (Anonymous class); }
+>{} : { [x: string]: any; Item: typeof I; Object: typeof Object; }
 
 var Workspace = {};
 >Workspace : typeof Workspace
->{} : { [x: string]: any; Object: typeof (Anonymous class); }
+>{} : { [x: string]: any; Object: typeof Object; }
 

--- a/tests/cases/compiler/classExpressionNames.ts
+++ b/tests/cases/compiler/classExpressionNames.ts
@@ -17,3 +17,8 @@ var A;
 A = class {
 }
 var a = new A()
+
+const {
+    B = class { }
+} = ({ B: undefined });
+var b = new B();

--- a/tests/cases/compiler/classExpressionNames.ts
+++ b/tests/cases/compiler/classExpressionNames.ts
@@ -1,0 +1,19 @@
+// @noEmit: true
+// @noImplicitAny: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: ts.ts
+var o = {
+    C: class {
+    }
+}
+var oc = new o.C()
+
+var V = class {
+}
+var v = new V()
+
+var A;
+A = class {
+}
+var a = new A()

--- a/tests/cases/compiler/functionExpressionNames.ts
+++ b/tests/cases/compiler/functionExpressionNames.ts
@@ -24,3 +24,10 @@ A = function () {
     this.a = 'assignment'
 }
 var a = new A();
+
+const {
+    B = function() {
+        this.b = 'binding pattern'
+    }
+} = { B: undefined };
+var b = new B();

--- a/tests/cases/compiler/functionExpressionNames.ts
+++ b/tests/cases/compiler/functionExpressionNames.ts
@@ -1,0 +1,26 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @Filename: b.js
+exports.E = function() {
+    this.e = 'exported'
+}
+var e = new exports.E();
+
+var o = {
+    C: function () {
+        this.c = 'nested object'
+    }
+}
+var og = new o.C();
+
+var V = function () {
+    this.v = 'simple'
+}
+var v = new V();
+
+var A;
+A = function () {
+    this.a = 'assignment'
+}
+var a = new A();

--- a/tests/cases/conformance/salsa/constructorFunctions3.ts
+++ b/tests/cases/conformance/salsa/constructorFunctions3.ts
@@ -1,0 +1,38 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @noImplicitAny: true
+// @Filename: a.js
+function Instance() {
+    this.i = 'simple'
+}
+var i = new Instance();
+Instance;
+i;
+
+function StaticToo() {
+    this.i = 'more complex'
+}
+StaticToo.property = 'yep'
+var s = new StaticToo();
+s;
+StaticToo;
+
+// Both!
+function A () {
+    this.x = 1
+    /** @type {1} */
+    this.second = 1
+}
+/** @param {number} n */
+A.prototype.z = function f(n) {
+    return n + this.x
+}
+/** @param {number} m */
+A.t = function g(m) {
+    return m + 1
+}
+var a = new A()
+a.z(3)
+A.t(2)
+a.second = 1

--- a/tests/cases/fourslash/findAllRefsClassExpression2.ts
+++ b/tests/cases/fourslash/findAllRefsClassExpression2.ts
@@ -10,7 +10,7 @@
 ////[|A|];
 
 const [r0, r1, r2] = test.ranges();
-const defs = { definition: "(property) A: typeof (Anonymous class)", ranges: [r0] };
-const imports = { definition: "(alias) (property) A: typeof (Anonymous class)\nimport A", ranges: [r1, r2] };
+const defs = { definition: "(property) A: typeof A", ranges: [r0] };
+const imports = { definition: "(alias) (property) A: typeof A\nimport A", ranges: [r1, r2] };
 verify.referenceGroups([r0], [defs, imports]);
 verify.referenceGroups([r1, r2], [imports, defs]);

--- a/tests/cases/fourslash/jsDocFunctionSignatures7.ts
+++ b/tests/cases/fourslash/jsDocFunctionSignatures7.ts
@@ -13,4 +13,4 @@
 ////
 ////var /**/test = new Test("");
 goTo.marker();
-verify.quickInfoIs('var test: {\n    P0: string;\n    P1: string;\n}');
+verify.quickInfoIs('var test: Test');

--- a/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
+++ b/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
@@ -99,7 +99,7 @@ verify.navigationTree({
             ]
         },
         {
-            "text": "global.cls",
+            "text": "cls",
             "kind": "class"
         }
     ]
@@ -123,7 +123,7 @@ verify.navigationBar([
                 "kind": "function"
             },
             {
-                "text": "global.cls",
+                "text": "cls",
                 "kind": "class"
             }
         ]
@@ -225,7 +225,7 @@ verify.navigationBar([
         "indent": 2
     },
     {
-        "text": "global.cls",
+        "text": "cls",
         "kind": "class",
         "indent": 1
     }

--- a/tests/cases/fourslash/navigationBarItemsFunctionProperties.ts
+++ b/tests/cases/fourslash/navigationBarItemsFunctionProperties.ts
@@ -16,12 +16,12 @@ verify.navigationTree(
       "kind": "function",
       "childItems": [
         {
-          "text": "A",
-          "kind": "var"
+          "text": "a",
+          "kind": "function"
         },
         {
-          "text": "A.a",
-          "kind": "function"
+          "text": "A",
+          "kind": "var"
         }
       ]
     }

--- a/tests/cases/fourslash/salsaMethodsOnAssignedFunctionExpressions.ts
+++ b/tests/cases/fourslash/salsaMethodsOnAssignedFunctionExpressions.ts
@@ -12,6 +12,6 @@
 ////var x = new C();
 ////x/*1*/./*2*/m();
 
-verify.quickInfoAt("1", "var x: {\n    m: (a: string) => void;\n}");
+verify.quickInfoAt("1", "var x: C");
 goTo.marker('2');
 verify.completionListContains('m', '(property) C.m: (a: string) => void', 'The prototype method.');


### PR DESCRIPTION
Instead of printing them as a type literal, which is scary.

Also, print the names of otherwise-anonymous functions and classes as the name of the declaration that they are assigned to:

```ts
var o = {
  C: class { }
}
var oc = new o.C()
```

In both Typescript and Javascript, we currently print "(Anonymous class)" for the type of `oc`. After this change, we print it as `C`. This isn't perfect (the accessible symbol chain isn't there), but it's better than what we have.