### PR TITLE
Allow both module.exports= and module.exports property assignments

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4396,7 +4396,7 @@ namespace ts {
                         const members = createSymbolTable();
                         copyEntries(o.members, members);
                         copyEntries(symbol.exports, members);
-                        type = createAnonymousType(symbol, members, o.callSignatures, o.constructSignatures, o.stringIndexInfo, o.numberIndexInfo);
+                        type = createAnonymousType(o.symbol, members, o.callSignatures, o.constructSignatures, o.stringIndexInfo, o.numberIndexInfo);
                     }
                     let anyedType = type;
                     if (isEmptyArrayLiteralType(type)) {

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment.errors.txt
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment.errors.txt
@@ -1,0 +1,21 @@
+tests/cases/conformance/salsa/a.js(1,12): error TS2304: Cannot find name 'require'.
+tests/cases/conformance/salsa/mod1.js(2,1): error TS2304: Cannot find name 'module'.
+tests/cases/conformance/salsa/mod1.js(3,1): error TS2304: Cannot find name 'module'.
+
+
+==== tests/cases/conformance/salsa/a.js (1 errors) ====
+    var mod1 = require('./mod1')
+               ~~~~~~~
+!!! error TS2304: Cannot find name 'require'.
+    mod1()
+    mod1.f()
+    
+==== tests/cases/conformance/salsa/mod1.js (2 errors) ====
+    // TODO: Test that this is not legal (or at least doesn't work) if module.exports is a primitive
+    module.exports = function () { }
+    ~~~~~~
+!!! error TS2304: Cannot find name 'module'.
+    module.exports.f = function () { }
+    ~~~~~~
+!!! error TS2304: Cannot find name 'module'.
+    

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment.symbols
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/salsa/a.js ===
+var mod1 = require('./mod1')
+>mod1 : Symbol(mod1, Decl(a.js, 0, 3))
+>'./mod1' : Symbol("tests/cases/conformance/salsa/mod1", Decl(mod1.js, 0, 0))
+
+mod1()
+>mod1 : Symbol(mod1, Decl(a.js, 0, 3))
+
+mod1.f()
+>mod1.f : Symbol(f, Decl(mod1.js, 1, 32))
+>mod1 : Symbol(mod1, Decl(a.js, 0, 3))
+>f : Symbol(f, Decl(mod1.js, 1, 32))
+
+=== tests/cases/conformance/salsa/mod1.js ===
+// TODO: Test that this is not legal (or at least doesn't work) if module.exports is a primitive
+module.exports = function () { }
+>module : Symbol(export=, Decl(mod1.js, 0, 0))
+>exports : Symbol(export=, Decl(mod1.js, 0, 0))
+
+module.exports.f = function () { }
+>module.exports : Symbol(f, Decl(mod1.js, 1, 32))
+>f : Symbol(f, Decl(mod1.js, 1, 32))
+

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment.types
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment.types
@@ -1,0 +1,35 @@
+=== tests/cases/conformance/salsa/a.js ===
+var mod1 = require('./mod1')
+>mod1 : { (): void; f: () => void; }
+>require('./mod1') : { (): void; f: () => void; }
+>require : any
+>'./mod1' : "./mod1"
+
+mod1()
+>mod1() : void
+>mod1 : { (): void; f: () => void; }
+
+mod1.f()
+>mod1.f() : void
+>mod1.f : () => void
+>mod1 : { (): void; f: () => void; }
+>f : () => void
+
+=== tests/cases/conformance/salsa/mod1.js ===
+// TODO: Test that this is not legal (or at least doesn't work) if module.exports is a primitive
+module.exports = function () { }
+>module.exports = function () { } : () => void
+>module.exports : any
+>module : any
+>exports : any
+>function () { } : () => void
+
+module.exports.f = function () { }
+>module.exports.f = function () { } : () => void
+>module.exports.f : any
+>module.exports : any
+>module : any
+>exports : any
+>f : any
+>function () { } : () => void
+

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment2.errors.txt
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment2.errors.txt
@@ -1,20 +1,19 @@
-tests/cases/conformance/salsa/a.js(4,1): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/salsa/a.js(4,6): error TS2339: Property 'f' does not exist on type 'number'.
 
 
 ==== tests/cases/conformance/salsa/a.js (1 errors) ====
     /// <reference path='./requires.d.ts' />
     var mod1 = require('./mod1')
-    mod1()
-    mod1.f() // error, not enough arguments
-    ~~~~~~~~
-!!! error TS2554: Expected 1 arguments, but got 0.
+    mod1.toFixed(12)
+    mod1.f() // error, 'f' is not a property on 'number'
+         ~
+!!! error TS2339: Property 'f' does not exist on type 'number'.
     
 ==== tests/cases/conformance/salsa/requires.d.ts (0 errors) ====
     declare var module: { exports: any };
     declare function require(name: string): any;
 ==== tests/cases/conformance/salsa/mod1.js (0 errors) ====
     /// <reference path='./requires.d.ts' />
-    module.exports = function () { }
-    /** @param {number} a */
-    module.exports.f = function (a) { }
+    module.exports = 1
+    module.exports.f = function () { }
     

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment2.symbols
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment2.symbols
@@ -5,13 +5,13 @@ var mod1 = require('./mod1')
 >require : Symbol(require, Decl(requires.d.ts, 0, 37))
 >'./mod1' : Symbol("tests/cases/conformance/salsa/mod1", Decl(mod1.js, 0, 0))
 
-mod1()
+mod1.toFixed(12)
+>mod1.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 >mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 
-mod1.f() // error, not enough arguments
->mod1.f : Symbol(f, Decl(mod1.js, 1, 32))
+mod1.f() // error, 'f' is not a property on 'number'
 >mod1 : Symbol(mod1, Decl(a.js, 1, 3))
->f : Symbol(f, Decl(mod1.js, 1, 32))
 
 === tests/cases/conformance/salsa/requires.d.ts ===
 declare var module: { exports: any };
@@ -24,16 +24,14 @@ declare function require(name: string): any;
 
 === tests/cases/conformance/salsa/mod1.js ===
 /// <reference path='./requires.d.ts' />
-module.exports = function () { }
+module.exports = 1
 >module.exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
 >module : Symbol(export=, Decl(mod1.js, 0, 0))
 >exports : Symbol(export=, Decl(mod1.js, 0, 0))
 
-/** @param {number} a */
-module.exports.f = function (a) { }
->module.exports : Symbol(f, Decl(mod1.js, 1, 32))
+module.exports.f = function () { }
+>module.exports : Symbol(f, Decl(mod1.js, 1, 18))
 >module : Symbol(module, Decl(requires.d.ts, 0, 11))
 >exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
->f : Symbol(f, Decl(mod1.js, 1, 32))
->a : Symbol(a, Decl(mod1.js, 3, 29))
+>f : Symbol(f, Decl(mod1.js, 1, 18))
 

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment2.types
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment2.types
@@ -1,20 +1,23 @@
 === tests/cases/conformance/salsa/a.js ===
 /// <reference path='./requires.d.ts' />
 var mod1 = require('./mod1')
->mod1 : { (): void; f: (a: number) => void; }
->require('./mod1') : { (): void; f: (a: number) => void; }
+>mod1 : number
+>require('./mod1') : number
 >require : (name: string) => any
 >'./mod1' : "./mod1"
 
-mod1()
->mod1() : void
->mod1 : { (): void; f: (a: number) => void; }
+mod1.toFixed(12)
+>mod1.toFixed(12) : string
+>mod1.toFixed : (fractionDigits?: number) => string
+>mod1 : number
+>toFixed : (fractionDigits?: number) => string
+>12 : 12
 
-mod1.f() // error, not enough arguments
->mod1.f() : void
->mod1.f : (a: number) => void
->mod1 : { (): void; f: (a: number) => void; }
->f : (a: number) => void
+mod1.f() // error, 'f' is not a property on 'number'
+>mod1.f() : any
+>mod1.f : any
+>mod1 : number
+>f : any
 
 === tests/cases/conformance/salsa/requires.d.ts ===
 declare var module: { exports: any };
@@ -27,21 +30,19 @@ declare function require(name: string): any;
 
 === tests/cases/conformance/salsa/mod1.js ===
 /// <reference path='./requires.d.ts' />
-module.exports = function () { }
->module.exports = function () { } : () => void
+module.exports = 1
+>module.exports = 1 : 1
 >module.exports : any
 >module : { exports: any; }
 >exports : any
->function () { } : () => void
+>1 : 1
 
-/** @param {number} a */
-module.exports.f = function (a) { }
->module.exports.f = function (a) { } : (a: number) => void
+module.exports.f = function () { }
+>module.exports.f = function () { } : () => void
 >module.exports.f : any
 >module.exports : any
 >module : { exports: any; }
 >exports : any
 >f : any
->function (a) { } : (a: number) => void
->a : number
+>function () { } : () => void
 

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment3.errors.txt
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment3.errors.txt
@@ -1,0 +1,34 @@
+tests/cases/conformance/salsa/a.js(4,17): error TS2339: Property 'toFixed' does not exist on type 'string | number'.
+  Property 'toFixed' does not exist on type 'string'.
+tests/cases/conformance/salsa/a.js(5,16): error TS2339: Property 'toFixed' does not exist on type 'string | number'.
+  Property 'toFixed' does not exist on type 'string'.
+
+
+==== tests/cases/conformance/salsa/a.js (2 errors) ====
+    /// <reference path='./requires.d.ts' />
+    var mod1 = require('./mod1')
+    mod1.justExport.toFixed()
+    mod1.bothBefore.toFixed() // error, 'toFixed' not on 'string | number'
+                    ~~~~~~~
+!!! error TS2339: Property 'toFixed' does not exist on type 'string | number'.
+!!! error TS2339:   Property 'toFixed' does not exist on type 'string'.
+    mod1.bothAfter.toFixed() // error, 'toFixed' not on 'string | number'
+                   ~~~~~~~
+!!! error TS2339: Property 'toFixed' does not exist on type 'string | number'.
+!!! error TS2339:   Property 'toFixed' does not exist on type 'string'.
+    mod1.justProperty.length
+    
+==== tests/cases/conformance/salsa/requires.d.ts (0 errors) ====
+    declare var module: { exports: any };
+    declare function require(name: string): any;
+==== tests/cases/conformance/salsa/mod1.js (0 errors) ====
+    /// <reference path='./requires.d.ts' />
+    module.exports.bothBefore = 'string'
+    module.exports = {
+        justExport: 1,
+        bothBefore: 2,
+        bothAfter: 3,
+    }
+    module.exports.bothAfter = 'string'
+    module.exports.justProperty = 'string'
+    

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment3.symbols
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment3.symbols
@@ -1,0 +1,74 @@
+=== tests/cases/conformance/salsa/a.js ===
+/// <reference path='./requires.d.ts' />
+var mod1 = require('./mod1')
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>require : Symbol(require, Decl(requires.d.ts, 0, 37))
+>'./mod1' : Symbol("tests/cases/conformance/salsa/mod1", Decl(mod1.js, 0, 0))
+
+mod1.justExport.toFixed()
+>mod1.justExport.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>mod1.justExport : Symbol(justExport, Decl(mod1.js, 2, 18))
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>justExport : Symbol(justExport, Decl(mod1.js, 2, 18))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+
+mod1.bothBefore.toFixed() // error, 'toFixed' not on 'string | number'
+>mod1.bothBefore : Symbol(bothBefore)
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>bothBefore : Symbol(bothBefore)
+
+mod1.bothAfter.toFixed() // error, 'toFixed' not on 'string | number'
+>mod1.bothAfter : Symbol(bothAfter)
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>bothAfter : Symbol(bothAfter)
+
+mod1.justProperty.length
+>mod1.justProperty.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>mod1.justProperty : Symbol(justProperty, Decl(mod1.js, 7, 35))
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>justProperty : Symbol(justProperty, Decl(mod1.js, 7, 35))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+
+=== tests/cases/conformance/salsa/requires.d.ts ===
+declare var module: { exports: any };
+>module : Symbol(module, Decl(requires.d.ts, 0, 11))
+>exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+
+declare function require(name: string): any;
+>require : Symbol(require, Decl(requires.d.ts, 0, 37))
+>name : Symbol(name, Decl(requires.d.ts, 1, 25))
+
+=== tests/cases/conformance/salsa/mod1.js ===
+/// <reference path='./requires.d.ts' />
+module.exports.bothBefore = 'string'
+>module.exports : Symbol(bothBefore, Decl(mod1.js, 0, 0))
+>module : Symbol(module, Decl(requires.d.ts, 0, 11))
+>exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+>bothBefore : Symbol(bothBefore, Decl(mod1.js, 0, 0))
+
+module.exports = {
+>module.exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+>module : Symbol(export=, Decl(mod1.js, 1, 36))
+>exports : Symbol(export=, Decl(mod1.js, 1, 36))
+
+    justExport: 1,
+>justExport : Symbol(justExport, Decl(mod1.js, 2, 18))
+
+    bothBefore: 2,
+>bothBefore : Symbol(bothBefore, Decl(mod1.js, 3, 18))
+
+    bothAfter: 3,
+>bothAfter : Symbol(bothAfter, Decl(mod1.js, 4, 18))
+}
+module.exports.bothAfter = 'string'
+>module.exports : Symbol(bothAfter, Decl(mod1.js, 6, 1))
+>module : Symbol(module, Decl(requires.d.ts, 0, 11))
+>exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+>bothAfter : Symbol(bothAfter, Decl(mod1.js, 6, 1))
+
+module.exports.justProperty = 'string'
+>module.exports : Symbol(justProperty, Decl(mod1.js, 7, 35))
+>module : Symbol(module, Decl(requires.d.ts, 0, 11))
+>exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+>justProperty : Symbol(justProperty, Decl(mod1.js, 7, 35))
+

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment3.types
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment3.types
@@ -1,0 +1,96 @@
+=== tests/cases/conformance/salsa/a.js ===
+/// <reference path='./requires.d.ts' />
+var mod1 = require('./mod1')
+>mod1 : { [x: string]: any; justExport: number; bothBefore: string | number; bothAfter: string | number; justProperty: string; }
+>require('./mod1') : { [x: string]: any; justExport: number; bothBefore: string | number; bothAfter: string | number; justProperty: string; }
+>require : (name: string) => any
+>'./mod1' : "./mod1"
+
+mod1.justExport.toFixed()
+>mod1.justExport.toFixed() : string
+>mod1.justExport.toFixed : (fractionDigits?: number) => string
+>mod1.justExport : number
+>mod1 : { [x: string]: any; justExport: number; bothBefore: string | number; bothAfter: string | number; justProperty: string; }
+>justExport : number
+>toFixed : (fractionDigits?: number) => string
+
+mod1.bothBefore.toFixed() // error, 'toFixed' not on 'string | number'
+>mod1.bothBefore.toFixed() : any
+>mod1.bothBefore.toFixed : any
+>mod1.bothBefore : string | number
+>mod1 : { [x: string]: any; justExport: number; bothBefore: string | number; bothAfter: string | number; justProperty: string; }
+>bothBefore : string | number
+>toFixed : any
+
+mod1.bothAfter.toFixed() // error, 'toFixed' not on 'string | number'
+>mod1.bothAfter.toFixed() : any
+>mod1.bothAfter.toFixed : any
+>mod1.bothAfter : string | number
+>mod1 : { [x: string]: any; justExport: number; bothBefore: string | number; bothAfter: string | number; justProperty: string; }
+>bothAfter : string | number
+>toFixed : any
+
+mod1.justProperty.length
+>mod1.justProperty.length : number
+>mod1.justProperty : string
+>mod1 : { [x: string]: any; justExport: number; bothBefore: string | number; bothAfter: string | number; justProperty: string; }
+>justProperty : string
+>length : number
+
+=== tests/cases/conformance/salsa/requires.d.ts ===
+declare var module: { exports: any };
+>module : { exports: any; }
+>exports : any
+
+declare function require(name: string): any;
+>require : (name: string) => any
+>name : string
+
+=== tests/cases/conformance/salsa/mod1.js ===
+/// <reference path='./requires.d.ts' />
+module.exports.bothBefore = 'string'
+>module.exports.bothBefore = 'string' : "string"
+>module.exports.bothBefore : any
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>bothBefore : any
+>'string' : "string"
+
+module.exports = {
+>module.exports = {    justExport: 1,    bothBefore: 2,    bothAfter: 3,} : { [x: string]: any; justExport: number; bothBefore: number; bothAfter: number; }
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>{    justExport: 1,    bothBefore: 2,    bothAfter: 3,} : { [x: string]: any; justExport: number; bothBefore: number; bothAfter: number; }
+
+    justExport: 1,
+>justExport : number
+>1 : 1
+
+    bothBefore: 2,
+>bothBefore : number
+>2 : 2
+
+    bothAfter: 3,
+>bothAfter : number
+>3 : 3
+}
+module.exports.bothAfter = 'string'
+>module.exports.bothAfter = 'string' : "string"
+>module.exports.bothAfter : any
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>bothAfter : any
+>'string' : "string"
+
+module.exports.justProperty = 'string'
+>module.exports.justProperty = 'string' : "string"
+>module.exports.justProperty : any
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>justProperty : any
+>'string' : "string"
+

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.errors.txt
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/conformance/salsa/a.js(4,17): error TS2339: Property 'toFixed' does not exist on type 'string | number'.
+  Property 'toFixed' does not exist on type 'string'.
+tests/cases/conformance/salsa/a.js(5,16): error TS2339: Property 'toFixed' does not exist on type 'string | number'.
+  Property 'toFixed' does not exist on type 'string'.
+
+
+==== tests/cases/conformance/salsa/a.js (2 errors) ====
+    /// <reference path='./requires.d.ts' />
+    var mod1 = require('./mod1')
+    mod1.justExport.toFixed()
+    mod1.bothBefore.toFixed() // error
+                    ~~~~~~~
+!!! error TS2339: Property 'toFixed' does not exist on type 'string | number'.
+!!! error TS2339:   Property 'toFixed' does not exist on type 'string'.
+    mod1.bothAfter.toFixed()
+                   ~~~~~~~
+!!! error TS2339: Property 'toFixed' does not exist on type 'string | number'.
+!!! error TS2339:   Property 'toFixed' does not exist on type 'string'.
+    mod1.justProperty.length
+    
+==== tests/cases/conformance/salsa/requires.d.ts (0 errors) ====
+    declare var module: { exports: any };
+    declare function require(name: string): any;
+==== tests/cases/conformance/salsa/mod1.js (0 errors) ====
+    /// <reference path='./requires.d.ts' />
+    module.exports.bothBefore = 'string'
+    A.justExport = 4
+    A.bothBefore = 2
+    A.bothAfter = 3
+    module.exports = A
+    function A() {
+        this.p = 1
+    }
+    module.exports.bothAfter = 'string'
+    module.exports.justProperty = 'string'
+    

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.symbols
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.symbols
@@ -1,0 +1,87 @@
+=== tests/cases/conformance/salsa/a.js ===
+/// <reference path='./requires.d.ts' />
+var mod1 = require('./mod1')
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>require : Symbol(require, Decl(requires.d.ts, 0, 37))
+>'./mod1' : Symbol("tests/cases/conformance/salsa/mod1", Decl(mod1.js, 0, 0))
+
+mod1.justExport.toFixed()
+>mod1.justExport.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>mod1.justExport : Symbol(A.justExport, Decl(mod1.js, 1, 36))
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>justExport : Symbol(A.justExport, Decl(mod1.js, 1, 36))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+
+mod1.bothBefore.toFixed() // error
+>mod1.bothBefore : Symbol(bothBefore)
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>bothBefore : Symbol(bothBefore)
+
+mod1.bothAfter.toFixed()
+>mod1.bothAfter : Symbol(bothAfter)
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>bothAfter : Symbol(bothAfter)
+
+mod1.justProperty.length
+>mod1.justProperty.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>mod1.justProperty : Symbol(justProperty, Decl(mod1.js, 9, 35))
+>mod1 : Symbol(mod1, Decl(a.js, 1, 3))
+>justProperty : Symbol(justProperty, Decl(mod1.js, 9, 35))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+
+=== tests/cases/conformance/salsa/requires.d.ts ===
+declare var module: { exports: any };
+>module : Symbol(module, Decl(requires.d.ts, 0, 11))
+>exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+
+declare function require(name: string): any;
+>require : Symbol(require, Decl(requires.d.ts, 0, 37))
+>name : Symbol(name, Decl(requires.d.ts, 1, 25))
+
+=== tests/cases/conformance/salsa/mod1.js ===
+/// <reference path='./requires.d.ts' />
+module.exports.bothBefore = 'string'
+>module.exports : Symbol(bothBefore, Decl(mod1.js, 0, 0))
+>module : Symbol(module, Decl(requires.d.ts, 0, 11))
+>exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+>bothBefore : Symbol(bothBefore, Decl(mod1.js, 0, 0))
+
+A.justExport = 4
+>A.justExport : Symbol(A.justExport, Decl(mod1.js, 1, 36))
+>A : Symbol(A, Decl(mod1.js, 5, 18))
+>justExport : Symbol(A.justExport, Decl(mod1.js, 1, 36))
+
+A.bothBefore = 2
+>A.bothBefore : Symbol(A.bothBefore, Decl(mod1.js, 2, 16))
+>A : Symbol(A, Decl(mod1.js, 5, 18))
+>bothBefore : Symbol(A.bothBefore, Decl(mod1.js, 2, 16))
+
+A.bothAfter = 3
+>A.bothAfter : Symbol(A.bothAfter, Decl(mod1.js, 3, 16))
+>A : Symbol(A, Decl(mod1.js, 5, 18))
+>bothAfter : Symbol(A.bothAfter, Decl(mod1.js, 3, 16))
+
+module.exports = A
+>module.exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+>module : Symbol(export=, Decl(mod1.js, 4, 15))
+>exports : Symbol(export=, Decl(mod1.js, 4, 15))
+>A : Symbol(A, Decl(mod1.js, 5, 18))
+
+function A() {
+>A : Symbol(A, Decl(mod1.js, 5, 18))
+
+    this.p = 1
+>p : Symbol(A.p, Decl(mod1.js, 6, 14))
+}
+module.exports.bothAfter = 'string'
+>module.exports : Symbol(bothAfter, Decl(mod1.js, 8, 1))
+>module : Symbol(module, Decl(requires.d.ts, 0, 11))
+>exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+>bothAfter : Symbol(bothAfter, Decl(mod1.js, 8, 1))
+
+module.exports.justProperty = 'string'
+>module.exports : Symbol(justProperty, Decl(mod1.js, 9, 35))
+>module : Symbol(module, Decl(requires.d.ts, 0, 11))
+>exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
+>justProperty : Symbol(justProperty, Decl(mod1.js, 9, 35))
+

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.types
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.types
@@ -1,0 +1,115 @@
+=== tests/cases/conformance/salsa/a.js ===
+/// <reference path='./requires.d.ts' />
+var mod1 = require('./mod1')
+>mod1 : typeof A
+>require('./mod1') : typeof A
+>require : (name: string) => any
+>'./mod1' : "./mod1"
+
+mod1.justExport.toFixed()
+>mod1.justExport.toFixed() : string
+>mod1.justExport.toFixed : (fractionDigits?: number) => string
+>mod1.justExport : number
+>mod1 : typeof A
+>justExport : number
+>toFixed : (fractionDigits?: number) => string
+
+mod1.bothBefore.toFixed() // error
+>mod1.bothBefore.toFixed() : any
+>mod1.bothBefore.toFixed : any
+>mod1.bothBefore : string | number
+>mod1 : typeof A
+>bothBefore : string | number
+>toFixed : any
+
+mod1.bothAfter.toFixed()
+>mod1.bothAfter.toFixed() : any
+>mod1.bothAfter.toFixed : any
+>mod1.bothAfter : string | number
+>mod1 : typeof A
+>bothAfter : string | number
+>toFixed : any
+
+mod1.justProperty.length
+>mod1.justProperty.length : number
+>mod1.justProperty : string
+>mod1 : typeof A
+>justProperty : string
+>length : number
+
+=== tests/cases/conformance/salsa/requires.d.ts ===
+declare var module: { exports: any };
+>module : { exports: any; }
+>exports : any
+
+declare function require(name: string): any;
+>require : (name: string) => any
+>name : string
+
+=== tests/cases/conformance/salsa/mod1.js ===
+/// <reference path='./requires.d.ts' />
+module.exports.bothBefore = 'string'
+>module.exports.bothBefore = 'string' : "string"
+>module.exports.bothBefore : any
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>bothBefore : any
+>'string' : "string"
+
+A.justExport = 4
+>A.justExport = 4 : 4
+>A.justExport : number
+>A : typeof A
+>justExport : number
+>4 : 4
+
+A.bothBefore = 2
+>A.bothBefore = 2 : 2
+>A.bothBefore : number
+>A : typeof A
+>bothBefore : number
+>2 : 2
+
+A.bothAfter = 3
+>A.bothAfter = 3 : 3
+>A.bothAfter : number
+>A : typeof A
+>bothAfter : number
+>3 : 3
+
+module.exports = A
+>module.exports = A : typeof A
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>A : typeof A
+
+function A() {
+>A : typeof A
+
+    this.p = 1
+>this.p = 1 : 1
+>this.p : any
+>this : any
+>p : any
+>1 : 1
+}
+module.exports.bothAfter = 'string'
+>module.exports.bothAfter = 'string' : "string"
+>module.exports.bothAfter : any
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>bothAfter : any
+>'string' : "string"
+
+module.exports.justProperty = 'string'
+>module.exports.justProperty = 'string' : "string"
+>module.exports.justProperty : any
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>justProperty : any
+>'string' : "string"
+

--- a/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment.ts
+++ b/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment.ts
@@ -1,0 +1,12 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: mod1.js
+// TODO: Test that this is not legal (or at least doesn't work) if module.exports is a primitive
+module.exports = function () { }
+module.exports.f = function () { }
+
+// @Filename: a.js
+var mod1 = require('./mod1')
+mod1()
+mod1.f()

--- a/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment2.ts
+++ b/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment2.ts
@@ -6,12 +6,11 @@ declare var module: { exports: any };
 declare function require(name: string): any;
 // @Filename: mod1.js
 /// <reference path='./requires.d.ts' />
-module.exports = function () { }
-/** @param {number} a */
-module.exports.f = function (a) { }
+module.exports = 1
+module.exports.f = function () { }
 
 // @Filename: a.js
 /// <reference path='./requires.d.ts' />
 var mod1 = require('./mod1')
-mod1()
-mod1.f() // error, not enough arguments
+mod1.toFixed(12)
+mod1.f() // error, 'f' is not a property on 'number'

--- a/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment3.ts
+++ b/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment3.ts
@@ -1,0 +1,24 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: requires.d.ts
+declare var module: { exports: any };
+declare function require(name: string): any;
+// @Filename: mod1.js
+/// <reference path='./requires.d.ts' />
+module.exports.bothBefore = 'string'
+module.exports = {
+    justExport: 1,
+    bothBefore: 2,
+    bothAfter: 3,
+}
+module.exports.bothAfter = 'string'
+module.exports.justProperty = 'string'
+
+// @Filename: a.js
+/// <reference path='./requires.d.ts' />
+var mod1 = require('./mod1')
+mod1.justExport.toFixed()
+mod1.bothBefore.toFixed() // error, 'toFixed' not on 'string | number'
+mod1.bothAfter.toFixed() // error, 'toFixed' not on 'string | number'
+mod1.justProperty.length

--- a/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment4.ts
+++ b/tests/cases/conformance/salsa/moduleExportWithExportPropertyAssignment4.ts
@@ -1,0 +1,26 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: requires.d.ts
+declare var module: { exports: any };
+declare function require(name: string): any;
+// @Filename: mod1.js
+/// <reference path='./requires.d.ts' />
+module.exports.bothBefore = 'string'
+A.justExport = 4
+A.bothBefore = 2
+A.bothAfter = 3
+module.exports = A
+function A() {
+    this.p = 1
+}
+module.exports.bothAfter = 'string'
+module.exports.justProperty = 'string'
+
+// @Filename: a.js
+/// <reference path='./requires.d.ts' />
+var mod1 = require('./mod1')
+mod1.justExport.toFixed()
+mod1.bothBefore.toFixed() // error
+mod1.bothAfter.toFixed()
+mod1.justProperty.length


### PR DESCRIPTION
In Javascript, it's common both to assign to `module.exports` and to assign properties to `module.exports`:

```js
module.exports = function A() {
  this.p = 1
}
module.exports.util = function() {
  return "Hooray, I'm useful! I'm having a wonderful time."
}
```

This should be treated as equivalent to the Typescript:

```ts
class A {
  p = 1
}
namespace A {
  export function util() {
    return "Looking for static public abstract readonly internal classes? Why not Typescript?"
  }
}
export = A
```

This PR merges `module.exports` assignments with `module.exports` property assignments to produce a symbol structure similar to the Typescript binding. Unfortunately, since we're merging values, the normal merging code will not work. After binding the first example, the file's exports have the following structure:

```
exports: {
  "export=": { valueDeclaration: module.exports = function ...
  "util": { valueDeclaration: module.exports.util = function ...
}
```

Then when the checker encounters `var x = require(...)`, it looks up the file's exports and retrieves the "export=" entry. 

This PR copies the other entries of exports over to export='s exports:

```
exports: {
  "export=": { 
    valueDeclaration: module.exports = function ..., 
    exports: {
      util: { valueDeclaration: ... }
    }
  },
  util: { valueDeclaration: ... }
}
```

This makes the `export=` symbol equivalent to the merged typescript in the second example.
Then when the checker asks for the type of this symbol, it can get the property assignments by looking at the `exports` of the symbol.

Since the same property can be assigned in both `export=` and property assignments, some unioning code is also required:

```js
module.exports = { both: 1 }
module.exports.both = 'both: string | number'
```

In addition, if the `module.exports = 1` (or any primitive type), then subsequent assignments will be ignored, so none of the property assignments should show up as exports either.

Fixes #22461