### PR TITLE
Update configurePrerelease to not utilize ts internals

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -215,8 +215,8 @@ for (const i in libraryTargets) {
             .pipe(gulp.dest(".")));
 }
 
-const configureNightlyJs = path.join(scriptsDirectory, "configureNightly.js");
-const configureNightlyTs = path.join(scriptsDirectory, "configureNightly.ts");
+const configureNightlyJs = path.join(scriptsDirectory, "configurePrerelease.js");
+const configureNightlyTs = path.join(scriptsDirectory, "configurePrerelease.ts");
 const packageJson = "package.json";
 const versionFile = path.join(compilerDirectory, "core.ts");
 
@@ -307,18 +307,19 @@ gulp.task(configureNightlyJs, /*help*/ false, [], () => {
         removeComments: true,
         noResolve: false,
         stripInternal: false,
+        module: "commonjs"
     };
     return gulp.src(configureNightlyTs)
         .pipe(sourcemaps.init())
         .pipe(tsc(settings))
-        .pipe(sourcemaps.write(path.dirname(configureNightlyJs)))
-        .pipe(gulp.dest(path.dirname(configureNightlyJs)));
+        .pipe(sourcemaps.write("."))
+        .pipe(gulp.dest("./scripts"));
 });
 
 
 // Nightly management tasks
-gulp.task("configure-nightly", "Runs scripts/configureNightly.ts to prepare a build for nightly publishing", [configureNightlyJs], (done) => {
-    exec(host, [configureNightlyJs, packageJson, versionFile], done, done);
+gulp.task("configure-nightly", "Runs scripts/configurePrerelease.ts to prepare a build for nightly publishing", [configureNightlyJs], (done) => {
+    exec(host, [configureNightlyJs, "dev", packageJson, versionFile], done, done);
 });
 gulp.task("publish-nightly", "Runs `npm publish --tag next` to create a new nightly build on npm", ["LKG"], () => {
     return runSequence("clean", "useDebugMode", "runtests-parallel", (done) => {

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -215,8 +215,8 @@ for (const i in libraryTargets) {
             .pipe(gulp.dest(".")));
 }
 
-const configureNightlyJs = path.join(scriptsDirectory, "configurePrerelease.js");
-const configureNightlyTs = path.join(scriptsDirectory, "configurePrerelease.ts");
+const configurePreleleaseJs = path.join(scriptsDirectory, "configurePrerelease.js");
+const configurePreleleaseTs = path.join(scriptsDirectory, "configurePrerelease.ts");
 const packageJson = "package.json";
 const versionFile = path.join(compilerDirectory, "core.ts");
 
@@ -301,7 +301,7 @@ function getCompilerSettings(base: tsc.Settings, useBuiltCompiler?: boolean): ts
     return copy;
 }
 
-gulp.task(configureNightlyJs, /*help*/ false, [], () => {
+gulp.task(configurePreleleaseJs, /*help*/ false, [], () => {
     const settings: tsc.Settings = {
         declaration: false,
         removeComments: true,
@@ -309,7 +309,7 @@ gulp.task(configureNightlyJs, /*help*/ false, [], () => {
         stripInternal: false,
         module: "commonjs"
     };
-    return gulp.src(configureNightlyTs)
+    return gulp.src(configurePreleleaseTs)
         .pipe(sourcemaps.init())
         .pipe(tsc(settings))
         .pipe(sourcemaps.write("."))
@@ -318,8 +318,8 @@ gulp.task(configureNightlyJs, /*help*/ false, [], () => {
 
 
 // Nightly management tasks
-gulp.task("configure-nightly", "Runs scripts/configurePrerelease.ts to prepare a build for nightly publishing", [configureNightlyJs], (done) => {
-    exec(host, [configureNightlyJs, "dev", packageJson, versionFile], done, done);
+gulp.task("configure-nightly", "Runs scripts/configurePrerelease.ts to prepare a build for nightly publishing", [configurePreleleaseJs], (done) => {
+    exec(host, [configurePreleleaseJs, "dev", packageJson, versionFile], done, done);
 });
 gulp.task("publish-nightly", "Runs `npm publish --tag next` to create a new nightly build on npm", ["LKG"], () => {
     return runSequence("clean", "useDebugMode", "runtests-parallel", (done) => {

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -491,7 +491,7 @@ compileFile(/*outfile*/configurePrereleaseJs,
             /*prereqs*/[configurePrereleaseTs],
             /*prefixes*/[],
             /*useBuiltCompiler*/ false,
-    { noOutFile: false, generateDeclarations: false, keepComments: false, noResolve: false, stripInternal: false });
+    { noOutFile: true, generateDeclarations: false, keepComments: false, noResolve: false, stripInternal: false });
 
 task("setDebugMode", function () {
     useDebugMode = true;

--- a/scripts/configurePrerelease.ts
+++ b/scripts/configurePrerelease.ts
@@ -1,4 +1,9 @@
-/// <reference path="../src/compiler/sys.ts" />
+/// <reference types="node"/>
+import { normalize } from "path";
+import assert = require("assert");
+import { readFileSync as readFile, writeFileSync as writeFile } from "fs";
+const args = process.argv.slice(2);
+
 
 /**
  * A minimal description for a parsed package.json object.
@@ -10,28 +15,27 @@ interface PackageJson {
 }
 
 function main(): void {
-    const sys = ts.sys;
-    if (sys.args.length < 3) {
-        sys.write("Usage:" + sys.newLine)
-        sys.write("\tnode configureNightly.js <dev|insiders> <package.json location> <file containing version>" + sys.newLine);
+    if (args.length < 3) {
+        console.log("Usage:");
+        console.log("\tnode configureNightly.js <dev|insiders> <package.json location> <file containing version>");
         return;
     }
 
-    const tag = sys.args[0];
+    const tag = args[0];
     if (tag !== "dev" && tag !== "insiders") {
         throw new Error(`Unexpected tag name '${tag}'.`);
     }
 
     // Acquire the version from the package.json file and modify it appropriately.
-    const packageJsonFilePath = ts.normalizePath(sys.args[1]);
-    const packageJsonValue: PackageJson = JSON.parse(sys.readFile(packageJsonFilePath));
+    const packageJsonFilePath = normalize(args[1]);
+    const packageJsonValue: PackageJson = JSON.parse(readFile(packageJsonFilePath).toString());
 
     const { majorMinor, patch } = parsePackageJsonVersion(packageJsonValue.version);
     const prereleasePatch = getPrereleasePatch(tag, patch);
 
     // Acquire and modify the source file that exposes the version string.
-    const tsFilePath = ts.normalizePath(sys.args[2]);
-    const tsFileContents = ts.sys.readFile(tsFilePath);
+    const tsFilePath = normalize(args[2]);
+    const tsFileContents = readFile(tsFilePath).toString();
     const modifiedTsFileContents = updateTsFile(tsFilePath, tsFileContents, majorMinor, patch, prereleasePatch);
 
     // Ensure we are actually changing something - the user probably wants to know that the update failed.
@@ -44,20 +48,20 @@ function main(): void {
     // Finally write the changes to disk.
     // Modify the package.json structure
     packageJsonValue.version = `${majorMinor}.${prereleasePatch}`;
-    sys.writeFile(packageJsonFilePath, JSON.stringify(packageJsonValue, /*replacer:*/ undefined, /*space:*/ 4))
-    sys.writeFile(tsFilePath, modifiedTsFileContents);
+    writeFile(packageJsonFilePath, JSON.stringify(packageJsonValue, /*replacer:*/ undefined, /*space:*/ 4))
+    writeFile(tsFilePath, modifiedTsFileContents);
 }
 
 function updateTsFile(tsFilePath: string, tsFileContents: string, majorMinor: string, patch: string, nightlyPatch: string): string {
     const majorMinorRgx = /export const versionMajorMinor = "(\d+\.\d+)"/;
     const majorMinorMatch = majorMinorRgx.exec(tsFileContents);
-    ts.Debug.assert(majorMinorMatch !== null, "", () => `The file seems to no longer have a string matching '${majorMinorRgx}'.`);
+    assert(majorMinorMatch !== null, `The file seems to no longer have a string matching '${majorMinorRgx}'.`);
     const parsedMajorMinor = majorMinorMatch[1];
-    ts.Debug.assert(parsedMajorMinor === majorMinor, "versionMajorMinor does not match.", () => `${tsFilePath}: '${parsedMajorMinor}'; package.json: '${majorMinor}'`);
+    assert(parsedMajorMinor === majorMinor, `versionMajorMinor does not match. ${tsFilePath}: '${parsedMajorMinor}'; package.json: '${majorMinor}'`);
 
     const versionRgx = /export const version = `\$\{versionMajorMinor\}\.(\d)(-dev)?`;/;
     const patchMatch = versionRgx.exec(tsFileContents);
-    ts.Debug.assert(patchMatch !== null, "The file seems to no longer have a string matching", () => versionRgx.toString());
+    assert(patchMatch !== null, "The file seems to no longer have a string matching " + versionRgx.toString());
     const parsedPatch = patchMatch[1];
     if (parsedPatch !== patch) {
         throw new Error(`patch does not match. ${tsFilePath}: '${parsedPatch}; package.json: '${patch}'`);
@@ -69,7 +73,7 @@ function updateTsFile(tsFilePath: string, tsFileContents: string, majorMinor: st
 function parsePackageJsonVersion(versionString: string): { majorMinor: string, patch: string } {
     const versionRgx = /(\d+\.\d+)\.(\d+)($|\-)/;
     const match = versionString.match(versionRgx);
-    ts.Debug.assert(match !== null, "package.json 'version' should match", () => versionRgx.toString());
+    assert(match !== null, "package.json 'version' should match " + versionRgx.toString());
     return { majorMinor: match[1], patch: match[2] };
 }
 

--- a/scripts/configurePrerelease.ts
+++ b/scripts/configurePrerelease.ts
@@ -1,7 +1,7 @@
 /// <reference types="node"/>
 import { normalize } from "path";
 import assert = require("assert");
-import { readFileSync as readFile, writeFileSync as writeFile } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 const args = process.argv.slice(2);
 
 
@@ -28,14 +28,14 @@ function main(): void {
 
     // Acquire the version from the package.json file and modify it appropriately.
     const packageJsonFilePath = normalize(args[1]);
-    const packageJsonValue: PackageJson = JSON.parse(readFile(packageJsonFilePath).toString());
+    const packageJsonValue: PackageJson = JSON.parse(readFileSync(packageJsonFilePath).toString());
 
     const { majorMinor, patch } = parsePackageJsonVersion(packageJsonValue.version);
     const prereleasePatch = getPrereleasePatch(tag, patch);
 
     // Acquire and modify the source file that exposes the version string.
     const tsFilePath = normalize(args[2]);
-    const tsFileContents = readFile(tsFilePath).toString();
+    const tsFileContents = readFileSync(tsFilePath).toString();
     const modifiedTsFileContents = updateTsFile(tsFilePath, tsFileContents, majorMinor, patch, prereleasePatch);
 
     // Ensure we are actually changing something - the user probably wants to know that the update failed.
@@ -48,8 +48,8 @@ function main(): void {
     // Finally write the changes to disk.
     // Modify the package.json structure
     packageJsonValue.version = `${majorMinor}.${prereleasePatch}`;
-    writeFile(packageJsonFilePath, JSON.stringify(packageJsonValue, /*replacer:*/ undefined, /*space:*/ 4))
-    writeFile(tsFilePath, modifiedTsFileContents);
+    writeFileSync(packageJsonFilePath, JSON.stringify(packageJsonValue, /*replacer:*/ undefined, /*space:*/ 4))
+    writeFileSync(tsFilePath, modifiedTsFileContents);
 }
 
 function updateTsFile(tsFilePath: string, tsFileContents: string, majorMinor: string, patch: string, nightlyPatch: string): string {


### PR DESCRIPTION
It relied on transitive deps being pulled in via a triple-slash reference of the `core.ts` file, which as of last week, is no longer the case. I simply removed it's dependence on our internals at all - it doesn't need them.

Should fix our nightly publishing. Fixes #23409.