### PR TITLE
Fix bug: Include comment for @param tag with nested tag

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6361,8 +6361,8 @@ namespace ts {
                             case "arg":
                             case "argument":
                             case "param":
-                                tag = parseParameterOrPropertyTag(atToken, tagName, PropertyLikeParse.Parameter);
-                                break;
+                                addTag(parseParameterOrPropertyTag(atToken, tagName, PropertyLikeParse.Parameter, indent));
+                                return;
                             case "return":
                             case "returns":
                                 tag = parseReturnTag(atToken, tagName);
@@ -6511,7 +6511,7 @@ namespace ts {
                     }
                 }
 
-                function parseParameterOrPropertyTag(atToken: AtToken, tagName: Identifier, target: PropertyLikeParse): JSDocParameterTag | JSDocPropertyTag {
+                function parseParameterOrPropertyTag(atToken: AtToken, tagName: Identifier, target: PropertyLikeParse, indent: number | undefined): JSDocParameterTag | JSDocPropertyTag {
                     let typeExpression = tryParseTypeExpression();
                     let isNameFirst = !typeExpression;
                     skipWhitespace();
@@ -6526,6 +6526,8 @@ namespace ts {
                     const result = target === PropertyLikeParse.Parameter ?
                         <JSDocParameterTag>createNode(SyntaxKind.JSDocParameterTag, atToken.pos) :
                         <JSDocPropertyTag>createNode(SyntaxKind.JSDocPropertyTag, atToken.pos);
+                    let comment: string | undefined;
+                    if (indent !== undefined) comment = parseTagComments(indent + scanner.getStartPos() - atToken.pos);
                     const nestedTypeLiteral = parseNestedTypeLiteral(typeExpression, name, target);
                     if (nestedTypeLiteral) {
                         typeExpression = nestedTypeLiteral;
@@ -6537,6 +6539,7 @@ namespace ts {
                     result.name = name;
                     result.isNameFirst = isNameFirst;
                     result.isBracketed = isBracketed;
+                    result.comment = comment;
                     return finishNode(result);
                 }
 
@@ -6783,7 +6786,7 @@ namespace ts {
                     if (target !== t) {
                         return false;
                     }
-                    const tag = parseParameterOrPropertyTag(atToken, tagName, target);
+                    const tag = parseParameterOrPropertyTag(atToken, tagName, target, /*indent*/ undefined);
                     tag.comment = parseTagComments(tag.end - tag.pos);
                     return tag;
                 }

--- a/src/harness/unittests/jsDocParsing.ts
+++ b/src/harness/unittests/jsDocParsing.ts
@@ -305,6 +305,12 @@ namespace ts {
  * @param x hi
 < > still part of the previous comment
  */`);
+
+                parsesCorrectly("Nested @param tags",
+`/**
+* @param {object} o Doc doc
+* @param {string} o.f
+*/`);
             });
         });
         describe("getFirstToken", () => {

--- a/src/harness/unittests/jsDocParsing.ts
+++ b/src/harness/unittests/jsDocParsing.ts
@@ -309,7 +309,7 @@ namespace ts {
                 parsesCorrectly("Nested @param tags",
 `/**
 * @param {object} o Doc doc
-* @param {string} o.f
+* @param {string} o.f Doc for f
 */`);
             });
         });

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
@@ -1,12 +1,12 @@
 {
     "kind": "JSDocComment",
     "pos": 0,
-    "end": 56,
+    "end": 66,
     "tags": {
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 6,
-            "end": 53,
+            "end": 63,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 6,
@@ -21,16 +21,16 @@
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 34,
-                "end": 53,
+                "end": 63,
                 "type": {
                     "kind": "JSDocTypeLiteral",
                     "pos": 34,
-                    "end": 53,
+                    "end": 63,
                     "jsDocPropertyTags": [
                         {
                             "kind": "JSDocParameterTag",
                             "pos": 34,
-                            "end": 53,
+                            "end": 54,
                             "atToken": {
                                 "kind": "AtToken",
                                 "pos": 34,
@@ -70,7 +70,8 @@
                                 }
                             },
                             "isNameFirst": false,
-                            "isBracketed": false
+                            "isBracketed": false,
+                            "comment": "Doc for f"
                         }
                     ]
                 }
@@ -87,6 +88,6 @@
         },
         "length": 1,
         "pos": 6,
-        "end": 53
+        "end": 63
     }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
@@ -1,0 +1,92 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 56,
+    "tags": {
+        "0": {
+            "kind": "JSDocParameterTag",
+            "pos": 6,
+            "end": 53,
+            "atToken": {
+                "kind": "AtToken",
+                "pos": 6,
+                "end": 7
+            },
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 7,
+                "end": 12,
+                "escapedText": "param"
+            },
+            "typeExpression": {
+                "kind": "JSDocTypeExpression",
+                "pos": 34,
+                "end": 53,
+                "type": {
+                    "kind": "JSDocTypeLiteral",
+                    "pos": 34,
+                    "end": 53,
+                    "jsDocPropertyTags": [
+                        {
+                            "kind": "JSDocParameterTag",
+                            "pos": 34,
+                            "end": 53,
+                            "atToken": {
+                                "kind": "AtToken",
+                                "pos": 34,
+                                "end": 35
+                            },
+                            "tagName": {
+                                "kind": "Identifier",
+                                "pos": 35,
+                                "end": 40,
+                                "escapedText": "param"
+                            },
+                            "typeExpression": {
+                                "kind": "JSDocTypeExpression",
+                                "pos": 41,
+                                "end": 49,
+                                "type": {
+                                    "kind": "StringKeyword",
+                                    "pos": 42,
+                                    "end": 48
+                                }
+                            },
+                            "name": {
+                                "kind": "FirstNode",
+                                "pos": 50,
+                                "end": 53,
+                                "left": {
+                                    "kind": "Identifier",
+                                    "pos": 50,
+                                    "end": 51,
+                                    "escapedText": "o"
+                                },
+                                "right": {
+                                    "kind": "Identifier",
+                                    "pos": 52,
+                                    "end": 53,
+                                    "escapedText": "f"
+                                }
+                            },
+                            "isNameFirst": false,
+                            "isBracketed": false
+                        }
+                    ]
+                }
+            },
+            "name": {
+                "kind": "Identifier",
+                "pos": 22,
+                "end": 23,
+                "escapedText": "o"
+            },
+            "isNameFirst": true,
+            "isBracketed": false,
+            "comment": "Doc doc"
+        },
+        "length": 1,
+        "pos": 6,
+        "end": 53
+    }
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
@@ -6,7 +6,7 @@
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 8,
-            "end": 28,
+            "end": 40,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 8,
@@ -40,6 +40,6 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 28
+        "end": 40
     }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
@@ -6,7 +6,7 @@
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 8,
-            "end": 33,
+            "end": 45,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 8,
@@ -40,6 +40,6 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 33
+        "end": 45
     }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
@@ -6,7 +6,7 @@
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 7,
-            "end": 16,
+            "end": 58,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 7,
@@ -30,6 +30,6 @@
         },
         "length": 1,
         "pos": 7,
-        "end": 16
+        "end": 58
     }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
@@ -6,7 +6,7 @@
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 8,
-            "end": 30,
+            "end": 55,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 8,
@@ -40,6 +40,6 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 30
+        "end": 55
     }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
@@ -6,7 +6,7 @@
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 8,
-            "end": 31,
+            "end": 57,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 8,
@@ -40,6 +40,6 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 31
+        "end": 57
     }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
@@ -6,7 +6,7 @@
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 8,
-            "end": 36,
+            "end": 62,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 8,
@@ -40,6 +40,6 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 36
+        "end": 62
     }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
@@ -6,7 +6,7 @@
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 8,
-            "end": 29,
+            "end": 42,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 8,
@@ -40,6 +40,6 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 29
+        "end": 42
     }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTag2.json
@@ -6,7 +6,7 @@
         "0": {
             "kind": "JSDocParameterTag",
             "pos": 8,
-            "end": 32,
+            "end": 34,
             "atToken": {
                 "kind": "AtToken",
                 "pos": 8,


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/23221#issuecomment-379812189

`parseChildParameterOrPropertyTag` contains code to skip ahead to the next line -- this means that the comment goes missing. We should probably *never* skip a comment, but that would be a bigger change than this.