### PR TITLE
Add typings for URLSearchParams methods

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -13429,6 +13429,10 @@ interface URLSearchParams {
      */
     delete(name: string): void;
     /**
+     * Returns an iterator over the key/value pairs.
+     */
+    entries(): IterableIterator<[string, string]>;
+    /**
      * Returns the first value associated to the given search parameter.
      */
     get(name: string): string | null;
@@ -13441,9 +13445,23 @@ interface URLSearchParams {
      */
     has(name: string): boolean;
     /**
+     * Returns an iterator over the keys.
+     */
+    keys(): IterableIterator<string>;
+    /**
      * Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
      */
     set(name: string, value: string): void;
+    /**
+     * Returns a string suitable for use in a URL.
+     */
+    toString(): string;
+    /**
+     * Returns an iterator over the values.
+     */
+    values(): IterableIterator<string>;
+    /** Iterator */
+    [Symbol.iterator](): IterableIterator<number>;
 }
 
 declare var URLSearchParams: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

There are methods in the [spec for URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) that are missing from the typings: entries, keys, toString, values, and Symbol.iterator.
