### PR TITLE
declare ts.versionMajorMinor as string

### DIFF
--- a/scripts/configurePrerelease.ts
+++ b/scripts/configurePrerelease.ts
@@ -12,8 +12,8 @@ interface PackageJson {
 function main(): void {
     const sys = ts.sys;
     if (sys.args.length < 3) {
-        sys.write("Usage:" + sys.newLine)
-        sys.write("\tnode configureNightly.js <dev|insiders> <package.json location> <file containing version>" + sys.newLine);
+        sys.write("Usage:" + sys.newLine);
+        sys.write("\tnode configurePrerelease.js <dev|insiders> <package.json location> <file containing version>" + sys.newLine);
         return;
     }
 
@@ -44,12 +44,12 @@ function main(): void {
     // Finally write the changes to disk.
     // Modify the package.json structure
     packageJsonValue.version = `${majorMinor}.${prereleasePatch}`;
-    sys.writeFile(packageJsonFilePath, JSON.stringify(packageJsonValue, /*replacer:*/ undefined, /*space:*/ 4))
+    sys.writeFile(packageJsonFilePath, JSON.stringify(packageJsonValue, /*replacer:*/ undefined, /*space:*/ 4));
     sys.writeFile(tsFilePath, modifiedTsFileContents);
 }
 
 function updateTsFile(tsFilePath: string, tsFileContents: string, majorMinor: string, patch: string, nightlyPatch: string): string {
-    const majorMinorRgx = /export const versionMajorMinor = "(\d+\.\d+)"/;
+    const majorMinorRgx = /export const versionMajorMinor: string = "(\d+\.\d+)"/;
     const majorMinorMatch = majorMinorRgx.exec(tsFileContents);
     ts.Debug.assert(majorMinorMatch !== null, "", () => `The file seems to no longer have a string matching '${majorMinorRgx}'.`);
     const parsedMajorMinor = majorMinorMatch[1];

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -4,7 +4,7 @@
 namespace ts {
     // WARNING: The script `configureNightly.ts` uses a regexp to parse out these values.
     // If changing the text in this section, be sure to test `configureNightly` too.
-    export const versionMajorMinor = "2.9";
+    export const versionMajorMinor: string = "2.9";
     /** The version of the TypeScript compiler release */
     export const version = `${versionMajorMinor}.0-dev`;
 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -4,7 +4,7 @@
 namespace ts {
     // WARNING: The script `configurePrerelease.ts` uses a regexp to parse out these values.
     // If changing the text in this section, be sure to test `configurePrerelease` too.
-    export const versionMajorMinor: string = "2.9";
+    export const versionMajorMinor: string = "2.9"; // tslint:disable-line:no-inferrable-types
     /** The version of the TypeScript compiler release */
     export const version = `${versionMajorMinor}.0-dev`;
 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2,8 +2,8 @@
 /// <reference path="performance.ts" />
 
 namespace ts {
-    // WARNING: The script `configureNightly.ts` uses a regexp to parse out these values.
-    // If changing the text in this section, be sure to test `configureNightly` too.
+    // WARNING: The script `configurePrerelease.ts` uses a regexp to parse out these values.
+    // If changing the text in this section, be sure to test `configurePrerelease` too.
     export const versionMajorMinor: string = "2.9";
     /** The version of the TypeScript compiler release */
     export const version = `${versionMajorMinor}.0-dev`;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2861,7 +2861,7 @@ declare namespace ts {
     }
 }
 declare namespace ts {
-    const versionMajorMinor = "2.9";
+    const versionMajorMinor: string;
     /** The version of the TypeScript compiler release */
     const version: string;
 }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2861,7 +2861,7 @@ declare namespace ts {
     }
 }
 declare namespace ts {
-    const versionMajorMinor = "2.9";
+    const versionMajorMinor: string;
     /** The version of the TypeScript compiler release */
     const version: string;
 }


### PR DESCRIPTION
Allows my script to compare `ts.versionMajorMinor` to an older or newer version:

```ts
// this comparison currently fails because `versionMajorMinor` has a literal type
if (ts.versionMajorMinor === '2.7') {
    // do something special
}
```