### PR TITLE
Misc. improvements to addImplementationReferences

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1105,28 +1105,29 @@ namespace ts.FindAllReferences.Core {
         }
 
         // If we got a type reference, try and see if the reference applies to any expressions that can implement an interface
-        const containingTypeReference = getContainingTypeReference(refNode);
-        if (containingTypeReference && state.markSeenContainingTypeReference(containingTypeReference)) {
-            const parent = containingTypeReference.parent;
-            if (hasType(parent) && parent.type === containingTypeReference && hasInitializer(parent) && isImplementationExpression(parent.initializer)) {
-                addReference(parent.initializer);
+        const typeHavingNode = findAncestor(refNode.parent, a => !isQualifiedName(a) && !isTypeNode(a) && !isTypeElement(a));
+        if (hasType(typeHavingNode) && state.markSeenContainingTypeReference(typeHavingNode)) {
+            if (hasInitializer(typeHavingNode)) {
+                addIfImplementation(typeHavingNode.initializer);
             }
-            else if (isFunctionLike(parent) && parent.type === containingTypeReference && (parent as FunctionLikeDeclaration).body) {
-                const body = (parent as FunctionLikeDeclaration).body;
+            else if (isFunctionLike(typeHavingNode) && (typeHavingNode as FunctionLikeDeclaration).body) {
+                const body = (typeHavingNode as FunctionLikeDeclaration).body;
                 if (body.kind === SyntaxKind.Block) {
                     forEachReturnStatement(<Block>body, returnStatement => {
-                        if (returnStatement.expression && isImplementationExpression(returnStatement.expression)) {
-                            addReference(returnStatement.expression);
-                        }
+                        if (returnStatement.expression) addIfImplementation(returnStatement.expression);
                     });
                 }
-                else if (isImplementationExpression(body)) {
-                    addReference(body);
+                else {
+                    addIfImplementation(body);
                 }
             }
-            else if (isAssertionExpression(parent) && isImplementationExpression(parent.expression)) {
-                addReference(parent.expression);
+            else if (isAssertionExpression(typeHavingNode)) {
+                addIfImplementation(typeHavingNode.expression);
             }
+        }
+
+        function addIfImplementation(e: Expression) {
+            if (isImplementationExpression(e)) addReference(e);
         }
     }
 
@@ -1142,32 +1143,9 @@ namespace ts.FindAllReferences.Core {
         return result;
     }
 
-    function getContainingTypeReference(node: Node): Node {
-        let topLevelTypeReference: Node;
-
-        while (node) {
-            if (isTypeNode(node)) {
-                topLevelTypeReference = node;
-            }
-            node = node.parent;
-        }
-
-        return topLevelTypeReference;
-    }
-
-    function getContainingClassIfInHeritageClause(node: Node): ClassLikeDeclaration {
-        if (node && node.parent) {
-            if (node.kind === SyntaxKind.ExpressionWithTypeArguments
-                && node.parent.kind === SyntaxKind.HeritageClause
-                && isClassLike(node.parent.parent)) {
-                return node.parent.parent;
-            }
-
-            else if (node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.PropertyAccessExpression) {
-                return getContainingClassIfInHeritageClause(node.parent);
-            }
-        }
-        return undefined;
+    function getContainingClassIfInHeritageClause(node: Node): ClassLikeDeclaration | InterfaceDeclaration {
+        return isIdentifier(node) || isPropertyAccessExpression(node) ? getContainingClassIfInHeritageClause(node.parent)
+            : isExpressionWithTypeArguments(node) ? tryCast(node.parent.parent, isClassLike) : undefined;
     }
 
     /**


### PR DESCRIPTION
* `getContainingClassIfInHeritageClause`: An `ExpressionWithTypeArguments` can only appear in a `HeritageClause`, and must have a `parent` if it's not a `SourceFile`, so remove some unnecessary checks.
* `getContainingTypeReference`: Previously this would climb all the way to the root and keep track of the last thing that was a type. We only need to climb to the first thing that's not in a type. This is a one-liner using `findAncestor`.
* Add an `addIfImplementation` helper since all uses of `isImplementationExpression` were immediately followed by `addReference`.