### PR TITLE
Add '?' in quick info for optional properties/methods

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -549,6 +549,10 @@ namespace ts.SymbolDisplay {
             const fullSymbolDisplayParts = symbolToDisplayParts(typeChecker, symbolToDisplay, enclosingDeclaration || sourceFile, /*meaning*/ undefined,
                 SymbolFormatFlags.WriteTypeParametersOrArguments | SymbolFormatFlags.UseOnlyExternalAliasing | SymbolFormatFlags.AllowAnyNodeKind);
             addRange(displayParts, fullSymbolDisplayParts);
+
+            if (symbol.flags & SymbolFlags.Optional) {
+                displayParts.push(punctuationPart(SyntaxKind.QuestionToken));
+            }
         }
 
         function addPrefixForAnyFunctionOrVar(symbol: Symbol, symbolKind: string) {

--- a/tests/cases/fourslash/findAllRefsForObjectSpread.ts
+++ b/tests/cases/fourslash/findAllRefsForObjectSpread.ts
@@ -12,12 +12,12 @@ const [r0, r1, r2, r3] = ranges;
 
 // members of spread types only refer to themselves and the resulting property
 verify.referenceGroups(r0, [{ definition: "(property) A1.a: string", ranges: [r0, r2, r3] }]);
-verify.referenceGroups(r1, [{ definition: "(property) A2.a: number", ranges: [r1, r2] }]);
+verify.referenceGroups(r1, [{ definition: "(property) A2.a?: number", ranges: [r1, r2] }]);
 
 // but the resulting property refers to everything
 verify.referenceGroups(r2, [
     { definition: "(property) A1.a: string", ranges: [r0, r2, r3] },
-    { definition: "(property) A2.a: number", ranges: [r1] },
+    { definition: "(property) A2.a?: number", ranges: [r1] },
 ]);
 
 verify.referenceGroups(r3, [{ definition: "(property) A1.a: string", ranges: [r0, r2, r3] }]);

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName10.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName10.ts
@@ -8,4 +8,4 @@
 ////function f ({ [|next|]: { [|next|]: x} }: Recursive) {
 ////}
 
-verify.singleReferenceGroup("(property) Recursive.next: Recursive");
+verify.singleReferenceGroup("(property) Recursive.next?: Recursive");

--- a/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName03.ts
+++ b/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName03.ts
@@ -9,5 +9,5 @@
 ////}
 
 for (const marker of test.markerNames()) {
-    verify.quickInfoAt(marker, "(property) Recursive.next: Recursive");
+    verify.quickInfoAt(marker, "(property) Recursive.next?: Recursive");
 }


### PR DESCRIPTION
Fixes #1411

#20839 was marked as fixing this, because `This can be used by editors to either change the completion item icon or add a ? to the completion item text`, but  that doesn't fix the completion details, or quick info (or go-to-definition or find-all-references).