### PR TITLE
Symbol kind for a method on a mapped type should still be 'method'

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -26,6 +26,15 @@ namespace ts.SymbolDisplay {
     }
 
     function getSymbolKindOfConstructorPropertyMethodAccessorFunctionOrVar(typeChecker: TypeChecker, symbol: Symbol, location: Node): ScriptElementKind {
+        const roots = typeChecker.getRootSymbols(symbol);
+        // If this is a method from a mapped type, leave as a method so long as it still has a call signature.
+        if (roots.length === 1
+            && first(roots).flags & SymbolFlags.Method
+            // Ensure the mapped version is still a method, as opposed to `{ [K in keyof I]: number }`.
+            && typeChecker.getTypeOfSymbolAtLocation(symbol, location).getNonNullableType().getCallSignatures().length !== 0) {
+            return ScriptElementKind.memberFunctionElement;
+        }
+
         if (typeChecker.isUndefinedSymbol(symbol)) {
             return ScriptElementKind.variableElement;
         }

--- a/tests/cases/fourslash/quickInfoMappedSpreadTypes.ts
+++ b/tests/cases/fourslash/quickInfoMappedSpreadTypes.ts
@@ -1,4 +1,4 @@
-/// <reference path="../fourslash.ts"/>
+/// <reference path="./fourslash.ts"/>
 
 ////interface Foo {
 ////    /** Doc */

--- a/tests/cases/fourslash/quickInfoMappedType.ts
+++ b/tests/cases/fourslash/quickInfoMappedType.ts
@@ -1,0 +1,11 @@
+/// <reference path="./fourslash.ts"/>
+
+////interface I { m(): void; }
+////declare const o: { [K in keyof I]: number };
+////o.m/*0*/;
+////
+////declare const p: { [K in keyof I]: I[K] };
+////p.m/*1*/;
+
+verify.quickInfoAt("0", "(property) m: number");
+verify.quickInfoAt("1", "(method) m(): void");


### PR DESCRIPTION
Fixes #23450