### PR TITLE
--pretty-er output by default

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -57,14 +57,6 @@ namespace ts {
             description: Diagnostics.Stylize_errors_and_messages_using_color_and_context_experimental
         },
         {
-            name: "diagnosticStyle",
-            type: createMapFromTemplate({
-                auto: DiagnosticStyle.Auto,
-                pretty: DiagnosticStyle.Pretty,
-                simple: DiagnosticStyle.Simple,
-            }),
-        },
-        {
             name: "preserveWatchOutput",
             type: "boolean",
             showInSimplifiedHelpView: false,

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -56,6 +56,14 @@ namespace ts {
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Stylize_errors_and_messages_using_color_and_context_experimental
         },
+    {
+        name: "diagnosticStyle",
+        type: createMapFromTemplate({
+            auto: DiagnosticStyle.Auto,
+            pretty: DiagnosticStyle.Pretty,
+            simple: DiagnosticStyle.Simple,
+        }),
+    },
         {
             name: "preserveWatchOutput",
             type: "boolean",

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -56,14 +56,14 @@ namespace ts {
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Stylize_errors_and_messages_using_color_and_context_experimental
         },
-    {
-        name: "diagnosticStyle",
-        type: createMapFromTemplate({
-            auto: DiagnosticStyle.Auto,
-            pretty: DiagnosticStyle.Pretty,
-            simple: DiagnosticStyle.Simple,
-        }),
-    },
+        {
+            name: "diagnosticStyle",
+            type: createMapFromTemplate({
+                auto: DiagnosticStyle.Auto,
+                pretty: DiagnosticStyle.Pretty,
+                simple: DiagnosticStyle.Simple,
+            }),
+        },
         {
             name: "preserveWatchOutput",
             type: "boolean",

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -428,7 +428,7 @@ namespace ts {
         newLine: string;
         useCaseSensitiveFileNames: boolean;
         write(s: string): void;
-        writeOutputIsTty?(): boolean;
+        writeOutputIsTTY?(): boolean;
         readFile(path: string, encoding?: string): string | undefined;
         getFileSize?(path: string): number;
         writeFile(path: string, data: string, writeByteOrderMark?: boolean): void;
@@ -562,7 +562,7 @@ namespace ts {
                 write(s: string): void {
                     process.stdout.write(s);
                 },
-                writeOutputIsTty() {
+                writeOutputIsTTY() {
                     return process.stdout.isTTY;
                 },
                 readFile,

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -428,6 +428,7 @@ namespace ts {
         newLine: string;
         useCaseSensitiveFileNames: boolean;
         write(s: string): void;
+        writeOutputIsTty?(): boolean;
         readFile(path: string, encoding?: string): string | undefined;
         getFileSize?(path: string): number;
         writeFile(path: string, data: string, writeByteOrderMark?: boolean): void;
@@ -560,6 +561,9 @@ namespace ts {
                 useCaseSensitiveFileNames,
                 write(s: string): void {
                     process.stdout.write(s);
+                },
+                writeOutputIsTty() {
+                    return process.stdout.isTTY;
                 },
                 readFile,
                 writeFile,

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -27,7 +27,7 @@ namespace ts {
     function shouldBePretty(options: CompilerOptions) {
         if ((typeof options.pretty === "undefined" && typeof options.diagnosticStyle === "undefined") || options.diagnosticStyle === DiagnosticStyle.Auto) {
             return !!sys.writeOutputIsTty && sys.writeOutputIsTty();
-    }
+        }
         return options.diagnosticStyle === DiagnosticStyle.Pretty || options.pretty;
     }
 

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -25,8 +25,8 @@ namespace ts {
     }
 
     function shouldBePretty(options: CompilerOptions) {
-        if ((typeof options.pretty === "undefined")) {
-            return !!sys.writeOutputIsTty && sys.writeOutputIsTty();
+        if (typeof options.pretty === "undefined") {
+            return !!sys.writeOutputIsTTY && sys.writeOutputIsTTY();
         }
         return options.pretty;
     }

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -19,9 +19,16 @@ namespace ts {
 
     let reportDiagnostic = createDiagnosticReporter(sys);
     function updateReportDiagnostic(options: CompilerOptions) {
-        if (options.pretty) {
+        if (shouldBePretty(options)) {
             reportDiagnostic = createDiagnosticReporter(sys, /*pretty*/ true);
         }
+    }
+
+    function shouldBePretty(options: CompilerOptions) {
+        if ((typeof options.pretty === "undefined" && typeof options.diagnosticStyle === "undefined") || options.diagnosticStyle === DiagnosticStyle.Auto) {
+            return !!sys.writeOutputIsTty && sys.writeOutputIsTty();
+    }
+        return options.diagnosticStyle === DiagnosticStyle.Pretty || options.pretty;
     }
 
     function padLeft(s: string, length: number) {
@@ -159,7 +166,7 @@ namespace ts {
     }
 
     function createWatchStatusReporter(options: CompilerOptions) {
-        return ts.createWatchStatusReporter(sys, !!options.pretty);
+        return ts.createWatchStatusReporter(sys, shouldBePretty(options));
     }
 
     function createWatchOfConfigFile(configParseResult: ParsedCommandLine, optionsToExtend: CompilerOptions) {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -25,10 +25,10 @@ namespace ts {
     }
 
     function shouldBePretty(options: CompilerOptions) {
-        if ((typeof options.pretty === "undefined" && typeof options.diagnosticStyle === "undefined") || options.diagnosticStyle === DiagnosticStyle.Auto) {
+        if ((typeof options.pretty === "undefined")) {
             return !!sys.writeOutputIsTty && sys.writeOutputIsTty();
         }
-        return options.diagnosticStyle === DiagnosticStyle.Pretty || options.pretty;
+        return options.pretty;
     }
 
     function padLeft(s: string, length: number) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4194,7 +4194,6 @@ namespace ts {
         /* @internal */ preserveWatchOutput?: boolean;
         project?: string;
         /* @internal */ pretty?: boolean;
-        /* @internal */ diagnosticStyle?: DiagnosticStyle;
         reactNamespace?: string;
         jsxFactory?: string;
         removeComments?: boolean;
@@ -4290,13 +4289,6 @@ namespace ts {
     export const enum LanguageVariant {
         Standard,
         JSX,
-    }
-
-    /* @internal */
-    export const enum DiagnosticStyle {
-        Auto,
-        Pretty,
-        Simple,
     }
 
     /** Either a parsed command line or a parsed tsconfig.json */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4193,7 +4193,8 @@ namespace ts {
         preserveSymlinks?: boolean;
         /* @internal */ preserveWatchOutput?: boolean;
         project?: string;
-        /* @internal */ pretty?: DiagnosticStyle;
+        /* @internal */ pretty?: boolean;
+        /* @internal */ diagnosticStyle?: DiagnosticStyle;
         reactNamespace?: string;
         jsxFactory?: string;
         removeComments?: boolean;
@@ -4293,8 +4294,9 @@ namespace ts {
 
     /* @internal */
     export const enum DiagnosticStyle {
-        Simple,
+        Auto,
         Pretty,
+        Simple,
     }
 
     /** Either a parsed command line or a parsed tsconfig.json */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2888,7 +2888,7 @@ declare namespace ts {
         newLine: string;
         useCaseSensitiveFileNames: boolean;
         write(s: string): void;
-        writeOutputIsTty?(): boolean;
+        writeOutputIsTTY?(): boolean;
         readFile(path: string, encoding?: string): string | undefined;
         getFileSize?(path: string): number;
         writeFile(path: string, data: string, writeByteOrderMark?: boolean): void;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2888,6 +2888,7 @@ declare namespace ts {
         newLine: string;
         useCaseSensitiveFileNames: boolean;
         write(s: string): void;
+        writeOutputIsTty?(): boolean;
         readFile(path: string, encoding?: string): string | undefined;
         getFileSize?(path: string): number;
         writeFile(path: string, data: string, writeByteOrderMark?: boolean): void;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2888,7 +2888,7 @@ declare namespace ts {
         newLine: string;
         useCaseSensitiveFileNames: boolean;
         write(s: string): void;
-        writeOutputIsTty?(): boolean;
+        writeOutputIsTTY?(): boolean;
         readFile(path: string, encoding?: string): string | undefined;
         getFileSize?(path: string): number;
         writeFile(path: string, data: string, writeByteOrderMark?: boolean): void;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2888,6 +2888,7 @@ declare namespace ts {
         newLine: string;
         useCaseSensitiveFileNames: boolean;
         write(s: string): void;
+        writeOutputIsTty?(): boolean;
         readFile(path: string, encoding?: string): string | undefined;
         getFileSize?(path: string): number;
         writeFile(path: string, data: string, writeByteOrderMark?: boolean): void;


### PR DESCRIPTION
This pull request always makes TypeScript's output `--pretty` when the compiler can detect whether its "output device" is appropriate for more colorful output.

If TypeScript's output is a psuedo-TTY, then it will enable today's prettified output and emit escape characters to the console; however, when piping to another file or program, it will automatically turned off.

Programs that want to specify the behavior can specifically set `--pretty`, or the new `--diagnosticStyle` flag.

This PR also affords us the room to give more variation in out emit modes. For example, with `--diagnosticStyle`, we could have a more colorful simple/terse mode as requested in #10745.

Fixes #10488.