### PR TITLE
Prototype assignments count as method-like

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16241,7 +16241,7 @@ namespace ts {
          * Note that this is not tracked well within the compiler, so the answer may be incorrect.
          */
         function isPrototypeProperty(symbol: Symbol) {
-            if(symbol.flags & SymbolFlags.Method || getCheckFlags(symbol) & CheckFlags.SyntheticMethod) {
+            if (symbol.flags & SymbolFlags.Method || getCheckFlags(symbol) & CheckFlags.SyntheticMethod) {
                 return true;
             }
             if (isInJavaScriptFile(symbol.valueDeclaration)) {

--- a/tests/baselines/reference/typeFromPropertyAssignment23.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment23.symbols
@@ -40,3 +40,38 @@ D.prototype.foo = () =>  {
     this.n = 'not checked, so no error'
 }
 
+// post-class prototype assignments are trying to show that these properties are abstract
+class Module {
+>Module : Symbol(Module, Decl(a.js, 17, 1))
+}
+Module.prototype.identifier = undefined
+>Module.prototype.identifier : Symbol(Module.identifier, Decl(a.js, 21, 1))
+>Module.prototype : Symbol(Module.identifier, Decl(a.js, 21, 1))
+>Module : Symbol(Module, Decl(a.js, 17, 1))
+>prototype : Symbol(Module.prototype)
+>identifier : Symbol(Module.identifier, Decl(a.js, 21, 1))
+>undefined : Symbol(undefined)
+
+Module.prototype.size = null
+>Module.prototype.size : Symbol(Module.size, Decl(a.js, 22, 39))
+>Module.prototype : Symbol(Module.size, Decl(a.js, 22, 39))
+>Module : Symbol(Module, Decl(a.js, 17, 1))
+>prototype : Symbol(Module.prototype)
+>size : Symbol(Module.size, Decl(a.js, 22, 39))
+
+class NormalModule extends Module {
+>NormalModule : Symbol(NormalModule, Decl(a.js, 23, 28))
+>Module : Symbol(Module, Decl(a.js, 17, 1))
+
+    identifier() {
+>identifier : Symbol(NormalModule.identifier, Decl(a.js, 25, 35))
+
+        return 'normal'
+    }
+    size() {
+>size : Symbol(NormalModule.size, Decl(a.js, 28, 5))
+
+        return 0
+    }
+}
+

--- a/tests/baselines/reference/typeFromPropertyAssignment23.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment23.types
@@ -51,3 +51,43 @@ D.prototype.foo = () =>  {
 >'not checked, so no error' : "not checked, so no error"
 }
 
+// post-class prototype assignments are trying to show that these properties are abstract
+class Module {
+>Module : Module
+}
+Module.prototype.identifier = undefined
+>Module.prototype.identifier = undefined : undefined
+>Module.prototype.identifier : any
+>Module.prototype : Module
+>Module : typeof Module
+>prototype : Module
+>identifier : any
+>undefined : undefined
+
+Module.prototype.size = null
+>Module.prototype.size = null : null
+>Module.prototype.size : any
+>Module.prototype : Module
+>Module : typeof Module
+>prototype : Module
+>size : any
+>null : null
+
+class NormalModule extends Module {
+>NormalModule : NormalModule
+>Module : Module
+
+    identifier() {
+>identifier : () => string
+
+        return 'normal'
+>'normal' : "normal"
+    }
+    size() {
+>size : () => number
+
+        return 0
+>0 : 0
+    }
+}
+

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment23.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment23.ts
@@ -20,3 +20,18 @@ class D extends B { }
 D.prototype.foo = () =>  {
     this.n = 'not checked, so no error'
 }
+
+// post-class prototype assignments are trying to show that these properties are abstract
+class Module {
+}
+Module.prototype.identifier = undefined
+Module.prototype.size = null
+
+class NormalModule extends Module {
+    identifier() {
+        return 'normal'
+    }
+    size() {
+        return 0
+    }
+}


### PR DESCRIPTION
For the purposes of reporting prototype/instance property conflicts, the compiler previously assumed that only methods were prototype properties. The intent of the error is to prevent instance vs property confusion like this:

```js
class Super {
  constructor() {
    this.p = () => 1
  }
}
class Sub extends Super {
  p() { return 2 }
}
console.log(new Sub().p()) // 1 ???!!!? i warned you about classes bro!!!! i told you dog!

class Base {
  get x() { return 1 }
}
class Derived extends Base { }
Derived.prototype.x = 2
console.log(new Derived().x) // 1 ??/?? it keeps happening
```

However, in Javascript, any assignment directly to the prototype is a prototype property, as in the line `Derived.prototype.x = 2`. So there's no conflict when the base property is on the prototype and the derived one is too:

```js
class Base { }
Base.prototype.mustImplement = null
class Derived extends Base {
  mustImplement() {
    return 101
  }
}
```

This [abstract-like pattern appears in webpack](https://github.com/mohsen1/webpack/tree/bd1c827c884d943f68bbbf00cd91003875ae0bb2). Note that "isMethodLike" should really be "isPrototypeProperty" but the compiler is not very good at tracking this distinction. I optimistically renamed the function and documented its limitations in a comment.

Fixes #22895  (for real this time)
