### PR TITLE
WIP: Instead of clearing resolution cache only invalidate the unresolved imports in response to action::set of typing installer

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2985,18 +2985,19 @@ namespace ts {
     }
 
     /** Remove the *first* occurrence of `item` from the array. */
-    export function unorderedRemoveItem<T>(array: T[], item: T): void {
-        unorderedRemoveFirstItemWhere(array, element => element === item);
+    export function unorderedRemoveItem<T>(array: T[], item: T): boolean {
+        return unorderedRemoveFirstItemWhere(array, element => element === item);
     }
 
     /** Remove the *first* element satisfying `predicate`. */
-    function unorderedRemoveFirstItemWhere<T>(array: T[], predicate: (element: T) => boolean): void {
+    function unorderedRemoveFirstItemWhere<T>(array: T[], predicate: (element: T) => boolean): boolean {
         for (let i = 0; i < array.length; i++) {
             if (predicate(array[i])) {
                 unorderedRemoveItemAt(array, i);
-                break;
+                return true;
             }
         }
+        return false;
     }
 
     export type GetCanonicalFileName = (fileName: string) => string;

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -23,6 +23,7 @@ namespace ts {
         closeTypeRootsWatch(): void;
 
         clear(): void;
+        invalidateAllResolutions(): void;
     }
 
     interface ResolutionWithFailedLookupLocations {
@@ -129,7 +130,8 @@ namespace ts {
             createHasInvalidatedResolution,
             updateTypeRootsWatch,
             closeTypeRootsWatch,
-            clear
+            clear,
+            invalidateAllResolutions
         };
 
         function getResolvedModule(resolution: ResolvedModuleWithFailedLookupLocations) {
@@ -552,6 +554,11 @@ namespace ts {
             });
         }
 
+        function invalidateAllResolutions() {
+            // Invalidate everything
+            allFilesHaveInvalidatedResolution = true;
+        }
+
         function hasReachedResolutionIterationLimit() {
             const maxSize = resolutionHost.maxNumberOfFilesToIterateForInvalidation || maxNumberOfFilesToIterateForInvalidation;
             return resolvedModuleNames.size > maxSize || resolvedTypeReferenceDirectives.size > maxSize;
@@ -563,7 +570,7 @@ namespace ts {
             // If more than maxNumberOfFilesToIterateForInvalidation present,
             // just invalidated all files and recalculate the resolutions for files instead
             if (hasReachedResolutionIterationLimit()) {
-                allFilesHaveInvalidatedResolution = true;
+                invalidateAllResolutions();
                 return;
             }
             invalidateResolutionCache(resolvedModuleNames, isInvalidatedResolution, getResolvedModule);

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -595,7 +595,7 @@ namespace ts {
             if (hasChangedCompilerOptions) {
                 newLine = updateNewLine();
                 if (program && changesAffectModuleResolution(program.getCompilerOptions(), compilerOptions)) {
-                    resolutionCache.clear();
+                    resolutionCache.invalidateAllResolutions();
                 }
             }
 

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -7,7 +7,7 @@ namespace ts.projectSystem {
     const nullCancellationToken = server.nullCancellationToken;
 
     function createTestTypingsInstaller(host: server.ServerHost) {
-        return new TestTypingsInstaller("/a/data/", /*throttleLimit*/5, host);
+        return new TestTypingsInstaller(typingsCacheLocation, /*throttleLimit*/5, host);
     }
 
     describe("CompileOnSave affected list", () => {

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -188,7 +188,7 @@ namespace ts.projectSystem {
             checkProjectActualFiles(p, [file1.path]);
 
             installer.installAll(/*expectedCount*/ 1);
-
+            host.checkTimeoutQueueLengthAndRun(2);
             checkNumberOfProjects(projectService, { inferredProjects: 1 });
             checkProjectActualFiles(p, [file1.path, jquery.path]);
         });
@@ -961,6 +961,7 @@ namespace ts.projectSystem {
             assert.isTrue(host.fileExists(node.path), "typings for 'node' should be created");
             assert.isTrue(host.fileExists(commander.path), "typings for 'commander' should be created");
 
+            host.checkTimeoutQueueLengthAndRun(2);
             checkProjectActualFiles(service.inferredProjects[0], [file.path, node.path, commander.path]);
         });
 
@@ -1106,7 +1107,7 @@ namespace ts.projectSystem {
             checkProjectActualFiles(p, [file1.path]);
 
             installer.installAll(/*expectedCount*/ 1);
-
+            host.checkTimeoutQueueLengthAndRun(2);
             checkNumberOfProjects(projectService, { inferredProjects: 1 });
             checkProjectActualFiles(p, [file1.path, jquery.path]);
         });

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1003,7 +1003,7 @@ namespace ts.projectSystem {
             installer.installAll(/*expectedCount*/ 1);
         });
 
-        it("should recompute resolutions after typings are installed", () => {
+        it("cached unresolved typings are not recomputed if program structure did not change", () => {
             const host = createServerHost([]);
             const session = createSession(host);
             const f = {
@@ -1045,7 +1045,7 @@ namespace ts.projectSystem {
             session.executeCommand(changeRequest);
             host.checkTimeoutQueueLengthAndRun(2); // This enqueues the updategraph and refresh inferred projects
             const version2 = proj.getCachedUnresolvedImportsPerFile_TestOnly().getVersion();
-            assert.notEqual(version1, version2, "set of unresolved imports should change");
+            assert.equal(version1, version2, "set of unresolved imports should not change");
         });
 
         it("expired cache entry (inferred project, should install typings)", () => {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -528,12 +528,12 @@ namespace ts.server {
             }
             switch (response.kind) {
                 case ActionSet:
-                    project.resolutionCache.clear();
                     this.typingsCache.updateTypingsForProject(response.projectName, response.compilerOptions, response.typeAcquisition, response.unresolvedImports, response.typings);
+                    project.resolutionCache.invalidateAllResolutions();
                     break;
                 case ActionInvalidate:
-                    project.resolutionCache.clear();
                     this.typingsCache.deleteTypingsForProject(response.projectName);
+                    project.resolutionCache.invalidateAllResolutions();
                     break;
             }
             this.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(project);

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -320,7 +320,8 @@ namespace ts.server {
 
     export class ProjectService {
 
-        public readonly typingsCache: TypingsCache;
+        /*@internal*/
+        readonly typingsCache: TypingsCache;
 
         private readonly documentRegistry: DocumentRegistry;
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -642,7 +642,6 @@ namespace ts.server {
                 return undefined;
             }
             if (isInferredProjectName(projectName)) {
-                this.ensureProjectStructuresUptoDate();
                 return findProjectByName(projectName, this.inferredProjects);
             }
             return this.findExternalProjectByProjectName(projectName) || this.findConfiguredProjectByProjectName(toNormalizedPath(projectName));

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -529,9 +529,13 @@ namespace ts.server {
             }
             switch (response.kind) {
                 case ActionSet:
-                    this.typingsCache.updateTypingsForProject(response.projectName, response.compilerOptions, response.typeAcquisition, response.unresolvedImports, response.typings);
-                    project.resolutionCache.invalidateAllResolutions();
+                    const typings = toSortedArray(response.typings);
+                    this.typingsCache.updateTypingsForProject(response.projectName, response.compilerOptions, response.typeAcquisition, response.unresolvedImports, typings);
+                    if (!project.updateTypingFiles(typings)) {
+                        return;
+                    }
                     break;
+
                 case ActionInvalidate:
                     this.typingsCache.deleteTypingsForProject(response.projectName);
                     project.resolutionCache.invalidateAllResolutions();

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -124,6 +124,9 @@ namespace ts.server {
         /*@internal*/
         resolutionCache: ResolutionCache;
 
+        /*@internal*/
+        hasStructureChange = false;
+
         private builderState: BuilderState | undefined;
         /**
          * Set of files names that were updated since the last call to getChangesSinceVersion.
@@ -810,6 +813,9 @@ namespace ts.server {
                 this.filesWithNoUnresolvedImports.delete(file);
             }
 
+            const hasMoreOrLessFiles = this.hasStructureChange;
+            this.hasStructureChange = false;
+
             // update builder only if language service is enabled
             // otherwise tell it to drop its internal state
             if (this.languageServiceEnabled) {
@@ -827,7 +833,7 @@ namespace ts.server {
                     }
                     this.lastCachedUnresolvedImportsList = result ? toDeduplicatedSortedArray(result) : emptyArray;
                 }
-                this.projectService.typingsCache.enqueueInstallTypingsForProject(this, this.lastCachedUnresolvedImportsList, hasChanges);
+                this.projectService.typingsCache.enqueueInstallTypingsForProject(this, this.lastCachedUnresolvedImportsList, hasMoreOrLessFiles);
             }
             else {
                 this.lastCachedUnresolvedImportsList = emptyArray;

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1001,7 +1001,7 @@ namespace ts.server {
                 this.compilerOptions = compilerOptions;
                 this.setInternalCompilerOptionsForEmittingJsFiles();
                 if (changesAffectModuleResolution(oldOptions, compilerOptions)) {
-                    this.resolutionCache.clear();
+                    this.resolutionCache.invalidateAllResolutions();
                 }
                 this.markAsDirty();
             }

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -306,6 +306,7 @@ namespace ts.server {
             const isNew = !this.isAttached(project);
             if (isNew) {
                 this.containingProjects.push(project);
+                project.hasStructureChange = true;
                 if (!project.getCompilerOptions().preserveSymlinks) {
                     this.ensureRealPath();
                 }
@@ -331,18 +332,23 @@ namespace ts.server {
                 case 1:
                     if (this.containingProjects[0] === project) {
                         this.containingProjects.pop();
+                        project.hasStructureChange = true;
                     }
                     break;
                 case 2:
                     if (this.containingProjects[0] === project) {
                         this.containingProjects[0] = this.containingProjects.pop();
+                        project.hasStructureChange = true;
                     }
                     else if (this.containingProjects[1] === project) {
                         this.containingProjects.pop();
+                        project.hasStructureChange = true;
                     }
                     break;
                 default:
-                    unorderedRemoveItem(this.containingProjects, project);
+                    if (unorderedRemoveItem(this.containingProjects, project)) {
+                        project.hasStructureChange = true;
+                    }
                     break;
             }
         }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -211,12 +211,6 @@ namespace ts.server {
         }
     }
 
-    // E.g. "12:34:56.789"
-    function nowString() {
-        const d = new Date();
-        return `${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}.${d.getMilliseconds()}`;
-    }
-
     interface QueuedOperation {
         operationId: string;
         operation: () => void;

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -33,4 +33,11 @@ namespace ts.server {
             ? sys.args[index + 1]
             : undefined;
     }
+
+    /*@internal*/
+    export function nowString() {
+        // E.g. "12:34:56.789"
+        const d = new Date();
+        return `${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}.${d.getMilliseconds()}`;
+    }
 }

--- a/src/server/typingsCache.ts
+++ b/src/server/typingsCache.ts
@@ -26,7 +26,7 @@ namespace ts.server {
         globalTypingsCacheLocation: undefined
     };
 
-    class TypingsCacheEntry {
+    interface TypingsCacheEntry {
         readonly typeAcquisition: TypeAcquisition;
         readonly compilerOptions: CompilerOptions;
         readonly typings: SortedReadonlyArray<string>;
@@ -82,6 +82,7 @@ namespace ts.server {
         return !arrayIsEqualTo(imports1, imports2);
     }
 
+    /*@internal*/
     export class TypingsCache {
         private readonly perProjectCache: Map<TypingsCacheEntry> = createMap<TypingsCacheEntry>();
 

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -21,7 +21,7 @@ namespace ts.server.typingsInstaller {
         }
         writeLine = (text: string) => {
             try {
-                fs.appendFileSync(this.logFile, text + sys.newLine);
+                fs.appendFileSync(this.logFile, `[${nowString()}] ${text}${sys.newLine}`);
             }
             catch (e) {
                 this.logEnabled = false;

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -127,7 +127,7 @@ namespace ts.JsTyping {
         getTypingNamesFromSourceFileNames(fileNames);
 
         // add typings for unresolved imports
-        if (unresolvedImports) {
+        if (unresolvedImports && unresolvedImports.length) {
             const module = deduplicate(
                 unresolvedImports.map(moduleId => nodeCoreModules.has(moduleId) ? "node" : moduleId),
                 equateStringsCaseSensitive,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7504,17 +7504,6 @@ declare namespace ts.server {
         readonly globalTypingsCacheLocation: string;
     }
     const nullTypingsInstaller: ITypingsInstaller;
-    class TypingsCache {
-        private readonly installer;
-        private readonly perProjectCache;
-        constructor(installer: ITypingsInstaller);
-        isKnownTypesPackageName(name: string): boolean;
-        installPackage(options: InstallPackageOptionsWithProject): Promise<ApplyCodeActionCommandResult>;
-        getTypingsForProject(project: Project, unresolvedImports: SortedReadonlyArray<string>, forceRefresh: boolean): SortedReadonlyArray<string>;
-        updateTypingsForProject(projectName: string, compilerOptions: CompilerOptions, typeAcquisition: TypeAcquisition, unresolvedImports: SortedReadonlyArray<string>, newTypings: string[]): void;
-        deleteTypingsForProject(projectName: string): void;
-        onProjectClosed(project: Project): void;
-    }
 }
 declare namespace ts {
     interface EmitOutput {
@@ -7873,7 +7862,6 @@ declare namespace ts.server {
         syntaxOnly?: boolean;
     }
     class ProjectService {
-        readonly typingsCache: TypingsCache;
         private readonly documentRegistry;
         /**
          * Container of all known scripts

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7524,15 +7524,6 @@ declare namespace ts.server {
     }
     function allRootFilesAreJsOrDts(project: Project): boolean;
     function allFilesAreJsOrDts(project: Project): boolean;
-    class UnresolvedImportsMap {
-        readonly perFileMap: Map<ReadonlyArray<string>>;
-        private version;
-        clear(): void;
-        getVersion(): number;
-        remove(path: Path): void;
-        get(path: Path): ReadonlyArray<string>;
-        set(path: Path, value: ReadonlyArray<string>): void;
-    }
     interface PluginCreateInfo {
         project: Project;
         languageService: LanguageService;
@@ -7565,8 +7556,7 @@ declare namespace ts.server {
         private externalFiles;
         private missingFilesMap;
         private plugins;
-        private cachedUnresolvedImportsPerFile;
-        private lastCachedUnresolvedImportsList;
+        private filesWithNoUnresolvedImports;
         private lastFileExceededProgramSize;
         protected languageService: LanguageService;
         languageServiceEnabled: boolean;
@@ -7601,11 +7591,9 @@ declare namespace ts.server {
         private readonly cancellationToken;
         isNonTsProject(): boolean;
         isJsOnlyProject(): boolean;
-        getCachedUnresolvedImportsPerFile_TestOnly(): UnresolvedImportsMap;
         static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void): {};
         isKnownTypesPackageName(name: string): boolean;
         installPackage(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult>;
-        private readonly typingsCache;
         getCompilationSettings(): CompilerOptions;
         getCompilerOptions(): CompilerOptions;
         getNewLine(): string;


### PR DESCRIPTION
This should potentially help Microsoft/vscode#46025 where in directory watchers and resolutions are not cleared on every action::set response from typing installer.