### PR TITLE
Fix bug: `<div a="1" b/**/ >` is not a jsx initializer

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -944,7 +944,8 @@ namespace ts.Completions {
                                 isJsxInitializer = true;
                                 break;
                             case SyntaxKind.Identifier:
-                                if (previousToken !== (parent as JsxAttribute).name) {
+                                // For `<div x=[|f/**/|]`, `parent` will be `x` and `previousToken.parent` will be `f` (which is its own JsxAttribute)
+                                if (parent !== previousToken.parent && !(parent as JsxAttribute).initializer) {
                                     isJsxInitializer = previousToken as Identifier;
                                 }
                         }

--- a/tests/cases/fourslash/completionsJsxAttributeInitializer2.ts
+++ b/tests/cases/fourslash/completionsJsxAttributeInitializer2.ts
@@ -1,13 +1,23 @@
 /// <reference path="fourslash.ts" />
 
 // @Filename: /a.tsx
+////declare namespace JSX {
+////    interface IntrinsicElements {
+////        div: { a: string, b: string }
+////    }
+////}
 ////const foo = 0;
-////<div x=[|f/**/|] />;
+////<div x=[|f/*0*/|] />;
+////
+////<div a="1" b/*1*/ />
+////<div a /*2*/ />
 
 const [replacementSpan] = test.ranges();
-goTo.marker();
+goTo.marker("0");
 verify.completionListContains("foo", "const foo: 0", undefined, "const", undefined, undefined, {
     includeInsertTextCompletions: true,
     insertText: "{foo}",
     replacementSpan,
 });
+
+verify.completionsAt(["1", "2"], ["b"]);


### PR DESCRIPTION
Fixes #23099

Was originally broken by #21681
