### PR TITLE
Use ts-check instead of ts-node to avoid transpilation overhead on gulp invoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
         "source-map-support": "latest",
         "through2": "latest",
         "travis-fold": "latest",
-        "ts-node": "latest",
         "tslint": "latest",
         "vinyl": "latest",
         "chalk": "latest",


### PR DESCRIPTION
Since `ts-node` now does an immensely costly full-typecheck (of all TS in the tree), and waiting full seconds just for `gulp` is unreasonable (if it doesn't crash from size limits, like it does for us).
However, the `Gulpfile` is still strongly typed, thanks to `@ts-check`, which we did not have back when we first started using a `Gulpfile.ts`.

Fixes https://github.com/Microsoft/TypeScript/issues/23479