### PR TITLE
Relax switch-case narrowing restrictions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11336,7 +11336,7 @@ namespace ts {
             return !!getPropertyOfType(type, "0" as __String);
         }
 
-        function isNotUnitTypeOrNever(type: Type): boolean {
+        function isNeitherUnitTypeNorNever(type: Type): boolean {
             return !(type.flags & (TypeFlags.Unit | TypeFlags.Never));
         }
 
@@ -18950,7 +18950,7 @@ namespace ts {
                 return false;
             }
             const switchTypes = getSwitchClauseTypes(node);
-            if (!switchTypes.length || some(switchTypes, isNotUnitTypeOrNever)) {
+            if (!switchTypes.length || some(switchTypes, isNeitherUnitTypeNorNever)) {
                 return false;
             }
             return eachTypeContainedIn(mapType(type, getRegularTypeOfLiteralType), switchTypes);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13534,10 +13534,6 @@ namespace ts {
                     return type;
                 }
                 const clauseTypes = switchTypes.slice(clauseStart, clauseEnd);
-                if (some(clauseTypes, isNotUnitTypeOrNever)) {
-                    // Only clauses containing only unit types can be narrowed
-                    return type;
-                }
                 const hasDefaultClause = clauseStart === clauseEnd || contains(clauseTypes, neverType);
                 const discriminantType = getUnionType(clauseTypes);
                 const caseType =

--- a/tests/baselines/reference/literalTypes1.types
+++ b/tests/baselines/reference/literalTypes1.types
@@ -68,7 +68,7 @@ function f2(x: 0 | 1 | 2) {
 >oneOrTwo : 1 | 2
 
             x;
->x : 0 | 1 | 2
+>x : 1 | 2
 
             break;
         default:

--- a/tests/baselines/reference/literalTypes1.types
+++ b/tests/baselines/reference/literalTypes1.types
@@ -61,7 +61,7 @@ function f2(x: 0 | 1 | 2) {
 >zero : 0
 
             x;
->x : 0 | 1 | 2
+>x : 0
 
             break;
         case oneOrTwo:
@@ -73,7 +73,7 @@ function f2(x: 0 | 1 | 2) {
             break;
         default:
             x;
->x : 0 | 1 | 2
+>x : 1 | 2
     }
 }
 

--- a/tests/baselines/reference/stringLiteralsWithSwitchStatements03.types
+++ b/tests/baselines/reference/stringLiteralsWithSwitchStatements03.types
@@ -51,7 +51,7 @@ switch (x) {
 >"baz" : "baz"
 
         x;
->x : "foo"
+>x : never
 
         y;
 >y : "foo" | "bar"

--- a/tests/baselines/reference/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.js
+++ b/tests/baselines/reference/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.js
@@ -1,0 +1,83 @@
+//// [switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts]
+export const narrowToLiterals = (str: string) => {
+    switch (str) {
+      case 'abc': {
+        // inferred type as `abc`
+        return str;
+      }
+      default:
+        return 'defaultValue';
+    }
+  };
+  
+  export const narrowToString = (str: string, someOtherStr: string) => {
+    switch (str) {
+      case 'abc': {
+        // inferred type should be `abc`
+        return str;
+      }
+      case someOtherStr: {
+        // `string`
+        return str;
+      }
+      default:
+        return 'defaultValue';
+    }
+  };
+  
+  export const narrowToStringOrNumber = (str: string | number, someNumber: number) => {
+    switch (str) {
+      case 'abc': {
+        // inferred type should be `abc`
+        return str;
+      }
+      case someNumber: {
+        // inferred type should be `number`
+        return str;
+      }
+      default:
+        return 'defaultValue';
+    }
+  };
+
+//// [switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.js]
+"use strict";
+exports.__esModule = true;
+exports.narrowToLiterals = function (str) {
+    switch (str) {
+        case 'abc': {
+            // inferred type as `abc`
+            return str;
+        }
+        default:
+            return 'defaultValue';
+    }
+};
+exports.narrowToString = function (str, someOtherStr) {
+    switch (str) {
+        case 'abc': {
+            // inferred type should be `abc`
+            return str;
+        }
+        case someOtherStr: {
+            // `string`
+            return str;
+        }
+        default:
+            return 'defaultValue';
+    }
+};
+exports.narrowToStringOrNumber = function (str, someNumber) {
+    switch (str) {
+        case 'abc': {
+            // inferred type should be `abc`
+            return str;
+        }
+        case someNumber: {
+            // inferred type should be `number`
+            return str;
+        }
+        default:
+            return 'defaultValue';
+    }
+};

--- a/tests/baselines/reference/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.symbols
+++ b/tests/baselines/reference/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.symbols
@@ -1,0 +1,67 @@
+=== tests/cases/compiler/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts ===
+export const narrowToLiterals = (str: string) => {
+>narrowToLiterals : Symbol(narrowToLiterals, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 0, 12))
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 0, 33))
+
+    switch (str) {
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 0, 33))
+
+      case 'abc': {
+        // inferred type as `abc`
+        return str;
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 0, 33))
+      }
+      default:
+        return 'defaultValue';
+    }
+  };
+  
+  export const narrowToString = (str: string, someOtherStr: string) => {
+>narrowToString : Symbol(narrowToString, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 11, 14))
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 11, 33))
+>someOtherStr : Symbol(someOtherStr, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 11, 45))
+
+    switch (str) {
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 11, 33))
+
+      case 'abc': {
+        // inferred type should be `abc`
+        return str;
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 11, 33))
+      }
+      case someOtherStr: {
+>someOtherStr : Symbol(someOtherStr, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 11, 45))
+
+        // `string`
+        return str;
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 11, 33))
+      }
+      default:
+        return 'defaultValue';
+    }
+  };
+  
+  export const narrowToStringOrNumber = (str: string | number, someNumber: number) => {
+>narrowToStringOrNumber : Symbol(narrowToStringOrNumber, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 26, 14))
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 26, 41))
+>someNumber : Symbol(someNumber, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 26, 62))
+
+    switch (str) {
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 26, 41))
+
+      case 'abc': {
+        // inferred type should be `abc`
+        return str;
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 26, 41))
+      }
+      case someNumber: {
+>someNumber : Symbol(someNumber, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 26, 62))
+
+        // inferred type should be `number`
+        return str;
+>str : Symbol(str, Decl(switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts, 26, 41))
+      }
+      default:
+        return 'defaultValue';
+    }
+  };

--- a/tests/baselines/reference/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.types
+++ b/tests/baselines/reference/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.types
@@ -50,8 +50,8 @@ export const narrowToLiterals = (str: string) => {
   };
   
   export const narrowToStringOrNumber = (str: string | number, someNumber: number) => {
->narrowToStringOrNumber : (str: string | number, someNumber: number) => string | number
->(str: string | number, someNumber: number) => {    switch (str) {      case 'abc': {        // inferred type should be `abc`        return str;      }      case someNumber: {        // inferred type should be `number`        return str;      }      default:        return 'defaultValue';    }  } : (str: string | number, someNumber: number) => string | number
+>narrowToStringOrNumber : (str: string | number, someNumber: number) => number | "abc" | "defaultValue"
+>(str: string | number, someNumber: number) => {    switch (str) {      case 'abc': {        // inferred type should be `abc`        return str;      }      case someNumber: {        // inferred type should be `number`        return str;      }      default:        return 'defaultValue';    }  } : (str: string | number, someNumber: number) => number | "abc" | "defaultValue"
 >str : string | number
 >someNumber : number
 
@@ -70,7 +70,7 @@ export const narrowToLiterals = (str: string) => {
 
         // inferred type should be `number`
         return str;
->str : string | number
+>str : number
       }
       default:
         return 'defaultValue';

--- a/tests/baselines/reference/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.types
+++ b/tests/baselines/reference/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.types
@@ -1,0 +1,79 @@
+=== tests/cases/compiler/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts ===
+export const narrowToLiterals = (str: string) => {
+>narrowToLiterals : (str: string) => "abc" | "defaultValue"
+>(str: string) => {    switch (str) {      case 'abc': {        // inferred type as `abc`        return str;      }      default:        return 'defaultValue';    }  } : (str: string) => "abc" | "defaultValue"
+>str : string
+
+    switch (str) {
+>str : string
+
+      case 'abc': {
+>'abc' : "abc"
+
+        // inferred type as `abc`
+        return str;
+>str : "abc"
+      }
+      default:
+        return 'defaultValue';
+>'defaultValue' : "defaultValue"
+    }
+  };
+  
+  export const narrowToString = (str: string, someOtherStr: string) => {
+>narrowToString : (str: string, someOtherStr: string) => string
+>(str: string, someOtherStr: string) => {    switch (str) {      case 'abc': {        // inferred type should be `abc`        return str;      }      case someOtherStr: {        // `string`        return str;      }      default:        return 'defaultValue';    }  } : (str: string, someOtherStr: string) => string
+>str : string
+>someOtherStr : string
+
+    switch (str) {
+>str : string
+
+      case 'abc': {
+>'abc' : "abc"
+
+        // inferred type should be `abc`
+        return str;
+>str : "abc"
+      }
+      case someOtherStr: {
+>someOtherStr : string
+
+        // `string`
+        return str;
+>str : string
+      }
+      default:
+        return 'defaultValue';
+>'defaultValue' : "defaultValue"
+    }
+  };
+  
+  export const narrowToStringOrNumber = (str: string | number, someNumber: number) => {
+>narrowToStringOrNumber : (str: string | number, someNumber: number) => string | number
+>(str: string | number, someNumber: number) => {    switch (str) {      case 'abc': {        // inferred type should be `abc`        return str;      }      case someNumber: {        // inferred type should be `number`        return str;      }      default:        return 'defaultValue';    }  } : (str: string | number, someNumber: number) => string | number
+>str : string | number
+>someNumber : number
+
+    switch (str) {
+>str : string | number
+
+      case 'abc': {
+>'abc' : "abc"
+
+        // inferred type should be `abc`
+        return str;
+>str : "abc"
+      }
+      case someNumber: {
+>someNumber : number
+
+        // inferred type should be `number`
+        return str;
+>str : string | number
+      }
+      default:
+        return 'defaultValue';
+>'defaultValue' : "defaultValue"
+    }
+  };

--- a/tests/cases/compiler/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts
+++ b/tests/cases/compiler/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts
@@ -1,0 +1,40 @@
+export const narrowToLiterals = (str: string) => {
+    switch (str) {
+      case 'abc': {
+        // inferred type as `abc`
+        return str;
+      }
+      default:
+        return 'defaultValue';
+    }
+  };
+  
+  export const narrowToString = (str: string, someOtherStr: string) => {
+    switch (str) {
+      case 'abc': {
+        // inferred type should be `abc`
+        return str;
+      }
+      case someOtherStr: {
+        // `string`
+        return str;
+      }
+      default:
+        return 'defaultValue';
+    }
+  };
+  
+  export const narrowToStringOrNumber = (str: string | number, someNumber: number) => {
+    switch (str) {
+      case 'abc': {
+        // inferred type should be `abc`
+        return str;
+      }
+      case someNumber: {
+        // inferred type should be `number`
+        return str;
+      }
+      default:
+        return 'defaultValue';
+    }
+  };


### PR DESCRIPTION
Fixes #23510

Switch-case exhaustiveness is still handled roughly the same way, however this removes the unit type restriction on switch-case narrowing (which brings it inline with `if` narrowing).