### PR TITLE
Unless checking accesses, do not include unique symbols or numbers in index types

### DIFF
--- a/tests/baselines/reference/keyofZeroOrderOnlyReturnsStrings.errors.txt
+++ b/tests/baselines/reference/keyofZeroOrderOnlyReturnsStrings.errors.txt
@@ -1,0 +1,41 @@
+tests/cases/compiler/keyofZeroOrderOnlyReturnsStrings.ts(11,30): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
+tests/cases/compiler/keyofZeroOrderOnlyReturnsStrings.ts(14,23): error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num" | "0"'.
+tests/cases/compiler/keyofZeroOrderOnlyReturnsStrings.ts(17,23): error TS2345: Argument of type '0' is not assignable to parameter of type '"str" | "num" | "0"'.
+
+
+==== tests/cases/compiler/keyofZeroOrderOnlyReturnsStrings.ts (3 errors) ====
+    const sym = Symbol();
+    const num = 0;
+    const obj = { num: 0, str: 's', [sym]: sym, [num]: num as 0 };
+    
+    function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+      return obj[key] = value;
+    }
+    
+    const val = set(obj, 'str', '');
+    // string
+    const valB = set(obj, 'num', '');
+                                 ~~
+!!! error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
+    // Expect type error
+    // Argument of type '""' is not assignable to parameter of type 'number'.
+    const valC = set(obj, sym, sym);
+                          ~~~
+!!! error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num" | "0"'.
+    // Expect type error
+    // Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num" | "0"
+    const valD = set(obj, num, num);
+                          ~~~
+!!! error TS2345: Argument of type '0' is not assignable to parameter of type '"str" | "num" | "0"'.
+    // Expect type error
+    // Argument of type '0' is not assignable to parameter of type '"str" | "num" | "0"
+    const valE = set(obj, "0", num);
+    // 0
+    
+    type KeyofObj = keyof typeof obj;
+    // "str" | "num" | "0"
+    
+    type Values<T> = T[keyof T];
+    
+    type ValuesOfObj = Values<typeof obj>;
+    

--- a/tests/baselines/reference/keyofZeroOrderOnlyReturnsStrings.js
+++ b/tests/baselines/reference/keyofZeroOrderOnlyReturnsStrings.js
@@ -1,0 +1,51 @@
+//// [keyofZeroOrderOnlyReturnsStrings.ts]
+const sym = Symbol();
+const num = 0;
+const obj = { num: 0, str: 's', [sym]: sym, [num]: num as 0 };
+
+function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+  return obj[key] = value;
+}
+
+const val = set(obj, 'str', '');
+// string
+const valB = set(obj, 'num', '');
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+const valC = set(obj, sym, sym);
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num" | "0"
+const valD = set(obj, num, num);
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type '"str" | "num" | "0"
+const valE = set(obj, "0", num);
+// 0
+
+type KeyofObj = keyof typeof obj;
+// "str" | "num" | "0"
+
+type Values<T> = T[keyof T];
+
+type ValuesOfObj = Values<typeof obj>;
+
+
+//// [keyofZeroOrderOnlyReturnsStrings.js]
+var sym = Symbol();
+var num = 0;
+var obj = (_a = { num: 0, str: 's' }, _a[sym] = sym, _a[num] = num, _a);
+function set(obj, key, value) {
+    return obj[key] = value;
+}
+var val = set(obj, 'str', '');
+// string
+var valB = set(obj, 'num', '');
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+var valC = set(obj, sym, sym);
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num" | "0"
+var valD = set(obj, num, num);
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type '"str" | "num" | "0"
+var valE = set(obj, "0", num);
+var _a;

--- a/tests/baselines/reference/keyofZeroOrderOnlyReturnsStrings.symbols
+++ b/tests/baselines/reference/keyofZeroOrderOnlyReturnsStrings.symbols
@@ -1,0 +1,96 @@
+=== tests/cases/compiler/keyofZeroOrderOnlyReturnsStrings.ts ===
+const sym = Symbol();
+>sym : Symbol(sym, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 0, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+
+const num = 0;
+>num : Symbol(num, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 1, 5))
+
+const obj = { num: 0, str: 's', [sym]: sym, [num]: num as 0 };
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 5))
+>num : Symbol(num, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 13))
+>str : Symbol(str, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 21))
+>[sym] : Symbol([sym], Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 31))
+>sym : Symbol(sym, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 0, 5))
+>sym : Symbol(sym, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 0, 5))
+>[num] : Symbol([num], Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 43))
+>num : Symbol(num, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 1, 5))
+>num : Symbol(num, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 1, 5))
+
+function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+>set : Symbol(set, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 62))
+>T : Symbol(T, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 14))
+>K : Symbol(K, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 31))
+>T : Symbol(T, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 14))
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 52))
+>T : Symbol(T, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 14))
+>key : Symbol(key, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 59))
+>K : Symbol(K, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 31))
+>value : Symbol(value, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 67))
+>T : Symbol(T, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 14))
+>K : Symbol(K, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 31))
+>T : Symbol(T, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 14))
+>K : Symbol(K, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 31))
+
+  return obj[key] = value;
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 52))
+>key : Symbol(key, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 59))
+>value : Symbol(value, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 4, 67))
+}
+
+const val = set(obj, 'str', '');
+>val : Symbol(val, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 8, 5))
+>set : Symbol(set, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 5))
+
+// string
+const valB = set(obj, 'num', '');
+>valB : Symbol(valB, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 10, 5))
+>set : Symbol(set, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 5))
+
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+const valC = set(obj, sym, sym);
+>valC : Symbol(valC, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 13, 5))
+>set : Symbol(set, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 5))
+>sym : Symbol(sym, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 0, 5))
+>sym : Symbol(sym, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 0, 5))
+
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num" | "0"
+const valD = set(obj, num, num);
+>valD : Symbol(valD, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 16, 5))
+>set : Symbol(set, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 5))
+>num : Symbol(num, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 1, 5))
+>num : Symbol(num, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 1, 5))
+
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type '"str" | "num" | "0"
+const valE = set(obj, "0", num);
+>valE : Symbol(valE, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 19, 5))
+>set : Symbol(set, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 5))
+>num : Symbol(num, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 1, 5))
+
+// 0
+
+type KeyofObj = keyof typeof obj;
+>KeyofObj : Symbol(KeyofObj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 19, 32))
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 5))
+
+// "str" | "num" | "0"
+
+type Values<T> = T[keyof T];
+>Values : Symbol(Values, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 22, 33))
+>T : Symbol(T, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 25, 12))
+>T : Symbol(T, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 25, 12))
+>T : Symbol(T, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 25, 12))
+
+type ValuesOfObj = Values<typeof obj>;
+>ValuesOfObj : Symbol(ValuesOfObj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 25, 28))
+>Values : Symbol(Values, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 22, 33))
+>obj : Symbol(obj, Decl(keyofZeroOrderOnlyReturnsStrings.ts, 2, 5))
+

--- a/tests/baselines/reference/keyofZeroOrderOnlyReturnsStrings.types
+++ b/tests/baselines/reference/keyofZeroOrderOnlyReturnsStrings.types
@@ -1,0 +1,114 @@
+=== tests/cases/compiler/keyofZeroOrderOnlyReturnsStrings.ts ===
+const sym = Symbol();
+>sym : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+const num = 0;
+>num : 0
+>0 : 0
+
+const obj = { num: 0, str: 's', [sym]: sym, [num]: num as 0 };
+>obj : { num: number; str: string; [sym]: symbol; [num]: 0; }
+>{ num: 0, str: 's', [sym]: sym, [num]: num as 0 } : { num: number; str: string; [sym]: symbol; [num]: 0; }
+>num : number
+>0 : 0
+>str : string
+>'s' : "s"
+>[sym] : symbol
+>sym : unique symbol
+>sym : unique symbol
+>[num] : 0
+>num : 0
+>num as 0 : 0
+>num : 0
+
+function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>T : T
+>K : K
+>T : T
+>obj : T
+>T : T
+>key : K
+>K : K
+>value : T[K]
+>T : T
+>K : K
+>T : T
+>K : K
+
+  return obj[key] = value;
+>obj[key] = value : T[K]
+>obj[key] : T[K]
+>obj : T
+>key : K
+>value : T[K]
+}
+
+const val = set(obj, 'str', '');
+>val : string
+>set(obj, 'str', '') : string
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [sym]: symbol; [num]: 0; }
+>'str' : "str"
+>'' : ""
+
+// string
+const valB = set(obj, 'num', '');
+>valB : any
+>set(obj, 'num', '') : any
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [sym]: symbol; [num]: 0; }
+>'num' : "num"
+>'' : ""
+
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+const valC = set(obj, sym, sym);
+>valC : any
+>set(obj, sym, sym) : any
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [sym]: symbol; [num]: 0; }
+>sym : unique symbol
+>sym : unique symbol
+
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num" | "0"
+const valD = set(obj, num, num);
+>valD : any
+>set(obj, num, num) : any
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [sym]: symbol; [num]: 0; }
+>num : 0
+>num : 0
+
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type '"str" | "num" | "0"
+const valE = set(obj, "0", num);
+>valE : 0
+>set(obj, "0", num) : 0
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [sym]: symbol; [num]: 0; }
+>"0" : "0"
+>num : 0
+
+// 0
+
+type KeyofObj = keyof typeof obj;
+>KeyofObj : "str" | "num" | "0"
+>obj : { num: number; str: string; [sym]: symbol; [num]: 0; }
+
+// "str" | "num" | "0"
+
+type Values<T> = T[keyof T];
+>Values : T[keyof T]
+>T : T
+>T : T
+>T : T
+
+type ValuesOfObj = Values<typeof obj>;
+>ValuesOfObj : string | number
+>Values : T[keyof T]
+>obj : { num: number; str: string; [sym]: symbol; [num]: 0; }
+

--- a/tests/cases/compiler/keyofZeroOrderOnlyReturnsStrings.ts
+++ b/tests/cases/compiler/keyofZeroOrderOnlyReturnsStrings.ts
@@ -1,0 +1,29 @@
+// @lib: es6
+const sym = Symbol();
+const num = 0;
+const obj = { num: 0, str: 's', [sym]: sym, [num]: num as 0 };
+
+function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+  return obj[key] = value;
+}
+
+const val = set(obj, 'str', '');
+// string
+const valB = set(obj, 'num', '');
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+const valC = set(obj, sym, sym);
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num" | "0"
+const valD = set(obj, num, num);
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type '"str" | "num" | "0"
+const valE = set(obj, "0", num);
+// 0
+
+type KeyofObj = keyof typeof obj;
+// "str" | "num" | "0"
+
+type Values<T> = T[keyof T];
+
+type ValuesOfObj = Values<typeof obj>;


### PR DESCRIPTION
Fixes the issue of `keyof` now returning `unique symbol`s that @kpdonn reported in #20721, and @ahejlsberg were you looking at another issue this fixed?

Regarding the implementation - I actually had to add a new relationship (ew) to handle comparing with constraints of generic index types. (To continue to allow, eg, `T[typeof sym]`).
