### PR TITLE
Fix assert in getjsdochost

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2332,7 +2332,7 @@ namespace ts {
     }
 
     export interface JSDocTag extends Node {
-        parent: JSDoc;
+        parent: JSDoc | JSDocTypeLiteral;
         atToken: AtToken;
         tagName: Identifier;
         comment: string | undefined;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1888,8 +1888,11 @@ namespace ts {
     }
 
     export function getJSDocHost(node: JSDocTag): HasJSDoc {
+        while (node.parent.kind === SyntaxKind.JSDocTypeLiteral) {
+            node = node.parent.parent.parent as JSDocParameterTag;
+        }
         Debug.assert(node.parent!.kind === SyntaxKind.JSDocComment);
-        return node.parent!.parent!;
+        return (node.parent! as JSDoc).parent!;
     }
 
     export function getTypeParameterFromJsDoc(node: TypeParameterDeclaration & { parent: JSDocTemplateTag }): TypeParameterDeclaration | undefined {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1892,7 +1892,7 @@ namespace ts {
             node = node.parent.parent.parent as JSDocParameterTag;
         }
         Debug.assert(node.parent!.kind === SyntaxKind.JSDocComment);
-        return (node.parent! as JSDoc).parent!;
+        return node.parent!.parent!;
     }
 
     export function getTypeParameterFromJsDoc(node: TypeParameterDeclaration & { parent: JSDocTemplateTag }): TypeParameterDeclaration | undefined {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1494,7 +1494,7 @@ declare namespace ts {
         comment: string | undefined;
     }
     interface JSDocTag extends Node {
-        parent: JSDoc;
+        parent: JSDoc | JSDocTypeLiteral;
         atToken: AtToken;
         tagName: Identifier;
         comment: string | undefined;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1494,7 +1494,7 @@ declare namespace ts {
         comment: string | undefined;
     }
     interface JSDocTag extends Node {
-        parent: JSDoc;
+        parent: JSDoc | JSDocTypeLiteral;
         atToken: AtToken;
         tagName: Identifier;
         comment: string | undefined;

--- a/tests/baselines/reference/jsdocTemplateConstructorFunction2.errors.txt
+++ b/tests/baselines/reference/jsdocTemplateConstructorFunction2.errors.txt
@@ -1,0 +1,28 @@
+tests/cases/conformance/jsdoc/templateTagWithNestedTypeLiteral.js(21,1): error TS2322: Type 'false' is not assignable to type 'number'.
+
+
+==== tests/cases/conformance/jsdoc/templateTagWithNestedTypeLiteral.js (1 errors) ====
+    /**
+     * @template {T}
+     * @param {T} t
+     */
+    function Zet(t) {
+        /** @type {T} */
+        this.u
+        this.t = t
+    }
+    /**
+     * @param {T} v
+     * @param {object} o
+     * @param {T} o.nested
+     */
+    Zet.prototype.add = function(v, o) {
+        this.u = v || o.nested
+        return this.u
+    }
+    var z = new Zet(1)
+    z.t = 2
+    z.u = false
+    ~~~
+!!! error TS2322: Type 'false' is not assignable to type 'number'.
+    

--- a/tests/baselines/reference/jsdocTemplateConstructorFunction2.symbols
+++ b/tests/baselines/reference/jsdocTemplateConstructorFunction2.symbols
@@ -1,0 +1,56 @@
+=== tests/cases/conformance/jsdoc/templateTagWithNestedTypeLiteral.js ===
+/**
+ * @template {T}
+ * @param {T} t
+ */
+function Zet(t) {
+>Zet : Symbol(Zet, Decl(templateTagWithNestedTypeLiteral.js, 0, 0))
+>t : Symbol(t, Decl(templateTagWithNestedTypeLiteral.js, 4, 13))
+
+    /** @type {T} */
+    this.u
+    this.t = t
+>t : Symbol(Zet.t, Decl(templateTagWithNestedTypeLiteral.js, 6, 10))
+>t : Symbol(t, Decl(templateTagWithNestedTypeLiteral.js, 4, 13))
+}
+/**
+ * @param {T} v
+ * @param {object} o
+ * @param {T} o.nested
+ */
+Zet.prototype.add = function(v, o) {
+>Zet.prototype : Symbol(Zet.add, Decl(templateTagWithNestedTypeLiteral.js, 8, 1))
+>Zet : Symbol(Zet, Decl(templateTagWithNestedTypeLiteral.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>add : Symbol(Zet.add, Decl(templateTagWithNestedTypeLiteral.js, 8, 1))
+>v : Symbol(v, Decl(templateTagWithNestedTypeLiteral.js, 14, 29))
+>o : Symbol(o, Decl(templateTagWithNestedTypeLiteral.js, 14, 31))
+
+    this.u = v || o.nested
+>this.u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
+>this : Symbol(Zet, Decl(templateTagWithNestedTypeLiteral.js, 0, 0))
+>u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
+>v : Symbol(v, Decl(templateTagWithNestedTypeLiteral.js, 14, 29))
+>o.nested : Symbol(nested, Decl(templateTagWithNestedTypeLiteral.js, 12, 3))
+>o : Symbol(o, Decl(templateTagWithNestedTypeLiteral.js, 14, 31))
+>nested : Symbol(nested, Decl(templateTagWithNestedTypeLiteral.js, 12, 3))
+
+    return this.u
+>this.u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
+>this : Symbol(Zet, Decl(templateTagWithNestedTypeLiteral.js, 0, 0))
+>u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
+}
+var z = new Zet(1)
+>z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3))
+>Zet : Symbol(Zet, Decl(templateTagWithNestedTypeLiteral.js, 0, 0))
+
+z.t = 2
+>z.t : Symbol(Zet.t, Decl(templateTagWithNestedTypeLiteral.js, 6, 10))
+>z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3))
+>t : Symbol(Zet.t, Decl(templateTagWithNestedTypeLiteral.js, 6, 10))
+
+z.u = false
+>z.u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
+>z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3))
+>u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
+

--- a/tests/baselines/reference/jsdocTemplateConstructorFunction2.types
+++ b/tests/baselines/reference/jsdocTemplateConstructorFunction2.types
@@ -1,0 +1,74 @@
+=== tests/cases/conformance/jsdoc/templateTagWithNestedTypeLiteral.js ===
+/**
+ * @template {T}
+ * @param {T} t
+ */
+function Zet(t) {
+>Zet : typeof Zet
+>t : T
+
+    /** @type {T} */
+    this.u
+>this.u : any
+>this : any
+>u : any
+
+    this.t = t
+>this.t = t : T
+>this.t : any
+>this : any
+>t : any
+>t : T
+}
+/**
+ * @param {T} v
+ * @param {object} o
+ * @param {T} o.nested
+ */
+Zet.prototype.add = function(v, o) {
+>Zet.prototype.add = function(v, o) {    this.u = v || o.nested    return this.u} : (v: T, o: { nested: T; }) => T
+>Zet.prototype.add : any
+>Zet.prototype : any
+>Zet : typeof Zet
+>prototype : any
+>add : any
+>function(v, o) {    this.u = v || o.nested    return this.u} : (v: T, o: { nested: T; }) => T
+>v : T
+>o : { nested: T; }
+
+    this.u = v || o.nested
+>this.u = v || o.nested : T
+>this.u : T
+>this : Zet
+>u : T
+>v || o.nested : T
+>v : T
+>o.nested : T
+>o : { nested: T; }
+>nested : T
+
+    return this.u
+>this.u : T
+>this : Zet
+>u : T
+}
+var z = new Zet(1)
+>z : typeof Zet
+>new Zet(1) : typeof Zet
+>Zet : typeof Zet
+>1 : 1
+
+z.t = 2
+>z.t = 2 : 2
+>z.t : number
+>z : typeof Zet
+>t : number
+>2 : 2
+
+z.u = false
+>z.u = false : false
+>z.u : number
+>z : typeof Zet
+>u : number
+>false : false
+

--- a/tests/cases/conformance/jsdoc/jsdocTemplateConstructorFunction2.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTemplateConstructorFunction2.ts
@@ -1,0 +1,26 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: templateTagWithNestedTypeLiteral.js
+
+/**
+ * @template {T}
+ * @param {T} t
+ */
+function Zet(t) {
+    /** @type {T} */
+    this.u
+    this.t = t
+}
+/**
+ * @param {T} v
+ * @param {object} o
+ * @param {T} o.nested
+ */
+Zet.prototype.add = function(v, o) {
+    this.u = v || o.nested
+    return this.u
+}
+var z = new Zet(1)
+z.t = 2
+z.u = false


### PR DESCRIPTION
After #23511, the assert in getJSDocHost throws when checking a type reference in a jsdoc type literal:

```js
function PluginFunction() {
}
/**
 * @param {object} options Options for the profiled fn.
 // assert here: this @param's parent is the options tag, not the entire comment
 * @param {PluginFunction} options.fn Plugin function
 * @returns {*} Chainable hooked function.
 */
const makeNewProfiledTapFn = ({ fn }) => {
};
```

The problem is that getJSDocHost doesn't work with param tags that are nested inside a jsdoc type literal. This PR makes getJSDocHost walk up through jsdoc type literals before getting the host.

Found by compiling webpack with typescript from master.

Fixes #23574