### PR TITLE
Better handling of typing installer events and consuming typing files in tsserver

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2987,18 +2987,19 @@ namespace ts {
     }
 
     /** Remove the *first* occurrence of `item` from the array. */
-    export function unorderedRemoveItem<T>(array: T[], item: T): void {
+    export function unorderedRemoveItem<T>(array: T[], item: T) {
         unorderedRemoveFirstItemWhere(array, element => element === item);
     }
 
     /** Remove the *first* element satisfying `predicate`. */
-    function unorderedRemoveFirstItemWhere<T>(array: T[], predicate: (element: T) => boolean): void {
+    function unorderedRemoveFirstItemWhere<T>(array: T[], predicate: (element: T) => boolean) {
         for (let i = 0; i < array.length; i++) {
             if (predicate(array[i])) {
                 unorderedRemoveItemAt(array, i);
-                break;
+                return true;
             }
         }
+        return false;
     }
 
     export type GetCanonicalFileName = (fileName: string) => string;

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2988,7 +2988,7 @@ namespace ts {
 
     /** Remove the *first* occurrence of `item` from the array. */
     export function unorderedRemoveItem<T>(array: T[], item: T) {
-        unorderedRemoveFirstItemWhere(array, element => element === item);
+        return unorderedRemoveFirstItemWhere(array, element => element === item);
     }
 
     /** Remove the *first* element satisfying `predicate`. */

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -7294,7 +7294,6 @@ namespace ts.projectSystem {
             const host = createServerHost(files);
             const session = createSession(host);
             const projectService = session.getProjectService();
-            debugger;
             session.executeCommandSeq<protocol.OpenRequest>({
                 command: protocol.CommandTypes.Open,
                 arguments: {

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -999,7 +999,7 @@ namespace ts.projectSystem {
             proj.updateGraph();
 
             assert.deepEqual(
-                proj.getCachedUnresolvedImportsPerFile_TestOnly().get(<Path>f1.path),
+                proj.cachedUnresolvedImportsPerFile.get(<Path>f1.path),
                 ["foo", "foo", "foo", "@bar/router", "@bar/common", "@bar/common"]
             );
 
@@ -1029,7 +1029,7 @@ namespace ts.projectSystem {
             const projectService = session.getProjectService();
             checkNumberOfProjects(projectService, { inferredProjects: 1 });
             const proj = projectService.inferredProjects[0];
-            const version1 = proj.getCachedUnresolvedImportsPerFile_TestOnly().getVersion();
+            const version1 = proj.lastCachedUnresolvedImportsList;
 
             // make a change that should not affect the structure of the program
             const changeRequest: server.protocol.ChangeRequest = {
@@ -1047,7 +1047,7 @@ namespace ts.projectSystem {
             };
             session.executeCommand(changeRequest);
             host.checkTimeoutQueueLengthAndRun(2); // This enqueues the updategraph and refresh inferred projects
-            const version2 = proj.getCachedUnresolvedImportsPerFile_TestOnly().getVersion();
+            const version2 = proj.lastCachedUnresolvedImportsList;
             assert.notEqual(version1, version2, "set of unresolved imports should change");
         });
 

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1006,7 +1006,7 @@ namespace ts.projectSystem {
             installer.installAll(/*expectedCount*/ 1);
         });
 
-        it("should recompute resolutions after typings are installed", () => {
+        it("cached unresolved typings are not recomputed if program structure did not change", () => {
             const host = createServerHost([]);
             const session = createSession(host);
             const f = {
@@ -1048,7 +1048,7 @@ namespace ts.projectSystem {
             session.executeCommand(changeRequest);
             host.checkTimeoutQueueLengthAndRun(2); // This enqueues the updategraph and refresh inferred projects
             const version2 = proj.lastCachedUnresolvedImportsList;
-            assert.notEqual(version1, version2, "set of unresolved imports should change");
+            assert.strictEqual(version1, version2, "set of unresolved imports should change");
         });
 
         it("expired cache entry (inferred project, should install typings)", () => {
@@ -1619,6 +1619,77 @@ namespace ts.projectSystem {
             });
             assert.isTrue(hasError);
             assert.deepEqual(commands, expectedCommands, "commands");
+        });
+    });
+
+    describe("recomputing resolutions of unresolved imports", () => {
+        const globalTypingsCacheLocation = "/tmp";
+        const appPath = "/a/b/app.js" as Path;
+        const foooPath = "/a/b/node_modules/fooo/index.d.ts";
+        function verifyResolvedModuleOfFooo(project: server.Project) {
+            const foooResolution = project.getLanguageService().getProgram().getSourceFileByPath(appPath).resolvedModules.get("fooo");
+            assert.equal(foooResolution.resolvedFileName, foooPath);
+            return foooResolution;
+        }
+
+        function verifyUnresolvedImportResolutions(appContents: string, typingNames: string[], typingFiles: FileOrFolder[]) {
+            const app: FileOrFolder = {
+                path: appPath,
+                content: `${appContents}import * as x from "fooo";`
+            };
+            const fooo: FileOrFolder = {
+                path: foooPath,
+                content: `export var x: string;`
+            };
+            const host = createServerHost([app, fooo]);
+            const installer = new (class extends Installer {
+                constructor() {
+                    super(host, { globalTypingsCacheLocation, typesRegistry: createTypesRegistry("foo") });
+                }
+                installWorker(_requestId: number, _args: string[], _cwd: string, cb: TI.RequestCompletedAction) {
+                    executeCommand(this, host, typingNames, typingFiles, cb);
+                }
+            })();
+            const projectService = createProjectService(host, { typingsInstaller: installer });
+            projectService.openClientFile(app.path);
+            projectService.checkNumberOfProjects({ inferredProjects: 1 });
+
+            const proj = projectService.inferredProjects[0];
+            checkProjectActualFiles(proj, [app.path, fooo.path]);
+            const foooResolution1 = verifyResolvedModuleOfFooo(proj);
+
+            installer.installAll(/*expectedCount*/ 1);
+            host.checkTimeoutQueueLengthAndRun(2);
+            checkProjectActualFiles(proj, typingFiles.map(f => f.path).concat(app.path, fooo.path));
+            const foooResolution2 = verifyResolvedModuleOfFooo(proj);
+            assert.strictEqual(foooResolution1, foooResolution2);
+        }
+
+        it("correctly invalidate the resolutions with typing names", () => {
+            verifyUnresolvedImportResolutions('import * as a from "foo";', ["foo"], [{
+                path: `${globalTypingsCacheLocation}/node_modules/foo/index.d.ts`,
+                content: "export function a(): void;"
+            }]);
+        });
+
+        it("correctly invalidate the resolutions with typing names that are trimmed", () => {
+            const fooAA: FileOrFolder = {
+                path: `${globalTypingsCacheLocation}/node_modules/foo/a/a.d.ts`,
+                content: "export function a (): void;"
+            };
+            const fooAB: FileOrFolder = {
+                path: `${globalTypingsCacheLocation}/node_modules/foo/a/b.d.ts`,
+                content: "export function b (): void;"
+            };
+            const fooAC: FileOrFolder = {
+                path: `${globalTypingsCacheLocation}/node_modules/foo/a/c.d.ts`,
+                content: "export function c (): void;"
+            };
+            verifyUnresolvedImportResolutions(`
+                    import * as a from "foo/a/a";
+                    import * as b from "foo/a/b";
+                    import * as c from "foo/a/c";
+            `, ["foo"], [fooAA, fooAB, fooAC]);
         });
     });
 }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -312,7 +312,8 @@ namespace ts.server {
 
     export class ProjectService {
 
-        public readonly typingsCache: TypingsCache;
+        /*@internal*/
+        readonly typingsCache: TypingsCache;
 
         private readonly documentRegistry: DocumentRegistry;
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -524,13 +524,13 @@ namespace ts.server {
             }
             switch (response.kind) {
                 case ActionSet:
-                    project.resolutionCache.clear();
-                    this.typingsCache.updateTypingsForProject(response.projectName, response.compilerOptions, response.typeAcquisition, response.unresolvedImports, response.typings);
+                    // Update the typing files and update the project
+                    project.updateTypingFiles(this.typingsCache.updateTypingsForProject(response.projectName, response.compilerOptions, response.typeAcquisition, response.unresolvedImports, response.typings));
                     break;
                 case ActionInvalidate:
-                    project.resolutionCache.clear();
-                    this.typingsCache.deleteTypingsForProject(response.projectName);
-                    break;
+                    // Do not clear resolution cache, there was changes detected in typings, so enque typing request and let it get us correct results
+                    this.typingsCache.enqueueInstallTypingsForProject(project, project.lastCachedUnresolvedImportsList, /*forceRefresh*/ true);
+                    return;
             }
             this.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(project);
         }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -99,7 +99,7 @@ namespace ts.server {
         /*@internal*/
         lastCachedUnresolvedImportsList: SortedReadonlyArray<string>;
         /*@internal*/
-        private hasMoreOrLessFiles = false;
+        private hasAddedorRemovedFiles = false;
 
         private lastFileExceededProgramSize: string | undefined;
 
@@ -777,8 +777,8 @@ namespace ts.server {
         }
 
         /* @internal */
-        setHasMoreOrLessFiles() {
-            this.hasMoreOrLessFiles = true;
+        onFileAddedOrRemoved() {
+            this.hasAddedorRemovedFiles = true;
         }
 
         /**
@@ -789,8 +789,8 @@ namespace ts.server {
             this.resolutionCache.startRecordingFilesWithChangedResolutions();
 
             const hasNewProgram = this.updateGraphWorker();
-            const hasMoreOrLessFiles = this.hasMoreOrLessFiles;
-            this.hasMoreOrLessFiles = false;
+            const hasAddedorRemovedFiles = this.hasAddedorRemovedFiles;
+            this.hasAddedorRemovedFiles = false;
 
             const changedFiles: ReadonlyArray<Path> = this.resolutionCache.finishRecordingFilesWithChangedResolutions() || emptyArray;
 
@@ -820,7 +820,7 @@ namespace ts.server {
                     this.lastCachedUnresolvedImportsList = result ? toDeduplicatedSortedArray(result) : emptyArray;
                 }
 
-                this.projectService.typingsCache.enqueueInstallTypingsForProject(this, this.lastCachedUnresolvedImportsList, hasMoreOrLessFiles);
+                this.projectService.typingsCache.enqueueInstallTypingsForProject(this, this.lastCachedUnresolvedImportsList, hasAddedorRemovedFiles);
             }
             else {
                 this.lastCachedUnresolvedImportsList = undefined;

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -92,6 +92,8 @@ namespace ts.server {
         cachedUnresolvedImportsPerFile = createMap<ReadonlyArray<string>>();
         /*@internal*/
         lastCachedUnresolvedImportsList: SortedReadonlyArray<string>;
+        /*@internal*/
+        hasMoreOrLessScriptInfos = false;
 
         private lastFileExceededProgramSize: string | undefined;
 
@@ -777,6 +779,8 @@ namespace ts.server {
             this.resolutionCache.startRecordingFilesWithChangedResolutions();
 
             let hasChanges = this.updateGraphWorker();
+            const hasMoreOrLessScriptInfos = this.hasMoreOrLessScriptInfos;
+            this.hasMoreOrLessScriptInfos = false;
 
             const changedFiles: ReadonlyArray<Path> = this.resolutionCache.finishRecordingFilesWithChangedResolutions() || emptyArray;
 
@@ -803,7 +807,7 @@ namespace ts.server {
                     this.lastCachedUnresolvedImportsList = toDeduplicatedSortedArray(result);
                 }
 
-                const cachedTypings = this.projectService.typingsCache.getTypingsForProject(this, this.lastCachedUnresolvedImportsList, hasChanges);
+                const cachedTypings = this.projectService.typingsCache.getTypingsForProject(this, this.lastCachedUnresolvedImportsList, hasMoreOrLessScriptInfos);
                 if (!arrayIsEqualTo(this.typingFiles, cachedTypings)) {
                     this.typingFiles = cachedTypings;
                     this.markAsDirty();

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -304,7 +304,7 @@ namespace ts.server {
             const isNew = !this.isAttached(project);
             if (isNew) {
                 this.containingProjects.push(project);
-                project.hasMoreOrLessScriptInfos = true;
+                project.setHasMoreOrLessFiles();
                 if (!project.getCompilerOptions().preserveSymlinks) {
                     this.ensureRealPath();
                 }
@@ -329,23 +329,23 @@ namespace ts.server {
                     return;
                 case 1:
                     if (this.containingProjects[0] === project) {
-                        project.hasMoreOrLessScriptInfos = true;
+                        project.setHasMoreOrLessFiles();
                         this.containingProjects.pop();
                     }
                     break;
                 case 2:
                     if (this.containingProjects[0] === project) {
-                        project.hasMoreOrLessScriptInfos = true;
+                        project.setHasMoreOrLessFiles();
                         this.containingProjects[0] = this.containingProjects.pop();
                     }
                     else if (this.containingProjects[1] === project) {
-                        project.hasMoreOrLessScriptInfos = true;
+                        project.setHasMoreOrLessFiles();
                         this.containingProjects.pop();
                     }
                     break;
                 default:
                     if (unorderedRemoveItem(this.containingProjects, project)) {
-                        project.hasMoreOrLessScriptInfos = true;
+                        project.setHasMoreOrLessFiles();
                     }
                     break;
             }

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -304,7 +304,7 @@ namespace ts.server {
             const isNew = !this.isAttached(project);
             if (isNew) {
                 this.containingProjects.push(project);
-                project.setHasMoreOrLessFiles();
+                project.onFileAddedOrRemoved();
                 if (!project.getCompilerOptions().preserveSymlinks) {
                     this.ensureRealPath();
                 }
@@ -329,23 +329,23 @@ namespace ts.server {
                     return;
                 case 1:
                     if (this.containingProjects[0] === project) {
-                        project.setHasMoreOrLessFiles();
+                        project.onFileAddedOrRemoved();
                         this.containingProjects.pop();
                     }
                     break;
                 case 2:
                     if (this.containingProjects[0] === project) {
-                        project.setHasMoreOrLessFiles();
+                        project.onFileAddedOrRemoved();
                         this.containingProjects[0] = this.containingProjects.pop();
                     }
                     else if (this.containingProjects[1] === project) {
-                        project.setHasMoreOrLessFiles();
+                        project.onFileAddedOrRemoved();
                         this.containingProjects.pop();
                     }
                     break;
                 default:
                     if (unorderedRemoveItem(this.containingProjects, project)) {
-                        project.setHasMoreOrLessFiles();
+                        project.onFileAddedOrRemoved();
                     }
                     break;
             }

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -304,6 +304,7 @@ namespace ts.server {
             const isNew = !this.isAttached(project);
             if (isNew) {
                 this.containingProjects.push(project);
+                project.hasMoreOrLessScriptInfos = true;
                 if (!project.getCompilerOptions().preserveSymlinks) {
                     this.ensureRealPath();
                 }
@@ -328,19 +329,24 @@ namespace ts.server {
                     return;
                 case 1:
                     if (this.containingProjects[0] === project) {
+                        project.hasMoreOrLessScriptInfos = true;
                         this.containingProjects.pop();
                     }
                     break;
                 case 2:
                     if (this.containingProjects[0] === project) {
+                        project.hasMoreOrLessScriptInfos = true;
                         this.containingProjects[0] = this.containingProjects.pop();
                     }
                     else if (this.containingProjects[1] === project) {
+                        project.hasMoreOrLessScriptInfos = true;
                         this.containingProjects.pop();
                     }
                     break;
                 default:
-                    unorderedRemoveItem(this.containingProjects, project);
+                    if (unorderedRemoveItem(this.containingProjects, project)) {
+                        project.hasMoreOrLessScriptInfos = true;
+                    }
                     break;
             }
         }

--- a/src/server/typingsCache.ts
+++ b/src/server/typingsCache.ts
@@ -95,15 +95,14 @@ namespace ts.server {
             return this.installer.installPackage(options);
         }
 
-        getTypingsForProject(project: Project, unresolvedImports: SortedReadonlyArray<string>, forceRefresh: boolean): SortedReadonlyArray<string> {
+        enqueueInstallTypingsForProject(project: Project, unresolvedImports: SortedReadonlyArray<string>, forceRefresh: boolean) {
             const typeAcquisition = project.getTypeAcquisition();
 
             if (!typeAcquisition || !typeAcquisition.enable) {
-                return <any>emptyArray;
+                return;
             }
 
             const entry = this.perProjectCache.get(project.getProjectName());
-            const result: SortedReadonlyArray<string> = entry ? entry.typings : <any>emptyArray;
             if (forceRefresh ||
                 !entry ||
                 typeAcquisitionChanged(typeAcquisition, entry.typeAcquisition) ||
@@ -114,28 +113,25 @@ namespace ts.server {
                 this.perProjectCache.set(project.getProjectName(), {
                     compilerOptions: project.getCompilationSettings(),
                     typeAcquisition,
-                    typings: result,
+                    typings: entry ? entry.typings : emptyArray,
                     unresolvedImports,
                     poisoned: true
                 });
                 // something has been changed, issue a request to update typings
                 this.installer.enqueueInstallTypingsRequest(project, typeAcquisition, unresolvedImports);
             }
-            return result;
         }
 
         updateTypingsForProject(projectName: string, compilerOptions: CompilerOptions, typeAcquisition: TypeAcquisition, unresolvedImports: SortedReadonlyArray<string>, newTypings: string[]) {
+            const typings = toSortedArray(newTypings);
             this.perProjectCache.set(projectName, {
                 compilerOptions,
                 typeAcquisition,
-                typings: toSortedArray(newTypings),
+                typings,
                 unresolvedImports,
                 poisoned: false
             });
-        }
-
-        deleteTypingsForProject(projectName: string) {
-            this.perProjectCache.delete(projectName);
+            return !typeAcquisition || !typeAcquisition.enable ? emptyArray : typings;
         }
 
         onProjectClosed(project: Project) {

--- a/src/server/typingsCache.ts
+++ b/src/server/typingsCache.ts
@@ -24,7 +24,7 @@ namespace ts.server {
         globalTypingsCacheLocation: undefined
     };
 
-    class TypingsCacheEntry {
+    interface TypingsCacheEntry {
         readonly typeAcquisition: TypeAcquisition;
         readonly compilerOptions: CompilerOptions;
         readonly typings: SortedReadonlyArray<string>;
@@ -80,6 +80,7 @@ namespace ts.server {
         return !arrayIsEqualTo(imports1, imports2);
     }
 
+    /*@internal*/
     export class TypingsCache {
         private readonly perProjectCache: Map<TypingsCacheEntry> = createMap<TypingsCacheEntry>();
 

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -64,11 +64,13 @@ namespace ts.server.typingsInstaller {
         onRequestCompleted: RequestCompletedAction;
     }
 
+    type ProjectWatchers = Map<FileWatcher> & { isInvoked?: boolean; };
+
     export abstract class TypingsInstaller {
         private readonly packageNameToTypingLocation: Map<JsTyping.CachedTyping> = createMap<JsTyping.CachedTyping>();
         private readonly missingTypingsSet: Map<true> = createMap<true>();
         private readonly knownCachesSet: Map<true> = createMap<true>();
-        private readonly projectWatchers = createMap<Map<FileWatcher>>();
+        private readonly projectWatchers = createMap<ProjectWatchers>();
         private safeList: JsTyping.SafeList | undefined;
         readonly pendingRunRequests: PendingRequest[] = [];
 
@@ -378,8 +380,8 @@ namespace ts.server.typingsInstaller {
                 this.projectWatchers.set(projectName, watchers);
             }
 
+            watchers.isInvoked = false;
             // handler should be invoked once for the entire set of files since it will trigger full rediscovery of typings
-            let isInvoked = false;
             const isLoggingEnabled = this.log.isEnabled();
             mutateMap(
                 watchers,
@@ -392,11 +394,11 @@ namespace ts.server.typingsInstaller {
                         }
                         const watcher = this.installTypingHost.watchFile(file, (f, eventKind) => {
                             if (isLoggingEnabled) {
-                                this.log.writeLine(`FileWatcher:: Triggered with ${f} eventKind: ${FileWatcherEventKind[eventKind]}:: WatchInfo: ${file}:: handler is already invoked '${isInvoked}'`);
+                                this.log.writeLine(`FileWatcher:: Triggered with ${f} eventKind: ${FileWatcherEventKind[eventKind]}:: WatchInfo: ${file}:: handler is already invoked '${watchers.isInvoked}'`);
                             }
-                            if (!isInvoked) {
+                            if (!watchers.isInvoked) {
+                                watchers.isInvoked = true;
                                 this.sendResponse({ projectName, kind: ActionInvalidate });
-                                isInvoked = true;
                             }
                         }, /*pollingInterval*/ 2000);
                         return isLoggingEnabled ? {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7602,17 +7602,6 @@ declare namespace ts.server {
         readonly globalTypingsCacheLocation: string;
     }
     const nullTypingsInstaller: ITypingsInstaller;
-    class TypingsCache {
-        private readonly installer;
-        private readonly perProjectCache;
-        constructor(installer: ITypingsInstaller);
-        isKnownTypesPackageName(name: string): boolean;
-        installPackage(options: InstallPackageOptionsWithProject): Promise<ApplyCodeActionCommandResult>;
-        getTypingsForProject(project: Project, unresolvedImports: SortedReadonlyArray<string>, forceRefresh: boolean): SortedReadonlyArray<string>;
-        updateTypingsForProject(projectName: string, compilerOptions: CompilerOptions, typeAcquisition: TypeAcquisition, unresolvedImports: SortedReadonlyArray<string>, newTypings: string[]): void;
-        deleteTypingsForProject(projectName: string): void;
-        onProjectClosed(project: Project): void;
-    }
 }
 declare namespace ts.server {
     enum ProjectKind {
@@ -7960,7 +7949,6 @@ declare namespace ts.server {
         syntaxOnly?: boolean;
     }
     class ProjectService {
-        readonly typingsCache: TypingsCache;
         private readonly documentRegistry;
         /**
          * Container of all known scripts

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7643,10 +7643,6 @@ declare namespace ts.server {
         private externalFiles;
         private missingFilesMap;
         private plugins;
-        /**
-         * This is the set that has entry to true if file doesnt contain any unresolved import
-         */
-        private filesWithNoUnresolvedImports;
         private lastFileExceededProgramSize;
         protected languageService: LanguageService;
         languageServiceEnabled: boolean;
@@ -7666,10 +7662,10 @@ declare namespace ts.server {
          */
         private lastReportedVersion;
         /**
-         * Current project structure version.
+         * Current project's program version. (incremented everytime new program is created that is not complete reuse from the old one)
          * This property is changed in 'updateGraph' based on the set of files in program
          */
-        private projectStructureVersion;
+        private projectProgramVersion;
         /**
          * Current version of the project state. It is changed when:
          * - new root file was added/removed

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7611,15 +7611,6 @@ declare namespace ts.server {
     }
     function allRootFilesAreJsOrDts(project: Project): boolean;
     function allFilesAreJsOrDts(project: Project): boolean;
-    class UnresolvedImportsMap {
-        readonly perFileMap: Map<ReadonlyArray<string>>;
-        private version;
-        clear(): void;
-        getVersion(): number;
-        remove(path: Path): void;
-        get(path: Path): ReadonlyArray<string>;
-        set(path: Path, value: ReadonlyArray<string>): void;
-    }
     interface PluginCreateInfo {
         project: Project;
         languageService: LanguageService;
@@ -7652,8 +7643,6 @@ declare namespace ts.server {
         private externalFiles;
         private missingFilesMap;
         private plugins;
-        private cachedUnresolvedImportsPerFile;
-        private lastCachedUnresolvedImportsList;
         private lastFileExceededProgramSize;
         protected languageService: LanguageService;
         languageServiceEnabled: boolean;
@@ -7688,7 +7677,6 @@ declare namespace ts.server {
         private readonly cancellationToken;
         isNonTsProject(): boolean;
         isJsOnlyProject(): boolean;
-        getCachedUnresolvedImportsPerFile_TestOnly(): UnresolvedImportsMap;
         static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void): {};
         isKnownTypesPackageName(name: string): boolean;
         installPackage(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult>;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7643,6 +7643,10 @@ declare namespace ts.server {
         private externalFiles;
         private missingFilesMap;
         private plugins;
+        /**
+         * This is the set that has entry to true if file doesnt contain any unresolved import
+         */
+        private filesWithNoUnresolvedImports;
         private lastFileExceededProgramSize;
         protected languageService: LanguageService;
         languageServiceEnabled: boolean;
@@ -7673,7 +7677,6 @@ declare namespace ts.server {
          * This property is different from projectStructureVersion since in most cases edits don't affect set of files in the project
          */
         private projectStateVersion;
-        private typingFiles;
         private readonly cancellationToken;
         isNonTsProject(): boolean;
         isJsOnlyProject(): boolean;


### PR DESCRIPTION
1. Removes unnecessary indirection of unresolved imports map
2. Force new typings resolution only if there are more or less script infos in the project. Earlier if program is not completely reused, we would enqueue new typing request, which is too frequent and not necessary. The unresolved imports and compiler options change is anyways detected to determine to queue typing request, so we want to force the typing request only if there are more or less source files in the program.
3. In update graph, do not re-update/create new program but rather just enqueue typing request. We would handle the typing files when there are events of setting typing files from typing installer.
4. When ActionSet event is received from typing installer, invalidate only files with unresolved imports and resolve those. The invalidation should be quite fast since it just passes list of files with unresolved imports and re-resolution happens during program creation.
5. When ActionInvalidate event is received, typing installer has detected some change in global typing cache location, so just enqueue a new typing installation request. This will repeat the cycle of setting correct typings and picking unresolved imports. Earlier we use to delete existing typing files and updated program. This meant there would be need to create new program with few files (all files - typing files) and then re-queuing the request and that would just be unnecessary step.
Note: this does not change any file/directory watches in typing installer. That needs to be handles irrespective of these changes.