### PR TITLE
Fix crash in type resolution in JS IIFEs

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2063,6 +2063,7 @@ namespace ts {
                     if (initializer) {
                         namespace = getSymbolOfNode(initializer);
                     }
+                    // Currently, IIFEs may not have a symbol and we don't know about their contents. Give up in this case.
                     if (!namespace) {
                         return undefined;
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2063,6 +2063,9 @@ namespace ts {
                     if (initializer) {
                         namespace = getSymbolOfNode(initializer);
                     }
+                    if (!namespace) {
+                        return undefined;
+                    }
                     if (namespace.valueDeclaration &&
                         isVariableDeclaration(namespace.valueDeclaration) &&
                         namespace.valueDeclaration.initializer &&

--- a/tests/baselines/reference/typeLookupInIIFE.symbols
+++ b/tests/baselines/reference/typeLookupInIIFE.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/salsa/a.js ===
+// #22973
+var ns = (function() {})();
+>ns : Symbol(ns, Decl(a.js, 1, 3))
+
+/** @type {ns.NotFound} */
+var crash;
+>crash : Symbol(crash, Decl(a.js, 3, 3))
+

--- a/tests/baselines/reference/typeLookupInIIFE.types
+++ b/tests/baselines/reference/typeLookupInIIFE.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/salsa/a.js ===
+// #22973
+var ns = (function() {})();
+>ns : void
+>(function() {})() : void
+>(function() {}) : () => void
+>function() {} : () => void
+
+/** @type {ns.NotFound} */
+var crash;
+>crash : any
+

--- a/tests/cases/conformance/salsa/typeLookupInIIFE.ts
+++ b/tests/cases/conformance/salsa/typeLookupInIIFE.ts
@@ -1,0 +1,9 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @noImplicitAny: true
+// @Filename: a.js
+// #22973
+var ns = (function() {})();
+/** @type {ns.NotFound} */
+var crash;


### PR DESCRIPTION
We recognise IIFEs as JS special assignment initialisers, but not as containers otherwise. That means that IIFEs will not have a symbol unless they have an *outside* assignment.

The permanent fix will be to make IIFEs a container, based on the containership of the value that they return. This fix does not do that; it just makes type resolution return undefined instead of crashing.

Fixes #22973 

This fix is bound for 2.8 since it's a fairly bad regression.