### PR TITLE
Consider jscontainer aliases as referencible even if they have other local meanings

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1933,9 +1933,11 @@ namespace ts {
 
         /**
          * Indicates that a symbol is an alias that does not merge with a local declaration.
+         * OR Is a JSContainer which may merge an alias with a local declaration
          */
         function isNonLocalAlias(symbol: Symbol, excludes = SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace) {
-            return symbol && (symbol.flags & (SymbolFlags.Alias | excludes)) === SymbolFlags.Alias;
+            if (!symbol) return false;
+            return (symbol.flags & (SymbolFlags.Alias | excludes)) === SymbolFlags.Alias || (symbol.flags & SymbolFlags.Alias && symbol.flags & SymbolFlags.JSContainer);
         }
 
         function resolveSymbol(symbol: Symbol, dontResolveAlias?: boolean): Symbol {

--- a/tests/baselines/reference/exportDefaultMarksIdentifierAsUsed.js
+++ b/tests/baselines/reference/exportDefaultMarksIdentifierAsUsed.js
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/exportDefaultMarksIdentifierAsUsed.ts] ////
+
+//// [a.js]
+const Obj = {};
+export default Obj;
+//// [b.js]
+import Obj from './a';
+
+Obj.fn = function() {};
+
+//// [a.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const Obj = {};
+exports.default = Obj;
+//// [b.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const a_1 = require("./a");
+a_1.default.fn = function () { };

--- a/tests/baselines/reference/exportDefaultMarksIdentifierAsUsed.symbols
+++ b/tests/baselines/reference/exportDefaultMarksIdentifierAsUsed.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/a.js ===
+const Obj = {};
+>Obj : Symbol(Obj, Decl(a.js, 0, 5))
+
+export default Obj;
+>Obj : Symbol(Obj, Decl(a.js, 0, 5))
+
+=== tests/cases/compiler/b.js ===
+import Obj from './a';
+>Obj : Symbol(Obj, Decl(b.js, 0, 6), Decl(b.js, 0, 22))
+
+Obj.fn = function() {};
+>Obj.fn : Symbol(Obj.fn, Decl(b.js, 0, 22))
+>Obj : Symbol(Obj, Decl(b.js, 0, 6), Decl(b.js, 0, 22))
+>fn : Symbol(Obj.fn, Decl(b.js, 0, 22))
+

--- a/tests/baselines/reference/exportDefaultMarksIdentifierAsUsed.types
+++ b/tests/baselines/reference/exportDefaultMarksIdentifierAsUsed.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/a.js ===
+const Obj = {};
+>Obj : { [x: string]: any; }
+>{} : { [x: string]: any; }
+
+export default Obj;
+>Obj : { [x: string]: any; }
+
+=== tests/cases/compiler/b.js ===
+import Obj from './a';
+>Obj : typeof Obj
+
+Obj.fn = function() {};
+>Obj.fn = function() {} : () => void
+>Obj.fn : () => void
+>Obj : typeof Obj
+>fn : () => void
+>function() {} : () => void
+

--- a/tests/cases/compiler/exportDefaultMarksIdentifierAsUsed.ts
+++ b/tests/cases/compiler/exportDefaultMarksIdentifierAsUsed.ts
@@ -1,0 +1,12 @@
+// @target: es2017
+// @module: commonjs
+// @strict: true
+// @allowJs: true
+// @outDir: /dist
+// @filename: a.js
+const Obj = {};
+export default Obj;
+// @filename: b.js
+import Obj from './a';
+
+Obj.fn = function() {};


### PR DESCRIPTION
Fixes #23065

We also should probably consider not running the `ts` transform on `js` files, which is what causes ellision to even be possible.