### PR TITLE
Add 'triggerCharacter' option for completions requests

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -842,6 +842,7 @@ namespace FourSlash {
 
             const actualCompletions = this.getCompletionListAtCaret(options);
             if (!actualCompletions) {
+                if (expected === undefined) return;
                 this.raiseError(`No completions at position '${this.currentCaretPosition}'.`);
             }
 
@@ -4646,10 +4647,12 @@ namespace FourSlashInterface {
 
     export type ExpectedCompletionEntry = string | { name: string, insertText?: string, replacementSpan?: FourSlash.Range };
     export interface CompletionsAtOptions extends Partial<ts.UserPreferences> {
+        triggerCharacter?: string;
         isNewIdentifierLocation?: boolean;
     }
 
     export interface VerifyCompletionListContainsOptions extends ts.UserPreferences {
+        triggerCharacter?: string;
         sourceDisplay: string;
         isRecommended?: true;
         insertText?: string;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1749,6 +1749,7 @@ namespace ts.server.protocol {
          * Optional prefix to apply to possible completions.
          */
         prefix?: string;
+        triggerCharacter?: string;
         /**
          * @deprecated Use UserPreferences.includeCompletionsForModuleExports
          */

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1286,6 +1286,7 @@ namespace ts.server {
 
             const completions = project.getLanguageService().getCompletionsAtPosition(file, position, {
                 ...this.getPreferences(file),
+                triggerCharacter: args.triggerCharacter,
                 includeExternalModuleExports: args.includeExternalModuleExports,
                 includeInsertTextCompletions: args.includeInsertTextCompletions
             });

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2199,7 +2199,7 @@ namespace ts.Completions {
         return !!type.getStringIndexType() || !!type.getNumberIndexType();
     }
 
-    function isInvalidTrigger(triggerCharacter: string | undefined, contextToken: Node, position: number): boolean {
+    function isInvalidTrigger(sourceFile: SourceFile, triggerCharacter: string | undefined, contextToken: Node, position: number): boolean {
         switch (triggerCharacter) {
             case '"':
             case "'":
@@ -2209,11 +2209,12 @@ namespace ts.Completions {
                     case SyntaxKind.NoSubstitutionTemplateLiteral:
                     case SyntaxKind.TemplateExpression:
                     case SyntaxKind.TaggedTemplateExpression:
-                        break;
+                        // Don't automatically bring up completions at closing quote
+                        return position === contextToken.parent.end;
                     default:
-                        Debug.fail();
+                        if (!isInComment(sourceFile, position, contextToken)) Debug.failBadSyntaxKind(contextToken);
+                        return true;
                 }
-                return position === contextToken.parent.end;
             case "<":
                 Debug.assert(contextToken.kind === SyntaxKind.LessThanToken);
                 return contextToken.parent.kind === SyntaxKind.BinaryExpression;

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2207,8 +2207,8 @@ namespace ts.Completions {
                 // Only automatically bring up completions if this is an opening quote.
                 return isStringLiteralOrTemplate(contextToken) && position === contextToken.getStart(sourceFile) + 1;
             case "<":
-                Debug.assert(contextToken.kind === SyntaxKind.LessThanToken);
-                return contextToken.parent.kind !== SyntaxKind.BinaryExpression;
+                // Opening JSX tag
+                return contextToken.kind === SyntaxKind.LessThanToken && contextToken.parent.kind !== SyntaxKind.BinaryExpression;
             default:
                 return Debug.fail(triggerCharacter);
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1409,7 +1409,8 @@ namespace ts {
                 log,
                 getValidSourceFile(fileName),
                 position,
-                fullPreferences);
+                fullPreferences,
+                options.triggerCharacter);
         }
 
         function getCompletionEntryDetails(fileName: string, position: number, name: string, formattingOptions: FormatCodeSettings | undefined, source: string | undefined, preferences: UserPreferences = defaultPreferences): CompletionEntryDetails {

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -912,7 +912,7 @@ namespace ts {
          * to provide at the given source position and providing a member completion
          * list if requested.
          */
-        public getCompletionsAtPosition(fileName: string, position: number, preferences: UserPreferences | undefined) {
+        public getCompletionsAtPosition(fileName: string, position: number, preferences: GetCompletionsAtPositionOptions | undefined) {
             return this.forwardJSONCall(
                 `getCompletionsAtPosition('${fileName}', ${position}, ${preferences})`,
                 () => this.languageService.getCompletionsAtPosition(fileName, position, preferences)

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -354,8 +354,9 @@ namespace ts {
 
     export type OrganizeImportsScope = CombinedCodeFixScope;
 
-    /** @deprecated Use UserPreferences */
     export interface GetCompletionsAtPositionOptions extends UserPreferences {
+        /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */
+        triggerCharacter?: string;
         /** @deprecated Use includeCompletionsForModuleExports */
         includeExternalModuleExports?: boolean;
         /** @deprecated Use includeCompletionsWithInsertText */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4451,8 +4451,9 @@ declare namespace ts {
         fileName: string;
     }
     type OrganizeImportsScope = CombinedCodeFixScope;
-    /** @deprecated Use UserPreferences */
     interface GetCompletionsAtPositionOptions extends UserPreferences {
+        /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */
+        triggerCharacter?: string;
         /** @deprecated Use includeCompletionsForModuleExports */
         includeExternalModuleExports?: boolean;
         /** @deprecated Use includeCompletionsWithInsertText */
@@ -6663,6 +6664,7 @@ declare namespace ts.server.protocol {
          * Optional prefix to apply to possible completions.
          */
         prefix?: string;
+        triggerCharacter?: string;
         /**
          * @deprecated Use UserPreferences.includeCompletionsForModuleExports
          */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4451,8 +4451,9 @@ declare namespace ts {
         fileName: string;
     }
     type OrganizeImportsScope = CombinedCodeFixScope;
-    /** @deprecated Use UserPreferences */
     interface GetCompletionsAtPositionOptions extends UserPreferences {
+        /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */
+        triggerCharacter?: string;
         /** @deprecated Use includeCompletionsForModuleExports */
         includeExternalModuleExports?: boolean;
         /** @deprecated Use includeCompletionsWithInsertText */

--- a/tests/cases/fourslash/completionsTriggerCharacter.ts
+++ b/tests/cases/fourslash/completionsTriggerCharacter.ts
@@ -5,6 +5,7 @@
 ////const x: "a" | "b" = "/*openQuote*/"/*closeQuote*/;
 ////const y: 'a' | 'b' = '/*openSingleQuote*/'/*closeSingleQuote*/;
 ////const z: 'a' | 'b' = `/*openTemplate*/`/*closeTemplate*/;
+////const q: "`a`" | "`b`" = "`/*openTemplateInQuote*/a`/*closeTemplateInQuote*/";
 
 // @Filename: /a.tsx
 ////declare namespace JSX {
@@ -24,6 +25,9 @@ verify.completionsAt("closeSingleQuote", undefined, { triggerCharacter: "'" });
 
 verify.completionsAt("openTemplate", ["a", "b"], { triggerCharacter: "`" });
 verify.completionsAt("closeTemplate", undefined, { triggerCharacter: "`" });
+
+verify.completionsAt("openTemplateInQuote", undefined, { triggerCharacter: '`' });
+verify.completionsAt("closeTemplateInQuote", undefined, { triggerCharacter: '`' });
 
 goTo.marker("openTag");
 verify.completionListContains("div", undefined, undefined, undefined, undefined, undefined, { triggerCharacter: "<" });

--- a/tests/cases/fourslash/completionsTriggerCharacter.ts
+++ b/tests/cases/fourslash/completionsTriggerCharacter.ts
@@ -7,6 +7,8 @@
 ////const z: 'a' | 'b' = `/*openTemplate*/`/*closeTemplate*/;
 ////const q: "`a`" | "`b`" = "`/*openTemplateInQuote*/a`/*closeTemplateInQuote*/";
 
+////// "/*quoteInComment*/ </*lessInComment*/
+
 // @Filename: /a.tsx
 ////declare namespace JSX {
 ////    interface Element {}
@@ -28,6 +30,9 @@ verify.completionsAt("closeTemplate", undefined, { triggerCharacter: "`" });
 
 verify.completionsAt("openTemplateInQuote", undefined, { triggerCharacter: '`' });
 verify.completionsAt("closeTemplateInQuote", undefined, { triggerCharacter: '`' });
+
+verify.completionsAt("quoteInComment", undefined, { triggerCharacter: '"' });
+verify.completionsAt("lessInComment", undefined, { triggerCharacter: "<" });
 
 goTo.marker("openTag");
 verify.completionListContains("div", undefined, undefined, undefined, undefined, undefined, { triggerCharacter: "<" });

--- a/tests/cases/fourslash/completionsTriggerCharacter.ts
+++ b/tests/cases/fourslash/completionsTriggerCharacter.ts
@@ -1,0 +1,30 @@
+/// <reference path="fourslash.ts" />
+
+// @jsx: preserve
+
+////const x: "a" | "b" = "/*openQuote*/"/*closeQuote*/;
+////const y: 'a' | 'b' = '/*openSingleQuote*/'/*closeSingleQuote*/;
+////const z: 'a' | 'b' = `/*openTemplate*/`/*closeTemplate*/;
+
+// @Filename: /a.tsx
+////declare namespace JSX {
+////    interface Element {}
+////    interface IntrinsicElements {
+////        div: {};
+////    }
+////}
+////const ctr = </*openTag*/
+////const less = 1 </*lessThan*/
+
+verify.completionsAt("openQuote", ["a", "b"], { triggerCharacter: '"' });
+verify.completionsAt("closeQuote", undefined, { triggerCharacter: '"' });
+
+verify.completionsAt("openSingleQuote", ["a", "b"], { triggerCharacter: "'" });
+verify.completionsAt("closeSingleQuote", undefined, { triggerCharacter: "'" });
+
+verify.completionsAt("openTemplate", ["a", "b"], { triggerCharacter: "`" });
+verify.completionsAt("closeTemplate", undefined, { triggerCharacter: "`" });
+
+goTo.marker("openTag");
+verify.completionListContains("div", undefined, undefined, undefined, undefined, undefined, { triggerCharacter: "<" });
+verify.completionsAt("lessThan", undefined, { triggerCharacter: "<" });

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -157,6 +157,7 @@ declare namespace FourSlashInterface {
             spanIndex?: number,
             hasAction?: boolean,
             options?: UserPreferences & {
+                triggerCharacter?: string,
                 sourceDisplay?: string,
                 isRecommended?: true,
                 insertText?: string,
@@ -530,6 +531,7 @@ declare namespace FourSlashInterface {
         importModuleSpecifierPreference?: "relative" | "non-relative";
     }
     interface CompletionsAtOptions extends UserPreferences {
+        triggerCharacter?: string;
         isNewIdentifierLocation?: boolean;
     }
 }


### PR DESCRIPTION
Fixes #21012

@mjbvz I don't think it should be necessary for the editor to send us the trigger character? Shouldn't that always be the character immediately preceding `position`?
@amcasey You may be interested in using this in visual studio too.
