### PR TITLE
goToDefinition: Remove isSignatureDeclaration, use isFunctionLike

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -213,23 +213,10 @@ namespace ts.GoToDefinition {
             if (!signatureDeclarations) {
                 return undefined;
             }
-            const declarations = signatureDeclarations.filter(selectConstructors ? isConstructorDeclaration : isSignatureDeclaration);
+            const declarations = signatureDeclarations.filter(selectConstructors ? isConstructorDeclaration : isFunctionLike);
             return declarations.length
                 ? [createDefinitionInfo(find(declarations, d => !!(<FunctionLikeDeclaration>d).body) || last(declarations), symbolKind, symbolName, containerName)]
                 : undefined;
-        }
-    }
-
-    function isSignatureDeclaration(node: Node): boolean {
-        switch (node.kind) {
-            case SyntaxKind.Constructor:
-            case SyntaxKind.ConstructSignature:
-            case SyntaxKind.FunctionDeclaration:
-            case SyntaxKind.MethodDeclaration:
-            case SyntaxKind.MethodSignature:
-                return true;
-            default:
-                return false;
         }
     }
 
@@ -298,13 +285,7 @@ namespace ts.GoToDefinition {
     function tryGetSignatureDeclaration(typeChecker: TypeChecker, node: Node): SignatureDeclaration | undefined {
         const callLike = getAncestorCallLikeExpression(node);
         const signature = callLike && typeChecker.getResolvedSignature(callLike);
-        if (signature) {
-            const decl = signature.declaration;
-            if (decl && isSignatureDeclaration(decl)) {
-                return decl;
-            }
-        }
         // Don't go to a function type, go to the value having that type.
-        return undefined;
+        return tryCast(signature && signature.declaration, (d): d is SignatureDeclaration => isFunctionLike(d) && !isFunctionTypeNode(d));
     }
 }


### PR DESCRIPTION
The only difference is that we specifically want to exclude `FunctionType` nodes and go to a variable instead.