### PR TITLE
Propagage reportsUnnecessary in convertToDiagnosticsWithLinePosition

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -634,7 +634,8 @@ namespace ts.server {
                 code: d.code,
                 source: d.source,
                 startLocation: scriptInfo && scriptInfo.positionToLineOffset(d.start),
-                endLocation: scriptInfo && scriptInfo.positionToLineOffset(d.start + d.length)
+                endLocation: scriptInfo && scriptInfo.positionToLineOffset(d.start + d.length),
+                reportsUnnecessary: d.reportsUnnecessary
             });
         }
 


### PR DESCRIPTION
Otherwise, it won't reach VS.