### PR TITLE
Update outdated comments

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -577,7 +577,6 @@ namespace ts {
         const packageIdToSourceFile = createMap<SourceFile>();
         // Maps from a SourceFile's `.path` to the name of the package it was imported with.
         let sourceFileToPackageName = createMap<string>();
-        // See `sourceFileIsRedirectedTo`.
         let redirectTargetsSet = createMap<true>();
 
         const filesByName = createMap<SourceFile | undefined>();

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2527,7 +2527,7 @@ namespace ts {
         /**
          * If two source files are for the same version of the same package, one will redirect to the other.
          * (See `createRedirectSourceFile` in program.ts.)
-         * The redirect will have this set. The other will not have anything set, but see Program#sourceFileIsRedirectedTo.
+         * The redirect will have this set. The redirected-to source file will be in `redirectTargetsSet`.
          */
         /* @internal */ redirectInfo?: RedirectInfo | undefined;
 


### PR DESCRIPTION
These comments were left behind after later commits in #16274 -- `sourceFileIsRedirectedTo` no longer exists, only `redirectTargetsSet` does.