### PR TITLE
Visit EOF to collect jsdoc import types

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1624,6 +1624,9 @@ namespace ts {
                     collectDynamicImportOrRequireCalls(node);
                 }
             }
+            if ((file.flags & NodeFlags.PossiblyContainsDynamicImport) || isJavaScriptFile) {
+                collectDynamicImportOrRequireCalls(file.endOfFileToken);
+            }
 
             file.imports = imports || emptyArray;
             file.moduleAugmentations = moduleAugmentations || emptyArray;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2007,7 +2007,8 @@ namespace ts {
                         && !options.noResolve
                         && i < file.imports.length
                         && !elideImport
-                        && !(isJsFile && !options.allowJs);
+                        && !(isJsFile && !options.allowJs)
+                        && (isInJavaScriptFile(file.imports[i]) || !(file.imports[i].flags & NodeFlags.JSDoc));
 
                     if (elideImport) {
                         modulesWithElidedImports.set(file.path, true);

--- a/tests/baselines/reference/importTypeResolutionJSDocEOF.symbols
+++ b/tests/baselines/reference/importTypeResolutionJSDocEOF.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/interfaces.d.ts ===
+export interface Bar {
+>Bar : Symbol(Bar, Decl(interfaces.d.ts, 0, 0))
+
+    prop: string
+>prop : Symbol(Bar.prop, Decl(interfaces.d.ts, 0, 22))
+}
+
+=== tests/cases/compiler/usage.js ===
+/** @type {Bar} */
+export let bar;
+>bar : Symbol(bar, Decl(usage.js, 1, 10))
+
+/** @typedef {import('./interfaces').Bar} Bar */

--- a/tests/baselines/reference/importTypeResolutionJSDocEOF.types
+++ b/tests/baselines/reference/importTypeResolutionJSDocEOF.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/interfaces.d.ts ===
+export interface Bar {
+>Bar : Bar
+
+    prop: string
+>prop : string
+}
+
+=== tests/cases/compiler/usage.js ===
+/** @type {Bar} */
+export let bar;
+>bar : Bar
+
+/** @typedef {import('./interfaces').Bar} Bar */

--- a/tests/cases/compiler/importTypeResolutionJSDocEOF.ts
+++ b/tests/cases/compiler/importTypeResolutionJSDocEOF.ts
@@ -1,0 +1,13 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @filename: interfaces.d.ts
+export interface Bar {
+    prop: string
+}
+
+// @filename: usage.js
+/** @type {Bar} */
+export let bar;
+
+/** @typedef {import('./interfaces').Bar} Bar */


### PR DESCRIPTION
Trailing jsdoc comments are attached to the EOF token, which we had not been visiting when collecting module resolutions.

Fixes #23508
