### PR TITLE
SyntaxKind.ImportTypeNode -> SyntaxKind.ImportType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8884,7 +8884,7 @@ namespace ts {
                     return getTypeFromConditionalTypeNode(<ConditionalTypeNode>node);
                 case SyntaxKind.InferType:
                     return getTypeFromInferTypeNode(<InferTypeNode>node);
-                case SyntaxKind.ImportTypeNode:
+                case SyntaxKind.ImportType:
                     return getTypeFromImportTypeNode(<ImportTypeNode>node);
                 // This function assumes that an identifier or qualified name is a type expression
                 // Callers should first ensure this by calling isTypeNode
@@ -16244,7 +16244,7 @@ namespace ts {
             const flags = getDeclarationModifierFlagsFromSymbol(prop);
             const errorNode = node.kind === SyntaxKind.PropertyAccessExpression || node.kind === SyntaxKind.VariableDeclaration ?
                 node.name :
-                node.kind === SyntaxKind.ImportTypeNode ?
+                node.kind === SyntaxKind.ImportType ?
                     node :
                     (<QualifiedName>node).right;
 
@@ -16691,13 +16691,13 @@ namespace ts {
                     return isValidPropertyAccessWithType(node, node.expression, propertyName, getWidenedType(checkExpression(node.expression)));
                 case SyntaxKind.QualifiedName:
                     return isValidPropertyAccessWithType(node, node.left, propertyName, getWidenedType(checkExpression(node.left)));
-                case SyntaxKind.ImportTypeNode:
+                case SyntaxKind.ImportType:
                     return isValidPropertyAccessWithType(node, node, propertyName, getTypeFromTypeNode(node));
             }
         }
 
         function isValidPropertyAccessForCompletions(node: PropertyAccessExpression | ImportTypeNode, type: Type, property: Symbol): boolean {
-            return isValidPropertyAccessWithType(node, node.kind === SyntaxKind.ImportTypeNode ? node : node.expression, property.escapedName, type)
+            return isValidPropertyAccessWithType(node, node.kind === SyntaxKind.ImportType ? node : node.expression, property.escapedName, type)
                 && (!(property.flags & SymbolFlags.Method) || isValidMethodAccess(property, type));
         }
         function isValidMethodAccess(method: Symbol, actualThisType: Type): boolean {
@@ -24605,7 +24605,7 @@ namespace ts {
                     return checkConditionalType(<ConditionalTypeNode>node);
                 case SyntaxKind.InferType:
                     return checkInferType(<InferTypeNode>node);
-                case SyntaxKind.ImportTypeNode:
+                case SyntaxKind.ImportType:
                     return checkImportType(<ImportTypeNode>node);
                 case SyntaxKind.JSDocAugmentsTag:
                     return checkJSDocAugmentsTag(node as JSDocAugmentsTag);
@@ -25123,7 +25123,7 @@ namespace ts {
                 node = parent;
                 parent = parent.parent;
             }
-            if (parent && parent.kind === SyntaxKind.ImportTypeNode && (parent as ImportTypeNode).qualifier === node) {
+            if (parent && parent.kind === SyntaxKind.ImportType && (parent as ImportTypeNode).qualifier === node) {
                 return parent as ImportTypeNode;
             }
             return undefined;
@@ -25344,7 +25344,7 @@ namespace ts {
                 case SyntaxKind.FunctionKeyword:
                 case SyntaxKind.EqualsGreaterThanToken:
                     return getSymbolOfNode(node.parent);
-                case SyntaxKind.ImportTypeNode:
+                case SyntaxKind.ImportType:
                     return isLiteralImportTypeNode(node) ? getSymbolAtLocation(node.argument.literal) : undefined;
 
                 default:

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -615,7 +615,7 @@ namespace ts {
                     return emitMappedType(<MappedTypeNode>node);
                 case SyntaxKind.LiteralType:
                     return emitLiteralType(<LiteralTypeNode>node);
-                case SyntaxKind.ImportTypeNode:
+                case SyntaxKind.ImportType:
                     return emitImportTypeNode(<ImportTypeNode>node);
                 case SyntaxKind.JSDocAllType:
                     write("*");

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -810,7 +810,7 @@ namespace ts {
     }
 
     export function createImportTypeNode(argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeNode>, isTypeOf?: boolean) {
-        const node = <ImportTypeNode>createSynthesizedNode(SyntaxKind.ImportTypeNode);
+        const node = <ImportTypeNode>createSynthesizedNode(SyntaxKind.ImportType);
         node.argument = argument;
         node.qualifier = qualifier;
         node.typeArguments = asNodeArray(typeArguments);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -189,7 +189,7 @@ namespace ts {
                     visitNode(cbNode, (<ConditionalTypeNode>node).falseType);
             case SyntaxKind.InferType:
                 return visitNode(cbNode, (<InferTypeNode>node).typeParameter);
-            case SyntaxKind.ImportTypeNode:
+            case SyntaxKind.ImportType:
                 return visitNode(cbNode, (<ImportTypeNode>node).argument) ||
                     visitNode(cbNode, (<ImportTypeNode>node).qualifier) ||
                     visitNodes(cbNode, cbNodes, (<ImportTypeNode>node).typeArguments);
@@ -2744,7 +2744,7 @@ namespace ts {
 
         function parseImportType(): ImportTypeNode {
             sourceFile.flags |= NodeFlags.PossiblyContainsDynamicImport;
-            const node = createNode(SyntaxKind.ImportTypeNode) as ImportTypeNode;
+            const node = createNode(SyntaxKind.ImportType) as ImportTypeNode;
             if (parseOptional(SyntaxKind.TypeOfKeyword)) {
                 node.isTypeOf = true;
             }

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -452,7 +452,7 @@ namespace ts {
 
         function rewriteModuleSpecifier<T extends Node>(parent: ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ModuleDeclaration | ImportTypeNode, input: T): T | StringLiteral {
             if (!input) return;
-            resultHasExternalModuleIndicator = resultHasExternalModuleIndicator || (parent.kind !== SyntaxKind.ModuleDeclaration && parent.kind !== SyntaxKind.ImportTypeNode);
+            resultHasExternalModuleIndicator = resultHasExternalModuleIndicator || (parent.kind !== SyntaxKind.ModuleDeclaration && parent.kind !== SyntaxKind.ImportType);
             if (input.kind === SyntaxKind.StringLiteral && isBundledEmit) {
                 const newName = getExternalModuleNameFromDeclaration(context.getEmitHost(), resolver, parent);
                 if (newName) {
@@ -765,7 +765,7 @@ namespace ts {
                     case SyntaxKind.ConstructorType: {
                         return cleanup(updateConstructorTypeNode(input, visitNodes(input.typeParameters, visitDeclarationSubtree), updateParamsList(input, input.parameters), visitNode(input.type, visitDeclarationSubtree)));
                     }
-                    case SyntaxKind.ImportTypeNode: {
+                    case SyntaxKind.ImportType: {
                         if (!isLiteralImportTypeNode(input)) return cleanup(input);
                         return cleanup(updateImportTypeNode(
                             input,
@@ -1296,7 +1296,7 @@ namespace ts {
             case SyntaxKind.ConditionalType:
             case SyntaxKind.FunctionType:
             case SyntaxKind.ConstructorType:
-            case SyntaxKind.ImportTypeNode:
+            case SyntaxKind.ImportType:
             return true;
         }
         return false;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -284,7 +284,7 @@ namespace ts {
         IndexedAccessType,
         MappedType,
         LiteralType,
-        ImportTypeNode,
+        ImportType,
         // Binding patterns
         ObjectBindingPattern,
         ArrayBindingPattern,
@@ -446,7 +446,7 @@ namespace ts {
         FirstFutureReservedWord = ImplementsKeyword,
         LastFutureReservedWord = YieldKeyword,
         FirstTypeNode = TypePredicate,
-        LastTypeNode = ImportTypeNode,
+        LastTypeNode = ImportType,
         FirstPunctuation = OpenBraceToken,
         LastPunctuation = CaretEqualsToken,
         FirstToken = Unknown,
@@ -1069,7 +1069,7 @@ namespace ts {
     }
 
     export interface ImportTypeNode extends NodeWithTypeArguments {
-        kind: SyntaxKind.ImportTypeNode;
+        kind: SyntaxKind.ImportType;
         isTypeOf?: boolean;
         argument: TypeNode;
         qualifier?: EntityName;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -735,7 +735,7 @@ namespace ts {
     }
 
     export function isLiteralImportTypeNode(n: Node): n is LiteralImportTypeNode {
-        return n.kind === SyntaxKind.ImportTypeNode &&
+        return n.kind === SyntaxKind.ImportType &&
             (n as ImportTypeNode).argument.kind === SyntaxKind.LiteralType &&
             isStringLiteral(((n as ImportTypeNode).argument as LiteralTypeNode).literal);
     }
@@ -811,7 +811,7 @@ namespace ts {
                 if (parent.kind === SyntaxKind.TypeQuery) {
                     return false;
                 }
-                if (parent.kind === SyntaxKind.ImportTypeNode) {
+                if (parent.kind === SyntaxKind.ImportType) {
                     return !(parent as ImportTypeNode).isTypeOf;
                 }
                 // Do not recursively call isPartOfTypeNode on the parent. In the example:
@@ -1713,7 +1713,7 @@ namespace ts {
                 return node.moduleSpecifier;
             case SyntaxKind.ImportEqualsDeclaration:
                 return node.moduleReference.kind === SyntaxKind.ExternalModuleReference ? node.moduleReference.expression : undefined;
-            case SyntaxKind.ImportTypeNode:
+            case SyntaxKind.ImportType:
                 return isLiteralImportTypeNode(node) ? node.argument.literal : undefined;
             default:
                 return Debug.assertNever(node);
@@ -5736,7 +5736,7 @@ namespace ts {
         const kind = node.kind;
         return kind === SyntaxKind.PropertyAccessExpression
             || kind === SyntaxKind.QualifiedName
-            || kind === SyntaxKind.ImportTypeNode;
+            || kind === SyntaxKind.ImportType;
     }
 
     // Expression

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -398,7 +398,7 @@ namespace ts {
                 return updateInferTypeNode(<InferTypeNode>node,
                     visitNode((<InferTypeNode>node).typeParameter, visitor, isTypeParameterDeclaration));
 
-            case SyntaxKind.ImportTypeNode:
+            case SyntaxKind.ImportType:
                 return updateImportTypeNode(<ImportTypeNode>node,
                     visitNode((<ImportTypeNode>node).argument, visitor, isTypeNode),
                     visitNode((<ImportTypeNode>node).qualifier, visitor, isEntityName),

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -380,7 +380,7 @@ namespace ts.Completions {
                         //      }
                         //      let x: Foo["/*completion position*/"]
                         return stringLiteralCompletionsFromProperties(typeChecker.getTypeFromTypeNode((node.parent.parent as IndexedAccessTypeNode).objectType));
-                    case SyntaxKind.ImportTypeNode:
+                    case SyntaxKind.ImportType:
                         return { kind: StringLiteralCompletionKind.Paths, paths: PathCompletions.getStringLiteralCompletionsFromModuleNames(sourceFile, node, compilerOptions, host, typeChecker) };
                     default:
                         return undefined;
@@ -881,7 +881,7 @@ namespace ts.Completions {
                     case SyntaxKind.QualifiedName:
                         node = (parent as QualifiedName).left;
                         break;
-                    case SyntaxKind.ImportTypeNode:
+                    case SyntaxKind.ImportType:
                         node = parent;
                         break;
                     default:
@@ -1067,7 +1067,7 @@ namespace ts.Completions {
             }
             else {
                 for (const symbol of type.getApparentProperties()) {
-                    if (typeChecker.isValidPropertyAccessForCompletions(node.kind === SyntaxKind.ImportTypeNode ? <ImportTypeNode>node : <PropertyAccessExpression>node.parent, type, symbol)) {
+                    if (typeChecker.isValidPropertyAccessForCompletions(node.kind === SyntaxKind.ImportType ? <ImportTypeNode>node : <PropertyAccessExpression>node.parent, type, symbol)) {
                         addPropertySymbol(symbol);
                     }
                 }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -240,7 +240,7 @@ declare namespace ts {
         IndexedAccessType = 175,
         MappedType = 176,
         LiteralType = 177,
-        ImportTypeNode = 178,
+        ImportType = 178,
         ObjectBindingPattern = 179,
         ArrayBindingPattern = 180,
         BindingElement = 181,
@@ -699,7 +699,7 @@ declare namespace ts {
         kind: SyntaxKind.AnyKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.StringKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.ThisKeyword | SyntaxKind.VoidKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.NullKeyword | SyntaxKind.NeverKeyword;
     }
     interface ImportTypeNode extends NodeWithTypeArguments {
-        kind: SyntaxKind.ImportTypeNode;
+        kind: SyntaxKind.ImportType;
         isTypeOf?: boolean;
         argument: TypeNode;
         qualifier?: EntityName;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -240,7 +240,7 @@ declare namespace ts {
         IndexedAccessType = 175,
         MappedType = 176,
         LiteralType = 177,
-        ImportTypeNode = 178,
+        ImportType = 178,
         ObjectBindingPattern = 179,
         ArrayBindingPattern = 180,
         BindingElement = 181,
@@ -699,7 +699,7 @@ declare namespace ts {
         kind: SyntaxKind.AnyKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.StringKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.ThisKeyword | SyntaxKind.VoidKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.NullKeyword | SyntaxKind.NeverKeyword;
     }
     interface ImportTypeNode extends NodeWithTypeArguments {
-        kind: SyntaxKind.ImportTypeNode;
+        kind: SyntaxKind.ImportType;
         isTypeOf?: boolean;
         argument: TypeNode;
         qualifier?: EntityName;


### PR DESCRIPTION
@ajafff pointed out that this was the only syntax kind postfixed with `Node`.
