### PR TITLE
No error referring to UMD symbol in CommonJS modules

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1506,7 +1506,7 @@ namespace ts {
                 }
 
                 // If we're in an external module, we can't reference value symbols created from UMD export declarations
-                if (result && isInExternalModule && (meaning & SymbolFlags.Value) === SymbolFlags.Value) {
+                if (result && isInExternalModule && (meaning & SymbolFlags.Value) === SymbolFlags.Value && !(originalLocation.flags & NodeFlags.JSDoc)) {
                     const decls = result.declarations;
                     if (decls && decls.length === 1 && decls[0].kind === SyntaxKind.NamespaceExportDeclaration) {
                         error(errorLocation, Diagnostics._0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead, unescapeLeadingUnderscores(name));

--- a/tests/baselines/reference/jsdocReferenceGlobalTypeInCommonJs.errors.txt
+++ b/tests/baselines/reference/jsdocReferenceGlobalTypeInCommonJs.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/compiler/a.js(1,15): error TS2304: Cannot find name 'require'.
+tests/cases/compiler/a.js(4,1): error TS2686: 'Puppeteer' refers to a UMD global, but the current file is a module. Consider adding an import instead.
+
+
+==== tests/cases/compiler/a.js (2 errors) ====
+    const other = require('./other');
+                  ~~~~~~~
+!!! error TS2304: Cannot find name 'require'.
+    /** @type {Puppeteer.Keyboard} */
+    var ppk;
+    Puppeteer.connect;
+    ~~~~~~~~~
+!!! error TS2686: 'Puppeteer' refers to a UMD global, but the current file is a module. Consider adding an import instead.
+==== tests/cases/compiler/puppet.d.ts (0 errors) ====
+    export as namespace Puppeteer;
+    export interface Keyboard {
+        key: string
+    }
+    export function connect(name: string): void;
+    
+==== tests/cases/compiler/other.d.ts (0 errors) ====
+    declare function f(): string;
+    export = f;
+    

--- a/tests/baselines/reference/jsdocReferenceGlobalTypeInCommonJs.symbols
+++ b/tests/baselines/reference/jsdocReferenceGlobalTypeInCommonJs.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/a.js ===
+const other = require('./other');
+>other : Symbol(other, Decl(a.js, 0, 5))
+>'./other' : Symbol("tests/cases/compiler/other", Decl(other.d.ts, 0, 0))
+
+/** @type {Puppeteer.Keyboard} */
+var ppk;
+>ppk : Symbol(ppk, Decl(a.js, 2, 3))
+
+Puppeteer.connect;
+>Puppeteer.connect : Symbol(Puppeteer.connect, Decl(puppet.d.ts, 3, 1))
+>Puppeteer : Symbol(Puppeteer, Decl(puppet.d.ts, 0, 0))
+>connect : Symbol(Puppeteer.connect, Decl(puppet.d.ts, 3, 1))
+
+=== tests/cases/compiler/puppet.d.ts ===
+export as namespace Puppeteer;
+>Puppeteer : Symbol(Puppeteer, Decl(puppet.d.ts, 0, 0))
+
+export interface Keyboard {
+>Keyboard : Symbol(Keyboard, Decl(puppet.d.ts, 0, 30))
+
+    key: string
+>key : Symbol(Keyboard.key, Decl(puppet.d.ts, 1, 27))
+}
+export function connect(name: string): void;
+>connect : Symbol(connect, Decl(puppet.d.ts, 3, 1))
+>name : Symbol(name, Decl(puppet.d.ts, 4, 24))
+
+=== tests/cases/compiler/other.d.ts ===
+declare function f(): string;
+>f : Symbol(f, Decl(other.d.ts, 0, 0))
+
+export = f;
+>f : Symbol(f, Decl(other.d.ts, 0, 0))
+

--- a/tests/baselines/reference/jsdocReferenceGlobalTypeInCommonJs.types
+++ b/tests/baselines/reference/jsdocReferenceGlobalTypeInCommonJs.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/a.js ===
+const other = require('./other');
+>other : () => string
+>require('./other') : () => string
+>require : any
+>'./other' : "./other"
+
+/** @type {Puppeteer.Keyboard} */
+var ppk;
+>ppk : Puppeteer.Keyboard
+
+Puppeteer.connect;
+>Puppeteer.connect : (name: string) => void
+>Puppeteer : typeof Puppeteer
+>connect : (name: string) => void
+
+=== tests/cases/compiler/puppet.d.ts ===
+export as namespace Puppeteer;
+>Puppeteer : typeof import("tests/cases/compiler/puppet")
+
+export interface Keyboard {
+>Keyboard : Keyboard
+
+    key: string
+>key : string
+}
+export function connect(name: string): void;
+>connect : (name: string) => void
+>name : string
+
+=== tests/cases/compiler/other.d.ts ===
+declare function f(): string;
+>f : () => string
+
+export = f;
+>f : () => string
+

--- a/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
+++ b/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
@@ -1,0 +1,18 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: a.js
+const other = require('./other');
+/** @type {Puppeteer.Keyboard} */
+var ppk;
+Puppeteer.connect;
+// @Filename: puppet.d.ts
+export as namespace Puppeteer;
+export interface Keyboard {
+    key: string
+}
+export function connect(name: string): void;
+
+// @Filename: other.d.ts
+declare function f(): string;
+export = f;


### PR DESCRIPTION
In Javascript CommonJS modules, references in JSDoc can refer to UMD symbols, the way that they could before 2.8.

Fixes #22969 
