### PR TITLE
handle any'd method signature types (ie, from special property declarations)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19090,6 +19090,9 @@ namespace ts {
 
             const links = getNodeLinks(node);
             const type = getTypeOfSymbol(node.symbol);
+            if (isTypeAny(type)) {
+                return type;
+            }
 
             // Check if function expression is contextually typed and assign parameter types if so.
             if (!(links.flags & NodeCheckFlags.ContextChecked)) {

--- a/tests/baselines/reference/allowJscheckJsTypeParameterNoCrash.errors.txt
+++ b/tests/baselines/reference/allowJscheckJsTypeParameterNoCrash.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/app.js(6,7): error TS2322: Type '1' is not assignable to type 'WatchHandler<any>'.
+
+
+==== tests/cases/compiler/func.ts (0 errors) ====
+    interface ComponentOptions<V> {
+        watch: Record<string, WatchHandler<any>>;
+    }
+    type WatchHandler<T> = (val: T) => void;
+    declare function extend(options: ComponentOptions<{}>): void;
+    export var vextend = extend;
+==== tests/cases/compiler/app.js (1 errors) ====
+    import {vextend} from './func';
+    // hover on vextend
+    export var a = vextend({
+      watch: {
+        data1(val) {
+          this.data2 = 1;
+          ~~~~~~~~~~
+!!! error TS2322: Type '1' is not assignable to type 'WatchHandler<any>'.
+        },
+        data2(val) { },
+      }
+    });

--- a/tests/baselines/reference/allowJscheckJsTypeParameterNoCrash.js
+++ b/tests/baselines/reference/allowJscheckJsTypeParameterNoCrash.js
@@ -1,0 +1,38 @@
+//// [tests/cases/compiler/allowJscheckJsTypeParameterNoCrash.ts] ////
+
+//// [func.ts]
+interface ComponentOptions<V> {
+    watch: Record<string, WatchHandler<any>>;
+}
+type WatchHandler<T> = (val: T) => void;
+declare function extend(options: ComponentOptions<{}>): void;
+export var vextend = extend;
+//// [app.js]
+import {vextend} from './func';
+// hover on vextend
+export var a = vextend({
+  watch: {
+    data1(val) {
+      this.data2 = 1;
+    },
+    data2(val) { },
+  }
+});
+
+//// [func.js]
+"use strict";
+exports.__esModule = true;
+exports.vextend = extend;
+//// [app.js]
+"use strict";
+exports.__esModule = true;
+var func_1 = require("./func");
+// hover on vextend
+exports.a = func_1.vextend({
+    watch: {
+        data1: function (val) {
+            this.data2 = 1;
+        },
+        data2: function (val) { }
+    }
+});

--- a/tests/baselines/reference/allowJscheckJsTypeParameterNoCrash.symbols
+++ b/tests/baselines/reference/allowJscheckJsTypeParameterNoCrash.symbols
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/func.ts ===
+interface ComponentOptions<V> {
+>ComponentOptions : Symbol(ComponentOptions, Decl(func.ts, 0, 0))
+>V : Symbol(V, Decl(func.ts, 0, 27))
+
+    watch: Record<string, WatchHandler<any>>;
+>watch : Symbol(ComponentOptions.watch, Decl(func.ts, 0, 31))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>WatchHandler : Symbol(WatchHandler, Decl(func.ts, 2, 1))
+}
+type WatchHandler<T> = (val: T) => void;
+>WatchHandler : Symbol(WatchHandler, Decl(func.ts, 2, 1))
+>T : Symbol(T, Decl(func.ts, 3, 18))
+>val : Symbol(val, Decl(func.ts, 3, 24))
+>T : Symbol(T, Decl(func.ts, 3, 18))
+
+declare function extend(options: ComponentOptions<{}>): void;
+>extend : Symbol(extend, Decl(func.ts, 3, 40))
+>options : Symbol(options, Decl(func.ts, 4, 24))
+>ComponentOptions : Symbol(ComponentOptions, Decl(func.ts, 0, 0))
+
+export var vextend = extend;
+>vextend : Symbol(vextend, Decl(func.ts, 5, 10))
+>extend : Symbol(extend, Decl(func.ts, 3, 40))
+
+=== tests/cases/compiler/app.js ===
+import {vextend} from './func';
+>vextend : Symbol(vextend, Decl(app.js, 0, 8))
+
+// hover on vextend
+export var a = vextend({
+>a : Symbol(a, Decl(app.js, 2, 10))
+>vextend : Symbol(vextend, Decl(app.js, 0, 8))
+
+  watch: {
+>watch : Symbol(watch, Decl(app.js, 2, 24))
+
+    data1(val) {
+>data1 : Symbol(data1, Decl(app.js, 3, 10))
+>val : Symbol(val, Decl(app.js, 4, 10))
+
+      this.data2 = 1;
+>this : Symbol(__type, Decl(lib.d.ts, --, --))
+>data2 : Symbol(data2, Decl(app.js, 4, 16), Decl(app.js, 6, 6))
+
+    },
+    data2(val) { },
+>data2 : Symbol(data2, Decl(app.js, 4, 16), Decl(app.js, 6, 6))
+>val : Symbol(val, Decl(app.js, 7, 10))
+  }
+});

--- a/tests/baselines/reference/allowJscheckJsTypeParameterNoCrash.types
+++ b/tests/baselines/reference/allowJscheckJsTypeParameterNoCrash.types
@@ -1,0 +1,57 @@
+=== tests/cases/compiler/func.ts ===
+interface ComponentOptions<V> {
+>ComponentOptions : ComponentOptions<V>
+>V : V
+
+    watch: Record<string, WatchHandler<any>>;
+>watch : Record<string, (val: any) => void>
+>Record : Record<K, T>
+>WatchHandler : (val: T) => void
+}
+type WatchHandler<T> = (val: T) => void;
+>WatchHandler : (val: T) => void
+>T : T
+>val : T
+>T : T
+
+declare function extend(options: ComponentOptions<{}>): void;
+>extend : (options: ComponentOptions<{}>) => void
+>options : ComponentOptions<{}>
+>ComponentOptions : ComponentOptions<V>
+
+export var vextend = extend;
+>vextend : (options: ComponentOptions<{}>) => void
+>extend : (options: ComponentOptions<{}>) => void
+
+=== tests/cases/compiler/app.js ===
+import {vextend} from './func';
+>vextend : (options: ComponentOptions<{}>) => void
+
+// hover on vextend
+export var a = vextend({
+>a : void
+>vextend({  watch: {    data1(val) {      this.data2 = 1;    },    data2(val) { },  }}) : void
+>vextend : (options: ComponentOptions<{}>) => void
+>{  watch: {    data1(val) {      this.data2 = 1;    },    data2(val) { },  }} : { watch: { data1(val: any): void; }; }
+
+  watch: {
+>watch : { data1(val: any): void; }
+>{    data1(val) {      this.data2 = 1;    },    data2(val) { },  } : { data1(val: any): void; }
+
+    data1(val) {
+>data1 : (val: any) => void
+>val : any
+
+      this.data2 = 1;
+>this.data2 = 1 : 1
+>this.data2 : (val: any) => void
+>this : Record<string, (val: any) => void>
+>data2 : (val: any) => void
+>1 : 1
+
+    },
+    data2(val) { },
+>data2 : any
+>val : any
+  }
+});

--- a/tests/cases/compiler/allowJscheckJsTypeParameterNoCrash.ts
+++ b/tests/cases/compiler/allowJscheckJsTypeParameterNoCrash.ts
@@ -1,0 +1,21 @@
+// @checkJs: true
+// @allowJs: true
+// @outDir: ./dist
+// @filename: func.ts
+interface ComponentOptions<V> {
+    watch: Record<string, WatchHandler<any>>;
+}
+type WatchHandler<T> = (val: T) => void;
+declare function extend(options: ComponentOptions<{}>): void;
+export var vextend = extend;
+// @filename: app.js
+import {vextend} from './func';
+// hover on vextend
+export var a = vextend({
+  watch: {
+    data1(val) {
+      this.data2 = 1;
+    },
+    data2(val) { },
+  }
+});


### PR DESCRIPTION
Fixes #23198

I ended up not changing the binder to just prioritize the method because it's not really set up to do so (in addition to changing the symbol's `valueDeclaration`, its flags would also need to be modified), and as it turns out the property type mismatch error generation code iterates over all the declarations in some way anyway.