### PR TITLE
Don't add import completion from a re-export in "./index"

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -97,16 +97,24 @@ namespace ts.codefix {
         symbolToken: Node | undefined,
         preferences: UserPreferences,
     ): { readonly moduleSpecifier: string, readonly codeAction: CodeAction } {
-        const exportInfos = getAllReExportingModules(exportedSymbol, symbolName, checker, allSourceFiles);
+        const exportInfos = getAllReExportingModules(exportedSymbol, symbolName, sourceFile, checker, allSourceFiles);
         Debug.assert(exportInfos.some(info => info.moduleSymbol === moduleSymbol));
         // We sort the best codefixes first, so taking `first` is best for completions.
         const moduleSpecifier = first(getNewImportInfos(program, sourceFile, exportInfos, compilerOptions, getCanonicalFileName, host, preferences)).moduleSpecifier;
         const ctx: ImportCodeFixContext = { host, program, checker, compilerOptions, sourceFile, formatContext, symbolName, getCanonicalFileName, symbolToken, preferences };
         return { moduleSpecifier, codeAction: first(getCodeActionsForImport(exportInfos, ctx)) };
     }
-    function getAllReExportingModules(exportedSymbol: Symbol, symbolName: string, checker: TypeChecker, allSourceFiles: ReadonlyArray<SourceFile>): ReadonlyArray<SymbolExportInfo> {
+    function getAllReExportingModules(exportedSymbol: Symbol, symbolName: string, sourceFile: SourceFile, checker: TypeChecker, allSourceFiles: ReadonlyArray<SourceFile>): ReadonlyArray<SymbolExportInfo> {
         const result: SymbolExportInfo[] = [];
-        forEachExternalModule(checker, allSourceFiles, moduleSymbol => {
+        forEachExternalModule(checker, allSourceFiles, (moduleSymbol, moduleFile) => {
+            // Ignore something in `./index` or `../index` if it's not the original exporting module.
+            if (moduleFile &&
+                exportedSymbol.parent !== moduleSymbol &&
+                removeFileExtension(getBaseFileName(moduleFile.fileName)) === "index" &&
+                startsWith(sourceFile.fileName, getDirectoryPath(moduleFile.fileName))) {
+                return;
+            }
+
             for (const exported of checker.getExportsOfModule(moduleSymbol)) {
                 if (exported.escapedName === InternalSymbolName.Default || exported.name === symbolName && skipAlias(exported, checker) === exportedSymbol) {
                     const isDefaultExport = checker.tryGetMemberInModuleExports(InternalSymbolName.Default, moduleSymbol) === exported;

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -97,21 +97,18 @@ namespace ts.codefix {
         symbolToken: Node | undefined,
         preferences: UserPreferences,
     ): { readonly moduleSpecifier: string, readonly codeAction: CodeAction } {
-        const exportInfos = getAllReExportingModules(exportedSymbol, symbolName, sourceFile, checker, allSourceFiles);
+        const exportInfos = getAllReExportingModules(exportedSymbol, moduleSymbol, symbolName, sourceFile, checker, allSourceFiles);
         Debug.assert(exportInfos.some(info => info.moduleSymbol === moduleSymbol));
         // We sort the best codefixes first, so taking `first` is best for completions.
         const moduleSpecifier = first(getNewImportInfos(program, sourceFile, exportInfos, compilerOptions, getCanonicalFileName, host, preferences)).moduleSpecifier;
         const ctx: ImportCodeFixContext = { host, program, checker, compilerOptions, sourceFile, formatContext, symbolName, getCanonicalFileName, symbolToken, preferences };
         return { moduleSpecifier, codeAction: first(getCodeActionsForImport(exportInfos, ctx)) };
     }
-    function getAllReExportingModules(exportedSymbol: Symbol, symbolName: string, sourceFile: SourceFile, checker: TypeChecker, allSourceFiles: ReadonlyArray<SourceFile>): ReadonlyArray<SymbolExportInfo> {
+    function getAllReExportingModules(exportedSymbol: Symbol, exportingModuleSymbol: Symbol, symbolName: string, sourceFile: SourceFile, checker: TypeChecker, allSourceFiles: ReadonlyArray<SourceFile>): ReadonlyArray<SymbolExportInfo> {
         const result: SymbolExportInfo[] = [];
         forEachExternalModule(checker, allSourceFiles, (moduleSymbol, moduleFile) => {
-            // Ignore something in `./index` or `../index` if it's not the original exporting module.
-            if (moduleFile &&
-                exportedSymbol.parent !== moduleSymbol &&
-                removeFileExtension(getBaseFileName(moduleFile.fileName)) === "index" &&
-                startsWith(sourceFile.fileName, getDirectoryPath(moduleFile.fileName))) {
+            // Don't import from a re-export when looking "up" like to `./index` or `../index`.
+            if (moduleFile && moduleSymbol !== exportingModuleSymbol && startsWith(sourceFile.fileName, getDirectoryPath(moduleFile.fileName))) {
                 return;
             }
 

--- a/tests/cases/fourslash/completionsImport_notFromIndex.ts
+++ b/tests/cases/fourslash/completionsImport_notFromIndex.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /src/a.ts
+////export const x = 0;
+
+// @Filename: /src/index.ts
+////export { x } from "./a";
+
+// @Filename: /0.ts
+////x/*0*/
+
+// @Filename: /src/1.ts
+////x/*1*/
+
+// @Filename: /src/inner/2.ts
+////x/*2*/
+
+for (const [marker, sourceDisplay] of [["0", "./src"], ["1", "./a"], ["2", "../a"]]) {
+    goTo.marker(marker);
+    verify.completionListContains({ name: "x", source: "/src/a" }, "const x: 0", "", "const", /*spanIndex*/ undefined, /*hasAction*/ true, { includeCompletionsForModuleExports: true, sourceDisplay });
+    verify.applyCodeActionFromCompletion(marker, {
+        name: "x",
+        source: "/src/a",
+        description: `Import 'x' from module "${sourceDisplay}"`,
+        newFileContent: `import { x } from "${sourceDisplay}";\n\nx`,
+    });
+}


### PR DESCRIPTION
Fixes #23598 and #23011

* We will no longer import from a re-export from "./index" (or "../index` or "../../index"...).
* We will still import if the *original* export is from "./index".
* We will still import from "./foo/index" over "./foo/bar".