### PR TITLE
Normalize document highlights paths

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2910,10 +2910,6 @@ Actual: ${stringify(fullActual)}`);
         }
 
         private verifyDocumentHighlights(expectedRanges: Range[], fileNames: ReadonlyArray<string> = [this.activeFile.fileName]) {
-            expectedRanges = ts.map(expectedRanges, r => {
-                r.fileName = ts.normalizePath(r.fileName);
-                return r;
-            });
             fileNames = ts.map(fileNames, ts.normalizePath);
             const documentHighlights = this.getDocumentHighlightsAtCurrentPosition(fileNames) || [];
 
@@ -2924,7 +2920,7 @@ Actual: ${stringify(fullActual)}`);
             }
 
             for (const fileName of fileNames) {
-                const expectedRangesInFile = expectedRanges.filter(r => r.fileName === fileName);
+                const expectedRangesInFile = expectedRanges.filter(r => ts.normalizePath(r.fileName) === fileName);
                 const highlights = ts.find(documentHighlights, dh => dh.fileName === fileName);
                 const spansInFile = highlights ? highlights.highlightSpans.sort((s1, s2) => s1.textSpan.start - s2.textSpan.start) : [];
 

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -3231,7 +3231,7 @@ Actual: ${stringify(fullActual)}`);
 
                 const availableNames: string[] = [];
                 const result = ts.forEach(this.testData.files, file => {
-                    const fn = file.fileName;
+                    const fn = ts.normalizePath(file.fileName);
                     if (fn) {
                         if (fn === name) {
                             return file;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2910,6 +2910,11 @@ Actual: ${stringify(fullActual)}`);
         }
 
         private verifyDocumentHighlights(expectedRanges: Range[], fileNames: ReadonlyArray<string> = [this.activeFile.fileName]) {
+            expectedRanges = ts.map(expectedRanges, r => {
+                r.fileName = ts.normalizePath(r.fileName);
+                return r;
+            });
+            fileNames = ts.map(fileNames, ts.normalizePath);
             const documentHighlights = this.getDocumentHighlightsAtCurrentPosition(fileNames) || [];
 
             for (const dh of documentHighlights) {
@@ -3219,7 +3224,7 @@ Actual: ${stringify(fullActual)}`);
                 }
             }
             else if (ts.isString(indexOrName)) {
-                let name = indexOrName;
+                let name = ts.normalizePath(indexOrName);
 
                 // names are stored in the compiler with this relative path, this allows people to use goTo.file on just the fileName
                 name = name.indexOf("/") === -1 ? (this.basePath + "/" + name) : name;

--- a/src/harness/virtualFileSystem.ts
+++ b/src/harness/virtualFileSystem.ts
@@ -125,7 +125,7 @@ namespace Utils {
 
         addFile(path: string, content?: Harness.LanguageService.ScriptInfo) {
             const absolutePath = ts.normalizePath(ts.getNormalizedAbsolutePath(path, this.currentDirectory));
-            const fileName = ts.getBaseFileName(path);
+            const fileName = ts.getBaseFileName(absolutePath);
             const directoryPath = ts.getDirectoryPath(absolutePath);
             const directory = this.addDirectory(directoryPath);
             return directory ? directory.addFile(fileName, content) : undefined;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -793,7 +793,7 @@ namespace ts.server {
         private getDocumentHighlights(args: protocol.DocumentHighlightsRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.DocumentHighlightsItem> | ReadonlyArray<DocumentHighlights> {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
-            const documentHighlights = project.getLanguageService().getDocumentHighlights(file, position, args.filesToSearch);
+            const documentHighlights = project.getLanguageService().getDocumentHighlights(file, position, map(args.filesToSearch, toNormalizedPath));
 
             if (!documentHighlights) {
                 return emptyArray;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -793,7 +793,7 @@ namespace ts.server {
         private getDocumentHighlights(args: protocol.DocumentHighlightsRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.DocumentHighlightsItem> | ReadonlyArray<DocumentHighlights> {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
-            const documentHighlights = project.getLanguageService().getDocumentHighlights(file, position, map(args.filesToSearch, toNormalizedPath));
+            const documentHighlights = project.getLanguageService().getDocumentHighlights(file, position, args.filesToSearch);
 
             if (!documentHighlights) {
                 return emptyArray;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1673,8 +1673,7 @@ namespace ts {
         }
 
         function getDocumentHighlights(fileName: string, position: number, filesToSearch: ReadonlyArray<string>): DocumentHighlights[] {
-            filesToSearch = map(filesToSearch, normalizePath);
-            Debug.assert(contains(filesToSearch, fileName));
+            Debug.assert(contains(map(filesToSearch, normalizePath), fileName));
             synchronizeHostData();
             const sourceFilesToSearch = map(filesToSearch, f => Debug.assertDefined(program.getSourceFile(f)));
             const sourceFile = getValidSourceFile(fileName);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1673,6 +1673,7 @@ namespace ts {
         }
 
         function getDocumentHighlights(fileName: string, position: number, filesToSearch: ReadonlyArray<string>): DocumentHighlights[] {
+            filesToSearch = ts.map(filesToSearch, ts.normalizePath);
             Debug.assert(contains(filesToSearch, fileName));
             synchronizeHostData();
             const sourceFilesToSearch = map(filesToSearch, f => Debug.assertDefined(program.getSourceFile(f)));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1673,7 +1673,7 @@ namespace ts {
         }
 
         function getDocumentHighlights(fileName: string, position: number, filesToSearch: ReadonlyArray<string>): DocumentHighlights[] {
-            filesToSearch = ts.map(filesToSearch, ts.normalizePath);
+            filesToSearch = map(filesToSearch, normalizePath);
             Debug.assert(contains(filesToSearch, fileName));
             synchronizeHostData();
             const sourceFilesToSearch = map(filesToSearch, f => Debug.assertDefined(program.getSourceFile(f)));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1673,7 +1673,7 @@ namespace ts {
         }
 
         function getDocumentHighlights(fileName: string, position: number, filesToSearch: ReadonlyArray<string>): DocumentHighlights[] {
-            Debug.assert(contains(map(filesToSearch, normalizePath), fileName));
+            Debug.assert(filesToSearch.some(f => normalizePath(f) === fileName));
             synchronizeHostData();
             const sourceFilesToSearch = map(filesToSearch, f => Debug.assertDefined(program.getSourceFile(f)));
             const sourceFile = getValidSourceFile(fileName);

--- a/tests/cases/fourslash/documentHighlights_windowsPath.ts
+++ b/tests/cases/fourslash/documentHighlights_windowsPath.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+//@Filename: C:\a\b\c.ts
+////var /*1*/[|x|] = 1;
+
+const range = test.ranges()[0];
+verify.documentHighlightsOf(range, [range], { filesToSearch: [range.fileName] });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

PR #23306 did not handle Windows-style paths, so document highlighting stopped working in VS.
This change normalizes paths appropriately and changes some test infrastructure so this can be tested effectively.
