### PR TITLE
Don't copy trivia when implementing an interface

### DIFF
--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -25,7 +25,7 @@ namespace ts.codefix {
         }
 
         const declaration = declarations[0];
-        const name = getSynthesizedDeepCloneWithoutTrivia(getNameOfDeclaration(declaration)) as PropertyName;
+        const name = getSynthesizedDeepClone(getNameOfDeclaration(declaration), /*includeTrivia*/ false) as PropertyName;
         const visibilityModifier = createVisibilityModifier(getModifierFlags(declaration));
         const modifiers = visibilityModifier ? createNodeArray([visibilityModifier]) : undefined;
         const type = checker.getWidenedType(checker.getTypeOfSymbolAtLocation(symbol, enclosingDeclaration));
@@ -68,7 +68,7 @@ namespace ts.codefix {
 
                 for (const signature of signatures) {
                     // Need to ensure nodes are fresh each time so they can have different positions.
-                    outputMethod(signature, getSynthesizedDeepClonesWithoutTrivia(modifiers), getSynthesizedDeepCloneWithoutTrivia(name));
+                    outputMethod(signature, getSynthesizedDeepClones(modifiers, /*includeTrivia*/ false), getSynthesizedDeepClone(name, /*includeTrivia*/ false));
                 }
 
                 if (declarations.length > signatures.length) {

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -25,8 +25,7 @@ namespace ts.codefix {
         }
 
         const declaration = declarations[0];
-        // Clone name to remove leading trivia.
-        const name = getSynthesizedDeepClone(getNameOfDeclaration(declaration)) as PropertyName;
+        const name = getSynthesizedDeepCloneWithoutTrivia(getNameOfDeclaration(declaration)) as PropertyName;
         const visibilityModifier = createVisibilityModifier(getModifierFlags(declaration));
         const modifiers = visibilityModifier ? createNodeArray([visibilityModifier]) : undefined;
         const type = checker.getWidenedType(checker.getTypeOfSymbolAtLocation(symbol, enclosingDeclaration));
@@ -69,7 +68,7 @@ namespace ts.codefix {
 
                 for (const signature of signatures) {
                     // Need to ensure nodes are fresh each time so they can have different positions.
-                    outputMethod(signature, getSynthesizedDeepClones(modifiers), getSynthesizedDeepClone(name));
+                    outputMethod(signature, getSynthesizedDeepClonesWithoutTrivia(modifiers), getSynthesizedDeepCloneWithoutTrivia(name));
                 }
 
                 if (declarations.length > signatures.length) {
@@ -101,10 +100,6 @@ namespace ts.codefix {
         signatureDeclaration.questionToken = optional ? createToken(SyntaxKind.QuestionToken) : undefined;
         signatureDeclaration.body = body;
         return signatureDeclaration;
-    }
-
-    function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T> | undefined): NodeArray<T> | undefined {
-        return nodes && createNodeArray(nodes.map(getSynthesizedDeepClone));
     }
 
     export function createMethodFromCallExpression(

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1488,8 +1488,18 @@ namespace ts {
         return visited;
     }
 
+    export function getSynthesizedDeepCloneWithoutTrivia<T extends Node>(node: T): T {
+       const clone = getSynthesizedDeepClone(node);
+       suppressLeadingAndTrailingTrivia(clone);
+       return clone;
+    }
+
     export function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T> | undefined): NodeArray<T> | undefined {
         return nodes && createNodeArray(nodes.map(getSynthesizedDeepClone), nodes.hasTrailingComma);
+    }
+
+    export function getSynthesizedDeepClonesWithoutTrivia<T extends Node>(nodes: NodeArray<T> | undefined): NodeArray<T> | undefined {
+        return nodes && createNodeArray(nodes.map(getSynthesizedDeepCloneWithoutTrivia), nodes.hasTrailingComma);
     }
 
     /**

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1459,11 +1459,13 @@ namespace ts {
      * WARNING: This is an expensive operation and is only intended to be used in refactorings
      * and code fixes (because those are triggered by explicit user actions).
      */
-    export function getSynthesizedDeepClone<T extends Node>(node: T | undefined): T | undefined {
-        if (node === undefined) {
-            return undefined;
-        }
+    export function getSynthesizedDeepClone<T extends Node>(node: T | undefined, includeTrivia = true): T | undefined {
+        const clone = node && getSynthesizedDeepCloneWorker(node);
+        if (clone && !includeTrivia) suppressLeadingAndTrailingTrivia(clone);
+        return clone;
+    }
 
+    function getSynthesizedDeepCloneWorker<T extends Node>(node: T): T | undefined {
         const visited = visitEachChild(node, getSynthesizedDeepClone, nullTransformationContext);
         if (visited === node) {
             // This only happens for leaf nodes - internal nodes always see their children change.
@@ -1474,32 +1476,18 @@ namespace ts {
             else if (isNumericLiteral(clone)) {
                 clone.numericLiteralFlags = (node as any).numericLiteralFlags;
             }
-            clone.pos = node.pos;
-            clone.end = node.end;
-            return clone;
+            return setTextRange(clone, node);
         }
 
         // PERF: As an optimization, rather than calling getSynthesizedClone, we'll update
         // the new node created by visitEachChild with the extra changes getSynthesizedClone
         // would have made.
-
         visited.parent = undefined;
-
         return visited;
     }
 
-    export function getSynthesizedDeepCloneWithoutTrivia<T extends Node>(node: T): T {
-       const clone = getSynthesizedDeepClone(node);
-       suppressLeadingAndTrailingTrivia(clone);
-       return clone;
-    }
-
-    export function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T> | undefined): NodeArray<T> | undefined {
-        return nodes && createNodeArray(nodes.map(getSynthesizedDeepClone), nodes.hasTrailingComma);
-    }
-
-    export function getSynthesizedDeepClonesWithoutTrivia<T extends Node>(nodes: NodeArray<T> | undefined): NodeArray<T> | undefined {
-        return nodes && createNodeArray(nodes.map(getSynthesizedDeepCloneWithoutTrivia), nodes.hasTrailingComma);
+    export function getSynthesizedDeepClones<T extends Node>(nodes: NodeArray<T> | undefined, includeTrivia = true): NodeArray<T> | undefined {
+        return nodes && createNodeArray(nodes.map(n => getSynthesizedDeepClone(n, includeTrivia)), nodes.hasTrailingComma);
     }
 
     /**

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceComments.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceComments.ts
@@ -36,9 +36,9 @@ verify.codeFix({
         /**close-brace prefix*/ }
 /**close-brace prefix*/ }
 class C implements N.I {
-    /** property prefix */ a /** colon prefix */: N.E.a;
-    /** property prefix */ b /** colon prefix */: N.E;
-    /**method signature prefix */ foo /**open angle prefix */<X>(a: X): string {
+    a: N.E.a;
+    b: N.E;
+    foo<X>(a: X): string {
         throw new Error("Method not implemented.");
     }
 }`,

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceMemberOrdering.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceMemberOrdering.ts
@@ -84,7 +84,6 @@ class C implements I {
     20: any;
     21: any;
     22: any;
-    /** a nice safe prime */
     23: any;
 }`,
 });


### PR DESCRIPTION
This was accidentally changed in #20338 to include the comments -- but we really shouldn't be copying the comments over from the base class.