### PR TITLE
Fix bug: isSymbolReferencedInFile should return true for shorthand property assignment

### DIFF
--- a/src/harness/unittests/organizeImports.ts
+++ b/src/harness/unittests/organizeImports.ts
@@ -247,6 +247,15 @@ import D from "lib";
                 },
                 libFile);
 
+            testOrganizeImports("Unused_false_positive_shorthand_assignment",
+            {
+                    path: "/test.ts",
+                    content: `
+import { x } from "a";
+const o = { x };
+`
+                });
+
             testOrganizeImports("MoveToTop",
                 {
                     path: "/test.ts",

--- a/src/harness/unittests/organizeImports.ts
+++ b/src/harness/unittests/organizeImports.ts
@@ -256,6 +256,15 @@ const o = { x };
 `
                 });
 
+            testOrganizeImports("Unused_false_positive_export_shorthand",
+            {
+                    path: "/test.ts",
+                    content: `
+import { x } from "a";
+export { x };
+`
+                });
+
             testOrganizeImports("MoveToTop",
                 {
                     path: "/test.ts",

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -708,8 +708,11 @@ namespace ts.FindAllReferences.Core {
         if (!symbol) return true; // Be lenient with invalid code.
         return getPossibleSymbolReferencePositions(sourceFile, symbol.name).some(position => {
             const token = tryCast(getTouchingPropertyName(sourceFile, position, /*includeJsDocComment*/ true), isIdentifier);
-            return token && token !== definition && token.escapedText === definition.escapedText
-                && (checker.getSymbolAtLocation(token) === symbol || checker.getShorthandAssignmentValueSymbol(token.parent) === symbol);
+            if (!token || token === definition || token.escapedText !== definition.escapedText) return false;
+            const referenceSymbol = checker.getSymbolAtLocation(token);
+            return referenceSymbol === symbol
+                || checker.getShorthandAssignmentValueSymbol(token.parent) === symbol
+                || isExportSpecifier(token.parent) && getLocalSymbolForExportSpecifier(token, referenceSymbol, token.parent, checker) === symbol;
         });
     }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -708,7 +708,8 @@ namespace ts.FindAllReferences.Core {
         if (!symbol) return true; // Be lenient with invalid code.
         return getPossibleSymbolReferencePositions(sourceFile, symbol.name).some(position => {
             const token = tryCast(getTouchingPropertyName(sourceFile, position, /*includeJsDocComment*/ true), isIdentifier);
-            return token && token !== definition && token.escapedText === definition.escapedText && checker.getSymbolAtLocation(token) === symbol;
+            return token && token !== definition && token.escapedText === definition.escapedText
+                && (checker.getSymbolAtLocation(token) === symbol || checker.getShorthandAssignmentValueSymbol(token.parent) === symbol);
         });
     }
 

--- a/tests/baselines/reference/organizeImports/Unused_false_positive_export_shorthand.ts
+++ b/tests/baselines/reference/organizeImports/Unused_false_positive_export_shorthand.ts
@@ -1,0 +1,9 @@
+// ==ORIGINAL==
+
+import { x } from "a";
+export { x };
+
+// ==ORGANIZED==
+
+import { x } from "a";
+export { x };

--- a/tests/baselines/reference/organizeImports/Unused_false_positive_shorthand_assignment.ts
+++ b/tests/baselines/reference/organizeImports/Unused_false_positive_shorthand_assignment.ts
@@ -1,0 +1,9 @@
+// ==ORIGINAL==
+
+import { x } from "a";
+const o = { x };
+
+// ==ORGANIZED==
+
+import { x } from "a";
+const o = { x };


### PR DESCRIPTION
Fixes #23308
