### PR TITLE
`module.exports = Entity` is an alias, just like `export = Entity`

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2325,6 +2325,8 @@ namespace ts {
             // An export default clause with an EntityNameExpression exports all meanings of that identifier
                 ? SymbolFlags.Alias
             // An export default clause with any other expression exports a value
+            // TODO: (1) might not need the last two flags
+            // TODO: (2) if not, should just be able to call bindExportAssignment
                 : SymbolFlags.Property | SymbolFlags.ExportValue | SymbolFlags.ValueModule;
             declareSymbol(file.symbol.exports, file.symbol, node, flags, SymbolFlags.None);
         }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2321,7 +2321,12 @@ namespace ts {
 
             // 'module.exports = expr' assignment
             setCommonJsModuleIndicator(node);
-            declareSymbol(file.symbol.exports, file.symbol, node, SymbolFlags.Property | SymbolFlags.ExportValue | SymbolFlags.ValueModule, SymbolFlags.None);
+            const flags = isEntityNameExpression(node.right)
+            // An export default clause with an EntityNameExpression exports all meanings of that identifier
+                ? SymbolFlags.Alias
+            // An export default clause with any other expression exports a value
+                : SymbolFlags.Property | SymbolFlags.ExportValue | SymbolFlags.ValueModule;
+            declareSymbol(file.symbol.exports, file.symbol, node, flags, SymbolFlags.None);
         }
 
         function bindThisPropertyAssignment(node: BinaryExpression | PropertyAccessExpression) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2322,11 +2322,7 @@ namespace ts {
             // 'module.exports = expr' assignment
             setCommonJsModuleIndicator(node);
             const flags = isEntityNameExpression(node.right)
-            // An export default clause with an EntityNameExpression exports all meanings of that identifier
-                ? SymbolFlags.Alias
-            // An export default clause with any other expression exports a value
-            // TODO: (1) might not need the last two flags
-            // TODO: (2) if not, should just be able to call bindExportAssignment
+                ? SymbolFlags.Alias // An export= with an EntityNameExpression exports all meanings of that identifier
                 : SymbolFlags.Property | SymbolFlags.ExportValue | SymbolFlags.ValueModule;
             declareSymbol(file.symbol.exports, file.symbol, node, flags, SymbolFlags.None);
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7495,7 +7495,6 @@ namespace ts {
                 return unknownType;
             }
 
-            // TODO: This might not be needed anymore? (Maybe)
             // A jsdoc TypeReference may have resolved to a value (as opposed to a type). If
             // the symbol is a constructor function, return the inferred class type; otherwise,
             // the type of this reference is just the type of the value we resolved to.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7495,6 +7495,7 @@ namespace ts {
                 return unknownType;
             }
 
+            // TODO: This might not be needed anymore? (Maybe)
             // A jsdoc TypeReference may have resolved to a value (as opposed to a type). If
             // the symbol is a constructor function, return the inferred class type; otherwise,
             // the type of this reference is just the type of the value we resolved to.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2226,18 +2226,8 @@ namespace ts {
                 merged.flags = merged.flags | SymbolFlags.ValueModule;
                 merged.exports = createSymbolTable();
             }
-            // TODO: ??? mergeSymbolTable(merged.exports, moduleSymbol.exports); // except export= of course
-            moduleSymbol.exports.forEach((s, name) => {
-                if (name === InternalSymbolName.ExportEquals) return;
-                if (!merged.exports.has(name)) {
-                    merged.exports.set(name, s);
-                }
-                else {
-                    const ms = cloneSymbol(merged.exports.get(name));
-                    mergeSymbol(ms, s);
-                    merged.exports.set(name, ms);
-                }
-            });
+            mergeSymbolTable(merged.exports, moduleSymbol.exports);
+            merged.exports.delete(InternalSymbolName.ExportEquals);
             return merged;
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1921,8 +1921,9 @@ namespace ts {
                 resolveEntityName(node.propertyName || node.name, meaning, /*ignoreErrors*/ false, dontResolveAlias);
         }
 
-        function getTargetOfExportAssignment(expression: Expression, dontResolveAlias: boolean): Symbol | undefined {
-            const aliasLike = resolveEntityName(<EntityNameExpression>expression, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace, /*ignoreErrors*/ true, dontResolveAlias);
+        function getTargetOfExportAssignment(node: ExportAssignment | BinaryExpression, dontResolveAlias: boolean): Symbol | undefined {
+            const expression = (isExportAssignment(node) ? node.expression : node.right) as EntityNameExpression;
+            const aliasLike = resolveEntityName(expression, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace, /*ignoreErrors*/ true, dontResolveAlias);
             if (aliasLike) {
                 return aliasLike;
             }
@@ -1943,11 +1944,10 @@ namespace ts {
                 case SyntaxKind.ExportSpecifier:
                     return getTargetOfExportSpecifier(<ExportSpecifier>node, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace, dontRecursivelyResolve);
                 case SyntaxKind.ExportAssignment:
-                    return getTargetOfExportAssignment((<ExportAssignment>node).expression, dontRecursivelyResolve);
+                case SyntaxKind.BinaryExpression:
+                    return getTargetOfExportAssignment((<ExportAssignment | BinaryExpression>node), dontRecursivelyResolve);
                 case SyntaxKind.NamespaceExportDeclaration:
                     return getTargetOfNamespaceExportDeclaration(<NamespaceExportDeclaration>node, dontRecursivelyResolve);
-                case SyntaxKind.BinaryExpression:
-                    return getTargetOfExportAssignment((node as BinaryExpression).right, dontRecursivelyResolve);
             }
         }
 
@@ -8665,7 +8665,6 @@ namespace ts {
                         resolveImportSymbolType(node, links, moduleSymbol, targetMeaning);
                     }
                     else if (node.flags & NodeFlags.JSDoc && moduleSymbol.flags & SymbolFlags.Value) {
-                        // TODO: Should this really be needed to avoid the error?
                         resolveImportSymbolType(node, links, moduleSymbol, SymbolFlags.Value);
                     }
                     else {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2137,7 +2137,8 @@ namespace ts {
             node.kind === SyntaxKind.NamespaceImport ||
             node.kind === SyntaxKind.ImportSpecifier ||
             node.kind === SyntaxKind.ExportSpecifier ||
-            node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(<ExportAssignment>node);
+            node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(<ExportAssignment>node) ||
+            isBinaryExpression(node) && getSpecialPropertyAssignmentKind(node) === SpecialPropertyAssignmentKind.ModuleExports;
     }
 
     export function exportAssignmentIsAlias(node: ExportAssignment): boolean {

--- a/tests/baselines/reference/es5ExportEquals.types
+++ b/tests/baselines/reference/es5ExportEquals.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/es5ExportEquals.ts ===
 export function f() { }
->f : () => void
+>f : typeof f
 
 export = f;
 >f : () => void

--- a/tests/baselines/reference/es6ExportEquals.types
+++ b/tests/baselines/reference/es6ExportEquals.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/es6ExportEquals.ts ===
 export function f() { }
->f : () => void
+>f : typeof f
 
 export = f;
 >f : () => void

--- a/tests/baselines/reference/jsdocImportType.symbols
+++ b/tests/baselines/reference/jsdocImportType.symbols
@@ -1,0 +1,56 @@
+=== tests/cases/conformance/jsdoc/use.js ===
+/// <reference path='./types.d.ts'/>
+/** @typedef {import("./mod1")} C
+ * @type {C} */
+var c;
+>c : Symbol(c, Decl(use.js, 3, 3))
+
+c.chunk;
+>c.chunk : Symbol(Chunk.chunk, Decl(mod1.js, 2, 19))
+>c : Symbol(c, Decl(use.js, 3, 3))
+>chunk : Symbol(Chunk.chunk, Decl(mod1.js, 2, 19))
+
+const D = require("./mod1");
+>D : Symbol(D, Decl(use.js, 6, 5))
+>require : Symbol(require, Decl(types.d.ts, 0, 0))
+>"./mod1" : Symbol("tests/cases/conformance/jsdoc/mod1", Decl(mod1.js, 0, 0))
+
+/** @type {D} */
+var d;
+>d : Symbol(d, Decl(use.js, 8, 3))
+
+d.chunk;
+>d.chunk : Symbol(Chunk.chunk, Decl(mod1.js, 2, 19))
+>d : Symbol(d, Decl(use.js, 8, 3))
+>chunk : Symbol(Chunk.chunk, Decl(mod1.js, 2, 19))
+
+=== tests/cases/conformance/jsdoc/types.d.ts ===
+declare function require(name: string): any;
+>require : Symbol(require, Decl(types.d.ts, 0, 0))
+>name : Symbol(name, Decl(types.d.ts, 0, 25))
+
+declare var exports: any;
+>exports : Symbol(exports, Decl(types.d.ts, 1, 11))
+
+declare var module: { exports: any };
+>module : Symbol(module, Decl(types.d.ts, 2, 11))
+>exports : Symbol(exports, Decl(types.d.ts, 2, 21))
+
+=== tests/cases/conformance/jsdoc/mod1.js ===
+/// <reference path='./types.d.ts'/>
+class Chunk {
+>Chunk : Symbol(Chunk, Decl(mod1.js, 0, 0))
+
+    constructor() {
+        this.chunk = 1;
+>this.chunk : Symbol(Chunk.chunk, Decl(mod1.js, 2, 19))
+>this : Symbol(Chunk, Decl(mod1.js, 0, 0))
+>chunk : Symbol(Chunk.chunk, Decl(mod1.js, 2, 19))
+    }
+}
+module.exports = Chunk;
+>module.exports : Symbol(exports, Decl(types.d.ts, 2, 21))
+>module : Symbol(export=, Decl(mod1.js, 5, 1))
+>exports : Symbol(export=, Decl(mod1.js, 5, 1))
+>Chunk : Symbol(Chunk, Decl(mod1.js, 0, 0))
+

--- a/tests/baselines/reference/jsdocImportType.types
+++ b/tests/baselines/reference/jsdocImportType.types
@@ -1,0 +1,60 @@
+=== tests/cases/conformance/jsdoc/use.js ===
+/// <reference path='./types.d.ts'/>
+/** @typedef {import("./mod1")} C
+ * @type {C} */
+var c;
+>c : Chunk
+
+c.chunk;
+>c.chunk : number
+>c : Chunk
+>chunk : number
+
+const D = require("./mod1");
+>D : typeof Chunk
+>require("./mod1") : typeof Chunk
+>require : (name: string) => any
+>"./mod1" : "./mod1"
+
+/** @type {D} */
+var d;
+>d : Chunk
+
+d.chunk;
+>d.chunk : number
+>d : Chunk
+>chunk : number
+
+=== tests/cases/conformance/jsdoc/types.d.ts ===
+declare function require(name: string): any;
+>require : (name: string) => any
+>name : string
+
+declare var exports: any;
+>exports : any
+
+declare var module: { exports: any };
+>module : { exports: any; }
+>exports : any
+
+=== tests/cases/conformance/jsdoc/mod1.js ===
+/// <reference path='./types.d.ts'/>
+class Chunk {
+>Chunk : Chunk
+
+    constructor() {
+        this.chunk = 1;
+>this.chunk = 1 : 1
+>this.chunk : number
+>this : this
+>chunk : number
+>1 : 1
+    }
+}
+module.exports = Chunk;
+>module.exports = Chunk : typeof Chunk
+>module.exports : any
+>module : { exports: any; }
+>exports : any
+>Chunk : typeof Chunk
+

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.symbols
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.symbols
@@ -13,14 +13,14 @@ mod1.justExport.toFixed()
 >toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 
 mod1.bothBefore.toFixed() // error
->mod1.bothBefore : Symbol(bothBefore)
+>mod1.bothBefore : Symbol(A.bothBefore, Decl(mod1.js, 2, 16), Decl(mod1.js, 0, 0))
 >mod1 : Symbol(mod1, Decl(a.js, 1, 3))
->bothBefore : Symbol(bothBefore)
+>bothBefore : Symbol(A.bothBefore, Decl(mod1.js, 2, 16), Decl(mod1.js, 0, 0))
 
 mod1.bothAfter.toFixed()
->mod1.bothAfter : Symbol(bothAfter)
+>mod1.bothAfter : Symbol(A.bothAfter, Decl(mod1.js, 3, 16), Decl(mod1.js, 8, 1))
 >mod1 : Symbol(mod1, Decl(a.js, 1, 3))
->bothAfter : Symbol(bothAfter)
+>bothAfter : Symbol(A.bothAfter, Decl(mod1.js, 3, 16), Decl(mod1.js, 8, 1))
 
 mod1.justProperty.length
 >mod1.justProperty.length : Symbol(String.length, Decl(lib.d.ts, --, --))
@@ -41,10 +41,10 @@ declare function require(name: string): any;
 === tests/cases/conformance/salsa/mod1.js ===
 /// <reference path='./requires.d.ts' />
 module.exports.bothBefore = 'string'
->module.exports : Symbol(bothBefore, Decl(mod1.js, 0, 0))
+>module.exports : Symbol(A.bothBefore, Decl(mod1.js, 2, 16), Decl(mod1.js, 0, 0))
 >module : Symbol(module, Decl(requires.d.ts, 0, 11))
 >exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
->bothBefore : Symbol(bothBefore, Decl(mod1.js, 0, 0))
+>bothBefore : Symbol(A.bothBefore, Decl(mod1.js, 2, 16), Decl(mod1.js, 0, 0))
 
 A.justExport = 4
 >A.justExport : Symbol(A.justExport, Decl(mod1.js, 1, 36))
@@ -74,10 +74,10 @@ function A() {
 >p : Symbol(A.p, Decl(mod1.js, 6, 14))
 }
 module.exports.bothAfter = 'string'
->module.exports : Symbol(bothAfter, Decl(mod1.js, 8, 1))
+>module.exports : Symbol(A.bothAfter, Decl(mod1.js, 3, 16), Decl(mod1.js, 8, 1))
 >module : Symbol(module, Decl(requires.d.ts, 0, 11))
 >exports : Symbol(exports, Decl(requires.d.ts, 0, 21))
->bothAfter : Symbol(bothAfter, Decl(mod1.js, 8, 1))
+>bothAfter : Symbol(A.bothAfter, Decl(mod1.js, 3, 16), Decl(mod1.js, 8, 1))
 
 module.exports.justProperty = 'string'
 >module.exports : Symbol(justProperty, Decl(mod1.js, 9, 35))

--- a/tests/cases/conformance/jsdoc/jsdocImportType.ts
+++ b/tests/cases/conformance/jsdoc/jsdocImportType.ts
@@ -1,0 +1,27 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: types.d.ts
+declare function require(name: string): any;
+declare var exports: any;
+declare var module: { exports: any };
+// @Filename: mod1.js
+/// <reference path='./types.d.ts'/>
+class Chunk {
+    constructor() {
+        this.chunk = 1;
+    }
+}
+module.exports = Chunk;
+
+// @Filename: use.js
+/// <reference path='./types.d.ts'/>
+/** @typedef {import("./mod1")} C
+ * @type {C} */
+var c;
+c.chunk;
+
+const D = require("./mod1");
+/** @type {D} */
+var d;
+d.chunk;


### PR DESCRIPTION
`module.exports = Entity` should create an alias the same way that `export = Entity` does in typescript. Doing this allows the type of a class to resolve correctly, for example.

The PR has a couple of other changes.
1. `getTypeFromImportTypeNode` needs a special case for import types in JSDoc to avoid the "Module 'foo' does not refer to a type but is used as a type here" error.
2. The recently added code to allow both module.export= assignments and module.export.property= assignments in JS now needs to resolve aliases first. I also made that code use mergeSymbolTable since it was basically identical.
3. Alias resolution needs to understand module.exports= declarations. This is a small change to getTargetOfExportAssignment and its surroundings.

Fixes #23375 
