### PR TITLE
goToDefinition: Reduce duplicate code around createDefinitionInfo

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -50,7 +50,7 @@ namespace ts.GoToDefinition {
         // assignment. This case and others are handled by the following code.
         if (node.parent.kind === SyntaxKind.ShorthandPropertyAssignment) {
             const shorthandSymbol = typeChecker.getShorthandAssignmentValueSymbol(symbol.valueDeclaration);
-            return shorthandSymbol ? shorthandSymbol.declarations.map(decl => createDefinitionInfo(decl, typeChecker, shorthandSymbol, node)) : emptyArray;
+            return shorthandSymbol ? shorthandSymbol.declarations.map(decl => createDefinitionInfo(decl, typeChecker, shorthandSymbol, node)) : [];
         }
 
         // If the node is the name of a BindingElement within an ObjectBindingPattern instead of just returning the

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -50,16 +50,7 @@ namespace ts.GoToDefinition {
         // assignment. This case and others are handled by the following code.
         if (node.parent.kind === SyntaxKind.ShorthandPropertyAssignment) {
             const shorthandSymbol = typeChecker.getShorthandAssignmentValueSymbol(symbol.valueDeclaration);
-            if (!shorthandSymbol) {
-                return [];
-            }
-
-            const shorthandDeclarations = shorthandSymbol.getDeclarations();
-            const shorthandSymbolKind = SymbolDisplay.getSymbolKind(typeChecker, shorthandSymbol, node);
-            const shorthandSymbolName = typeChecker.symbolToString(shorthandSymbol);
-            const shorthandContainerName = typeChecker.symbolToString(symbol.parent, node);
-            return map(shorthandDeclarations,
-                declaration => createDefinitionInfo(declaration, shorthandSymbolKind, shorthandSymbolName, shorthandContainerName));
+            return shorthandSymbol ? shorthandSymbol.declarations.map(decl => createDefinitionInfo(decl, typeChecker, shorthandSymbol, node)) : emptyArray;
         }
 
         // If the node is the name of a BindingElement within an ObjectBindingPattern instead of just returning the
@@ -191,8 +182,7 @@ namespace ts.GoToDefinition {
     }
 
     function getDefinitionFromSymbol(typeChecker: TypeChecker, symbol: Symbol, node: Node): DefinitionInfo[] {
-        const { symbolName, symbolKind, containerName } = getSymbolInfo(typeChecker, symbol, node);
-        return getConstructSignatureDefinition() || getCallSignatureDefinition() || map(symbol.declarations, declaration => createDefinitionInfo(declaration, symbolKind, symbolName, containerName));
+        return getConstructSignatureDefinition() || getCallSignatureDefinition() || map(symbol.declarations, declaration => createDefinitionInfo(declaration, typeChecker, symbol, node));
 
         function getConstructSignatureDefinition(): DefinitionInfo[] | undefined {
             // Applicable only if we are in a new expression, or we are on a constructor declaration
@@ -215,7 +205,7 @@ namespace ts.GoToDefinition {
             }
             const declarations = signatureDeclarations.filter(selectConstructors ? isConstructorDeclaration : isSignatureDeclaration);
             return declarations.length
-                ? [createDefinitionInfo(find(declarations, d => !!(<FunctionLikeDeclaration>d).body) || last(declarations), symbolKind, symbolName, containerName)]
+                ? [createDefinitionInfo(find(declarations, d => !!(<FunctionLikeDeclaration>d).body) || last(declarations), typeChecker, symbol, node)]
                 : undefined;
         }
     }
@@ -234,12 +224,16 @@ namespace ts.GoToDefinition {
     }
 
     /** Creates a DefinitionInfo from a Declaration, using the declaration's name if possible. */
-    function createDefinitionInfo(node: Declaration, symbolKind: ScriptElementKind, symbolName: string, containerName: string): DefinitionInfo {
-        return createDefinitionInfoFromName(getNameOfDeclaration(node) || node, symbolKind, symbolName, containerName);
+    function createDefinitionInfo(declaration: Declaration, checker: TypeChecker, symbol: Symbol, node: Node): DefinitionInfo {//symbolKind: ScriptElementKind, symbolName: string, containerName: string): DefinitionInfo {
+        const symbolName = checker.symbolToString(symbol); // Do not get scoped name, just the name of the symbol
+        const symbolKind = SymbolDisplay.getSymbolKind(checker, symbol, node);
+        const containerName = symbol.parent ? checker.symbolToString(symbol.parent, node) : "";
+        return createDefinitionInfoFromName(declaration, symbolKind, symbolName, containerName);
     }
 
     /** Creates a DefinitionInfo directly from the name of a declaration. */
-    function createDefinitionInfoFromName(name: Node, symbolKind: ScriptElementKind, symbolName: string, containerName: string): DefinitionInfo {
+    function createDefinitionInfoFromName(declaration: Declaration, symbolKind: ScriptElementKind, symbolName: string, containerName: string): DefinitionInfo {
+        const name = getNameOfDeclaration(declaration) || declaration;
         const sourceFile = name.getSourceFile();
         return {
             fileName: sourceFile.fileName,
@@ -251,26 +245,12 @@ namespace ts.GoToDefinition {
         };
     }
 
-    function getSymbolInfo(typeChecker: TypeChecker, symbol: Symbol, node: Node) {
-        return {
-            symbolName: typeChecker.symbolToString(symbol), // Do not get scoped name, just the name of the symbol
-            symbolKind: SymbolDisplay.getSymbolKind(typeChecker, symbol, node),
-            containerName: symbol.parent ? typeChecker.symbolToString(symbol.parent, node) : ""
-        };
-    }
-
     function createDefinitionFromSignatureDeclaration(typeChecker: TypeChecker, decl: SignatureDeclaration): DefinitionInfo {
-        const { symbolName, symbolKind, containerName } = getSymbolInfo(typeChecker, decl.symbol, decl);
-        return createDefinitionInfo(decl, symbolKind, symbolName, containerName);
+        return createDefinitionInfo(decl, typeChecker, decl.symbol, decl);
     }
 
     export function findReferenceInPosition(refs: ReadonlyArray<FileReference>, pos: number): FileReference | undefined {
-        for (const ref of refs) {
-            if (ref.pos <= pos && pos <= ref.end) {
-                return ref;
-            }
-        }
-        return undefined;
+        return find(refs, ref => ref.pos <= pos && pos <= ref.end);
     }
 
     function getDefinitionInfoForFileReference(name: string, targetFileName: string): DefinitionInfo {

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -224,7 +224,7 @@ namespace ts.GoToDefinition {
     }
 
     /** Creates a DefinitionInfo from a Declaration, using the declaration's name if possible. */
-    function createDefinitionInfo(declaration: Declaration, checker: TypeChecker, symbol: Symbol, node: Node): DefinitionInfo {//symbolKind: ScriptElementKind, symbolName: string, containerName: string): DefinitionInfo {
+    function createDefinitionInfo(declaration: Declaration, checker: TypeChecker, symbol: Symbol, node: Node): DefinitionInfo {
         const symbolName = checker.symbolToString(symbol); // Do not get scoped name, just the name of the symbol
         const symbolKind = SymbolDisplay.getSymbolKind(checker, symbol, node);
         const containerName = symbol.parent ? checker.symbolToString(symbol.parent, node) : "";


### PR DESCRIPTION
* The result of `getSymbolInfo` is only ever sent to `createDefinitionInfo` -- so just compute it there.
* Also reuse this code for shorthand declarations.
* Use `find` in `findReferenceInPosition`.