### PR TITLE
Fix bug: don't insert a semicolon when inserting a FunctionDeclaration

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5618,6 +5618,10 @@ namespace ts {
             || kind === SyntaxKind.MissingDeclaration;
     }
 
+    export function isClassOrTypeElement(node: Node): node is ClassElement | TypeElement {
+        return isTypeElement(node) || isClassElement(node);
+    }
+
     export function isObjectLiteralElementLike(node: Node): node is ObjectLiteralElementLike {
         const kind = node.kind;
         return kind === SyntaxKind.PropertyAssignment

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2248,7 +2248,7 @@ namespace ts.Completions {
 
     // TODO: GH#19856 Would like to return `node is Node & { parent: (ClassElement | TypeElement) & { parent: ObjectTypeDeclaration } }` but then compilation takes > 10 minutes
     function isFromObjectTypeDeclaration(node: Node): boolean {
-        return node.parent && (isClassElement(node.parent) || isTypeElement(node.parent)) && isObjectTypeDeclaration(node.parent.parent);
+        return node.parent && isClassOrTypeElement(node.parent) && isObjectTypeDeclaration(node.parent.parent);
     }
 
     function hasIndexSignature(type: Type): boolean {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3243,6 +3243,7 @@ declare namespace ts {
     function isClassLike(node: Node): node is ClassLikeDeclaration;
     function isAccessor(node: Node): node is AccessorDeclaration;
     function isTypeElement(node: Node): node is TypeElement;
+    function isClassOrTypeElement(node: Node): node is ClassElement | TypeElement;
     function isObjectLiteralElementLike(node: Node): node is ObjectLiteralElementLike;
     /**
      * Node test that determines whether a node is a valid type node.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3298,6 +3298,7 @@ declare namespace ts {
     function isClassLike(node: Node): node is ClassLikeDeclaration;
     function isAccessor(node: Node): node is AccessorDeclaration;
     function isTypeElement(node: Node): node is TypeElement;
+    function isClassOrTypeElement(node: Node): node is ClassElement | TypeElement;
     function isObjectLiteralElementLike(node: Node): node is ObjectLiteralElementLike;
     /**
      * Node test that determines whether a node is a valid type node.

--- a/tests/baselines/reference/textChanges/insertNodeAfterInClass1.js
+++ b/tests/baselines/reference/textChanges/insertNodeAfterInClass1.js
@@ -7,6 +7,6 @@ class A {
 ===MODIFIED===
 
 class A {
-    x;
+    x
     a: boolean;
 }

--- a/tests/baselines/reference/textChanges/insertNodeInInterfaceAfterNodeWithoutSeparator2.js
+++ b/tests/baselines/reference/textChanges/insertNodeInInterfaceAfterNodeWithoutSeparator2.js
@@ -7,6 +7,6 @@ interface A {
 ===MODIFIED===
 
 interface A {
-    x();
+    x()
     [1]: any;
 }

--- a/tests/cases/fourslash/convertFunctionToEs6ClassNoSemicolon.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6ClassNoSemicolon.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+
+// @Filename: /a.js
+////var C = function() { this.x = 0; }
+////0;
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class C {
+    constructor() { this.x = 0; }
+}
+0;`,
+});


### PR DESCRIPTION
Fixes  #23235 
The bug was because we were trying to insert a semicolon after a node we were also deleting.
A better fix might be to use `replaceNode` instead of `deleteNode` and `insertNodeAfter`, but that seemed to break a few tests. (It also wouldn't work with a variable declaration in a VariableDeclarationList with multiple entries, but I don't think it's too important to support that use case.)