### PR TITLE
Actually preserve nonblock for of statements in forofs with object rest

### DIFF
--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -304,6 +304,11 @@ namespace ts {
                     bodyLocation = node.statement;
                     statementsLocation = node.statement.statements;
                 }
+                else if (node.statement) {
+                    append(statements, node.statement);
+                    bodyLocation = node.statement;
+                    statementsLocation = node.statement;
+                }
                 return updateForOf(
                     node,
                     node.awaitModifier,

--- a/tests/baselines/reference/forLoopWithDestructuringDoesNotElideFollowingStatement.js
+++ b/tests/baselines/reference/forLoopWithDestructuringDoesNotElideFollowingStatement.js
@@ -1,0 +1,21 @@
+//// [forLoopWithDestructuringDoesNotElideFollowingStatement.ts]
+let array = [{a: 0, b: 1}]
+for (let { a, ...rest } of array)
+    void a
+
+//// [forLoopWithDestructuringDoesNotElideFollowingStatement.js]
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+            t[p[i]] = s[p[i]];
+    return t;
+};
+var array = [{ a: 0, b: 1 }];
+for (var _i = 0, array_1 = array; _i < array_1.length; _i++) {
+    var _a = array_1[_i];
+    var a = _a.a, rest = __rest(_a, ["a"]);
+    void a;
+}

--- a/tests/baselines/reference/forLoopWithDestructuringDoesNotElideFollowingStatement.symbols
+++ b/tests/baselines/reference/forLoopWithDestructuringDoesNotElideFollowingStatement.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts ===
+let array = [{a: 0, b: 1}]
+>array : Symbol(array, Decl(forLoopWithDestructuringDoesNotElideFollowingStatement.ts, 0, 3))
+>a : Symbol(a, Decl(forLoopWithDestructuringDoesNotElideFollowingStatement.ts, 0, 14))
+>b : Symbol(b, Decl(forLoopWithDestructuringDoesNotElideFollowingStatement.ts, 0, 19))
+
+for (let { a, ...rest } of array)
+>a : Symbol(a, Decl(forLoopWithDestructuringDoesNotElideFollowingStatement.ts, 1, 10))
+>rest : Symbol(rest, Decl(forLoopWithDestructuringDoesNotElideFollowingStatement.ts, 1, 13))
+>array : Symbol(array, Decl(forLoopWithDestructuringDoesNotElideFollowingStatement.ts, 0, 3))
+
+    void a
+>a : Symbol(a, Decl(forLoopWithDestructuringDoesNotElideFollowingStatement.ts, 1, 10))
+

--- a/tests/baselines/reference/forLoopWithDestructuringDoesNotElideFollowingStatement.types
+++ b/tests/baselines/reference/forLoopWithDestructuringDoesNotElideFollowingStatement.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts ===
+let array = [{a: 0, b: 1}]
+>array : { a: number; b: number; }[]
+>[{a: 0, b: 1}] : { a: number; b: number; }[]
+>{a: 0, b: 1} : { a: number; b: number; }
+>a : number
+>0 : 0
+>b : number
+>1 : 1
+
+for (let { a, ...rest } of array)
+>a : number
+>rest : { b: number; }
+>array : { a: number; b: number; }[]
+
+    void a
+>void a : undefined
+>a : number
+

--- a/tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts
+++ b/tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts
@@ -1,0 +1,3 @@
+let array = [{a: 0, b: 1}]
+for (let { a, ...rest } of array)
+    void a


### PR DESCRIPTION
We were missing an `else` to handle nonblock bodies in the `esnext` transform 😄 

Fixes #23098
