### PR TITLE
Check return type inside generators

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23219,14 +23219,15 @@ namespace ts {
             const returnType = getReturnTypeOfSignature(signature);
             const functionFlags = getFunctionFlags(func);
             const isGenerator = functionFlags & FunctionFlags.Generator;
+            const isAsync = (functionFlags & FunctionFlags.Async) !== 0;
             if (strictNullChecks || node.expression || returnType.flags & TypeFlags.Never) {
                 const exprType = node.expression ? checkExpressionCached(node.expression) : undefinedType;
-                if (isGenerator) { // AsyncGenerator function or Generator function
-                    // A generator does not need its return expressions checked against its return type.
-                    // Instead, the yield expressions are checked against the element type.
-                    // TODO: Check return types of generators when return type tracking is added
-                    // for generators.
-                    return;
+                if (isGenerator) {
+                    const returnType = getEffectiveReturnTypeNode(func);
+                    if (returnType) {
+                        const signatureElementType = getIteratedTypeOfGenerator(getTypeFromTypeNode(returnType), isAsync) || anyType;
+                        checkTypeAssignableTo(exprType, signatureElementType, node);
+                    }
                 }
                 else if (func.kind === SyntaxKind.SetAccessor) {
                     if (node.expression) {

--- a/tests/baselines/reference/generatorTypeCheck12.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck12.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck12.ts(2,5): error TS2322: Type '""' is not assignable to type 'number'.
+
+
+==== tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck12.ts (1 errors) ====
+    function* g(): IterableIterator<number> {
+        return "";
+        ~~~~~~~~~~
+!!! error TS2322: Type '""' is not assignable to type 'number'.
+    }

--- a/tests/baselines/reference/generatorTypeCheck13.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck13.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck13.ts(3,5): error TS2322: Type '""' is not assignable to type 'number'.
+
+
+==== tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck13.ts (1 errors) ====
+    function* g(): IterableIterator<number> {
+        yield 0;
+        return "";
+        ~~~~~~~~~~
+!!! error TS2322: Type '""' is not assignable to type 'number'.
+    }


### PR DESCRIPTION
Fixes #18726.

I saw [another pull request for this](https://github.com/Microsoft/TypeScript/pull/18729) only after I did my fix and mine seems somewhat lighter (I maybe missed something).

### Test case

```typescript
async function* makeGenerator(): AsyncIterableIterator<number> {
  yield 1;
  yield 2;
  yield 3;
  yield 4;
  return "abc";
}

async function pull(gen: AsyncIterableIterator<number>) {
  const { done, value } = await gen.next();
  console.log(value);
  if (!done) {
    await pull(gen);
  }
}

pull(makeGenerator());
```

### Command

```
node built/local/tsc.js --lib 'esnext,esnext.asynciterable' hello.ts
```

### Before

No errors.

### After

```
hello.ts:6:3 - error TS2322: Type '"abc"' is not assignable to type 'number'.

6   return "abc";
    ~~~~~~~~~~~~~
```