### PR TITLE
Only include unique symbols when getting index types for access checks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8142,12 +8142,7 @@ namespace ts {
 
         function getLiteralTypeFromPropertyNames(type: Type, includeDeclaredTypes?: boolean) {
             const originalKeys = map(getPropertiesOfType(type), getLiteralTypeFromPropertyName);
-            if (includeDeclaredTypes) {
-                return getUnionType(originalKeys);
-            }
-            else {
-                return getUnionType(filter(originalKeys, isTypeString));
-            }
+            return getUnionType(includeDeclaredTypes ? originalKeys : filter(originalKeys, isTypeString));
         }
 
         function getIndexType(type: Type, includeDeclaredTypes?: boolean): Type {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3753,6 +3753,8 @@ namespace ts {
         /* @internal */
         resolvedIndexType: IndexType;
         /* @internal */
+        resolvedDeclaredIndexType: IndexType;
+        /* @internal */
         resolvedBaseConstraint: Type;
         /* @internal */
         couldContainTypeVariables: boolean;
@@ -3839,6 +3841,8 @@ namespace ts {
         resolvedBaseConstraint?: Type;
         /* @internal */
         resolvedIndexType?: IndexType;
+        /* @internal */
+        resolvedDeclaredIndexType?: IndexType;
     }
 
     // Type parameters (TypeFlags.TypeParameter)
@@ -3870,6 +3874,8 @@ namespace ts {
 
     // keyof T types (TypeFlags.Index)
     export interface IndexType extends InstantiableType {
+        /* @internal */
+        isDeclaredType?: boolean;
         type: InstantiableType | UnionOrIntersectionType;
     }
 

--- a/tests/baselines/reference/keyofDoesntContainSymbols.errors.txt
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.errors.txt
@@ -1,0 +1,29 @@
+tests/cases/compiler/keyofDoesntContainSymbols.ts(10,30): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
+tests/cases/compiler/keyofDoesntContainSymbols.ts(13,23): error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"'.
+
+
+==== tests/cases/compiler/keyofDoesntContainSymbols.ts (2 errors) ====
+    const sym = Symbol();
+    const obj = { num: 0, str: 's', [sym]: sym };
+    
+    function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+      return obj[key] = value;
+    }
+    
+    const val = set(obj, 'str', '');
+    // string
+    const valB = set(obj, 'num', '');
+                                 ~~
+!!! error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
+    // Expect type error
+    // Argument of type '""' is not assignable to parameter of type 'number'.
+    const valC = set(obj, sym, sym);
+                          ~~~
+!!! error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"'.
+    // Expect type error
+    // Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+    type KeyofObj = keyof typeof obj;
+    // "str" | "num"
+    type Values<T> = T[keyof T];
+    
+    type ValuesOfObj = Values<typeof obj>;

--- a/tests/baselines/reference/keyofDoesntContainSymbols.errors.txt
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.errors.txt
@@ -1,10 +1,12 @@
-tests/cases/compiler/keyofDoesntContainSymbols.ts(10,30): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
-tests/cases/compiler/keyofDoesntContainSymbols.ts(13,23): error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"'.
+tests/cases/compiler/keyofDoesntContainSymbols.ts(11,30): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
+tests/cases/compiler/keyofDoesntContainSymbols.ts(14,23): error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"'.
+tests/cases/compiler/keyofDoesntContainSymbols.ts(17,23): error TS2345: Argument of type '0' is not assignable to parameter of type '"str" | "num"'.
 
 
-==== tests/cases/compiler/keyofDoesntContainSymbols.ts (2 errors) ====
+==== tests/cases/compiler/keyofDoesntContainSymbols.ts (3 errors) ====
     const sym = Symbol();
-    const obj = { num: 0, str: 's', [sym]: sym };
+    const num = 0;
+    const obj = { num: 0, str: 's', [num]: num as 0, [sym]: sym };
     
     function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
       return obj[key] = value;
@@ -21,7 +23,12 @@ tests/cases/compiler/keyofDoesntContainSymbols.ts(13,23): error TS2345: Argument
                           ~~~
 !!! error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"'.
     // Expect type error
-    // Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+    // Argument of type 'unique symbol' is not assignable to parameter of type "str" | "num"
+    const valD = set(obj, num, num);
+                          ~~~
+!!! error TS2345: Argument of type '0' is not assignable to parameter of type '"str" | "num"'.
+    // Expect type error
+    // Argument of type '0' is not assignable to parameter of type "str" | "num"
     type KeyofObj = keyof typeof obj;
     // "str" | "num"
     type Values<T> = T[keyof T];

--- a/tests/baselines/reference/keyofDoesntContainSymbols.js
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.js
@@ -1,6 +1,7 @@
 //// [keyofDoesntContainSymbols.ts]
 const sym = Symbol();
-const obj = { num: 0, str: 's', [sym]: sym };
+const num = 0;
+const obj = { num: 0, str: 's', [num]: num as 0, [sym]: sym };
 
 function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
   return obj[key] = value;
@@ -13,7 +14,10 @@ const valB = set(obj, 'num', '');
 // Argument of type '""' is not assignable to parameter of type 'number'.
 const valC = set(obj, sym, sym);
 // Expect type error
-// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+// Argument of type 'unique symbol' is not assignable to parameter of type "str" | "num"
+const valD = set(obj, num, num);
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type "str" | "num"
 type KeyofObj = keyof typeof obj;
 // "str" | "num"
 type Values<T> = T[keyof T];
@@ -22,7 +26,8 @@ type ValuesOfObj = Values<typeof obj>;
 
 //// [keyofDoesntContainSymbols.js]
 var sym = Symbol();
-var obj = (_a = { num: 0, str: 's' }, _a[sym] = sym, _a);
+var num = 0;
+var obj = (_a = { num: 0, str: 's' }, _a[num] = num, _a[sym] = sym, _a);
 function set(obj, key, value) {
     return obj[key] = value;
 }
@@ -32,4 +37,7 @@ var valB = set(obj, 'num', '');
 // Expect type error
 // Argument of type '""' is not assignable to parameter of type 'number'.
 var valC = set(obj, sym, sym);
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type "str" | "num"
+var valD = set(obj, num, num);
 var _a;

--- a/tests/baselines/reference/keyofDoesntContainSymbols.js
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.js
@@ -1,0 +1,35 @@
+//// [keyofDoesntContainSymbols.ts]
+const sym = Symbol();
+const obj = { num: 0, str: 's', [sym]: sym };
+
+function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+  return obj[key] = value;
+}
+
+const val = set(obj, 'str', '');
+// string
+const valB = set(obj, 'num', '');
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+const valC = set(obj, sym, sym);
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+type KeyofObj = keyof typeof obj;
+// "str" | "num"
+type Values<T> = T[keyof T];
+
+type ValuesOfObj = Values<typeof obj>;
+
+//// [keyofDoesntContainSymbols.js]
+var sym = Symbol();
+var obj = (_a = { num: 0, str: 's' }, _a[sym] = sym, _a);
+function set(obj, key, value) {
+    return obj[key] = value;
+}
+var val = set(obj, 'str', '');
+// string
+var valB = set(obj, 'num', '');
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+var valC = set(obj, sym, sym);
+var _a;

--- a/tests/baselines/reference/keyofDoesntContainSymbols.symbols
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.symbols
@@ -1,0 +1,72 @@
+=== tests/cases/compiler/keyofDoesntContainSymbols.ts ===
+const sym = Symbol();
+>sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+
+const obj = { num: 0, str: 's', [sym]: sym };
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 1, 13))
+>str : Symbol(str, Decl(keyofDoesntContainSymbols.ts, 1, 21))
+>[sym] : Symbol([sym], Decl(keyofDoesntContainSymbols.ts, 1, 31))
+>sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
+>sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
+
+function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 1, 45))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
+>K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 3, 31))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 3, 52))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
+>key : Symbol(key, Decl(keyofDoesntContainSymbols.ts, 3, 59))
+>K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 3, 31))
+>value : Symbol(value, Decl(keyofDoesntContainSymbols.ts, 3, 67))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
+>K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 3, 31))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
+>K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 3, 31))
+
+  return obj[key] = value;
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 3, 52))
+>key : Symbol(key, Decl(keyofDoesntContainSymbols.ts, 3, 59))
+>value : Symbol(value, Decl(keyofDoesntContainSymbols.ts, 3, 67))
+}
+
+const val = set(obj, 'str', '');
+>val : Symbol(val, Decl(keyofDoesntContainSymbols.ts, 7, 5))
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 1, 45))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+
+// string
+const valB = set(obj, 'num', '');
+>valB : Symbol(valB, Decl(keyofDoesntContainSymbols.ts, 9, 5))
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 1, 45))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+const valC = set(obj, sym, sym);
+>valC : Symbol(valC, Decl(keyofDoesntContainSymbols.ts, 12, 5))
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 1, 45))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
+>sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
+
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+type KeyofObj = keyof typeof obj;
+>KeyofObj : Symbol(KeyofObj, Decl(keyofDoesntContainSymbols.ts, 12, 32))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+
+// "str" | "num"
+type Values<T> = T[keyof T];
+>Values : Symbol(Values, Decl(keyofDoesntContainSymbols.ts, 15, 33))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 17, 12))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 17, 12))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 17, 12))
+
+type ValuesOfObj = Values<typeof obj>;
+>ValuesOfObj : Symbol(ValuesOfObj, Decl(keyofDoesntContainSymbols.ts, 17, 28))
+>Values : Symbol(Values, Decl(keyofDoesntContainSymbols.ts, 15, 33))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+

--- a/tests/baselines/reference/keyofDoesntContainSymbols.symbols
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.symbols
@@ -3,70 +3,85 @@ const sym = Symbol();
 >sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
 >Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
-const obj = { num: 0, str: 's', [sym]: sym };
->obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
->num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 1, 13))
->str : Symbol(str, Decl(keyofDoesntContainSymbols.ts, 1, 21))
->[sym] : Symbol([sym], Decl(keyofDoesntContainSymbols.ts, 1, 31))
+const num = 0;
+>num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+
+const obj = { num: 0, str: 's', [num]: num as 0, [sym]: sym };
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 2, 5))
+>num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 2, 13))
+>str : Symbol(str, Decl(keyofDoesntContainSymbols.ts, 2, 21))
+>[num] : Symbol([num], Decl(keyofDoesntContainSymbols.ts, 2, 31))
+>num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>[sym] : Symbol([sym], Decl(keyofDoesntContainSymbols.ts, 2, 48))
 >sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
 >sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
 
 function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
->set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 1, 45))
->T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
->K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 3, 31))
->T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
->obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 3, 52))
->T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
->key : Symbol(key, Decl(keyofDoesntContainSymbols.ts, 3, 59))
->K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 3, 31))
->value : Symbol(value, Decl(keyofDoesntContainSymbols.ts, 3, 67))
->T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
->K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 3, 31))
->T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 3, 14))
->K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 3, 31))
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 2, 62))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 4, 14))
+>K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 4, 31))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 4, 14))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 4, 52))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 4, 14))
+>key : Symbol(key, Decl(keyofDoesntContainSymbols.ts, 4, 59))
+>K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 4, 31))
+>value : Symbol(value, Decl(keyofDoesntContainSymbols.ts, 4, 67))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 4, 14))
+>K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 4, 31))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 4, 14))
+>K : Symbol(K, Decl(keyofDoesntContainSymbols.ts, 4, 31))
 
   return obj[key] = value;
->obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 3, 52))
->key : Symbol(key, Decl(keyofDoesntContainSymbols.ts, 3, 59))
->value : Symbol(value, Decl(keyofDoesntContainSymbols.ts, 3, 67))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 4, 52))
+>key : Symbol(key, Decl(keyofDoesntContainSymbols.ts, 4, 59))
+>value : Symbol(value, Decl(keyofDoesntContainSymbols.ts, 4, 67))
 }
 
 const val = set(obj, 'str', '');
->val : Symbol(val, Decl(keyofDoesntContainSymbols.ts, 7, 5))
->set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 1, 45))
->obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>val : Symbol(val, Decl(keyofDoesntContainSymbols.ts, 8, 5))
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 2, 5))
 
 // string
 const valB = set(obj, 'num', '');
->valB : Symbol(valB, Decl(keyofDoesntContainSymbols.ts, 9, 5))
->set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 1, 45))
->obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>valB : Symbol(valB, Decl(keyofDoesntContainSymbols.ts, 10, 5))
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 2, 5))
 
 // Expect type error
 // Argument of type '""' is not assignable to parameter of type 'number'.
 const valC = set(obj, sym, sym);
->valC : Symbol(valC, Decl(keyofDoesntContainSymbols.ts, 12, 5))
->set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 1, 45))
->obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>valC : Symbol(valC, Decl(keyofDoesntContainSymbols.ts, 13, 5))
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 2, 5))
 >sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
 >sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
 
 // Expect type error
-// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+// Argument of type 'unique symbol' is not assignable to parameter of type "str" | "num"
+const valD = set(obj, num, num);
+>valD : Symbol(valD, Decl(keyofDoesntContainSymbols.ts, 16, 5))
+>set : Symbol(set, Decl(keyofDoesntContainSymbols.ts, 2, 62))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 2, 5))
+>num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type "str" | "num"
 type KeyofObj = keyof typeof obj;
->KeyofObj : Symbol(KeyofObj, Decl(keyofDoesntContainSymbols.ts, 12, 32))
->obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>KeyofObj : Symbol(KeyofObj, Decl(keyofDoesntContainSymbols.ts, 16, 32))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 2, 5))
 
 // "str" | "num"
 type Values<T> = T[keyof T];
->Values : Symbol(Values, Decl(keyofDoesntContainSymbols.ts, 15, 33))
->T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 17, 12))
->T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 17, 12))
->T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 17, 12))
+>Values : Symbol(Values, Decl(keyofDoesntContainSymbols.ts, 19, 33))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 21, 12))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 21, 12))
+>T : Symbol(T, Decl(keyofDoesntContainSymbols.ts, 21, 12))
 
 type ValuesOfObj = Values<typeof obj>;
->ValuesOfObj : Symbol(ValuesOfObj, Decl(keyofDoesntContainSymbols.ts, 17, 28))
->Values : Symbol(Values, Decl(keyofDoesntContainSymbols.ts, 15, 33))
->obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 1, 5))
+>ValuesOfObj : Symbol(ValuesOfObj, Decl(keyofDoesntContainSymbols.ts, 21, 28))
+>Values : Symbol(Values, Decl(keyofDoesntContainSymbols.ts, 19, 33))
+>obj : Symbol(obj, Decl(keyofDoesntContainSymbols.ts, 2, 5))
 

--- a/tests/baselines/reference/keyofDoesntContainSymbols.types
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.types
@@ -1,0 +1,85 @@
+=== tests/cases/compiler/keyofDoesntContainSymbols.ts ===
+const sym = Symbol();
+>sym : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+const obj = { num: 0, str: 's', [sym]: sym };
+>obj : { num: number; str: string; [sym]: symbol; }
+>{ num: 0, str: 's', [sym]: sym } : { num: number; str: string; [sym]: symbol; }
+>num : number
+>0 : 0
+>str : string
+>'s' : "s"
+>[sym] : symbol
+>sym : unique symbol
+>sym : unique symbol
+
+function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>T : T
+>K : K
+>T : T
+>obj : T
+>T : T
+>key : K
+>K : K
+>value : T[K]
+>T : T
+>K : K
+>T : T
+>K : K
+
+  return obj[key] = value;
+>obj[key] = value : T[K]
+>obj[key] : T[K]
+>obj : T
+>key : K
+>value : T[K]
+}
+
+const val = set(obj, 'str', '');
+>val : string
+>set(obj, 'str', '') : string
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [sym]: symbol; }
+>'str' : "str"
+>'' : ""
+
+// string
+const valB = set(obj, 'num', '');
+>valB : any
+>set(obj, 'num', '') : any
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [sym]: symbol; }
+>'num' : "num"
+>'' : ""
+
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+const valC = set(obj, sym, sym);
+>valC : any
+>set(obj, sym, sym) : any
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [sym]: symbol; }
+>sym : unique symbol
+>sym : unique symbol
+
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+type KeyofObj = keyof typeof obj;
+>KeyofObj : "str" | "num"
+>obj : { num: number; str: string; [sym]: symbol; }
+
+// "str" | "num"
+type Values<T> = T[keyof T];
+>Values : T[keyof T]
+>T : T
+>T : T
+>T : T
+
+type ValuesOfObj = Values<typeof obj>;
+>ValuesOfObj : string | number
+>Values : T[keyof T]
+>obj : { num: number; str: string; [sym]: symbol; }
+

--- a/tests/baselines/reference/keyofDoesntContainSymbols.types
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.types
@@ -4,13 +4,21 @@ const sym = Symbol();
 >Symbol() : unique symbol
 >Symbol : SymbolConstructor
 
-const obj = { num: 0, str: 's', [sym]: sym };
->obj : { num: number; str: string; [sym]: symbol; }
->{ num: 0, str: 's', [sym]: sym } : { num: number; str: string; [sym]: symbol; }
+const num = 0;
+>num : 0
+>0 : 0
+
+const obj = { num: 0, str: 's', [num]: num as 0, [sym]: sym };
+>obj : { num: number; str: string; [num]: 0; [sym]: symbol; }
+>{ num: 0, str: 's', [num]: num as 0, [sym]: sym } : { num: number; str: string; [num]: 0; [sym]: symbol; }
 >num : number
 >0 : 0
 >str : string
 >'s' : "s"
+>[num] : 0
+>num : 0
+>num as 0 : 0
+>num : 0
 >[sym] : symbol
 >sym : unique symbol
 >sym : unique symbol
@@ -42,7 +50,7 @@ const val = set(obj, 'str', '');
 >val : string
 >set(obj, 'str', '') : string
 >set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
->obj : { num: number; str: string; [sym]: symbol; }
+>obj : { num: number; str: string; [num]: 0; [sym]: symbol; }
 >'str' : "str"
 >'' : ""
 
@@ -51,7 +59,7 @@ const valB = set(obj, 'num', '');
 >valB : any
 >set(obj, 'num', '') : any
 >set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
->obj : { num: number; str: string; [sym]: symbol; }
+>obj : { num: number; str: string; [num]: 0; [sym]: symbol; }
 >'num' : "num"
 >'' : ""
 
@@ -61,15 +69,25 @@ const valC = set(obj, sym, sym);
 >valC : any
 >set(obj, sym, sym) : any
 >set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
->obj : { num: number; str: string; [sym]: symbol; }
+>obj : { num: number; str: string; [num]: 0; [sym]: symbol; }
 >sym : unique symbol
 >sym : unique symbol
 
 // Expect type error
-// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+// Argument of type 'unique symbol' is not assignable to parameter of type "str" | "num"
+const valD = set(obj, num, num);
+>valD : any
+>set(obj, num, num) : any
+>set : <T extends object, K extends keyof T>(obj: T, key: K, value: T[K]) => T[K]
+>obj : { num: number; str: string; [num]: 0; [sym]: symbol; }
+>num : 0
+>num : 0
+
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type "str" | "num"
 type KeyofObj = keyof typeof obj;
 >KeyofObj : "str" | "num"
->obj : { num: number; str: string; [sym]: symbol; }
+>obj : { num: number; str: string; [num]: 0; [sym]: symbol; }
 
 // "str" | "num"
 type Values<T> = T[keyof T];
@@ -81,5 +99,5 @@ type Values<T> = T[keyof T];
 type ValuesOfObj = Values<typeof obj>;
 >ValuesOfObj : string | number
 >Values : T[keyof T]
->obj : { num: number; str: string; [sym]: symbol; }
+>obj : { num: number; str: string; [num]: 0; [sym]: symbol; }
 

--- a/tests/cases/compiler/keyofDoesntContainSymbols.ts
+++ b/tests/cases/compiler/keyofDoesntContainSymbols.ts
@@ -1,6 +1,7 @@
 // @lib: es6
 const sym = Symbol();
-const obj = { num: 0, str: 's', [sym]: sym };
+const num = 0;
+const obj = { num: 0, str: 's', [num]: num as 0, [sym]: sym };
 
 function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
   return obj[key] = value;
@@ -13,7 +14,10 @@ const valB = set(obj, 'num', '');
 // Argument of type '""' is not assignable to parameter of type 'number'.
 const valC = set(obj, sym, sym);
 // Expect type error
-// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+// Argument of type 'unique symbol' is not assignable to parameter of type "str" | "num"
+const valD = set(obj, num, num);
+// Expect type error
+// Argument of type '0' is not assignable to parameter of type "str" | "num"
 type KeyofObj = keyof typeof obj;
 // "str" | "num"
 type Values<T> = T[keyof T];

--- a/tests/cases/compiler/keyofDoesntContainSymbols.ts
+++ b/tests/cases/compiler/keyofDoesntContainSymbols.ts
@@ -1,0 +1,21 @@
+// @lib: es6
+const sym = Symbol();
+const obj = { num: 0, str: 's', [sym]: sym };
+
+function set <T extends object, K extends keyof T> (obj: T, key: K, value: T[K]): T[K] {
+  return obj[key] = value;
+}
+
+const val = set(obj, 'str', '');
+// string
+const valB = set(obj, 'num', '');
+// Expect type error
+// Argument of type '""' is not assignable to parameter of type 'number'.
+const valC = set(obj, sym, sym);
+// Expect type error
+// Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"
+type KeyofObj = keyof typeof obj;
+// "str" | "num"
+type Values<T> = T[keyof T];
+
+type ValuesOfObj = Values<typeof obj>;


### PR DESCRIPTION
Alternative to #23090 that moves towards the `indexof` type we talked about the other day, but is lightweight enough to be more acceptable as a patch. Note that this only removes/fixes symbols - `number` literals from late bound symbols will still be an issue (though they've been an issue for longer and need to have more confusing behavior, so probably should wait for the full `indexof` implementation).