### PR TITLE
fix #23589 - stripping internal constructor parameter properties

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -966,6 +966,7 @@ namespace ts {
                         const oldDiag = getSymbolAccessibilityDiagnostic;
                         parameterProperties = compact(flatMap(ctor.parameters, param => {
                             if (!hasModifier(param, ModifierFlags.ParameterPropertyModifier)) return;
+                            if (shouldStripInternalParameterProperty(param)) return;
                             getSymbolAccessibilityDiagnostic = createGetSymbolAccessibilityDiagnosticForNode(param);
                             if (param.name.kind === SyntaxKind.Identifier) {
                                 return preserveJsDoc(createProperty(
@@ -1148,6 +1149,12 @@ namespace ts {
                 }
             }
             return false;
+        }
+
+        // shouldStripInternal does not work with constructor parameters. This variant does.
+        function shouldStripInternalParameterProperty(param: ParameterDeclaration) {
+            return param.jsDoc && param.jsDoc.some(doc =>
+                doc.tags.some(tag => getTextOfNode(tag) === "@internal"));
         }
 
         function ensureModifiers(node: Node, privateDeclaration?: boolean): ReadonlyArray<Modifier> {

--- a/tests/baselines/reference/stripInternalParameterProperty.js
+++ b/tests/baselines/reference/stripInternalParameterProperty.js
@@ -1,0 +1,24 @@
+//// [stripInternalParameterProperty.ts]
+export class C {
+    constructor(/** @internal */ public foo, public bar) {}
+}
+
+
+//// [stripInternalParameterProperty.js]
+"use strict";
+exports.__esModule = true;
+var C = /** @class */ (function () {
+    function C(/** @internal */ foo, bar) {
+        this.foo = foo;
+        this.bar = bar;
+    }
+    return C;
+}());
+exports.C = C;
+
+
+//// [stripInternalParameterProperty.d.ts]
+export declare class C {
+    bar: any;
+    constructor(/** @internal */ foo: any, bar: any);
+}

--- a/tests/baselines/reference/stripInternalParameterProperty.symbols
+++ b/tests/baselines/reference/stripInternalParameterProperty.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/stripInternalParameterProperty.ts ===
+export class C {
+>C : Symbol(C, Decl(stripInternalParameterProperty.ts, 0, 0))
+
+    constructor(/** @internal */ public foo, public bar) {}
+>foo : Symbol(C.foo, Decl(stripInternalParameterProperty.ts, 1, 16))
+>bar : Symbol(C.bar, Decl(stripInternalParameterProperty.ts, 1, 44))
+}
+

--- a/tests/baselines/reference/stripInternalParameterProperty.types
+++ b/tests/baselines/reference/stripInternalParameterProperty.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/stripInternalParameterProperty.ts ===
+export class C {
+>C : C
+
+    constructor(/** @internal */ public foo, public bar) {}
+>foo : any
+>bar : any
+}
+

--- a/tests/cases/compiler/stripInternalParameterProperty.ts
+++ b/tests/cases/compiler/stripInternalParameterProperty.ts
@@ -1,0 +1,7 @@
+
+// @declaration:true
+// @stripInternal:true
+
+export class C {
+    constructor(/** @internal */ public foo, public bar) {}
+}


### PR DESCRIPTION
[x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Fixes #23589
