### PR TITLE
Add 'renameFile' command to services

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2212,6 +2212,15 @@ namespace ts {
         return absolutePath;
     }
 
+    export function getRelativePath(path: string, directoryPath: string, getCanonicalFileName: GetCanonicalFileName) {
+        const relativePath = getRelativePathToDirectoryOrUrl(directoryPath, path, directoryPath, getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
+        return ensurePathIsRelative(relativePath);
+    }
+
+    export function ensurePathIsRelative(path: string): string {
+        return !pathIsRelative(path) ? "./" + path : path;
+    }
+
     export function getBaseFileName(path: string) {
         if (path === undefined) {
             return undefined;

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -444,6 +444,12 @@ namespace ts {
         }
     }
 
+    export function resolveModuleNameFromCache(moduleName: string, containingFile: string, cache: ModuleResolutionCache): ResolvedModuleWithFailedLookupLocations | undefined {
+        const containingDirectory = getDirectoryPath(containingFile);
+        const perFolderCache = cache && cache.getOrCreateCacheForDirectory(containingDirectory);
+        return perFolderCache && perFolderCache.get(moduleName);
+    }
+
     export function resolveModuleName(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: ModuleResolutionCache): ResolvedModuleWithFailedLookupLocations {
         const traceEnabled = isTraceEnabled(compilerOptions, host);
         if (traceEnabled) {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -622,9 +622,6 @@ namespace ts {
 
         Debug.assert(!!missingFilePaths);
 
-        // unconditionally set moduleResolutionCache to undefined to avoid unnecessary leaks
-        moduleResolutionCache = undefined;
-
         // Release any files we have acquired in the old program but are
         // not part of the new program.
         if (oldProgram && host.onReleaseOldSourceFile) {
@@ -670,7 +667,8 @@ namespace ts {
             sourceFileToPackageName,
             redirectTargetsSet,
             isEmittedFile,
-            getConfigFileParsingDiagnostics
+            getConfigFileParsingDiagnostics,
+            getResolvedModuleWithFailedLookupLocationsFromCache,
         };
 
         verifyCompilerOptions();
@@ -678,6 +676,10 @@ namespace ts {
         performance.measure("Program", "beforeProgram", "afterProgram");
 
         return program;
+
+        function getResolvedModuleWithFailedLookupLocationsFromCache(moduleName: string, containingFile: string): ResolvedModuleWithFailedLookupLocations {
+            return moduleResolutionCache && resolveModuleNameFromCache(moduleName, containingFile, moduleResolutionCache);
+        }
 
         function toPath(fileName: string): Path {
             return ts.toPath(fileName, currentDirectory, getCanonicalFileName);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2725,6 +2725,8 @@ namespace ts {
         /* @internal */ redirectTargetsSet: Map<true>;
         /** Is the file emitted file */
         /* @internal */ isEmittedFile(file: string): boolean;
+
+        /* @internal */ getResolvedModuleWithFailedLookupLocationsFromCache(moduleName: string, containingFile: string): ResolvedModuleWithFailedLookupLocations | undefined;
     }
 
     /* @internal */

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -3279,6 +3279,15 @@ Actual: ${stringify(fullActual)}`);
         private static textSpansEqual(a: ts.TextSpan, b: ts.TextSpan) {
             return a && b && a.start === b.start && a.length === b.length;
         }
+
+        public renameFile(options: FourSlashInterface.RenameFileOptions): void {
+            const changes = this.languageService.renameFile(options.oldPath, options.newPath, this.formatCodeSettings);
+            this.applyChanges(changes);
+            for (const fileName in options.newFileContents) {
+                this.openFile(fileName);
+                this.verifyCurrentFileContent(options.newFileContents[fileName]);
+            }
+        }
     }
 
     export function runFourSlashTest(basePath: string, testType: FourSlashTestType, fileName: string) {
@@ -4370,6 +4379,10 @@ namespace FourSlashInterface {
         public allRangesAppearInImplementationList(markerName: string) {
             this.state.verifyRangesInImplementationList(markerName);
         }
+
+        public renameFile(options: RenameFileOptions) {
+            this.state.renameFile(options);
+        }
     }
 
     export class Edit {
@@ -4709,5 +4722,11 @@ namespace FourSlashInterface {
         message: string;
         range?: FourSlash.Range;
         code: number;
+    }
+
+    export interface RenameFileOptions {
+        readonly oldPath: string;
+        readonly newPath: string;
+        readonly newFileContents: { readonly [fileName: string]: string };
     }
 }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -3280,8 +3280,8 @@ Actual: ${stringify(fullActual)}`);
             return a && b && a.start === b.start && a.length === b.length;
         }
 
-        public renameFile(options: FourSlashInterface.RenameFileOptions): void {
-            const changes = this.languageService.renameFile(options.oldPath, options.newPath, this.formatCodeSettings);
+        public getEditsForFileRename(options: FourSlashInterface.GetEditsForFileRenameOptions): void {
+            const changes = this.languageService.getEditsForFileRename(options.oldPath, options.newPath, this.formatCodeSettings);
             this.applyChanges(changes);
             for (const fileName in options.newFileContents) {
                 this.openFile(fileName);
@@ -4380,8 +4380,8 @@ namespace FourSlashInterface {
             this.state.verifyRangesInImplementationList(markerName);
         }
 
-        public renameFile(options: RenameFileOptions) {
-            this.state.renameFile(options);
+        public getEditsForFileRename(options: GetEditsForFileRenameOptions) {
+            this.state.getEditsForFileRename(options);
         }
     }
 
@@ -4724,7 +4724,7 @@ namespace FourSlashInterface {
         code: number;
     }
 
-    export interface RenameFileOptions {
+    export interface GetEditsForFileRenameOptions {
         readonly oldPath: string;
         readonly newPath: string;
         readonly newFileContents: { readonly [fileName: string]: string };

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -528,6 +528,9 @@ namespace Harness.LanguageService {
         organizeImports(_scope: ts.OrganizeImportsScope, _formatOptions: ts.FormatCodeSettings): ReadonlyArray<ts.FileTextChanges> {
             throw new Error("Not supported on the shim.");
         }
+        renameFile(): ReadonlyArray<ts.FileTextChanges> {
+            throw new Error("Not supported on the shim.");
+        }
         getEmitOutput(fileName: string): ts.EmitOutput {
             return unwrapJSONCallResult(this.shim.getEmitOutput(fileName));
         }

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -528,7 +528,7 @@ namespace Harness.LanguageService {
         organizeImports(_scope: ts.OrganizeImportsScope, _formatOptions: ts.FormatCodeSettings): ReadonlyArray<ts.FileTextChanges> {
             throw new Error("Not supported on the shim.");
         }
-        renameFile(): ReadonlyArray<ts.FileTextChanges> {
+        getEditsForFileRename(): ReadonlyArray<ts.FileTextChanges> {
             throw new Error("Not supported on the shim.");
         }
         getEmitOutput(fileName: string): ts.EmitOutput {

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -70,6 +70,7 @@
         "../services/navigateTo.ts",
         "../services/navigationBar.ts",
         "../services/organizeImports.ts",
+        "../services/renameFile.ts",
         "../services/outliningElementsCollector.ts",
         "../services/patternMatcher.ts",
         "../services/preProcess.ts",

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -70,7 +70,7 @@
         "../services/navigateTo.ts",
         "../services/navigationBar.ts",
         "../services/organizeImports.ts",
-        "../services/renameFile.ts",
+        "../services/getEditsForFileRename.ts",
         "../services/outliningElementsCollector.ts",
         "../services/patternMatcher.ts",
         "../services/preProcess.ts",

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -263,6 +263,8 @@ namespace ts.server {
                 CommandNames.GetEditsForRefactorFull,
                 CommandNames.OrganizeImports,
                 CommandNames.OrganizeImportsFull,
+                CommandNames.RenameFile,
+                CommandNames.RenameFileFull,
             ];
 
             it("should not throw when commands are executed with invalid arguments", () => {

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -263,8 +263,8 @@ namespace ts.server {
                 CommandNames.GetEditsForRefactorFull,
                 CommandNames.OrganizeImports,
                 CommandNames.OrganizeImportsFull,
-                CommandNames.RenameFile,
-                CommandNames.RenameFileFull,
+                CommandNames.GetEditsForFileRename,
+                CommandNames.GetEditsForFileRenameFull,
             ];
 
             it("should not throw when commands are executed with invalid arguments", () => {

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -632,6 +632,10 @@ namespace ts.server {
             return notImplemented();
         }
 
+        renameFile() {
+            return notImplemented();
+        }
+
         private convertCodeEditsToTextChanges(edits: protocol.FileCodeEdits[]): FileTextChanges[] {
             return edits.map(edit => {
                 const fileName = edit.fileName;

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -632,7 +632,7 @@ namespace ts.server {
             return notImplemented();
         }
 
-        renameFile() {
+        getEditsForFileRename() {
             return notImplemented();
         }
 

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -121,6 +121,9 @@ namespace ts.server.protocol {
         OrganizeImports = "organizeImports",
         /* @internal */
         OrganizeImportsFull = "organizeImports-full",
+        RenameFile = "renameFile",
+        /* @internal */
+        RenameFileFull = "renameFile-full",
 
         // NOTE: If updating this, be sure to also update `allCommandNames` in `harness/unittests/session.ts`.
     }
@@ -607,6 +610,22 @@ namespace ts.server.protocol {
     }
 
     export interface OrganizeImportsResponse extends Response {
+        edits: ReadonlyArray<FileCodeEdits>;
+    }
+
+    export interface RenameFileRequest extends Request {
+        command: CommandTypes.RenameFile;
+        arguments: RenameFileRequestArgs;
+    }
+
+    // Note: The file from FileRequestArgs is just any file in the project.
+    // We will generate code changes for every file in that project, so the choice is arbitrary.
+    export interface RenameFileRequestArgs extends FileRequestArgs {
+        readonly oldFilePath: string;
+        readonly newFilePath: string;
+    }
+
+    export interface RenameFileResponse extends Response {
         edits: ReadonlyArray<FileCodeEdits>;
     }
 

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -121,9 +121,9 @@ namespace ts.server.protocol {
         OrganizeImports = "organizeImports",
         /* @internal */
         OrganizeImportsFull = "organizeImports-full",
-        RenameFile = "renameFile",
+        GetEditsForFileRename = "getEditsForFileRename",
         /* @internal */
-        RenameFileFull = "renameFile-full",
+        GetEditsForFileRenameFull = "getEditsForFileRename-full",
 
         // NOTE: If updating this, be sure to also update `allCommandNames` in `harness/unittests/session.ts`.
     }
@@ -613,19 +613,19 @@ namespace ts.server.protocol {
         edits: ReadonlyArray<FileCodeEdits>;
     }
 
-    export interface RenameFileRequest extends Request {
-        command: CommandTypes.RenameFile;
-        arguments: RenameFileRequestArgs;
+    export interface GetEditsForFileRenameRequest extends Request {
+        command: CommandTypes.GetEditsForFileRename;
+        arguments: GetEditsForFileRenameRequestArgs;
     }
 
     // Note: The file from FileRequestArgs is just any file in the project.
     // We will generate code changes for every file in that project, so the choice is arbitrary.
-    export interface RenameFileRequestArgs extends FileRequestArgs {
+    export interface GetEditsForFileRenameRequestArgs extends FileRequestArgs {
         readonly oldFilePath: string;
         readonly newFilePath: string;
     }
 
-    export interface RenameFileResponse extends Response {
+    export interface GetEditsForFileRenameResponse extends Response {
         edits: ReadonlyArray<FileCodeEdits>;
     }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1664,9 +1664,9 @@ namespace ts.server {
             }
         }
 
-        private renameFile(args: protocol.RenameFileRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.FileCodeEdits> | ReadonlyArray<FileTextChanges> {
+        private getEditsForFileRename(args: protocol.GetEditsForFileRenameRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.FileCodeEdits> | ReadonlyArray<FileTextChanges> {
             const { file, project } = this.getFileAndProject(args);
-            const changes = project.getLanguageService().renameFile(args.oldFilePath, args.newFilePath, this.getFormatOptions(file));
+            const changes = project.getLanguageService().getEditsForFileRename(args.oldFilePath, args.newFilePath, this.getFormatOptions(file));
             return simplifiedResult ? this.mapTextChangesToCodeEdits(project, changes) : changes;
         }
 
@@ -2124,11 +2124,11 @@ namespace ts.server {
             [CommandNames.OrganizeImportsFull]: (request: protocol.OrganizeImportsRequest) => {
                 return this.requiredResponse(this.organizeImports(request.arguments, /*simplifiedResult*/ false));
             },
-            [CommandNames.RenameFile]: (request: protocol.RenameFileRequest) => {
-                return this.requiredResponse(this.renameFile(request.arguments, /*simplifiedResult*/ true));
+            [CommandNames.GetEditsForFileRename]: (request: protocol.GetEditsForFileRenameRequest) => {
+                return this.requiredResponse(this.getEditsForFileRename(request.arguments, /*simplifiedResult*/ true));
             },
-            [CommandNames.RenameFileFull]: (request: protocol.RenameFileRequest) => {
-                return this.requiredResponse(this.renameFile(request.arguments, /*simplifiedResult*/ false));
+            [CommandNames.GetEditsForFileRenameFull]: (request: protocol.GetEditsForFileRenameRequest) => {
+                return this.requiredResponse(this.getEditsForFileRename(request.arguments, /*simplifiedResult*/ false));
             },
         });
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1664,6 +1664,12 @@ namespace ts.server {
             }
         }
 
+        private renameFile(args: protocol.RenameFileRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.FileCodeEdits> | ReadonlyArray<FileTextChanges> {
+            const { file, project } = this.getFileAndProject(args);
+            const changes = project.getLanguageService().renameFile(args.oldFilePath, args.newFilePath, this.getFormatOptions(file));
+            return simplifiedResult ? this.mapTextChangesToCodeEdits(project, changes) : changes;
+        }
+
         private getCodeFixes(args: protocol.CodeFixRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.CodeFixAction> | ReadonlyArray<CodeFixAction> {
             if (args.errorCodes.length === 0) {
                 return undefined;
@@ -2117,7 +2123,13 @@ namespace ts.server {
             },
             [CommandNames.OrganizeImportsFull]: (request: protocol.OrganizeImportsRequest) => {
                 return this.requiredResponse(this.organizeImports(request.arguments, /*simplifiedResult*/ false));
-            }
+            },
+            [CommandNames.RenameFile]: (request: protocol.RenameFileRequest) => {
+                return this.requiredResponse(this.renameFile(request.arguments, /*simplifiedResult*/ true));
+            },
+            [CommandNames.RenameFileFull]: (request: protocol.RenameFileRequest) => {
+                return this.requiredResponse(this.renameFile(request.arguments, /*simplifiedResult*/ false));
+            },
         });
 
         public addProtocolHandler(command: string, handler: (request: protocol.Request) => HandlerResponse) {

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -66,6 +66,7 @@
         "../services/navigateTo.ts",
         "../services/navigationBar.ts",
         "../services/organizeImports.ts",
+        "../services/renameFile.ts",
         "../services/outliningElementsCollector.ts",
         "../services/patternMatcher.ts",
         "../services/preProcess.ts",

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -66,7 +66,7 @@
         "../services/navigateTo.ts",
         "../services/navigationBar.ts",
         "../services/organizeImports.ts",
-        "../services/renameFile.ts",
+        "../services/getEditsForFileRename.ts",
         "../services/outliningElementsCollector.ts",
         "../services/patternMatcher.ts",
         "../services/preProcess.ts",

--- a/src/server/tsconfig.library.json
+++ b/src/server/tsconfig.library.json
@@ -72,6 +72,7 @@
         "../services/navigateTo.ts",
         "../services/navigationBar.ts",
         "../services/organizeImports.ts",
+        "../services/renameFile.ts",
         "../services/outliningElementsCollector.ts",
         "../services/patternMatcher.ts",
         "../services/preProcess.ts",

--- a/src/server/tsconfig.library.json
+++ b/src/server/tsconfig.library.json
@@ -72,7 +72,7 @@
         "../services/navigateTo.ts",
         "../services/navigationBar.ts",
         "../services/organizeImports.ts",
-        "../services/renameFile.ts",
+        "../services/getEditsForFileRename.ts",
         "../services/outliningElementsCollector.ts",
         "../services/patternMatcher.ts",
         "../services/preProcess.ts",

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -39,7 +39,6 @@ namespace ts.codefix {
     }
 
     function convertToImportCodeFixContext(context: CodeFixContext, symbolToken: Node, symbolName: string): ImportCodeFixContext {
-        const useCaseSensitiveFileNames = context.host.useCaseSensitiveFileNames ? context.host.useCaseSensitiveFileNames() : false;
         const { program } = context;
         const checker = program.getTypeChecker();
 
@@ -51,7 +50,7 @@ namespace ts.codefix {
             checker,
             compilerOptions: program.getCompilerOptions(),
             cachedImportDeclarations: [],
-            getCanonicalFileName: createGetCanonicalFileName(useCaseSensitiveFileNames),
+            getCanonicalFileName: createGetCanonicalFileName(hostUsesCaseSensitiveFileNames(context.host)),
             symbolName,
             symbolToken,
             preferences: context.preferences,
@@ -545,11 +544,6 @@ namespace ts.codefix {
 
     function isPathRelativeToParent(path: string): boolean {
         return startsWith(path, "..");
-    }
-
-    function getRelativePath(path: string, directoryPath: string, getCanonicalFileName: GetCanonicalFileName) {
-        const relativePath = getRelativePathToDirectoryOrUrl(directoryPath, path, directoryPath, getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
-        return !pathIsRelative(relativePath) ? "./" + relativePath : relativePath;
     }
 
     function getCodeActionsForAddImport(

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -1,6 +1,6 @@
 /* @internal */
 namespace ts {
-    export function renameFile(program: Program, oldFilePath: string, newFilePath: string, host: LanguageServiceHost, formatContext: formatting.FormatContext): ReadonlyArray<FileTextChanges> {
+    export function getEditsForFileRename(program: Program, oldFilePath: string, newFilePath: string, host: LanguageServiceHost, formatContext: formatting.FormatContext): ReadonlyArray<FileTextChanges> {
         const pathUpdater = getPathUpdater(oldFilePath, newFilePath, host);
         return textChanges.ChangeTracker.with({ host, formatContext }, changeTracker => {
             const importsToUpdate = getImportsToUpdate(program, oldFilePath);

--- a/src/services/renameFile.ts
+++ b/src/services/renameFile.ts
@@ -1,0 +1,45 @@
+/* @internal */
+namespace ts {
+    export function renameFile(program: Program, oldFilePath: string, newFilePath: string, host: LanguageServiceHost, formatContext: formatting.FormatContext): ReadonlyArray<FileTextChanges> {
+        const pathUpdater = getPathUpdater(oldFilePath, newFilePath, host);
+        return textChanges.ChangeTracker.with({ host, formatContext }, changeTracker => {
+            const importsToUpdate = getImportsToUpdate(program, oldFilePath);
+            for (const importToUpdate of importsToUpdate) {
+                const newPath = pathUpdater(importToUpdate.text);
+                if (newPath !== undefined) {
+                    changeTracker.replaceNode(importToUpdate.getSourceFile(), importToUpdate, updateStringLiteralLike(importToUpdate, newPath));
+                }
+            }
+        });
+    }
+
+    function getImportsToUpdate(program: Program, oldFilePath: string): ReadonlyArray<StringLiteralLike> {
+        const checker = program.getTypeChecker();
+        const result: StringLiteralLike[] = [];
+        for (const file of program.getSourceFiles()) {
+            for (const importStringLiteral of file.imports) {
+                // If it resolved to something already, ignore.
+                if (checker.getSymbolAtLocation(importStringLiteral)) continue;
+
+                const resolved = program.getResolvedModuleWithFailedLookupLocationsFromCache(importStringLiteral.text, file.fileName);
+                if (contains(resolved.failedLookupLocations, oldFilePath)) {
+                    result.push(importStringLiteral);
+                }
+            }
+        }
+        return result;
+    }
+
+    function getPathUpdater(oldFilePath: string, newFilePath: string, host: LanguageServiceHost): (oldPath: string) => string | undefined {
+        // Get the relative path from old to new location, and append it on to the end of imports and normalize.
+        const rel = removeFileExtension(getRelativePath(newFilePath, getDirectoryPath(oldFilePath), createGetCanonicalFileName(hostUsesCaseSensitiveFileNames(host))));
+        return oldPath => {
+            if (!pathIsRelative(oldPath)) return;
+            return ensurePathIsRelative(normalizePath(combinePaths(getDirectoryPath(oldPath), rel)));
+        };
+    }
+
+    function updateStringLiteralLike(old: StringLiteralLike, newText: string): StringLiteralLike {
+        return old.kind === SyntaxKind.StringLiteral ? createLiteral(newText, /*isSingleQuote*/ old.singleQuote) : createNoSubstitutionTemplateLiteral(newText);
+    }
+}

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1128,7 +1128,6 @@ namespace ts {
         let lastProjectVersion: string;
         let lastTypesRootVersion = 0;
 
-        const useCaseSensitivefileNames = host.useCaseSensitiveFileNames && host.useCaseSensitiveFileNames();
         const cancellationToken = new CancellationTokenObject(host.getCancellationToken && host.getCancellationToken());
 
         const currentDirectory = host.getCurrentDirectory();
@@ -1145,7 +1144,8 @@ namespace ts {
             }
         }
 
-        const getCanonicalFileName = createGetCanonicalFileName(useCaseSensitivefileNames);
+        const useCaseSensitiveFileNames = hostUsesCaseSensitiveFileNames(host);
+        const getCanonicalFileName = createGetCanonicalFileName(useCaseSensitiveFileNames);
 
         function getValidSourceFile(fileName: string): SourceFile {
             const sourceFile = program.getSourceFile(fileName);
@@ -1202,7 +1202,7 @@ namespace ts {
                 getSourceFileByPath: getOrCreateSourceFileByPath,
                 getCancellationToken: () => cancellationToken,
                 getCanonicalFileName,
-                useCaseSensitiveFileNames: () => useCaseSensitivefileNames,
+                useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
                 getNewLine: () => getNewLineCharacter(newSettings, () => getNewLineOrDefaultFromHost(host)),
                 getDefaultLibFileName: (options) => host.getDefaultLibFileName(options),
                 writeFile: noop,
@@ -1950,6 +1950,10 @@ namespace ts {
             return OrganizeImports.organizeImports(sourceFile, formatContext, host, program, preferences);
         }
 
+        function renameFile(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings): ReadonlyArray<FileTextChanges> {
+            return ts.renameFile(getProgram(), oldFilePath, newFilePath, host, formatting.getFormatContext(formatOptions));
+        }
+
         function applyCodeActionCommand(action: CodeActionCommand): Promise<ApplyCodeActionCommandResult>;
         function applyCodeActionCommand(action: CodeActionCommand[]): Promise<ApplyCodeActionCommandResult[]>;
         function applyCodeActionCommand(action: CodeActionCommand | CodeActionCommand[]): Promise<ApplyCodeActionCommandResult | ApplyCodeActionCommandResult[]>;
@@ -2250,6 +2254,7 @@ namespace ts {
             getCombinedCodeFix,
             applyCodeActionCommand,
             organizeImports,
+            renameFile,
             getEmitOutput,
             getNonBoundSourceFile,
             getSourceFile,

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1950,8 +1950,8 @@ namespace ts {
             return OrganizeImports.organizeImports(sourceFile, formatContext, host, program, preferences);
         }
 
-        function renameFile(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings): ReadonlyArray<FileTextChanges> {
-            return ts.renameFile(getProgram(), oldFilePath, newFilePath, host, formatting.getFormatContext(formatOptions));
+        function getEditsForFileRename(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings): ReadonlyArray<FileTextChanges> {
+            return ts.getEditsForFileRename(getProgram(), oldFilePath, newFilePath, host, formatting.getFormatContext(formatOptions));
         }
 
         function applyCodeActionCommand(action: CodeActionCommand): Promise<ApplyCodeActionCommandResult>;
@@ -2254,7 +2254,7 @@ namespace ts {
             getCombinedCodeFix,
             applyCodeActionCommand,
             organizeImports,
-            renameFile,
+            getEditsForFileRename,
             getEmitOutput,
             getNonBoundSourceFile,
             getSourceFile,

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -365,8 +365,12 @@ namespace ts.textChanges {
             this.insertText(sourceFile, token.getStart(sourceFile), text);
         }
 
+        public replaceRangeWithText(sourceFile: SourceFile, range: TextRange, text: string) {
+            this.changes.push({ kind: ChangeKind.Text, sourceFile, range, text });
+        }
+
         private insertText(sourceFile: SourceFile, pos: number, text: string): void {
-            this.changes.push({ kind: ChangeKind.Text, sourceFile, range: { pos, end: pos }, text });
+            this.replaceRangeWithText(sourceFile, createTextRange(pos), text);
         }
 
         /** Prefer this over replacing a node with another that has a type annotation, as it avoids reformatting the other parts of the node. */

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -63,6 +63,7 @@
         "navigateTo.ts",
         "navigationBar.ts",
         "organizeImports.ts",
+        "../services/renameFile.ts",
         "outliningElementsCollector.ts",
         "patternMatcher.ts",
         "preProcess.ts",

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -63,7 +63,7 @@
         "navigateTo.ts",
         "navigationBar.ts",
         "organizeImports.ts",
-        "../services/renameFile.ts",
+        "getEditsForFileRename.ts",
         "outliningElementsCollector.ts",
         "patternMatcher.ts",
         "preProcess.ts",

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -334,6 +334,7 @@ namespace ts {
         getApplicableRefactors(fileName: string, positionOrRaneg: number | TextRange, preferences: UserPreferences | undefined): ApplicableRefactorInfo[];
         getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined): RefactorEditInfo | undefined;
         organizeImports(scope: OrganizeImportsScope, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): ReadonlyArray<FileTextChanges>;
+        renameFile(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings): ReadonlyArray<FileTextChanges>;
 
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -334,7 +334,7 @@ namespace ts {
         getApplicableRefactors(fileName: string, positionOrRaneg: number | TextRange, preferences: UserPreferences | undefined): ApplicableRefactorInfo[];
         getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined): RefactorEditInfo | undefined;
         organizeImports(scope: OrganizeImportsScope, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): ReadonlyArray<FileTextChanges>;
-        renameFile(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings): ReadonlyArray<FileTextChanges>;
+        getEditsForFileRename(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings): ReadonlyArray<FileTextChanges>;
 
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1213,6 +1213,14 @@ namespace ts {
             ? isStringOrNumericLiteral(name.expression) ? name.expression.text : undefined
             : getTextOfIdentifierOrLiteral(name);
     }
+
+    export function hostUsesCaseSensitiveFileNames(host: LanguageServiceHost): boolean {
+        return host.useCaseSensitiveFileNames ? host.useCaseSensitiveFileNames() : false;
+    }
+
+    export function hostGetCanonicalFileName(host: LanguageServiceHost): GetCanonicalFileName {
+        return createGetCanonicalFileName(hostUsesCaseSensitiveFileNames(host));
+    }
 }
 
 // Display-part writer helpers

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3402,6 +3402,7 @@ declare namespace ts {
         set(directory: string, result: ResolvedModuleWithFailedLookupLocations): void;
     }
     function createModuleResolutionCache(currentDirectory: string, getCanonicalFileName: (s: string) => string): ModuleResolutionCache;
+    function resolveModuleNameFromCache(moduleName: string, containingFile: string, cache: ModuleResolutionCache): ResolvedModuleWithFailedLookupLocations | undefined;
     function resolveModuleName(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: ModuleResolutionCache): ResolvedModuleWithFailedLookupLocations;
     function nodeModuleNameResolver(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: ModuleResolutionCache): ResolvedModuleWithFailedLookupLocations;
     function classicNameResolver(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: NonRelativeModuleNameResolutionCache): ResolvedModuleWithFailedLookupLocations;
@@ -4446,6 +4447,7 @@ declare namespace ts {
         getApplicableRefactors(fileName: string, positionOrRaneg: number | TextRange, preferences: UserPreferences | undefined): ApplicableRefactorInfo[];
         getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined): RefactorEditInfo | undefined;
         organizeImports(scope: OrganizeImportsScope, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): ReadonlyArray<FileTextChanges>;
+        getEditsForFileRename(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings): ReadonlyArray<FileTextChanges>;
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
         getProgram(): Program;
         dispose(): void;
@@ -5409,7 +5411,8 @@ declare namespace ts.server.protocol {
         GetSupportedCodeFixes = "getSupportedCodeFixes",
         GetApplicableRefactors = "getApplicableRefactors",
         GetEditsForRefactor = "getEditsForRefactor",
-        OrganizeImports = "organizeImports"
+        OrganizeImports = "organizeImports",
+        GetEditsForFileRename = "getEditsForFileRename"
     }
     /**
      * A TypeScript Server message
@@ -5803,6 +5806,17 @@ declare namespace ts.server.protocol {
         scope: OrganizeImportsScope;
     }
     interface OrganizeImportsResponse extends Response {
+        edits: ReadonlyArray<FileCodeEdits>;
+    }
+    interface GetEditsForFileRenameRequest extends Request {
+        command: CommandTypes.GetEditsForFileRename;
+        arguments: GetEditsForFileRenameRequestArgs;
+    }
+    interface GetEditsForFileRenameRequestArgs extends FileRequestArgs {
+        readonly oldFilePath: string;
+        readonly newFilePath: string;
+    }
+    interface GetEditsForFileRenameResponse extends Response {
         edits: ReadonlyArray<FileCodeEdits>;
     }
     /**
@@ -8320,6 +8334,7 @@ declare namespace ts.server {
         private getApplicableRefactors;
         private getEditsForRefactor;
         private organizeImports;
+        private getEditsForFileRename;
         private getCodeFixes;
         private getCombinedCodeFix;
         private applyCodeActionCommand;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3402,6 +3402,7 @@ declare namespace ts {
         set(directory: string, result: ResolvedModuleWithFailedLookupLocations): void;
     }
     function createModuleResolutionCache(currentDirectory: string, getCanonicalFileName: (s: string) => string): ModuleResolutionCache;
+    function resolveModuleNameFromCache(moduleName: string, containingFile: string, cache: ModuleResolutionCache): ResolvedModuleWithFailedLookupLocations | undefined;
     function resolveModuleName(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: ModuleResolutionCache): ResolvedModuleWithFailedLookupLocations;
     function nodeModuleNameResolver(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: ModuleResolutionCache): ResolvedModuleWithFailedLookupLocations;
     function classicNameResolver(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: NonRelativeModuleNameResolutionCache): ResolvedModuleWithFailedLookupLocations;
@@ -4446,6 +4447,7 @@ declare namespace ts {
         getApplicableRefactors(fileName: string, positionOrRaneg: number | TextRange, preferences: UserPreferences | undefined): ApplicableRefactorInfo[];
         getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined): RefactorEditInfo | undefined;
         organizeImports(scope: OrganizeImportsScope, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): ReadonlyArray<FileTextChanges>;
+        getEditsForFileRename(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings): ReadonlyArray<FileTextChanges>;
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
         getProgram(): Program;
         dispose(): void;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -344,6 +344,11 @@ declare namespace FourSlashInterface {
         getSuggestionDiagnostics(expected: ReadonlyArray<Diagnostic>): void;
         ProjectInfo(expected: string[]): void;
         allRangesAppearInImplementationList(markerName: string): void;
+        renameFile(options: {
+            oldPath: string;
+            newPath: string;
+            newFileContents: { [fileName: string]: string };
+        });
     }
     class edit {
         backspace(count?: number): void;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -344,7 +344,7 @@ declare namespace FourSlashInterface {
         getSuggestionDiagnostics(expected: ReadonlyArray<Diagnostic>): void;
         ProjectInfo(expected: string[]): void;
         allRangesAppearInImplementationList(markerName: string): void;
-        renameFile(options: {
+        getEditsForFileRename(options: {
             oldPath: string;
             newPath: string;
             newFileContents: { [fileName: string]: string };

--- a/tests/cases/fourslash/getEditsForFileRename.ts
+++ b/tests/cases/fourslash/getEditsForFileRename.ts
@@ -9,7 +9,7 @@
 // @Filename: /src/foo/a.ts
 ////import old from "../old";
 
-verify.renameFile({
+verify.getEditsForFileRename({
     oldPath: "/src/old.ts",
     newPath: "/src/new.ts",
     newFileContents: {

--- a/tests/cases/fourslash/getEditsForFileRename.ts
+++ b/tests/cases/fourslash/getEditsForFileRename.ts
@@ -1,20 +1,23 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: /a.ts
+/////// <reference path="./src/old.ts" />
 ////import old from "./src/old";
 
 // @Filename: /src/a.ts
+/////// <reference path="./old.ts" />
 ////import old from "./old";
 
 // @Filename: /src/foo/a.ts
+/////// <reference path="../old.ts" />
 ////import old from "../old";
 
 verify.getEditsForFileRename({
     oldPath: "/src/old.ts",
     newPath: "/src/new.ts",
     newFileContents: {
-        "/a.ts": 'import old from "./src/new";',
-        "/src/a.ts": 'import old from "./new";',
-        "/src/foo/a.ts": 'import old from "../new";',
+        "/a.ts": '/// <reference path="./src/new.ts" />\nimport old from "./src/new";',
+        "/src/a.ts": '/// <reference path="./new.ts" />\nimport old from "./new";',
+        "/src/foo/a.ts": '/// <reference path="../new.ts" />\nimport old from "../new";',
     },
 });

--- a/tests/cases/fourslash/renameFile.ts
+++ b/tests/cases/fourslash/renameFile.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////import old from "./src/old";
+
+// @Filename: /src/a.ts
+////import old from "./old";
+
+// @Filename: /src/foo/a.ts
+////import old from "../old";
+
+verify.renameFile({
+    oldPath: "/src/old.ts",
+    newPath: "/src/new.ts",
+    newFileContents: {
+        "/a.ts": 'import old from "./src/new";',
+        "/src/a.ts": 'import old from "./new";',
+        "/src/foo/a.ts": 'import old from "../new";',
+    },
+});


### PR DESCRIPTION
Here's how I think it would work:
* First, the user renames a file normally using the file explorer in their editor.
* Tsserver will pick up on this change and update the project (which will break a lot of imports to the old location).
* *After* the rename, the editor will offer the user to update references to the file.
* If the user says yes, it will then ask tsserver to get code edits, passing in the old  and new paths to the file.
* Tsserver will walk all imports, see which ones are unresolved now and could have resolved to the old path (but don't since that's been moved now), and update them to the new path instead, and send these edits to the editor.
* The editor will apply the edits to all files. (Hopefully with undo functionality if the user decides against renaming the file.)

This is a bit tricky on the tsserver side since we need to be able to figure out what unresolved imports could have resolved to. This meant I had to leave `moduleResolutionCache` around so we could look at the failed lookup locations for failed imports.

Fully expecting to need a lot of revision on this. CC @mjbvz for protocol review.