### PR TITLE
Report errors in JSX properties on the failing prop or the tag name

### DIFF
--- a/tests/baselines/reference/checkJsxChildrenProperty14.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty14.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(42,27): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
+tests/cases/conformance/jsx/file.tsx(42,11): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
   Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
     Types of property 'children' are incompatible.
       Type 'Element[]' is not assignable to type 'Element'.
@@ -48,7 +48,7 @@ tests/cases/conformance/jsx/file.tsx(42,27): error TS2322: Type '{ children: Ele
     
     // Error
     let k5 = <SingleChildComp a={10} b="hi"><></><Button /><AnotherButton /></SingleChildComp>;
-                              ~~~~~~~~~~~~~
+              ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
 !!! error TS2322:   Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
 !!! error TS2322:     Types of property 'children' are incompatible.

--- a/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
@@ -1,26 +1,26 @@
-tests/cases/conformance/jsx/file.tsx(14,15): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(14,10): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
     Property 'children' is missing in type '{ a: number; b: string; }'.
 tests/cases/conformance/jsx/file.tsx(17,11): error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
-tests/cases/conformance/jsx/file.tsx(31,11): error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(31,6): error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
         Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
           Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
-tests/cases/conformance/jsx/file.tsx(37,11): error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(37,6): error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(number | Element)[]' is not assignable to type 'string | Element'.
         Type '(number | Element)[]' is not assignable to type 'Element'.
           Property 'type' is missing in type '(number | Element)[]'.
-tests/cases/conformance/jsx/file.tsx(43,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(43,6): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'string | Element'.
         Type '(string | Element)[]' is not assignable to type 'Element'.
           Property 'type' is missing in type '(string | Element)[]'.
-tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type 'Element[]' is not assignable to type 'string | Element'.
@@ -43,7 +43,7 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ children: Ele
     
     // Error: missing children
     let k = <Comp a={10} b="hi" />;
-                  ~~~~~~~~~~~~~
+             ~~~~
 !!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Property 'children' is missing in type '{ a: number; b: string; }'.
@@ -66,7 +66,7 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ children: Ele
     // Error: incorrect type
     let k2 =
         <Comp a={10} b="hi">
-              ~~~~~~~~~~~~~
+         ~~~~
 !!! error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
@@ -79,7 +79,7 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ children: Ele
     
     let k3 =
         <Comp a={10} b="hi">
-              ~~~~~~~~~~~~~
+         ~~~~
 !!! error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
@@ -92,7 +92,7 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ children: Ele
     
     let k4 =
         <Comp a={10} b="hi" >
-              ~~~~~~~~~~~~~
+         ~~~~
 !!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
@@ -105,7 +105,7 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ children: Ele
     
     let k5 =
         <Comp a={10} b="hi" >
-              ~~~~~~~~~~~~~
+         ~~~~
 !!! error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.

--- a/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/jsx/file.tsx(24,28): error TS2551: Property 'NAme' does not exist on type 'IUser'. Did you mean 'Name'?
-tests/cases/conformance/jsx/file.tsx(32,9): error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<FetchUser> & IFetchUserProps & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<FetchUser> & IFetchUserProps & { children?: ReactNode; }'.
   Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
     Types of property 'children' are incompatible.
       Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
@@ -41,7 +41,7 @@ tests/cases/conformance/jsx/file.tsx(32,9): error TS2322: Type '{ children: ((us
     function UserName1() {
         return (
             <FetchUser>
-            ~~~~~~~~~~~
+             ~~~~~~~~~
 !!! error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<FetchUser> & IFetchUserProps & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
 !!! error TS2322:     Types of property 'children' are incompatible.

--- a/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
@@ -1,12 +1,12 @@
-tests/cases/conformance/jsx/file.tsx(20,15): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
     Property 'children' is missing in type '{ a: number; b: string; }'.
-tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(24,6): error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type 'Element' is not assignable to type 'Button'.
         Property 'render' is missing in type 'Element'.
-tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(28,6): error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type 'typeof Button' is not assignable to type 'Button'.
@@ -34,7 +34,7 @@ tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{ children: typ
     
     // Error: no children specified
     let k = <Comp a={10} b="hi" />;
-                  ~~~~~~~~~~~~~
+             ~~~~
 !!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Property 'children' is missing in type '{ a: number; b: string; }'.
@@ -42,7 +42,7 @@ tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{ children: typ
     // Error: JSX.element is not the same as JSX.ElementClass
     let k1 =
         <Comp a={10} b="hi">
-              ~~~~~~~~~~~~~
+         ~~~~
 !!! error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
@@ -52,7 +52,7 @@ tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{ children: typ
         </Comp>;
     let k2 =
         <Comp a={10} b="hi">
-              ~~~~~~~~~~~~~
+         ~~~~
 !!! error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.

--- a/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/jsx/file.tsx(24,16): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
         Type '(string | Element)[]' is not assignable to type 'Element[]'.
           Type 'string | Element' is not assignable to type 'Element'.
             Type 'string' is not assignable to type 'Element'.
-tests/cases/conformance/jsx/file.tsx(25,16): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(25,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
         Type '(string | Element)[]' is not assignable to type 'Element[]'.
-tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
+tests/cases/conformance/jsx/file.tsx(27,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
@@ -42,7 +42,7 @@ tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ children: (st
     
     // Error: whitespaces matters
     let k1 = <Comp a={10} b="hi"><Button />  <AnotherButton /></Comp>;
-                   ~~~~~~~~~~~~~
+              ~~~~
 !!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
@@ -51,7 +51,7 @@ tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ children: (st
 !!! error TS2322:           Type 'string | Element' is not assignable to type 'Element'.
 !!! error TS2322:             Type 'string' is not assignable to type 'Element'.
     let k2 = <Comp a={10} b="hi"><Button />
-                   ~~~~~~~~~~~~~
+              ~~~~
 !!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.
@@ -59,7 +59,7 @@ tests/cases/conformance/jsx/file.tsx(27,16): error TS2322: Type '{ children: (st
 !!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
         <AnotherButton />  </Comp>;
     let k3 = <Comp a={10} b="hi">    <Button />
-                   ~~~~~~~~~~~~~
+              ~~~~
 !!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
 !!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'children' are incompatible.

--- a/tests/baselines/reference/checkJsxGenericTagHasCorrectInferences.errors.txt
+++ b/tests/baselines/reference/checkJsxGenericTagHasCorrectInferences.errors.txt
@@ -1,8 +1,6 @@
-tests/cases/conformance/jsx/file.tsx(13,27): error TS2322: Type '{ initialValues: { x: string; }; nextValues: (a: { x: string; }) => string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<GenericComponent<{ initialValues: { x: string; }; nextValues: {}; }, { x: string; }>> & { initialValues: { x: string; }; nextValues: {}; } & BaseProps<{ x: string; }> & { children?: ReactNode; }'.
-  Type '{ initialValues: { x: string; }; nextValues: (a: { x: string; }) => string; }' is not assignable to type 'BaseProps<{ x: string; }>'.
-    Types of property 'nextValues' are incompatible.
-      Type '(a: { x: string; }) => string' is not assignable to type '(cur: { x: string; }) => { x: string; }'.
-        Type 'string' is not assignable to type '{ x: string; }'.
+tests/cases/conformance/jsx/file.tsx(13,54): error TS2326: Types of property 'nextValues' are incompatible.
+  Type '(a: { x: string; }) => string' is not assignable to type '(cur: { x: string; }) => { x: string; }'.
+    Type 'string' is not assignable to type '{ x: string; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,9 +17,7 @@ tests/cases/conformance/jsx/file.tsx(13,27): error TS2322: Type '{ initialValues
     let b = <GenericComponent initialValues={12} nextValues={a => a} />; // No error - Values should be reinstantiated with `number` (since `object` is a default, not a constraint)
     let c = <GenericComponent initialValues={{ x: "y" }} nextValues={a => ({ x: a.x })} />; // No Error
     let d = <GenericComponent initialValues={{ x: "y" }} nextValues={a => a.x} />; // Error - `string` is not assignable to `{x: string}`
-                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ initialValues: { x: string; }; nextValues: (a: { x: string; }) => string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<GenericComponent<{ initialValues: { x: string; }; nextValues: {}; }, { x: string; }>> & { initialValues: { x: string; }; nextValues: {}; } & BaseProps<{ x: string; }> & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ initialValues: { x: string; }; nextValues: (a: { x: string; }) => string; }' is not assignable to type 'BaseProps<{ x: string; }>'.
-!!! error TS2322:     Types of property 'nextValues' are incompatible.
-!!! error TS2322:       Type '(a: { x: string; }) => string' is not assignable to type '(cur: { x: string; }) => { x: string; }'.
-!!! error TS2322:         Type 'string' is not assignable to type '{ x: string; }'.
+                                                         ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2326: Types of property 'nextValues' are incompatible.
+!!! error TS2326:   Type '(a: { x: string; }) => string' is not assignable to type '(cur: { x: string; }) => { x: string; }'.
+!!! error TS2326:     Type 'string' is not assignable to type '{ x: string; }'.

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(15,15): error TS2322: Type '{ foo: "f"; }' is not assignable to type '{ foo: "A" | "B" | "C"; }'.
-  Types of property 'foo' are incompatible.
-    Type '"f"' is not assignable to type '"A" | "B" | "C"'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(16,15): error TS2322: Type '{ foo: "f"; }' is not assignable to type '{ foo: "A" | "B" | "C"; }'.
-  Types of property 'foo' are incompatible.
-    Type '"f"' is not assignable to type '"A" | "B" | "C"'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(15,15): error TS2326: Types of property 'foo' are incompatible.
+  Type '"f"' is not assignable to type '"A" | "B" | "C"'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(16,15): error TS2326: Types of property 'foo' are incompatible.
+  Type '"f"' is not assignable to type '"A" | "B" | "C"'.
 
 
 ==== tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx (2 errors) ====
@@ -23,11 +21,9 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStr
     
     <FooComponent foo={"f"} />;
                   ~~~~~~~~~
-!!! error TS2322: Type '{ foo: "f"; }' is not assignable to type '{ foo: "A" | "B" | "C"; }'.
-!!! error TS2322:   Types of property 'foo' are incompatible.
-!!! error TS2322:     Type '"f"' is not assignable to type '"A" | "B" | "C"'.
+!!! error TS2326: Types of property 'foo' are incompatible.
+!!! error TS2326:   Type '"f"' is not assignable to type '"A" | "B" | "C"'.
     <FooComponent foo="f"   />;
                   ~~~~~~~
-!!! error TS2322: Type '{ foo: "f"; }' is not assignable to type '{ foo: "A" | "B" | "C"; }'.
-!!! error TS2322:   Types of property 'foo' are incompatible.
-!!! error TS2322:     Type '"f"' is not assignable to type '"A" | "B" | "C"'.
+!!! error TS2326: Types of property 'foo' are incompatible.
+!!! error TS2326:   Type '"f"' is not assignable to type '"A" | "B" | "C"'.

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,24): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,13): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
   Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
     Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,24): error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,13): error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
   Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
     Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,43): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
@@ -38,12 +38,12 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): err
     }
     
     const b0 = <MainButton {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type "left" | "right"
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2322:   Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
 !!! error TS2322:     Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2322:   Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
 !!! error TS2322:     Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.

--- a/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.errors.txt
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/jsx/inline/index.tsx(5,1): error TS2322: Type 'dom.JSX.E
   Property '__predomBrand' is missing in type 'Element'.
 tests/cases/conformance/jsx/inline/index.tsx(21,21): error TS2605: JSX element type 'Element' is not a constructor function for JSX elements.
   Property 'render' is missing in type 'Element'.
-tests/cases/conformance/jsx/inline/index.tsx(21,28): error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ children?: Element[]; }'.
+tests/cases/conformance/jsx/inline/index.tsx(21,22): error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ children?: Element[]; }'.
   Types of property 'children' are incompatible.
     Type 'dom.JSX.Element[]' is not assignable to type 'predom.JSX.Element[]'.
       Type 'dom.JSX.Element' is not assignable to type 'predom.JSX.Element'.
@@ -10,7 +10,7 @@ tests/cases/conformance/jsx/inline/index.tsx(21,40): error TS2605: JSX element t
 tests/cases/conformance/jsx/inline/index.tsx(21,40): error TS2605: JSX element type 'MyClass' is not a constructor function for JSX elements.
   Property '__domBrand' is missing in type 'MyClass'.
 tests/cases/conformance/jsx/inline/index.tsx(21,63): error TS2605: JSX element type 'MyClass' is not a constructor function for JSX elements.
-tests/cases/conformance/jsx/inline/index.tsx(24,30): error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ x: number; y: number; children?: Element[]; }'.
+tests/cases/conformance/jsx/inline/index.tsx(24,23): error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ x: number; y: number; children?: Element[]; }'.
   Types of property 'children' are incompatible.
     Type 'predom.JSX.Element[]' is not assignable to type 'dom.JSX.Element[]'.
       Type 'predom.JSX.Element' is not assignable to type 'dom.JSX.Element'.
@@ -105,7 +105,7 @@ tests/cases/conformance/jsx/inline/index.tsx(24,30): error TS2322: Type '{ child
                         ~~~~~~~~~~~~~~~~~~~
 !!! error TS2605: JSX element type 'Element' is not a constructor function for JSX elements.
 !!! error TS2605:   Property 'render' is missing in type 'Element'.
-                               ~~~~~~~~~~~
+                         ~~~~~
 !!! error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ children?: Element[]; }'.
 !!! error TS2322:   Types of property 'children' are incompatible.
 !!! error TS2322:     Type 'dom.JSX.Element[]' is not assignable to type 'predom.JSX.Element[]'.
@@ -120,7 +120,7 @@ tests/cases/conformance/jsx/inline/index.tsx(24,30): error TS2322: Type '{ child
     
     // Should fail, nondom isn't allowed as children of dom
     const _brokenTree2 = <DOMSFC x={1} y={2}>{tree}{tree}</DOMSFC>
-                                 ~~~~~~~~~~~
+                          ~~~~~~
 !!! error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ x: number; y: number; children?: Element[]; }'.
 !!! error TS2322:   Types of property 'children' are incompatible.
 !!! error TS2322:     Type 'predom.JSX.Element[]' is not assignable to type 'dom.JSX.Element[]'.

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.errors.txt
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(20,22): error TS2322: Type '{ prop: "x"; children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
-  Type '{ prop: "x"; children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; }' is not assignable to type 'LitProps<"x">'.
-    Types of property 'children' are incompatible.
-      Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
-        Type '"y"' is not assignable to type '"x"'.
-tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(21,27): error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(20,31): error TS2326: Types of property 'children' are incompatible.
+  Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: IntrinsicAttributes & LitProps<"x">) => "x"'.
+    Type '"y"' is not assignable to type '"x"'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(21,19): error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
   Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
     Types of property 'children' are incompatible.
       Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x" | "y">) => "x" | "y"'.
@@ -13,7 +11,7 @@ tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(21,27): error TS2322:
               Types of property 'prop' are incompatible.
                 Type '"x" | "y"' is not assignable to type '"x"'.
                   Type '"y"' is not assignable to type '"x"'.
-tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,29): error TS2322: Type '{ children: () => number; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,21): error TS2322: Type '{ children: () => number; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
   Type '{ children: () => number; prop: "x"; }' is not assignable to type 'LitProps<"x">'.
     Types of property 'children' are incompatible.
       Type '() => number' is not assignable to type '(x: LitProps<"x">) => "x"'.
@@ -41,14 +39,12 @@ tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,29): error TS2322:
     
     // Should error
     const arg = <ElemLit prop="x" children={p => "y"} />
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ prop: "x"; children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
-!!! error TS2322:   Type '{ prop: "x"; children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; }' is not assignable to type 'LitProps<"x">'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x">) => "x"'.
-!!! error TS2322:         Type '"y"' is not assignable to type '"x"'.
+                                  ~~~~~~~~~~~~~~~~~~~
+!!! error TS2326: Types of property 'children' are incompatible.
+!!! error TS2326:   Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: IntrinsicAttributes & LitProps<"x">) => "x"'.
+!!! error TS2326:     Type '"y"' is not assignable to type '"x"'.
     const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
-                              ~~~~~~~~
+                      ~~~~~~~
 !!! error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
 !!! error TS2322:   Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
 !!! error TS2322:     Types of property 'children' are incompatible.
@@ -60,7 +56,7 @@ tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,29): error TS2322:
 !!! error TS2322:                 Type '"x" | "y"' is not assignable to type '"x"'.
 !!! error TS2322:                   Type '"y"' is not assignable to type '"x"'.
     const mismatched = <ElemLit prop="x">{() => 12}</ElemLit>
-                                ~~~~~~~~
+                        ~~~~~~~
 !!! error TS2322: Type '{ children: () => number; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
 !!! error TS2322:   Type '{ children: () => number; prop: "x"; }' is not assignable to type 'LitProps<"x">'.
 !!! error TS2322:     Types of property 'children' are incompatible.

--- a/tests/baselines/reference/tsxAttributeErrors.errors.txt
+++ b/tests/baselines/reference/tsxAttributeErrors.errors.txt
@@ -1,10 +1,8 @@
-tests/cases/conformance/jsx/tsxAttributeErrors.tsx(14,6): error TS2322: Type '{ text: number; }' is not assignable to type '{ text?: string; width?: number; }'.
-  Types of property 'text' are incompatible.
-    Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/tsxAttributeErrors.tsx(17,6): error TS2322: Type '{ width: string; }' is not assignable to type '{ text?: string; width?: number; }'.
-  Types of property 'width' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsx/tsxAttributeErrors.tsx(21,6): error TS2322: Type '{ text: number; }' is not assignable to type '{ text?: string; width?: number; }'.
+tests/cases/conformance/jsx/tsxAttributeErrors.tsx(14,6): error TS2326: Types of property 'text' are incompatible.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/tsxAttributeErrors.tsx(17,6): error TS2326: Types of property 'width' are incompatible.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/tsxAttributeErrors.tsx(21,2): error TS2322: Type '{ text: number; }' is not assignable to type '{ text?: string; width?: number; }'.
   Types of property 'text' are incompatible.
     Type 'number' is not assignable to type 'string'.
 
@@ -25,21 +23,19 @@ tests/cases/conformance/jsx/tsxAttributeErrors.tsx(21,6): error TS2322: Type '{ 
     // Error, number is not assignable to string
     <div text={42} />;
          ~~~~~~~~~
-!!! error TS2322: Type '{ text: number; }' is not assignable to type '{ text?: string; width?: number; }'.
-!!! error TS2322:   Types of property 'text' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'text' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     
     // Error, string is not assignable to number
     <div width={'foo'} />;
          ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ width: string; }' is not assignable to type '{ text?: string; width?: number; }'.
-!!! error TS2322:   Types of property 'width' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2326: Types of property 'width' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number'.
     
     // Error, number is not assignable to string
     var attribs = { text: 100 };
     <div {...attribs} />;
-         ~~~~~~~~~~~~
+     ~~~
 !!! error TS2322: Type '{ text: number; }' is not assignable to type '{ text?: string; width?: number; }'.
 !!! error TS2322:   Types of property 'text' are incompatible.
 !!! error TS2322:     Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxAttributeResolution1.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution1.errors.txt
@@ -1,17 +1,14 @@
-tests/cases/conformance/jsx/file.tsx(23,8): error TS2322: Type '{ x: string; }' is not assignable to type 'Attribs1'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(24,8): error TS2559: Type '{ y: number; }' has no properties in common with type 'Attribs1'.
-tests/cases/conformance/jsx/file.tsx(25,8): error TS2559: Type '{ y: string; }' has no properties in common with type 'Attribs1'.
-tests/cases/conformance/jsx/file.tsx(26,8): error TS2322: Type '{ x: string; }' is not assignable to type 'Attribs1'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(27,8): error TS2559: Type '{ var: string; }' has no properties in common with type 'Attribs1'.
-tests/cases/conformance/jsx/file.tsx(29,1): error TS2322: Type '{}' is not assignable to type '{ reqd: string; }'.
+tests/cases/conformance/jsx/file.tsx(23,8): error TS2326: Types of property 'x' are incompatible.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(24,2): error TS2559: Type '{ y: number; }' has no properties in common with type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(25,2): error TS2559: Type '{ y: string; }' has no properties in common with type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(26,8): error TS2326: Types of property 'x' are incompatible.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(27,2): error TS2559: Type '{ var: string; }' has no properties in common with type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(29,2): error TS2322: Type '{}' is not assignable to type '{ reqd: string; }'.
   Property 'reqd' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: number; }' is not assignable to type '{ reqd: string; }'.
-  Types of property 'reqd' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(30,8): error TS2326: Types of property 'reqd' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (7 errors) ====
@@ -39,33 +36,30 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: number; 
     // Errors
     <test1 x={'0'} />; // Error, '0' is not number
            ~~~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number'.
     <test1 y={0} />; // Error, no property "y"
-           ~~~~~
+     ~~~~~
 !!! error TS2559: Type '{ y: number; }' has no properties in common with type 'Attribs1'.
     <test1 y="foo" />; // Error, no property "y"
-           ~~~~~~~
+     ~~~~~
 !!! error TS2559: Type '{ y: string; }' has no properties in common with type 'Attribs1'.
     <test1 x="32" />; // Error, "32" is not number
            ~~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number'.
     <test1 var="10" />; // Error, no 'var' property
-           ~~~~~~~~
+     ~~~~~
 !!! error TS2559: Type '{ var: string; }' has no properties in common with type 'Attribs1'.
     
     <test2 />; // Error, missing reqd
-    ~~~~~~~~~
+     ~~~~~
 !!! error TS2322: Type '{}' is not assignable to type '{ reqd: string; }'.
 !!! error TS2322:   Property 'reqd' is missing in type '{}'.
     <test2 reqd={10} />; // Error, reqd is not string
            ~~~~~~~~~
-!!! error TS2322: Type '{ reqd: number; }' is not assignable to type '{ reqd: string; }'.
-!!! error TS2322:   Types of property 'reqd' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'reqd' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     
     // Should be OK
     <var var='var' />;

--- a/tests/baselines/reference/tsxAttributeResolution10.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution10.errors.txt
@@ -1,6 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(11,14): error TS2322: Type '{ bar: string; }' is not assignable to type '{ [s: string]: boolean; }'.
-  Property 'bar' is incompatible with index signature.
-    Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(11,14): error TS2326: Types of property 'bar' are incompatible.
+  Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -26,9 +25,8 @@ tests/cases/conformance/jsx/file.tsx(11,14): error TS2322: Type '{ bar: string; 
     // Should be an error
     <MyComponent bar='world' />;
                  ~~~~~~~~~~~
-!!! error TS2322: Type '{ bar: string; }' is not assignable to type '{ [s: string]: boolean; }'.
-!!! error TS2322:   Property 'bar' is incompatible with index signature.
-!!! error TS2322:     Type 'string' is not assignable to type 'boolean'.
+!!! error TS2326: Types of property 'bar' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'boolean'.
     
     // Should be OK
     <MyComponent bar={true} />;

--- a/tests/baselines/reference/tsxAttributeResolution11.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution11.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,22): error TS2559: Type '{ bar: string; }' has no properties in common with type 'IntrinsicAttributes & { ref?: string; }'.
+tests/cases/conformance/jsx/file.tsx(11,10): error TS2559: Type '{ bar: string; }' has no properties in common with type 'IntrinsicAttributes & { ref?: string; }'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -26,7 +26,7 @@ tests/cases/conformance/jsx/file.tsx(11,22): error TS2559: Type '{ bar: string; 
     
     // Should be an OK
     var x = <MyComponent bar='world' />;
-                         ~~~~~~~~~~~
+             ~~~~~~~~~~~
 !!! error TS2559: Type '{ bar: string; }' has no properties in common with type 'IntrinsicAttributes & { ref?: string; }'.
     
     

--- a/tests/baselines/reference/tsxAttributeResolution12.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution12.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(25,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
+tests/cases/conformance/jsx/file.tsx(25,11): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
   Type '{}' is not assignable to type '{ reqd: any; }'.
     Property 'reqd' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(28,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
+tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
   Type '{}' is not assignable to type '{ reqd: any; }'.
     Property 'reqd' is missing in type '{}'.
 
@@ -45,14 +45,14 @@ tests/cases/conformance/jsx/file.tsx(28,10): error TS2322: Type '{}' is not assi
     // Errors correctly
     const T = TestMod.Test;
     var t1 = <T />;
-             ~~~~~
+              ~
 !!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
 !!! error TS2322:   Type '{}' is not assignable to type '{ reqd: any; }'.
 !!! error TS2322:     Property 'reqd' is missing in type '{}'.
     
     // Should error
     var t2 = <TestMod.Test />;
-             ~~~~~~~~~~~~~~~~
+              ~~~~~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
 !!! error TS2322:   Type '{}' is not assignable to type '{ reqd: any; }'.
 !!! error TS2322:     Property 'reqd' is missing in type '{}'.

--- a/tests/baselines/reference/tsxAttributeResolution14.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution14.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(13,28): error TS2322: Type '{ primaryText: number; }' is not assignable to type 'IProps'.
-  Types of property 'primaryText' are incompatible.
-    Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(15,28): error TS2322: Type '{ justRandomProp1: boolean; primaryText: string; }' is not assignable to type 'IProps'.
-  Property 'justRandomProp1' is incompatible with index signature.
-    Type 'boolean' is not assignable to type 'string | number'.
+tests/cases/conformance/jsx/file.tsx(13,28): error TS2326: Types of property 'primaryText' are incompatible.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(15,28): error TS2326: Types of property 'justRandomProp1' are incompatible.
+  Type 'boolean' is not assignable to type 'string | number'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -30,15 +28,13 @@ tests/cases/conformance/jsx/file.tsx(15,28): error TS2322: Type '{ justRandomPro
         <div>
           <VerticalNavMenuItem primaryText={2} />  // error
                                ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ primaryText: number; }' is not assignable to type 'IProps'.
-!!! error TS2322:   Types of property 'primaryText' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'primaryText' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
           <VerticalNavMenuItem justRandomProp={2} primaryText={"hello"} />  // ok
           <VerticalNavMenuItem justRandomProp1={true} primaryText={"hello"} />  // error
-                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ justRandomProp1: boolean; primaryText: string; }' is not assignable to type 'IProps'.
-!!! error TS2322:   Property 'justRandomProp1' is incompatible with index signature.
-!!! error TS2322:     Type 'boolean' is not assignable to type 'string | number'.
+                               ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2326: Types of property 'justRandomProp1' are incompatible.
+!!! error TS2326:   Type 'boolean' is not assignable to type 'string | number'.
         </div>
       )
     } 

--- a/tests/baselines/reference/tsxAttributeResolution15.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution15.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,21): error TS2559: Type '{ prop1: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(11,10): error TS2559: Type '{ prop1: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -13,7 +13,7 @@ tests/cases/conformance/jsx/file.tsx(11,21): error TS2559: Type '{ prop1: string
     
     // Error
     let a = <BigGreeter prop1="hello" />
-                        ~~~~~~~~~~~~~
+             ~~~~~~~~~~
 !!! error TS2559: Type '{ prop1: string; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
     
     // OK

--- a/tests/baselines/reference/tsxAttributeResolution3.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution3.errors.txt
@@ -1,11 +1,10 @@
-tests/cases/conformance/jsx/file.tsx(19,8): error TS2322: Type '{ x: number; }' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(19,2): error TS2322: Type '{ x: number; }' is not assignable to type 'Attribs1'.
   Types of property 'x' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(23,8): error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(23,2): error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
   Property 'x' is missing in type '{ y: number; }'.
-tests/cases/conformance/jsx/file.tsx(31,8): error TS2322: Type '{ x: number; y: number; }' is not assignable to type 'Attribs1'.
-  Types of property 'x' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(31,8): error TS2326: Types of property 'x' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -28,7 +27,7 @@ tests/cases/conformance/jsx/file.tsx(31,8): error TS2322: Type '{ x: number; y: 
     // Error, x is not string
     var obj2 = { x: 32 };
     <test1 {...obj2} />
-           ~~~~~~~~~
+     ~~~~~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Types of property 'x' are incompatible.
 !!! error TS2322:     Type 'number' is not assignable to type 'string'.
@@ -36,7 +35,7 @@ tests/cases/conformance/jsx/file.tsx(31,8): error TS2322: Type '{ x: number; y: 
     // Error, x is missing
     var obj3 = { y: 32 };
     <test1 {...obj3} />
-           ~~~~~~~~~
+     ~~~~~
 !!! error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Property 'x' is missing in type '{ y: number; }'.
     
@@ -47,10 +46,9 @@ tests/cases/conformance/jsx/file.tsx(31,8): error TS2322: Type '{ x: number; y: 
     // Error
     var obj5 = { x: 32, y: 32 };
     <test1 x="ok" {...obj5} />
-           ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ x: number; y: number; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+           ~~~~~~
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     
     // Ok
     var obj6 = { x: 'ok', y: 32, extra: 100 };

--- a/tests/baselines/reference/tsxAttributeResolution5.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution5.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/jsx/file.tsx(21,16): error TS2322: Type 'T' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(21,10): error TS2322: Type 'T' is not assignable to type 'Attribs1'.
   Type '{ x: number; }' is not assignable to type 'Attribs1'.
     Types of property 'x' are incompatible.
       Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(25,16): error TS2322: Type 'T' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(25,10): error TS2322: Type 'T' is not assignable to type 'Attribs1'.
   Type '{ y: string; }' is not assignable to type 'Attribs1'.
     Property 'x' is missing in type '{ y: string; }'.
-tests/cases/conformance/jsx/file.tsx(29,8): error TS2322: Type '{}' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(29,2): error TS2322: Type '{}' is not assignable to type 'Attribs1'.
   Property 'x' is missing in type '{}'.
 
 
@@ -31,7 +31,7 @@ tests/cases/conformance/jsx/file.tsx(29,8): error TS2322: Type '{}' is not assig
     
     function make2<T extends {x: number}> (obj: T) {
     	return <test1 {...obj} />; // Error (x is number, not string)
-    	              ~~~~~~~~
+    	        ~~~~~
 !!! error TS2322: Type 'T' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Type '{ x: number; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:     Types of property 'x' are incompatible.
@@ -40,7 +40,7 @@ tests/cases/conformance/jsx/file.tsx(29,8): error TS2322: Type '{}' is not assig
     
     function make3<T extends {y: string}> (obj: T) {
     	return <test1 {...obj} />; // Error, missing x
-    	              ~~~~~~~~
+    	        ~~~~~
 !!! error TS2322: Type 'T' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Type '{ y: string; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:     Property 'x' is missing in type '{ y: string; }'.
@@ -48,7 +48,7 @@ tests/cases/conformance/jsx/file.tsx(29,8): error TS2322: Type '{}' is not assig
     
     
     <test1 {...{}} />; // Error, missing x
-           ~~~~~~~
+     ~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Property 'x' is missing in type '{}'.
     <test2 {...{}} />; // Error, missing toString

--- a/tests/baselines/reference/tsxAttributeResolution6.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution6.errors.txt
@@ -1,10 +1,8 @@
-tests/cases/conformance/jsx/file.tsx(10,8): error TS2322: Type '{ s: true; }' is not assignable to type '{ n?: boolean; s?: string; }'.
-  Types of property 's' are incompatible.
-    Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(11,8): error TS2322: Type '{ n: string; }' is not assignable to type '{ n?: boolean; s?: string; }'.
-  Types of property 'n' are incompatible.
-    Type 'string' is not assignable to type 'boolean'.
-tests/cases/conformance/jsx/file.tsx(12,1): error TS2322: Type '{}' is not assignable to type '{ n: boolean; }'.
+tests/cases/conformance/jsx/file.tsx(10,8): error TS2326: Types of property 's' are incompatible.
+  Type 'true' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(11,8): error TS2326: Types of property 'n' are incompatible.
+  Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(12,2): error TS2322: Type '{}' is not assignable to type '{ n: boolean; }'.
   Property 'n' is missing in type '{}'.
 
 
@@ -20,16 +18,14 @@ tests/cases/conformance/jsx/file.tsx(12,1): error TS2322: Type '{}' is not assig
     // Error
     <test1 s />;
            ~
-!!! error TS2322: Type '{ s: true; }' is not assignable to type '{ n?: boolean; s?: string; }'.
-!!! error TS2322:   Types of property 's' are incompatible.
-!!! error TS2322:     Type 'true' is not assignable to type 'string'.
+!!! error TS2326: Types of property 's' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type 'string'.
     <test1 n='true' />;
            ~~~~~~~~
-!!! error TS2322: Type '{ n: string; }' is not assignable to type '{ n?: boolean; s?: string; }'.
-!!! error TS2322:   Types of property 'n' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'boolean'.
+!!! error TS2326: Types of property 'n' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'boolean'.
     <test2 />;
-    ~~~~~~~~~
+     ~~~~~
 !!! error TS2322: Type '{}' is not assignable to type '{ n: boolean; }'.
 !!! error TS2322:   Property 'n' is missing in type '{}'.
     

--- a/tests/baselines/reference/tsxAttributeResolution7.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution7.errors.txt
@@ -1,6 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(9,8): error TS2322: Type '{ data-foo: number; }' is not assignable to type '{ "data-foo"?: string; }'.
-  Types of property '"data-foo"' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(9,8): error TS2326: Types of property 'data-foo' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -14,9 +13,8 @@ tests/cases/conformance/jsx/file.tsx(9,8): error TS2322: Type '{ data-foo: numbe
     // Error
     <test1 data-foo={32} />;
            ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ data-foo: number; }' is not assignable to type '{ "data-foo"?: string; }'.
-!!! error TS2322:   Types of property '"data-foo"' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'data-foo' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     
     // OK
     <test1 data-foo={'32'} />;

--- a/tests/baselines/reference/tsxAttributeResolution9.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution9.errors.txt
@@ -1,6 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(9,14): error TS2322: Type '{ foo: number; }' is not assignable to type '{ foo: string; }'.
-  Types of property 'foo' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(9,14): error TS2326: Types of property 'foo' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -28,7 +27,6 @@ tests/cases/conformance/jsx/file.tsx(9,14): error TS2322: Type '{ foo: number; }
     <MyComponent foo="bar" />; // ok  
     <MyComponent foo={0} />; // should be an error
                  ~~~~~~~
-!!! error TS2322: Type '{ foo: number; }' is not assignable to type '{ foo: string; }'.
-!!! error TS2322:   Types of property 'foo' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'foo' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/tsxDefaultAttributesResolution3.errors.txt
+++ b/tests/baselines/reference/tsxDefaultAttributesResolution3.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(13,19): error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & Prop & { children?: ReactNode; }'.
-  Type '{ x: true; }' is not assignable to type 'Prop'.
-    Types of property 'x' are incompatible.
-      Type 'true' is not assignable to type 'false'.
+tests/cases/conformance/jsx/file.tsx(13,19): error TS2326: Types of property 'x' are incompatible.
+  Type 'true' is not assignable to type 'false'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,7 +17,5 @@ tests/cases/conformance/jsx/file.tsx(13,19): error TS2322: Type '{ x: true; }' i
     // Error
     let p = <Poisoned x/>;
                       ~
-!!! error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: true; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type 'true' is not assignable to type 'false'.
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type 'false'.

--- a/tests/baselines/reference/tsxElementResolution10.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution10.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/jsx/file.tsx(13,1): error TS2605: JSX element type '{ x: number; }' is not a constructor function for JSX elements.
   Property 'render' is missing in type '{ x: number; }'.
-tests/cases/conformance/jsx/file.tsx(13,7): error TS2322: Type '{ x: number; }' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(19,7): error TS2322: Type '{ x: number; render: number; }' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(13,2): error TS2322: Type '{ x: number; }' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(19,2): error TS2322: Type '{ x: number; render: number; }' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -21,7 +21,7 @@ tests/cases/conformance/jsx/file.tsx(19,7): error TS2322: Type '{ x: number; ren
     ~~~~~~~~~~~~~~~
 !!! error TS2605: JSX element type '{ x: number; }' is not a constructor function for JSX elements.
 !!! error TS2605:   Property 'render' is missing in type '{ x: number; }'.
-          ~~~~~~
+     ~~~~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type 'string'.
     
     interface Obj2type {
@@ -29,6 +29,6 @@ tests/cases/conformance/jsx/file.tsx(19,7): error TS2322: Type '{ x: number; ren
     }
     var Obj2: Obj2type;
     <Obj2 x={32} render={100} />; // OK
-          ~~~~~~~~~~~~~~~~~~~
+     ~~~~
 !!! error TS2322: Type '{ x: number; render: number; }' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/tsxElementResolution11.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution11.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(17,7): error TS2559: Type '{ x: number; }' has no properties in common with type '{ q?: number; }'.
+tests/cases/conformance/jsx/file.tsx(17,2): error TS2559: Type '{ x: number; }' has no properties in common with type '{ q?: number; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,7 +19,7 @@ tests/cases/conformance/jsx/file.tsx(17,7): error TS2559: Type '{ x: number; }' 
     }
     var Obj2: Obj2type;
     <Obj2 x={10} />; // Error
-          ~~~~~~
+     ~~~~
 !!! error TS2559: Type '{ x: number; }' has no properties in common with type '{ q?: number; }'.
     
     interface Obj3type {

--- a/tests/baselines/reference/tsxElementResolution12.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution12.errors.txt
@@ -2,9 +2,8 @@ tests/cases/conformance/jsx/file.tsx(23,1): error TS2607: JSX element class does
 tests/cases/conformance/jsx/file.tsx(23,7): error TS2339: Property 'x' does not exist on type '{}'.
 tests/cases/conformance/jsx/file.tsx(25,1): error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
 tests/cases/conformance/jsx/file.tsx(26,1): error TS2607: JSX element class does not support attributes because it does not have a 'pr' property.
-tests/cases/conformance/jsx/file.tsx(33,7): error TS2322: Type '{ x: string; }' is not assignable to type '{ x: number; }'.
-  Types of property 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(33,7): error TS2326: Types of property 'x' are incompatible.
+  Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (5 errors) ====
@@ -50,7 +49,6 @@ tests/cases/conformance/jsx/file.tsx(33,7): error TS2322: Type '{ x: string; }' 
     <Obj4 x={10} />; // OK
     <Obj4 x={'10'} />; // Error
           ~~~~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type '{ x: number; }'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number'.
     

--- a/tests/baselines/reference/tsxElementResolution15.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution15.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/jsx/file.tsx(3,12): error TS2608: The global type 'JSX.ElementAttributesProperty' may not have more than one property.
-tests/cases/conformance/jsx/file.tsx(11,7): error TS2322: Type '{ x: number; }' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(11,2): error TS2322: Type '{ x: number; }' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -16,6 +16,6 @@ tests/cases/conformance/jsx/file.tsx(11,7): error TS2322: Type '{ x: number; }' 
     }
     var Obj1: Obj1type;
     <Obj1 x={10} />; // Error
-          ~~~~~~
+     ~~~~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/tsxElementResolution3.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution3.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
+tests/cases/conformance/jsx/file.tsx(12,2): error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
   Property 'n' is missing in type '{ w: string; }'.
 
 
@@ -15,6 +15,6 @@ tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: string; }' 
     
     // Error
     <span w='err' />;
-          ~~~~~~~
+     ~~~~
 !!! error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
 !!! error TS2322:   Property 'n' is missing in type '{ w: string; }'.

--- a/tests/baselines/reference/tsxElementResolution4.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution4.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
+tests/cases/conformance/jsx/file.tsx(16,2): error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
   Property 'm' is missing in type '{ q: string; }'.
 
 
@@ -19,7 +19,7 @@ tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: string; }' 
     
     // Error
     <span q='' />;
-          ~~~~
+     ~~~~
 !!! error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
 !!! error TS2322:   Property 'm' is missing in type '{ q: string; }'.
     

--- a/tests/baselines/reference/tsxElementResolution9.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution9.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/jsx/file.tsx(11,1): error TS2322: Type '{}' is not assignable to type 'string | number'.
+tests/cases/conformance/jsx/file.tsx(11,2): error TS2322: Type '{}' is not assignable to type 'string | number'.
   Type '{}' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(18,1): error TS2322: Type '{}' is not assignable to type 'string | number'.
+tests/cases/conformance/jsx/file.tsx(18,2): error TS2322: Type '{}' is not assignable to type 'string | number'.
   Type '{}' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(25,7): error TS2322: Type '{ x: number; }' is not assignable to type 'string | number'.
+tests/cases/conformance/jsx/file.tsx(25,2): error TS2322: Type '{ x: number; }' is not assignable to type 'string | number'.
   Type '{ x: number; }' is not assignable to type 'number'.
 
 
@@ -18,7 +18,7 @@ tests/cases/conformance/jsx/file.tsx(25,7): error TS2322: Type '{ x: number; }' 
     }
     var Obj1: Obj1;
     <Obj1 />; // Error, return type is not an object type
-    ~~~~~~~~
+     ~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'string | number'.
 !!! error TS2322:   Type '{}' is not assignable to type 'number'.
     
@@ -28,7 +28,7 @@ tests/cases/conformance/jsx/file.tsx(25,7): error TS2322: Type '{ x: number; }' 
     }
     var Obj2: Obj2;
     <Obj2 />; // Error, return type is not an object type
-    ~~~~~~~~
+     ~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'string | number'.
 !!! error TS2322:   Type '{}' is not assignable to type 'number'.
     
@@ -38,7 +38,7 @@ tests/cases/conformance/jsx/file.tsx(25,7): error TS2322: Type '{ x: number; }' 
     }
     var Obj3: Obj3;
     <Obj3 x={42} />; // OK
-          ~~~~~~
+     ~~~~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type 'string | number'.
 !!! error TS2322:   Type '{ x: number; }' is not assignable to type 'number'.
     

--- a/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
+++ b/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
@@ -1,9 +1,8 @@
-tests/cases/conformance/jsx/file.tsx(13,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(13,11): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
   Type '{}' is not assignable to type 'Prop'.
     Property 'a' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(19,18): error TS2322: Type '{ a: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-  Type '{ a: string; }' is not assignable to type 'Prop'.
-    Property 'b' is missing in type '{ a: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,18): error TS2326: Types of property 'a' are incompatible.
+  Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -20,7 +19,7 @@ tests/cases/conformance/jsx/file.tsx(19,18): error TS2322: Type '{ a: string; }'
     
     // Error
     let x1 = <MyComp />
-             ~~~~~~~~~~
+              ~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{}' is not assignable to type 'Prop'.
 !!! error TS2322:     Property 'a' is missing in type '{}'.
@@ -31,6 +30,5 @@ tests/cases/conformance/jsx/file.tsx(19,18): error TS2322: Type '{ a: string; }'
     // Error
     let x2 = <MyComp a="hi"/>
                      ~~~~~~
-!!! error TS2322: Type '{ a: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ a: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Property 'b' is missing in type '{ a: string; }'.
+!!! error TS2326: Types of property 'a' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution10.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution10.errors.txt
@@ -1,19 +1,11 @@
-tests/cases/conformance/jsx/file.tsx(19,14): error TS2322: Type '{ x: 3; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-  Type '{ x: 3; }' is not assignable to type 'OptionProp'.
-    Types of property 'x' are incompatible.
-      Type '3' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(20,15): error TS2322: Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-  Type '{ x: string; }' is not assignable to type 'OptionProp'.
-    Types of property 'x' are incompatible.
-      Type 'string' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(21,15): error TS2322: Type '{ x: 3; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-  Type '{ x: 3; }' is not assignable to type 'OptionProp'.
-    Types of property 'x' are incompatible.
-      Type '3' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(22,15): error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-  Type '{ x: true; }' is not assignable to type 'OptionProp'.
-    Types of property 'x' are incompatible.
-      Type 'true' is not assignable to type '2'.
+tests/cases/conformance/jsx/file.tsx(19,23): error TS2326: Types of property 'x' are incompatible.
+  Type '3' is not assignable to type '2'.
+tests/cases/conformance/jsx/file.tsx(20,25): error TS2326: Types of property 'x' are incompatible.
+  Type 'string' is not assignable to type '2'.
+tests/cases/conformance/jsx/file.tsx(21,25): error TS2326: Types of property 'x' are incompatible.
+  Type '3' is not assignable to type '2'.
+tests/cases/conformance/jsx/file.tsx(22,15): error TS2326: Types of property 'x' are incompatible.
+  Type 'true' is not assignable to type '2'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (4 errors) ====
@@ -36,27 +28,19 @@ tests/cases/conformance/jsx/file.tsx(22,15): error TS2322: Type '{ x: true; }' i
     
     // Error
     let y = <Opt {...obj} x={3}/>;
-                 ~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ x: 3; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: 3; }' is not assignable to type 'OptionProp'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type '3' is not assignable to type '2'.
+                          ~~~~~
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type '3' is not assignable to type '2'.
     let y1 = <Opt {...obj1} x="Hi"/>;
-                  ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: string; }' is not assignable to type 'OptionProp'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type 'string' is not assignable to type '2'.
+                            ~~~~~~
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type '2'.
     let y2 = <Opt {...obj1} x={3}/>;
-                  ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ x: 3; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: 3; }' is not assignable to type 'OptionProp'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type '3' is not assignable to type '2'.
+                            ~~~~~
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type '3' is not assignable to type '2'.
     let y3 = <Opt x />;
                   ~
-!!! error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Opt> & OptionProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: true; }' is not assignable to type 'OptionProp'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type 'true' is not assignable to type '2'.
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type '2'.
     

--- a/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
@@ -1,12 +1,8 @@
-tests/cases/conformance/jsx/file.tsx(27,24): error TS2322: Type '{ x: 2; y: true; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-  Type '{ x: 2; y: true; overwrite: string; }' is not assignable to type 'Prop'.
-    Types of property 'y' are incompatible.
-      Type 'true' is not assignable to type 'false'.
-tests/cases/conformance/jsx/file.tsx(28,25): error TS2322: Type '{ y: true; x: 3; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-  Type '{ y: true; x: 3; overwrite: string; }' is not assignable to type 'Prop'.
-    Types of property 'x' are incompatible.
-      Type '3' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(30,25): error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(27,33): error TS2326: Types of property 'y' are incompatible.
+  Type 'true' is not assignable to type 'false'.
+tests/cases/conformance/jsx/file.tsx(28,50): error TS2326: Types of property 'x' are incompatible.
+  Type '3' is not assignable to type '2'.
+tests/cases/conformance/jsx/file.tsx(30,11): error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
   Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
     Types of property 'y' are incompatible.
       Type 'true' is not assignable to type 'false'.
@@ -40,20 +36,16 @@ tests/cases/conformance/jsx/file.tsx(30,25): error TS2322: Type '{ y: true; x: 2
     
     // Error
     let x = <OverWriteAttr {...obj} y overwrite="hi" {...obj1} />
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ x: 2; y: true; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: 2; y: true; overwrite: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'y' are incompatible.
-!!! error TS2322:       Type 'true' is not assignable to type 'false'.
+                                    ~
+!!! error TS2326: Types of property 'y' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type 'false'.
     let x1 = <OverWriteAttr overwrite="hi" {...obj1} x={3} {...{y: true}} />
-                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y: true; x: 3; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ y: true; x: 3; overwrite: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type '3' is not assignable to type '2'.
+                                                     ~~~~~
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type '3' is not assignable to type '2'.
     let x2 = <OverWriteAttr {...anyobj} x={3} />
     let x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{y: true}} />
-                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~~~~~~~~~~~~
 !!! error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
 !!! error TS2322:     Types of property 'y' are incompatible.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution16.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution16.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,27): error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
+tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
   Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
     Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
 
@@ -15,7 +15,7 @@ tests/cases/conformance/jsx/file.tsx(11,27): error TS2322: Type '{ property1: st
         return (
             // Error: missing property
             <AnotherComponent {...props} />
-                              ~~~~~~~~~~
+             ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
 !!! error TS2322:   Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
 !!! error TS2322:     Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -1,24 +1,24 @@
-tests/cases/conformance/jsx/file.tsx(17,19): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(17,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
   Type '{}' is not assignable to type 'PoisonedProp'.
     Property 'x' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(18,9): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(18,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
   Type '{}' is not assignable to type 'PoisonedProp'.
     Property 'x' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(19,19): error TS2322: Type '{ x: true; y: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-  Type '{ x: true; y: true; }' is not assignable to type 'PoisonedProp'.
-    Types of property 'x' are incompatible.
-      Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(20,19): error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(19,19): error TS2326: Types of property 'x' are incompatible.
+  Type 'true' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(19,21): error TS2326: Types of property 'y' are incompatible.
+  Type 'true' is not assignable to type '"2"'.
+tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
   Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
     Types of property 'x' are incompatible.
       Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(21,20): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(21,11): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
   Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
     Types of property 'x' are incompatible.
       Type 'number' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (5 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (6 errors) ====
     import React = require('react');
     
     interface PoisonedProp {
@@ -36,29 +36,30 @@ tests/cases/conformance/jsx/file.tsx(21,20): error TS2322: Type '{ X: string; x:
     
     // Error
     let p = <Poisoned {...obj} />;
-                      ~~~~~~~~
+             ~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{}' is not assignable to type 'PoisonedProp'.
 !!! error TS2322:     Property 'x' is missing in type '{}'.
     let y = <Poisoned />;
-            ~~~~~~~~~~~~
+             ~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{}' is not assignable to type 'PoisonedProp'.
 !!! error TS2322:     Property 'x' is missing in type '{}'.
     let z = <Poisoned x y/>;
-                      ~~~
-!!! error TS2322: Type '{ x: true; y: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: true; y: true; }' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type 'true' is not assignable to type 'string'.
+                      ~
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type 'string'.
+                        ~
+!!! error TS2326: Types of property 'y' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type '"2"'.
     let w = <Poisoned {...{x: 5, y: "2"}}/>;
-                      ~~~~~~~~~~~~~~~~~~~
+             ~~~~~~~~
 !!! error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
 !!! error TS2322:     Types of property 'x' are incompatible.
 !!! error TS2322:       Type 'number' is not assignable to type 'string'.
     let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~~~~~~~
 !!! error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
 !!! error TS2322:     Types of property 'x' are incompatible.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution5.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution5.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/jsx/file.tsx(20,19): error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
   Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
     Types of property 'y' are incompatible.
       Type 'number' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(33,20): error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(33,10): error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -26,7 +26,7 @@ tests/cases/conformance/jsx/file.tsx(33,20): error TS2559: Type '{ prop1: boolea
     
     // Error as "obj" has type { x: string; y: number }
     let p = <Poisoned {...obj} />;
-                      ~~~~~~~~
+             ~~~~~~~~
 !!! error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 !!! error TS2322:   Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
 !!! error TS2322:     Types of property 'y' are incompatible.
@@ -44,5 +44,5 @@ tests/cases/conformance/jsx/file.tsx(33,20): error TS2559: Type '{ prop1: boolea
     }
     // Ok
     let e = <EmptyProp {...o} />;
-                       ~~~~~~
+             ~~~~~~~~~
 !!! error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
+tests/cases/conformance/jsx/file.tsx(13,10): error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
   Type '{ editable: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
     Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
       Property 'onEdit' is missing in type '{ editable: true; }'.
@@ -18,7 +18,7 @@ tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ editable: tru
     
     // Error
     let x = <TextComponent editable={true} />
-                           ~~~~~~~~~~~~~~~
+             ~~~~~~~~~~~~~
 !!! error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
 !!! error TS2322:   Type '{ editable: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
 !!! error TS2322:     Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -1,39 +1,29 @@
-tests/cases/conformance/jsx/file.tsx(12,22): error TS2322: Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+tests/cases/conformance/jsx/file.tsx(12,13): error TS2322: Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
   Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
     Property 'yy' is missing in type '{ extraProp: true; }'.
-tests/cases/conformance/jsx/file.tsx(13,22): error TS2322: Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+tests/cases/conformance/jsx/file.tsx(13,13): error TS2322: Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
   Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
     Property 'yy1' is missing in type '{ yy: number; }'.
-tests/cases/conformance/jsx/file.tsx(14,22): error TS2322: Type '{ yy1: true; yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-  Type '{ yy1: true; yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
-    Types of property 'yy1' are incompatible.
-      Type 'true' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(14,31): error TS2326: Types of property 'yy1' are incompatible.
+  Type 'true' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(16,31): error TS2339: Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-tests/cases/conformance/jsx/file.tsx(17,22): error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+tests/cases/conformance/jsx/file.tsx(17,13): error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
   Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
     Types of property 'yy' are incompatible.
       Type 'boolean' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(25,29): error TS2322: Type '{ extra-data: true; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
+tests/cases/conformance/jsx/file.tsx(25,13): error TS2322: Type '{ extra-data: true; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
   Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
     Property 'yy' is missing in type '{ extra-data: true; }'.
-tests/cases/conformance/jsx/file.tsx(26,29): error TS2322: Type '{ yy: string; direction: string; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
-  Type '{ yy: string; direction: string; }' is not assignable to type '{ yy: string; direction?: number; }'.
-    Types of property 'direction' are incompatible.
-      Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(33,29): error TS2322: Type '{ y1: true; y3: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Type '{ y1: true; y3: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-    Types of property 'y3' are incompatible.
-      Type 'string' is not assignable to type 'boolean'.
-tests/cases/conformance/jsx/file.tsx(34,29): error TS2322: Type '{ y1: string; y2: number; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Type '{ y1: string; y2: number; y3: true; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-    Types of property 'y1' are incompatible.
-      Type 'string' is not assignable to type 'boolean'.
-tests/cases/conformance/jsx/file.tsx(35,29): error TS2322: Type '{ y1: string; y2: number; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Type '{ y1: string; y2: number; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-    Property 'y3' is missing in type '{ y1: string; y2: number; children: string; }'.
-tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ children: string; y1: string; y2: number; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Type '{ children: string; y1: string; y2: number; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-    Property 'y3' is missing in type '{ children: string; y1: string; y2: number; }'.
+tests/cases/conformance/jsx/file.tsx(26,40): error TS2326: Types of property 'direction' are incompatible.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(33,32): error TS2326: Types of property 'y3' are incompatible.
+  Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(34,29): error TS2326: Types of property 'y1' are incompatible.
+  Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(35,29): error TS2326: Types of property 'y1' are incompatible.
+  Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(36,29): error TS2326: Types of property 'y1' are incompatible.
+  Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (11 errors) ====
@@ -49,27 +39,25 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ children: str
     
     // Error
     const c0 = <OneThing extraProp />;  // extra property;
-                         ~~~~~~~~~
+                ~~~~~~~~
 !!! error TS2322: Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 !!! error TS2322:   Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
 !!! error TS2322:     Property 'yy' is missing in type '{ extraProp: true; }'.
     const c1 = <OneThing yy={10}/>;  // missing property;
-                         ~~~~~~~
+                ~~~~~~~~
 !!! error TS2322: Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 !!! error TS2322:   Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
 !!! error TS2322:     Property 'yy1' is missing in type '{ yy: number; }'.
     const c2 = <OneThing {...obj} yy1 />; // type incompatible;
-                         ~~~~~~~~~~~~
-!!! error TS2322: Type '{ yy1: true; yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2322:   Type '{ yy1: true; yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
-!!! error TS2322:     Types of property 'yy1' are incompatible.
-!!! error TS2322:       Type 'true' is not assignable to type 'string'.
+                                  ~~~
+!!! error TS2326: Types of property 'yy1' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type 'string'.
     const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  //  This is OK becuase all attribute are spread
     const c4 = <OneThing {...obj} y1={10000} />;  // extra property;
                                   ~~~~~~~~~~
 !!! error TS2339: Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
     const c5 = <OneThing {...obj} {...{yy: true}} />;  // type incompatible;
-                         ~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~
 !!! error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 !!! error TS2322:   Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
 !!! error TS2322:     Types of property 'yy' are incompatible.
@@ -82,16 +70,14 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ children: str
     
     // Error
     const d1 = <TestingOneThing extra-data />
-                                ~~~~~~~~~~
+                ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ extra-data: true; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
 !!! error TS2322:   Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
 !!! error TS2322:     Property 'yy' is missing in type '{ extra-data: true; }'.
     const d2 = <TestingOneThing yy="hello" direction="left" />
-                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ yy: string; direction: string; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
-!!! error TS2322:   Type '{ yy: string; direction: string; }' is not assignable to type '{ yy: string; direction?: number; }'.
-!!! error TS2322:     Types of property 'direction' are incompatible.
-!!! error TS2322:       Type 'string' is not assignable to type 'number'.
+                                           ~~~~~~~~~~~~~~~~
+!!! error TS2326: Types of property 'direction' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number'.
     
     declare function TestingOptional(a: {y1?: string, y2?: number}): JSX.Element;
     declare function TestingOptional(a: {y1?: string, y2?: number, children: JSX.Element}): JSX.Element;
@@ -99,25 +85,19 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ children: str
     
     // Error
     const e1 = <TestingOptional y1 y3="hello"/>
-                                ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y1: true; y3: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Type '{ y1: true; y3: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:     Types of property 'y3' are incompatible.
-!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
+                                   ~~~~~~~~~~
+!!! error TS2326: Types of property 'y3' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'boolean'.
     const e2 = <TestingOptional y1="hello" y2={1000} y3 />
-                                ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y1: string; y2: number; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Type '{ y1: string; y2: number; y3: true; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:     Types of property 'y1' are incompatible.
-!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
+                                ~~~~~~~~~~
+!!! error TS2326: Types of property 'y1' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'boolean'.
     const e3 = <TestingOptional y1="hello" y2={1000} children="hi" />
-                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y1: string; y2: number; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Type '{ y1: string; y2: number; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:     Property 'y3' is missing in type '{ y1: string; y2: number; children: string; }'.
+                                ~~~~~~~~~~
+!!! error TS2326: Types of property 'y1' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'boolean'.
     const e4 = <TestingOptional y1="hello" y2={1000}>Hi</TestingOptional>
-                                ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ children: string; y1: string; y2: number; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Type '{ children: string; y1: string; y2: number; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:     Property 'y3' is missing in type '{ children: string; y1: string; y2: number; }'.
+                                ~~~~~~~~~~
+!!! error TS2326: Types of property 'y1' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'boolean'.
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,28 +1,24 @@
-tests/cases/conformance/jsx/file.tsx(48,24): error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+tests/cases/conformance/jsx/file.tsx(48,13): error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
-tests/cases/conformance/jsx/file.tsx(49,24): error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+tests/cases/conformance/jsx/file.tsx(49,13): error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
-tests/cases/conformance/jsx/file.tsx(50,24): error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+tests/cases/conformance/jsx/file.tsx(50,13): error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
-tests/cases/conformance/jsx/file.tsx(51,24): error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+tests/cases/conformance/jsx/file.tsx(51,13): error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
-tests/cases/conformance/jsx/file.tsx(53,24): error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
+tests/cases/conformance/jsx/file.tsx(53,13): error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
-tests/cases/conformance/jsx/file.tsx(54,24): error TS2322: Type '{ children: number; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ children: number; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ children: number; onClick(e: any): void; }'.
-tests/cases/conformance/jsx/file.tsx(55,24): error TS2322: Type '{ children: string; className: true; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ children: string; className: true; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ children: string; className: true; onClick(e: any): void; }'.
-tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: true; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ data-format: true; }' is not assignable to type 'HyphenProps'.
-    Types of property '"data-format"' are incompatible.
-      Type 'true' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(54,51): error TS2326: Types of property 'children' are incompatible.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(55,68): error TS2326: Types of property 'className' are incompatible.
+  Type 'true' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(56,24): error TS2326: Types of property 'data-format' are incompatible.
+  Type 'true' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (8 errors) ====
@@ -74,44 +70,40 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: 
     
     // Error
     const b0 = <MainButton to='/some/path' onClick={(e)=>{}}>GO</MainButton>;  // extra property;
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2322:   Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
 !!! error TS2322:     Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2322:   Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
 !!! error TS2322:     Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
     const b2 = <MainButton {...{to: "10000"}} {...obj2} />;  // extra property
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2322:   Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
 !!! error TS2322:     Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
     const b3 = <MainButton {...{to: "10000"}} {...{onClick: (k) => {}}} />;  // extra property
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2322:   Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
 !!! error TS2322:     Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
     const b4 = <MainButton {...obj3} to />;  // Should error because Incorrect type; but attributes are any so everything is allowed
     const b5 = <MainButton {...{ onClick(e: any) { } }} {...obj0} />;  // Spread retain method declaration (see GitHub #13365), so now there is an extra attributes
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2322:   Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
 !!! error TS2322:     Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
     const b6 = <MainButton {...{ onClick(e: any){} }} children={10} />;  // incorrect type for optional attribute
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ children: number; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ children: number; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ children: number; onClick(e: any): void; }'.
+                                                      ~~~~~~~~~~~~~
+!!! error TS2326: Types of property 'children' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     const b7 = <MainButton {...{ onClick(e: any){} }} children="hello" className />;  // incorrect type for optional attribute
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ children: string; className: true; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ children: string; className: true; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ children: string; className: true; onClick(e: any): void; }'.
+                                                                       ~~~~~~~~~
+!!! error TS2326: Types of property 'className' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type 'string'.
     const b8 = <MainButton data-format />;  // incorrect type for specified hyphanated name
                            ~~~~~~~~~~~
-!!! error TS2322: Type '{ data-format: true; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ data-format: true; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Types of property '"data-format"' are incompatible.
-!!! error TS2322:       Type 'true' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'data-format' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentWithDefaultTypeParameter2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentWithDefaultTypeParameter2.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ values: number; }' is not assignable to type 'IntrinsicAttributes & MyComponentProp'.
-  Type '{ values: number; }' is not assignable to type 'MyComponentProp'.
-    Types of property 'values' are incompatible.
-      Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(13,24): error TS2326: Types of property 'values' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,7 +17,5 @@ tests/cases/conformance/jsx/file.tsx(13,24): error TS2322: Type '{ values: numbe
     // Error
     let i1 = <MyComponent1 values={5}/>;
                            ~~~~~~~~~~
-!!! error TS2322: Type '{ values: number; }' is not assignable to type 'IntrinsicAttributes & MyComponentProp'.
-!!! error TS2322:   Type '{ values: number; }' is not assignable to type 'MyComponentProp'.
-!!! error TS2322:     Types of property 'values' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'values' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -1,18 +1,16 @@
-tests/cases/conformance/jsx/file.tsx(19,16): error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,10): error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
   Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
     Property 'name' is missing in type '{ naaame: string; }'.
-tests/cases/conformance/jsx/file.tsx(27,15): error TS2322: Type '{ name: number; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-  Type '{ name: number; }' is not assignable to type '{ name?: string; }'.
-    Types of property 'name' are incompatible.
-      Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(29,15): error TS2559: Type '{ naaaaaaame: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
-tests/cases/conformance/jsx/file.tsx(34,23): error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type 'IntrinsicAttributes & { "prop-name": string; }'.
+tests/cases/conformance/jsx/file.tsx(27,15): error TS2326: Types of property 'name' are incompatible.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(29,10): error TS2559: Type '{ naaaaaaame: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
+tests/cases/conformance/jsx/file.tsx(34,10): error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type 'IntrinsicAttributes & { "prop-name": string; }'.
   Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
     Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
-tests/cases/conformance/jsx/file.tsx(37,23): error TS2559: Type '{ prop1: true; }' has no properties in common with type 'IntrinsicAttributes'.
-tests/cases/conformance/jsx/file.tsx(38,24): error TS2559: Type '{ ref: (x: any) => any; }' has no properties in common with type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(37,10): error TS2559: Type '{ prop1: true; }' has no properties in common with type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(38,11): error TS2559: Type '{ ref: (x: any) => any; }' has no properties in common with type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
-tests/cases/conformance/jsx/file.tsx(45,24): error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (8 errors) ====
@@ -35,7 +33,7 @@ tests/cases/conformance/jsx/file.tsx(45,24): error TS2559: Type '{ prop1: boolea
     let a1 = <Greet name='world' extra-prop />;
     // Error
     let b = <Greet naaame='world' />;
-                   ~~~~~~~~~~~~~~
+             ~~~~~
 !!! error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
 !!! error TS2322:   Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
 !!! error TS2322:     Property 'name' is missing in type '{ naaame: string; }'.
@@ -48,30 +46,28 @@ tests/cases/conformance/jsx/file.tsx(45,24): error TS2559: Type '{ prop1: boolea
     // Error
     let e = <Meet name={42} />;
                   ~~~~~~~~~
-!!! error TS2322: Type '{ name: number; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-!!! error TS2322:   Type '{ name: number; }' is not assignable to type '{ name?: string; }'.
-!!! error TS2322:     Types of property 'name' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'name' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     // Error
     let f = <Meet naaaaaaame='no' />;
-                  ~~~~~~~~~~~~~~~
+             ~~~~
 !!! error TS2559: Type '{ naaaaaaame: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
     
     // OK
     let g = <MeetAndGreet prop-name="Bob" />;
     // Error
     let h = <MeetAndGreet extra-prop-name="World" />;
-                          ~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~~~~~~~~~~
 !!! error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type 'IntrinsicAttributes & { "prop-name": string; }'.
 !!! error TS2322:   Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
 !!! error TS2322:     Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
     
     // Error
     let i = <EmptyPropSFC prop1 />
-                          ~~~~~
+             ~~~~~~~~~~~~
 !!! error TS2559: Type '{ prop1: true; }' has no properties in common with type 'IntrinsicAttributes'.
     let i1 = <EmptyPropSFC ref={x => x.greeting.substr(10)} />
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~~~~~~~~~~~
 !!! error TS2559: Type '{ ref: (x: any) => any; }' has no properties in common with type 'IntrinsicAttributes'.
     
     let o = {
@@ -82,7 +78,7 @@ tests/cases/conformance/jsx/file.tsx(45,24): error TS2559: Type '{ prop1: boolea
     
     // OK as access properties are allow when spread
     let i2 = <EmptyPropSFC {...o} />
-                           ~~~~~~
+              ~~~~~~~~~~~~
 !!! error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes'.
     
     let o1: any;

--- a/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(19,16): error TS2559: Type '{ ref: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,10): error TS2559: Type '{ ref: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
 tests/cases/conformance/jsx/file.tsx(25,42): error TS2551: Property 'subtr' does not exist on type 'string'. Did you mean 'substr'?
 tests/cases/conformance/jsx/file.tsx(27,33): error TS2339: Property 'notARealProperty' does not exist on type 'BigGreeter'.
 tests/cases/conformance/jsx/file.tsx(35,26): error TS2339: Property 'propertyNotOnHtmlDivElement' does not exist on type 'HTMLDivElement'.
@@ -24,7 +24,7 @@ tests/cases/conformance/jsx/file.tsx(35,26): error TS2339: Property 'propertyNot
     let b = <Greet key="k" />;
     // Error - not allowed to specify 'ref' on SFCs
     let c = <Greet ref="myRef" />;
-                   ~~~~~~~~~~~
+             ~~~~~
 !!! error TS2559: Type '{ ref: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
     
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.errors.txt
@@ -1,19 +1,14 @@
-tests/cases/conformance/jsx/file.tsx(8,34): error TS2322: Type 'T & { ignore-prop: number; }' is not assignable to type 'IntrinsicAttributes & { prop: number; "ignore-prop": string; }'.
-  Type 'T & { ignore-prop: number; }' is not assignable to type '{ prop: number; "ignore-prop": string; }'.
-    Types of property '"ignore-prop"' are incompatible.
-      Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(13,34): error TS2322: Type 'T' is not assignable to type 'IntrinsicAttributes & { prop: {}; "ignore-prop": string; }'.
+tests/cases/conformance/jsx/file.tsx(8,43): error TS2326: Types of property 'ignore-prop' are incompatible.
+  Type '(T & { ignore-prop: number; })["ignore-prop"]' is not assignable to type 'string'.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(13,15): error TS2322: Type 'T' is not assignable to type 'IntrinsicAttributes & { prop: {}; "ignore-prop": string; }'.
   Type 'T' is not assignable to type '{ prop: {}; "ignore-prop": string; }'.
-tests/cases/conformance/jsx/file.tsx(20,19): error TS2322: Type '{ func: (a: number, b: string) => void; }' is not assignable to type 'IntrinsicAttributes & { func: (arg: number) => void; }'.
-  Type '{ func: (a: number, b: string) => void; }' is not assignable to type '{ func: (arg: number) => void; }'.
-    Types of property 'func' are incompatible.
-      Type '(a: number, b: string) => void' is not assignable to type '(arg: number) => void'.
-tests/cases/conformance/jsx/file.tsx(31,30): error TS2322: Type '{ values: number[]; selectHandler: (val: string) => void; }' is not assignable to type 'IntrinsicAttributes & InferParamProp<number>'.
-  Type '{ values: number[]; selectHandler: (val: string) => void; }' is not assignable to type 'InferParamProp<number>'.
-    Types of property 'selectHandler' are incompatible.
-      Type '(val: string) => void' is not assignable to type '(selectedVal: number) => void'.
-        Types of parameters 'val' and 'selectedVal' are incompatible.
-          Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(20,19): error TS2326: Types of property 'func' are incompatible.
+  Type '(a: number, b: string) => void' is not assignable to type '(arg: number) => void'.
+tests/cases/conformance/jsx/file.tsx(31,52): error TS2326: Types of property 'selectHandler' are incompatible.
+  Type '(val: string) => void' is not assignable to type '(selectedVal: number) => void'.
+    Types of parameters 'val' and 'selectedVal' are incompatible.
+      Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (4 errors) ====
@@ -25,17 +20,16 @@ tests/cases/conformance/jsx/file.tsx(31,30): error TS2322: Type '{ values: numbe
     // Error
     function Bar<T extends {prop: number}>(arg: T) {
         let a1 = <ComponentSpecific1 {...arg} ignore-prop={10} />;
-                                     ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'T & { ignore-prop: number; }' is not assignable to type 'IntrinsicAttributes & { prop: number; "ignore-prop": string; }'.
-!!! error TS2322:   Type 'T & { ignore-prop: number; }' is not assignable to type '{ prop: number; "ignore-prop": string; }'.
-!!! error TS2322:     Types of property '"ignore-prop"' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+                                              ~~~~~~~~~~~~~~~~
+!!! error TS2326: Types of property 'ignore-prop' are incompatible.
+!!! error TS2326:   Type '(T & { ignore-prop: number; })["ignore-prop"]' is not assignable to type 'string'.
+!!! error TS2326:     Type 'number' is not assignable to type 'string'.
      }
     
     // Error
     function Baz<T>(arg: T) {
         let a0 = <ComponentSpecific1 {...arg} />
-                                     ~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'T' is not assignable to type 'IntrinsicAttributes & { prop: {}; "ignore-prop": string; }'.
 !!! error TS2322:   Type 'T' is not assignable to type '{ prop: {}; "ignore-prop": string; }'.
     }
@@ -46,10 +40,8 @@ tests/cases/conformance/jsx/file.tsx(31,30): error TS2322: Type '{ values: numbe
     function createLink(func: (a: number, b: string)=>void) {
         let o = <Link func={func} />
                       ~~~~~~~~~~~
-!!! error TS2322: Type '{ func: (a: number, b: string) => void; }' is not assignable to type 'IntrinsicAttributes & { func: (arg: number) => void; }'.
-!!! error TS2322:   Type '{ func: (a: number, b: string) => void; }' is not assignable to type '{ func: (arg: number) => void; }'.
-!!! error TS2322:     Types of property 'func' are incompatible.
-!!! error TS2322:       Type '(a: number, b: string) => void' is not assignable to type '(arg: number) => void'.
+!!! error TS2326: Types of property 'func' are incompatible.
+!!! error TS2326:   Type '(a: number, b: string) => void' is not assignable to type '(arg: number) => void'.
     }
     
     interface InferParamProp<T> {
@@ -61,11 +53,9 @@ tests/cases/conformance/jsx/file.tsx(31,30): error TS2322: Type '{ values: numbe
     
     // Error
     let i = <InferParamComponent values={[1, 2, 3, 4]} selectHandler={(val: string) => { }} />;
-                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ values: number[]; selectHandler: (val: string) => void; }' is not assignable to type 'IntrinsicAttributes & InferParamProp<number>'.
-!!! error TS2322:   Type '{ values: number[]; selectHandler: (val: string) => void; }' is not assignable to type 'InferParamProp<number>'.
-!!! error TS2322:     Types of property 'selectHandler' are incompatible.
-!!! error TS2322:       Type '(val: string) => void' is not assignable to type '(selectedVal: number) => void'.
-!!! error TS2322:         Types of parameters 'val' and 'selectedVal' are incompatible.
-!!! error TS2322:           Type 'number' is not assignable to type 'string'.
+                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2326: Types of property 'selectHandler' are incompatible.
+!!! error TS2326:   Type '(val: string) => void' is not assignable to type '(selectedVal: number) => void'.
+!!! error TS2326:     Types of parameters 'val' and 'selectedVal' are incompatible.
+!!! error TS2326:       Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(9,33): error TS2322: Type '{ a: number; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: number; }'.
+tests/cases/conformance/jsx/file.tsx(9,15): error TS2322: Type '{ a: number; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: number; }'.
   Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
     Property 'b' is missing in type '{ a: number; }'.
-tests/cases/conformance/jsx/file.tsx(10,33): error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: {}; }'.
+tests/cases/conformance/jsx/file.tsx(10,15): error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: {}; }'.
   Type 'T & { ignore-prop: true; }' is not assignable to type '{ b: {}; a: {}; }'.
     Property 'a' is missing in type '{ b: number; } & { ignore-prop: true; }'.
 
@@ -16,12 +16,12 @@ tests/cases/conformance/jsx/file.tsx(10,33): error TS2322: Type 'T & { ignore-pr
     // Error
     function Baz<T extends {b: number}, U extends {a: boolean, b:string}>(arg1: T, arg2: U) {
         let a0 = <OverloadComponent a={arg1.b}/>
-                                    ~~~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ a: number; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: number; }'.
 !!! error TS2322:   Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
 !!! error TS2322:     Property 'b' is missing in type '{ a: number; }'.
         let a2 = <OverloadComponent {...arg1} ignore-prop />  // missing a
-                                    ~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: {}; }'.
 !!! error TS2322:   Type 'T & { ignore-prop: true; }' is not assignable to type '{ b: {}; a: {}; }'.
 !!! error TS2322:     Property 'a' is missing in type '{ b: number; } & { ignore-prop: true; }'.

--- a/tests/baselines/reference/tsxTypeArgumentPartialDefinitionStillErrors.errors.txt
+++ b/tests/baselines/reference/tsxTypeArgumentPartialDefinitionStillErrors.errors.txt
@@ -1,6 +1,5 @@
-tests/cases/compiler/file.tsx(11,14): error TS2322: Type '{ prop: number; }' is not assignable to type 'Record<string, string>'.
-  Property 'prop' is incompatible with index signature.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/file.tsx(11,14): error TS2326: Types of property 'prop' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/file.tsx (1 errors) ====
@@ -16,7 +15,6 @@ tests/cases/compiler/file.tsx(11,14): error TS2322: Type '{ prop: number; }' is 
     
     <SFC<string> prop={1}></SFC>; // should error
                  ~~~~~~~~
-!!! error TS2322: Type '{ prop: number; }' is not assignable to type 'Record<string, string>'.
-!!! error TS2322:   Property 'prop' is incompatible with index signature.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'prop' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/tsxTypeArgumentResolution.errors.txt
+++ b/tests/baselines/reference/tsxTypeArgumentResolution.errors.txt
@@ -1,11 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(16,19): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-  Type '{ a: number; b: number; }' is not assignable to type 'Prop'.
-    Types of property 'b' are incompatible.
-      Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(18,19): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-  Type '{ a: number; b: number; }' is not assignable to type 'Prop'.
-    Types of property 'b' are incompatible.
-      Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(16,26): error TS2326: Types of property 'b' are incompatible.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(18,26): error TS2326: Types of property 'b' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(20,13): error TS2558: Expected 1 type arguments, but got 2.
 tests/cases/conformance/jsx/file.tsx(22,13): error TS2558: Expected 1 type arguments, but got 2.
 tests/cases/conformance/jsx/file.tsx(24,12): error TS1099: Type argument list cannot be empty.
@@ -13,27 +9,19 @@ tests/cases/conformance/jsx/file.tsx(26,12): error TS1099: Type argument list ca
 tests/cases/conformance/jsx/file.tsx(39,14): error TS2344: Type 'Prop' does not satisfy the constraint '{ a: string; }'.
   Types of property 'a' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(39,20): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, {}>> & { a: string; } & { children?: ReactNode; }'.
-  Type '{ a: number; b: string; }' is not assignable to type '{ a: string; }'.
-    Types of property 'a' are incompatible.
-      Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(39,20): error TS2326: Types of property 'a' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(41,14): error TS2344: Type 'Prop' does not satisfy the constraint '{ a: string; }'.
-tests/cases/conformance/jsx/file.tsx(41,20): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, {}>> & { a: string; } & { children?: ReactNode; }'.
-  Type '{ a: number; b: string; }' is not assignable to type '{ a: string; }'.
-    Types of property 'a' are incompatible.
-      Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(41,20): error TS2326: Types of property 'a' are incompatible.
+  Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(47,14): error TS2558: Expected 1-2 type arguments, but got 3.
 tests/cases/conformance/jsx/file.tsx(47,53): error TS2339: Property 'b' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, {}>> & { a: string; } & { children?: ReactNode; }'.
 tests/cases/conformance/jsx/file.tsx(49,14): error TS2558: Expected 1-2 type arguments, but got 3.
 tests/cases/conformance/jsx/file.tsx(49,53): error TS2339: Property 'b' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, {}>> & { a: string; } & { children?: ReactNode; }'.
-tests/cases/conformance/jsx/file.tsx(51,40): error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, { b: number; }>> & { a: string; } & { b: number; } & { children?: ReactNode; }'.
-  Type '{ a: string; b: string; }' is not assignable to type '{ b: number; }'.
-    Types of property 'b' are incompatible.
-      Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(53,40): error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, { b: number; }>> & { a: string; } & { b: number; } & { children?: ReactNode; }'.
-  Type '{ a: string; b: string; }' is not assignable to type '{ b: number; }'.
-    Types of property 'b' are incompatible.
-      Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(51,47): error TS2326: Types of property 'b' are incompatible.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(53,47): error TS2326: Types of property 'b' are incompatible.
+  Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (16 errors) ====
@@ -53,18 +41,14 @@ tests/cases/conformance/jsx/file.tsx(53,40): error TS2322: Type '{ a: string; b:
     x = <MyComp<Prop> a={10} b="hi"></MyComp>; // OK
     
     x = <MyComp<Prop> a={10} b={20} />; // error
-                      ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ a: number; b: number; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'b' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+                             ~~~~~~
+!!! error TS2326: Types of property 'b' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     
     x = <MyComp<Prop> a={10} b={20}></MyComp>; // error
-                      ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ a: number; b: number; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'b' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+                             ~~~~~~
+!!! error TS2326: Types of property 'b' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     
     x = <MyComp<Prop, Prop> a={10} b="hi" />; // error
                 ~~~~~~~~~~
@@ -98,20 +82,16 @@ tests/cases/conformance/jsx/file.tsx(53,40): error TS2322: Type '{ a: string; b:
 !!! error TS2344: Type 'Prop' does not satisfy the constraint '{ a: string; }'.
 !!! error TS2344:   Types of property 'a' are incompatible.
 !!! error TS2344:     Type 'number' is not assignable to type 'string'.
-                       ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, {}>> & { a: string; } & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type '{ a: string; }'.
-!!! error TS2322:     Types of property 'a' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+                       ~~~~~~
+!!! error TS2326: Types of property 'a' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     
     x = <MyComp2<Prop> a={10} b="hi"></MyComp2>; // error
                  ~~~~
 !!! error TS2344: Type 'Prop' does not satisfy the constraint '{ a: string; }'.
-                       ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, {}>> & { a: string; } & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type '{ a: string; }'.
-!!! error TS2322:     Types of property 'a' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+                       ~~~~~~
+!!! error TS2326: Types of property 'a' are incompatible.
+!!! error TS2326:   Type 'number' is not assignable to type 'string'.
     
     x = <MyComp2<{a: string}, {b: string}> a="hi" b="hi" />; // OK
     
@@ -130,16 +110,12 @@ tests/cases/conformance/jsx/file.tsx(53,40): error TS2322: Type '{ a: string; b:
 !!! error TS2339: Property 'b' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, {}>> & { a: string; } & { children?: ReactNode; }'.
     
     x = <MyComp2<{a: string}, {b: number}> a="hi" b="hi" />; // error
-                                           ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, { b: number; }>> & { a: string; } & { b: number; } & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ a: string; b: string; }' is not assignable to type '{ b: number; }'.
-!!! error TS2322:     Types of property 'b' are incompatible.
-!!! error TS2322:       Type 'string' is not assignable to type 'number'.
+                                                  ~~~~~~
+!!! error TS2326: Types of property 'b' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number'.
     
     x = <MyComp2<{a: string}, {b: number}> a="hi" b="hi"></MyComp2>; // error
-                                           ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp2<{ a: string; }, { b: number; }>> & { a: string; } & { b: number; } & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ a: string; b: string; }' is not assignable to type '{ b: number; }'.
-!!! error TS2322:     Types of property 'b' are incompatible.
-!!! error TS2322:       Type 'string' is not assignable to type 'number'.
+                                                  ~~~~~~
+!!! error TS2326: Types of property 'b' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number'.
     

--- a/tests/baselines/reference/tsxUnionElementType2.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType2.errors.txt
@@ -1,8 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(12,10): error TS2322: Type '{ x: string; }' is not assignable to type '(IntrinsicAttributes & { x: number; }) | (IntrinsicAttributes & { x: boolean; })'.
-  Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-    Type '{ x: string; }' is not assignable to type '{ x: boolean; }'.
-      Types of property 'x' are incompatible.
-        Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(12,10): error TS2326: Types of property 'x' are incompatible.
+  Type 'string' is not assignable to type 'number | boolean'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -19,8 +16,5 @@ tests/cases/conformance/jsx/file.tsx(12,10): error TS2322: Type '{ x: string; }'
     var SFCComp = SFC1 || SFC2;
     <SFCComp x={"hi"}/>
              ~~~~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type '(IntrinsicAttributes & { x: number; }) | (IntrinsicAttributes & { x: boolean; })'.
-!!! error TS2322:   Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-!!! error TS2322:     Type '{ x: string; }' is not assignable to type '{ x: boolean; }'.
-!!! error TS2322:       Types of property 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'boolean'.
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'number | boolean'.

--- a/tests/baselines/reference/tsxUnionElementType4.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType4.errors.txt
@@ -1,10 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(32,17): error TS2322: Type '{ x: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<RC1> & { x: number; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<RC2> & { x: string; } & { children?: ReactNode; })'.
-  Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC2> & { x: string; } & { children?: ReactNode; }'.
-    Type '{ x: true; }' is not assignable to type '{ x: string; }'.
-      Types of property 'x' are incompatible.
-        Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(33,21): error TS2559: Type '{ x: number; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
-tests/cases/conformance/jsx/file.tsx(34,22): error TS2559: Type '{ prop: true; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(32,17): error TS2326: Types of property 'x' are incompatible.
+  Type 'true' is not assignable to type 'ReactText'.
+tests/cases/conformance/jsx/file.tsx(33,10): error TS2559: Type '{ x: number; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(34,10): error TS2559: Type '{ prop: true; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -41,15 +38,12 @@ tests/cases/conformance/jsx/file.tsx(34,22): error TS2559: Type '{ prop: true; }
     // Error
     let a = <RCComp x />;
                     ~
-!!! error TS2322: Type '{ x: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<RC1> & { x: number; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<RC2> & { x: string; } & { children?: ReactNode; })'.
-!!! error TS2322:   Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC2> & { x: string; } & { children?: ReactNode; }'.
-!!! error TS2322:     Type '{ x: true; }' is not assignable to type '{ x: string; }'.
-!!! error TS2322:       Types of property 'x' are incompatible.
-!!! error TS2322:         Type 'true' is not assignable to type 'string'.
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'true' is not assignable to type 'ReactText'.
     let b = <PartRCComp x={10} />
-                        ~~~~~~
+             ~~~~~~~~~~
 !!! error TS2559: Type '{ x: number; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
     let c = <EmptyRCComp prop />;
-                         ~~~~
+             ~~~~~~~~~~~
 !!! error TS2559: Type '{ prop: true; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
     

--- a/tests/baselines/reference/tsxUnionElementType6.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType6.errors.txt
@@ -1,12 +1,10 @@
-tests/cases/conformance/jsx/file.tsx(18,23): error TS2559: Type '{ x: true; }' has no properties in common with type 'IntrinsicAttributes'.
-tests/cases/conformance/jsx/file.tsx(19,27): error TS2322: Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-  Type '{ x: string; }' is not assignable to type '{ x: boolean; }'.
-    Types of property 'x' are incompatible.
-      Type 'string' is not assignable to type 'boolean'.
-tests/cases/conformance/jsx/file.tsx(20,9): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
+tests/cases/conformance/jsx/file.tsx(18,10): error TS2559: Type '{ x: true; }' has no properties in common with type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(19,27): error TS2326: Types of property 'x' are incompatible.
+  Type 'string' is not assignable to type 'boolean'.
+tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
   Type '{}' is not assignable to type '{ x: boolean; }'.
     Property 'x' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(21,27): error TS2322: Type '{ data-prop: true; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
+tests/cases/conformance/jsx/file.tsx(21,10): error TS2322: Type '{ data-prop: true; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
   Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
     Property 'x' is missing in type '{ data-prop: true; }'.
 
@@ -30,21 +28,19 @@ tests/cases/conformance/jsx/file.tsx(21,27): error TS2322: Type '{ data-prop: tr
     var SFC2AndEmptyComp = SFC2 || EmptySFC1;
     // Error
     let a = <EmptySFCComp x />;
-                          ~
+             ~~~~~~~~~~~~
 !!! error TS2559: Type '{ x: true; }' has no properties in common with type 'IntrinsicAttributes'.
     let b = <SFC2AndEmptyComp x="hi" />;
                               ~~~~~~
-!!! error TS2322: Type '{ x: string; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-!!! error TS2322:   Type '{ x: string; }' is not assignable to type '{ x: boolean; }'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type 'string' is not assignable to type 'boolean'.
+!!! error TS2326: Types of property 'x' are incompatible.
+!!! error TS2326:   Type 'string' is not assignable to type 'boolean'.
     let c = <SFC2AndEmptyComp />;
-            ~~~~~~~~~~~~~~~~~~~~
+             ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
 !!! error TS2322:   Type '{}' is not assignable to type '{ x: boolean; }'.
 !!! error TS2322:     Property 'x' is missing in type '{}'.
     let d = <SFC2AndEmptyComp data-prop />;
-                              ~~~~~~~~~
+             ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ data-prop: true; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
 !!! error TS2322:   Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
 !!! error TS2322:     Property 'x' is missing in type '{ data-prop: true; }'.


### PR DESCRIPTION
Instead of the entire attributes or the entire tag. This works similarly to how base-class assignability errors are reported.

Fixes #23116.
Fixes #23117.