### PR TITLE
Skip parens and non-null assertions when looking for this-context

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17267,11 +17267,8 @@ namespace ts {
         function getThisArgumentOfCall(node: CallLikeExpression): LeftHandSideExpression {
             if (node.kind === SyntaxKind.CallExpression) {
                 const callee = skipParenthesesAndNonNull(node.expression);
-                if (callee.kind === SyntaxKind.PropertyAccessExpression) {
-                    return (callee as PropertyAccessExpression).expression;
-                }
-                else if (callee.kind === SyntaxKind.ElementAccessExpression) {
-                    return (callee as ElementAccessExpression).expression;
+                if (callee.kind === SyntaxKind.PropertyAccessExpression || callee.kind === SyntaxKind.ElementAccessExpression) {
+                    return (callee as PropertyAccessExpression | ElementAccessExpression).expression;
                 }
             }
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17266,7 +17266,7 @@ namespace ts {
          */
         function getThisArgumentOfCall(node: CallLikeExpression): LeftHandSideExpression {
             if (node.kind === SyntaxKind.CallExpression) {
-                const callee = skipParenthesesAndNonNull(node.expression);
+                const callee = skipOuterExpressions(node.expression);
                 if (callee.kind === SyntaxKind.PropertyAccessExpression || callee.kind === SyntaxKind.ElementAccessExpression) {
                     return (callee as PropertyAccessExpression | ElementAccessExpression).expression;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17266,7 +17266,7 @@ namespace ts {
          */
         function getThisArgumentOfCall(node: CallLikeExpression): LeftHandSideExpression {
             if (node.kind === SyntaxKind.CallExpression) {
-                const callee = node.expression;
+                const callee = skipParenthesesAndNonNull(node.expression);
                 if (callee.kind === SyntaxKind.PropertyAccessExpression) {
                     return (callee as PropertyAccessExpression).expression;
                 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2028,16 +2028,6 @@ namespace ts {
         return node;
     }
 
-    export function skipParenthesesAndNonNull(node: Expression): Expression;
-    export function skipParenthesesAndNonNull(node: Node): Node;
-    export function skipParenthesesAndNonNull(node: Node): Node {
-        while (node.kind === SyntaxKind.ParenthesizedExpression || node.kind === SyntaxKind.NonNullExpression) {
-            node = (node as ParenthesizedExpression | NonNullExpression).expression;
-        }
-
-        return node;
-    }
-
     // a node is delete target iff. it is PropertyAccessExpression/ElementAccessExpression with parentheses skipped
     export function isDeleteTarget(node: Node): boolean {
         if (node.kind !== SyntaxKind.PropertyAccessExpression && node.kind !== SyntaxKind.ElementAccessExpression) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2022,7 +2022,17 @@ namespace ts {
     export function skipParentheses(node: Node): Node;
     export function skipParentheses(node: Node): Node {
         while (node.kind === SyntaxKind.ParenthesizedExpression) {
-            node = (<ParenthesizedExpression>node).expression;
+            node = (node as ParenthesizedExpression).expression;
+        }
+
+        return node;
+    }
+
+    export function skipParenthesesAndNonNull(node: Expression): Expression;
+    export function skipParenthesesAndNonNull(node: Node): Node;
+    export function skipParenthesesAndNonNull(node: Node): Node {
+        while (node.kind === SyntaxKind.ParenthesizedExpression || node.kind === SyntaxKind.NonNullExpression) {
+            node = (node as ParenthesizedExpression | NonNullExpression).expression;
         }
 
         return node;

--- a/tests/baselines/reference/thisTypeSyntacticContext.js
+++ b/tests/baselines/reference/thisTypeSyntacticContext.js
@@ -1,0 +1,27 @@
+//// [thisTypeSyntacticContext.ts]
+function f(this: { n: number }) {
+}
+
+const o: { n: number, test?: (this: { n: number }) => void } = { n: 1 }
+o.test = f
+
+o.test();
+o!.test();
+o.test!();
+o.test!!!();
+(o.test!)();
+(o.test)();
+
+
+
+//// [thisTypeSyntacticContext.js]
+function f() {
+}
+var o = { n: 1 };
+o.test = f;
+o.test();
+o.test();
+o.test();
+o.test();
+(o.test)();
+(o.test)();

--- a/tests/baselines/reference/thisTypeSyntacticContext.symbols
+++ b/tests/baselines/reference/thisTypeSyntacticContext.symbols
@@ -1,0 +1,52 @@
+=== tests/cases/conformance/types/thisType/thisTypeSyntacticContext.ts ===
+function f(this: { n: number }) {
+>f : Symbol(f, Decl(thisTypeSyntacticContext.ts, 0, 0))
+>this : Symbol(this, Decl(thisTypeSyntacticContext.ts, 0, 11))
+>n : Symbol(n, Decl(thisTypeSyntacticContext.ts, 0, 18))
+}
+
+const o: { n: number, test?: (this: { n: number }) => void } = { n: 1 }
+>o : Symbol(o, Decl(thisTypeSyntacticContext.ts, 3, 5))
+>n : Symbol(n, Decl(thisTypeSyntacticContext.ts, 3, 10))
+>test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>this : Symbol(this, Decl(thisTypeSyntacticContext.ts, 3, 30))
+>n : Symbol(n, Decl(thisTypeSyntacticContext.ts, 3, 37))
+>n : Symbol(n, Decl(thisTypeSyntacticContext.ts, 3, 64))
+
+o.test = f
+>o.test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>o : Symbol(o, Decl(thisTypeSyntacticContext.ts, 3, 5))
+>test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>f : Symbol(f, Decl(thisTypeSyntacticContext.ts, 0, 0))
+
+o.test();
+>o.test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>o : Symbol(o, Decl(thisTypeSyntacticContext.ts, 3, 5))
+>test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+
+o!.test();
+>o!.test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>o : Symbol(o, Decl(thisTypeSyntacticContext.ts, 3, 5))
+>test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+
+o.test!();
+>o.test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>o : Symbol(o, Decl(thisTypeSyntacticContext.ts, 3, 5))
+>test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+
+o.test!!!();
+>o.test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>o : Symbol(o, Decl(thisTypeSyntacticContext.ts, 3, 5))
+>test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+
+(o.test!)();
+>o.test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>o : Symbol(o, Decl(thisTypeSyntacticContext.ts, 3, 5))
+>test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+
+(o.test)();
+>o.test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+>o : Symbol(o, Decl(thisTypeSyntacticContext.ts, 3, 5))
+>test : Symbol(test, Decl(thisTypeSyntacticContext.ts, 3, 21))
+
+

--- a/tests/baselines/reference/thisTypeSyntacticContext.types
+++ b/tests/baselines/reference/thisTypeSyntacticContext.types
@@ -1,0 +1,69 @@
+=== tests/cases/conformance/types/thisType/thisTypeSyntacticContext.ts ===
+function f(this: { n: number }) {
+>f : (this: { n: number; }) => void
+>this : { n: number; }
+>n : number
+}
+
+const o: { n: number, test?: (this: { n: number }) => void } = { n: 1 }
+>o : { n: number; test?: (this: { n: number; }) => void; }
+>n : number
+>test : (this: { n: number; }) => void
+>this : { n: number; }
+>n : number
+>{ n: 1 } : { n: number; }
+>n : number
+>1 : 1
+
+o.test = f
+>o.test = f : (this: { n: number; }) => void
+>o.test : (this: { n: number; }) => void
+>o : { n: number; test?: (this: { n: number; }) => void; }
+>test : (this: { n: number; }) => void
+>f : (this: { n: number; }) => void
+
+o.test();
+>o.test() : void
+>o.test : (this: { n: number; }) => void
+>o : { n: number; test?: (this: { n: number; }) => void; }
+>test : (this: { n: number; }) => void
+
+o!.test();
+>o!.test() : void
+>o!.test : (this: { n: number; }) => void
+>o! : { n: number; test?: (this: { n: number; }) => void; }
+>o : { n: number; test?: (this: { n: number; }) => void; }
+>test : (this: { n: number; }) => void
+
+o.test!();
+>o.test!() : void
+>o.test! : (this: { n: number; }) => void
+>o.test : (this: { n: number; }) => void
+>o : { n: number; test?: (this: { n: number; }) => void; }
+>test : (this: { n: number; }) => void
+
+o.test!!!();
+>o.test!!!() : void
+>o.test!!! : (this: { n: number; }) => void
+>o.test!! : (this: { n: number; }) => void
+>o.test! : (this: { n: number; }) => void
+>o.test : (this: { n: number; }) => void
+>o : { n: number; test?: (this: { n: number; }) => void; }
+>test : (this: { n: number; }) => void
+
+(o.test!)();
+>(o.test!)() : void
+>(o.test!) : (this: { n: number; }) => void
+>o.test! : (this: { n: number; }) => void
+>o.test : (this: { n: number; }) => void
+>o : { n: number; test?: (this: { n: number; }) => void; }
+>test : (this: { n: number; }) => void
+
+(o.test)();
+>(o.test)() : void
+>(o.test) : (this: { n: number; }) => void
+>o.test : (this: { n: number; }) => void
+>o : { n: number; test?: (this: { n: number; }) => void; }
+>test : (this: { n: number; }) => void
+
+

--- a/tests/cases/conformance/types/thisType/thisTypeSyntacticContext.ts
+++ b/tests/cases/conformance/types/thisType/thisTypeSyntacticContext.ts
@@ -1,0 +1,13 @@
+function f(this: { n: number }) {
+}
+
+const o: { n: number, test?: (this: { n: number }) => void } = { n: 1 }
+o.test = f
+
+o.test();
+o!.test();
+o.test!();
+o.test!!!();
+(o.test!)();
+(o.test)();
+


### PR DESCRIPTION
The check is syntactic and was previously very simple.

Fixes #23040