### PR TITLE
fourslash: Don't parse lib if 'nolib' is set

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -328,8 +328,10 @@ namespace FourSlash {
                         this.languageServiceAdapterHost.addScript(fileName, file, /*isRootFile*/ true);
                     }
                 });
-                this.languageServiceAdapterHost.addScript(Harness.Compiler.defaultLibFileName,
-                    Harness.Compiler.getDefaultLibrarySourceFile().text, /*isRootFile*/ false);
+                if (!compilationOptions.noLib) {
+                    this.languageServiceAdapterHost.addScript(Harness.Compiler.defaultLibFileName,
+                        Harness.Compiler.getDefaultLibrarySourceFile().text, /*isRootFile*/ false);
+                }
             }
 
             for (const file of testData.files) {


### PR DESCRIPTION
Avoids parsing a file we won't need -- especially useful if you have breakpoints in `parser.ts` and want to be hitting them for your test and not for `lib.d.ts`.