### PR TITLE
Removed duplicate ban-types declaration

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -93,7 +93,6 @@
         // TODO
         "arrow-parens": false, // [true, "ban-single-arg-parens"]
         "arrow-return-shorthand": false,
-        "ban-types": false,
         "forin": false,
         "member-access": false, // [true, "no-public"]
         "no-conditional-assignment": false,


### PR DESCRIPTION
Line 8 defines a list of banned types, while line 96 was setting `ban-types` to false.  After reviewing blame, I'm assuming #19586 is the intended setting, and am removing line 96.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
