### PR TITLE
quickInfo: Get JSDoc tags from aliased symbol

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -134,6 +134,7 @@ namespace ts.SymbolDisplay {
         let type: Type;
         let printer: Printer;
         let documentationFromAlias: SymbolDisplayPart[];
+        let tagsFromAlias: JSDocTagInfo[];
 
         // Class at constructor site need to be shown as constructor apart from property,method, vars
         if (symbolKind !== ScriptElementKind.unknown || symbolFlags & SymbolFlags.Class || symbolFlags & SymbolFlags.Alias) {
@@ -396,6 +397,7 @@ namespace ts.SymbolDisplay {
                         displayParts.push(...resolvedInfo.displayParts);
                         displayParts.push(lineBreakPart());
                         documentationFromAlias = resolvedInfo.documentation;
+                        tagsFromAlias = resolvedInfo.tags;
                     }
                 }
             }
@@ -520,6 +522,9 @@ namespace ts.SymbolDisplay {
 
         if (documentation.length === 0 && documentationFromAlias) {
             documentation = documentationFromAlias;
+        }
+        if (tags.length === 0 && tagsFromAlias) {
+            tags = tagsFromAlias;
         }
 
         return { displayParts, documentation, symbolKind, tags };

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -338,7 +338,7 @@ declare namespace FourSlashInterface {
         verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: {
             start: number;
             length: number;
-        }, displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[], tags: ts.JSDocTagInfo[]): void;
+        }, displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[], tags: { name: string, text?: string }[]): void;
         getSyntacticDiagnostics(expected: ReadonlyArray<Diagnostic>): void;
         getSemanticDiagnostics(expected: ReadonlyArray<Diagnostic>): void;
         getSuggestionDiagnostics(expected: ReadonlyArray<Diagnostic>): void;

--- a/tests/cases/fourslash/quickInfoAlias.ts
+++ b/tests/cases/fourslash/quickInfoAlias.ts
@@ -9,28 +9,43 @@
 
 // @Filename: /b.ts
 ////import { x } from "./a";
-////x/**/;
+////x/*b*/;
 
-goTo.marker("");
-verify.verifyQuickInfoDisplayParts(
-    "alias",
-    "",
-    { start: 25, length: 1 },
-    [
-        { text:"(",kind:"punctuation" },
-        { text:"alias",kind:"text" },
-        { text:")",kind:"punctuation" },
-        { text:" ",kind:"space" },
-        { text:"const",kind:"keyword" },
-        { text:" ",kind:"space" },
-        { text:"x",kind:"aliasName" },
-        { text:":",kind:"punctuation" },
-        { text:" ",kind:"space" },
-        { text:"0",kind:"stringLiteral" },
-        { text:"\n",kind:"lineBreak" },
-        { text:"import",kind:"keyword" },
-        { text:" ",kind:"space" },
-        { text:"x",kind:"aliasName" },
-    ],
-    [{ text: "Doc", kind: "text" }],
-    [{ name: "tag", text: "Tag text" }]);
+// @Filename: /c.ts
+/////**
+//// * Doc 2
+//// * @tag Tag text 2
+//// */
+////import {
+////    /**
+////     * Doc 3
+////     * @tag Tag text 3
+////     */
+////    x
+////} from "./a";
+////x/*c*/;
+
+goTo.eachMarker((_, index) => {
+    verify.verifyQuickInfoDisplayParts(
+        "alias",
+        "",
+        { start: index === 0 ? 25 : 117, length: 1 },
+        [
+            { text:"(",kind:"punctuation" },
+            { text:"alias",kind:"text" },
+            { text:")",kind:"punctuation" },
+            { text:" ",kind:"space" },
+            { text:"const",kind:"keyword" },
+            { text:" ",kind:"space" },
+            { text:"x",kind:"aliasName" },
+            { text:":",kind:"punctuation" },
+            { text:" ",kind:"space" },
+            { text:"0",kind:"stringLiteral" },
+            { text:"\n",kind:"lineBreak" },
+            { text:"import",kind:"keyword" },
+            { text:" ",kind:"space" },
+            { text:"x",kind:"aliasName" },
+        ],
+        [{ text: "Doc", kind: "text" }],
+        [{ name: "tag", text: "Tag text" }]);
+});

--- a/tests/cases/fourslash/quickInfoAlias.ts
+++ b/tests/cases/fourslash/quickInfoAlias.ts
@@ -1,0 +1,36 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: /a.ts
+/////**
+//// * Doc
+//// * @tag Tag text
+//// */
+////export const x = 0;
+
+// @Filename: /b.ts
+////import { x } from "./a";
+////x/**/;
+
+goTo.marker("");
+verify.verifyQuickInfoDisplayParts(
+    "alias",
+    "",
+    { start: 25, length: 1 },
+    [
+        { text:"(",kind:"punctuation" },
+        { text:"alias",kind:"text" },
+        { text:")",kind:"punctuation" },
+        { text:" ",kind:"space" },
+        { text:"const",kind:"keyword" },
+        { text:" ",kind:"space" },
+        { text:"x",kind:"aliasName" },
+        { text:":",kind:"punctuation" },
+        { text:" ",kind:"space" },
+        { text:"0",kind:"stringLiteral" },
+        { text:"\n",kind:"lineBreak" },
+        { text:"import",kind:"keyword" },
+        { text:" ",kind:"space" },
+        { text:"x",kind:"aliasName" },
+    ],
+    [{ text: "Doc", kind: "text" }],
+    [{ name: "tag", text: "Tag text" }]);


### PR DESCRIPTION
Fixes #23518
