### PR TITLE
Add relList to HTMLAnchorElement

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -4978,6 +4978,10 @@ interface HTMLAnchorElement extends HTMLElement, HTMLHyperlinkElementUtils {
      */
     rel: string;
     /**
+     * Returns a live DOMTokenList containing the set of link types indicating the relationship between the resource represented by the <a> element and the current document.
+     */
+    readonly relList: DOMTokenList;
+    /**
      * Sets or retrieves the relationship between the object and the destination of the link.
      */
     /** @deprecated */


### PR DESCRIPTION
Add `HTMLAnchorElement.relList` property.
https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/relList
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
