### PR TITLE
Clone signature return type nodes if they are present and yield the same type as the signature return type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2822,7 +2822,7 @@ namespace ts {
             return symbol;
         }
 
-        function isEntityNameVisible(entityName: EntityNameOrEntityNameExpression, enclosingDeclaration: Node, shouldComputeAliasToMakeVisible: boolean = true): SymbolVisibilityResult {
+        function isEntityNameVisible(entityName: EntityNameOrEntityNameExpression, enclosingDeclaration: Node, shouldComputeAliasToMakeVisible = true): SymbolVisibilityResult {
             const symbol = resolveNameFromEntityName(entityName, enclosingDeclaration);
             const firstIdentifier = getFirstIdentifier(entityName);
             // Verify if the symbol is accessible

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2240,9 +2240,7 @@ Actual: ${stringify(fullActual)}`);
 
         public verifyCurrentFileContent(text: string) {
             const actual = this.getFileContent(this.activeFile.fileName);
-            if (actual !== text) {
-                throw new Error(`verifyCurrentFileContent failed:\n${showTextDiff(text, actual)}`);
-            }
+            assert.equal(text, actual);
         }
 
         public verifyTextAtCaretIs(text: string) {

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures3.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures3.errors.txt
@@ -37,13 +37,13 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     Type 'T' is not assignable to type '{ foo: string; bar: string; }'.
       Type 'Base' is not assignable to type '{ foo: string; bar: string; }'.
         Property 'bar' is missing in type 'Base'.
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts(80,1): error TS2322: Type '(x: Base[], y: Derived2[]) => Derived[]' is not assignable to type '<T extends Base[]>(x: Base[], y: T) => Derived[]'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts(80,1): error TS2322: Type '(x: Base[], y: Derived2[]) => Array<Derived>' is not assignable to type '<T extends Base[]>(x: Base[], y: T) => Array<Derived>'.
   Types of parameters 'y' and 'y' are incompatible.
     Type 'T' is not assignable to type 'Derived2[]'.
       Type 'Base[]' is not assignable to type 'Derived2[]'.
         Type 'Base' is not assignable to type 'Derived2'.
           Property 'baz' is missing in type 'Base'.
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts(83,1): error TS2322: Type '(x: Base[], y: Derived[]) => Derived[]' is not assignable to type '<T extends Derived[]>(x: Base[], y: T) => T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts(83,1): error TS2322: Type '(x: Base[], y: Derived[]) => Array<Derived>' is not assignable to type '<T extends Derived[]>(x: Base[], y: T) => T'.
   Type 'Derived[]' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts(86,1): error TS2322: Type '(x: { a: string; b: number; }) => Object' is not assignable to type '<T>(x: { a: T; b: T; }) => T'.
   Types of parameters 'x' and 'x' are incompatible.
@@ -184,7 +184,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     a12 = b12; // ok
     b12 = a12; // ok
     ~~~
-!!! error TS2322: Type '(x: Base[], y: Derived2[]) => Derived[]' is not assignable to type '<T extends Base[]>(x: Base[], y: T) => Derived[]'.
+!!! error TS2322: Type '(x: Base[], y: Derived2[]) => Array<Derived>' is not assignable to type '<T extends Base[]>(x: Base[], y: T) => Array<Derived>'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived2[]'.
 !!! error TS2322:       Type 'Base[]' is not assignable to type 'Derived2[]'.
@@ -194,7 +194,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     a13 = b13; // ok
     b13 = a13; // ok
     ~~~
-!!! error TS2322: Type '(x: Base[], y: Derived[]) => Derived[]' is not assignable to type '<T extends Derived[]>(x: Base[], y: T) => T'.
+!!! error TS2322: Type '(x: Base[], y: Derived[]) => Array<Derived>' is not assignable to type '<T extends Derived[]>(x: Base[], y: T) => T'.
 !!! error TS2322:   Type 'Derived[]' is not assignable to type 'T'.
     var b14: <T>(x: { a: T; b: T }) => T; 
     a14 = b14; // ok

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures3.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures3.types
@@ -104,7 +104,7 @@ var a11: (x: { foo: string }, y: { foo: string; bar: string }) => Base;
 >Base : Base
 
 var a12: (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
->a12 : (x: Base[], y: Derived2[]) => Derived[]
+>a12 : (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -115,7 +115,7 @@ var a12: (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
 >Derived : Derived
 
 var a13: (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
->a13 : (x: Base[], y: Derived[]) => Derived[]
+>a13 : (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -427,7 +427,7 @@ b11 = a11; // ok
 >a11 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 
 var b12: <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; 
->b12 : <T extends Base[]>(x: Base[], y: T) => Derived[]
+>b12 : <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 >T : T
 >Array : T[]
 >Base : Base
@@ -440,14 +440,14 @@ var b12: <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>;
 >Derived : Derived
 
 a12 = b12; // ok
->a12 = b12 : <T extends Base[]>(x: Base[], y: T) => Derived[]
->a12 : (x: Base[], y: Derived2[]) => Derived[]
->b12 : <T extends Base[]>(x: Base[], y: T) => Derived[]
+>a12 = b12 : <T extends Base[]>(x: Base[], y: T) => Array<Derived>
+>a12 : (x: Base[], y: Derived2[]) => Array<Derived>
+>b12 : <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 
 b12 = a12; // ok
->b12 = a12 : (x: Base[], y: Derived2[]) => Derived[]
->b12 : <T extends Base[]>(x: Base[], y: T) => Derived[]
->a12 : (x: Base[], y: Derived2[]) => Derived[]
+>b12 = a12 : (x: Base[], y: Derived2[]) => Array<Derived>
+>b12 : <T extends Base[]>(x: Base[], y: T) => Array<Derived>
+>a12 : (x: Base[], y: Derived2[]) => Array<Derived>
 
 var b13: <T extends Array<Derived>>(x: Array<Base>, y: T) => T; 
 >b13 : <T extends Derived[]>(x: Base[], y: T) => T
@@ -463,13 +463,13 @@ var b13: <T extends Array<Derived>>(x: Array<Base>, y: T) => T;
 
 a13 = b13; // ok
 >a13 = b13 : <T extends Derived[]>(x: Base[], y: T) => T
->a13 : (x: Base[], y: Derived[]) => Derived[]
+>a13 : (x: Base[], y: Derived[]) => Array<Derived>
 >b13 : <T extends Derived[]>(x: Base[], y: T) => T
 
 b13 = a13; // ok
->b13 = a13 : (x: Base[], y: Derived[]) => Derived[]
+>b13 = a13 : (x: Base[], y: Derived[]) => Array<Derived>
 >b13 : <T extends Derived[]>(x: Base[], y: T) => T
->a13 : (x: Base[], y: Derived[]) => Derived[]
+>a13 : (x: Base[], y: Derived[]) => Array<Derived>
 
 var b14: <T>(x: { a: T; b: T }) => T; 
 >b14 : <T>(x: { a: T; b: T; }) => T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures3.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures3.errors.txt
@@ -37,13 +37,13 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     Type 'T' is not assignable to type '{ foo: string; bar: string; }'.
       Type 'Base' is not assignable to type '{ foo: string; bar: string; }'.
         Property 'bar' is missing in type 'Base'.
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts(80,1): error TS2322: Type 'new (x: Base[], y: Derived2[]) => Derived[]' is not assignable to type 'new <T extends Base[]>(x: Base[], y: T) => Derived[]'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts(80,1): error TS2322: Type 'new (x: Base[], y: Derived2[]) => Array<Derived>' is not assignable to type 'new <T extends Base[]>(x: Base[], y: T) => Array<Derived>'.
   Types of parameters 'y' and 'y' are incompatible.
     Type 'T' is not assignable to type 'Derived2[]'.
       Type 'Base[]' is not assignable to type 'Derived2[]'.
         Type 'Base' is not assignable to type 'Derived2'.
           Property 'baz' is missing in type 'Base'.
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts(83,1): error TS2322: Type 'new (x: Base[], y: Derived[]) => Derived[]' is not assignable to type 'new <T extends Derived[]>(x: Base[], y: T) => T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts(83,1): error TS2322: Type 'new (x: Base[], y: Derived[]) => Array<Derived>' is not assignable to type 'new <T extends Derived[]>(x: Base[], y: T) => T'.
   Type 'Derived[]' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts(86,1): error TS2322: Type 'new (x: { a: string; b: number; }) => Object' is not assignable to type 'new <T>(x: { a: T; b: T; }) => T'.
   Types of parameters 'x' and 'x' are incompatible.
@@ -184,7 +184,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     a12 = b12; // ok
     b12 = a12; // ok
     ~~~
-!!! error TS2322: Type 'new (x: Base[], y: Derived2[]) => Derived[]' is not assignable to type 'new <T extends Base[]>(x: Base[], y: T) => Derived[]'.
+!!! error TS2322: Type 'new (x: Base[], y: Derived2[]) => Array<Derived>' is not assignable to type 'new <T extends Base[]>(x: Base[], y: T) => Array<Derived>'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived2[]'.
 !!! error TS2322:       Type 'Base[]' is not assignable to type 'Derived2[]'.
@@ -194,7 +194,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     a13 = b13; // ok
     b13 = a13; // ok
     ~~~
-!!! error TS2322: Type 'new (x: Base[], y: Derived[]) => Derived[]' is not assignable to type 'new <T extends Derived[]>(x: Base[], y: T) => T'.
+!!! error TS2322: Type 'new (x: Base[], y: Derived[]) => Array<Derived>' is not assignable to type 'new <T extends Derived[]>(x: Base[], y: T) => T'.
 !!! error TS2322:   Type 'Derived[]' is not assignable to type 'T'.
     var b14: new <T>(x: { a: T; b: T }) => T; 
     a14 = b14; // ok

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures3.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures3.types
@@ -104,7 +104,7 @@ var a11: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
 >Base : Base
 
 var a12: new (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
->a12 : new (x: Base[], y: Derived2[]) => Derived[]
+>a12 : new (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -115,7 +115,7 @@ var a12: new (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
 >Derived : Derived
 
 var a13: new (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
->a13 : new (x: Base[], y: Derived[]) => Derived[]
+>a13 : new (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -427,7 +427,7 @@ b11 = a11; // ok
 >a11 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 
 var b12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; 
->b12 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
+>b12 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 >T : T
 >Array : T[]
 >Base : Base
@@ -440,14 +440,14 @@ var b12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>;
 >Derived : Derived
 
 a12 = b12; // ok
->a12 = b12 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
->a12 : new (x: Base[], y: Derived2[]) => Derived[]
->b12 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
+>a12 = b12 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
+>a12 : new (x: Base[], y: Derived2[]) => Array<Derived>
+>b12 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 
 b12 = a12; // ok
->b12 = a12 : new (x: Base[], y: Derived2[]) => Derived[]
->b12 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
->a12 : new (x: Base[], y: Derived2[]) => Derived[]
+>b12 = a12 : new (x: Base[], y: Derived2[]) => Array<Derived>
+>b12 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
+>a12 : new (x: Base[], y: Derived2[]) => Array<Derived>
 
 var b13: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T; 
 >b13 : new <T extends Derived[]>(x: Base[], y: T) => T
@@ -463,13 +463,13 @@ var b13: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T;
 
 a13 = b13; // ok
 >a13 = b13 : new <T extends Derived[]>(x: Base[], y: T) => T
->a13 : new (x: Base[], y: Derived[]) => Derived[]
+>a13 : new (x: Base[], y: Derived[]) => Array<Derived>
 >b13 : new <T extends Derived[]>(x: Base[], y: T) => T
 
 b13 = a13; // ok
->b13 = a13 : new (x: Base[], y: Derived[]) => Derived[]
+>b13 = a13 : new (x: Base[], y: Derived[]) => Array<Derived>
 >b13 : new <T extends Derived[]>(x: Base[], y: T) => T
->a13 : new (x: Base[], y: Derived[]) => Derived[]
+>a13 : new (x: Base[], y: Derived[]) => Array<Derived>
 
 var b14: new <T>(x: { a: T; b: T }) => T; 
 >b14 : new <T>(x: { a: T; b: T; }) => T

--- a/tests/baselines/reference/asyncAliasReturnType_es5.types
+++ b/tests/baselines/reference/asyncAliasReturnType_es5.types
@@ -6,6 +6,6 @@ type PromiseAlias<T> = Promise<T>;
 >T : T
 
 async function f(): PromiseAlias<void> {
->f : () => Promise<void>
+>f : () => PromiseAlias<void>
 >PromiseAlias : Promise<T>
 }

--- a/tests/baselines/reference/asyncAliasReturnType_es6.types
+++ b/tests/baselines/reference/asyncAliasReturnType_es6.types
@@ -6,6 +6,6 @@ type PromiseAlias<T> = Promise<T>;
 >T : T
 
 async function f(): PromiseAlias<void> {
->f : () => Promise<void>
+>f : () => PromiseAlias<void>
 >PromiseAlias : Promise<T>
 }

--- a/tests/baselines/reference/asyncAwaitIsolatedModules_es2017.types
+++ b/tests/baselines/reference/asyncAwaitIsolatedModules_es2017.types
@@ -18,7 +18,7 @@ async function f1(): Promise<void> { }
 >Promise : Promise<T>
 
 async function f3(): MyPromise<void> { }
->f3 : () => any
+>f3 : () => MyPromise<void>
 >MyPromise : any
 
 let f4 = async function() { }
@@ -31,8 +31,8 @@ let f5 = async function(): Promise<void> { }
 >Promise : Promise<T>
 
 let f6 = async function(): MyPromise<void> { }
->f6 : () => any
->async function(): MyPromise<void> { } : () => any
+>f6 : () => MyPromise<void>
+>async function(): MyPromise<void> { } : () => MyPromise<void>
 >MyPromise : any
 
 let f7 = async () => { };
@@ -45,8 +45,8 @@ let f8 = async (): Promise<void> => { };
 >Promise : Promise<T>
 
 let f9 = async (): MyPromise<void> => { }; 
->f9 : () => any
->async (): MyPromise<void> => { } : () => any
+>f9 : () => MyPromise<void>
+>async (): MyPromise<void> => { } : () => MyPromise<void>
 >MyPromise : any
 
 let f10 = async () => p;
@@ -66,14 +66,14 @@ let f12 = async (): Promise<number> => mp;
 >mp : any
 
 let f13 = async (): MyPromise<number> => p;
->f13 : () => any
->async (): MyPromise<number> => p : () => any
+>f13 : () => MyPromise<number>
+>async (): MyPromise<number> => p : () => MyPromise<number>
 >MyPromise : any
 >p : Promise<number>
 
 let o = {
->o : { m1(): Promise<void>; m2(): Promise<void>; m3(): any; }
->{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): any; }
+>o : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
+>{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
 
 	async m1() { },
 >m1 : () => Promise<void>
@@ -83,7 +83,7 @@ let o = {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => any
+>m3 : () => MyPromise<void>
 >MyPromise : any
 
 };
@@ -99,7 +99,7 @@ class C {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => any
+>m3 : () => MyPromise<void>
 >MyPromise : any
 
 	static async m4() { }
@@ -110,7 +110,7 @@ class C {
 >Promise : Promise<T>
 
 	static async m6(): MyPromise<void> { }
->m6 : () => any
+>m6 : () => MyPromise<void>
 >MyPromise : any
 }
 

--- a/tests/baselines/reference/asyncAwaitIsolatedModules_es5.types
+++ b/tests/baselines/reference/asyncAwaitIsolatedModules_es5.types
@@ -18,7 +18,7 @@ async function f1(): Promise<void> { }
 >Promise : Promise<T>
 
 async function f3(): MyPromise<void> { }
->f3 : () => any
+>f3 : () => MyPromise<void>
 >MyPromise : any
 
 let f4 = async function() { }
@@ -31,8 +31,8 @@ let f5 = async function(): Promise<void> { }
 >Promise : Promise<T>
 
 let f6 = async function(): MyPromise<void> { }
->f6 : () => any
->async function(): MyPromise<void> { } : () => any
+>f6 : () => MyPromise<void>
+>async function(): MyPromise<void> { } : () => MyPromise<void>
 >MyPromise : any
 
 let f7 = async () => { };
@@ -45,8 +45,8 @@ let f8 = async (): Promise<void> => { };
 >Promise : Promise<T>
 
 let f9 = async (): MyPromise<void> => { };
->f9 : () => any
->async (): MyPromise<void> => { } : () => any
+>f9 : () => MyPromise<void>
+>async (): MyPromise<void> => { } : () => MyPromise<void>
 >MyPromise : any
 
 let f10 = async () => p;
@@ -66,14 +66,14 @@ let f12 = async (): Promise<number> => mp;
 >mp : any
 
 let f13 = async (): MyPromise<number> => p;
->f13 : () => any
->async (): MyPromise<number> => p : () => any
+>f13 : () => MyPromise<number>
+>async (): MyPromise<number> => p : () => MyPromise<number>
 >MyPromise : any
 >p : Promise<number>
 
 let o = {
->o : { m1(): Promise<void>; m2(): Promise<void>; m3(): any; }
->{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): any; }
+>o : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
+>{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
 
 	async m1() { },
 >m1 : () => Promise<void>
@@ -83,7 +83,7 @@ let o = {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => any
+>m3 : () => MyPromise<void>
 >MyPromise : any
 
 };
@@ -99,7 +99,7 @@ class C {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => any
+>m3 : () => MyPromise<void>
 >MyPromise : any
 
 	static async m4() { }
@@ -110,7 +110,7 @@ class C {
 >Promise : Promise<T>
 
 	static async m6(): MyPromise<void> { }
->m6 : () => any
+>m6 : () => MyPromise<void>
 >MyPromise : any
 }
 

--- a/tests/baselines/reference/asyncAwaitIsolatedModules_es6.types
+++ b/tests/baselines/reference/asyncAwaitIsolatedModules_es6.types
@@ -18,7 +18,7 @@ async function f1(): Promise<void> { }
 >Promise : Promise<T>
 
 async function f3(): MyPromise<void> { }
->f3 : () => any
+>f3 : () => MyPromise<void>
 >MyPromise : any
 
 let f4 = async function() { }
@@ -31,8 +31,8 @@ let f5 = async function(): Promise<void> { }
 >Promise : Promise<T>
 
 let f6 = async function(): MyPromise<void> { }
->f6 : () => any
->async function(): MyPromise<void> { } : () => any
+>f6 : () => MyPromise<void>
+>async function(): MyPromise<void> { } : () => MyPromise<void>
 >MyPromise : any
 
 let f7 = async () => { };
@@ -45,8 +45,8 @@ let f8 = async (): Promise<void> => { };
 >Promise : Promise<T>
 
 let f9 = async (): MyPromise<void> => { }; 
->f9 : () => any
->async (): MyPromise<void> => { } : () => any
+>f9 : () => MyPromise<void>
+>async (): MyPromise<void> => { } : () => MyPromise<void>
 >MyPromise : any
 
 let f10 = async () => p;
@@ -66,14 +66,14 @@ let f12 = async (): Promise<number> => mp;
 >mp : any
 
 let f13 = async (): MyPromise<number> => p;
->f13 : () => any
->async (): MyPromise<number> => p : () => any
+>f13 : () => MyPromise<number>
+>async (): MyPromise<number> => p : () => MyPromise<number>
 >MyPromise : any
 >p : Promise<number>
 
 let o = {
->o : { m1(): Promise<void>; m2(): Promise<void>; m3(): any; }
->{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): any; }
+>o : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
+>{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
 
 	async m1() { },
 >m1 : () => Promise<void>
@@ -83,7 +83,7 @@ let o = {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => any
+>m3 : () => MyPromise<void>
 >MyPromise : any
 
 };
@@ -99,7 +99,7 @@ class C {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => any
+>m3 : () => MyPromise<void>
 >MyPromise : any
 
 	static async m4() { }
@@ -110,7 +110,7 @@ class C {
 >Promise : Promise<T>
 
 	static async m6(): MyPromise<void> { }
->m6 : () => any
+>m6 : () => MyPromise<void>
 >MyPromise : any
 }
 

--- a/tests/baselines/reference/asyncAwait_es2017.types
+++ b/tests/baselines/reference/asyncAwait_es2017.types
@@ -25,7 +25,7 @@ async function f1(): Promise<void> { }
 >Promise : Promise<T>
 
 async function f3(): MyPromise<void> { }
->f3 : () => Promise<void>
+>f3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f4 = async function() { }
@@ -38,8 +38,8 @@ let f5 = async function(): Promise<void> { }
 >Promise : Promise<T>
 
 let f6 = async function(): MyPromise<void> { }
->f6 : () => Promise<void>
->async function(): MyPromise<void> { } : () => Promise<void>
+>f6 : () => MyPromise<void>
+>async function(): MyPromise<void> { } : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f7 = async () => { };
@@ -52,8 +52,8 @@ let f8 = async (): Promise<void> => { };
 >Promise : Promise<T>
 
 let f9 = async (): MyPromise<void> => { };
->f9 : () => Promise<void>
->async (): MyPromise<void> => { } : () => Promise<void>
+>f9 : () => MyPromise<void>
+>async (): MyPromise<void> => { } : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f10 = async () => p;
@@ -73,14 +73,14 @@ let f12 = async (): Promise<number> => mp;
 >mp : Promise<number>
 
 let f13 = async (): MyPromise<number> => p;
->f13 : () => Promise<number>
->async (): MyPromise<number> => p : () => Promise<number>
+>f13 : () => MyPromise<number>
+>async (): MyPromise<number> => p : () => MyPromise<number>
 >MyPromise : Promise<T>
 >p : Promise<number>
 
 let o = {
->o : { m1(): Promise<void>; m2(): Promise<void>; m3(): Promise<void>; }
->{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): Promise<void>; }
+>o : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
+>{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
 
 	async m1() { },
 >m1 : () => Promise<void>
@@ -90,7 +90,7 @@ let o = {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => Promise<void>
+>m3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 };
@@ -106,7 +106,7 @@ class C {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => Promise<void>
+>m3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 	static async m4() { }
@@ -117,7 +117,7 @@ class C {
 >Promise : Promise<T>
 
 	static async m6(): MyPromise<void> { }
->m6 : () => Promise<void>
+>m6 : () => MyPromise<void>
 >MyPromise : Promise<T>
 }
 

--- a/tests/baselines/reference/asyncAwait_es5.types
+++ b/tests/baselines/reference/asyncAwait_es5.types
@@ -25,7 +25,7 @@ async function f1(): Promise<void> { }
 >Promise : Promise<T>
 
 async function f3(): MyPromise<void> { }
->f3 : () => Promise<void>
+>f3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f4 = async function() { }
@@ -38,8 +38,8 @@ let f5 = async function(): Promise<void> { }
 >Promise : Promise<T>
 
 let f6 = async function(): MyPromise<void> { }
->f6 : () => Promise<void>
->async function(): MyPromise<void> { } : () => Promise<void>
+>f6 : () => MyPromise<void>
+>async function(): MyPromise<void> { } : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f7 = async () => { };
@@ -52,8 +52,8 @@ let f8 = async (): Promise<void> => { };
 >Promise : Promise<T>
 
 let f9 = async (): MyPromise<void> => { };
->f9 : () => Promise<void>
->async (): MyPromise<void> => { } : () => Promise<void>
+>f9 : () => MyPromise<void>
+>async (): MyPromise<void> => { } : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f10 = async () => p;
@@ -73,14 +73,14 @@ let f12 = async (): Promise<number> => mp;
 >mp : Promise<number>
 
 let f13 = async (): MyPromise<number> => p;
->f13 : () => Promise<number>
->async (): MyPromise<number> => p : () => Promise<number>
+>f13 : () => MyPromise<number>
+>async (): MyPromise<number> => p : () => MyPromise<number>
 >MyPromise : Promise<T>
 >p : Promise<number>
 
 let o = {
->o : { m1(): Promise<void>; m2(): Promise<void>; m3(): Promise<void>; }
->{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): Promise<void>; }
+>o : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
+>{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
 
 	async m1() { },
 >m1 : () => Promise<void>
@@ -90,7 +90,7 @@ let o = {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => Promise<void>
+>m3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 };
@@ -106,7 +106,7 @@ class C {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => Promise<void>
+>m3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 	static async m4() { }
@@ -117,7 +117,7 @@ class C {
 >Promise : Promise<T>
 
 	static async m6(): MyPromise<void> { }
->m6 : () => Promise<void>
+>m6 : () => MyPromise<void>
 >MyPromise : Promise<T>
 }
 

--- a/tests/baselines/reference/asyncAwait_es6.types
+++ b/tests/baselines/reference/asyncAwait_es6.types
@@ -25,7 +25,7 @@ async function f1(): Promise<void> { }
 >Promise : Promise<T>
 
 async function f3(): MyPromise<void> { }
->f3 : () => Promise<void>
+>f3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f4 = async function() { }
@@ -38,8 +38,8 @@ let f5 = async function(): Promise<void> { }
 >Promise : Promise<T>
 
 let f6 = async function(): MyPromise<void> { }
->f6 : () => Promise<void>
->async function(): MyPromise<void> { } : () => Promise<void>
+>f6 : () => MyPromise<void>
+>async function(): MyPromise<void> { } : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f7 = async () => { };
@@ -52,8 +52,8 @@ let f8 = async (): Promise<void> => { };
 >Promise : Promise<T>
 
 let f9 = async (): MyPromise<void> => { };
->f9 : () => Promise<void>
->async (): MyPromise<void> => { } : () => Promise<void>
+>f9 : () => MyPromise<void>
+>async (): MyPromise<void> => { } : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 let f10 = async () => p;
@@ -73,14 +73,14 @@ let f12 = async (): Promise<number> => mp;
 >mp : Promise<number>
 
 let f13 = async (): MyPromise<number> => p;
->f13 : () => Promise<number>
->async (): MyPromise<number> => p : () => Promise<number>
+>f13 : () => MyPromise<number>
+>async (): MyPromise<number> => p : () => MyPromise<number>
 >MyPromise : Promise<T>
 >p : Promise<number>
 
 let o = {
->o : { m1(): Promise<void>; m2(): Promise<void>; m3(): Promise<void>; }
->{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): Promise<void>; }
+>o : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
+>{	async m1() { },	async m2(): Promise<void> { },	async m3(): MyPromise<void> { }} : { m1(): Promise<void>; m2(): Promise<void>; m3(): MyPromise<void>; }
 
 	async m1() { },
 >m1 : () => Promise<void>
@@ -90,7 +90,7 @@ let o = {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => Promise<void>
+>m3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 };
@@ -106,7 +106,7 @@ class C {
 >Promise : Promise<T>
 
 	async m3(): MyPromise<void> { }
->m3 : () => Promise<void>
+>m3 : () => MyPromise<void>
 >MyPromise : Promise<T>
 
 	static async m4() { }
@@ -117,7 +117,7 @@ class C {
 >Promise : Promise<T>
 
 	static async m6(): MyPromise<void> { }
->m6 : () => Promise<void>
+>m6 : () => MyPromise<void>
 >MyPromise : Promise<T>
 }
 

--- a/tests/baselines/reference/asyncFunctionReturnType.types
+++ b/tests/baselines/reference/asyncFunctionReturnType.types
@@ -32,7 +32,7 @@ interface Obj {
 }
 
 async function fIndexedTypeForStringProp(obj: Obj): Promise<Obj["stringProp"]> {
->fIndexedTypeForStringProp : (obj: Obj) => Promise<string>
+>fIndexedTypeForStringProp : (obj: Obj) => Promise<Obj["stringProp"]>
 >obj : Obj
 >Obj : Obj
 >Promise : Promise<T>
@@ -45,7 +45,7 @@ async function fIndexedTypeForStringProp(obj: Obj): Promise<Obj["stringProp"]> {
 }
 
 async function fIndexedTypeForPromiseOfStringProp(obj: Obj): Promise<Obj["stringProp"]> {
->fIndexedTypeForPromiseOfStringProp : (obj: Obj) => Promise<string>
+>fIndexedTypeForPromiseOfStringProp : (obj: Obj) => Promise<Obj["stringProp"]>
 >obj : Obj
 >Obj : Obj
 >Promise : Promise<T>
@@ -62,7 +62,7 @@ async function fIndexedTypeForPromiseOfStringProp(obj: Obj): Promise<Obj["string
 }
 
 async function fIndexedTypeForExplicitPromiseOfStringProp(obj: Obj): Promise<Obj["stringProp"]> {
->fIndexedTypeForExplicitPromiseOfStringProp : (obj: Obj) => Promise<string>
+>fIndexedTypeForExplicitPromiseOfStringProp : (obj: Obj) => Promise<Obj["stringProp"]>
 >obj : Obj
 >Obj : Obj
 >Promise : Promise<T>
@@ -80,7 +80,7 @@ async function fIndexedTypeForExplicitPromiseOfStringProp(obj: Obj): Promise<Obj
 }
 
 async function fIndexedTypeForAnyProp(obj: Obj): Promise<Obj["anyProp"]> {
->fIndexedTypeForAnyProp : (obj: Obj) => Promise<any>
+>fIndexedTypeForAnyProp : (obj: Obj) => Promise<Obj["anyProp"]>
 >obj : Obj
 >Obj : Obj
 >Promise : Promise<T>
@@ -93,7 +93,7 @@ async function fIndexedTypeForAnyProp(obj: Obj): Promise<Obj["anyProp"]> {
 }
 
 async function fIndexedTypeForPromiseOfAnyProp(obj: Obj): Promise<Obj["anyProp"]> {
->fIndexedTypeForPromiseOfAnyProp : (obj: Obj) => Promise<any>
+>fIndexedTypeForPromiseOfAnyProp : (obj: Obj) => Promise<Obj["anyProp"]>
 >obj : Obj
 >Obj : Obj
 >Promise : Promise<T>
@@ -110,7 +110,7 @@ async function fIndexedTypeForPromiseOfAnyProp(obj: Obj): Promise<Obj["anyProp"]
 }
 
 async function fIndexedTypeForExplicitPromiseOfAnyProp(obj: Obj): Promise<Obj["anyProp"]> {
->fIndexedTypeForExplicitPromiseOfAnyProp : (obj: Obj) => Promise<any>
+>fIndexedTypeForExplicitPromiseOfAnyProp : (obj: Obj) => Promise<Obj["anyProp"]>
 >obj : Obj
 >Obj : Obj
 >Promise : Promise<T>

--- a/tests/baselines/reference/awaitUnionPromise.types
+++ b/tests/baselines/reference/awaitUnionPromise.types
@@ -10,7 +10,7 @@ interface IAsyncEnumerator<T> {
 >T : T
 
     next1(): Promise<T | AsyncEnumeratorDone>;
->next1 : () => Promise<AsyncEnumeratorDone | T>
+>next1 : () => Promise<T | AsyncEnumeratorDone>
 >Promise : Promise<T>
 >T : T
 >AsyncEnumeratorDone : AsyncEnumeratorDone
@@ -23,7 +23,7 @@ interface IAsyncEnumerator<T> {
 >AsyncEnumeratorDone : AsyncEnumeratorDone
 
     next3(): Promise<T | {}>;
->next3 : () => Promise<{} | T>
+>next3 : () => Promise<T | {}>
 >Promise : Promise<T>
 >T : T
 

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance2.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance2.types
@@ -108,7 +108,7 @@ interface A { // T
 >Base : Base
 
     a12: (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
->a12 : (x: Base[], y: Derived2[]) => Derived[]
+>a12 : (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -119,7 +119,7 @@ interface A { // T
 >Derived : Derived
 
     a13: (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
->a13 : (x: Base[], y: Derived[]) => Derived[]
+>a13 : (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -330,7 +330,7 @@ interface I extends A {
 >T : T
 
     a12: <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
->a12 : <T extends Base[]>(x: Base[], y: T) => Derived[]
+>a12 : <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 >T : T
 >Array : T[]
 >Base : Base

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance5.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance5.types
@@ -109,7 +109,7 @@ interface A { // T
 >Base : Base
 
     a12: (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
->a12 : (x: Base[], y: Derived2[]) => Derived[]
+>a12 : (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -120,7 +120,7 @@ interface A { // T
 >Derived : Derived
 
     a13: (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
->a13 : (x: Base[], y: Derived[]) => Derived[]
+>a13 : (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -278,7 +278,7 @@ interface I extends B {
 >T : T
 
     a12: <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
->a12 : <T extends Base[]>(x: Base[], y: T) => Derived[]
+>a12 : <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 >T : T
 >Array : T[]
 >Base : Base

--- a/tests/baselines/reference/circularTypeofWithVarOrFunc.types
+++ b/tests/baselines/reference/circularTypeofWithVarOrFunc.types
@@ -16,14 +16,14 @@ type typeAlias2 = typeof varOfAliasedType2;
 >varOfAliasedType2 : any
 
 function func(): typeAlias3 { return null; }
->func : () => any
+>func : () => typeAlias3
 >typeAlias3 : any
 >null : null
 
 var varOfAliasedType3 = func();
 >varOfAliasedType3 : any
 >func() : any
->func : () => any
+>func : () => typeAlias3
 
 type typeAlias3 = typeof varOfAliasedType3;
 >typeAlias3 : any

--- a/tests/baselines/reference/classExtendsInterfaceInExpression.types
+++ b/tests/baselines/reference/classExtendsInterfaceInExpression.types
@@ -3,7 +3,7 @@ interface A {}
 >A : A
 
 function factory(a: any): {new(): Object} {
->factory : (a: any) => new () => Object
+>factory : (a: any) => {    new (): Object;}
 >a : any
 >Object : Object
 
@@ -14,6 +14,6 @@ function factory(a: any): {new(): Object} {
 class C extends factory(A) {}
 >C : C
 >factory(A) : Object
->factory : (a: any) => new () => Object
+>factory : (a: any) => {    new (): Object;}
 >A : any
 

--- a/tests/baselines/reference/commentOnAmbientfunction.types
+++ b/tests/baselines/reference/commentOnAmbientfunction.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/b.ts ===
 ///<reference path="a.ts"/>
 declare function foobar(a: typeof foo): typeof bar;
->foobar : (a: () => any) => () => any
+>foobar : (a: () => any) => typeof bar
 >a : () => any
 >foo : () => any
 >bar : () => any

--- a/tests/baselines/reference/complexRecursiveCollections.types
+++ b/tests/baselines/reference/complexRecursiveCollections.types
@@ -814,7 +814,7 @@ declare module Immutable {
 >VC : VC
 
     concat<C>(...collections: Array<{[key: string]: C}>): Map<K | string, V | C>;
->concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Map<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Map<string | K, V | C>; }
+>concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Map<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Map<K | string, V | C>; }
 >C : C
 >collections : { [key: string]: C; }[]
 >Array : T[]
@@ -991,7 +991,7 @@ declare module Immutable {
 >VC : VC
 
     concat<C>(...collections: Array<{[key: string]: C}>): OrderedMap<K | string, V | C>;
->concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): OrderedMap<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): OrderedMap<string | K, V | C>; }
+>concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): OrderedMap<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): OrderedMap<K | string, V | C>; }
 >C : C
 >collections : { [key: string]: C; }[]
 >Array : T[]
@@ -1526,7 +1526,7 @@ declare module Immutable {
 
     // Reading values
     peek(): T | undefined;
->peek : () => T
+>peek : () => T | undefined
 >T : T
 
     // Persistent changes
@@ -1941,7 +1941,7 @@ declare module Immutable {
 >Keyed : Keyed<K, V>
 
     function of<T>(...values: Array<T>): Seq.Indexed<T>;
->of : <T>(...values: T[]) => Indexed<T>
+>of : <T>(...values: T[]) => Seq.Indexed<T>
 >T : T
 >values : T[]
 >Array : T[]
@@ -1951,10 +1951,10 @@ declare module Immutable {
 >T : T
 
     export module Keyed {}
->Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Keyed<any, any>; }
+>Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Seq.Keyed<any, any>; }
 
     export function Keyed<K, V>(collection: Iterable<[K, V]>): Seq.Keyed<K, V>;
->Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Keyed<any, any>; }
+>Keyed : { <K, V>(collection: Iterable<[K, V]>): Seq.Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Seq.Keyed<any, any>; }
 >K : K
 >V : V
 >collection : Iterable<[K, V]>
@@ -1967,7 +1967,7 @@ declare module Immutable {
 >V : V
 
     export function Keyed<V>(obj: {[key: string]: V}): Seq.Keyed<string, V>;
->Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Keyed<any, any>; }
+>Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Seq.Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Seq.Keyed<any, any>; }
 >V : V
 >obj : { [key: string]: V; }
 >key : string
@@ -1977,7 +1977,7 @@ declare module Immutable {
 >V : V
 
     export function Keyed<K, V>(): Seq.Keyed<K, V>;
->Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Keyed<any, any>; }
+>Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Seq.Keyed<K, V>; (): Seq.Keyed<any, any>; }
 >K : K
 >V : V
 >Seq : any
@@ -1986,7 +1986,7 @@ declare module Immutable {
 >V : V
 
     export function Keyed(): Seq.Keyed<any, any>;
->Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Keyed<any, any>; }
+>Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; <K, V>(): Keyed<K, V>; (): Seq.Keyed<any, any>; }
 >Seq : any
 >Keyed : Keyed<K, V>
 
@@ -2016,7 +2016,7 @@ declare module Immutable {
 >toSeq : () => this
 
       concat<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): Seq.Keyed<K | KC, V | VC>;
->concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Keyed<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Keyed<string | K, V | C>; }
+>concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Seq.Keyed<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Keyed<string | K, V | C>; }
 >KC : KC
 >VC : VC
 >collections : Iterable<[KC, VC]>[]
@@ -2032,7 +2032,7 @@ declare module Immutable {
 >VC : VC
 
       concat<C>(...collections: Array<{[key: string]: C}>): Seq.Keyed<K | string, V | C>;
->concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Keyed<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Keyed<string | K, V | C>; }
+>concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Keyed<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Seq.Keyed<K | string, V | C>; }
 >C : C
 >collections : { [key: string]: C; }[]
 >Array : T[]
@@ -2045,7 +2045,7 @@ declare module Immutable {
 >C : C
 
       map<M>(mapper: (value: V, key: K, iter: this) => M, context?: any): Seq.Keyed<K, M>;
->map : <M>(mapper: (value: V, key: K, iter: this) => M, context?: any) => Keyed<K, M>
+>map : <M>(mapper: (value: V, key: K, iter: this) => M, context?: any) => Seq.Keyed<K, M>
 >M : M
 >mapper : (value: V, key: K, iter: this) => M
 >value : V
@@ -2061,7 +2061,7 @@ declare module Immutable {
 >M : M
 
       mapKeys<M>(mapper: (key: K, value: V, iter: this) => M, context?: any): Seq.Keyed<M, V>;
->mapKeys : <M>(mapper: (key: K, value: V, iter: this) => M, context?: any) => Keyed<M, V>
+>mapKeys : <M>(mapper: (key: K, value: V, iter: this) => M, context?: any) => Seq.Keyed<M, V>
 >M : M
 >mapper : (key: K, value: V, iter: this) => M
 >key : K
@@ -2077,7 +2077,7 @@ declare module Immutable {
 >V : V
 
       mapEntries<KM, VM>(mapper: (entry: [K, V], index: number, iter: this) => [KM, VM], context?: any): Seq.Keyed<KM, VM>;
->mapEntries : <KM, VM>(mapper: (entry: [K, V], index: number, iter: this) => [KM, VM], context?: any) => Keyed<KM, VM>
+>mapEntries : <KM, VM>(mapper: (entry: [K, V], index: number, iter: this) => [KM, VM], context?: any) => Seq.Keyed<KM, VM>
 >KM : KM
 >VM : VM
 >mapper : (entry: [K, V], index: number, iter: this) => [KM, VM]
@@ -2095,7 +2095,7 @@ declare module Immutable {
 >VM : VM
 
       flatMap<M>(mapper: (value: V, key: K, iter: this) => Iterable<M>, context?: any): Seq.Keyed<any, any>;
->flatMap : <M>(mapper: (value: V, key: K, iter: this) => Iterable<M>, context?: any) => Keyed<any, any>
+>flatMap : <M>(mapper: (value: V, key: K, iter: this) => Iterable<M>, context?: any) => Seq.Keyed<any, any>
 >M : M
 >mapper : (value: V, key: K, iter: this) => Iterable<M>
 >value : V
@@ -2110,7 +2110,7 @@ declare module Immutable {
 >Keyed : Keyed<K, V>
 
       filter<F extends V>(predicate: (value: V, key: K, iter: this) => value is F, context?: any): Seq.Keyed<K, F>;
->filter : { <F extends V>(predicate: (value: V, key: K, iter: this) => value is F, context?: any): Keyed<K, F>; (predicate: (value: V, key: K, iter: this) => any, context?: any): this; }
+>filter : { <F extends V>(predicate: (value: V, key: K, iter: this) => value is F, context?: any): Seq.Keyed<K, F>; (predicate: (value: V, key: K, iter: this) => any, context?: any): this; }
 >F : F
 >V : V
 >predicate : (value: V, key: K, iter: this) => value is F
@@ -2141,7 +2141,7 @@ declare module Immutable {
 >Indexed : typeof Indexed
 
       function of<T>(...values: Array<T>): Seq.Indexed<T>;
->of : <T>(...values: T[]) => Indexed<T>
+>of : <T>(...values: T[]) => Seq.Indexed<T>
 >T : T
 >values : T[]
 >Array : T[]
@@ -2183,11 +2183,11 @@ declare module Immutable {
 >T : T
 
       toJS(): Array<any>;
->toJS : () => any[]
+>toJS : () => Array<any>
 >Array : T[]
 
       toJSON(): Array<T>;
->toJSON : () => T[]
+>toJSON : () => Array<T>
 >Array : T[]
 >T : T
 
@@ -2195,7 +2195,7 @@ declare module Immutable {
 >toSeq : () => this
 
       concat<C>(...valuesOrCollections: Array<Iterable<C> | C>): Seq.Indexed<T | C>;
->concat : <C>(...valuesOrCollections: (C | Iterable<C>)[]) => Indexed<T | C>
+>concat : <C>(...valuesOrCollections: (C | Iterable<C>)[]) => Seq.Indexed<T | C>
 >C : C
 >valuesOrCollections : (C | Iterable<C>)[]
 >Array : T[]
@@ -2208,7 +2208,7 @@ declare module Immutable {
 >C : C
 
       map<M>(mapper: (value: T, key: number, iter: this) => M, context?: any): Seq.Indexed<M>;
->map : <M>(mapper: (value: T, key: number, iter: this) => M, context?: any) => Indexed<M>
+>map : <M>(mapper: (value: T, key: number, iter: this) => M, context?: any) => Seq.Indexed<M>
 >M : M
 >mapper : (value: T, key: number, iter: this) => M
 >value : T
@@ -2222,7 +2222,7 @@ declare module Immutable {
 >M : M
 
       flatMap<M>(mapper: (value: T, key: number, iter: this) => Iterable<M>, context?: any): Seq.Indexed<M>;
->flatMap : <M>(mapper: (value: T, key: number, iter: this) => Iterable<M>, context?: any) => Indexed<M>
+>flatMap : <M>(mapper: (value: T, key: number, iter: this) => Iterable<M>, context?: any) => Seq.Indexed<M>
 >M : M
 >mapper : (value: T, key: number, iter: this) => Iterable<M>
 >value : T
@@ -2237,7 +2237,7 @@ declare module Immutable {
 >M : M
 
       filter<F extends T>(predicate: (value: T, index: number, iter: this) => value is F, context?: any): Seq.Indexed<F>;
->filter : { <F extends T>(predicate: (value: T, index: number, iter: this) => value is F, context?: any): Indexed<F>; (predicate: (value: T, index: number, iter: this) => any, context?: any): this; }
+>filter : { <F extends T>(predicate: (value: T, index: number, iter: this) => value is F, context?: any): Seq.Indexed<F>; (predicate: (value: T, index: number, iter: this) => any, context?: any): this; }
 >F : F
 >T : T
 >predicate : (value: T, index: number, iter: this) => value is F
@@ -2265,7 +2265,7 @@ declare module Immutable {
 >Set : typeof Set
 
       function of<T>(...values: Array<T>): Seq.Set<T>;
->of : <T>(...values: T[]) => Set<T>
+>of : <T>(...values: T[]) => Seq.Set<T>
 >T : T
 >values : T[]
 >Array : T[]
@@ -2307,11 +2307,11 @@ declare module Immutable {
 >T : T
 
       toJS(): Array<any>;
->toJS : () => any[]
+>toJS : () => Array<any>
 >Array : T[]
 
       toJSON(): Array<T>;
->toJSON : () => T[]
+>toJSON : () => Array<T>
 >Array : T[]
 >T : T
 
@@ -2319,7 +2319,7 @@ declare module Immutable {
 >toSeq : () => this
 
       concat<C>(...valuesOrCollections: Array<Iterable<C> | C>): Seq.Set<T | C>;
->concat : <C>(...valuesOrCollections: (C | Iterable<C>)[]) => Set<T | C>
+>concat : <C>(...valuesOrCollections: (C | Iterable<C>)[]) => Seq.Set<T | C>
 >C : C
 >valuesOrCollections : (C | Iterable<C>)[]
 >Array : T[]
@@ -2332,7 +2332,7 @@ declare module Immutable {
 >C : C
 
       map<M>(mapper: (value: T, key: never, iter: this) => M, context?: any): Seq.Set<M>;
->map : <M>(mapper: (value: T, key: never, iter: this) => M, context?: any) => Set<M>
+>map : <M>(mapper: (value: T, key: never, iter: this) => M, context?: any) => Seq.Set<M>
 >M : M
 >mapper : (value: T, key: never, iter: this) => M
 >value : T
@@ -2346,7 +2346,7 @@ declare module Immutable {
 >M : M
 
       flatMap<M>(mapper: (value: T, key: never, iter: this) => Iterable<M>, context?: any): Seq.Set<M>;
->flatMap : <M>(mapper: (value: T, key: never, iter: this) => Iterable<M>, context?: any) => Set<M>
+>flatMap : <M>(mapper: (value: T, key: never, iter: this) => Iterable<M>, context?: any) => Seq.Set<M>
 >M : M
 >mapper : (value: T, key: never, iter: this) => Iterable<M>
 >value : T
@@ -2361,7 +2361,7 @@ declare module Immutable {
 >M : M
 
       filter<F extends T>(predicate: (value: T, key: never, iter: this) => value is F, context?: any): Seq.Set<F>;
->filter : { <F extends T>(predicate: (value: T, key: never, iter: this) => value is F, context?: any): Set<F>; (predicate: (value: T, key: never, iter: this) => any, context?: any): this; }
+>filter : { <F extends T>(predicate: (value: T, key: never, iter: this) => value is F, context?: any): Seq.Set<F>; (predicate: (value: T, key: never, iter: this) => any, context?: any): this; }
 >F : F
 >T : T
 >predicate : (value: T, key: never, iter: this) => value is F
@@ -2562,7 +2562,7 @@ declare module Immutable {
 >Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; }
 
     export function Keyed<K, V>(collection: Iterable<[K, V]>): Collection.Keyed<K, V>;
->Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; }
+>Keyed : { <K, V>(collection: Iterable<[K, V]>): Collection.Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; }
 >K : K
 >V : V
 >collection : Iterable<[K, V]>
@@ -2575,7 +2575,7 @@ declare module Immutable {
 >V : V
 
     export function Keyed<V>(obj: {[key: string]: V}): Collection.Keyed<string, V>;
->Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V>; }
+>Keyed : { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Collection.Keyed<string, V>; }
 >V : V
 >obj : { [key: string]: V; }
 >key : string
@@ -2613,7 +2613,7 @@ declare module Immutable {
 >flip : () => this
 
       concat<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): Collection.Keyed<K | KC, V | VC>;
->concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Keyed<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Keyed<string | K, V | C>; }
+>concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Collection.Keyed<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Keyed<string | K, V | C>; }
 >KC : KC
 >VC : VC
 >collections : Iterable<[KC, VC]>[]
@@ -2629,7 +2629,7 @@ declare module Immutable {
 >VC : VC
 
       concat<C>(...collections: Array<{[key: string]: C}>): Collection.Keyed<K | string, V | C>;
->concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Keyed<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Keyed<string | K, V | C>; }
+>concat : { <KC, VC>(...collections: Iterable<[KC, VC]>[]): Keyed<K | KC, V | VC>; <C>(...collections: { [key: string]: C; }[]): Collection.Keyed<K | string, V | C>; }
 >C : C
 >collections : { [key: string]: C; }[]
 >Array : T[]
@@ -2642,7 +2642,7 @@ declare module Immutable {
 >C : C
 
       map<M>(mapper: (value: V, key: K, iter: this) => M, context?: any): Collection.Keyed<K, M>;
->map : <M>(mapper: (value: V, key: K, iter: this) => M, context?: any) => Keyed<K, M>
+>map : <M>(mapper: (value: V, key: K, iter: this) => M, context?: any) => Collection.Keyed<K, M>
 >M : M
 >mapper : (value: V, key: K, iter: this) => M
 >value : V
@@ -2658,7 +2658,7 @@ declare module Immutable {
 >M : M
 
       mapKeys<M>(mapper: (key: K, value: V, iter: this) => M, context?: any): Collection.Keyed<M, V>;
->mapKeys : <M>(mapper: (key: K, value: V, iter: this) => M, context?: any) => Keyed<M, V>
+>mapKeys : <M>(mapper: (key: K, value: V, iter: this) => M, context?: any) => Collection.Keyed<M, V>
 >M : M
 >mapper : (key: K, value: V, iter: this) => M
 >key : K
@@ -2674,7 +2674,7 @@ declare module Immutable {
 >V : V
 
       mapEntries<KM, VM>(mapper: (entry: [K, V], index: number, iter: this) => [KM, VM], context?: any): Collection.Keyed<KM, VM>;
->mapEntries : <KM, VM>(mapper: (entry: [K, V], index: number, iter: this) => [KM, VM], context?: any) => Keyed<KM, VM>
+>mapEntries : <KM, VM>(mapper: (entry: [K, V], index: number, iter: this) => [KM, VM], context?: any) => Collection.Keyed<KM, VM>
 >KM : KM
 >VM : VM
 >mapper : (entry: [K, V], index: number, iter: this) => [KM, VM]
@@ -2692,7 +2692,7 @@ declare module Immutable {
 >VM : VM
 
       flatMap<M>(mapper: (value: V, key: K, iter: this) => Iterable<M>, context?: any): Collection.Keyed<any, any>;
->flatMap : <M>(mapper: (value: V, key: K, iter: this) => Iterable<M>, context?: any) => Keyed<any, any>
+>flatMap : <M>(mapper: (value: V, key: K, iter: this) => Iterable<M>, context?: any) => Collection.Keyed<any, any>
 >M : M
 >mapper : (value: V, key: K, iter: this) => Iterable<M>
 >value : V
@@ -2707,7 +2707,7 @@ declare module Immutable {
 >Keyed : Keyed<K, V>
 
       filter<F extends V>(predicate: (value: V, key: K, iter: this) => value is F, context?: any): Collection.Keyed<K, F>;
->filter : { <F extends V>(predicate: (value: V, key: K, iter: this) => value is F, context?: any): Keyed<K, F>; (predicate: (value: V, key: K, iter: this) => any, context?: any): this; }
+>filter : { <F extends V>(predicate: (value: V, key: K, iter: this) => value is F, context?: any): Collection.Keyed<K, F>; (predicate: (value: V, key: K, iter: this) => any, context?: any): this; }
 >F : F
 >V : V
 >predicate : (value: V, key: K, iter: this) => value is F
@@ -2747,7 +2747,7 @@ declare module Immutable {
 >Indexed : <T>(collection: Iterable<T>) => Indexed<T>
 
     export function Indexed<T>(collection: Iterable<T>): Collection.Indexed<T>;
->Indexed : <T>(collection: Iterable<T>) => Indexed<T>
+>Indexed : <T>(collection: Iterable<T>) => Collection.Indexed<T>
 >T : T
 >collection : Iterable<T>
 >Iterable : Iterable<T>
@@ -2763,17 +2763,17 @@ declare module Immutable {
 >T : T
 
       toJS(): Array<any>;
->toJS : () => any[]
+>toJS : () => Array<any>
 >Array : T[]
 
       toJSON(): Array<T>;
->toJSON : () => T[]
+>toJSON : () => Array<T>
 >Array : T[]
 >T : T
 
       // Reading values
       get<NSV>(index: number, notSetValue: NSV): T | NSV;
->get : { <NSV>(index: number, notSetValue: NSV): T | NSV; (index: number): T; }
+>get : { <NSV>(index: number, notSetValue: NSV): T | NSV; (index: number): T | undefined; }
 >NSV : NSV
 >index : number
 >notSetValue : NSV
@@ -2782,7 +2782,7 @@ declare module Immutable {
 >NSV : NSV
 
       get(index: number): T | undefined;
->get : { <NSV>(index: number, notSetValue: NSV): T | NSV; (index: number): T; }
+>get : { <NSV>(index: number, notSetValue: NSV): T | NSV; (index: number): T | undefined; }
 >index : number
 >T : T
 
@@ -2820,7 +2820,7 @@ declare module Immutable {
 >T : T
 
       zip(...collections: Array<Collection<any, any>>): Collection.Indexed<any>;
->zip : (...collections: Collection<any, any>[]) => Indexed<any>
+>zip : (...collections: Collection<any, any>[]) => Collection.Indexed<any>
 >collections : Collection<any, any>[]
 >Array : T[]
 >Collection : Collection<K, V>
@@ -2828,7 +2828,7 @@ declare module Immutable {
 >Indexed : Indexed<T>
 
       zipWith<U, Z>(zipper: (value: T, otherValue: U) => Z, otherCollection: Collection<any, U>): Collection.Indexed<Z>;
->zipWith : { <U, Z>(zipper: (value: T, otherValue: U) => Z, otherCollection: Collection<any, U>): Indexed<Z>; <U, V, Z>(zipper: (value: T, otherValue: U, thirdValue: V) => Z, otherCollection: Collection<any, U>, thirdCollection: Collection<any, V>): Indexed<Z>; <Z>(zipper: (...any: any[]) => Z, ...collections: Collection<any, any>[]): Indexed<Z>; }
+>zipWith : { <U, Z>(zipper: (value: T, otherValue: U) => Z, otherCollection: Collection<any, U>): Collection.Indexed<Z>; <U, V, Z>(zipper: (value: T, otherValue: U, thirdValue: V) => Z, otherCollection: Collection<any, U>, thirdCollection: Collection<any, V>): Indexed<Z>; <Z>(zipper: (...any: any[]) => Z, ...collections: Collection<any, any>[]): Indexed<Z>; }
 >U : U
 >Z : Z
 >zipper : (value: T, otherValue: U) => Z
@@ -2845,7 +2845,7 @@ declare module Immutable {
 >Z : Z
 
       zipWith<U, V, Z>(zipper: (value: T, otherValue: U, thirdValue: V) => Z, otherCollection: Collection<any, U>, thirdCollection: Collection<any, V>): Collection.Indexed<Z>;
->zipWith : { <U, Z>(zipper: (value: T, otherValue: U) => Z, otherCollection: Collection<any, U>): Indexed<Z>; <U, V, Z>(zipper: (value: T, otherValue: U, thirdValue: V) => Z, otherCollection: Collection<any, U>, thirdCollection: Collection<any, V>): Indexed<Z>; <Z>(zipper: (...any: any[]) => Z, ...collections: Collection<any, any>[]): Indexed<Z>; }
+>zipWith : { <U, Z>(zipper: (value: T, otherValue: U) => Z, otherCollection: Collection<any, U>): Indexed<Z>; <U, V, Z>(zipper: (value: T, otherValue: U, thirdValue: V) => Z, otherCollection: Collection<any, U>, thirdCollection: Collection<any, V>): Collection.Indexed<Z>; <Z>(zipper: (...any: any[]) => Z, ...collections: Collection<any, any>[]): Indexed<Z>; }
 >U : U
 >V : V
 >Z : Z
@@ -2868,7 +2868,7 @@ declare module Immutable {
 >Z : Z
 
       zipWith<Z>(zipper: (...any: Array<any>) => Z, ...collections: Array<Collection<any, any>>): Collection.Indexed<Z>;
->zipWith : { <U, Z>(zipper: (value: T, otherValue: U) => Z, otherCollection: Collection<any, U>): Indexed<Z>; <U, V, Z>(zipper: (value: T, otherValue: U, thirdValue: V) => Z, otherCollection: Collection<any, U>, thirdCollection: Collection<any, V>): Indexed<Z>; <Z>(zipper: (...any: any[]) => Z, ...collections: Collection<any, any>[]): Indexed<Z>; }
+>zipWith : { <U, Z>(zipper: (value: T, otherValue: U) => Z, otherCollection: Collection<any, U>): Indexed<Z>; <U, V, Z>(zipper: (value: T, otherValue: U, thirdValue: V) => Z, otherCollection: Collection<any, U>, thirdCollection: Collection<any, V>): Indexed<Z>; <Z>(zipper: (...any: any[]) => Z, ...collections: Collection<any, any>[]): Collection.Indexed<Z>; }
 >Z : Z
 >zipper : (...any: any[]) => Z
 >any : any[]
@@ -2912,7 +2912,7 @@ declare module Immutable {
 
       // Sequence algorithms
       concat<C>(...valuesOrCollections: Array<Iterable<C> | C>): Collection.Indexed<T | C>;
->concat : <C>(...valuesOrCollections: (C | Iterable<C>)[]) => Indexed<T | C>
+>concat : <C>(...valuesOrCollections: (C | Iterable<C>)[]) => Collection.Indexed<T | C>
 >C : C
 >valuesOrCollections : (C | Iterable<C>)[]
 >Array : T[]
@@ -2925,7 +2925,7 @@ declare module Immutable {
 >C : C
 
       map<M>(mapper: (value: T, key: number, iter: this) => M, context?: any): Collection.Indexed<M>;
->map : <M>(mapper: (value: T, key: number, iter: this) => M, context?: any) => Indexed<M>
+>map : <M>(mapper: (value: T, key: number, iter: this) => M, context?: any) => Collection.Indexed<M>
 >M : M
 >mapper : (value: T, key: number, iter: this) => M
 >value : T
@@ -2939,7 +2939,7 @@ declare module Immutable {
 >M : M
 
       flatMap<M>(mapper: (value: T, key: number, iter: this) => Iterable<M>, context?: any): Collection.Indexed<M>;
->flatMap : <M>(mapper: (value: T, key: number, iter: this) => Iterable<M>, context?: any) => Indexed<M>
+>flatMap : <M>(mapper: (value: T, key: number, iter: this) => Iterable<M>, context?: any) => Collection.Indexed<M>
 >M : M
 >mapper : (value: T, key: number, iter: this) => Iterable<M>
 >value : T
@@ -2954,7 +2954,7 @@ declare module Immutable {
 >M : M
 
       filter<F extends T>(predicate: (value: T, index: number, iter: this) => value is F, context?: any): Collection.Indexed<F>;
->filter : { <F extends T>(predicate: (value: T, index: number, iter: this) => value is F, context?: any): Indexed<F>; (predicate: (value: T, index: number, iter: this) => any, context?: any): this; }
+>filter : { <F extends T>(predicate: (value: T, index: number, iter: this) => value is F, context?: any): Collection.Indexed<F>; (predicate: (value: T, index: number, iter: this) => any, context?: any): this; }
 >F : F
 >T : T
 >predicate : (value: T, index: number, iter: this) => value is F
@@ -2990,7 +2990,7 @@ declare module Immutable {
 >Set : <T>(collection: Iterable<T>) => Set<T>
 
     export function Set<T>(collection: Iterable<T>): Collection.Set<T>;
->Set : <T>(collection: Iterable<T>) => Set<T>
+>Set : <T>(collection: Iterable<T>) => Collection.Set<T>
 >T : T
 >collection : Iterable<T>
 >Iterable : Iterable<T>
@@ -3006,11 +3006,11 @@ declare module Immutable {
 >T : T
 
       toJS(): Array<any>;
->toJS : () => any[]
+>toJS : () => Array<any>
 >Array : T[]
 
       toJSON(): Array<T>;
->toJSON : () => T[]
+>toJSON : () => Array<T>
 >Array : T[]
 >T : T
 
@@ -3022,7 +3022,7 @@ declare module Immutable {
 
       // Sequence algorithms
       concat<C>(...valuesOrCollections: Array<Iterable<C> | C>): Collection.Set<T | C>;
->concat : <C>(...valuesOrCollections: (C | Iterable<C>)[]) => Set<T | C>
+>concat : <C>(...valuesOrCollections: (C | Iterable<C>)[]) => Collection.Set<T | C>
 >C : C
 >valuesOrCollections : (C | Iterable<C>)[]
 >Array : T[]
@@ -3035,7 +3035,7 @@ declare module Immutable {
 >C : C
 
       map<M>(mapper: (value: T, key: never, iter: this) => M, context?: any): Collection.Set<M>;
->map : <M>(mapper: (value: T, key: never, iter: this) => M, context?: any) => Set<M>
+>map : <M>(mapper: (value: T, key: never, iter: this) => M, context?: any) => Collection.Set<M>
 >M : M
 >mapper : (value: T, key: never, iter: this) => M
 >value : T
@@ -3049,7 +3049,7 @@ declare module Immutable {
 >M : M
 
       flatMap<M>(mapper: (value: T, key: never, iter: this) => Iterable<M>, context?: any):  Collection.Set<M>;
->flatMap : <M>(mapper: (value: T, key: never, iter: this) => Iterable<M>, context?: any) => Set<M>
+>flatMap : <M>(mapper: (value: T, key: never, iter: this) => Iterable<M>, context?: any) => Collection.Set<M>
 >M : M
 >mapper : (value: T, key: never, iter: this) => Iterable<M>
 >value : T
@@ -3064,7 +3064,7 @@ declare module Immutable {
 >M : M
 
       filter<F extends T>(predicate: (value: T, key: never, iter: this) => value is F, context?: any): Collection.Set<F>;
->filter : { <F extends T>(predicate: (value: T, key: never, iter: this) => value is F, context?: any): Set<F>; (predicate: (value: T, key: never, iter: this) => any, context?: any): this; }
+>filter : { <F extends T>(predicate: (value: T, key: never, iter: this) => value is F, context?: any): Collection.Set<F>; (predicate: (value: T, key: never, iter: this) => any, context?: any): this; }
 >F : F
 >T : T
 >predicate : (value: T, key: never, iter: this) => value is F
@@ -3141,7 +3141,7 @@ declare module Immutable {
 
     // Reading values
     get<NSV>(key: K, notSetValue: NSV): V | NSV;
->get : { <NSV>(key: K, notSetValue: NSV): V | NSV; (key: K): V; }
+>get : { <NSV>(key: K, notSetValue: NSV): V | NSV; (key: K): V | undefined; }
 >NSV : NSV
 >key : K
 >K : K
@@ -3151,7 +3151,7 @@ declare module Immutable {
 >NSV : NSV
 
     get(key: K): V | undefined;
->get : { <NSV>(key: K, notSetValue: NSV): V | NSV; (key: K): V; }
+>get : { <NSV>(key: K, notSetValue: NSV): V | NSV; (key: K): V | undefined; }
 >key : K
 >K : K
 >V : V
@@ -3172,11 +3172,11 @@ declare module Immutable {
 >V : V
 
     first(): V | undefined;
->first : () => V
+>first : () => V | undefined
 >V : V
 
     last(): V | undefined;
->last : () => V
+>last : () => V | undefined
 >V : V
 
     // Reading deep values
@@ -3214,7 +3214,7 @@ declare module Immutable {
 >V : V
 
     toArray(): Array<V>;
->toArray : () => V[]
+>toArray : () => Array<V>
 >Array : T[]
 >V : V
 
@@ -3647,7 +3647,7 @@ declare module Immutable {
 
     // Search for value
     find(predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V): V | undefined;
->find : (predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V) => V
+>find : (predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V) => V | undefined
 >predicate : (value: V, key: K, iter: this) => boolean
 >value : V
 >V : V
@@ -3660,7 +3660,7 @@ declare module Immutable {
 >V : V
 
     findLast(predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V): V | undefined;
->findLast : (predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V) => V
+>findLast : (predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V) => V | undefined
 >predicate : (value: V, key: K, iter: this) => boolean
 >value : V
 >V : V
@@ -3673,7 +3673,7 @@ declare module Immutable {
 >V : V
 
     findEntry(predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V): [K, V] | undefined;
->findEntry : (predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V) => [K, V]
+>findEntry : (predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V) => [K, V] | undefined
 >predicate : (value: V, key: K, iter: this) => boolean
 >value : V
 >V : V
@@ -3687,7 +3687,7 @@ declare module Immutable {
 >V : V
 
     findLastEntry(predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V): [K, V] | undefined;
->findLastEntry : (predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V) => [K, V]
+>findLastEntry : (predicate: (value: V, key: K, iter: this) => boolean, context?: any, notSetValue?: V) => [K, V] | undefined
 >predicate : (value: V, key: K, iter: this) => boolean
 >value : V
 >V : V
@@ -3701,7 +3701,7 @@ declare module Immutable {
 >V : V
 
     findKey(predicate: (value: V, key: K, iter: this) => boolean, context?: any): K | undefined;
->findKey : (predicate: (value: V, key: K, iter: this) => boolean, context?: any) => K
+>findKey : (predicate: (value: V, key: K, iter: this) => boolean, context?: any) => K | undefined
 >predicate : (value: V, key: K, iter: this) => boolean
 >value : V
 >V : V
@@ -3712,7 +3712,7 @@ declare module Immutable {
 >K : K
 
     findLastKey(predicate: (value: V, key: K, iter: this) => boolean, context?: any): K | undefined;
->findLastKey : (predicate: (value: V, key: K, iter: this) => boolean, context?: any) => K
+>findLastKey : (predicate: (value: V, key: K, iter: this) => boolean, context?: any) => K | undefined
 >predicate : (value: V, key: K, iter: this) => boolean
 >value : V
 >V : V
@@ -3723,19 +3723,19 @@ declare module Immutable {
 >K : K
 
     keyOf(searchValue: V): K | undefined;
->keyOf : (searchValue: V) => K
+>keyOf : (searchValue: V) => K | undefined
 >searchValue : V
 >V : V
 >K : K
 
     lastKeyOf(searchValue: V): K | undefined;
->lastKeyOf : (searchValue: V) => K
+>lastKeyOf : (searchValue: V) => K | undefined
 >searchValue : V
 >V : V
 >K : K
 
     max(comparator?: (valueA: V, valueB: V) => number): V | undefined;
->max : (comparator?: (valueA: V, valueB: V) => number) => V
+>max : (comparator?: (valueA: V, valueB: V) => number) => V | undefined
 >comparator : (valueA: V, valueB: V) => number
 >valueA : V
 >V : V
@@ -3744,7 +3744,7 @@ declare module Immutable {
 >V : V
 
     maxBy<C>(comparatorValueMapper: (value: V, key: K, iter: this) => C, comparator?: (valueA: C, valueB: C) => number): V | undefined;
->maxBy : <C>(comparatorValueMapper: (value: V, key: K, iter: this) => C, comparator?: (valueA: C, valueB: C) => number) => V
+>maxBy : <C>(comparatorValueMapper: (value: V, key: K, iter: this) => C, comparator?: (valueA: C, valueB: C) => number) => V | undefined
 >C : C
 >comparatorValueMapper : (value: V, key: K, iter: this) => C
 >value : V
@@ -3761,7 +3761,7 @@ declare module Immutable {
 >V : V
 
     min(comparator?: (valueA: V, valueB: V) => number): V | undefined;
->min : (comparator?: (valueA: V, valueB: V) => number) => V
+>min : (comparator?: (valueA: V, valueB: V) => number) => V | undefined
 >comparator : (valueA: V, valueB: V) => number
 >valueA : V
 >V : V
@@ -3770,7 +3770,7 @@ declare module Immutable {
 >V : V
 
     minBy<C>(comparatorValueMapper: (value: V, key: K, iter: this) => C, comparator?: (valueA: C, valueB: C) => number): V | undefined;
->minBy : <C>(comparatorValueMapper: (value: V, key: K, iter: this) => C, comparator?: (valueA: C, valueB: C) => number) => V
+>minBy : <C>(comparatorValueMapper: (value: V, key: K, iter: this) => C, comparator?: (valueA: C, valueB: C) => number) => V | undefined
 >C : C
 >comparatorValueMapper : (value: V, key: K, iter: this) => C
 >value : V

--- a/tests/baselines/reference/conditionalOperatorWithoutIdenticalBCT.types
+++ b/tests/baselines/reference/conditionalOperatorWithoutIdenticalBCT.types
@@ -120,7 +120,7 @@ var result6: (t: X) => boolean = true ? (m) => m.propertyX1 : (n) => n.propertyX
 >propertyX2 : string
 
 var result61: (t: X) => number| string = true ? (m) => m.propertyX1 : (n) => n.propertyX2;
->result61 : (t: X) => string | number
+>result61 : (t: X) => number | string
 >t : X
 >X : X
 >true ? (m) => m.propertyX1 : (n) => n.propertyX2 : ((m: X) => number) | ((n: X) => string)

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.types
@@ -108,7 +108,7 @@ interface A { // T
 >Base : Base
 
     a12: new (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
->a12 : new (x: Base[], y: Derived2[]) => Derived[]
+>a12 : new (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -119,7 +119,7 @@ interface A { // T
 >Derived : Derived
 
     a13: new (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
->a13 : new (x: Base[], y: Derived[]) => Derived[]
+>a13 : new (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -330,7 +330,7 @@ interface I extends A {
 >T : T
 
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
->a12 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
+>a12 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 >T : T
 >Array : T[]
 >Base : Base

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.types
@@ -109,7 +109,7 @@ interface A { // T
 >Base : Base
 
     a12: new (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
->a12 : new (x: Base[], y: Derived2[]) => Derived[]
+>a12 : new (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -120,7 +120,7 @@ interface A { // T
 >Derived : Derived
 
     a13: new (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
->a13 : new (x: Base[], y: Derived[]) => Derived[]
+>a13 : new (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -278,7 +278,7 @@ interface I extends B {
 >T : T
 
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
->a12 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
+>a12 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 >T : T
 >Array : T[]
 >Base : Base

--- a/tests/baselines/reference/declFileForInterfaceWithRestParams.types
+++ b/tests/baselines/reference/declFileForInterfaceWithRestParams.types
@@ -3,18 +3,18 @@ interface I {
 >I : I
 
     foo(...x): typeof x;
->foo : (...x: any[]) => any[]
+>foo : (...x: any[]) => typeof x
 >x : any[]
 >x : any[]
 
     foo2(a: number, ...x): typeof x;
->foo2 : (a: number, ...x: any[]) => any[]
+>foo2 : (a: number, ...x: any[]) => typeof x
 >a : number
 >x : any[]
 >x : any[]
 
     foo3(b: string, ...x: string[]): typeof x;
->foo3 : (b: string, ...x: string[]) => string[]
+>foo3 : (b: string, ...x: string[]) => typeof x
 >b : string
 >x : string[]
 >x : string[]

--- a/tests/baselines/reference/declFileTypeofFunction.types
+++ b/tests/baselines/reference/declFileTypeofFunction.types
@@ -28,8 +28,8 @@ function g() { return undefined; }
 >undefined : undefined
 
 var b: () => typeof b;
->b : () => any
->b : () => any
+>b : () => typeof b
+>b : () => typeof b
 
 function b1() {
 >b1 : () => typeof b1

--- a/tests/baselines/reference/declarationEmitWillUseAliasForName.js
+++ b/tests/baselines/reference/declarationEmitWillUseAliasForName.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/declarationEmitWillUseAliasForName.ts] ////
+
+//// [a.ts]
+export interface I { x: number; }
+export type J = I;
+
+//// [b.ts]
+import { J } from './a';
+export const f = (): J => ({ x: 0 });
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+exports.f = function () { return ({ x: 0 }); };
+
+
+//// [a.d.ts]
+export interface I {
+    x: number;
+}
+export declare type J = I;
+//// [b.d.ts]
+import { J } from './a';
+export declare const f: () => J;

--- a/tests/baselines/reference/declarationEmitWillUseAliasForName.symbols
+++ b/tests/baselines/reference/declarationEmitWillUseAliasForName.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/a.ts ===
+export interface I { x: number; }
+>I : Symbol(I, Decl(a.ts, 0, 0))
+>x : Symbol(I.x, Decl(a.ts, 0, 20))
+
+export type J = I;
+>J : Symbol(J, Decl(a.ts, 0, 33))
+>I : Symbol(I, Decl(a.ts, 0, 0))
+
+=== tests/cases/compiler/b.ts ===
+import { J } from './a';
+>J : Symbol(J, Decl(b.ts, 0, 8))
+
+export const f = (): J => ({ x: 0 });
+>f : Symbol(f, Decl(b.ts, 1, 12))
+>J : Symbol(J, Decl(b.ts, 0, 8))
+>x : Symbol(x, Decl(b.ts, 1, 28))
+

--- a/tests/baselines/reference/declarationEmitWillUseAliasForName.types
+++ b/tests/baselines/reference/declarationEmitWillUseAliasForName.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/a.ts ===
+export interface I { x: number; }
+>I : I
+>x : number
+
+export type J = I;
+>J : I
+>I : I
+
+=== tests/cases/compiler/b.ts ===
+import { J } from './a';
+>J : any
+
+export const f = (): J => ({ x: 0 });
+>f : () => J
+>(): J => ({ x: 0 }) : () => J
+>J : I
+>({ x: 0 }) : { x: number; }
+>{ x: 0 } : { x: number; }
+>x : number
+>0 : 0
+

--- a/tests/baselines/reference/declarationNoDanglingGenerics.types
+++ b/tests/baselines/reference/declarationNoDanglingGenerics.types
@@ -5,7 +5,7 @@ const kindCache: { [kind: string]: boolean } = {};
 >{} : {}
 
 function register(kind: string): void | never {
->register : (kind: string) => void
+>register : (kind: string) => void | never
 >kind : string
 
   if (kindCache[kind]) {
@@ -35,7 +35,7 @@ function ClassFactory<TKind extends string>(kind: TKind) {
 
   register(kind);
 >register(kind) : void
->register : (kind: string) => void
+>register : (kind: string) => void | never
 >kind : TKind
 
   return class {

--- a/tests/baselines/reference/deeplyNestedCheck.types
+++ b/tests/baselines/reference/deeplyNestedCheck.types
@@ -6,7 +6,7 @@ interface DataSnapshot<X = {}> {
 >X : X
 
   child(path: string): DataSnapshot;
->child : (path: string) => DataSnapshot<{}>
+>child : (path: string) => DataSnapshot
 >path : string
 >DataSnapshot : DataSnapshot<X>
 }

--- a/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.types
+++ b/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.types
@@ -16,7 +16,7 @@ export interface Things<P, T> {
 >T : T
 }
 export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
->make : <P, CTor>(x: new () => CTor & { props: P; }) => me.Things<P, CTor>
+>make : <P, CTor>(x: new () => CTor & { props: P; }) => Things<P, CTor>
 >P : P
 >CTor : CTor
 >x : new () => CTor & { props: P; }

--- a/tests/baselines/reference/enumLiteralTypes3.types
+++ b/tests/baselines/reference/enumLiteralTypes3.types
@@ -446,7 +446,7 @@ function f7(a: Yes, b: YesNo, c: UnknownYesNo, d: Choice) {
 }
 
 function f10(x: Yes): Yes {
->f10 : (x: Choice.Yes) => Choice.Yes
+>f10 : (x: Choice.Yes) => Yes
 >x : Choice.Yes
 >Yes : Choice.Yes
 >Yes : Choice.Yes
@@ -508,7 +508,7 @@ function f11(x: YesNo): YesNo {
 }
 
 function f12(x: UnknownYesNo): UnknownYesNo {
->f12 : (x: Choice) => Choice
+>f12 : (x: Choice) => UnknownYesNo
 >x : Choice
 >UnknownYesNo : Choice
 >UnknownYesNo : Choice

--- a/tests/baselines/reference/exportAssignmentMembersVisibleInAugmentation.types
+++ b/tests/baselines/reference/exportAssignmentMembersVisibleInAugmentation.types
@@ -17,7 +17,7 @@ declare module "foo" {
 >"foo" : typeof foo
 
     export function f(): T; // OK
->f : () => number
+>f : () => T
 >T : number
 }
 

--- a/tests/baselines/reference/functionOverloads44.types
+++ b/tests/baselines/reference/functionOverloads44.types
@@ -36,20 +36,20 @@ function foo1([x]: { a:number | string }[]): Dog {
 }
 
 function foo2(bar: { a:number }[]): Cat;
->foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog | Cat; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Cat | Dog; }
 >bar : { a: number; }[]
 >a : number
 >Cat : Cat
 
 function foo2(bar: { a:string }[]): Cat | Dog;
->foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog | Cat; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Cat | Dog; }
 >bar : { a: string; }[]
 >a : string
 >Cat : Cat
 >Dog : Dog
 
 function foo2([x]: { a:number | string }[]): Cat {
->foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog | Cat; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Cat | Dog; }
 >x : { a: string | number; }
 >a : string | number
 >Cat : Cat
@@ -80,7 +80,7 @@ var y1 = foo1([{a: 100}]);
 var x2 = foo2([{a: "str"}]);
 >x2 : Dog | Cat
 >foo2([{a: "str"}]) : Dog | Cat
->foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog | Cat; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Cat | Dog; }
 >[{a: "str"}] : { a: string; }[]
 >{a: "str"} : { a: string; }
 >a : string
@@ -89,7 +89,7 @@ var x2 = foo2([{a: "str"}]);
 var y2 = foo2([{a: 100}]);
 >y2 : Cat
 >foo2([{a: 100}]) : Cat
->foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog | Cat; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Cat | Dog; }
 >[{a: 100}] : { a: number; }[]
 >{a: 100} : { a: number; }
 >a : number

--- a/tests/baselines/reference/functionReturnTypeQuery.types
+++ b/tests/baselines/reference/functionReturnTypeQuery.types
@@ -3,14 +3,14 @@ declare let foo: number;
 >foo : number
 
 declare function test1(foo: string, bar: typeof foo): typeof foo;
->test1 : (foo: string, bar: string) => string
+>test1 : (foo: string, bar: string) => typeof foo
 >foo : string
 >bar : string
 >foo : string
 >foo : string
 
 declare function test2({foo}: {foo: string}, bar: typeof foo): typeof foo;
->test2 : ({ foo }: { foo: string; }, bar: string) => string
+>test2 : ({ foo }: { foo: string; }, bar: string) => typeof foo
 >foo : string
 >foo : string
 >bar : string

--- a/tests/baselines/reference/functionsMissingReturnStatementsAndExpressions.types
+++ b/tests/baselines/reference/functionsMissingReturnStatementsAndExpressions.types
@@ -142,19 +142,19 @@ function f18() {
 }
 
 function f19(): void | number {
->f19 : () => number | void
+>f19 : () => void | number
 
     // Okay; function return type is union containing void
 }
 
 function f20(): any | number {
->f20 : () => any
+>f20 : () => any | number
 
     // Okay; function return type is union containing any
 }
 
 function f21(): number | string {
->f21 : () => string | number
+>f21 : () => number | string
 
     // Not okay; union does not contain void or any
 }

--- a/tests/baselines/reference/generatedContextualTyping.types
+++ b/tests/baselines/reference/generatedContextualTyping.types
@@ -1332,7 +1332,7 @@ function x135(): () => Base[] { return function named() { return [d1, d2] }; }
 >d2 : Derived2
 
 function x136(): { (): Base[]; } { return () => [d1, d2]; }
->x136 : () => () => Base[]
+>x136 : () => {    (): Base[];}
 >Base : Base
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1340,7 +1340,7 @@ function x136(): { (): Base[]; } { return () => [d1, d2]; }
 >d2 : Derived2
 
 function x137(): { (): Base[]; } { return function() { return [d1, d2] }; }
->x137 : () => () => Base[]
+>x137 : () => {    (): Base[];}
 >Base : Base
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1348,7 +1348,7 @@ function x137(): { (): Base[]; } { return function() { return [d1, d2] }; }
 >d2 : Derived2
 
 function x138(): { (): Base[]; } { return function named() { return [d1, d2] }; }
->x138 : () => () => Base[]
+>x138 : () => {    (): Base[];}
 >Base : Base
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >named : () => (Derived1 | Derived2)[]
@@ -1364,7 +1364,7 @@ function x139(): Base[] { return [d1, d2]; }
 >d2 : Derived2
 
 function x140(): Array<Base> { return [d1, d2]; }
->x140 : () => Base[]
+>x140 : () => Array<Base>
 >Array : T[]
 >Base : Base
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1450,7 +1450,7 @@ function x147(): () => Base[] { return function named() { return [d1, d2] }; ret
 >d2 : Derived2
 
 function x148(): { (): Base[]; } { return () => [d1, d2]; return () => [d1, d2]; }
->x148 : () => () => Base[]
+>x148 : () => {    (): Base[];}
 >Base : Base
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1462,7 +1462,7 @@ function x148(): { (): Base[]; } { return () => [d1, d2]; return () => [d1, d2];
 >d2 : Derived2
 
 function x149(): { (): Base[]; } { return function() { return [d1, d2] }; return function() { return [d1, d2] }; }
->x149 : () => () => Base[]
+>x149 : () => {    (): Base[];}
 >Base : Base
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1474,7 +1474,7 @@ function x149(): { (): Base[]; } { return function() { return [d1, d2] }; return
 >d2 : Derived2
 
 function x150(): { (): Base[]; } { return function named() { return [d1, d2] }; return function named() { return [d1, d2] }; }
->x150 : () => () => Base[]
+>x150 : () => {    (): Base[];}
 >Base : Base
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >named : () => (Derived1 | Derived2)[]
@@ -1498,7 +1498,7 @@ function x151(): Base[] { return [d1, d2]; return [d1, d2]; }
 >d2 : Derived2
 
 function x152(): Array<Base> { return [d1, d2]; return [d1, d2]; }
->x152 : () => Base[]
+>x152 : () => Array<Base>
 >Array : T[]
 >Base : Base
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1597,7 +1597,7 @@ var x159: () => () => Base[] = () => { return function named() { return [d1, d2]
 >d2 : Derived2
 
 var x160: () => { (): Base[]; } = () => { return () => [d1, d2]; };
->x160 : () => () => Base[]
+>x160 : () => {    (): Base[];}
 >Base : Base
 >() => { return () => [d1, d2]; } : () => () => (Derived1 | Derived2)[]
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
@@ -1606,7 +1606,7 @@ var x160: () => { (): Base[]; } = () => { return () => [d1, d2]; };
 >d2 : Derived2
 
 var x161: () => { (): Base[]; } = () => { return function() { return [d1, d2] }; };
->x161 : () => () => Base[]
+>x161 : () => {    (): Base[];}
 >Base : Base
 >() => { return function() { return [d1, d2] }; } : () => () => (Derived1 | Derived2)[]
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
@@ -1615,7 +1615,7 @@ var x161: () => { (): Base[]; } = () => { return function() { return [d1, d2] };
 >d2 : Derived2
 
 var x162: () => { (): Base[]; } = () => { return function named() { return [d1, d2] }; };
->x162 : () => () => Base[]
+>x162 : () => {    (): Base[];}
 >Base : Base
 >() => { return function named() { return [d1, d2] }; } : () => () => (Derived1 | Derived2)[]
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
@@ -1633,7 +1633,7 @@ var x163: () => Base[] = () => { return [d1, d2]; };
 >d2 : Derived2
 
 var x164: () => Array<Base> = () => { return [d1, d2]; };
->x164 : () => Base[]
+>x164 : () => Array<Base>
 >Array : T[]
 >Base : Base
 >() => { return [d1, d2]; } : () => (Derived1 | Derived2)[]
@@ -1714,7 +1714,7 @@ var x171: () => () => Base[] = function() { return function named() { return [d1
 >d2 : Derived2
 
 var x172: () => { (): Base[]; } = function() { return () => [d1, d2]; };
->x172 : () => () => Base[]
+>x172 : () => {    (): Base[];}
 >Base : Base
 >function() { return () => [d1, d2]; } : () => () => (Derived1 | Derived2)[]
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
@@ -1723,7 +1723,7 @@ var x172: () => { (): Base[]; } = function() { return () => [d1, d2]; };
 >d2 : Derived2
 
 var x173: () => { (): Base[]; } = function() { return function() { return [d1, d2] }; };
->x173 : () => () => Base[]
+>x173 : () => {    (): Base[];}
 >Base : Base
 >function() { return function() { return [d1, d2] }; } : () => () => (Derived1 | Derived2)[]
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
@@ -1732,7 +1732,7 @@ var x173: () => { (): Base[]; } = function() { return function() { return [d1, d
 >d2 : Derived2
 
 var x174: () => { (): Base[]; } = function() { return function named() { return [d1, d2] }; };
->x174 : () => () => Base[]
+>x174 : () => {    (): Base[];}
 >Base : Base
 >function() { return function named() { return [d1, d2] }; } : () => () => (Derived1 | Derived2)[]
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
@@ -1750,7 +1750,7 @@ var x175: () => Base[] = function() { return [d1, d2]; };
 >d2 : Derived2
 
 var x176: () => Array<Base> = function() { return [d1, d2]; };
->x176 : () => Base[]
+>x176 : () => Array<Base>
 >Array : T[]
 >Base : Base
 >function() { return [d1, d2]; } : () => (Derived1 | Derived2)[]

--- a/tests/baselines/reference/generatorTypeCheck62.types
+++ b/tests/baselines/reference/generatorTypeCheck62.types
@@ -7,11 +7,11 @@ export interface StrategicState {
 }
 
 export function strategy<T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T | undefined>): (a: T) => IterableIterator<T | undefined> {
->strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
+>strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T | undefined>) => (a: T) => IterableIterator<T | undefined>
 >T : T
 >StrategicState : StrategicState
 >stratName : string
->gen : (a: T) => IterableIterator<T>
+>gen : (a: T) => IterableIterator<T | undefined>
 >a : T
 >T : T
 >IterableIterator : IterableIterator<T>
@@ -28,7 +28,7 @@ export function strategy<T extends StrategicState>(stratName: string, gen: (a: T
         for (const next of gen(state)) {
 >next : T
 >gen(state) : IterableIterator<T>
->gen : (a: T) => IterableIterator<T>
+>gen : (a: T) => IterableIterator<T | undefined>
 >state : T
 
             if (next) {

--- a/tests/baselines/reference/generatorTypeCheck63.types
+++ b/tests/baselines/reference/generatorTypeCheck63.types
@@ -7,11 +7,11 @@ export interface StrategicState {
 }
 
 export function strategy<T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T | undefined>): (a: T) => IterableIterator<T | undefined> {
->strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
+>strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T | undefined>) => (a: T) => IterableIterator<T | undefined>
 >T : T
 >StrategicState : StrategicState
 >stratName : string
->gen : (a: T) => IterableIterator<T>
+>gen : (a: T) => IterableIterator<T | undefined>
 >a : T
 >T : T
 >IterableIterator : IterableIterator<T>
@@ -28,7 +28,7 @@ export function strategy<T extends StrategicState>(stratName: string, gen: (a: T
         for (const next of gen(state)) {
 >next : T
 >gen(state) : IterableIterator<T>
->gen : (a: T) => IterableIterator<T>
+>gen : (a: T) => IterableIterator<T | undefined>
 >state : T
 
             if (next) {

--- a/tests/baselines/reference/genericRecursiveImplicitConstructorErrors3.types
+++ b/tests/baselines/reference/genericRecursiveImplicitConstructorErrors3.types
@@ -9,7 +9,7 @@ module TypeScript {
 >C : C
 
         static create<A,B,C>(arg1: any, arg2?: any, arg3?: any): MemberName {
->create : <A, B, C>(arg1: any, arg2?: any, arg3?: any) => any
+>create : <A, B, C>(arg1: any, arg2?: any, arg3?: any) => MemberName
 >A : A
 >B : B
 >C : C
@@ -138,9 +138,9 @@ module TypeScript {
 
                 return MemberName.create(elementMemberName, "", "[]");
 >MemberName.create(elementMemberName, "", "[]") : any
->MemberName.create : <A, B, C>(arg1: any, arg2?: any, arg3?: any) => any
+>MemberName.create : <A, B, C>(arg1: any, arg2?: any, arg3?: any) => MemberName
 >MemberName : typeof MemberName
->create : <A, B, C>(arg1: any, arg2?: any, arg3?: any) => any
+>create : <A, B, C>(arg1: any, arg2?: any, arg3?: any) => MemberName
 >elementMemberName : any
 >"" : ""
 >"[]" : "[]"

--- a/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument.d.types
+++ b/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument.d.types
@@ -21,7 +21,7 @@ declare var a: { x: C };
 >C : C<T>
 
 declare var b: { (x: C): C };
->b : (x: any) => any
+>b : (x: any) => C
 >x : any
 >C : C<T>
 >C : C<T>
@@ -33,7 +33,7 @@ declare var d: { [x: C]: C };
 >C : C<T>
 
 declare function f(x: C): C;
->f : (x: any) => any
+>f : (x: any) => C
 >x : any
 >C : C<T>
 >C : C<T>

--- a/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument.types
+++ b/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument.types
@@ -21,7 +21,7 @@ var a: { x: C };
 >C : C<T>
 
 var b: { (x: C): C };
->b : (x: any) => any
+>b : (x: any) => C
 >x : any
 >C : C<T>
 >C : C<T>
@@ -42,7 +42,7 @@ var e = (x: C) => { var y: C; return y; }
 >y : any
 
 function f(x: C): C { var y: C; return y; }
->f : (x: any) => any
+>f : (x: any) => C
 >x : any
 >C : C<T>
 >C : C<T>
@@ -51,9 +51,9 @@ function f(x: C): C { var y: C; return y; }
 >y : any
 
 var g = function f(x: C): C { var y: C; return y; }
->g : (x: any) => any
->function f(x: C): C { var y: C; return y; } : (x: any) => any
->f : (x: any) => any
+>g : (x: any) => C
+>function f(x: C): C { var y: C; return y; } : (x: any) => C
+>f : (x: any) => C
 >x : any
 >C : C<T>
 >C : C<T>

--- a/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument2.types
+++ b/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument2.types
@@ -21,7 +21,7 @@ var a: { x: I };
 >I : I<T>
 
 var b: { (x: I): I };
->b : (x: any) => any
+>b : (x: any) => I
 >x : any
 >I : I<T>
 >I : I<T>
@@ -42,7 +42,7 @@ var e = (x: I) => { var y: I; return y; }
 >y : any
 
 function f(x: I): I { var y: I; return y; }
->f : (x: any) => any
+>f : (x: any) => I
 >x : any
 >I : I<T>
 >I : I<T>
@@ -51,9 +51,9 @@ function f(x: I): I { var y: I; return y; }
 >y : any
 
 var g = function f(x: I): I { var y: I; return y; }
->g : (x: any) => any
->function f(x: I): I { var y: I; return y; } : (x: any) => any
->f : (x: any) => any
+>g : (x: any) => I
+>function f(x: I): I { var y: I; return y; } : (x: any) => I
+>f : (x: any) => I
 >x : any
 >I : I<T>
 >I : I<T>

--- a/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument3.types
+++ b/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument3.types
@@ -21,7 +21,7 @@ declare var a: { x: C };
 >C : C<T>
 
 declare var b: { (x: C): C };
->b : (x: any) => any
+>b : (x: any) => C
 >x : any
 >C : C<T>
 >C : C<T>
@@ -33,7 +33,7 @@ declare var d: { [x: C]: C };
 >C : C<T>
 
 declare function f(x: C): C;
->f : (x: any) => any
+>f : (x: any) => C
 >x : any
 >C : C<T>
 >C : C<T>

--- a/tests/baselines/reference/genericsWithoutTypeParameters1.types
+++ b/tests/baselines/reference/genericsWithoutTypeParameters1.types
@@ -102,7 +102,7 @@ class A<T> { }
 >T : T
 
 function f<T>(x: T): A {
->f : <T>(x: T) => any
+>f : <T>(x: T) => A
 >T : T
 >x : T
 >T : T

--- a/tests/baselines/reference/inferParameterWithMethodCallInitializer.types
+++ b/tests/baselines/reference/inferParameterWithMethodCallInitializer.types
@@ -15,7 +15,7 @@ class Example {
 >1 : 1
     }
     doSomething(a = this.getNumber()): typeof a {
->doSomething : (a?: number) => number
+>doSomething : (a?: number) => typeof a
 >a : number
 >this.getNumber() : number
 >this.getNumber : () => number

--- a/tests/baselines/reference/initializedDestructuringAssignmentTypes.types
+++ b/tests/baselines/reference/initializedDestructuringAssignmentTypes.types
@@ -5,9 +5,9 @@ const [, a = ''] = ''.match('') || [];
 >'' : ""
 >''.match('') || [] : RegExpMatchArray | [undefined, ""]
 >''.match('') : RegExpMatchArray
->''.match : (regexp: string | RegExp) => RegExpMatchArray
+>''.match : (regexp: string | RegExp) => RegExpMatchArray | null
 >'' : ""
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: string | RegExp) => RegExpMatchArray | null
 >'' : ""
 >[] : [undefined, ""]
 

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -1953,7 +1953,7 @@ type MethodDescriptor = {
 }
 
 declare function dispatchMethod<M extends MethodDescriptor>(name: M['name'], args: M['args']): M['returnValue'];
->dispatchMethod : <M extends MethodDescriptor>(name: M["name"], args: M["args"]) => M["returnValue"]
+>dispatchMethod : <M extends MethodDescriptor>(name: M["name"], args: M["args"]) => M['returnValue']
 >M : M
 >MethodDescriptor : MethodDescriptor
 >name : M["name"]

--- a/tests/baselines/reference/missingTypeArguments1.types
+++ b/tests/baselines/reference/missingTypeArguments1.types
@@ -12,7 +12,7 @@ class X<T> {
 >T : T
 
     p1: () => X;
->p1 : () => any
+>p1 : () => X
 >X : X<T>
 }
 var a: X<number>;
@@ -74,7 +74,7 @@ class X6<T> {
 >T : T
 
     p6: () => Y;
->p6 : () => any
+>p6 : () => Y
 >Y : Y<T>
 }
 var a6: X6<number>;

--- a/tests/baselines/reference/missingTypeArguments2.types
+++ b/tests/baselines/reference/missingTypeArguments2.types
@@ -4,7 +4,7 @@ class A<T> { }
 >T : T
 
 var x: () => A;
->x : () => any
+>x : () => A
 >A : A<T>
 
 (a: A) => { };
@@ -18,7 +18,7 @@ var y: A<A>;
 >A : A<T>
 
 (): A => null;
->(): A => null : () => any
+>(): A => null : () => A
 >A : A<T>
 >null : null
 

--- a/tests/baselines/reference/moduleAugmentationImportsAndExports2.types
+++ b/tests/baselines/reference/moduleAugmentationImportsAndExports2.types
@@ -60,7 +60,7 @@ declare module "./f1" {
 >A : A
 
         foo(): B;
->foo : () => any
+>foo : () => B
 >B : any
 
         bar(): I;

--- a/tests/baselines/reference/moduleAugmentationImportsAndExports3.types
+++ b/tests/baselines/reference/moduleAugmentationImportsAndExports3.types
@@ -56,7 +56,7 @@ declare module "./f1" {
 >A : A
 
         foo(): B;
->foo : () => any
+>foo : () => B
 >B : any
 
         bar(): I;

--- a/tests/baselines/reference/noTypeArgumentOnReturnType1.types
+++ b/tests/baselines/reference/noTypeArgumentOnReturnType1.types
@@ -4,7 +4,7 @@ class A<T>{
 >T : T
  
  foo(): A{
->foo : () => any
+>foo : () => A
 >A : A<T>
 
   return null;

--- a/tests/baselines/reference/parser630933.types
+++ b/tests/baselines/reference/parser630933.types
@@ -6,8 +6,8 @@ var a = "Hello";
 var b = a.match(/\/ver=([^/]+)/);
 >b : RegExpMatchArray
 >a.match(/\/ver=([^/]+)/) : RegExpMatchArray
->a.match : (regexp: string | RegExp) => RegExpMatchArray
+>a.match : (regexp: string | RegExp) => RegExpMatchArray | null
 >a : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: string | RegExp) => RegExpMatchArray | null
 >/\/ver=([^/]+)/ : RegExp
 

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -287,9 +287,9 @@ module Harness {
             var bugs = content.match(/\bbug (\d+)/i);
 >bugs : RegExpMatchArray
 >content.match(/\bbug (\d+)/i) : RegExpMatchArray
->content.match : (regexp: string | RegExp) => RegExpMatchArray
+>content.match : (regexp: string | RegExp) => RegExpMatchArray | null
 >content : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: string | RegExp) => RegExpMatchArray | null
 >/\bbug (\d+)/i : RegExp
 
             if (bugs) {
@@ -4940,11 +4940,11 @@ module Harness {
                         var match = errorLines[i].match(/([^\(]*)\((\d+),(\d+)\):\s+((.*[\s\r\n]*.*)+)\s*$/);
 >match : RegExpMatchArray
 >errorLines[i].match(/([^\(]*)\((\d+),(\d+)\):\s+((.*[\s\r\n]*.*)+)\s*$/) : RegExpMatchArray
->errorLines[i].match : (regexp: string | RegExp) => RegExpMatchArray
+>errorLines[i].match : (regexp: string | RegExp) => RegExpMatchArray | null
 >errorLines[i] : string
 >errorLines : string[]
 >i : number
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: string | RegExp) => RegExpMatchArray | null
 >/([^\(]*)\((\d+),(\d+)\):\s+((.*[\s\r\n]*.*)+)\s*$/ : RegExp
 
                         if (match) {
@@ -5374,9 +5374,9 @@ module Harness {
 >filename : string
 >path.match(/[^\/]*$/)[0] : string
 >path.match(/[^\/]*$/) : RegExpMatchArray
->path.match : (regexp: string | RegExp) => RegExpMatchArray
+>path.match : (regexp: string | RegExp) => RegExpMatchArray | null
 >path : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: string | RegExp) => RegExpMatchArray | null
 >/[^\/]*$/ : RegExp
 >0 : 0
 
@@ -5562,13 +5562,13 @@ module Harness {
 >unitName : string
 >switchToForwardSlashes(lastUnit.name).match(/[^\/]*$/)[0] : string
 >switchToForwardSlashes(lastUnit.name).match(/[^\/]*$/) : RegExpMatchArray
->switchToForwardSlashes(lastUnit.name).match : (regexp: string | RegExp) => RegExpMatchArray
+>switchToForwardSlashes(lastUnit.name).match : (regexp: string | RegExp) => RegExpMatchArray | null
 >switchToForwardSlashes(lastUnit.name) : string
 >switchToForwardSlashes : (path: string) => string
 >lastUnit.name : string
 >lastUnit : TestCaseParser.TestUnitData
 >name : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: string | RegExp) => RegExpMatchArray | null
 >/[^\/]*$/ : RegExp
 >0 : 0
 
@@ -6084,9 +6084,9 @@ module Harness {
                     var isRef = line.match(/reference\spath='(\w*_?\w*\.?d?\.ts)'/);
 >isRef : RegExpMatchArray
 >line.match(/reference\spath='(\w*_?\w*\.?d?\.ts)'/) : RegExpMatchArray
->line.match : (regexp: string | RegExp) => RegExpMatchArray
+>line.match : (regexp: string | RegExp) => RegExpMatchArray | null
 >line : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: string | RegExp) => RegExpMatchArray | null
 >/reference\spath='(\w*_?\w*\.?d?\.ts)'/ : RegExp
 
                     if (isRef) {
@@ -7840,9 +7840,9 @@ module Harness {
 >path : string
 >path.match(/[^\/]*$/)[0] : string
 >path.match(/[^\/]*$/) : RegExpMatchArray
->path.match : (regexp: string | RegExp) => RegExpMatchArray
+>path.match : (regexp: string | RegExp) => RegExpMatchArray | null
 >path : string
->match : (regexp: string | RegExp) => RegExpMatchArray
+>match : (regexp: string | RegExp) => RegExpMatchArray | null
 >/[^\/]*$/ : RegExp
 >0 : 0
 >callback : (error: Error, result: any) => void

--- a/tests/baselines/reference/recursiveFunctionTypes.errors.txt
+++ b/tests/baselines/reference/recursiveFunctionTypes.errors.txt
@@ -6,7 +6,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(11,16): error TS2355: A function 
 tests/cases/compiler/recursiveFunctionTypes.ts(12,16): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 tests/cases/compiler/recursiveFunctionTypes.ts(17,5): error TS2322: Type '() => I<typeof f3>' is not assignable to type 'number'.
 tests/cases/compiler/recursiveFunctionTypes.ts(22,5): error TS2345: Argument of type '3' is not assignable to parameter of type '(t: typeof g) => void'.
-tests/cases/compiler/recursiveFunctionTypes.ts(25,1): error TS2322: Type '3' is not assignable to type '() => any'.
+tests/cases/compiler/recursiveFunctionTypes.ts(25,1): error TS2322: Type '3' is not assignable to type '() => typeof f4'.
 tests/cases/compiler/recursiveFunctionTypes.ts(30,10): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/compiler/recursiveFunctionTypes.ts(33,1): error TS2554: Expected 0-1 arguments, but got 2.
 tests/cases/compiler/recursiveFunctionTypes.ts(34,4): error TS2345: Argument of type '""' is not assignable to parameter of type '{ (): typeof f6; (a: typeof f6): () => number; }'.
@@ -56,7 +56,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(43,4): error TS2345: Argument of 
     var f4: () => typeof f4;
     f4 = 3; // error
     ~~
-!!! error TS2322: Type '3' is not assignable to type '() => any'.
+!!! error TS2322: Type '3' is not assignable to type '() => typeof f4'.
     
     function f5() { return f5; }
     

--- a/tests/baselines/reference/recursiveFunctionTypes.types
+++ b/tests/baselines/reference/recursiveFunctionTypes.types
@@ -13,12 +13,12 @@ var y: () => number = fn; // ok
 >fn : () => typeof fn
 
 var f: () => typeof g;
->f : () => () => any
->g : () => () => any
+>f : () => typeof g
+>g : () => typeof f
 
 var g: () => typeof f;
->g : () => () => any
->f : () => () => any
+>g : () => typeof f
+>f : () => typeof g
 
 function f1(d: typeof f1) { }
 >f1 : (d: typeof f1) => void
@@ -26,12 +26,12 @@ function f1(d: typeof f1) { }
 >f1 : (d: typeof f1) => void
 
 function f2(): typeof g2 { } 
->f2 : () => () => typeof f2
->g2 : () => () => typeof g2
+>f2 : () => typeof g2
+>g2 : () => typeof f2
 
 function g2(): typeof f2 { } 
->g2 : () => () => typeof g2
->f2 : () => () => typeof f2
+>g2 : () => typeof f2
+>f2 : () => typeof g2
 
 interface I<T> { }
 >I : I<T>
@@ -65,12 +65,12 @@ C.g(3); // error
 >3 : 3
 
 var f4: () => typeof f4;
->f4 : () => any
->f4 : () => any
+>f4 : () => typeof f4
+>f4 : () => typeof f4
 
 f4 = 3; // error
 >f4 = 3 : 3
->f4 : () => any
+>f4 : () => typeof f4
 >3 : 3
 
 function f5() { return f5; }

--- a/tests/baselines/reference/recursiveTypesWithTypeof.types
+++ b/tests/baselines/reference/recursiveTypesWithTypeof.types
@@ -63,19 +63,19 @@ var g: typeof g.x;
 >x : { x: any; }
 
 var h: () => typeof h;
->h : () => any
->h : () => any
+>h : () => typeof h
+>h : () => typeof h
 
 var h = h();
->h : () => any
->h() : () => any
->h : () => any
+>h : () => typeof h
+>h() : () => typeof h
+>h : () => typeof h
 
 var i: (x: typeof i) => typeof x;
 >i : (x: any) => any
->x : (x: any) => any
->i : (x: any) => any
->x : (x: any) => any
+>x : (x: any) => typeof x
+>i : (x: any) => typeof x
+>x : (x: any) => typeof x
 
 var i = i(i);
 >i : (x: any) => any
@@ -99,19 +99,19 @@ var j = j(j);
 
 // Same as h, i, j with construct signatures
 var h2: new () => typeof h2;
->h2 : new () => any
->h2 : new () => any
+>h2 : new () => typeof h2
+>h2 : new () => typeof h2
 
 var h2 = new h2();
->h2 : new () => any
->new h2() : new () => any
->h2 : new () => any
+>h2 : new () => typeof h2
+>new h2() : new () => typeof h2
+>h2 : new () => typeof h2
 
 var i2: new (x: typeof i2) => typeof x;
 >i2 : new (x: any) => any
->x : new (x: any) => any
->i2 : new (x: any) => any
->x : new (x: any) => any
+>x : new (x: any) => typeof x
+>i2 : new (x: any) => typeof x
+>x : new (x: any) => typeof x
 
 var i2 = new i2(i2);
 >i2 : new (x: any) => any

--- a/tests/baselines/reference/returnTypeParameterWithModules.types
+++ b/tests/baselines/reference/returnTypeParameterWithModules.types
@@ -3,7 +3,7 @@ module M1 {
 >M1 : typeof M1
 
     export function reduce<A>(ar, f, e?): Array<A> {
->reduce : <A>(ar: any, f: any, e?: any) => A[]
+>reduce : <A>(ar: any, f: any, e?: any) => Array<A>
 >A : A
 >ar : any
 >f : any

--- a/tests/baselines/reference/returnTypeTypeArguments.types
+++ b/tests/baselines/reference/returnTypeTypeArguments.types
@@ -40,32 +40,32 @@ class Three<T, U, V>{
 }
 
 function A1(): One { return null; }
->A1 : () => any
+>A1 : () => One
 >One : One<T>
 >null : null
 
 function A2(): Two { return null; }
->A2 : () => any
+>A2 : () => Two
 >Two : Two<T, U>
 >null : null
 
 function A3(): Three { return null; }
->A3 : () => any
+>A3 : () => Three
 >Three : Three<T, U, V>
 >null : null
 
 function B1(): Two<number> { return null; }
->B1 : () => any
+>B1 : () => Two<number>
 >Two : Two<T, U>
 >null : null
 
 function B2(): Three<string> { return null; }
->B2 : () => any
+>B2 : () => Three<string>
 >Three : Three<T, U, V>
 >null : null
 
 function B3(): Three<string, number> { return null; }
->B3 : () => any
+>B3 : () => Three<string, number>
 >Three : Three<T, U, V>
 >null : null
 
@@ -73,32 +73,32 @@ class C {
 >C : C
 
     A1(): One { return null; }
->A1 : () => any
+>A1 : () => One
 >One : One<T>
 >null : null
 
     A2(): Two { return null; }
->A2 : () => any
+>A2 : () => Two
 >Two : Two<T, U>
 >null : null
 
     A3(): Three { return null; }
->A3 : () => any
+>A3 : () => Three
 >Three : Three<T, U, V>
 >null : null
 
     B1(): Two<number> { return null; }
->B1 : () => any
+>B1 : () => Two<number>
 >Two : Two<T, U>
 >null : null
 
     B2(): Three<string> { return null; }
->B2 : () => any
+>B2 : () => Three<string>
 >Three : Three<T, U, V>
 >null : null
 
     B3(): Three<string, number> { return null; }
->B3 : () => any
+>B3 : () => Three<string, number>
 >Three : Three<T, U, V>
 >null : null
 }
@@ -108,31 +108,31 @@ class D<T> {
 >T : T
 
     A2(): Two<T> { return null; }
->A2 : () => any
+>A2 : () => Two<T>
 >Two : Two<T, U>
 >T : T
 >null : null
 
     A3(): Three<T> { return null; }
->A3 : () => any
+>A3 : () => Three<T>
 >Three : Three<T, U, V>
 >T : T
 >null : null
 
     B1(): Two<T> { return null; }
->B1 : () => any
+>B1 : () => Two<T>
 >Two : Two<T, U>
 >T : T
 >null : null
 
     B2(): Three<T> { return null; }
->B2 : () => any
+>B2 : () => Three<T>
 >Three : Three<T, U, V>
 >T : T
 >null : null
 
     B3(): Three<string, T> { return null; }
->B3 : () => any
+>B3 : () => Three<string, T>
 >Three : Three<T, U, V>
 >T : T
 >null : null
@@ -161,7 +161,7 @@ class X<T>
 >T : T
 {
     p1: () => X;
->p1 : () => any
+>p1 : () => X
 >X : X<T>
 
     p2: { [idx: number]: X }
@@ -183,7 +183,7 @@ class X<T>
 >X : X<T>
 
     p6: () => Y;
->p6 : () => any
+>p6 : () => Y
 >Y : Y<T>
 
     p7: { [idx: number]: Y }
@@ -206,10 +206,10 @@ class X<T>
 }
 
 declare var a: {
->a : { p1: () => any; p2: { [idx: number]: any; }; p3: any[]; p4: I<any>; p5: any; p6: () => any; p7: { [idx: number]: any; }; p8: any[]; p9: I<any>; pa: any; }
+>a : { p1: () => X; p2: { [idx: number]: any; }; p3: any[]; p4: I<any>; p5: any; p6: () => Y; p7: { [idx: number]: any; }; p8: any[]; p9: I<any>; pa: any; }
 
     p1: () => X;
->p1 : () => any
+>p1 : () => X
 >X : X<T>
 
     p2: { [idx: number]: X }
@@ -231,7 +231,7 @@ declare var a: {
 >X : X<T>
 
     p6: () => Y;
->p6 : () => any
+>p6 : () => Y
 >Y : Y<T>
 
     p7: { [idx: number]: Y }

--- a/tests/baselines/reference/stringEnumLiteralTypes3.types
+++ b/tests/baselines/reference/stringEnumLiteralTypes3.types
@@ -449,7 +449,7 @@ function f7(a: Yes, b: YesNo, c: UnknownYesNo, d: Choice) {
 }
 
 function f10(x: Yes): Yes {
->f10 : (x: Choice.Yes) => Choice.Yes
+>f10 : (x: Choice.Yes) => Yes
 >x : Choice.Yes
 >Yes : Choice.Yes
 >Yes : Choice.Yes
@@ -511,7 +511,7 @@ function f11(x: YesNo): YesNo {
 }
 
 function f12(x: UnknownYesNo): UnknownYesNo {
->f12 : (x: Choice) => Choice
+>f12 : (x: Choice) => UnknownYesNo
 >x : Choice
 >UnknownYesNo : Choice
 >UnknownYesNo : Choice

--- a/tests/baselines/reference/stringLiteralTypesOverloads01.types
+++ b/tests/baselines/reference/stringLiteralTypesOverloads01.types
@@ -3,35 +3,35 @@ type PrimitiveName = 'string' | 'number' | 'boolean';
 >PrimitiveName : PrimitiveName
 
 function getFalsyPrimitive(x: "string"): string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >x : "string"
 
 function getFalsyPrimitive(x: "number"): number;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >x : "number"
 
 function getFalsyPrimitive(x: "boolean"): boolean;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >x : "boolean"
 
 function getFalsyPrimitive(x: "boolean" | "string"): boolean | string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >x : "string" | "boolean"
 
 function getFalsyPrimitive(x: "boolean" | "number"): boolean | number;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >x : "number" | "boolean"
 
 function getFalsyPrimitive(x: "number" | "string"): number | string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >x : "string" | "number"
 
 function getFalsyPrimitive(x: "number" | "string" | "boolean"): number | string | boolean;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >x : PrimitiveName
 
 function getFalsyPrimitive(x: PrimitiveName): number | string | boolean {
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >x : PrimitiveName
 >PrimitiveName : PrimitiveName
 
@@ -71,19 +71,19 @@ namespace Consts1 {
     const EMPTY_STRING = getFalsyPrimitive("string");
 >EMPTY_STRING : string
 >getFalsyPrimitive("string") : string
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >"string" : "string"
 
     const ZERO = getFalsyPrimitive('number');
 >ZERO : number
 >getFalsyPrimitive('number') : number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >'number' : "number"
 
     const FALSE = getFalsyPrimitive("boolean");
 >FALSE : boolean
 >getFalsyPrimitive("boolean") : boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >"boolean" : "boolean"
 }
 
@@ -129,43 +129,43 @@ namespace Consts2 {
     const EMPTY_STRING = getFalsyPrimitive(string);
 >EMPTY_STRING : string
 >getFalsyPrimitive(string) : string
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >string : "string"
 
     const ZERO = getFalsyPrimitive(number);
 >ZERO : number
 >getFalsyPrimitive(number) : number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >number : "number"
 
     const FALSE = getFalsyPrimitive(boolean);
 >FALSE : boolean
 >getFalsyPrimitive(boolean) : boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >boolean : "boolean"
 
     const a = getFalsyPrimitive(stringOrNumber);
 >a : string | number
 >getFalsyPrimitive(stringOrNumber) : string | number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >stringOrNumber : "string" | "number"
 
     const b = getFalsyPrimitive(stringOrBoolean);
 >b : string | boolean
 >getFalsyPrimitive(stringOrBoolean) : string | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >stringOrBoolean : "string" | "boolean"
 
     const c = getFalsyPrimitive(booleanOrNumber);
 >c : number | boolean
 >getFalsyPrimitive(booleanOrNumber) : number | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >booleanOrNumber : "number" | "boolean"
 
     const d = getFalsyPrimitive(stringOrBooleanOrNumber);
 >d : string | number | boolean
 >getFalsyPrimitive(stringOrBooleanOrNumber) : string | number | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: PrimitiveName): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: PrimitiveName): number | string | boolean; }
 >stringOrBooleanOrNumber : PrimitiveName
 }
 

--- a/tests/baselines/reference/stringLiteralTypesOverloads02.types
+++ b/tests/baselines/reference/stringLiteralTypesOverloads02.types
@@ -1,34 +1,34 @@
 === tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads02.ts ===
 function getFalsyPrimitive(x: "string"): string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >x : "string"
 
 function getFalsyPrimitive(x: "number"): number;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >x : "number"
 
 function getFalsyPrimitive(x: "boolean"): boolean;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >x : "boolean"
 
 function getFalsyPrimitive(x: "boolean" | "string"): boolean | string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >x : "string" | "boolean"
 
 function getFalsyPrimitive(x: "boolean" | "number"): boolean | number;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >x : "number" | "boolean"
 
 function getFalsyPrimitive(x: "number" | "string"): number | string;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >x : "string" | "number"
 
 function getFalsyPrimitive(x: "number" | "string" | "boolean"): number | string | boolean;
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >x : "string" | "number" | "boolean"
 
 function getFalsyPrimitive(x: string): string | number | boolean {
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >x : string
 
     if (x === "string") {
@@ -67,19 +67,19 @@ namespace Consts1 {
     const EMPTY_STRING = getFalsyPrimitive("string");
 >EMPTY_STRING : string
 >getFalsyPrimitive("string") : string
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >"string" : "string"
 
     const ZERO = getFalsyPrimitive('number');
 >ZERO : number
 >getFalsyPrimitive('number') : number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >'number' : "number"
 
     const FALSE = getFalsyPrimitive("boolean");
 >FALSE : boolean
 >getFalsyPrimitive("boolean") : boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >"boolean" : "boolean"
 }
 
@@ -125,43 +125,43 @@ namespace Consts2 {
     const EMPTY_STRING = getFalsyPrimitive(string);
 >EMPTY_STRING : string
 >getFalsyPrimitive(string) : string
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >string : "string"
 
     const ZERO = getFalsyPrimitive(number);
 >ZERO : number
 >getFalsyPrimitive(number) : number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >number : "number"
 
     const FALSE = getFalsyPrimitive(boolean);
 >FALSE : boolean
 >getFalsyPrimitive(boolean) : boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >boolean : "boolean"
 
     const a = getFalsyPrimitive(stringOrNumber);
 >a : string | number
 >getFalsyPrimitive(stringOrNumber) : string | number
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >stringOrNumber : "string" | "number"
 
     const b = getFalsyPrimitive(stringOrBoolean);
 >b : string | boolean
 >getFalsyPrimitive(stringOrBoolean) : string | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >stringOrBoolean : "string" | "boolean"
 
     const c = getFalsyPrimitive(booleanOrNumber);
 >c : number | boolean
 >getFalsyPrimitive(booleanOrNumber) : number | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >booleanOrNumber : "number" | "boolean"
 
     const d = getFalsyPrimitive(stringOrBooleanOrNumber);
 >d : string | number | boolean
 >getFalsyPrimitive(stringOrBooleanOrNumber) : string | number | boolean
->getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): string | boolean; (x: "number" | "boolean"): number | boolean; (x: "string" | "number"): string | number; (x: "string" | "number" | "boolean"): string | number | boolean; }
+>getFalsyPrimitive : { (x: "string"): string; (x: "number"): number; (x: "boolean"): boolean; (x: "string" | "boolean"): boolean | string; (x: "number" | "boolean"): boolean | number; (x: "string" | "number"): number | string; (x: "string" | "number" | "boolean"): number | string | boolean; }
 >stringOrBooleanOrNumber : "string" | "number" | "boolean"
 }
 

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -21,7 +21,7 @@ class OtherDerived extends Base { bing: string; }
 >bing : string
 
 declare function foo1(a: (x: number) => number[]): typeof a;
->foo1 : { (a: (x: number) => number[]): (x: number) => number[]; (a: any): any; }
+>foo1 : { (a: (x: number) => number[]): typeof a; (a: any): any; }
 >a : (x: number) => number[]
 >x : number
 >a : (x: number) => number[]
@@ -31,7 +31,7 @@ declare function foo1(a: any): any;
 >a : any
 
 declare function foo2(a: (x: number) => string[]): typeof a;
->foo2 : { (a: (x: number) => string[]): (x: number) => string[]; (a: any): any; }
+>foo2 : { (a: (x: number) => string[]): typeof a; (a: any): any; }
 >a : (x: number) => string[]
 >x : number
 >a : (x: number) => string[]
@@ -41,7 +41,7 @@ declare function foo2(a: any): any;
 >a : any
 
 declare function foo3(a: (x: number) => void): typeof a;
->foo3 : { (a: (x: number) => void): (x: number) => void; (a: any): any; }
+>foo3 : { (a: (x: number) => void): typeof a; (a: any): any; }
 >a : (x: number) => void
 >x : number
 >a : (x: number) => void
@@ -51,7 +51,7 @@ declare function foo3(a: any): any;
 >a : any
 
 declare function foo4(a: (x: string, y: number) => string): typeof a;
->foo4 : { (a: (x: string, y: number) => string): (x: string, y: number) => string; (a: any): any; }
+>foo4 : { (a: (x: string, y: number) => string): typeof a; (a: any): any; }
 >a : (x: string, y: number) => string
 >x : string
 >y : number
@@ -62,7 +62,7 @@ declare function foo4(a: any): any;
 >a : any
 
 declare function foo5(a: (x: (arg: string) => number) => string): typeof a;
->foo5 : { (a: (x: (arg: string) => number) => string): (x: (arg: string) => number) => string; (a: any): any; }
+>foo5 : { (a: (x: (arg: string) => number) => string): typeof a; (a: any): any; }
 >a : (x: (arg: string) => number) => string
 >x : (arg: string) => number
 >arg : string
@@ -73,7 +73,7 @@ declare function foo5(a: any): any;
 >a : any
 
 declare function foo6(a: (x: (arg: Base) => Derived) => Base): typeof a;
->foo6 : { (a: (x: (arg: Base) => Derived) => Base): (x: (arg: Base) => Derived) => Base; (a: any): any; }
+>foo6 : { (a: (x: (arg: Base) => Derived) => Base): typeof a; (a: any): any; }
 >a : (x: (arg: Base) => Derived) => Base
 >x : (arg: Base) => Derived
 >arg : Base
@@ -87,7 +87,7 @@ declare function foo6(a: any): any;
 >a : any
 
 declare function foo7(a: (x: (arg: Base) => Derived) => (r: Base) => Derived): typeof a;
->foo7 : { (a: (x: (arg: Base) => Derived) => (r: Base) => Derived): (x: (arg: Base) => Derived) => (r: Base) => Derived; (a: any): any; }
+>foo7 : { (a: (x: (arg: Base) => Derived) => (r: Base) => Derived): typeof a; (a: any): any; }
 >a : (x: (arg: Base) => Derived) => (r: Base) => Derived
 >x : (arg: Base) => Derived
 >arg : Base
@@ -103,7 +103,7 @@ declare function foo7(a: any): any;
 >a : any
 
 declare function foo8(a: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived): typeof a;
->foo8 : { (a: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived): (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived; (a: any): any; }
+>foo8 : { (a: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived): typeof a; (a: any): any; }
 >a : (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived
 >x : (arg: Base) => Derived
 >arg : Base
@@ -123,7 +123,7 @@ declare function foo8(a: any): any;
 >a : any
 
 declare function foo9(a: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived): typeof a;
->foo9 : { (a: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived): (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived; (a: any): any; }
+>foo9 : { (a: (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived): typeof a; (a: any): any; }
 >a : (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived
 >x : (arg: Base) => Derived
 >arg : Base
@@ -143,7 +143,7 @@ declare function foo9(a: any): any;
 >a : any
 
 declare function foo10(a: (...x: Derived[]) => Derived): typeof a;
->foo10 : { (a: (...x: Derived[]) => Derived): (...x: Derived[]) => Derived; (a: any): any; }
+>foo10 : { (a: (...x: Derived[]) => Derived): typeof a; (a: any): any; }
 >a : (...x: Derived[]) => Derived
 >x : Derived[]
 >Derived : Derived
@@ -155,7 +155,7 @@ declare function foo10(a: any): any;
 >a : any
 
 declare function foo11(a: (x: { foo: string }, y: { foo: string; bar: string }) => Base): typeof a;
->foo11 : { (a: (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): (x: { foo: string; }, y: { foo: string; bar: string; }) => Base; (a: any): any; }
+>foo11 : { (a: (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): typeof a; (a: any): any; }
 >a : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
@@ -170,8 +170,8 @@ declare function foo11(a: any): any;
 >a : any
 
 declare function foo12(a: (x: Array<Base>, y: Array<Derived2>) => Array<Derived>): typeof a;
->foo12 : { (a: (x: Base[], y: Derived2[]) => Derived[]): (x: Base[], y: Derived2[]) => Derived[]; (a: any): any; }
->a : (x: Base[], y: Derived2[]) => Derived[]
+>foo12 : { (a: (x: Base[], y: Derived2[]) => Array<Derived>): typeof a; (a: any): any; }
+>a : (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -180,15 +180,15 @@ declare function foo12(a: (x: Array<Base>, y: Array<Derived2>) => Array<Derived>
 >Derived2 : Derived2
 >Array : T[]
 >Derived : Derived
->a : (x: Base[], y: Derived2[]) => Derived[]
+>a : (x: Base[], y: Derived2[]) => Array<Derived>
 
 declare function foo12(a: any): any;
->foo12 : { (a: (x: Base[], y: Derived2[]) => Derived[]): (x: Base[], y: Derived2[]) => Derived[]; (a: any): any; }
+>foo12 : { (a: (x: Base[], y: Derived2[]) => Array<Derived>): (x: Base[], y: Derived2[]) => Array<Derived>; (a: any): any; }
 >a : any
 
 declare function foo13(a: (x: Array<Base>, y: Array<Derived>) => Array<Derived>): typeof a;
->foo13 : { (a: (x: Base[], y: Derived[]) => Derived[]): (x: Base[], y: Derived[]) => Derived[]; (a: any): any; }
->a : (x: Base[], y: Derived[]) => Derived[]
+>foo13 : { (a: (x: Base[], y: Derived[]) => Array<Derived>): typeof a; (a: any): any; }
+>a : (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -197,14 +197,14 @@ declare function foo13(a: (x: Array<Base>, y: Array<Derived>) => Array<Derived>)
 >Derived : Derived
 >Array : T[]
 >Derived : Derived
->a : (x: Base[], y: Derived[]) => Derived[]
+>a : (x: Base[], y: Derived[]) => Array<Derived>
 
 declare function foo13(a: any): any;
->foo13 : { (a: (x: Base[], y: Derived[]) => Derived[]): (x: Base[], y: Derived[]) => Derived[]; (a: any): any; }
+>foo13 : { (a: (x: Base[], y: Derived[]) => Array<Derived>): (x: Base[], y: Derived[]) => Array<Derived>; (a: any): any; }
 >a : any
 
 declare function foo14(a: (x: { a: string; b: number }) => Object): typeof a;
->foo14 : { (a: (x: { a: string; b: number; }) => Object): (x: { a: string; b: number; }) => Object; (a: any): any; }
+>foo14 : { (a: (x: { a: string; b: number; }) => Object): typeof a; (a: any): any; }
 >a : (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
@@ -217,7 +217,7 @@ declare function foo14(a: any): any;
 >a : any
 
 declare function foo15(a: { 
->foo15 : { (a: { (x: number): number[]; (x: string): string[]; }): { (x: number): number[]; (x: string): string[]; }; (a: any): any; }
+>foo15 : { (a: { (x: number): number[]; (x: string): string[]; }): typeof a; (a: any): any; }
 >a : { (x: number): number[]; (x: string): string[]; }
 
     (x: number): number[];
@@ -234,7 +234,7 @@ declare function foo15(a: any): any;
 >a : any
 
 declare function foo16(a: {
->foo16 : { (a: { <T extends Derived>(x: T): number[]; <U extends Base>(x: U): number[]; }): { <T extends Derived>(x: T): number[]; <U extends Base>(x: U): number[]; }; (a: any): any; }
+>foo16 : { (a: { <T extends Derived>(x: T): number[]; <U extends Base>(x: U): number[]; }): typeof a; (a: any): any; }
 >a : { <T extends Derived>(x: T): number[]; <U extends Base>(x: U): number[]; }
 
     <T extends Derived>(x: T): number[];
@@ -257,7 +257,7 @@ declare function foo16(a: any): any;
 >a : any
 
 declare function foo17(a: {
->foo17 : { (a: { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }): { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }; (a: any): any; }
+>foo17 : { (a: { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }): typeof a; (a: any): any; }
 >a : { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }
 
     (x: (a: number) => number): number[];
@@ -276,7 +276,7 @@ declare function foo17(a: any): any;
 >a : any
 
 declare function foo18(a: {
->foo18 : { (a: { (x: { (a: number): number; (a: string): string; }): any[]; (x: { (a: boolean): boolean; (a: Date): Date; }): any[]; }): { (x: { (a: number): number; (a: string): string; }): any[]; (x: { (a: boolean): boolean; (a: Date): Date; }): any[]; }; (a: any): any; }
+>foo18 : { (a: { (x: { (a: number): number; (a: string): string; }): any[]; (x: { (a: boolean): boolean; (a: Date): Date; }): any[]; }): typeof a; (a: any): any; }
 >a : { (x: { (a: number): number; (a: string): string; }): any[]; (x: { (a: boolean): boolean; (a: Date): Date; }): any[]; }
 
     (x: {
@@ -802,9 +802,9 @@ var r12arg2 = (x: Array<Base>, y: Array<Derived2>) => <Array<Derived>>null;
 >null : null
 
 var r12 = foo12(r12arg1); // any
->r12 : (x: Base[], y: Derived2[]) => Derived[]
->foo12(r12arg1) : (x: Base[], y: Derived2[]) => Derived[]
->foo12 : { (a: (x: Base[], y: Derived2[]) => Derived[]): (x: Base[], y: Derived2[]) => Derived[]; (a: any): any; }
+>r12 : (x: Base[], y: Derived2[]) => Array<Derived>
+>foo12(r12arg1) : (x: Base[], y: Derived2[]) => Array<Derived>
+>foo12 : { (a: (x: Base[], y: Derived2[]) => Array<Derived>): (x: Base[], y: Derived2[]) => Array<Derived>; (a: any): any; }
 >r12arg1 : <T extends Base[]>(x: Base[], y: T) => Derived[]
 
 var r12a = [r12arg1, r12arg2];
@@ -847,9 +847,9 @@ var r13arg2 = (x: Array<Base>, y: Array<Derived>) => <Array<Derived>>null;
 >null : null
 
 var r13 = foo13(r13arg1); // any
->r13 : (x: Base[], y: Derived[]) => Derived[]
->foo13(r13arg1) : (x: Base[], y: Derived[]) => Derived[]
->foo13 : { (a: (x: Base[], y: Derived[]) => Derived[]): (x: Base[], y: Derived[]) => Derived[]; (a: any): any; }
+>r13 : (x: Base[], y: Derived[]) => Array<Derived>
+>foo13(r13arg1) : (x: Base[], y: Derived[]) => Array<Derived>
+>foo13 : { (a: (x: Base[], y: Derived[]) => Array<Derived>): (x: Base[], y: Derived[]) => Array<Derived>; (a: any): any; }
 >r13arg1 : <T extends Derived[]>(x: Base[], y: T) => T
 
 var r13a = [r13arg1, r13arg2];

--- a/tests/baselines/reference/subtypingWithCallSignaturesA.types
+++ b/tests/baselines/reference/subtypingWithCallSignaturesA.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesA.ts ===
 declare function foo3(cb: (x: number) => number): typeof cb;
->foo3 : (cb: (x: number) => number) => (x: number) => number
+>foo3 : (cb: (x: number) => number) => typeof cb
 >cb : (x: number) => number
 >x : number
 >cb : (x: number) => number

--- a/tests/baselines/reference/subtypingWithConstructSignatures2.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures2.types
@@ -21,7 +21,7 @@ class OtherDerived extends Base { bing: string; }
 >bing : string
 
 declare function foo1(a: new (x: number) => number[]): typeof a;
->foo1 : { (a: new (x: number) => number[]): new (x: number) => number[]; (a: any): any; }
+>foo1 : { (a: new (x: number) => number[]): typeof a; (a: any): any; }
 >a : new (x: number) => number[]
 >x : number
 >a : new (x: number) => number[]
@@ -31,7 +31,7 @@ declare function foo1(a: any): any;
 >a : any
 
 declare function foo2(a: new (x: number) => string[]): typeof a;
->foo2 : { (a: new (x: number) => string[]): new (x: number) => string[]; (a: any): any; }
+>foo2 : { (a: new (x: number) => string[]): typeof a; (a: any): any; }
 >a : new (x: number) => string[]
 >x : number
 >a : new (x: number) => string[]
@@ -41,7 +41,7 @@ declare function foo2(a: any): any;
 >a : any
 
 declare function foo3(a: new (x: number) => void): typeof a;
->foo3 : { (a: new (x: number) => void): new (x: number) => void; (a: any): any; }
+>foo3 : { (a: new (x: number) => void): typeof a; (a: any): any; }
 >a : new (x: number) => void
 >x : number
 >a : new (x: number) => void
@@ -51,7 +51,7 @@ declare function foo3(a: any): any;
 >a : any
 
 declare function foo4(a: new (x: string, y: number) => string): typeof a;
->foo4 : { (a: new (x: string, y: number) => string): new (x: string, y: number) => string; (a: any): any; }
+>foo4 : { (a: new (x: string, y: number) => string): typeof a; (a: any): any; }
 >a : new (x: string, y: number) => string
 >x : string
 >y : number
@@ -62,7 +62,7 @@ declare function foo4(a: any): any;
 >a : any
 
 declare function foo5(a: new (x: new (arg: string) => number) => string): typeof a;
->foo5 : { (a: new (x: new (arg: string) => number) => string): new (x: new (arg: string) => number) => string; (a: any): any; }
+>foo5 : { (a: new (x: new (arg: string) => number) => string): typeof a; (a: any): any; }
 >a : new (x: new (arg: string) => number) => string
 >x : new (arg: string) => number
 >arg : string
@@ -73,7 +73,7 @@ declare function foo5(a: any): any;
 >a : any
 
 declare function foo6(a: new (x: new (arg: Base) => Derived) => Base): typeof a;
->foo6 : { (a: new (x: new (arg: Base) => Derived) => Base): new (x: new (arg: Base) => Derived) => Base; (a: any): any; }
+>foo6 : { (a: new (x: new (arg: Base) => Derived) => Base): typeof a; (a: any): any; }
 >a : new (x: new (arg: Base) => Derived) => Base
 >x : new (arg: Base) => Derived
 >arg : Base
@@ -87,7 +87,7 @@ declare function foo6(a: any): any;
 >a : any
 
 declare function foo7(a: new (x: new (arg: Base) => Derived) => new (r: Base) => Derived): typeof a;
->foo7 : { (a: new (x: new (arg: Base) => Derived) => new (r: Base) => Derived): new (x: new (arg: Base) => Derived) => new (r: Base) => Derived; (a: any): any; }
+>foo7 : { (a: new (x: new (arg: Base) => Derived) => new (r: Base) => Derived): typeof a; (a: any): any; }
 >a : new (x: new (arg: Base) => Derived) => new (r: Base) => Derived
 >x : new (arg: Base) => Derived
 >arg : Base
@@ -103,7 +103,7 @@ declare function foo7(a: any): any;
 >a : any
 
 declare function foo8(a: new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived): typeof a;
->foo8 : { (a: new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived): new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived; (a: any): any; }
+>foo8 : { (a: new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived): typeof a; (a: any): any; }
 >a : new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived
 >x : new (arg: Base) => Derived
 >arg : Base
@@ -123,7 +123,7 @@ declare function foo8(a: any): any;
 >a : any
 
 declare function foo9(a: new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived): typeof a;
->foo9 : { (a: new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived): new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived; (a: any): any; }
+>foo9 : { (a: new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived): typeof a; (a: any): any; }
 >a : new (x: new (arg: Base) => Derived, y: new (arg2: Base) => Derived) => new (r: Base) => Derived
 >x : new (arg: Base) => Derived
 >arg : Base
@@ -143,7 +143,7 @@ declare function foo9(a: any): any;
 >a : any
 
 declare function foo10(a: new (...x: Derived[]) => Derived): typeof a;
->foo10 : { (a: new (...x: Derived[]) => Derived): new (...x: Derived[]) => Derived; (a: any): any; }
+>foo10 : { (a: new (...x: Derived[]) => Derived): typeof a; (a: any): any; }
 >a : new (...x: Derived[]) => Derived
 >x : Derived[]
 >Derived : Derived
@@ -155,7 +155,7 @@ declare function foo10(a: any): any;
 >a : any
 
 declare function foo11(a: new (x: { foo: string }, y: { foo: string; bar: string }) => Base): typeof a;
->foo11 : { (a: new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base; (a: any): any; }
+>foo11 : { (a: new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): typeof a; (a: any): any; }
 >a : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
@@ -170,8 +170,8 @@ declare function foo11(a: any): any;
 >a : any
 
 declare function foo12(a: new (x: Array<Base>, y: Array<Derived2>) => Array<Derived>): typeof a;
->foo12 : { (a: new (x: Base[], y: Derived2[]) => Derived[]): new (x: Base[], y: Derived2[]) => Derived[]; (a: any): any; }
->a : new (x: Base[], y: Derived2[]) => Derived[]
+>foo12 : { (a: new (x: Base[], y: Derived2[]) => Array<Derived>): typeof a; (a: any): any; }
+>a : new (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -180,15 +180,15 @@ declare function foo12(a: new (x: Array<Base>, y: Array<Derived2>) => Array<Deri
 >Derived2 : Derived2
 >Array : T[]
 >Derived : Derived
->a : new (x: Base[], y: Derived2[]) => Derived[]
+>a : new (x: Base[], y: Derived2[]) => Array<Derived>
 
 declare function foo12(a: any): any;
->foo12 : { (a: new (x: Base[], y: Derived2[]) => Derived[]): new (x: Base[], y: Derived2[]) => Derived[]; (a: any): any; }
+>foo12 : { (a: new (x: Base[], y: Derived2[]) => Array<Derived>): new (x: Base[], y: Derived2[]) => Array<Derived>; (a: any): any; }
 >a : any
 
 declare function foo13(a: new (x: Array<Base>, y: Array<Derived>) => Array<Derived>): typeof a;
->foo13 : { (a: new (x: Base[], y: Derived[]) => Derived[]): new (x: Base[], y: Derived[]) => Derived[]; (a: any): any; }
->a : new (x: Base[], y: Derived[]) => Derived[]
+>foo13 : { (a: new (x: Base[], y: Derived[]) => Array<Derived>): typeof a; (a: any): any; }
+>a : new (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -197,14 +197,14 @@ declare function foo13(a: new (x: Array<Base>, y: Array<Derived>) => Array<Deriv
 >Derived : Derived
 >Array : T[]
 >Derived : Derived
->a : new (x: Base[], y: Derived[]) => Derived[]
+>a : new (x: Base[], y: Derived[]) => Array<Derived>
 
 declare function foo13(a: any): any;
->foo13 : { (a: new (x: Base[], y: Derived[]) => Derived[]): new (x: Base[], y: Derived[]) => Derived[]; (a: any): any; }
+>foo13 : { (a: new (x: Base[], y: Derived[]) => Array<Derived>): new (x: Base[], y: Derived[]) => Array<Derived>; (a: any): any; }
 >a : any
 
 declare function foo14(a: new (x: { a: string; b: number }) => Object): typeof a;
->foo14 : { (a: new (x: { a: string; b: number; }) => Object): new (x: { a: string; b: number; }) => Object; (a: any): any; }
+>foo14 : { (a: new (x: { a: string; b: number; }) => Object): typeof a; (a: any): any; }
 >a : new (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
@@ -217,7 +217,7 @@ declare function foo14(a: any): any;
 >a : any
 
 declare function foo15(a: { 
->foo15 : { (a: { new (x: number): number[]; new (x: string): string[]; }): { new (x: number): number[]; new (x: string): string[]; }; (a: any): any; }
+>foo15 : { (a: { new (x: number): number[]; new (x: string): string[]; }): typeof a; (a: any): any; }
 >a : { new (x: number): number[]; new (x: string): string[]; }
 
     new (x: number): number[];
@@ -234,7 +234,7 @@ declare function foo15(a: any): any;
 >a : any
 
 declare function foo16(a: {
->foo16 : { (a: { new <T extends Derived>(x: T): number[]; new <U extends Base>(x: U): number[]; }): { new <T extends Derived>(x: T): number[]; new <U extends Base>(x: U): number[]; }; (a: any): any; }
+>foo16 : { (a: { new <T extends Derived>(x: T): number[]; new <U extends Base>(x: U): number[]; }): typeof a; (a: any): any; }
 >a : { new <T extends Derived>(x: T): number[]; new <U extends Base>(x: U): number[]; }
 
     new <T extends Derived>(x: T): number[];
@@ -257,7 +257,7 @@ declare function foo16(a: any): any;
 >a : any
 
 declare function foo17(a: {
->foo17 : { (a: { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }): { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }; (a: any): any; }
+>foo17 : { (a: { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }): typeof a; (a: any): any; }
 >a : { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }
 
     new (x: (a: number) => number): number[];
@@ -276,7 +276,7 @@ declare function foo17(a: any): any;
 >a : any
 
 declare function foo18(a: {
->foo18 : { (a: { new (x: { new (a: number): number; new (a: string): string; }): any[]; new (x: { new (a: boolean): boolean; new (a: Date): Date; }): any[]; }): { new (x: { new (a: number): number; new (a: string): string; }): any[]; new (x: { new (a: boolean): boolean; new (a: Date): Date; }): any[]; }; (a: any): any; }
+>foo18 : { (a: { new (x: { new (a: number): number; new (a: string): string; }): any[]; new (x: { new (a: boolean): boolean; new (a: Date): Date; }): any[]; }): typeof a; (a: any): any; }
 >a : { new (x: { new (a: number): number; new (a: string): string; }): any[]; new (x: { new (a: boolean): boolean; new (a: Date): Date; }): any[]; }
 
     new (x: {
@@ -711,7 +711,7 @@ var r11b = [r11arg2, r11arg1];
 >r11arg1 : new <T extends Base>(x: T, y: T) => T
 
 var r12arg1: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>;
->r12arg1 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
+>r12arg1 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 >T : T
 >Array : T[]
 >Base : Base
@@ -724,7 +724,7 @@ var r12arg1: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>
 >Derived : Derived
 
 var r12arg2: new (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
->r12arg2 : new (x: Base[], y: Derived2[]) => Derived[]
+>r12arg2 : new (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -735,22 +735,22 @@ var r12arg2: new (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
 >Derived : Derived
 
 var r12 = foo12(r12arg1); // any
->r12 : new (x: Base[], y: Derived2[]) => Derived[]
->foo12(r12arg1) : new (x: Base[], y: Derived2[]) => Derived[]
->foo12 : { (a: new (x: Base[], y: Derived2[]) => Derived[]): new (x: Base[], y: Derived2[]) => Derived[]; (a: any): any; }
->r12arg1 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
+>r12 : new (x: Base[], y: Derived2[]) => Array<Derived>
+>foo12(r12arg1) : new (x: Base[], y: Derived2[]) => Array<Derived>
+>foo12 : { (a: new (x: Base[], y: Derived2[]) => Array<Derived>): new (x: Base[], y: Derived2[]) => Array<Derived>; (a: any): any; }
+>r12arg1 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 
 var r12a = [r12arg1, r12arg2];
->r12a : (new (x: Base[], y: Derived2[]) => Derived[])[]
->[r12arg1, r12arg2] : (new (x: Base[], y: Derived2[]) => Derived[])[]
->r12arg1 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
->r12arg2 : new (x: Base[], y: Derived2[]) => Derived[]
+>r12a : (new (x: Base[], y: Derived2[]) => Array<Derived>)[]
+>[r12arg1, r12arg2] : (new (x: Base[], y: Derived2[]) => Array<Derived>)[]
+>r12arg1 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
+>r12arg2 : new (x: Base[], y: Derived2[]) => Array<Derived>
 
 var r12b = [r12arg2, r12arg1];
->r12b : (new (x: Base[], y: Derived2[]) => Derived[])[]
->[r12arg2, r12arg1] : (new (x: Base[], y: Derived2[]) => Derived[])[]
->r12arg2 : new (x: Base[], y: Derived2[]) => Derived[]
->r12arg1 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
+>r12b : (new (x: Base[], y: Derived2[]) => Array<Derived>)[]
+>[r12arg2, r12arg1] : (new (x: Base[], y: Derived2[]) => Array<Derived>)[]
+>r12arg2 : new (x: Base[], y: Derived2[]) => Array<Derived>
+>r12arg1 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 
 var r13arg1: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T;
 >r13arg1 : new <T extends Derived[]>(x: Base[], y: T) => T
@@ -765,7 +765,7 @@ var r13arg1: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T;
 >T : T
 
 var r13arg2: new (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
->r13arg2 : new (x: Base[], y: Derived[]) => Derived[]
+>r13arg2 : new (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -776,21 +776,21 @@ var r13arg2: new (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
 >Derived : Derived
 
 var r13 = foo13(r13arg1); // any
->r13 : new (x: Base[], y: Derived[]) => Derived[]
->foo13(r13arg1) : new (x: Base[], y: Derived[]) => Derived[]
->foo13 : { (a: new (x: Base[], y: Derived[]) => Derived[]): new (x: Base[], y: Derived[]) => Derived[]; (a: any): any; }
+>r13 : new (x: Base[], y: Derived[]) => Array<Derived>
+>foo13(r13arg1) : new (x: Base[], y: Derived[]) => Array<Derived>
+>foo13 : { (a: new (x: Base[], y: Derived[]) => Array<Derived>): new (x: Base[], y: Derived[]) => Array<Derived>; (a: any): any; }
 >r13arg1 : new <T extends Derived[]>(x: Base[], y: T) => T
 
 var r13a = [r13arg1, r13arg2];
->r13a : (new (x: Base[], y: Derived[]) => Derived[])[]
->[r13arg1, r13arg2] : (new (x: Base[], y: Derived[]) => Derived[])[]
+>r13a : (new (x: Base[], y: Derived[]) => Array<Derived>)[]
+>[r13arg1, r13arg2] : (new (x: Base[], y: Derived[]) => Array<Derived>)[]
 >r13arg1 : new <T extends Derived[]>(x: Base[], y: T) => T
->r13arg2 : new (x: Base[], y: Derived[]) => Derived[]
+>r13arg2 : new (x: Base[], y: Derived[]) => Array<Derived>
 
 var r13b = [r13arg2, r13arg1];
->r13b : (new (x: Base[], y: Derived[]) => Derived[])[]
->[r13arg2, r13arg1] : (new (x: Base[], y: Derived[]) => Derived[])[]
->r13arg2 : new (x: Base[], y: Derived[]) => Derived[]
+>r13b : (new (x: Base[], y: Derived[]) => Array<Derived>)[]
+>[r13arg2, r13arg1] : (new (x: Base[], y: Derived[]) => Array<Derived>)[]
+>r13arg2 : new (x: Base[], y: Derived[]) => Array<Derived>
 >r13arg1 : new <T extends Derived[]>(x: Base[], y: T) => T
 
 var r14arg1: new <T>(x: { a: T; b: T }) => T;

--- a/tests/baselines/reference/subtypingWithConstructSignatures5.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures5.types
@@ -109,7 +109,7 @@ interface A { // T
 >Base : Base
 
     a12: new (x: Array<Base>, y: Array<Derived2>) => Array<Derived>;
->a12 : new (x: Base[], y: Derived2[]) => Derived[]
+>a12 : new (x: Base[], y: Derived2[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -120,7 +120,7 @@ interface A { // T
 >Derived : Derived
 
     a13: new (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
->a13 : new (x: Base[], y: Derived[]) => Derived[]
+>a13 : new (x: Base[], y: Derived[]) => Array<Derived>
 >x : Base[]
 >Array : T[]
 >Base : Base
@@ -278,7 +278,7 @@ interface I extends B {
 >T : T
 
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
->a12 : new <T extends Base[]>(x: Base[], y: T) => Derived[]
+>a12 : new <T extends Base[]>(x: Base[], y: T) => Array<Derived>
 >T : T
 >Array : T[]
 >Base : Base

--- a/tests/baselines/reference/symbolProperty59.types
+++ b/tests/baselines/reference/symbolProperty59.types
@@ -4,7 +4,7 @@ interface I {
 
     [Symbol.keyFor]: string;
 >[Symbol.keyFor] : string
->Symbol.keyFor : (sym: symbol) => string
+>Symbol.keyFor : (sym: symbol) => string | undefined
 >Symbol : SymbolConstructor
->keyFor : (sym: symbol) => string
+>keyFor : (sym: symbol) => string | undefined
 }

--- a/tests/baselines/reference/taggedTemplateStringsWithManyCallAndMemberExpressions.types
+++ b/tests/baselines/reference/taggedTemplateStringsWithManyCallAndMemberExpressions.types
@@ -9,7 +9,7 @@ interface I {
 >I : I
 
     member: {
->member : new (s: string) => new (n: number) => new () => boolean
+>member : new (s: string) => new (n: number) => {    new (): boolean;}
 
         new (s: string): {
 >s : string
@@ -31,13 +31,13 @@ var x = new new new f `abc${ 0 }def`.member("hello")(42) === true;
 >new new new f `abc${ 0 }def`.member("hello")(42) === true : boolean
 >new new new f `abc${ 0 }def`.member("hello")(42) : boolean
 >new new f `abc${ 0 }def`.member("hello")(42) : new () => boolean
->new f `abc${ 0 }def`.member("hello") : new (n: number) => new () => boolean
->f `abc${ 0 }def`.member : new (s: string) => new (n: number) => new () => boolean
+>new f `abc${ 0 }def`.member("hello") : new (n: number) => {    new (): boolean;}
+>f `abc${ 0 }def`.member : new (s: string) => new (n: number) => {    new (): boolean;}
 >f `abc${ 0 }def` : I
 >f : I
 >`abc${ 0 }def` : string
 >0 : 0
->member : new (s: string) => new (n: number) => new () => boolean
+>member : new (s: string) => new (n: number) => {    new (): boolean;}
 >"hello" : "hello"
 >42 : 42
 >true : true

--- a/tests/baselines/reference/taggedTemplateStringsWithManyCallAndMemberExpressionsES6.types
+++ b/tests/baselines/reference/taggedTemplateStringsWithManyCallAndMemberExpressionsES6.types
@@ -9,7 +9,7 @@ interface I {
 >I : I
 
     member: {
->member : new (s: string) => new (n: number) => new () => boolean
+>member : new (s: string) => new (n: number) => {    new (): boolean;}
 
         new (s: string): {
 >s : string
@@ -31,13 +31,13 @@ var x = new new new f `abc${ 0 }def`.member("hello")(42) === true;
 >new new new f `abc${ 0 }def`.member("hello")(42) === true : boolean
 >new new new f `abc${ 0 }def`.member("hello")(42) : boolean
 >new new f `abc${ 0 }def`.member("hello")(42) : new () => boolean
->new f `abc${ 0 }def`.member("hello") : new (n: number) => new () => boolean
->f `abc${ 0 }def`.member : new (s: string) => new (n: number) => new () => boolean
+>new f `abc${ 0 }def`.member("hello") : new (n: number) => {    new (): boolean;}
+>f `abc${ 0 }def`.member : new (s: string) => new (n: number) => {    new (): boolean;}
 >f `abc${ 0 }def` : I
 >f : I
 >`abc${ 0 }def` : string
 >0 : 0
->member : new (s: string) => new (n: number) => new () => boolean
+>member : new (s: string) => new (n: number) => {    new (): boolean;}
 >"hello" : "hello"
 >42 : 42
 >true : true

--- a/tests/baselines/reference/targetTypeVoidFunc.types
+++ b/tests/baselines/reference/targetTypeVoidFunc.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/targetTypeVoidFunc.ts ===
 function f1(): { new (): number; } {
->f1 : () => new () => number
+>f1 : () => {    new (): number;}
 
     return function () { return; }
 >function () { return; } : () => void
@@ -10,7 +10,7 @@ function f1(): { new (): number; } {
 var x = f1();
 >x : new () => number
 >f1() : new () => number
->f1 : () => new () => number
+>f1 : () => {    new (): number;}
 
 var y = new x();
 >y : number
@@ -22,5 +22,5 @@ var z = new (f1())();
 >new (f1())() : number
 >(f1()) : new () => number
 >f1() : new () => number
->f1 : () => new () => number
+>f1 : () => {    new (): number;}
 

--- a/tests/baselines/reference/thisTypeErrors.types
+++ b/tests/baselines/reference/thisTypeErrors.types
@@ -10,7 +10,7 @@ var x3: this[];
 >x3 : any[]
 
 function f1(x: this): this {
->f1 : (x: any) => any
+>f1 : (x: any) => this
 >x : any
 
     var y: this;
@@ -28,18 +28,18 @@ interface I1 {
 >x : any
 
     b: { (): this };
->b : () => any
+>b : () => this
 
     c: { new (): this };
->c : new () => any
+>c : new () => this
 
     d: { [x: string]: this };
 >d : { [x: string]: any; }
 >x : string
 
     e: { f(x: this): this };
->e : { f(x: any): any; }
->f : (x: any) => any
+>e : { f(x: any): this; }
+>f : (x: any) => this
 >x : any
 }
 
@@ -51,18 +51,18 @@ class C1 {
 >x : any
 
     b: { (): this };
->b : () => any
+>b : () => this
 
     c: { new (): this };
->c : new () => any
+>c : new () => this
 
     d: { [x: string]: this };
 >d : { [x: string]: any; }
 >x : string
 
     e: { f(x: this): this };
->e : { f(x: any): any; }
->f : (x: any) => any
+>e : { f(x: any): this; }
+>f : (x: any) => this
 >x : any
 }
 
@@ -78,7 +78,7 @@ class C2 {
 >undefined : undefined
 
     static foo(x: this): this {
->foo : (x: any) => any
+>foo : (x: any) => this
 >x : any
 
         return undefined;
@@ -101,11 +101,11 @@ class C3 {
 >C3 : C3
 
     x1 = {
->x1 : { g(x: any): any; }
->{        g(x: this): this {            return undefined;        }    } : { g(x: any): any; }
+>x1 : { g(x: any): this; }
+>{        g(x: this): this {            return undefined;        }    } : { g(x: any): this; }
 
         g(x: this): this {
->g : (x: any) => any
+>g : (x: any) => this
 >x : any
 
             return undefined;
@@ -116,18 +116,18 @@ class C3 {
 >f : () => void
 
         function g(x: this): this {
->g : (x: any) => any
+>g : (x: any) => this
 >x : any
 
             return undefined;
 >undefined : undefined
         }
         let x2 = {
->x2 : { h(x: any): any; }
->{            h(x: this): this {                return undefined;            }        } : { h(x: any): any; }
+>x2 : { h(x: any): this; }
+>{            h(x: this): this {                return undefined;            }        } : { h(x: any): this; }
 
             h(x: this): this {
->h : (x: any) => any
+>h : (x: any) => this
 >x : any
 
                 return undefined;

--- a/tests/baselines/reference/transformNestedGeneratorsWithTry.types
+++ b/tests/baselines/reference/transformNestedGeneratorsWithTry.types
@@ -4,14 +4,14 @@ import * as Bluebird from 'bluebird';
 >Bluebird : PromiseConstructor
 
 async function a(): Bluebird<void> {
->a : () => Promise<void>
+>a : () => Bluebird<void>
 >Bluebird : Promise<T>
 
   try {
     const b = async function b(): Bluebird<void> {
->b : () => Promise<void>
->async function b(): Bluebird<void> {      try {        await Bluebird.resolve(); // -- remove this and it compiles      } catch (error) { }    } : () => Promise<void>
->b : () => Promise<void>
+>b : () => Bluebird<void>
+>async function b(): Bluebird<void> {      try {        await Bluebird.resolve(); // -- remove this and it compiles      } catch (error) { }    } : () => Bluebird<void>
+>b : () => Bluebird<void>
 >Bluebird : Promise<T>
 
       try {
@@ -30,7 +30,7 @@ async function a(): Bluebird<void> {
     await b(); // -- or remove this and it compiles
 >await b() : void
 >b() : Promise<void>
->b : () => Promise<void>
+>b : () => Bluebird<void>
 
   } catch (error) { }
 >error : any

--- a/tests/baselines/reference/tsxTypeArgumentPartialDefinitionStillErrors.types
+++ b/tests/baselines/reference/tsxTypeArgumentPartialDefinitionStillErrors.types
@@ -6,7 +6,7 @@ declare namespace JSX {
 >Element : Element
 
         render(): Element | string | false;
->render : () => string | false | Element
+>render : () => Element | string | false
 >Element : Element
 >false : false
     }

--- a/tests/baselines/reference/typeInferenceLiteralUnion.types
+++ b/tests/baselines/reference/typeInferenceLiteralUnion.types
@@ -48,7 +48,7 @@ class NumCoercible {
  * Return the min and max simultaneously.
  */
 export function extent<T extends Numeric>(array: Array<T | Primitive>): [T | Primitive, T | Primitive] | [undefined, undefined] {
->extent : <T extends Numeric>(array: (string | number | boolean | Date | T)[]) => [string | number | boolean | Date | T, string | number | boolean | Date | T] | [undefined, undefined]
+>extent : <T extends Numeric>(array: (string | number | boolean | Date | T)[]) => [T | Primitive, T | Primitive] | [undefined, undefined]
 >T : T
 >Numeric : Numeric
 >array : (string | number | boolean | Date | T)[]

--- a/tests/baselines/reference/typePredicateStructuralMatch.types
+++ b/tests/baselines/reference/typePredicateStructuralMatch.types
@@ -3,24 +3,24 @@
 
 getResults1([]);
 >getResults1([]) : Result[]
->getResults1 : (value: Result[] | { data: Result[]; }) => Result[]
+>getResults1 : (value: Result[] | { data: Result[]; }) => Results
 >[] : undefined[]
 
 getResults1({data: []});
 >getResults1({data: []}) : Result[]
->getResults1 : (value: Result[] | { data: Result[]; }) => Result[]
+>getResults1 : (value: Result[] | { data: Result[]; }) => Results
 >{data: []} : { data: undefined[]; }
 >data : undefined[]
 >[] : undefined[]
 
 getResults2([]);
 >getResults2([]) : Result[]
->getResults2 : (value: Result[] | { data: Result[]; }) => Result[]
+>getResults2 : (value: Result[] | { data: Result[]; }) => Results
 >[] : undefined[]
 
 getResults2({data: []});
 >getResults2({data: []}) : Result[]
->getResults2 : (value: Result[] | { data: Result[]; }) => Result[]
+>getResults2 : (value: Result[] | { data: Result[]; }) => Results
 >{data: []} : { data: undefined[]; }
 >data : undefined[]
 >[] : undefined[]
@@ -53,7 +53,7 @@ function isResponseInData<T>(value: T | { data: T}): value is { data: T } {
 }
 
 function getResults1(value: Results | { data: Results }): Results {
->getResults1 : (value: Result[] | { data: Result[]; }) => Result[]
+>getResults1 : (value: Result[] | { data: Result[]; }) => Results
 >value : Result[] | { data: Result[]; }
 >Results : Result[]
 >data : Result[]
@@ -91,7 +91,7 @@ function isPlainResponse<T>(value: T | { data: T}): value is T {
 }
 
 function getResults2(value: Results | { data: Results }): Results {
->getResults2 : (value: Result[] | { data: Result[]; }) => Result[]
+>getResults2 : (value: Result[] | { data: Result[]; }) => Results
 >value : Result[] | { data: Result[]; }
 >Results : Result[]
 >data : Result[]

--- a/tests/baselines/reference/typeReferenceDirectives13.types
+++ b/tests/baselines/reference/typeReferenceDirectives13.types
@@ -7,7 +7,7 @@ export interface A {
 >A : A
 
     x: () => typeof $
->x : () => { x: number; }
+>x : () => typeof $
 >$ : { x: number; }
 }
 

--- a/tests/baselines/reference/uniqueSymbols.types
+++ b/tests/baselines/reference/uniqueSymbols.types
@@ -100,7 +100,7 @@ function funcReturnVarCall() { return varCall; }
 
 // function return value with type query
 function funcReturnConstCallWithTypeQuery(): typeof constCall { return constCall; }
->funcReturnConstCallWithTypeQuery : () => unique symbol
+>funcReturnConstCallWithTypeQuery : () => typeof constCall
 >constCall : unique symbol
 >constCall : unique symbol
 
@@ -122,7 +122,7 @@ function* genFuncYieldVarCall() { yield varCall; }
 
 // generator function yield with return type query
 function* genFuncYieldConstCallWithTypeQuery(): IterableIterator<typeof constCall> { yield constCall; }
->genFuncYieldConstCallWithTypeQuery : () => IterableIterator<unique symbol>
+>genFuncYieldConstCallWithTypeQuery : () => IterableIterator<typeof constCall>
 >IterableIterator : IterableIterator<T>
 >constCall : unique symbol
 >yield constCall : any
@@ -804,26 +804,26 @@ interface Context {
 >Context : Context
 
     method1(): typeof s;
->method1 : () => unique symbol
+>method1 : () => typeof s
 >s : unique symbol
 
     method2(): Promise<typeof s>;
->method2 : () => Promise<unique symbol>
+>method2 : () => Promise<typeof s>
 >Promise : Promise<T>
 >s : unique symbol
 
     method3(): AsyncIterableIterator<typeof s>;
->method3 : () => AsyncIterableIterator<unique symbol>
+>method3 : () => AsyncIterableIterator<typeof s>
 >AsyncIterableIterator : AsyncIterableIterator<T>
 >s : unique symbol
 
     method4(): IterableIterator<typeof s>;
->method4 : () => IterableIterator<unique symbol>
+>method4 : () => IterableIterator<typeof s>
 >IterableIterator : IterableIterator<T>
 >s : unique symbol
 
     method5(p?: typeof s): typeof s;
->method5 : (p?: unique symbol) => unique symbol
+>method5 : (p?: unique symbol) => typeof s
 >p : unique symbol
 >s : unique symbol
 >s : unique symbol
@@ -878,11 +878,11 @@ const o3: Context = {
 // allowed when not emitting declarations
 
 const o4 = {
->o4 : { method1(p: unique symbol): unique symbol; method2(p: unique symbol): unique symbol; }
->{    method1(p: typeof s): typeof s {        return p;    },    method2(p: I["readonlyType"]): I["readonlyType"] {        return p;    }} : { method1(p: unique symbol): unique symbol; method2(p: unique symbol): unique symbol; }
+>o4 : { method1(p: unique symbol): typeof s; method2(p: unique symbol): I["readonlyType"]; }
+>{    method1(p: typeof s): typeof s {        return p;    },    method2(p: I["readonlyType"]): I["readonlyType"] {        return p;    }} : { method1(p: unique symbol): typeof s; method2(p: unique symbol): I["readonlyType"]; }
 
     method1(p: typeof s): typeof s {
->method1 : (p: unique symbol) => unique symbol
+>method1 : (p: unique symbol) => typeof s
 >p : unique symbol
 >s : unique symbol
 >s : unique symbol
@@ -892,7 +892,7 @@ const o4 = {
 
     },
     method2(p: I["readonlyType"]): I["readonlyType"] {
->method2 : (p: unique symbol) => unique symbol
+>method2 : (p: unique symbol) => I["readonlyType"]
 >p : unique symbol
 >I : I
 >I : I
@@ -907,7 +907,7 @@ const ce0 = class {
 >class {    method1(p: typeof s): typeof s {        return p;    }    method2(p: I["readonlyType"]): I["readonlyType"] {        return p;    }} : typeof ce0
 
     method1(p: typeof s): typeof s {
->method1 : (p: unique symbol) => unique symbol
+>method1 : (p: unique symbol) => typeof s
 >p : unique symbol
 >s : unique symbol
 >s : unique symbol
@@ -916,7 +916,7 @@ const ce0 = class {
 >p : unique symbol
     }
     method2(p: I["readonlyType"]): I["readonlyType"] {
->method2 : (p: unique symbol) => unique symbol
+>method2 : (p: unique symbol) => I["readonlyType"]
 >p : unique symbol
 >I : I
 >I : I

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.types
@@ -100,7 +100,7 @@ function funcReturnVarCall() { return varCall; }
 
 // function return value with type query
 function funcReturnConstCallWithTypeQuery(): typeof constCall { return constCall; }
->funcReturnConstCallWithTypeQuery : () => unique symbol
+>funcReturnConstCallWithTypeQuery : () => typeof constCall
 >constCall : unique symbol
 >constCall : unique symbol
 
@@ -122,7 +122,7 @@ function* genFuncYieldVarCall() { yield varCall; }
 
 // generator function yield with return type query
 function* genFuncYieldConstCallWithTypeQuery(): IterableIterator<typeof constCall> { yield constCall; }
->genFuncYieldConstCallWithTypeQuery : () => IterableIterator<unique symbol>
+>genFuncYieldConstCallWithTypeQuery : () => IterableIterator<typeof constCall>
 >IterableIterator : IterableIterator<T>
 >constCall : unique symbol
 >yield constCall : any
@@ -804,26 +804,26 @@ interface Context {
 >Context : Context
 
     method1(): typeof s;
->method1 : () => unique symbol
+>method1 : () => typeof s
 >s : unique symbol
 
     method2(): Promise<typeof s>;
->method2 : () => Promise<unique symbol>
+>method2 : () => Promise<typeof s>
 >Promise : Promise<T>
 >s : unique symbol
 
     method3(): AsyncIterableIterator<typeof s>;
->method3 : () => AsyncIterableIterator<unique symbol>
+>method3 : () => AsyncIterableIterator<typeof s>
 >AsyncIterableIterator : AsyncIterableIterator<T>
 >s : unique symbol
 
     method4(): IterableIterator<typeof s>;
->method4 : () => IterableIterator<unique symbol>
+>method4 : () => IterableIterator<typeof s>
 >IterableIterator : IterableIterator<T>
 >s : unique symbol
 
     method5(p?: typeof s): typeof s;
->method5 : (p?: unique symbol) => unique symbol
+>method5 : (p?: unique symbol) => typeof s
 >p : unique symbol
 >s : unique symbol
 >s : unique symbol

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsErrors.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsErrors.types
@@ -9,11 +9,11 @@ interface I { readonly readonlyType: unique symbol; }
 // not allowed when emitting declarations
 
 export const obj = {
->obj : { method1(p: unique symbol): unique symbol; method2(p: unique symbol): unique symbol; }
->{    method1(p: typeof s): typeof s {        return p;    },    method2(p: I["readonlyType"]): I["readonlyType"] {        return p;    }} : { method1(p: unique symbol): unique symbol; method2(p: unique symbol): unique symbol; }
+>obj : { method1(p: unique symbol): typeof s; method2(p: unique symbol): unique symbol; }
+>{    method1(p: typeof s): typeof s {        return p;    },    method2(p: I["readonlyType"]): I["readonlyType"] {        return p;    }} : { method1(p: unique symbol): typeof s; method2(p: unique symbol): unique symbol; }
 
     method1(p: typeof s): typeof s {
->method1 : (p: unique symbol) => unique symbol
+>method1 : (p: unique symbol) => typeof s
 >p : unique symbol
 >s : unique symbol
 >s : unique symbol
@@ -38,7 +38,7 @@ export const classExpression = class {
 >class {    method1(p: typeof s): typeof s {        return p;    }    method2(p: I["readonlyType"]): I["readonlyType"] {        return p;    }} : typeof classExpression
 
     method1(p: typeof s): typeof s {
->method1 : (p: unique symbol) => unique symbol
+>method1 : (p: unique symbol) => typeof s
 >p : unique symbol
 >s : unique symbol
 >s : unique symbol

--- a/tests/baselines/reference/uniqueSymbolsErrors.types
+++ b/tests/baselines/reference/uniqueSymbolsErrors.types
@@ -20,7 +20,7 @@ declare function invalidRestArgType(...arg: (unique symbol)[]): void;
 >arg : symbol[]
 
 declare function invalidReturnType(): unique symbol;
->invalidReturnType : () => symbol
+>invalidReturnType : () => unique symbol
 
 declare function invalidThisType(this: unique symbol): void;
 >invalidThisType : (this: symbol) => void
@@ -61,7 +61,7 @@ class InvalidClass {
 >args : symbol[]
 
     invalidReturnType(): unique symbol { return; }
->invalidReturnType : () => symbol
+>invalidReturnType : () => unique symbol
 
     invalidThisType(this: unique symbol): void { return; }
 >invalidThisType : (this: symbol) => void
@@ -99,7 +99,7 @@ class InvalidClass {
 >args : symbol[]
 
     static invalidStaticReturnType(): unique symbol { return; }
->invalidStaticReturnType : () => symbol
+>invalidStaticReturnType : () => unique symbol
 
     static invalidStaticThisType(this: unique symbol): void { return; }
 >invalidStaticThisType : (this: symbol) => void
@@ -142,7 +142,7 @@ interface InvalidInterface {
 >args : symbol[]
 
     invalidReturnType(): unique symbol;
->invalidReturnType : () => symbol
+>invalidReturnType : () => unique symbol
 
     invalidThisType(this: unique symbol);
 >invalidThisType : (this: symbol) => any
@@ -178,7 +178,7 @@ type InvalidTypeLiteral = {
 >args : symbol[]
 
     invalidReturnType(): unique symbol;
->invalidReturnType : () => symbol
+>invalidReturnType : () => unique symbol
 
     invalidThisType(this: unique symbol);
 >invalidThisType : (this: symbol) => any

--- a/tests/baselines/reference/useRegexpGroups.types
+++ b/tests/baselines/reference/useRegexpGroups.types
@@ -6,9 +6,9 @@ let re = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/u;
 let result = re.exec("2015-01-02");
 >result : RegExpExecArray
 >re.exec("2015-01-02") : RegExpExecArray
->re.exec : (string: string) => RegExpExecArray
+>re.exec : (string: string) => RegExpExecArray | null
 >re : RegExp
->exec : (string: string) => RegExpExecArray
+>exec : (string: string) => RegExpExecArray | null
 >"2015-01-02" : "2015-01-02"
 
 let date = result[0];
@@ -65,9 +65,9 @@ let foo = "foo".match(/(?<bar>foo)/)!.groups.foo;
 >"foo".match(/(?<bar>foo)/)!.groups : { [key: string]: string; }
 >"foo".match(/(?<bar>foo)/)! : RegExpMatchArray
 >"foo".match(/(?<bar>foo)/) : RegExpMatchArray
->"foo".match : { (regexp: string | RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
+>"foo".match : { (regexp: string | RegExp): RegExpMatchArray | null; (matcher: { [Symbol.match](string: string): RegExpMatchArray | null; }): RegExpMatchArray | null; }
 >"foo" : "foo"
->match : { (regexp: string | RegExp): RegExpMatchArray; (matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray; }
+>match : { (regexp: string | RegExp): RegExpMatchArray | null; (matcher: { [Symbol.match](string: string): RegExpMatchArray | null; }): RegExpMatchArray | null; }
 >/(?<bar>foo)/ : RegExp
 >groups : { [key: string]: string; }
 >foo : string

--- a/tests/cases/compiler/declarationEmitWillUseAliasForName.ts
+++ b/tests/cases/compiler/declarationEmitWillUseAliasForName.ts
@@ -1,0 +1,8 @@
+// @declaration: true
+// @filename: a.ts
+export interface I { x: number; }
+export type J = I;
+
+// @filename: b.ts
+import { J } from './a';
+export const f = (): J => ({ x: 0 });

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceComments.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceComments.ts
@@ -38,7 +38,7 @@ verify.codeFix({
 class C implements N.I {
     /** property prefix */ a /** colon prefix */: N.E.a;
     /** property prefix */ b /** colon prefix */: N.E;
-    /**method signature prefix */ foo /**open angle prefix */<X>(a: X): string {
+    /**method signature prefix */ foo /**open angle prefix */<X>(a: X): string /** semicolon prefix */ {
         throw new Error("Method not implemented.");
     }
 }`,

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceComputedPropertyNameWellKnownSymbols.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceComputedPropertyNameWellKnownSymbols.ts
@@ -55,7 +55,7 @@ class C implements I<number> {
     [Symbol.species](): number {
         throw new Error("Method not implemented.");
     }
-    [Symbol.split](str: string, limit?: number): {} {
+    [Symbol.split](str: string, limit?: number): string[] {
         throw new Error("Method not implemented.");
     }
     [Symbol.toPrimitive](hint: "number"): number;


### PR DESCRIPTION
In #23280 @andy-ms brought up that we never preserve aliases used to create inferred types (which makes sense, given that we immediately collapse type aliases down to their target types). With this PR, we preserve and clone return types of signatures (and thereby their aliases) provided they still yield the same type in the new context. This won't solve the issue in the OP of #23280 (as the alias is annotated within the function body and not as the signature return type node itself), but does make @andy-ms's simplified example work as one may hope.

I'm not 100% sold on this _always_ being a good thing (checkout the type baselines for all the places where `any` became a copy of the erroneous declaration that generated `any`), but it does produce nice results in many places (including preserving input style).