### PR TITLE
In `new Promise`, default T to void

### DIFF
--- a/src/lib/es2015.promise.d.ts
+++ b/src/lib/es2015.promise.d.ts
@@ -10,7 +10,7 @@ interface PromiseConstructor {
      * a resolve callback used resolve the promise with a value or the result of another promise,
      * and a reject callback used to reject the promise with a provided reason or error.
      */
-    new <T>(executor: (resolve: [T] extends [void] ? (value?: T | PromiseLike<T>) => void : (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
+    new <T = void>(executor: (resolve: [T] extends [void] ? (value?: T | PromiseLike<T>) => void : (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises

--- a/tests/baselines/reference/defaultExportInAwaitExpression01.js
+++ b/tests/baselines/reference/defaultExportInAwaitExpression01.js
@@ -1,7 +1,7 @@
 //// [tests/cases/conformance/es6/modules/defaultExportInAwaitExpression01.ts] ////
 
 //// [a.ts]
-const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
+const x = new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } );
 export default x;
 
 //// [b.ts]

--- a/tests/baselines/reference/defaultExportInAwaitExpression01.symbols
+++ b/tests/baselines/reference/defaultExportInAwaitExpression01.symbols
@@ -1,10 +1,10 @@
 === tests/cases/conformance/es6/modules/a.ts ===
-const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
+const x = new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } );
 >x : Symbol(x, Decl(a.ts, 0, 5))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
->resolve : Symbol(resolve, Decl(a.ts, 0, 24))
->reject : Symbol(reject, Decl(a.ts, 0, 33))
->resolve : Symbol(resolve, Decl(a.ts, 0, 24))
+>resolve : Symbol(resolve, Decl(a.ts, 0, 28))
+>reject : Symbol(reject, Decl(a.ts, 0, 37))
+>resolve : Symbol(resolve, Decl(a.ts, 0, 28))
 
 export default x;
 >x : Symbol(x, Decl(a.ts, 0, 5))

--- a/tests/baselines/reference/defaultExportInAwaitExpression01.types
+++ b/tests/baselines/reference/defaultExportInAwaitExpression01.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/modules/a.ts ===
-const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
+const x = new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } );
 >x : Promise<{}>
->new Promise( ( resolve, reject ) => { resolve( {} ); } ) : Promise<{}>
+>new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } ) : Promise<{}>
 >Promise : PromiseConstructor
 >( resolve, reject ) => { resolve( {} ); } : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
 >resolve : (value: {} | PromiseLike<{}>) => void

--- a/tests/baselines/reference/defaultExportInAwaitExpression02.js
+++ b/tests/baselines/reference/defaultExportInAwaitExpression02.js
@@ -1,7 +1,7 @@
 //// [tests/cases/conformance/es6/modules/defaultExportInAwaitExpression02.ts] ////
 
 //// [a.ts]
-const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
+const x = new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } );
 export default x;
 
 //// [b.ts]

--- a/tests/baselines/reference/defaultExportInAwaitExpression02.symbols
+++ b/tests/baselines/reference/defaultExportInAwaitExpression02.symbols
@@ -1,10 +1,10 @@
 === tests/cases/conformance/es6/modules/a.ts ===
-const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
+const x = new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } );
 >x : Symbol(x, Decl(a.ts, 0, 5))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
->resolve : Symbol(resolve, Decl(a.ts, 0, 24))
->reject : Symbol(reject, Decl(a.ts, 0, 33))
->resolve : Symbol(resolve, Decl(a.ts, 0, 24))
+>resolve : Symbol(resolve, Decl(a.ts, 0, 28))
+>reject : Symbol(reject, Decl(a.ts, 0, 37))
+>resolve : Symbol(resolve, Decl(a.ts, 0, 28))
 
 export default x;
 >x : Symbol(x, Decl(a.ts, 0, 5))

--- a/tests/baselines/reference/defaultExportInAwaitExpression02.types
+++ b/tests/baselines/reference/defaultExportInAwaitExpression02.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/modules/a.ts ===
-const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
+const x = new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } );
 >x : Promise<{}>
->new Promise( ( resolve, reject ) => { resolve( {} ); } ) : Promise<{}>
+>new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } ) : Promise<{}>
 >Promise : PromiseConstructor
 >( resolve, reject ) => { resolve( {} ); } : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
 >resolve : (value: {} | PromiseLike<{}>) => void

--- a/tests/baselines/reference/inferenceLimit.js
+++ b/tests/baselines/reference/inferenceLimit.js
@@ -14,7 +14,7 @@ export class BrokenClass {
     let result: Array<MyModule.MyModel> = [];
 
     let populateItems = (order) => {
-      return new Promise((resolve, reject) => {
+      return new Promise<{}>((resolve, reject) => {
         this.doStuff(order.id)
           .then((items) => {
             order.items = items;

--- a/tests/baselines/reference/inferenceLimit.symbols
+++ b/tests/baselines/reference/inferenceLimit.symbols
@@ -31,10 +31,10 @@ export class BrokenClass {
 >populateItems : Symbol(populateItems, Decl(file1.ts, 12, 7))
 >order : Symbol(order, Decl(file1.ts, 12, 25))
 
-      return new Promise((resolve, reject) => {
+      return new Promise<{}>((resolve, reject) => {
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
->resolve : Symbol(resolve, Decl(file1.ts, 13, 26))
->reject : Symbol(reject, Decl(file1.ts, 13, 34))
+>resolve : Symbol(resolve, Decl(file1.ts, 13, 30))
+>reject : Symbol(reject, Decl(file1.ts, 13, 38))
 
         this.doStuff(order.id)
 >this.doStuff(order.id)          .then : Symbol(Promise.then, Decl(lib.es5.d.ts, --, --))
@@ -52,7 +52,7 @@ export class BrokenClass {
 >items : Symbol(items, Decl(file1.ts, 15, 17))
 
             resolve(order);
->resolve : Symbol(resolve, Decl(file1.ts, 13, 26))
+>resolve : Symbol(resolve, Decl(file1.ts, 13, 30))
 >order : Symbol(order, Decl(file1.ts, 12, 25))
 
           });

--- a/tests/baselines/reference/inferenceLimit.types
+++ b/tests/baselines/reference/inferenceLimit.types
@@ -16,12 +16,12 @@ export class BrokenClass {
 >value : string
 
   return new Promise<Array<MyModule.MyModel>>((resolve, reject) => {
->new Promise<Array<MyModule.MyModel>>((resolve, reject) => {    let result: Array<MyModule.MyModel> = [];    let populateItems = (order) => {      return new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    };    return Promise.all(result.map(populateItems))      .then((orders: Array<MyModule.MyModel>) => {        resolve(orders);      });    }) : Promise<MyModule.MyModel[]>
+>new Promise<Array<MyModule.MyModel>>((resolve, reject) => {    let result: Array<MyModule.MyModel> = [];    let populateItems = (order) => {      return new Promise<{}>((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    };    return Promise.all(result.map(populateItems))      .then((orders: Array<MyModule.MyModel>) => {        resolve(orders);      });    }) : Promise<MyModule.MyModel[]>
 >Promise : PromiseConstructor
 >Array : T[]
 >MyModule : any
 >MyModel : MyModule.MyModel
->(resolve, reject) => {    let result: Array<MyModule.MyModel> = [];    let populateItems = (order) => {      return new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    };    return Promise.all(result.map(populateItems))      .then((orders: Array<MyModule.MyModel>) => {        resolve(orders);      });    } : (resolve: (value: MyModule.MyModel[] | PromiseLike<MyModule.MyModel[]>) => void, reject: (reason?: any) => void) => Promise<void>
+>(resolve, reject) => {    let result: Array<MyModule.MyModel> = [];    let populateItems = (order) => {      return new Promise<{}>((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    };    return Promise.all(result.map(populateItems))      .then((orders: Array<MyModule.MyModel>) => {        resolve(orders);      });    } : (resolve: (value: MyModule.MyModel[] | PromiseLike<MyModule.MyModel[]>) => void, reject: (reason?: any) => void) => Promise<void>
 >resolve : (value: MyModule.MyModel[] | PromiseLike<MyModule.MyModel[]>) => void
 >reject : (reason?: any) => void
 
@@ -34,11 +34,11 @@ export class BrokenClass {
 
     let populateItems = (order) => {
 >populateItems : (order: any) => Promise<{}>
->(order) => {      return new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    } : (order: any) => Promise<{}>
+>(order) => {      return new Promise<{}>((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    } : (order: any) => Promise<{}>
 >order : any
 
-      return new Promise((resolve, reject) => {
->new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      }) : Promise<{}>
+      return new Promise<{}>((resolve, reject) => {
+>new Promise<{}>((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      }) : Promise<{}>
 >Promise : PromiseConstructor
 >(resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      } : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
 >resolve : (value: {} | PromiseLike<{}>) => void

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.types
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.types
@@ -133,13 +133,13 @@ o.hasOwnProperty(Symbol.hasInstance);
 
 // Using ES6 promise
 async function out() {
->out : () => Promise<{}>
+>out : () => Promise<void>
 
     return new Promise(function (resolve, reject) {});
->new Promise(function (resolve, reject) {}) : Promise<{}>
+>new Promise(function (resolve, reject) {}) : Promise<void>
 >Promise : PromiseConstructor
->function (resolve, reject) {} : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
->resolve : (value: {} | PromiseLike<{}>) => void
+>function (resolve, reject) {} : (resolve: (value?: void | PromiseLike<void>) => void, reject: (reason?: any) => void) => void
+>resolve : (value?: void | PromiseLike<void>) => void
 >reject : (reason?: any) => void
 }
 
@@ -148,10 +148,10 @@ declare var console: any;
 
 out().then(() => {
 >out().then(() => {    console.log("Yea!");}) : Promise<void>
->out().then : <TResult1 = {}, TResult2 = never>(onfulfilled?: (value: {}) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->out() : Promise<{}>
->out : () => Promise<{}>
->then : <TResult1 = {}, TResult2 = never>(onfulfilled?: (value: {}) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>out().then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>out() : Promise<void>
+>out : () => Promise<void>
+>then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => {    console.log("Yea!");} : () => void
 
     console.log("Yea!");

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.types
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.types
@@ -133,13 +133,13 @@ o.hasOwnProperty(Symbol.hasInstance);
 
 // Using ES6 promise
 async function out() {
->out : () => Promise<{}>
+>out : () => Promise<void>
 
     return new Promise(function (resolve, reject) {});
->new Promise(function (resolve, reject) {}) : Promise<{}>
+>new Promise(function (resolve, reject) {}) : Promise<void>
 >Promise : PromiseConstructor
->function (resolve, reject) {} : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
->resolve : (value: {} | PromiseLike<{}>) => void
+>function (resolve, reject) {} : (resolve: (value?: void | PromiseLike<void>) => void, reject: (reason?: any) => void) => void
+>resolve : (value?: void | PromiseLike<void>) => void
 >reject : (reason?: any) => void
 }
 
@@ -148,10 +148,10 @@ declare var console: any;
 
 out().then(() => {
 >out().then(() => {    console.log("Yea!");}) : Promise<void>
->out().then : <TResult1 = {}, TResult2 = never>(onfulfilled?: (value: {}) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->out() : Promise<{}>
->out : () => Promise<{}>
->then : <TResult1 = {}, TResult2 = never>(onfulfilled?: (value: {}) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>out().then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>out() : Promise<void>
+>out : () => Promise<void>
+>then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => {    console.log("Yea!");} : () => void
 
     console.log("Yea!");

--- a/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.types
+++ b/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.types
@@ -133,13 +133,13 @@ o.hasOwnProperty(Symbol.hasInstance);
 
 // Using ES6 promise
 async function out() {
->out : () => Promise<{}>
+>out : () => Promise<void>
 
     return new Promise(function (resolve, reject) {});
->new Promise(function (resolve, reject) {}) : Promise<{}>
+>new Promise(function (resolve, reject) {}) : Promise<void>
 >Promise : PromiseConstructor
->function (resolve, reject) {} : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
->resolve : (value: {} | PromiseLike<{}>) => void
+>function (resolve, reject) {} : (resolve: (value?: void | PromiseLike<void>) => void, reject: (reason?: any) => void) => void
+>resolve : (value?: void | PromiseLike<void>) => void
 >reject : (reason?: any) => void
 }
 
@@ -148,10 +148,10 @@ declare var console: any;
 
 out().then(() => {
 >out().then(() => {    console.log("Yea!");}) : Promise<void>
->out().then : <TResult1 = {}, TResult2 = never>(onfulfilled?: (value: {}) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->out() : Promise<{}>
->out : () => Promise<{}>
->then : <TResult1 = {}, TResult2 = never>(onfulfilled?: (value: {}) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>out().then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>out() : Promise<void>
+>out : () => Promise<void>
+>then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => {    console.log("Yea!");} : () => void
 
     console.log("Yea!");

--- a/tests/baselines/reference/promiseType.js
+++ b/tests/baselines/reference/promiseType.js
@@ -218,6 +218,11 @@ const pc7 = p.then(() => Promise.reject("1"), () => {throw 1});
 const pc8 = p.then(() => Promise.reject("1"), () => Promise.resolve(1));
 const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
 
+new Promise((resolve, reject) => {
+    if (1) resolve();
+    else reject();
+});
+
 
 //// [promiseType.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -439,3 +444,9 @@ const pc6 = p.then(() => Promise.reject("1"), () => { });
 const pc7 = p.then(() => Promise.reject("1"), () => { throw 1; });
 const pc8 = p.then(() => Promise.reject("1"), () => Promise.resolve(1));
 const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
+new Promise((resolve, reject) => {
+    if (1)
+        resolve();
+    else
+        reject();
+});

--- a/tests/baselines/reference/promiseType.symbols
+++ b/tests/baselines/reference/promiseType.symbols
@@ -1089,3 +1089,16 @@ const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 >reject : Symbol(PromiseConstructor.reject, Decl(lib.es2015.promise.d.ts, --, --))
 
+new Promise((resolve, reject) => {
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(promiseType.ts, 219, 13))
+>reject : Symbol(reject, Decl(promiseType.ts, 219, 21))
+
+    if (1) resolve();
+>resolve : Symbol(resolve, Decl(promiseType.ts, 219, 13))
+
+    else reject();
+>reject : Symbol(reject, Decl(promiseType.ts, 219, 21))
+
+});
+

--- a/tests/baselines/reference/promiseType.types
+++ b/tests/baselines/reference/promiseType.types
@@ -1584,3 +1584,21 @@ const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
 >reject : <T = never>(reason?: any) => Promise<T>
 >1 : 1
 
+new Promise((resolve, reject) => {
+>new Promise((resolve, reject) => {    if (1) resolve();    else reject();}) : Promise<void>
+>Promise : PromiseConstructor
+>(resolve, reject) => {    if (1) resolve();    else reject();} : (resolve: (value?: void | PromiseLike<void>) => void, reject: (reason?: any) => void) => void
+>resolve : (value?: void | PromiseLike<void>) => void
+>reject : (reason?: any) => void
+
+    if (1) resolve();
+>1 : 1
+>resolve() : void
+>resolve : (value?: void | PromiseLike<void>) => void
+
+    else reject();
+>reject() : void
+>reject : (reason?: any) => void
+
+});
+

--- a/tests/baselines/reference/usePromiseFinally.types
+++ b/tests/baselines/reference/usePromiseFinally.types
@@ -1,15 +1,15 @@
 === tests/cases/conformance/es2018/usePromiseFinally.ts ===
 let promise1 = new Promise(function(resolve, reject) {})
->promise1 : Promise<{}>
->new Promise(function(resolve, reject) {})                .finally(function() {}) : Promise<{}>
->new Promise(function(resolve, reject) {})                .finally : (onfinally?: () => void) => Promise<{}>
->new Promise(function(resolve, reject) {}) : Promise<{}>
+>promise1 : Promise<void>
+>new Promise(function(resolve, reject) {})                .finally(function() {}) : Promise<void>
+>new Promise(function(resolve, reject) {})                .finally : (onfinally?: () => void) => Promise<void>
+>new Promise(function(resolve, reject) {}) : Promise<void>
 >Promise : PromiseConstructor
->function(resolve, reject) {} : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
->resolve : (value: {} | PromiseLike<{}>) => void
+>function(resolve, reject) {} : (resolve: (value?: void | PromiseLike<void>) => void, reject: (reason?: any) => void) => void
+>resolve : (value?: void | PromiseLike<void>) => void
 >reject : (reason?: any) => void
 
                 .finally(function() {});
->finally : (onfinally?: () => void) => Promise<{}>
+>finally : (onfinally?: () => void) => Promise<void>
 >function() {} : () => void
 

--- a/tests/cases/compiler/inferenceLimit.ts
+++ b/tests/cases/compiler/inferenceLimit.ts
@@ -14,7 +14,7 @@ export class BrokenClass {
     let result: Array<MyModule.MyModel> = [];
 
     let populateItems = (order) => {
-      return new Promise((resolve, reject) => {
+      return new Promise<{}>((resolve, reject) => {
         this.doStuff(order.id)
           .then((items) => {
             order.items = items;

--- a/tests/cases/compiler/promiseType.ts
+++ b/tests/cases/compiler/promiseType.ts
@@ -217,3 +217,8 @@ const pc6 = p.then(() => Promise.reject("1"), () => {});
 const pc7 = p.then(() => Promise.reject("1"), () => {throw 1});
 const pc8 = p.then(() => Promise.reject("1"), () => Promise.resolve(1));
 const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
+
+new Promise((resolve, reject) => {
+    if (1) resolve();
+    else reject();
+});

--- a/tests/cases/conformance/es6/modules/defaultExportInAwaitExpression01.ts
+++ b/tests/cases/conformance/es6/modules/defaultExportInAwaitExpression01.ts
@@ -1,7 +1,7 @@
 // @target: ES6
 // @module: umd
 // @filename: a.ts
-const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
+const x = new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } );
 export default x;
 
 // @filename: b.ts

--- a/tests/cases/conformance/es6/modules/defaultExportInAwaitExpression02.ts
+++ b/tests/cases/conformance/es6/modules/defaultExportInAwaitExpression02.ts
@@ -1,7 +1,7 @@
 // @target: ES6
 // @module: commonjs
 // @filename: a.ts
-const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
+const x = new Promise<{}>( ( resolve, reject ) => { resolve( {} ); } );
 export default x;
 
 // @filename: b.ts


### PR DESCRIPTION
Currently the following is a compile error:
```ts
new Promise(resolve => { resolve()) };
```
Because the constructor provides:
```ts
resolve: [T] extends [void] ? (value?: T | PromiseLike<T>) => void : (value: T | PromiseLike<T>) => void
```

Since there's no way to infer `T`, it is `{}` by default.
Before #22772, `value` was always optional and there was no problem. But now many DefinitelyTyped tests are failing because they rely on being able to call `resolve()` without providing an explicit type argument.
I think `void` makes a more sensible default than `{}`, which would fix the issue, but would technically be a breaking change because `new Promise(resolve => { resolve({}); })` will now be broken.
(CC @falsandtru)