### PR TITLE
patternMatcher: Just return 'undefined' for an invalid pattern

### DIFF
--- a/src/harness/unittests/services/patternMatcher.ts
+++ b/src/harness/unittests/services/patternMatcher.ts
@@ -343,15 +343,11 @@ describe("PatternMatcher", () => {
         });
 
         it("BlankPattern", () => {
-            const matches = getAllMatches("AddMetadataReference", "");
-
-            assert.isTrue(matches === undefined);
+            assertInvalidPattern("");
         });
 
         it("WhitespaceOnlyPattern", () => {
-            const matches = getAllMatches("AddMetadataReference", " ");
-
-            assert.isTrue(matches === undefined);
+            assertInvalidPattern(" ");
         });
 
         it("EachWordSeparately1", () => {
@@ -448,6 +444,10 @@ describe("PatternMatcher", () => {
             assert.isTrue(match === undefined);
         });
     });
+
+    function assertInvalidPattern(pattern: string) {
+        assert.equal(ts.createPatternMatcher(pattern), undefined);
+    }
 
     function getFirstMatch(candidate: string, pattern: string): ts.PatternMatch {
         const matches = ts.createPatternMatcher(pattern).getMatchesForLastSegmentOfPattern(candidate);

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -10,6 +10,7 @@ namespace ts.NavigateTo {
 
     export function getNavigateToItems(sourceFiles: ReadonlyArray<SourceFile>, checker: TypeChecker, cancellationToken: CancellationToken, searchValue: string, maxResultCount: number, excludeDtsFiles: boolean): NavigateToItem[] {
         const patternMatcher = createPatternMatcher(searchValue);
+        if (!patternMatcher) return emptyArray;
         let rawItems: RawNavigateToItem[] = [];
 
         // Search the declarations in all files and output matched NavigateToItem into array of NavigateToItem[]


### PR DESCRIPTION
A PatternMatcher for an invalid pattern will just return `undefined` for all queries, so we might as well not use it at all.
Also, `dotSeparatedSegments` is guaranteed to have length at least 1 because it comes from `.split()`.