### PR TITLE
completions: Properly handle preferences.includeCompletionsWithInsertText

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -202,26 +202,24 @@ namespace ts.Completions {
 
         let insertText: string | undefined;
         let replacementSpan: TextSpan | undefined;
-        if (preferences.includeCompletionsWithInsertText) {
-            if (origin && origin.type === "this-type") {
-                insertText = needsConvertPropertyAccess ? `this[${quote(name, preferences)}]` : `this.${name}`;
-            }
-            // We should only have needsConvertPropertyAccess if there's a property access to convert. But see #21790.
-            // Somehow there was a global with a non-identifier name. Hopefully someone will complain about getting a "foo bar" global completion and provide a repro.
-            else if (needsConvertPropertyAccess && propertyAccessToConvert) {
-                insertText = `[${quote(name, preferences)}]`;
-                const dot = findChildOfKind(propertyAccessToConvert, SyntaxKind.DotToken, sourceFile)!;
-                // If the text after the '.' starts with this name, write over it. Else, add new text.
-                const end = startsWith(name, propertyAccessToConvert.name.text) ? propertyAccessToConvert.name.end : dot.end;
-                replacementSpan = createTextSpanFromBounds(dot.getStart(sourceFile), end);
-            }
+        if (origin && origin.type === "this-type") {
+            insertText = needsConvertPropertyAccess ? `this[${quote(name, preferences)}]` : `this.${name}`;
+        }
+        // We should only have needsConvertPropertyAccess if there's a property access to convert. But see #21790.
+        // Somehow there was a global with a non-identifier name. Hopefully someone will complain about getting a "foo bar" global completion and provide a repro.
+        else if (needsConvertPropertyAccess && propertyAccessToConvert) {
+            insertText = `[${quote(name, preferences)}]`;
+            const dot = findChildOfKind(propertyAccessToConvert, SyntaxKind.DotToken, sourceFile)!;
+            // If the text after the '.' starts with this name, write over it. Else, add new text.
+            const end = startsWith(name, propertyAccessToConvert.name.text) ? propertyAccessToConvert.name.end : dot.end;
+            replacementSpan = createTextSpanFromBounds(dot.getStart(sourceFile), end);
+        }
 
-            if (isJsxInitializer) {
-                if (insertText === undefined) insertText = name;
-                insertText = `{${insertText}}`;
-                if (typeof isJsxInitializer !== "boolean") {
-                    replacementSpan = createTextSpanFromNode(isJsxInitializer, sourceFile);
-                }
+        if (isJsxInitializer) {
+            if (insertText === undefined) insertText = name;
+            insertText = `{${insertText}}`;
+            if (typeof isJsxInitializer !== "boolean") {
+                replacementSpan = createTextSpanFromNode(isJsxInitializer, sourceFile);
             }
         }
 

--- a/tests/cases/fourslash/completionsRecommended_contextualTypes.ts
+++ b/tests/cases/fourslash/completionsRecommended_contextualTypes.ts
@@ -16,12 +16,16 @@
 ////<MainButton e=/*jsx2*/ />
 
 recommended("arg0");
-recommended("arg1", "F");
+recommended("arg1", { enumName: "F" });
 recommended("tag");
 recommended("jsx");
-recommended("jsx2");
+recommended("jsx2", { insertText: "{E}" });
 
-function recommended(markerName: string, enumName = "E") {
+function recommended(markerName: string, { insertText, enumName = "E" }: { insertText?: string, enumName?: string } = {}) {
     goTo.marker(markerName);
-    verify.completionListContains(enumName, `enum ${enumName}`, "", "enum", undefined, undefined , { isRecommended: true });
+    verify.completionListContains(enumName, `enum ${enumName}`, "", "enum", undefined, undefined , {
+        isRecommended: true,
+        includeInsertTextCompletions: true,
+        insertText,
+    });
 }


### PR DESCRIPTION
(view diff with [`?w=1`](https://github.com/Microsoft/TypeScript/pull/23092/files?w=1))
We handle this with `if (insertText !== undefined && !preferences.includeCompletionsWithInsertText) { return undefined; }`. Before this PR, that if statement is dead code because we'll never set `insertText` if `!preferences.includeCompletionsWithInsertText`. so we should go ahead and set `insertText` before that.