### PR TITLE
Find-all-references: Don't crash on 'typeof import'

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3187,13 +3187,14 @@ namespace ts {
     export type AnyImportSyntax = ImportDeclaration | ImportEqualsDeclaration;
 
     /* @internal */
-    export type AnyImportOrReExport = AnyImportSyntax | ExportDeclaration;
+    export type AnyImportOrReExport = AnyImportSyntax | ExportDeclaration | ImportTypeNode;
 
     /* @internal */
     export type AnyValidImportOrReExport =
         | (ImportDeclaration | ExportDeclaration) & { moduleSpecifier: StringLiteral }
         | ImportEqualsDeclaration & { moduleReference: ExternalModuleReference & { expression: StringLiteral } }
-        | RequireOrImportCall;
+        | RequireOrImportCall
+        | ImportTypeNode & { argument: LiteralType };
 
     /* @internal */
     export type RequireOrImportCall = CallExpression & { arguments: [StringLiteralLike] };

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3187,7 +3187,7 @@ namespace ts {
     export type AnyImportSyntax = ImportDeclaration | ImportEqualsDeclaration;
 
     /* @internal */
-    export type AnyImportOrReExport = AnyImportSyntax | ExportDeclaration | ImportTypeNode;
+    export type AnyImportOrReExport = AnyImportSyntax | ExportDeclaration;
 
     /* @internal */
     export type AnyValidImportOrReExport =

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1710,8 +1710,10 @@ namespace ts {
                 return (node.parent as ExternalModuleReference).parent as AnyValidImportOrReExport;
             case SyntaxKind.CallExpression:
                 return node.parent as AnyValidImportOrReExport;
+            case SyntaxKind.LiteralType:
+                return cast(node.parent.parent, isImportTypeNode) as ImportTypeNode & { argument: LiteralType };
             default:
-                return Debug.fail(Debug.showSyntaxKind(node));
+                return Debug.fail(Debug.showSyntaxKind(node.parent));
         }
     }
 
@@ -4924,6 +4926,10 @@ namespace ts {
 
     export function isLiteralTypeNode(node: Node): node is LiteralTypeNode {
         return node.kind === SyntaxKind.LiteralType;
+    }
+
+    export function isImportTypeNode(node: Node): node is ImportTypeNode {
+        return node.kind === SyntaxKind.ImportType;
     }
 
     // Binding patterns

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -33,7 +33,7 @@ namespace ts.FindAllReferences {
     interface AmbientModuleDeclaration extends ModuleDeclaration { body?: ModuleBlock; }
     type SourceFileLike = SourceFile | AmbientModuleDeclaration;
     // Identifier for the case of `const x = require("y")`.
-    type Importer = AnyImportOrReExport | Identifier;
+    type Importer = AnyImportOrReExport | ImportTypeNode | Identifier;
     type ImporterOrCallExpression = Importer | CallExpression;
 
     /** Returns import statements that directly reference the exporting module, and a list of files that may access the module through a namespace. */

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -215,6 +215,10 @@ namespace ts.FindAllReferences {
                 return;
             }
 
+            if (decl.kind === SyntaxKind.ImportType) {
+                return;
+            }
+
             // Ignore if there's a grammar error
             if (decl.moduleSpecifier.kind !== SyntaxKind.StringLiteral) {
                 return;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3169,6 +3169,7 @@ declare namespace ts {
     function isIndexedAccessTypeNode(node: Node): node is IndexedAccessTypeNode;
     function isMappedTypeNode(node: Node): node is MappedTypeNode;
     function isLiteralTypeNode(node: Node): node is LiteralTypeNode;
+    function isImportTypeNode(node: Node): node is ImportTypeNode;
     function isObjectBindingPattern(node: Node): node is ObjectBindingPattern;
     function isArrayBindingPattern(node: Node): node is ArrayBindingPattern;
     function isBindingElement(node: Node): node is BindingElement;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3169,6 +3169,7 @@ declare namespace ts {
     function isIndexedAccessTypeNode(node: Node): node is IndexedAccessTypeNode;
     function isMappedTypeNode(node: Node): node is MappedTypeNode;
     function isLiteralTypeNode(node: Node): node is LiteralTypeNode;
+    function isImportTypeNode(node: Node): node is ImportTypeNode;
     function isObjectBindingPattern(node: Node): node is ObjectBindingPattern;
     function isArrayBindingPattern(node: Node): node is ArrayBindingPattern;
     function isBindingElement(node: Node): node is BindingElement;

--- a/tests/cases/fourslash/findAllRefsTypeofImport.ts
+++ b/tests/cases/fourslash/findAllRefsTypeofImport.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////export const [|{| "isWriteAccess": true, "isDefinition": true |}x|] = 0;
+////declare const a: typeof import("./a");
+////a.[|x|];
+
+verify.singleReferenceGroup("const x: 0");


### PR DESCRIPTION
Previously this was crashing because we expected a member of `SourceFile.imports` to be one of only a few kinds.