### PR TITLE
Dont bind a local symbol for a default export without a name

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -288,10 +288,6 @@ namespace ts {
                     }
                     Debug.fail("Unknown binary declaration kind");
                     break;
-
-                case SyntaxKind.FunctionDeclaration:
-                case SyntaxKind.ClassDeclaration:
-                    return (hasModifier(node, ModifierFlags.Default) ? InternalSymbolName.Default : undefined);
                 case SyntaxKind.JSDocFunctionType:
                     return (isJSDocConstructSignature(node) ? InternalSymbolName.New : InternalSymbolName.Call);
                 case SyntaxKind.Parameter:
@@ -459,6 +455,9 @@ namespace ts {
                 if (node.kind === SyntaxKind.JSDocTypedefTag) Debug.assert(isInJavaScriptFile(node)); // We shouldn't add symbols for JSDoc nodes if not in a JS file.
                 const isJSDocTypedefInJSDocNamespace = isJSDocTypedefTag(node) && node.name && node.name.kind === SyntaxKind.Identifier && node.name.isInJSDocNamespace;
                 if ((!isAmbientModule(node) && (hasExportModifier || container.flags & NodeFlags.ExportContext)) || isJSDocTypedefInJSDocNamespace) {
+                    if (hasModifier(node, ModifierFlags.Default) && !getDeclarationName(node)) {
+                        return declareSymbol(container.symbol.exports, container.symbol, node, symbolFlags, symbolExcludes); // No local symbol for an unnamed default!
+                    }
                     const exportKind = symbolFlags & SymbolFlags.Value ? SymbolFlags.ExportValue : 0;
                     const local = declareSymbol(container.locals, /*parent*/ undefined, node, exportKind, symbolExcludes);
                     local.exportSymbol = declareSymbol(container.symbol.exports, container.symbol, node, symbolFlags, symbolExcludes);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1291,7 +1291,7 @@ namespace ts {
                             }
                         }
 
-                        if (result = lookup(moduleExports, name, meaning & SymbolFlags.ModuleMember)) {
+                        if (name !== InternalSymbolName.Default && (result = lookup(moduleExports, name, meaning & SymbolFlags.ModuleMember))) {
                             break loop;
                         }
                         break;

--- a/tests/baselines/reference/defaultIsNotVisibleInLocalScope.errors.txt
+++ b/tests/baselines/reference/defaultIsNotVisibleInLocalScope.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/a.ts(4,24): error TS2304: Cannot find name 'default'.
+tests/cases/compiler/b.ts(2,24): error TS2304: Cannot find name 'default'.
+
+
+==== tests/cases/compiler/a.ts (1 errors) ====
+    export default function () {
+        return true;
+    }
+    export type X = typeof default;  // expect error
+                           ~~~~~~~
+!!! error TS2304: Cannot find name 'default'.
+    
+==== tests/cases/compiler/b.ts (1 errors) ====
+    export default { a: true }
+    export type X = typeof default; // expect error
+                           ~~~~~~~
+!!! error TS2304: Cannot find name 'default'.

--- a/tests/baselines/reference/defaultIsNotVisibleInLocalScope.js
+++ b/tests/baselines/reference/defaultIsNotVisibleInLocalScope.js
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/defaultIsNotVisibleInLocalScope.ts] ////
+
+//// [a.ts]
+export default function () {
+    return true;
+}
+export type X = typeof default;  // expect error
+
+//// [b.ts]
+export default { a: true }
+export type X = typeof default; // expect error
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+function default_1() {
+    return true;
+}
+exports["default"] = default_1;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+exports["default"] = { a: true };

--- a/tests/baselines/reference/defaultIsNotVisibleInLocalScope.symbols
+++ b/tests/baselines/reference/defaultIsNotVisibleInLocalScope.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/a.ts ===
+export default function () {
+    return true;
+}
+export type X = typeof default;  // expect error
+>X : Symbol(X, Decl(a.ts, 2, 1))
+
+=== tests/cases/compiler/b.ts ===
+export default { a: true }
+>a : Symbol(a, Decl(b.ts, 0, 16))
+
+export type X = typeof default; // expect error
+>X : Symbol(X, Decl(b.ts, 0, 26))
+

--- a/tests/baselines/reference/defaultIsNotVisibleInLocalScope.types
+++ b/tests/baselines/reference/defaultIsNotVisibleInLocalScope.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/a.ts ===
+export default function () {
+    return true;
+>true : true
+}
+export type X = typeof default;  // expect error
+>X : any
+>default : any
+
+=== tests/cases/compiler/b.ts ===
+export default { a: true }
+>{ a: true } : { a: boolean; }
+>a : boolean
+>true : true
+
+export type X = typeof default; // expect error
+>X : any
+>default : any
+

--- a/tests/cases/compiler/defaultIsNotVisibleInLocalScope.ts
+++ b/tests/cases/compiler/defaultIsNotVisibleInLocalScope.ts
@@ -1,0 +1,9 @@
+// @filename: a.ts
+export default function () {
+    return true;
+}
+export type X = typeof default;  // expect error
+
+// @filename: b.ts
+export default { a: true }
+export type X = typeof default; // expect error


### PR DESCRIPTION
Fixes #23010
