### PR TITLE
Distribute 'keyof' union types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -67,6 +67,7 @@ namespace ts {
         const strictPropertyInitialization = getStrictOptionValue(compilerOptions, "strictPropertyInitialization");
         const noImplicitAny = getStrictOptionValue(compilerOptions, "noImplicitAny");
         const noImplicitThis = getStrictOptionValue(compilerOptions, "noImplicitThis");
+        const keyofStringsOnly = !!compilerOptions.keyofStringsOnly;
 
         const emitResolver = createResolver();
         const nodeBuilder = createNodeBuilder();
@@ -356,6 +357,8 @@ namespace ts {
         const silentNeverType = createIntrinsicType(TypeFlags.Never, "never");
         const implicitNeverType = createIntrinsicType(TypeFlags.Never, "never");
         const nonPrimitiveType = createIntrinsicType(TypeFlags.NonPrimitive, "object");
+        const stringNumberSymbolType = getUnionType([stringType, numberType, esSymbolType]);
+        const keyofConstraintType = keyofStringsOnly ? stringType : stringNumberSymbolType;
 
         const emptyObjectType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
 
@@ -430,6 +433,7 @@ namespace ts {
         let deferredGlobalAsyncIteratorType: GenericType;
         let deferredGlobalAsyncIterableIteratorType: GenericType;
         let deferredGlobalTemplateStringsArrayType: ObjectType;
+        let deferredGlobalExtractSymbol: Symbol;
 
         let deferredNodes: Node[];
         const allPotentiallyUnusedIdentifiers = createMap<ReadonlyArray<PotentiallyUnusedIdentifier>>(); // key is file name
@@ -3859,10 +3863,13 @@ namespace ts {
                         return "(Anonymous function)";
                 }
             }
-            if ((symbol as TransientSymbol).nameType && (symbol as TransientSymbol).nameType.flags & TypeFlags.StringLiteral) {
-                const stringValue = ((symbol as TransientSymbol).nameType as StringLiteralType).value;
-                if (!isIdentifierText(stringValue, compilerOptions.target)) {
-                    return `"${escapeString(stringValue, CharacterCodes.doubleQuote)}"`;
+            const nameType = symbol.nameType;
+            if (nameType) {
+                if (nameType.flags & TypeFlags.StringLiteral && !isIdentifierText((<StringLiteralType>nameType).value, compilerOptions.target)) {
+                    return `"${escapeString((<StringLiteralType>nameType).value, CharacterCodes.doubleQuote)}"`;
+                }
+                if (nameType && nameType.flags & TypeFlags.UniqueESSymbol) {
+                    return `[${getNameOfSymbolAsWritten((<UniqueESSymbolType>nameType).symbol, context)}]`;
                 }
             }
             return symbolName(symbol);
@@ -4273,7 +4280,7 @@ namespace ts {
             // right hand expression is of a type parameter type.
             if (isVariableDeclaration(declaration) && declaration.parent.parent.kind === SyntaxKind.ForInStatement) {
                 const indexType = getIndexType(checkNonNullExpression(declaration.parent.parent.expression));
-                return indexType.flags & (TypeFlags.TypeParameter | TypeFlags.Index) ? indexType : stringType;
+                return indexType.flags & (TypeFlags.TypeParameter | TypeFlags.Index) ? getExtractStringType(indexType) : stringType;
             }
 
             if (isVariableDeclaration(declaration) && declaration.parent.parent.kind === SyntaxKind.ForOfStatement) {
@@ -5677,13 +5684,7 @@ namespace ts {
                         error(decl.name || decl, Diagnostics.Duplicate_declaration_0, name);
                         lateSymbol = createSymbol(SymbolFlags.None, memberName, CheckFlags.Late);
                     }
-
-                    const symbolLinks = getSymbolLinks(lateSymbol);
-                    if (!symbolLinks.nameType) {
-                        // Retain link to name type so that it can be reused later
-                        symbolLinks.nameType = type;
-                    }
-
+                    lateSymbol.nameType = type;
                     addDeclarationToLateBoundSymbol(lateSymbol, decl, symbolFlags);
                     if (lateSymbol.parent) {
                         Debug.assert(lateSymbol.parent === parent, "Existing symbol parent should match new one");
@@ -6115,6 +6116,7 @@ namespace ts {
                 const checkFlags = CheckFlags.ReverseMapped | (readonlyMask && isReadonlySymbol(prop) ? CheckFlags.Readonly : 0);
                 const inferredProp = createSymbol(SymbolFlags.Property | prop.flags & optionalMask, prop.escapedName, checkFlags) as ReverseMappedSymbol;
                 inferredProp.declarations = prop.declarations;
+                inferredProp.nameType = prop.nameType;
                 inferredProp.propertyType = getTypeOfSymbol(prop);
                 inferredProp.mappedType = type.mappedType;
                 members.set(prop.escapedName, inferredProp);
@@ -6126,6 +6128,7 @@ namespace ts {
         function resolveMappedTypeMembers(type: MappedType) {
             const members: SymbolTable = createSymbolTable();
             let stringIndexInfo: IndexInfo;
+            let numberIndexInfo: IndexInfo;
             // Resolve upfront such that recursive references see an empty object type.
             setStructuredTypeMembers(type, emptySymbols, emptyArray, emptyArray, undefined, undefined);
             // In { [P in K]: T }, we refer to P as the type parameter type, K as the constraint type,
@@ -6136,14 +6139,18 @@ namespace ts {
             const modifiersType = getApparentType(getModifiersTypeFromMappedType(type)); // The 'T' in 'keyof T'
             const templateModifiers = getMappedTypeModifiers(type);
             const constraintDeclaration = type.declaration.typeParameter.constraint;
+            const include = keyofStringsOnly ? TypeFlags.StringLiteral : TypeFlags.StringOrNumberLiteralOrUnique;
             if (constraintDeclaration.kind === SyntaxKind.TypeOperator &&
                 (<TypeOperatorNode>constraintDeclaration).operator === SyntaxKind.KeyOfKeyword) {
                 // We have a { [P in keyof T]: X }
-                for (const propertySymbol of getPropertiesOfType(modifiersType)) {
-                    addMemberForKeyType(getLiteralTypeFromPropertyName(propertySymbol), propertySymbol);
+                for (const prop of getPropertiesOfType(modifiersType)) {
+                    addMemberForKeyType(getLiteralTypeFromPropertyName(prop, include), /*_index*/ undefined, prop);
                 }
                 if (modifiersType.flags & TypeFlags.Any || getIndexInfoOfType(modifiersType, IndexKind.String)) {
                     addMemberForKeyType(stringType);
+                }
+                if (!keyofStringsOnly && getIndexInfoOfType(modifiersType, IndexKind.Number)) {
+                    addMemberForKeyType(numberType);
                 }
             }
             else {
@@ -6154,16 +6161,9 @@ namespace ts {
                 const iterationType = keyType.flags & TypeFlags.Index ? getIndexType(getApparentType((<IndexType>keyType).type)) : keyType;
                 forEachType(iterationType, addMemberForKeyType);
             }
-            setStructuredTypeMembers(type, members, emptyArray, emptyArray, stringIndexInfo, undefined);
+            setStructuredTypeMembers(type, members, emptyArray, emptyArray, stringIndexInfo, numberIndexInfo);
 
-            function addMemberForKeyType(t: Type, propertySymbolOrIndex?: Symbol | number) {
-                let propertySymbol: Symbol;
-                // forEachType delegates to forEach, which calls with a numeric second argument
-                //  the type system currently doesn't catch this incompatibility, so we annotate
-                //  the function ourselves to indicate the runtime behavior and deal with it here
-                if (typeof propertySymbolOrIndex === "object") {
-                    propertySymbol = propertySymbolOrIndex;
-                }
+            function addMemberForKeyType(t: Type, _index?: number, origin?: Symbol) {
                 // Create a mapper from T to the current iteration type constituent. Then, if the
                 // mapped type is itself an instantiated type, combine the iteration mapper with the
                 // instantiation mapper.
@@ -6171,8 +6171,8 @@ namespace ts {
                 const propType = instantiateType(templateType, templateMapper);
                 // If the current iteration type constituent is a string literal type, create a property.
                 // Otherwise, for type string create a string index signature.
-                if (t.flags & TypeFlags.StringLiteral) {
-                    const propName = getLateBoundNameFromType(t as LiteralType | UniqueESSymbolType);
+                if (t.flags & TypeFlags.StringOrNumberLiteralOrUnique) {
+                    const propName = getLateBoundNameFromType(t as LiteralType);
                     const modifiersProp = getPropertyOfType(modifiersType, propName);
                     const isOptional = !!(templateModifiers & MappedTypeModifiers.IncludeOptional ||
                         !(templateModifiers & MappedTypeModifiers.ExcludeOptional) && modifiersProp && modifiersProp.flags & SymbolFlags.Optional);
@@ -6185,15 +6185,18 @@ namespace ts {
                     prop.type = strictNullChecks && isOptional && !isTypeAssignableTo(undefinedType, propType) ? getOptionalType(propType) :
                         strictNullChecks && !isOptional && modifiersProp && modifiersProp.flags & SymbolFlags.Optional ? getTypeWithFacts(propType, TypeFacts.NEUndefined) :
                         propType;
-                    if (propertySymbol) {
-                        prop.syntheticOrigin = propertySymbol;
-                        prop.declarations = propertySymbol.declarations;
+                    if (origin) {
+                        prop.syntheticOrigin = origin;
+                        prop.declarations = origin.declarations;
                     }
                     prop.nameType = t;
                     members.set(propName, prop);
                 }
                 else if (t.flags & (TypeFlags.Any | TypeFlags.String)) {
                     stringIndexInfo = createIndexInfo(propType, !!(templateModifiers & MappedTypeModifiers.IncludeReadonly));
+                }
+                else if (t.flags & TypeFlags.Number) {
+                    numberIndexInfo = createIndexInfo(propType, !!(templateModifiers & MappedTypeModifiers.IncludeReadonly));
                 }
             }
         }
@@ -6374,18 +6377,10 @@ namespace ts {
         }
 
         function getConstraintOfIndexedAccess(type: IndexedAccessType) {
-            const transformed = getSimplifiedIndexedAccessType(type);
-            if (transformed) {
-                return transformed;
-            }
-            const baseObjectType = getBaseConstraintOfType(type.objectType);
-            const baseIndexType = getBaseConstraintOfType(type.indexType);
-            if (baseIndexType === stringType && !getIndexInfoOfType(baseObjectType || type.objectType, IndexKind.String)) {
-                // getIndexedAccessType returns `any` for X[string] where X doesn't have an index signature.
-                // to avoid this, return `undefined`.
-                return undefined;
-            }
-            return baseObjectType || baseIndexType ? getIndexedAccessType(baseObjectType || type.objectType, baseIndexType || type.indexType) : undefined;
+            const objectType = getBaseConstraintOfType(type.objectType) || type.objectType;
+            const indexType = getBaseConstraintOfType(type.indexType) || type.indexType;
+            const constraint = !isGenericObjectType(objectType) && !isGenericIndexType(indexType) ? getIndexedAccessType(objectType, indexType) : undefined;
+            return constraint && constraint !== unknownType ? constraint : undefined;
         }
 
         function getDefaultConstraintOfConditionalType(type: ConditionalType) {
@@ -6432,7 +6427,7 @@ namespace ts {
         function getBaseConstraintOfType(type: Type): Type {
             const constraint = getBaseConstraintOfInstantiableNonPrimitiveUnionOrIntersection(type);
             if (!constraint && type.flags & TypeFlags.Index) {
-                return stringType;
+                return keyofConstraintType;
             }
             return constraint;
         }
@@ -6467,7 +6462,7 @@ namespace ts {
                     circular = true;
                     return undefined;
                 }
-                const result = computeBaseConstraint(t);
+                const result = computeBaseConstraint(getSimplifiedType(t));
                 if (!popTypeResolution()) {
                     circular = true;
                     return undefined;
@@ -6496,13 +6491,9 @@ namespace ts {
                             undefined;
                 }
                 if (t.flags & TypeFlags.Index) {
-                    return stringType;
+                    return keyofConstraintType;
                 }
                 if (t.flags & TypeFlags.IndexedAccess) {
-                    const transformed = getSimplifiedIndexedAccessType(<IndexedAccessType>t);
-                    if (transformed) {
-                        return getBaseConstraint(transformed);
-                    }
                     const baseObjectType = getBaseConstraint((<IndexedAccessType>t).objectType);
                     const baseIndexType = getBaseConstraint((<IndexedAccessType>t).indexType);
                     const baseIndexedAccess = baseObjectType && baseIndexType ? getIndexedAccessType(baseObjectType, baseIndexType) : undefined;
@@ -6586,6 +6577,7 @@ namespace ts {
                 t.flags & TypeFlags.BooleanLike ? globalBooleanType :
                 t.flags & TypeFlags.ESSymbolLike ? getGlobalESSymbolType(/*reportErrors*/ languageVersion >= ScriptTarget.ES2015) :
                 t.flags & TypeFlags.NonPrimitive ? emptyObjectType :
+                t.flags & TypeFlags.Index ? keyofConstraintType :
                 t;
         }
 
@@ -6625,25 +6617,30 @@ namespace ts {
             if (props.length === 1 && !(checkFlags & CheckFlags.Partial)) {
                 return props[0];
             }
-            const propTypes: Type[] = [];
-            const declarations: Declaration[] = [];
+            let declarations: Declaration[];
             let commonType: Type;
+            let nameType: Type;
+            const propTypes: Type[] = [];
+            let first = true;
             for (const prop of props) {
-                if (prop.declarations) {
-                    addRange(declarations, prop.declarations);
-                }
+                declarations = addRange(declarations, prop.declarations);
                 const type = getTypeOfSymbol(prop);
-                if (!commonType) {
+                if (first) {
                     commonType = type;
+                    nameType = prop.nameType;
+                    first = false;
                 }
-                else if (type !== commonType) {
-                    checkFlags |= CheckFlags.HasNonUniformType;
+                else {
+                    if (type !== commonType) {
+                        checkFlags |= CheckFlags.HasNonUniformType;
+                    }
                 }
                 propTypes.push(type);
             }
             const result = createSymbol(SymbolFlags.Property | commonFlags, name, syntheticFlag | checkFlags);
             result.containingType = containingType;
             result.declarations = declarations;
+            result.nameType = nameType;
             result.type = isUnion ? getUnionType(propTypes) : getIntersectionType(propTypes);
             return result;
         }
@@ -7781,6 +7778,10 @@ namespace ts {
             return symbol && <GenericType>getTypeOfGlobalSymbol(symbol, arity);
         }
 
+        function getGlobalExtractSymbol(): Symbol {
+            return deferredGlobalExtractSymbol || (deferredGlobalExtractSymbol = getGlobalSymbol("Extract" as __String, SymbolFlags.TypeAlias, Diagnostics.Cannot_find_global_type_0));
+        }
+
         /**
          * Instantiates a global type that is generic with some element type, and returns that instantiation.
          */
@@ -7883,8 +7884,13 @@ namespace ts {
             return binarySearch(types, type, getTypeId, compareValues) >= 0;
         }
 
-        // Return true if the given intersection type contains (a) more than one unit type or (b) an object
-        // type and a nullable type (null or undefined).
+        // Return true if the given intersection type contains
+        // more than one unit type or,
+        // an object type and a nullable type (null or undefined), or
+        // a string-like type and a non-string-like primitive type, or
+        // a number-like type and a non-number-like primitive type, or
+        // a symbol-like type and a non-symbol-like primitive type, or
+        // a void-like type and a non-void-like primitive type.
         function isEmptyIntersectionType(type: IntersectionType) {
             let combined: TypeFlags = 0;
             for (const t of type.types) {
@@ -7892,7 +7898,11 @@ namespace ts {
                     return true;
                 }
                 combined |= t.flags;
-                if (combined & TypeFlags.Nullable && combined & (TypeFlags.Object | TypeFlags.NonPrimitive)) {
+                if (combined & TypeFlags.Nullable && combined & (TypeFlags.Object | TypeFlags.NonPrimitive) ||
+                    combined & TypeFlags.StringLike && combined & (TypeFlags.Primitive & ~TypeFlags.StringLike) ||
+                    combined & TypeFlags.NumberLike && combined & (TypeFlags.Primitive & ~TypeFlags.NumberLike) ||
+                    combined & TypeFlags.ESSymbolLike && combined & (TypeFlags.Primitive & ~TypeFlags.ESSymbolLike) ||
+                    combined & TypeFlags.VoidLike && combined & (TypeFlags.Primitive & ~TypeFlags.VoidLike)) {
                     return true;
                 }
             }
@@ -8215,54 +8225,67 @@ namespace ts {
             return links.resolvedType;
         }
 
-        function getIndexTypeForGenericType(type: InstantiableType | UnionOrIntersectionType, includeDeclaredTypes?: boolean) {
-            const cacheLocation = includeDeclaredTypes ? "resolvedDeclaredIndexType" : "resolvedIndexType";
-            if (!type[cacheLocation]) {
-                type[cacheLocation] = <IndexType>createType(TypeFlags.Index);
-                type[cacheLocation].type = type;
-                if (includeDeclaredTypes) {
-                    type[cacheLocation].isDeclaredType = true;
-                }
-            }
-            return type[cacheLocation];
+        function createIndexType(type: InstantiableType | UnionOrIntersectionType, stringsOnly: boolean) {
+            const result = <IndexType>createType(TypeFlags.Index);
+            result.type = type;
+            result.stringsOnly = stringsOnly;
+            return result;
         }
 
-        function getLiteralTypeFromPropertyName(prop: Symbol) {
-            const links = getSymbolLinks(getLateBoundSymbol(prop));
-            if (!links.nameType) {
-                if (links.target && links.target !== unknownSymbol && links.target !== resolvingSymbol && links.target.escapedName === prop.escapedName) {
-                    links.nameType = getLiteralTypeFromPropertyName(links.target);
-                }
-                else {
-                    links.nameType = getDeclarationModifierFlagsFromSymbol(prop) & ModifierFlags.NonPublicAccessibilityModifier || isKnownSymbol(prop) ?
-                        neverType :
+        function getIndexTypeForGenericType(type: InstantiableType | UnionOrIntersectionType, stringsOnly: boolean) {
+            return stringsOnly ?
+                type.resolvedStringIndexType || (type.resolvedStringIndexType = createIndexType(type, /*stringsOnly*/ true)) :
+                type.resolvedIndexType || (type.resolvedIndexType = createIndexType(type, /*stringsOnly*/ false));
+        }
+
+        function getLiteralTypeFromPropertyName(prop: Symbol, include: TypeFlags) {
+            if (!(getDeclarationModifierFlagsFromSymbol(prop) & ModifierFlags.NonPublicAccessibilityModifier)) {
+                let type = getLateBoundSymbol(prop).nameType;
+                if (!type && !isKnownSymbol(prop)) {
+                    const name = getNameOfDeclaration(prop.valueDeclaration);
+                    type = name && isNumericLiteral(name) ? getLiteralType(+name.text) :
+                        name && name.kind === SyntaxKind.ComputedPropertyName && isNumericLiteral(name.expression) ? getLiteralType(+name.expression.text) :
                         getLiteralType(symbolName(prop));
                 }
+                if (type && type.flags & include) {
+                    return type;
+                }
             }
-            return links.nameType;
+            return neverType;
         }
 
-        function isTypeString(type: Type) {
-            return isTypeAssignableToKind(type, TypeFlags.StringLike);
+        function getLiteralTypeFromPropertyNames(type: Type, include: TypeFlags) {
+            return getUnionType(map(getPropertiesOfType(type), t => getLiteralTypeFromPropertyName(t, include)));
         }
 
-        function getLiteralTypeFromPropertyNames(type: Type, includeDeclaredTypes?: boolean) {
-            const originalKeys = map(getPropertiesOfType(type), getLiteralTypeFromPropertyName);
-            return getUnionType(includeDeclaredTypes ? originalKeys : filter(originalKeys, isTypeString));
+        function getNonEnumNumberIndexInfo(type: Type) {
+            const numberIndexInfo = getIndexInfoOfType(type, IndexKind.Number);
+            return numberIndexInfo !== enumNumberIndexInfo ? numberIndexInfo : undefined;
         }
 
-        function getIndexType(type: Type, includeDeclaredTypes?: boolean): Type {
-            return type.flags & TypeFlags.Union ? getIntersectionType(map((<IntersectionType>type).types, t => getIndexType(t, includeDeclaredTypes))) :
-                type.flags & TypeFlags.Intersection ? getUnionType(map((<IntersectionType>type).types, t => getIndexType(t, includeDeclaredTypes))) :
-                maybeTypeOfKind(type, TypeFlags.InstantiableNonPrimitive) ? getIndexTypeForGenericType(<InstantiableType | UnionOrIntersectionType>type, includeDeclaredTypes) :
+        function getIndexType(type: Type, stringsOnly = keyofStringsOnly): Type {
+            return type.flags & TypeFlags.Union ? getIntersectionType(map((<IntersectionType>type).types, t => getIndexType(t, stringsOnly))) :
+                type.flags & TypeFlags.Intersection ? getUnionType(map((<IntersectionType>type).types, t => getIndexType(t, stringsOnly))) :
+                maybeTypeOfKind(type, TypeFlags.InstantiableNonPrimitive) ? getIndexTypeForGenericType(<InstantiableType | UnionOrIntersectionType>type, stringsOnly) :
                 getObjectFlags(type) & ObjectFlags.Mapped ? getConstraintTypeFromMappedType(<MappedType>type) :
                 type === wildcardType ? wildcardType :
-                type.flags & TypeFlags.Any || getIndexInfoOfType(type, IndexKind.String) ? stringType :
-                getLiteralTypeFromPropertyNames(type, includeDeclaredTypes);
+                type.flags & TypeFlags.Any ? keyofConstraintType :
+                stringsOnly ? getIndexInfoOfType(type, IndexKind.String) ? stringType : getLiteralTypeFromPropertyNames(type, TypeFlags.StringLiteral) :
+                getIndexInfoOfType(type, IndexKind.String) ? getUnionType([stringType, numberType, getLiteralTypeFromPropertyNames(type, TypeFlags.UniqueESSymbol)]) :
+                getNonEnumNumberIndexInfo(type) ? getUnionType([numberType, getLiteralTypeFromPropertyNames(type, TypeFlags.StringLiteral | TypeFlags.UniqueESSymbol)]) :
+                getLiteralTypeFromPropertyNames(type, TypeFlags.StringOrNumberLiteralOrUnique);
+        }
+
+        function getExtractStringType(type: Type) {
+            if (keyofStringsOnly) {
+                return type;
+            }
+            const extractTypeAlias = getGlobalExtractSymbol();
+            return extractTypeAlias ? getTypeAliasInstantiation(extractTypeAlias, [type, stringType]) : stringType;
         }
 
         function getIndexTypeOrString(type: Type): Type {
-            const indexType = getIndexType(type);
+            const indexType = getExtractStringType(getIndexType(type));
             return indexType.flags & TypeFlags.Never ? stringType : indexType;
         }
 
@@ -8320,7 +8343,11 @@ namespace ts {
                     getIndexInfoOfType(objectType, IndexKind.String) ||
                     undefined;
                 if (indexInfo) {
-                    if (accessExpression && indexInfo.isReadonly && (isAssignmentTarget(accessExpression) || isDeleteTarget(accessExpression))) {
+                    if (accessNode && !isTypeAssignableToKind(indexType, TypeFlags.String | TypeFlags.Number)) {
+                        const indexNode = accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode.argumentExpression : accessNode.indexType;
+                        error(indexNode, Diagnostics.Type_0_cannot_be_used_as_an_index_type, typeToString(indexType));
+                    }
+                    else if (accessExpression && indexInfo.isReadonly && (isAssignmentTarget(accessExpression) || isDeleteTarget(accessExpression))) {
                         error(accessExpression, Diagnostics.Index_signature_in_type_0_only_permits_reading, typeToString(objectType));
                     }
                     return indexInfo.type;
@@ -8351,9 +8378,8 @@ namespace ts {
                 else {
                     error(indexNode, Diagnostics.Type_0_cannot_be_used_as_an_index_type, typeToString(indexType));
                 }
-                return unknownType;
             }
-            return anyType;
+            return unknownType;
         }
 
         function isGenericObjectType(type: Type): boolean {
@@ -8380,8 +8406,12 @@ namespace ts {
             return getObjectFlags(type) & ObjectFlags.Mapped && getTemplateTypeFromMappedType(type as MappedType) === neverType;
         }
 
+        function getSimplifiedType(type: Type): Type {
+            return type.flags & TypeFlags.IndexedAccess ? getSimplifiedIndexedAccessType(<IndexedAccessType>type) : type;
+        }
+
         // Transform an indexed access to a simpler form, if possible. Return the simpler form, or return
-        // undefined if no transformation is possible.
+        // the type itself if no transformation is possible.
         function getSimplifiedIndexedAccessType(type: IndexedAccessType): Type {
             const objectType = type.objectType;
             if (objectType.flags & TypeFlags.Intersection && isGenericObjectType(objectType)) {
@@ -8401,7 +8431,7 @@ namespace ts {
                         }
                     }
                     return getUnionType([
-                        getIndexedAccessType(getIntersectionType(regularTypes), type.indexType),
+                        getSimplifiedType(getIndexedAccessType(getIntersectionType(regularTypes), type.indexType)),
                         getIntersectionType(stringIndexTypes)
                     ]);
                 }
@@ -8411,13 +8441,13 @@ namespace ts {
                 // eventually anyway, but it easier to reason about.
                 if (some((<IntersectionType>objectType).types, isMappedTypeToNever)) {
                     const nonNeverTypes = filter((<IntersectionType>objectType).types, t => !isMappedTypeToNever(t));
-                    return getIndexedAccessType(getIntersectionType(nonNeverTypes), type.indexType);
+                    return getSimplifiedType(getIndexedAccessType(getIntersectionType(nonNeverTypes), type.indexType));
                 }
             }
-
             // If the object type is a mapped type { [P in K]: E }, where K is generic, instantiate E using a mapper
             // that substitutes the index type for P. For example, for an index access { [P in K]: Box<T[P]> }[X], we
-            // construct the type Box<T[X]>.
+            // construct the type Box<T[X]>. We do not further simplify the result because mapped types can be recursive
+            // and we might never terminate.
             if (isGenericMappedType(objectType)) {
                 return substituteIndexedMappedType(objectType, type);
             }
@@ -8427,7 +8457,7 @@ namespace ts {
                     return substituteIndexedMappedType(constraint, type);
                 }
             }
-            return undefined;
+            return type;
         }
 
         function substituteIndexedMappedType(objectType: MappedType, type: IndexedAccessType) {
@@ -8760,7 +8790,7 @@ namespace ts {
             if (right.flags & TypeFlags.Union) {
                 return mapType(right, t => getSpreadType(left, t, symbol, typeFlags, objectFlags));
             }
-            if (right.flags & (TypeFlags.BooleanLike | TypeFlags.NumberLike | TypeFlags.StringLike | TypeFlags.EnumLike | TypeFlags.NonPrimitive)) {
+            if (right.flags & (TypeFlags.BooleanLike | TypeFlags.NumberLike | TypeFlags.StringLike | TypeFlags.EnumLike | TypeFlags.NonPrimitive | TypeFlags.Index)) {
                 return left;
             }
 
@@ -8806,6 +8836,7 @@ namespace ts {
                         result.leftSpread = leftProp;
                         result.rightSpread = rightProp;
                         result.declarations = declarations;
+                        result.nameType = leftProp.nameType;
                         members.set(leftProp.escapedName, result);
                     }
                 }
@@ -8834,6 +8865,7 @@ namespace ts {
             const result = createSymbol(flags, prop.escapedName);
             result.type = getTypeOfSymbol(prop);
             result.declarations = prop.declarations;
+            result.nameType = prop.nameType;
             result.syntheticOrigin = prop;
             return result;
         }
@@ -9179,8 +9211,13 @@ namespace ts {
             if (symbol.valueDeclaration) {
                 result.valueDeclaration = symbol.valueDeclaration;
             }
-            if ((symbol as TransientSymbol).isRestParameter) {
-                result.isRestParameter = (symbol as TransientSymbol).isRestParameter;
+            if (symbol.nameType) {
+                result.nameType = symbol.nameType;
+            }
+            if (isTransientSymbol(symbol)) {
+                if (symbol.isRestParameter) {
+                    result.isRestParameter = symbol.isRestParameter;
+                }
             }
             return result;
         }
@@ -9986,6 +10023,12 @@ namespace ts {
                 if (target.flags & TypeFlags.Substitution) {
                     target = (<SubstitutionType>target).typeVariable;
                 }
+                if (source.flags & TypeFlags.IndexedAccess) {
+                    source = getSimplifiedType(source);
+                }
+                if (target.flags & TypeFlags.IndexedAccess) {
+                    target = getSimplifiedType(target);
+                }
 
                 // both types are the same - covers 'they are the same primitive type or both are Any' or the same type parameter cases
                 if (source === target) return Ternary.True;
@@ -10439,15 +10482,15 @@ namespace ts {
                     // constraint of T.
                     const constraint = getConstraintForRelation((<IndexType>target).type);
                     if (constraint) {
-                        if (result = isRelatedTo(source, getIndexType(constraint, (target as IndexType).isDeclaredType), reportErrors)) {
+                        if (result = isRelatedTo(source, getIndexType(constraint, (target as IndexType).stringsOnly), reportErrors)) {
                             return result;
                         }
                     }
                 }
                 else if (target.flags & TypeFlags.IndexedAccess) {
-                    // A type S is related to a type T[K] if S is related to A[K], where K is string-like and
-                    // A is the apparent type of T.
-                    const constraint = getConstraintForRelation(<IndexedAccessType>target);
+                    // A type S is related to a type T[K] if S is related to C, where C is the
+                    // constraint of T[K]
+                    const constraint = getConstraintForRelation(target);
                     if (constraint) {
                         if (result = isRelatedTo(source, constraint, reportErrors)) {
                             errorInfo = saveErrorInfo;
@@ -10460,20 +10503,20 @@ namespace ts {
                     const template = getTemplateTypeFromMappedType(target);
                     const modifiers = getMappedTypeModifiers(target);
                     if (!(modifiers & MappedTypeModifiers.ExcludeOptional)) {
-                    if (template.flags & TypeFlags.IndexedAccess && (<IndexedAccessType>template).objectType === source &&
-                        (<IndexedAccessType>template).indexType === getTypeParameterFromMappedType(target)) {
-                        return Ternary.True;
-                    }
-                    // A source type T is related to a target type { [P in keyof T]: X } if T[P] is related to X.
-                    if (!isGenericMappedType(source) && getConstraintTypeFromMappedType(target) === getIndexType(source)) {
-                        const indexedAccessType = getIndexedAccessType(source, getTypeParameterFromMappedType(target));
-                        const templateType = getTemplateTypeFromMappedType(target);
-                        if (result = isRelatedTo(indexedAccessType, templateType, reportErrors)) {
-                            errorInfo = saveErrorInfo;
-                            return result;
+                        if (template.flags & TypeFlags.IndexedAccess && (<IndexedAccessType>template).objectType === source &&
+                            (<IndexedAccessType>template).indexType === getTypeParameterFromMappedType(target)) {
+                            return Ternary.True;
+                        }
+                        // A source type T is related to a target type { [P in keyof T]: X } if T[P] is related to X.
+                        if (!isGenericMappedType(source) && getConstraintTypeFromMappedType(target) === getIndexType(source)) {
+                            const indexedAccessType = getIndexedAccessType(source, getTypeParameterFromMappedType(target));
+                            const templateType = getTemplateTypeFromMappedType(target);
+                            if (result = isRelatedTo(indexedAccessType, templateType, reportErrors)) {
+                                errorInfo = saveErrorInfo;
+                                return result;
+                            }
                         }
                     }
-                }
                 }
 
                 if (source.flags & TypeFlags.TypeParameter) {
@@ -10492,16 +10535,8 @@ namespace ts {
                     }
                 }
                 else if (source.flags & TypeFlags.IndexedAccess) {
-                    // A type S[K] is related to a type T if A[K] is related to T, where K is string-like and
-                    // A is the apparent type of S.
-                    const constraint = getConstraintForRelation(<IndexedAccessType>source);
-                    if (constraint) {
-                        if (result = isRelatedTo(constraint, target, reportErrors)) {
-                            errorInfo = saveErrorInfo;
-                            return result;
-                        }
-                    }
-                    else if (target.flags & TypeFlags.IndexedAccess) {
+                    if (target.flags & TypeFlags.IndexedAccess) {
+                        // A type S[K] is related to a type T[J] if S is related to T and K is related to J.
                         if (result = isRelatedTo((<IndexedAccessType>source).objectType, (<IndexedAccessType>target).objectType, reportErrors)) {
                             result &= isRelatedTo((<IndexedAccessType>source).indexType, (<IndexedAccessType>target).indexType, reportErrors);
                         }
@@ -10509,6 +10544,21 @@ namespace ts {
                             errorInfo = saveErrorInfo;
                             return result;
                         }
+                    }
+                    // A type S[K] is related to a type T if C is related to T, where C is the
+                    // constraint of S[K].
+                    const constraint = getConstraintForRelation(<IndexedAccessType>source);
+                    if (constraint) {
+                        if (result = isRelatedTo(constraint, target, reportErrors)) {
+                            errorInfo = saveErrorInfo;
+                            return result;
+                        }
+                    }
+                }
+                else if (source.flags & TypeFlags.Index) {
+                    if (result = isRelatedTo(keyofConstraintType, target, reportErrors)) {
+                        errorInfo = saveErrorInfo;
+                        return result;
                     }
                 }
                 else if (source.flags & TypeFlags.Conditional) {
@@ -10902,8 +10952,7 @@ namespace ts {
                         continue;
                     }
                     // Skip over symbol-named members
-                    const nameType = getLiteralTypeFromPropertyName(prop);
-                    if (nameType !== undefined && !(isRelatedTo(nameType, stringType) || isRelatedTo(nameType, numberType))) {
+                    if (prop.nameType && prop.nameType.flags & TypeFlags.UniqueESSymbol) {
                         continue;
                     }
                     if (kind === IndexKind.String || isNumericLiteralName(prop.escapedName)) {
@@ -11506,6 +11555,9 @@ namespace ts {
             if (source.valueDeclaration) {
                 symbol.valueDeclaration = source.valueDeclaration;
             }
+            if (source.nameType) {
+                symbol.nameType = source.nameType;
+            }
             return symbol;
         }
 
@@ -11548,7 +11600,7 @@ namespace ts {
         }
 
         function createWideningContext(parent: WideningContext, propertyName: __String, siblings: Type[]): WideningContext {
-            return { parent, propertyName, siblings, resolvedPropertyNames: undefined };
+            return { parent, propertyName, siblings, resolvedProperties: undefined };
         }
 
         function getSiblingsOfContext(context: WideningContext): Type[] {
@@ -11569,19 +11621,19 @@ namespace ts {
             return context.siblings;
         }
 
-        function getPropertyNamesOfContext(context: WideningContext): __String[] {
-            if (!context.resolvedPropertyNames) {
-                const names = createMap<boolean>() as UnderscoreEscapedMap<boolean>;
+        function getPropertiesOfContext(context: WideningContext): Symbol[] {
+            if (!context.resolvedProperties) {
+                const names = createMap<Symbol>() as UnderscoreEscapedMap<Symbol>;
                 for (const t of getSiblingsOfContext(context)) {
                     if (isObjectLiteralType(t) && !(getObjectFlags(t) & ObjectFlags.ContainsSpread)) {
                         for (const prop of getPropertiesOfType(t)) {
-                            names.set(prop.escapedName, true);
+                            names.set(prop.escapedName, prop);
                         }
                     }
                 }
-                context.resolvedPropertyNames = arrayFrom(names.keys());
+                context.resolvedProperties = arrayFrom(names.values());
             }
-            return context.resolvedPropertyNames;
+            return context.resolvedProperties;
         }
 
         function getWidenedProperty(prop: Symbol, context: WideningContext): Symbol {
@@ -11591,18 +11643,14 @@ namespace ts {
             return widened === original ? prop : createSymbolWithType(prop, widened);
         }
 
-        function getUndefinedProperty(name: __String) {
-            const cached = undefinedProperties.get(name);
+        function getUndefinedProperty(prop: Symbol) {
+            const cached = undefinedProperties.get(prop.escapedName);
             if (cached) {
                 return cached;
             }
-            const result = createSymbol(SymbolFlags.Property | SymbolFlags.Optional, name);
-            result.type = undefinedType;
-            const associatedKeyType = getLiteralType(unescapeLeadingUnderscores(name));
-            if (associatedKeyType.flags & TypeFlags.StringLiteral) {
-                result.nameType = associatedKeyType;
-            }
-            undefinedProperties.set(name, result);
+            const result = createSymbolWithType(prop, undefinedType);
+            result.flags |= SymbolFlags.Optional;
+            undefinedProperties.set(prop.escapedName, result);
             return result;
         }
 
@@ -11614,9 +11662,9 @@ namespace ts {
                 members.set(prop.escapedName, prop.flags & SymbolFlags.Property ? getWidenedProperty(prop, context) : prop);
             }
             if (context) {
-                for (const name of getPropertyNamesOfContext(context)) {
-                    if (!members.has(name)) {
-                        members.set(name, getUndefinedProperty(name));
+                for (const prop of getPropertiesOfContext(context)) {
+                    if (!members.has(prop.escapedName)) {
+                        members.set(prop.escapedName, getUndefinedProperty(prop));
                     }
                 }
             }
@@ -12373,14 +12421,13 @@ namespace ts {
                     inferredType = getTypeFromInference(inference);
                 }
 
-                inferredType = getWidenedUniqueESSymbolType(inferredType);
                 inference.inferredType = inferredType;
 
                 const constraint = getConstraintOfTypeParameter(inference.typeParameter);
                 if (constraint) {
                     const instantiatedConstraint = instantiateType(constraint, context);
                     if (!context.compareTypes(inferredType, getTypeWithThisArgument(instantiatedConstraint, inferredType))) {
-                        inference.inferredType = inferredType = getWidenedUniqueESSymbolType(instantiatedConstraint);
+                        inference.inferredType = inferredType = instantiatedConstraint;
                     }
                 }
             }
@@ -15324,7 +15371,7 @@ namespace ts {
                 // type, and any union of these types (like string | number).
                 if (links.resolvedType.flags & TypeFlags.Nullable ||
                     !isTypeAssignableToKind(links.resolvedType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbolLike) &&
-                    !isTypeAssignableTo(links.resolvedType, getUnionType([stringType, numberType, esSymbolType]))) {
+                    !isTypeAssignableTo(links.resolvedType, stringNumberSymbolType)) {
                     error(node, Diagnostics.A_computed_property_name_must_be_of_type_string_number_symbol_or_any);
                 }
                 else {
@@ -15365,6 +15412,7 @@ namespace ts {
             let patternWithComputedProperties = false;
             let hasComputedStringProperty = false;
             let hasComputedNumberProperty = false;
+
             if (isInJSFile && node.properties.length === 0) {
                 // an empty JS object literal that nonetheless has members is a JS namespace
                 const symbol = getSymbolOfNode(node);
@@ -15380,47 +15428,28 @@ namespace ts {
             for (let i = 0; i < node.properties.length; i++) {
                 const memberDecl = node.properties[i];
                 let member = getSymbolOfNode(memberDecl);
-                let literalName: __String | undefined;
+                const computedNameType = memberDecl.name && memberDecl.name.kind === SyntaxKind.ComputedPropertyName && !isWellKnownSymbolSyntactically(memberDecl.name.expression) ?
+                    checkComputedPropertyName(memberDecl.name) : undefined;
                 if (memberDecl.kind === SyntaxKind.PropertyAssignment ||
                     memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment ||
                     isObjectLiteralMethod(memberDecl)) {
-                    let jsdocType: Type;
+                    let type = memberDecl.kind === SyntaxKind.PropertyAssignment ? checkPropertyAssignment(memberDecl, checkMode) :
+                        memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment ? checkExpressionForMutableLocation(memberDecl.name, checkMode) :
+                        checkObjectLiteralMethod(memberDecl, checkMode);
                     if (isInJSFile) {
-                        jsdocType = getTypeForDeclarationFromJSDocComment(memberDecl);
-                    }
-
-                    let type: Type;
-                    if (memberDecl.kind === SyntaxKind.PropertyAssignment) {
-                        if (memberDecl.name.kind === SyntaxKind.ComputedPropertyName) {
-                            const t = checkComputedPropertyName(memberDecl.name);
-                            if (t.flags & TypeFlags.Literal) {
-                                literalName = escapeLeadingUnderscores("" + (t as LiteralType).value);
-                            }
+                        const jsDocType = getTypeForDeclarationFromJSDocComment(memberDecl);
+                        if (jsDocType) {
+                            checkTypeAssignableTo(type, jsDocType, memberDecl);
+                            type = jsDocType;
                         }
-                        type = checkPropertyAssignment(memberDecl, checkMode);
                     }
-                    else if (memberDecl.kind === SyntaxKind.MethodDeclaration) {
-                        type = checkObjectLiteralMethod(memberDecl, checkMode);
-                    }
-                    else {
-                        Debug.assert(memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment);
-                        type = checkExpressionForMutableLocation(memberDecl.name, checkMode);
-                    }
-
-                    if (jsdocType) {
-                        checkTypeAssignableTo(type, jsdocType, memberDecl);
-                        type = jsdocType;
-                    }
-
                     typeFlags |= type.flags;
-
-                    const nameType = hasLateBindableName(memberDecl) ? checkComputedPropertyName(memberDecl.name) : undefined;
-                    const hasLateBoundName = nameType && isTypeUsableAsLateBoundName(nameType);
-                    const prop = hasLateBoundName
-                        ? createSymbol(SymbolFlags.Property | member.flags, getLateBoundNameFromType(nameType as LiteralType | UniqueESSymbolType), CheckFlags.Late)
-                        : createSymbol(SymbolFlags.Property | member.flags, literalName || member.escapedName);
-
-                    if (hasLateBoundName) {
+                    const nameType = computedNameType && computedNameType.flags & TypeFlags.StringOrNumberLiteralOrUnique ?
+                        <LiteralType | UniqueESSymbolType>computedNameType : undefined;
+                    const prop = nameType ?
+                        createSymbol(SymbolFlags.Property | member.flags, getLateBoundNameFromType(nameType), CheckFlags.Late) :
+                        createSymbol(SymbolFlags.Property | member.flags, member.escapedName);
+                    if (nameType) {
                         prop.nameType = nameType;
                     }
 
@@ -15432,9 +15461,6 @@ namespace ts {
                             (memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment && memberDecl.objectAssignmentInitializer);
                         if (isOptional) {
                             prop.flags |= SymbolFlags.Optional;
-                        }
-                        if (!literalName && hasDynamicName(memberDecl)) {
-                            patternWithComputedProperties = true;
                         }
                     }
                     else if (contextualTypeHasPattern && !(getObjectFlags(contextualType) & ObjectFlags.ObjectLiteralPatternWithComputedProperties)) {
@@ -15491,12 +15517,17 @@ namespace ts {
                     checkNodeDeferred(memberDecl);
                 }
 
-                if (!literalName && hasNonBindableDynamicName(memberDecl)) {
-                    if (isNumericName(memberDecl.name)) {
-                        hasComputedNumberProperty = true;
-                    }
-                    else {
-                        hasComputedStringProperty = true;
+                if (computedNameType && !(computedNameType.flags & TypeFlags.StringOrNumberLiteralOrUnique)) {
+                    if (isTypeAssignableTo(computedNameType, stringNumberSymbolType)) {
+                        if (isTypeAssignableTo(computedNameType, numberType)) {
+                            hasComputedNumberProperty = true;
+                        }
+                        else {
+                            hasComputedStringProperty = true;
+                        }
+                        if (inDestructuringPattern) {
+                            patternWithComputedProperties = true;
+                        }
                     }
                 }
                 else {
@@ -20058,6 +20089,15 @@ namespace ts {
             return widened;
         }
 
+        function isTypeParameterWithKeyofConstraint(type: Type) {
+            if (type.flags & TypeFlags.TypeParameter) {
+                const constraintDeclaration = getConstraintDeclaration(<TypeParameter>type);
+                return constraintDeclaration && constraintDeclaration.kind === SyntaxKind.TypeOperator &&
+                    (<TypeOperatorNode>constraintDeclaration).operator === SyntaxKind.KeyOfKeyword;
+            }
+            return false;
+        }
+
         function isLiteralOfContextualType(candidateType: Type, contextualType: Type): boolean {
             if (contextualType) {
                 if (contextualType.flags & TypeFlags.UnionOrIntersection) {
@@ -20069,7 +20109,8 @@ namespace ts {
                     // this a literal context for literals of that primitive type. For example, given a
                     // type parameter 'T extends string', infer string literal types for T.
                     const constraint = getBaseConstraintOfType(contextualType) || emptyObjectType;
-                    return constraint.flags & TypeFlags.String && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
+                    return isTypeParameterWithKeyofConstraint(contextualType) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral | TypeFlags.NumberLiteral | TypeFlags.UniqueESSymbol) ||
+                        constraint.flags & TypeFlags.String && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
                         constraint.flags & TypeFlags.Number && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral) ||
                         constraint.flags & TypeFlags.Boolean && maybeTypeOfKind(candidateType, TypeFlags.BooleanLiteral) ||
                         constraint.flags & TypeFlags.ESSymbol && maybeTypeOfKind(candidateType, TypeFlags.UniqueESSymbol) ||
@@ -20998,7 +21039,7 @@ namespace ts {
             // Check if the index type is assignable to 'keyof T' for the object type.
             const objectType = (<IndexedAccessType>type).objectType;
             const indexType = (<IndexedAccessType>type).indexType;
-            if (isTypeAssignableTo(indexType, getIndexType(objectType, /*includeDeclaredTypes*/ true))) {
+            if (isTypeAssignableTo(indexType, getIndexType(objectType, /*stringsOnly*/ false))) {
                 if (accessNode.kind === SyntaxKind.ElementAccessExpression && isAssignmentTarget(accessNode) &&
                     getObjectFlags(objectType) & ObjectFlags.Mapped && getMappedTypeModifiers(<MappedType>objectType) & MappedTypeModifiers.IncludeReadonly) {
                     error(accessNode, Diagnostics.Index_signature_in_type_0_only_permits_reading, typeToString(objectType));
@@ -21030,7 +21071,7 @@ namespace ts {
 
             const type = <MappedType>getTypeFromMappedTypeNode(node);
             const constraintType = getConstraintTypeFromMappedType(type);
-            checkTypeAssignableTo(constraintType, stringType, node.typeParameter.constraint);
+            checkTypeAssignableTo(constraintType, keyofConstraintType, node.typeParameter.constraint);
         }
 
         function checkTypeOperator(node: TypeOperatorNode) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8252,7 +8252,8 @@ namespace ts {
         }
 
         function getIndexType(type: Type, includeDeclaredTypes?: boolean): Type {
-            return type.flags & TypeFlags.Intersection ? getUnionType(map((<IntersectionType>type).types, t => getIndexType(t, includeDeclaredTypes))) :
+            return type.flags & TypeFlags.Union ? getIntersectionType(map((<IntersectionType>type).types, t => getIndexType(t, includeDeclaredTypes))) :
+                type.flags & TypeFlags.Intersection ? getUnionType(map((<IntersectionType>type).types, t => getIndexType(t, includeDeclaredTypes))) :
                 maybeTypeOfKind(type, TypeFlags.InstantiableNonPrimitive) ? getIndexTypeForGenericType(<InstantiableType | UnionOrIntersectionType>type, includeDeclaredTypes) :
                 getObjectFlags(type) & ObjectFlags.Mapped ? getConstraintTypeFromMappedType(<MappedType>type) :
                 type === wildcardType ? wildcardType :

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -673,6 +673,12 @@ namespace ts {
             description: Diagnostics.Disable_strict_checking_of_generic_signatures_in_function_types,
         },
         {
+            name: "keyofStringsOnly",
+            type: "boolean",
+            category: Diagnostics.Advanced_Options,
+            description: Diagnostics.Resolve_keyof_to_string_valued_property_names_only_no_numbers_or_symbols,
+        },
+        {
             // A list of plugins to load in the language service
             name: "plugins",
             type: "list",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3526,6 +3526,10 @@
         "category": "Message",
         "code": 6194
     },
+    "Resolve 'keyof' to string valued property names only (no numbers or symbols).": {
+        "category": "Message",
+        "code": 6195
+    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3377,6 +3377,7 @@ namespace ts {
         /* @internal */ mergeId?: number;       // Merge id (used to look up merged symbol)
         /* @internal */ parent?: Symbol;        // Parent symbol
         /* @internal */ exportSymbol?: Symbol;  // Exported symbol associated with this symbol
+        /* @internal */ nameType?: Type;        // Type associated with a late-bound symbol
         /* @internal */ constEnumOnlyModule?: boolean; // True if module contains only const enums or other modules with only const enums
         /* @internal */ isReferenced?: SymbolFlags; // True if the symbol is referenced elsewhere. Keeps track of the meaning of a reference in case a symbol is both a type parameter and parameter.
         /* @internal */ isReplaceableByMethod?: boolean; // Can this Javascript class property be replaced by a method symbol?
@@ -3411,7 +3412,6 @@ namespace ts {
         enumKind?: EnumKind;                // Enum declaration classification
         originatingImport?: ImportDeclaration | ImportCall; // Import declaration which produced the symbol, present if the symbol is marked as uncallable but had call signatures in `resolveESModuleSymbol`
         lateSymbol?: Symbol;                // Late-bound symbol for a computed property
-        nameType?: Type;                    // Type associate with a late-bound or mapped type property symbol's name
     }
 
     /* @internal */
@@ -3608,11 +3608,12 @@ namespace ts {
         Intrinsic = Any | String | Number | Boolean | BooleanLiteral | ESSymbol | Void | Undefined | Null | Never | NonPrimitive,
         /* @internal */
         Primitive = String | Number | Boolean | Enum | EnumLiteral | ESSymbol | Void | Undefined | Null | Literal | UniqueESSymbol,
-        StringLike = String | StringLiteral | Index,
+        StringLike = String | StringLiteral,
         NumberLike = Number | NumberLiteral | Enum,
         BooleanLike = Boolean | BooleanLiteral,
         EnumLike = Enum | EnumLiteral,
         ESSymbolLike = ESSymbol | UniqueESSymbol,
+        VoidLike = Void | Undefined,
         UnionOrIntersection = Union | Intersection,
         StructuredType = Object | Union | Intersection,
         TypeVariable = TypeParameter | IndexedAccess,
@@ -3765,7 +3766,7 @@ namespace ts {
         /* @internal */
         resolvedIndexType: IndexType;
         /* @internal */
-        resolvedDeclaredIndexType: IndexType;
+        resolvedStringIndexType: IndexType;
         /* @internal */
         resolvedBaseConstraint: Type;
         /* @internal */
@@ -3854,7 +3855,7 @@ namespace ts {
         /* @internal */
         resolvedIndexType?: IndexType;
         /* @internal */
-        resolvedDeclaredIndexType?: IndexType;
+        resolvedStringIndexType?: IndexType;
     }
 
     // Type parameters (TypeFlags.TypeParameter)
@@ -3886,9 +3887,9 @@ namespace ts {
 
     // keyof T types (TypeFlags.Index)
     export interface IndexType extends InstantiableType {
-        /* @internal */
-        isDeclaredType?: boolean;
         type: InstantiableType | UnionOrIntersectionType;
+        /* @internal */
+        stringsOnly: boolean;
     }
 
     export interface ConditionalRoot {
@@ -4047,10 +4048,10 @@ namespace ts {
 
     /* @internal */
     export interface WideningContext {
-        parent?: WideningContext;            // Parent context
-        propertyName?: __String;             // Name of property in parent
-        siblings?: Type[];                   // Types of siblings
-        resolvedPropertyNames?: __String[];  // Property names occurring in sibling object literals
+        parent?: WideningContext;       // Parent context
+        propertyName?: __String;        // Name of property in parent
+        siblings?: Type[];              // Types of siblings
+        resolvedProperties?: Symbol[];  // Properties occurring in sibling object literals
     }
 
     /* @internal */
@@ -4165,6 +4166,7 @@ namespace ts {
         inlineSources?: boolean;
         isolatedModules?: boolean;
         jsx?: JsxEmit;
+        keyofStringsOnly?: boolean;
         lib?: string[];
         /*@internal*/listEmittedFiles?: boolean;
         /*@internal*/listFiles?: boolean;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -276,13 +276,9 @@ namespace FourSlash {
             if (configFileName) {
                 const baseDir = ts.normalizePath(ts.getDirectoryPath(configFileName));
                 const host = new Utils.MockParseConfigHost(baseDir, /*ignoreCase*/ false, this.inputFiles);
-
-                const configJsonObj = ts.parseConfigFileTextToJson(configFileName, this.inputFiles.get(configFileName));
-                assert.isTrue(configJsonObj.config !== undefined);
-
-                compilationOptions = ts.parseJsonConfigFileContent(configJsonObj.config, host, baseDir, compilationOptions, configFileName).options;
+                const jsonSourceFile = ts.parseJsonText(configFileName, this.inputFiles.get(configFileName));
+                compilationOptions = ts.parseJsonSourceFileConfigFileContent(jsonSourceFile, host, baseDir, compilationOptions, configFileName).options;
             }
-
 
             if (compilationOptions.typeRoots) {
                 compilationOptions.typeRoots = compilationOptions.typeRoots.map(p => ts.getNormalizedAbsolutePath(p, this.basePath));
@@ -2423,14 +2419,7 @@ Actual: ${stringify(fullActual)}`);
         public applyCodeActionFromCompletion(markerName: string, options: FourSlashInterface.VerifyCompletionActionOptions) {
             this.goToMarker(markerName);
 
-            const actualCompletion = this.getCompletionListAtCaret({ ...ts.defaultPreferences, includeCompletionsForModuleExports: true }).entries.find(e =>
-                e.name === options.name && e.source === options.source);
-
-            if (!actualCompletion.hasAction) {
-                this.raiseError(`Completion for ${options.name} does not have an associated action.`);
-            }
-
-            const details = this.getCompletionEntryDetails(options.name, actualCompletion.source, options.preferences);
+            const details = this.getCompletionEntryDetails(options.name, options.source, options.preferences);
             if (details.codeActions.length !== 1) {
                 this.raiseError(`Expected one code action, got ${details.codeActions.length}`);
             }

--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -1,5 +1,3 @@
-declare type PropertyKey = string | number | symbol;
-
 interface Array<T> {
     /**
      * Returns the value of the first element in the array where predicate is true, and undefined
@@ -258,20 +256,6 @@ interface NumberConstructor {
     parseInt(string: string, radix?: number): number;
 }
 
-interface Object {
-    /**
-     * Determines whether an object has a property with the specified name.
-     * @param v A property name.
-     */
-    hasOwnProperty(v: PropertyKey): boolean;
-
-    /**
-     * Determines whether a specified property is enumerable.
-     * @param v A property name.
-     */
-    propertyIsEnumerable(v: PropertyKey): boolean;
-}
-
 interface ObjectConstructor {
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
@@ -327,25 +311,6 @@ interface ObjectConstructor {
      * @param proto The value of the new prototype or null.
      */
     setPrototypeOf(o: any, proto: object | null): any;
-
-    /**
-     * Gets the own property descriptor of the specified object.
-     * An own property descriptor is one that is defined directly on the object and is not
-     * inherited from the object's prototype.
-     * @param o Object that contains the property.
-     * @param p Name of the property.
-     */
-    getOwnPropertyDescriptor(o: any, propertyKey: PropertyKey): PropertyDescriptor | undefined;
-
-    /**
-     * Adds a property to an object, or modifies attributes of an existing property.
-     * @param o Object on which to add or modify the property. This can be a native JavaScript
-     * object (that is, a user-defined object or a built in object) or a DOM object.
-     * @param p The property name.
-     * @param attributes Descriptor for the property. It can be for a data property or an accessor
-     *  property.
-     */
-    defineProperty(o: any, propertyKey: PropertyKey, attributes: PropertyDescriptor): any;
 }
 
 interface ReadonlyArray<T> {

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -74,6 +74,8 @@ declare function escape(string: string): string;
   */
 declare function unescape(string: string): string;
 
+declare type PropertyKey = string | number | symbol;
+
 interface PropertyDescriptor {
     configurable?: boolean;
     enumerable?: boolean;
@@ -104,7 +106,7 @@ interface Object {
       * Determines whether an object has a property with the specified name.
       * @param v A property name.
       */
-    hasOwnProperty(v: string): boolean;
+    hasOwnProperty(v: PropertyKey): boolean;
 
     /**
       * Determines whether an object exists in another object's prototype chain.
@@ -116,7 +118,7 @@ interface Object {
       * Determines whether a specified property is enumerable.
       * @param v A property name.
       */
-    propertyIsEnumerable(v: string): boolean;
+    propertyIsEnumerable(v: PropertyKey): boolean;
 }
 
 interface ObjectConstructor {
@@ -139,7 +141,7 @@ interface ObjectConstructor {
       * @param o Object that contains the property.
       * @param p Name of the property.
     */
-    getOwnPropertyDescriptor(o: any, p: string): PropertyDescriptor | undefined;
+    getOwnPropertyDescriptor(o: any, p: PropertyKey): PropertyDescriptor | undefined;
 
     /**
       * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly
@@ -167,7 +169,7 @@ interface ObjectConstructor {
       * @param p The property name.
       * @param attributes Descriptor for the property. It can be for a data property or an accessor property.
       */
-    defineProperty(o: any, p: string, attributes: PropertyDescriptor & ThisType<any>): any;
+    defineProperty(o: any, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>): any;
 
     /**
       * Adds one or more properties to an object, and/or modifies attributes of existing properties.
@@ -1340,7 +1342,7 @@ type Pick<T, K extends keyof T> = {
 /**
  * Construct a type with a set of properties K of type T
  */
-type Record<K extends string, T> = {
+type Record<K extends keyof any, T> = {
     [P in K]: T;
 };
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -47,7 +47,7 @@ namespace ts.Completions {
             return getLabelCompletionAtPosition(contextToken.parent);
         }
 
-        const completionData = getCompletionData(program, log, sourceFile, position, preferences);
+        const completionData = getCompletionData(program, log, sourceFile, position, preferences, /*detailsEntryId*/ undefined);
         if (!completionData) {
             return undefined;
         }
@@ -486,9 +486,9 @@ namespace ts.Completions {
         previousToken: Node;
         readonly isJsxInitializer: IsJsxInitializer;
     }
-    function getSymbolCompletionFromEntryId(program: Program, log: Log, sourceFile: SourceFile, position: number, { name, source }: CompletionEntryIdentifier,
+    function getSymbolCompletionFromEntryId(program: Program, log: Log, sourceFile: SourceFile, position: number, entryId: CompletionEntryIdentifier,
     ): SymbolCompletion | { type: "request", request: Request } | { type: "none" } {
-        const completionData = getCompletionData(program, log, sourceFile, position, { includeCompletionsForModuleExports: true, includeCompletionsWithInsertText: true });
+        const completionData = getCompletionData(program, log, sourceFile, position, { includeCompletionsForModuleExports: true, includeCompletionsWithInsertText: true }, entryId);
         if (!completionData) {
             return { type: "none" };
         }
@@ -505,7 +505,9 @@ namespace ts.Completions {
         return firstDefined<Symbol, SymbolCompletion>(symbols, (symbol): SymbolCompletion => { // TODO: Shouldn't need return type annotation (GH#12632)
             const origin = symbolToOriginInfoMap[getSymbolId(symbol)];
             const info = getCompletionEntryDisplayNameForSymbol(symbol, program.getCompilerOptions().target, origin, completionKind);
-            return info && info.name === name && getSourceFromOrigin(origin) === source ? { type: "symbol" as "symbol", symbol, location, symbolToOriginInfoMap, previousToken, isJsxInitializer } : undefined;
+            return info && info.name === entryId.name && getSourceFromOrigin(origin) === entryId.source
+                ? { type: "symbol" as "symbol", symbol, location, symbolToOriginInfoMap, previousToken, isJsxInitializer }
+                : undefined;
         }) || { type: "none" };
     }
 
@@ -755,6 +757,7 @@ namespace ts.Completions {
         sourceFile: SourceFile,
         position: number,
         preferences: Pick<UserPreferences, "includeCompletionsForModuleExports" | "includeCompletionsWithInsertText">,
+        detailsEntryId: CompletionEntryIdentifier | undefined,
     ): CompletionData | Request | undefined {
         const typeChecker = program.getTypeChecker();
 
@@ -1302,6 +1305,11 @@ namespace ts.Completions {
             const tokenTextLowerCase = tokenText.toLowerCase();
 
             codefix.forEachExternalModuleToImportFrom(typeChecker, sourceFile, program.getSourceFiles(), moduleSymbol => {
+                // Perf -- ignore other modules if this is a request for details
+                if (detailsEntryId && detailsEntryId.source && stripQuotes(moduleSymbol.name) !== detailsEntryId.source) {
+                    return;
+                }
+
                 for (let symbol of typeChecker.getExportsOfModule(moduleSymbol)) {
                     // Don't add a completion for a re-export, only for the original.
                     // The actual import fix might end up coming from a re-export -- we don't compute that until getting completion details.
@@ -1320,7 +1328,7 @@ namespace ts.Completions {
                     }
 
                     const origin: SymbolOriginInfo = { type: "export", moduleSymbol, isDefaultExport };
-                    if (stringContainsCharactersInOrder(getSymbolName(symbol, origin, target).toLowerCase(), tokenTextLowerCase)) {
+                    if (detailsEntryId || stringContainsCharactersInOrder(getSymbolName(symbol, origin, target).toLowerCase(), tokenTextLowerCase)) {
                         symbols.push(symbol);
                         symbolToOriginInfoMap[getSymbolId(symbol)] = origin;
                     }

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -3,14 +3,31 @@ namespace ts {
     export function getEditsForFileRename(program: Program, oldFilePath: string, newFilePath: string, host: LanguageServiceHost, formatContext: formatting.FormatContext): ReadonlyArray<FileTextChanges> {
         const pathUpdater = getPathUpdater(oldFilePath, newFilePath, host);
         return textChanges.ChangeTracker.with({ host, formatContext }, changeTracker => {
+            updateTsconfigFiles(program, changeTracker, oldFilePath, newFilePath);
             for (const { sourceFile, toUpdate } of getImportsToUpdate(program, oldFilePath)) {
                 const newPath = pathUpdater(isRef(toUpdate) ? toUpdate.fileName : toUpdate.text);
                 if (newPath !== undefined) {
-                    const range = isRef(toUpdate) ? toUpdate : createTextRange(toUpdate.getStart(sourceFile) + 1, toUpdate.end - 1);
+                    const range = isRef(toUpdate) ? toUpdate : createStringRange(toUpdate, sourceFile);
                     changeTracker.replaceRangeWithText(sourceFile, range, isRef(toUpdate) ? newPath : removeFileExtension(newPath));
                 }
             }
         });
+    }
+
+    function updateTsconfigFiles(program: Program, changeTracker: textChanges.ChangeTracker, oldFilePath: string, newFilePath: string): void {
+        const cfg = program.getCompilerOptions().configFile;
+        if (!cfg) return;
+        const oldFile = cfg.jsonObject && getFilesEntry(cfg.jsonObject, oldFilePath);
+        if (oldFile) {
+            changeTracker.replaceRangeWithText(cfg, createStringRange(oldFile, cfg), newFilePath);
+        }
+    }
+
+    function getFilesEntry(cfg: ObjectLiteralExpression, fileName: string): StringLiteral | undefined {
+        const filesProp = find(cfg.properties, (prop): prop is PropertyAssignment =>
+            isPropertyAssignment(prop) && isStringLiteral(prop.name) && prop.name.text === "files");
+        const files = filesProp && filesProp.initializer;
+        return files && isArrayLiteralExpression(files) ? find(files.elements, (e): e is StringLiteral => isStringLiteral(e) && e.text === fileName) : undefined;
     }
 
     interface ToUpdate {
@@ -51,5 +68,9 @@ namespace ts {
             if (!pathIsRelative(oldPath)) return;
             return ensurePathIsRelative(normalizePath(combinePaths(getDirectoryPath(oldPath), rel)));
         };
+    }
+
+    function createStringRange(node: StringLiteralLike, sourceFile: SourceFileLike): TextRange {
+        return createTextRange(node.getStart(sourceFile) + 1, node.end - 1);
     }
 }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2100,11 +2100,12 @@ declare namespace ts {
         Unit = 13536,
         StringOrNumberLiteral = 96,
         PossiblyFalsy = 14574,
-        StringLike = 524322,
+        StringLike = 34,
         NumberLike = 84,
         BooleanLike = 136,
         EnumLike = 272,
         ESSymbolLike = 1536,
+        VoidLike = 6144,
         UnionOrIntersection = 393216,
         StructuredType = 458752,
         TypeVariable = 1081344,
@@ -2340,6 +2341,7 @@ declare namespace ts {
         inlineSources?: boolean;
         isolatedModules?: boolean;
         jsx?: JsxEmit;
+        keyofStringsOnly?: boolean;
         lib?: string[];
         locale?: string;
         mapRoot?: string;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2100,11 +2100,12 @@ declare namespace ts {
         Unit = 13536,
         StringOrNumberLiteral = 96,
         PossiblyFalsy = 14574,
-        StringLike = 524322,
+        StringLike = 34,
         NumberLike = 84,
         BooleanLike = 136,
         EnumLike = 272,
         ESSymbolLike = 1536,
+        VoidLike = 6144,
         UnionOrIntersection = 393216,
         StructuredType = 458752,
         TypeVariable = 1081344,
@@ -2340,6 +2341,7 @@ declare namespace ts {
         inlineSources?: boolean;
         isolatedModules?: boolean;
         jsx?: JsxEmit;
+        keyofStringsOnly?: boolean;
         lib?: string[];
         locale?: string;
         mapRoot?: string;

--- a/tests/baselines/reference/classAppearsToHaveMembersOfObject.types
+++ b/tests/baselines/reference/classAppearsToHaveMembersOfObject.types
@@ -17,9 +17,9 @@ var r = c.toString();
 var r2 = c.hasOwnProperty('');
 >r2 : boolean
 >c.hasOwnProperty('') : boolean
->c.hasOwnProperty : (v: string) => boolean
+>c.hasOwnProperty : (v: string | number | symbol) => boolean
 >c : C
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >'' : ""
 
 var o: Object = c;

--- a/tests/baselines/reference/complexRecursiveCollections.symbols
+++ b/tests/baselines/reference/complexRecursiveCollections.symbols
@@ -1689,7 +1689,7 @@ declare module Immutable {
     export interface Class<T extends Object> {
 >Class : Symbol(Class, Decl(immutable.ts, 214, 70))
 >T : Symbol(T, Decl(immutable.ts, 215, 27))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
       (values?: Partial<T> | Iterable<[string, any]>): Instance<T> & Readonly<T>;
 >values : Symbol(values, Decl(immutable.ts, 216, 7))
@@ -1714,7 +1714,7 @@ declare module Immutable {
     export interface Instance<T extends Object> {
 >Instance : Symbol(Instance, Decl(immutable.ts, 218, 5))
 >T : Symbol(T, Decl(immutable.ts, 219, 30))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
       readonly size: number;
 >size : Symbol(Instance.size, Decl(immutable.ts, 219, 49))
@@ -2005,7 +2005,7 @@ declare module Immutable {
 
       toJS(): Object;
 >toJS : Symbol(Keyed.toJS, Decl(immutable.ts, 269, 76))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
       toJSON(): { [key: string]: V };
 >toJSON : Symbol(Keyed.toJSON, Decl(immutable.ts, 270, 21))
@@ -2594,7 +2594,7 @@ declare module Immutable {
 
       toJS(): Object;
 >toJS : Symbol(Keyed.toJS, Decl(immutable.ts, 340, 59))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
       toJSON(): { [key: string]: V };
 >toJSON : Symbol(Keyed.toJSON, Decl(immutable.ts, 341, 21))

--- a/tests/baselines/reference/computedPropertyNames10_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames10_ES5.types
@@ -9,8 +9,8 @@ var a: any;
 >a : any
 
 var v = {
->v : { [x: string]: () => void; [x: number]: () => void; [""](): void; [0](): void; }
->{    [s]() { },    [n]() { },    [s + s]() { },    [s + n]() { },    [+s]() { },    [""]() { },    [0]() { },    [a]() { },    [<any>true]() { },    [`hello bye`]() { },    [`hello ${a} bye`]() { }} : { [x: string]: () => void; [x: number]: () => void; [""](): void; [0](): void; }
+>v : { [x: string]: () => void; [x: number]: () => void; [""](): void; [0](): void; [`hello bye`](): void; }
+>{    [s]() { },    [n]() { },    [s + s]() { },    [s + n]() { },    [+s]() { },    [""]() { },    [0]() { },    [a]() { },    [<any>true]() { },    [`hello bye`]() { },    [`hello ${a} bye`]() { }} : { [x: string]: () => void; [x: number]: () => void; [""](): void; [0](): void; [`hello bye`](): void; }
 
     [s]() { },
 >[s] : () => void

--- a/tests/baselines/reference/computedPropertyNames10_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames10_ES6.types
@@ -9,8 +9,8 @@ var a: any;
 >a : any
 
 var v = {
->v : { [x: string]: () => void; [x: number]: () => void; [""](): void; [0](): void; }
->{    [s]() { },    [n]() { },    [s + s]() { },    [s + n]() { },    [+s]() { },    [""]() { },    [0]() { },    [a]() { },    [<any>true]() { },    [`hello bye`]() { },    [`hello ${a} bye`]() { }} : { [x: string]: () => void; [x: number]: () => void; [""](): void; [0](): void; }
+>v : { [x: string]: () => void; [x: number]: () => void; [""](): void; [0](): void; [`hello bye`](): void; }
+>{    [s]() { },    [n]() { },    [s + s]() { },    [s + n]() { },    [+s]() { },    [""]() { },    [0]() { },    [a]() { },    [<any>true]() { },    [`hello bye`]() { },    [`hello ${a} bye`]() { }} : { [x: string]: () => void; [x: number]: () => void; [""](): void; [0](): void; [`hello bye`](): void; }
 
     [s]() { },
 >[s] : () => void

--- a/tests/baselines/reference/computedPropertyNames28_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames28_ES5.types
@@ -12,8 +12,8 @@ class C extends Base {
 >super : typeof Base
 
         var obj = {
->obj : { [x: string]: () => void; }
->{            [(super(), "prop")]() { }        } : { [x: string]: () => void; }
+>obj : { [(super(), "prop")](): void; }
+>{            [(super(), "prop")]() { }        } : { [(super(), "prop")](): void; }
 
             [(super(), "prop")]() { }
 >[(super(), "prop")] : () => void

--- a/tests/baselines/reference/computedPropertyNames28_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames28_ES6.types
@@ -12,8 +12,8 @@ class C extends Base {
 >super : typeof Base
 
         var obj = {
->obj : { [x: string]: () => void; }
->{            [(super(), "prop")]() { }        } : { [x: string]: () => void; }
+>obj : { [(super(), "prop")](): void; }
+>{            [(super(), "prop")]() { }        } : { [(super(), "prop")](): void; }
 
             [(super(), "prop")]() { }
 >[(super(), "prop")] : () => void

--- a/tests/baselines/reference/computedPropertyNames30_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames30_ES5.types
@@ -15,8 +15,8 @@ class C extends Base {
 >() => {            var obj = {                // Ideally, we would capture this. But the reference is                // illegal, and not capturing this is consistent with                //treatment of other similar violations.                [(super(), "prop")]() { }            };        } : () => void
 
             var obj = {
->obj : { [x: string]: () => void; }
->{                // Ideally, we would capture this. But the reference is                // illegal, and not capturing this is consistent with                //treatment of other similar violations.                [(super(), "prop")]() { }            } : { [x: string]: () => void; }
+>obj : { [(super(), "prop")](): void; }
+>{                // Ideally, we would capture this. But the reference is                // illegal, and not capturing this is consistent with                //treatment of other similar violations.                [(super(), "prop")]() { }            } : { [(super(), "prop")](): void; }
 
                 // Ideally, we would capture this. But the reference is
                 // illegal, and not capturing this is consistent with

--- a/tests/baselines/reference/computedPropertyNames30_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames30_ES6.types
@@ -15,8 +15,8 @@ class C extends Base {
 >() => {            var obj = {                // Ideally, we would capture this. But the reference is                // illegal, and not capturing this is consistent with                //treatment of other similar violations.                [(super(), "prop")]() { }            };        } : () => void
 
             var obj = {
->obj : { [x: string]: () => void; }
->{                // Ideally, we would capture this. But the reference is                // illegal, and not capturing this is consistent with                //treatment of other similar violations.                [(super(), "prop")]() { }            } : { [x: string]: () => void; }
+>obj : { [(super(), "prop")](): void; }
+>{                // Ideally, we would capture this. But the reference is                // illegal, and not capturing this is consistent with                //treatment of other similar violations.                [(super(), "prop")]() { }            } : { [(super(), "prop")](): void; }
 
                 // Ideally, we would capture this. But the reference is
                 // illegal, and not capturing this is consistent with

--- a/tests/baselines/reference/computedPropertyNames5_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames5_ES5.types
@@ -3,8 +3,8 @@ var b: boolean;
 >b : boolean
 
 var v = {
->v : { [x: string]: number; [x: number]: any; [true]: number; }
->{    [b]: 0,    [true]: 1,    [[]]: 0,    [{}]: 0,    [undefined]: undefined,    [null]: null} : { [x: string]: number; [x: number]: null; [true]: number; }
+>v : { [x: number]: any; }
+>{    [b]: 0,    [true]: 1,    [[]]: 0,    [{}]: 0,    [undefined]: undefined,    [null]: null} : { [x: number]: null; }
 
     [b]: 0,
 >[b] : number

--- a/tests/baselines/reference/computedPropertyNames5_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames5_ES6.types
@@ -3,8 +3,8 @@ var b: boolean;
 >b : boolean
 
 var v = {
->v : { [x: string]: number; [x: number]: any; [true]: number; }
->{    [b]: 0,    [true]: 1,    [[]]: 0,    [{}]: 0,    [undefined]: undefined,    [null]: null} : { [x: string]: number; [x: number]: null; [true]: number; }
+>v : { [x: number]: any; }
+>{    [b]: 0,    [true]: 1,    [[]]: 0,    [{}]: 0,    [undefined]: undefined,    [null]: null} : { [x: number]: null; }
 
     [b]: 0,
 >[b] : number

--- a/tests/baselines/reference/computedPropertyNames9_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames9_ES5.types
@@ -19,8 +19,8 @@ function f(x): any { }
 >x : any
 
 var v = {
->v : { [x: string]: number; [x: number]: number; [f(true)]: number; }
->{    [f("")]: 0,    [f(0)]: 0,    [f(true)]: 0} : { [x: string]: number; [x: number]: number; [f(true)]: number; }
+>v : { [x: string]: number; [x: number]: number; }
+>{    [f("")]: 0,    [f(0)]: 0,    [f(true)]: 0} : { [x: string]: number; [x: number]: number; }
 
     [f("")]: 0,
 >[f("")] : number

--- a/tests/baselines/reference/computedPropertyNames9_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames9_ES6.types
@@ -19,8 +19,8 @@ function f(x): any { }
 >x : any
 
 var v = {
->v : { [x: string]: number; [x: number]: number; [f(true)]: number; }
->{    [f("")]: 0,    [f(0)]: 0,    [f(true)]: 0} : { [x: string]: number; [x: number]: number; [f(true)]: number; }
+>v : { [x: string]: number; [x: number]: number; }
+>{    [f("")]: 0,    [f(0)]: 0,    [f(true)]: 0} : { [x: string]: number; [x: number]: number; }
 
     [f("")]: 0,
 >[f("")] : number

--- a/tests/baselines/reference/conditionalTypes1.errors.txt
+++ b/tests/baselines/reference/conditionalTypes1.errors.txt
@@ -5,9 +5,8 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(17,5): error TS23
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(18,9): error TS2322: Type 'T' is not assignable to type 'string'.
   Type 'string | undefined' is not assignable to type 'string'.
     Type 'undefined' is not assignable to type 'string'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(24,5): error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
-  Type 'T[keyof T] | undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
-    Type 'undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(24,5): error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+  Type 'undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(29,5): error TS2322: Type 'T["x"]' is not assignable to type 'NonNullable<T["x"]>'.
   Type 'string | undefined' is not assignable to type 'NonNullable<T["x"]>'.
     Type 'undefined' is not assignable to type 'NonNullable<T["x"]>'.
@@ -17,41 +16,25 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(30,9): error TS23
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(103,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'T'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(104,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'T'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(106,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>'.
-  Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-    Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-      Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-        Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-          Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-            Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-              Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-                Type 'keyof T' is not assignable to type 'never'.
+  Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+    Type 'keyof T' is not assignable to type 'never'.
+      Type 'string | number | symbol' is not assignable to type 'never'.
+        Type 'string' is not assignable to type 'never'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(108,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
-  Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-    Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-      Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-        Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-          Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-            Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-              Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-                Type 'keyof T' is not assignable to type 'never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(114,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-  Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(115,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-  Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-    Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-      Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-        Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-          Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-            Type 'keyof T' is not assignable to type 'never'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(116,5): error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-  Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-tests/cases/conformance/types/conditional/conditionalTypes1.ts(117,5): error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-  Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-    Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-      Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-        Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-          Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-            Type 'keyof T' is not assignable to type 'never'.
+  Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+    Type 'keyof T' is not assignable to type 'never'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(114,5): error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+  Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+    Type 'string' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(115,5): error TS2322: Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+  Type 'keyof T' is not assignable to type 'never'.
+    Type 'string | number | symbol' is not assignable to type 'never'.
+      Type 'string' is not assignable to type 'never'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(116,5): error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+  Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+    Type 'string' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+tests/cases/conformance/types/conditional/conditionalTypes1.ts(117,5): error TS2322: Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+  Type 'keyof T' is not assignable to type 'never'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(134,10): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(135,5): error TS2542: Index signature in type 'DeepReadonlyArray<Part>' only permits reading.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(136,22): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
@@ -105,9 +88,8 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(288,43): error TS
         x = y;
         y = x;  // Error
         ~
-!!! error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
-!!! error TS2322:   Type 'T[keyof T] | undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
-!!! error TS2322:     Type 'undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+!!! error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'NonNullable<Partial<T>[keyof T]>'.
     }
     
     function f4<T extends { x: string | undefined }>(x: T["x"], y: NonNullable<T["x"]>) {
@@ -204,26 +186,16 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(288,43): error TS
         y = z;  // Error
         ~
 !!! error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>'.
-!!! error TS2322:   Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-!!! error TS2322:     Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-!!! error TS2322:       Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-!!! error TS2322:         Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:           Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:             Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:               Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:                 Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:   Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+!!! error TS2322:     Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:       Type 'string | number | symbol' is not assignable to type 'never'.
+!!! error TS2322:         Type 'string' is not assignable to type 'never'.
         z = x;
         z = y;  // Error
         ~
 !!! error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
-!!! error TS2322:   Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-!!! error TS2322:     Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-!!! error TS2322:       Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-!!! error TS2322:         Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:           Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:             Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:               Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:                 Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:   Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+!!! error TS2322:     Type 'keyof T' is not assignable to type 'never'.
     }
     
     function f8<T>(x: keyof T, y: FunctionPropertyNames<T>, z: NonFunctionPropertyNames<T>) {
@@ -231,30 +203,24 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(288,43): error TS
         x = z;
         y = x;  // Error
         ~
-!!! error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-!!! error TS2322:   Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+!!! error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+!!! error TS2322:   Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+!!! error TS2322:     Type 'string' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
         y = z;  // Error
         ~
-!!! error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-!!! error TS2322:   Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-!!! error TS2322:     Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]'.
-!!! error TS2322:       Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:         Type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:           Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
-!!! error TS2322:             Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322: Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+!!! error TS2322:   Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'never'.
+!!! error TS2322:       Type 'string' is not assignable to type 'never'.
         z = x;  // Error
         ~
-!!! error TS2322: Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-!!! error TS2322:   Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+!!! error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+!!! error TS2322:   Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+!!! error TS2322:     Type 'string' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
         z = y;  // Error
         ~
-!!! error TS2322: Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-!!! error TS2322:   Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-!!! error TS2322:     Type 'keyof T' is not assignable to type '{ [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]'.
-!!! error TS2322:       Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:         Type '{ [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:           Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
-!!! error TS2322:             Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322: Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+!!! error TS2322:   Type 'keyof T' is not assignable to type 'never'.
     }
     
     type DeepReadonly<T> =
@@ -463,7 +429,7 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(288,43): error TS
     
     // Repro from #21862
     
-    type OldDiff<T extends string, U extends string> = (
+    type OldDiff<T extends keyof any, U extends keyof any> = (
         & { [P in T]: P; }
         & { [P in U]: never; }
         & { [x: string]: never; }

--- a/tests/baselines/reference/conditionalTypes1.js
+++ b/tests/baselines/reference/conditionalTypes1.js
@@ -301,7 +301,7 @@ function f50() {
 
 // Repro from #21862
 
-type OldDiff<T extends string, U extends string> = (
+type OldDiff<T extends keyof any, U extends keyof any> = (
     & { [P in T]: P; }
     & { [P in U]: never; }
     & { [x: string]: never; }
@@ -656,7 +656,7 @@ declare type T95<T> = T extends string ? boolean : number;
 declare const f44: <U>(value: T94<U>) => T95<U>;
 declare const f45: <U>(value: T95<U>) => T94<U>;
 declare function f50(): void;
-declare type OldDiff<T extends string, U extends string> = ({
+declare type OldDiff<T extends keyof any, U extends keyof any> = ({
     [P in T]: P;
 } & {
     [P in U]: never;

--- a/tests/baselines/reference/conditionalTypes1.symbols
+++ b/tests/baselines/reference/conditionalTypes1.symbols
@@ -1186,10 +1186,10 @@ function f50() {
 
 // Repro from #21862
 
-type OldDiff<T extends string, U extends string> = (
+type OldDiff<T extends keyof any, U extends keyof any> = (
 >OldDiff : Symbol(OldDiff, Decl(conditionalTypes1.ts, 298, 1))
 >T : Symbol(T, Decl(conditionalTypes1.ts, 302, 13))
->U : Symbol(U, Decl(conditionalTypes1.ts, 302, 30))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 302, 33))
 
     & { [P in T]: P; }
 >P : Symbol(P, Decl(conditionalTypes1.ts, 303, 9))
@@ -1198,7 +1198,7 @@ type OldDiff<T extends string, U extends string> = (
 
     & { [P in U]: never; }
 >P : Symbol(P, Decl(conditionalTypes1.ts, 304, 9))
->U : Symbol(U, Decl(conditionalTypes1.ts, 302, 30))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 302, 33))
 
     & { [x: string]: never; }
 >x : Symbol(x, Decl(conditionalTypes1.ts, 305, 9))

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -1343,7 +1343,7 @@ function f50() {
 
 // Repro from #21862
 
-type OldDiff<T extends string, U extends string> = (
+type OldDiff<T extends keyof any, U extends keyof any> = (
 >OldDiff : ({ [P in T]: P; } & { [P in U]: never; } & { [x: string]: never; })[T]
 >T : T
 >U : U

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -6,6 +6,8 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(24,5): error TS23
   Types of property 'foo' are incompatible.
     Type 'B extends string ? keyof B : B' is not assignable to type 'A extends string ? keyof A : A'.
       Type 'keyof B' is not assignable to type 'keyof A'.
+        Type 'string | number | symbol' is not assignable to type 'keyof A'.
+          Type 'string' is not assignable to type 'keyof A'.
 tests/cases/conformance/types/conditional/conditionalTypes2.ts(25,5): error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
   Types of property 'foo' are incompatible.
     Type 'A extends string ? keyof A : A' is not assignable to type 'B extends string ? keyof B : B'.
@@ -60,6 +62,8 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type 'B extends string ? keyof B : B' is not assignable to type 'A extends string ? keyof A : A'.
 !!! error TS2322:       Type 'keyof B' is not assignable to type 'keyof A'.
+!!! error TS2322:         Type 'string | number | symbol' is not assignable to type 'keyof A'.
+!!! error TS2322:           Type 'string' is not assignable to type 'keyof A'.
         b = a;  // Error
         ~
 !!! error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.

--- a/tests/baselines/reference/controlFlowPropertyDeclarations.types
+++ b/tests/baselines/reference/controlFlowPropertyDeclarations.types
@@ -371,11 +371,11 @@ export class StyleParser {
       if (!this.styles.hasOwnProperty(key)) {
 >!this.styles.hasOwnProperty(key) : boolean
 >this.styles.hasOwnProperty(key) : boolean
->this.styles.hasOwnProperty : (v: string) => boolean
+>this.styles.hasOwnProperty : (v: string | number | symbol) => boolean
 >this.styles : {}
 >this : this
 >styles : {}
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >key : string
       }
     }

--- a/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.symbols
@@ -2,7 +2,7 @@
 declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
 >dec : Symbol(dec, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 0))
 >target : Symbol(target, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 21))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >propertyKey : Symbol(propertyKey, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 36))
 >parameterIndex : Symbol(parameterIndex, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 66))
 

--- a/tests/baselines/reference/decoratorsOnComputedProperties.symbols
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.symbols
@@ -3,7 +3,7 @@ function x(o: object, k: PropertyKey) { }
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >o : Symbol(o, Decl(decoratorsOnComputedProperties.ts, 0, 11))
 >k : Symbol(k, Decl(decoratorsOnComputedProperties.ts, 0, 21))
->PropertyKey : Symbol(PropertyKey, Decl(lib.es2015.core.d.ts, --, --))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.es5.d.ts, --, --))
 
 let i = 0;
 >i : Symbol(i, Decl(decoratorsOnComputedProperties.ts, 1, 3))

--- a/tests/baselines/reference/decoratorsOnComputedProperties.types
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.types
@@ -1,9 +1,9 @@
 === tests/cases/compiler/decoratorsOnComputedProperties.ts ===
 function x(o: object, k: PropertyKey) { }
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >o : object
->k : PropertyKey
->PropertyKey : PropertyKey
+>k : string | number | symbol
+>PropertyKey : string | number | symbol
 
 let i = 0;
 >i : number
@@ -32,25 +32,25 @@ class A {
 >A : A
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -85,13 +85,13 @@ class A {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
@@ -102,12 +102,12 @@ class A {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -119,25 +119,25 @@ void class B {
 >B : typeof B
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -172,13 +172,13 @@ void class B {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
@@ -189,12 +189,12 @@ void class B {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -205,25 +205,25 @@ class C {
 >C : C
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -258,13 +258,13 @@ class C {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
@@ -275,12 +275,12 @@ class C {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -298,25 +298,25 @@ void class D {
 >D : typeof D
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -351,13 +351,13 @@ void class D {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
@@ -368,12 +368,12 @@ void class D {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -390,25 +390,25 @@ class E {
 >E : E
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -443,13 +443,13 @@ class E {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
@@ -466,12 +466,12 @@ class E {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -483,25 +483,25 @@ void class F {
 >F : typeof F
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -536,13 +536,13 @@ void class F {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
@@ -559,12 +559,12 @@ void class F {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -575,25 +575,25 @@ class G {
 >G : G
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -628,13 +628,13 @@ class G {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
@@ -651,7 +651,7 @@ class G {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
@@ -662,7 +662,7 @@ class G {
 >"method2" : "method2"
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -674,25 +674,25 @@ void class H {
 >H : typeof H
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -727,13 +727,13 @@ void class H {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
@@ -750,7 +750,7 @@ void class H {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
@@ -761,7 +761,7 @@ void class H {
 >"method2" : "method2"
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -772,25 +772,25 @@ class I {
 >I : I
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -825,20 +825,20 @@ class I {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 >null : null
 
     @x ["some" + "method"]() {}
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["some" + "method"] : () => void
 >"some" + "method" : string
 >"some" : "some"
@@ -849,7 +849,7 @@ class I {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
@@ -860,7 +860,7 @@ class I {
 >"method2" : "method2"
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null
@@ -872,25 +872,25 @@ void class J {
 >J : typeof J
 
     @x ["property"]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property"] : any
 >"property" : "property"
 
     @x [Symbol.toStringTag]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.toStringTag] : any
 >Symbol.toStringTag : symbol
 >Symbol : SymbolConstructor
 >toStringTag : symbol
 
     @x ["property2"]: any = 2;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["property2"] : any
 >"property2" : "property2"
 >2 : 2
 
     @x [Symbol.iterator]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[Symbol.iterator] : any
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
@@ -925,20 +925,20 @@ void class J {
 >foo : () => string
 
     @x [foo()]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 
     @x [foo()]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[foo()] : any
 >foo() : string
 >foo : () => string
 >null : null
 
     @x ["some" + "method"]() {}
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >["some" + "method"] : () => void
 >"some" + "method" : string
 >"some" : "some"
@@ -949,7 +949,7 @@ void class J {
 >fieldNameA : string
 
     @x [fieldNameB]: any;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameB] : any
 >fieldNameB : string
 
@@ -960,7 +960,7 @@ void class J {
 >"method2" : "method2"
 
     @x [fieldNameC]: any = null;
->x : (o: object, k: PropertyKey) => void
+>x : (o: object, k: string | number | symbol) => void
 >[fieldNameC] : any
 >fieldNameC : string
 >null : null

--- a/tests/baselines/reference/deeplyNestedCheck.js
+++ b/tests/baselines/reference/deeplyNestedCheck.js
@@ -6,7 +6,7 @@ interface DataSnapshot<X = {}> {
 }
 
 interface Snapshot<T> extends DataSnapshot {
-  child<U extends keyof T>(path: U): Snapshot<T[U]>;
+  child<U extends Extract<keyof T, string>>(path: U): Snapshot<T[U]>;
 }
 
 

--- a/tests/baselines/reference/deeplyNestedCheck.symbols
+++ b/tests/baselines/reference/deeplyNestedCheck.symbols
@@ -16,11 +16,12 @@ interface Snapshot<T> extends DataSnapshot {
 >T : Symbol(T, Decl(deeplyNestedCheck.ts, 6, 19))
 >DataSnapshot : Symbol(DataSnapshot, Decl(deeplyNestedCheck.ts, 0, 0))
 
-  child<U extends keyof T>(path: U): Snapshot<T[U]>;
+  child<U extends Extract<keyof T, string>>(path: U): Snapshot<T[U]>;
 >child : Symbol(Snapshot.child, Decl(deeplyNestedCheck.ts, 6, 44))
 >U : Symbol(U, Decl(deeplyNestedCheck.ts, 7, 8))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(deeplyNestedCheck.ts, 6, 19))
->path : Symbol(path, Decl(deeplyNestedCheck.ts, 7, 27))
+>path : Symbol(path, Decl(deeplyNestedCheck.ts, 7, 44))
 >U : Symbol(U, Decl(deeplyNestedCheck.ts, 7, 8))
 >Snapshot : Symbol(Snapshot, Decl(deeplyNestedCheck.ts, 4, 1))
 >T : Symbol(T, Decl(deeplyNestedCheck.ts, 6, 19))

--- a/tests/baselines/reference/deeplyNestedCheck.types
+++ b/tests/baselines/reference/deeplyNestedCheck.types
@@ -16,9 +16,10 @@ interface Snapshot<T> extends DataSnapshot {
 >T : T
 >DataSnapshot : DataSnapshot<X>
 
-  child<U extends keyof T>(path: U): Snapshot<T[U]>;
->child : <U extends keyof T>(path: U) => Snapshot<T[U]>
+  child<U extends Extract<keyof T, string>>(path: U): Snapshot<T[U]>;
+>child : <U extends Extract<keyof T, string>>(path: U) => Snapshot<T[U]>
 >U : U
+>Extract : Extract<T, U>
 >T : T
 >path : U
 >U : U

--- a/tests/baselines/reference/deferredLookupTypeResolution.js
+++ b/tests/baselines/reference/deferredLookupTypeResolution.js
@@ -6,7 +6,7 @@ type StringContains<S extends string, L extends string> = (
     { [key: string]: 'false' }
   )[L]
 
-type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>
+type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>
 
 type First<T> = ObjectHasKey<T, '0'>;  // Should be deferred
 
@@ -43,7 +43,7 @@ declare type StringContains<S extends string, L extends string> = ({
 } & {
     [key: string]: 'false';
 })[L];
-declare type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+declare type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>;
 declare type First<T> = ObjectHasKey<T, '0'>;
 declare type T1 = ObjectHasKey<{
     a: string;

--- a/tests/baselines/reference/deferredLookupTypeResolution.symbols
+++ b/tests/baselines/reference/deferredLookupTypeResolution.symbols
@@ -16,16 +16,17 @@ type StringContains<S extends string, L extends string> = (
   )[L]
 >L : Symbol(L, Decl(deferredLookupTypeResolution.ts, 2, 37))
 
-type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>
+type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>
 >ObjectHasKey : Symbol(ObjectHasKey, Decl(deferredLookupTypeResolution.ts, 5, 6))
 >O : Symbol(O, Decl(deferredLookupTypeResolution.ts, 7, 18))
 >L : Symbol(L, Decl(deferredLookupTypeResolution.ts, 7, 20))
 >StringContains : Symbol(StringContains, Decl(deferredLookupTypeResolution.ts, 0, 0))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
 >O : Symbol(O, Decl(deferredLookupTypeResolution.ts, 7, 18))
 >L : Symbol(L, Decl(deferredLookupTypeResolution.ts, 7, 20))
 
 type First<T> = ObjectHasKey<T, '0'>;  // Should be deferred
->First : Symbol(First, Decl(deferredLookupTypeResolution.ts, 7, 67))
+>First : Symbol(First, Decl(deferredLookupTypeResolution.ts, 7, 84))
 >T : Symbol(T, Decl(deferredLookupTypeResolution.ts, 9, 11))
 >ObjectHasKey : Symbol(ObjectHasKey, Decl(deferredLookupTypeResolution.ts, 5, 6))
 >T : Symbol(T, Decl(deferredLookupTypeResolution.ts, 9, 11))

--- a/tests/baselines/reference/deferredLookupTypeResolution.types
+++ b/tests/baselines/reference/deferredLookupTypeResolution.types
@@ -16,28 +16,29 @@ type StringContains<S extends string, L extends string> = (
   )[L]
 >L : L
 
-type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 >O : O
 >L : L
 >StringContains : ({ [K in S]: "true"; } & { [key: string]: "false"; })[L]
+>Extract : Extract<T, U>
 >O : O
 >L : L
 
 type First<T> = ObjectHasKey<T, '0'>;  // Should be deferred
->First : ({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["0"]
+>First : ({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["0"]
 >T : T
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 >T : T
 
 type T1 = ObjectHasKey<{ a: string }, 'a'>;  // 'true'
 >T1 : "true"
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 >a : string
 
 type T2 = ObjectHasKey<{ a: string }, 'b'>;  // 'false'
 >T2 : "false"
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 >a : string
 
 // Verify that mapped type isn't eagerly resolved in type-to-string operation

--- a/tests/baselines/reference/deferredLookupTypeResolution2.errors.txt
+++ b/tests/baselines/reference/deferredLookupTypeResolution2.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/deferredLookupTypeResolution2.ts(14,13): error TS2536: Type '({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]' cannot be used to index type '{ true: "true"; }'.
-tests/cases/compiler/deferredLookupTypeResolution2.ts(19,21): error TS2536: Type '({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]]' cannot be used to index type '{ true: "true"; }'.
+tests/cases/compiler/deferredLookupTypeResolution2.ts(14,13): error TS2536: Type '({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]' cannot be used to index type '{ true: "true"; }'.
+tests/cases/compiler/deferredLookupTypeResolution2.ts(19,21): error TS2536: Type '({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]]' cannot be used to index type '{ true: "true"; }'.
 
 
 ==== tests/cases/compiler/deferredLookupTypeResolution2.ts (2 errors) ====
@@ -7,7 +7,7 @@ tests/cases/compiler/deferredLookupTypeResolution2.ts(19,21): error TS2536: Type
     
     type StringContains<S extends string, L extends string> = ({ [K in S]: 'true' } & { [key: string]: 'false'})[L];
     
-    type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+    type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>;
     
     type A<T> = ObjectHasKey<T, '0'>;
     
@@ -18,14 +18,14 @@ tests/cases/compiler/deferredLookupTypeResolution2.ts(19,21): error TS2536: Type
     // Error, "false" not handled
     type E<T> = { true: 'true' }[ObjectHasKey<T, '1'>];
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2536: Type '({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]' cannot be used to index type '{ true: "true"; }'.
+!!! error TS2536: Type '({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]' cannot be used to index type '{ true: "true"; }'.
     
     type Juxtapose<T> = ({ true: 'otherwise' } & { [k: string]: 'true' })[ObjectHasKey<T, '1'>];
     
     // Error, "otherwise" is missing
     type DeepError<T> = { true: 'true' }[Juxtapose<T>];
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2536: Type '({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]]' cannot be used to index type '{ true: "true"; }'.
+!!! error TS2536: Type '({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]]' cannot be used to index type '{ true: "true"; }'.
     
     type DeepOK<T> = { true: 'true', otherwise: 'false' }[Juxtapose<T>];
     

--- a/tests/baselines/reference/deferredLookupTypeResolution2.js
+++ b/tests/baselines/reference/deferredLookupTypeResolution2.js
@@ -3,7 +3,7 @@
 
 type StringContains<S extends string, L extends string> = ({ [K in S]: 'true' } & { [key: string]: 'false'})[L];
 
-type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>;
 
 type A<T> = ObjectHasKey<T, '0'>;
 
@@ -33,7 +33,7 @@ declare type StringContains<S extends string, L extends string> = ({
 } & {
     [key: string]: 'false';
 })[L];
-declare type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+declare type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>;
 declare type A<T> = ObjectHasKey<T, '0'>;
 declare type B = ObjectHasKey<[string, number], '1'>;
 declare type C = ObjectHasKey<[string, number], '2'>;

--- a/tests/baselines/reference/deferredLookupTypeResolution2.symbols
+++ b/tests/baselines/reference/deferredLookupTypeResolution2.symbols
@@ -10,16 +10,17 @@ type StringContains<S extends string, L extends string> = ({ [K in S]: 'true' } 
 >key : Symbol(key, Decl(deferredLookupTypeResolution2.ts, 2, 85))
 >L : Symbol(L, Decl(deferredLookupTypeResolution2.ts, 2, 37))
 
-type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>;
 >ObjectHasKey : Symbol(ObjectHasKey, Decl(deferredLookupTypeResolution2.ts, 2, 112))
 >O : Symbol(O, Decl(deferredLookupTypeResolution2.ts, 4, 18))
 >L : Symbol(L, Decl(deferredLookupTypeResolution2.ts, 4, 20))
 >StringContains : Symbol(StringContains, Decl(deferredLookupTypeResolution2.ts, 0, 0))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
 >O : Symbol(O, Decl(deferredLookupTypeResolution2.ts, 4, 18))
 >L : Symbol(L, Decl(deferredLookupTypeResolution2.ts, 4, 20))
 
 type A<T> = ObjectHasKey<T, '0'>;
->A : Symbol(A, Decl(deferredLookupTypeResolution2.ts, 4, 68))
+>A : Symbol(A, Decl(deferredLookupTypeResolution2.ts, 4, 85))
 >T : Symbol(T, Decl(deferredLookupTypeResolution2.ts, 6, 7))
 >ObjectHasKey : Symbol(ObjectHasKey, Decl(deferredLookupTypeResolution2.ts, 2, 112))
 >T : Symbol(T, Decl(deferredLookupTypeResolution2.ts, 6, 7))
@@ -34,7 +35,7 @@ type C = ObjectHasKey<[string, number], '2'>;  // "false"
 
 type D = A<[string]>;  // "true"
 >D : Symbol(D, Decl(deferredLookupTypeResolution2.ts, 9, 45))
->A : Symbol(A, Decl(deferredLookupTypeResolution2.ts, 4, 68))
+>A : Symbol(A, Decl(deferredLookupTypeResolution2.ts, 4, 85))
 
 // Error, "false" not handled
 type E<T> = { true: 'true' }[ObjectHasKey<T, '1'>];

--- a/tests/baselines/reference/deferredLookupTypeResolution2.types
+++ b/tests/baselines/reference/deferredLookupTypeResolution2.types
@@ -10,61 +10,62 @@ type StringContains<S extends string, L extends string> = ({ [K in S]: 'true' } 
 >key : string
 >L : L
 
-type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>;
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 >O : O
 >L : L
 >StringContains : ({ [K in S]: "true"; } & { [key: string]: "false"; })[L]
+>Extract : Extract<T, U>
 >O : O
 >L : L
 
 type A<T> = ObjectHasKey<T, '0'>;
->A : ({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["0"]
+>A : ({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["0"]
 >T : T
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 >T : T
 
 type B = ObjectHasKey<[string, number], '1'>;  // "true"
 >B : "true"
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 
 type C = ObjectHasKey<[string, number], '2'>;  // "false"
 >C : "false"
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 
 type D = A<[string]>;  // "true"
 >D : "true"
->A : ({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["0"]
+>A : ({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["0"]
 
 // Error, "false" not handled
 type E<T> = { true: 'true' }[ObjectHasKey<T, '1'>];
->E : { true: "true"; }[({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]]
+>E : { true: "true"; }[({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]]
 >T : T
 >true : "true"
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 >T : T
 
 type Juxtapose<T> = ({ true: 'otherwise' } & { [k: string]: 'true' })[ObjectHasKey<T, '1'>];
->Juxtapose : ({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]]
+>Juxtapose : ({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]]
 >T : T
 >true : "otherwise"
 >k : string
->ObjectHasKey : ({ [K in keyof O]: "true"; } & { [key: string]: "false"; })[L]
+>ObjectHasKey : ({ [K in Extract<keyof O, string>]: "true"; } & { [key: string]: "false"; })[L]
 >T : T
 
 // Error, "otherwise" is missing
 type DeepError<T> = { true: 'true' }[Juxtapose<T>];
->DeepError : { true: "true"; }[({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]]]
+>DeepError : { true: "true"; }[({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]]]
 >T : T
 >true : "true"
->Juxtapose : ({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]]
+>Juxtapose : ({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]]
 >T : T
 
 type DeepOK<T> = { true: 'true', otherwise: 'false' }[Juxtapose<T>];
->DeepOK : { true: "true"; otherwise: "false"; }[({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]]]
+>DeepOK : { true: "true"; otherwise: "false"; }[({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]]]
 >T : T
 >true : "true"
 >otherwise : "false"
->Juxtapose : ({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in keyof T]: "true"; } & { [key: string]: "false"; })["1"]]
+>Juxtapose : ({ true: "otherwise"; } & { [k: string]: "true"; })[({ [K in Extract<keyof T, string>]: "true"; } & { [key: string]: "false"; })["1"]]
 >T : T
 

--- a/tests/baselines/reference/errorMessagesIntersectionTypes04.errors.txt
+++ b/tests/baselines/reference/errorMessagesIntersectionTypes04.errors.txt
@@ -1,11 +1,9 @@
 tests/cases/compiler/errorMessagesIntersectionTypes04.ts(17,5): error TS2322: Type 'A & B' is not assignable to type 'number'.
 tests/cases/compiler/errorMessagesIntersectionTypes04.ts(18,5): error TS2322: Type 'A & B' is not assignable to type 'boolean'.
 tests/cases/compiler/errorMessagesIntersectionTypes04.ts(19,5): error TS2322: Type 'A & B' is not assignable to type 'string'.
-tests/cases/compiler/errorMessagesIntersectionTypes04.ts(21,5): error TS2322: Type '(number & true) | (number & false)' is not assignable to type 'string'.
-  Type 'number & true' is not assignable to type 'string'.
 
 
-==== tests/cases/compiler/errorMessagesIntersectionTypes04.ts (4 errors) ====
+==== tests/cases/compiler/errorMessagesIntersectionTypes04.ts (3 errors) ====
     interface A {
         a;
     }
@@ -33,7 +31,4 @@ tests/cases/compiler/errorMessagesIntersectionTypes04.ts(21,5): error TS2322: Ty
 !!! error TS2322: Type 'A & B' is not assignable to type 'string'.
     
         str = num_and_bool;
-        ~~~
-!!! error TS2322: Type '(number & true) | (number & false)' is not assignable to type 'string'.
-!!! error TS2322:   Type 'number & true' is not assignable to type 'string'.
     }

--- a/tests/baselines/reference/errorMessagesIntersectionTypes04.types
+++ b/tests/baselines/reference/errorMessagesIntersectionTypes04.types
@@ -36,7 +36,7 @@ function f<T, U extends A, V extends U>(): void {
 >B : B
 
     let num_and_bool: number & boolean;
->num_and_bool : (number & true) | (number & false)
+>num_and_bool : never
 
     num = a_and_b;
 >num = a_and_b : A & B
@@ -54,7 +54,7 @@ function f<T, U extends A, V extends U>(): void {
 >a_and_b : A & B
 
     str = num_and_bool;
->str = num_and_bool : (number & true) | (number & false)
+>str = num_and_bool : never
 >str : string
->num_and_bool : (number & true) | (number & false)
+>num_and_bool : never
 }

--- a/tests/baselines/reference/excessPropertyCheckWithEmptyObject.types
+++ b/tests/baselines/reference/excessPropertyCheckWithEmptyObject.types
@@ -4,9 +4,9 @@
 // Excess property error expected here
 Object.defineProperty(window, "prop", { value: "v1.0.0", readonly: false });
 >Object.defineProperty(window, "prop", { value: "v1.0.0", readonly: false }) : any
->Object.defineProperty : (o: any, p: string, attributes: PropertyDescriptor & ThisType<any>) => any
+>Object.defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
 >Object : ObjectConstructor
->defineProperty : (o: any, p: string, attributes: PropertyDescriptor & ThisType<any>) => any
+>defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
 >window : any
 >"prop" : "prop"
 >{ value: "v1.0.0", readonly: false } : { value: string; readonly: boolean; }

--- a/tests/baselines/reference/fixSignatureCaching.types
+++ b/tests/baselines/reference/fixSignatureCaching.types
@@ -1068,12 +1068,12 @@ define(function () {
     };
 
     var hasOwnProp = Object.prototype.hasOwnProperty,
->hasOwnProp : (v: string) => boolean
->Object.prototype.hasOwnProperty : (v: string) => boolean
+>hasOwnProp : (v: string | number | symbol) => boolean
+>Object.prototype.hasOwnProperty : (v: string | number | symbol) => boolean
 >Object.prototype : Object
 >Object : ObjectConstructor
 >prototype : Object
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 
         isArray;
 >isArray : any
@@ -1249,7 +1249,7 @@ define(function () {
             if (hasOwnProp.call(object, key)) {
 >hasOwnProp.call(object, key) : any
 >hasOwnProp.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->hasOwnProp : (v: string) => boolean
+>hasOwnProp : (v: string | number | symbol) => boolean
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >object : any
 >key : string
@@ -1296,7 +1296,7 @@ define(function () {
             if (hasOwnProp.call(mobileDetectRules.props, key)) {
 >hasOwnProp.call(mobileDetectRules.props, key) : any
 >hasOwnProp.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->hasOwnProp : (v: string) => boolean
+>hasOwnProp : (v: string | number | symbol) => boolean
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >mobileDetectRules.props : any
 >mobileDetectRules : any
@@ -1487,7 +1487,7 @@ define(function () {
             if (hasOwnProp.call(rules, key)) {
 >hasOwnProp.call(rules, key) : any
 >hasOwnProp.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->hasOwnProp : (v: string) => boolean
+>hasOwnProp : (v: string | number | symbol) => boolean
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >rules : any
 >key : string
@@ -1538,7 +1538,7 @@ define(function () {
             if (hasOwnProp.call(rules, key)) {
 >hasOwnProp.call(rules, key) : any
 >hasOwnProp.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->hasOwnProp : (v: string) => boolean
+>hasOwnProp : (v: string | number | symbol) => boolean
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >rules : any
 >key : string
@@ -1598,7 +1598,7 @@ define(function () {
         if (hasOwnProp.call(props, propertyName)) {
 >hasOwnProp.call(props, propertyName) : any
 >hasOwnProp.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->hasOwnProp : (v: string) => boolean
+>hasOwnProp : (v: string | number | symbol) => boolean
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >props : any
 >propertyName : any

--- a/tests/baselines/reference/for-inStatements.errors.txt
+++ b/tests/baselines/reference/for-inStatements.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(33,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
-tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(50,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
+tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(33,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
+tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(50,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
 tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(79,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'Color.Blue'.
 
 
@@ -38,7 +38,7 @@ tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(79,15): 
             for (var x in this.biz) { }
             for (var x in this) { }
                      ~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
             return null;
         }
     
@@ -57,7 +57,7 @@ tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(79,15): 
             for (var x in this.biz) { }
             for (var x in this) { }
                      ~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
     
             for (var x in super.biz) { }
             for (var x in super.biz()) { }

--- a/tests/baselines/reference/for-inStatementsInvalid.errors.txt
+++ b/tests/baselines/reference/for-inStatementsInvalid.errors.txt
@@ -9,10 +9,10 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(1
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(20,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(22,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'string'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(29,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(31,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(31,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(38,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(46,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(48,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(48,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(51,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(62,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'.
 
@@ -72,7 +72,7 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
             for (var x in this.biz) { }
             for (var x in this) { }
                      ~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
             return null;
         }
     
@@ -95,7 +95,7 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
             for (var x in this.biz) { }
             for (var x in this) { }
                      ~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'Extract<keyof this, string>'.
     
             for (var x in super.biz) { }
             for (var x in super.biz()) { }

--- a/tests/baselines/reference/forInStatement3.types
+++ b/tests/baselines/reference/forInStatement3.types
@@ -8,7 +8,7 @@ function F<T>() {
 >T : T
 
   for (var a in expr) {
->a : keyof T
+>a : Extract<keyof T, string>
 >expr : T
   }
 }

--- a/tests/baselines/reference/getterSetterNonAccessor.types
+++ b/tests/baselines/reference/getterSetterNonAccessor.types
@@ -9,9 +9,9 @@ function setFunc(v){}
 
 Object.defineProperty({}, "0", <PropertyDescriptor>({
 >Object.defineProperty({}, "0", <PropertyDescriptor>({          get: getFunc,          set: setFunc,          configurable: true      })) : any
->Object.defineProperty : (o: any, p: string, attributes: PropertyDescriptor & ThisType<any>) => any
+>Object.defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
 >Object : ObjectConstructor
->defineProperty : (o: any, p: string, attributes: PropertyDescriptor & ThisType<any>) => any
+>defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
 >{} : {}
 >"0" : "0"
 ><PropertyDescriptor>({          get: getFunc,          set: setFunc,          configurable: true      }) : PropertyDescriptor

--- a/tests/baselines/reference/implicitAnyInCatch.types
+++ b/tests/baselines/reference/implicitAnyInCatch.types
@@ -22,7 +22,7 @@ class C {
 >temp : () => void
 
         for (var x in this) {
->x : keyof this
+>x : Extract<keyof this, string>
 >this : this
         }
     }

--- a/tests/baselines/reference/inOperatorWithGeneric.types
+++ b/tests/baselines/reference/inOperatorWithGeneric.types
@@ -9,7 +9,7 @@ class C<T> {
 >T : T
 
         for (var p in x) {
->p : keyof T
+>p : Extract<keyof T, string>
 >x : T
         }
     }

--- a/tests/baselines/reference/indexedAccessRetainsIndexSignature.js
+++ b/tests/baselines/reference/indexedAccessRetainsIndexSignature.js
@@ -1,5 +1,5 @@
 //// [indexedAccessRetainsIndexSignature.ts]
-type Diff<T extends string, U extends string> =
+type Diff<T extends keyof any, U extends keyof any> =
     ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
 type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>
 type Omit1<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;

--- a/tests/baselines/reference/indexedAccessRetainsIndexSignature.symbols
+++ b/tests/baselines/reference/indexedAccessRetainsIndexSignature.symbols
@@ -1,15 +1,15 @@
 === tests/cases/compiler/indexedAccessRetainsIndexSignature.ts ===
-type Diff<T extends string, U extends string> =
+type Diff<T extends keyof any, U extends keyof any> =
 >Diff : Symbol(Diff, Decl(indexedAccessRetainsIndexSignature.ts, 0, 0))
 >T : Symbol(T, Decl(indexedAccessRetainsIndexSignature.ts, 0, 10))
->U : Symbol(U, Decl(indexedAccessRetainsIndexSignature.ts, 0, 27))
+>U : Symbol(U, Decl(indexedAccessRetainsIndexSignature.ts, 0, 30))
 
     ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
 >P : Symbol(P, Decl(indexedAccessRetainsIndexSignature.ts, 1, 8))
 >T : Symbol(T, Decl(indexedAccessRetainsIndexSignature.ts, 0, 10))
 >P : Symbol(P, Decl(indexedAccessRetainsIndexSignature.ts, 1, 8))
 >P : Symbol(P, Decl(indexedAccessRetainsIndexSignature.ts, 1, 26))
->U : Symbol(U, Decl(indexedAccessRetainsIndexSignature.ts, 0, 27))
+>U : Symbol(U, Decl(indexedAccessRetainsIndexSignature.ts, 0, 30))
 >x : Symbol(x, Decl(indexedAccessRetainsIndexSignature.ts, 1, 48))
 >T : Symbol(T, Decl(indexedAccessRetainsIndexSignature.ts, 0, 10))
 

--- a/tests/baselines/reference/indexedAccessRetainsIndexSignature.types
+++ b/tests/baselines/reference/indexedAccessRetainsIndexSignature.types
@@ -1,5 +1,5 @@
 === tests/cases/compiler/indexedAccessRetainsIndexSignature.ts ===
-type Diff<T extends string, U extends string> =
+type Diff<T extends keyof any, U extends keyof any> =
 >Diff : ({ [P in T]: P; } & { [P in U]: never; } & { [x: string]: never; })[T]
 >T : T
 >U : U

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -17,7 +17,8 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(75,43): error TS2304: C
 tests/cases/conformance/types/conditional/inferTypes1.ts(75,43): error TS4081: Exported type alias 'T62' has or is using private name 'U'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(82,44): error TS2344: Type 'U' does not satisfy the constraint 'string'.
   Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(144,40): error TS2322: Type 'T' is not assignable to type 'string'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(144,40): error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
+  Type 'T' is not assignable to type 'symbol'.
 
 
 ==== tests/cases/conformance/types/conditional/inferTypes1.ts (16 errors) ====
@@ -200,7 +201,8 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(144,40): error TS2322: 
     type A<T> = T extends string ? { [P in T]: void; } : T;
     type B<T> = string extends T ? { [P in T]: void; } : T;  // Error
                                            ~
-!!! error TS2322: Type 'T' is not assignable to type 'string'.
+!!! error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
+!!! error TS2322:   Type 'T' is not assignable to type 'symbol'.
     
     // Repro from #22302
     

--- a/tests/baselines/reference/isomorphicMappedTypeInference.types
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.types
@@ -64,19 +64,19 @@ function boxify<T>(obj: T): Boxified<T> {
 >T : T
 
     for (let k in obj) {
->k : keyof T
+>k : Extract<keyof T, string>
 >obj : T
 
         result[k] = box(obj[k]);
->result[k] = box(obj[k]) : Box<T[keyof T]>
->result[k] : Boxified<T>[keyof T]
+>result[k] = box(obj[k]) : Box<T[Extract<keyof T, string>]>
+>result[k] : Boxified<T>[Extract<keyof T, string>]
 >result : Boxified<T>
->k : keyof T
->box(obj[k]) : Box<T[keyof T]>
+>k : Extract<keyof T, string>
+>box(obj[k]) : Box<T[Extract<keyof T, string>]>
 >box : <T>(x: T) => Box<T>
->obj[k] : T[keyof T]
+>obj[k] : T[Extract<keyof T, string>]
 >obj : T
->k : keyof T
+>k : Extract<keyof T, string>
     }
     return result;
 >result : Boxified<T>
@@ -97,19 +97,19 @@ function unboxify<T>(obj: Boxified<T>): T {
 >T : T
 
     for (let k in obj) {
->k : keyof T
+>k : Extract<keyof T, string>
 >obj : Boxified<T>
 
         result[k] = unbox(obj[k]);
->result[k] = unbox(obj[k]) : T[keyof T]
->result[k] : T[keyof T]
+>result[k] = unbox(obj[k]) : T[Extract<keyof T, string>]
+>result[k] : T[Extract<keyof T, string>]
 >result : T
->k : keyof T
->unbox(obj[k]) : T[keyof T]
+>k : Extract<keyof T, string>
+>unbox(obj[k]) : T[Extract<keyof T, string>]
 >unbox : <T>(x: Box<T>) => T
->obj[k] : Boxified<T>[keyof T]
+>obj[k] : Boxified<T>[Extract<keyof T, string>]
 >obj : Boxified<T>
->k : keyof T
+>k : Extract<keyof T, string>
     }
     return result;
 >result : T
@@ -125,19 +125,19 @@ function assignBoxified<T>(obj: Boxified<T>, values: T) {
 >T : T
 
     for (let k in values) {
->k : keyof T
+>k : Extract<keyof T, string>
 >values : T
 
         obj[k].value = values[k];
->obj[k].value = values[k] : T[keyof T]
->obj[k].value : T[keyof T]
->obj[k] : Boxified<T>[keyof T]
+>obj[k].value = values[k] : T[Extract<keyof T, string>]
+>obj[k].value : T[Extract<keyof T, string>]
+>obj[k] : Boxified<T>[Extract<keyof T, string>]
 >obj : Boxified<T>
->k : keyof T
->value : T[keyof T]
->values[k] : T[keyof T]
+>k : Extract<keyof T, string>
+>value : T[Extract<keyof T, string>]
+>values[k] : T[Extract<keyof T, string>]
 >values : T
->k : keyof T
+>k : Extract<keyof T, string>
     }
 }
 

--- a/tests/baselines/reference/keyofAndForIn.types
+++ b/tests/baselines/reference/keyofAndForIn.types
@@ -33,14 +33,14 @@ function f1<K extends string, T>(obj: { [P in K]: T }, k: K) {
 >k1 : K
     }
     for (let k2 in obj) {
->k2 : K
+>k2 : Extract<K, string>
 >obj : { [P in K]: T; }
 
         let x2 = obj[k2];
->x2 : { [P in K]: T; }[K]
->obj[k2] : { [P in K]: T; }[K]
+>x2 : { [P in K]: T; }[Extract<K, string>]
+>obj[k2] : { [P in K]: T; }[Extract<K, string>]
 >obj : { [P in K]: T; }
->k2 : K
+>k2 : Extract<K, string>
     }
 }
 
@@ -76,14 +76,14 @@ function f2<T>(obj: { [P in keyof T]: T[P] }, k: keyof T) {
 >k1 : keyof T
     }
     for (let k2 in obj) {
->k2 : keyof T
+>k2 : Extract<keyof T, string>
 >obj : { [P in keyof T]: T[P]; }
 
         let x2 = obj[k2];
->x2 : { [P in keyof T]: T[P]; }[keyof T]
->obj[k2] : { [P in keyof T]: T[P]; }[keyof T]
+>x2 : { [P in keyof T]: T[P]; }[Extract<keyof T, string>]
+>obj[k2] : { [P in keyof T]: T[P]; }[Extract<keyof T, string>]
 >obj : { [P in keyof T]: T[P]; }
->k2 : keyof T
+>k2 : Extract<keyof T, string>
     }
 }
 
@@ -121,13 +121,13 @@ function f3<T, K extends keyof T>(obj: { [P in K]: T[P] }, k: K) {
 >k1 : K
     }
     for (let k2 in obj) {
->k2 : K
+>k2 : Extract<K, string>
 >obj : { [P in K]: T[P]; }
 
         let x2 = obj[k2];
->x2 : { [P in K]: T[P]; }[K]
->obj[k2] : { [P in K]: T[P]; }[K]
+>x2 : { [P in K]: T[P]; }[Extract<K, string>]
+>obj[k2] : { [P in K]: T[P]; }[Extract<K, string>]
 >obj : { [P in K]: T[P]; }
->k2 : K
+>k2 : Extract<K, string>
     }
 }

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -188,13 +188,13 @@ function f51<T, K extends keyof T>(k: K, s: string) {
     const x2 = k as string;
 }
 
-function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {
+function f52<T>(obj: { [x: string]: boolean }, k: Exclude<keyof T, symbol>, s: string, n: number) {
     const x1 = obj[s];
     const x2 = obj[n];
     const x3 = obj[k];
 }
 
-function f53<T, K extends keyof T>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
+function f53<T, K extends Exclude<keyof T, symbol>>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
     const x1 = obj[s];
     const x2 = obj[n];
     const x3 = obj[k];
@@ -554,7 +554,7 @@ class AnotherSampleClass<T> extends SampleClass<T & Foo> {
 new AnotherSampleClass({});
 
 // Positive repro from #17166
-function f3<T, K extends keyof T>(t: T, k: K, tk: T[K]): void {
+function f3<T, K extends Extract<keyof T, string>>(t: T, k: K, tk: T[K]): void {
     for (let key in t) {
         key = k // ok, K ==> keyof T
         t[key] = tk; // ok, T[K] ==> T[keyof T]
@@ -1078,8 +1078,8 @@ declare function f50<T>(k: keyof T, s: string): void;
 declare function f51<T, K extends keyof T>(k: K, s: string): void;
 declare function f52<T>(obj: {
     [x: string]: boolean;
-}, k: keyof T, s: string, n: number): void;
-declare function f53<T, K extends keyof T>(obj: {
+}, k: Exclude<keyof T, symbol>, s: string, n: number): void;
+declare function f53<T, K extends Exclude<keyof T, symbol>>(obj: {
     [x: string]: boolean;
 }, k: K, s: string, n: number): void;
 declare function f54<T>(obj: T, key: keyof T): void;
@@ -1238,7 +1238,7 @@ declare class AnotherSampleClass<T> extends SampleClass<T & Foo> {
     constructor(props: T);
     brokenMethod(): void;
 }
-declare function f3<T, K extends keyof T>(t: T, k: K, tk: T[K]): void;
+declare function f3<T, K extends Extract<keyof T, string>>(t: T, k: K, tk: T[K]): void;
 declare type Predicates<TaggedRecord> = {
     [T in keyof TaggedRecord]: (variant: TaggedRecord[keyof TaggedRecord]) => variant is TaggedRecord[T];
 };

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -567,6 +567,25 @@ type Predicates<TaggedRecord> = {
 }
 
 
+// Repro from #23618
+
+type DBBoolTable<K extends string> = { [k in K]: 0 | 1 } 
+enum Flag {
+    FLAG_1 = "flag_1",
+    FLAG_2 = "flag_2"
+}
+
+type SimpleDBRecord<Flag extends string> = { staticField: number } & DBBoolTable<Flag>
+function getFlagsFromSimpleRecord<Flag extends string>(record: SimpleDBRecord<Flag>, flags: Flag[]) {
+    return record[flags[0]];
+}
+
+type DynamicDBRecord<Flag extends string> = ({ dynamicField: number } | { dynamicField: string }) & DBBoolTable<Flag>
+function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]) {
+    return record[flags[0]];
+}
+
+
 //// [keyofAndIndexedAccess.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = Object.setPrototypeOf ||
@@ -948,6 +967,17 @@ function f3(t, k, tk) {
         t[key] = tk; // ok, T[K] ==> T[keyof T]
     }
 }
+var Flag;
+(function (Flag) {
+    Flag["FLAG_1"] = "flag_1";
+    Flag["FLAG_2"] = "flag_2";
+})(Flag || (Flag = {}));
+function getFlagsFromSimpleRecord(record, flags) {
+    return record[flags[0]];
+}
+function getFlagsFromDynamicRecord(record, flags) {
+    return record[flags[0]];
+}
 
 
 //// [keyofAndIndexedAccess.d.ts]
@@ -1212,3 +1242,20 @@ declare function f3<T, K extends keyof T>(t: T, k: K, tk: T[K]): void;
 declare type Predicates<TaggedRecord> = {
     [T in keyof TaggedRecord]: (variant: TaggedRecord[keyof TaggedRecord]) => variant is TaggedRecord[T];
 };
+declare type DBBoolTable<K extends string> = {
+    [k in K]: 0 | 1;
+};
+declare enum Flag {
+    FLAG_1 = "flag_1",
+    FLAG_2 = "flag_2"
+}
+declare type SimpleDBRecord<Flag extends string> = {
+    staticField: number;
+} & DBBoolTable<Flag>;
+declare function getFlagsFromSimpleRecord<Flag extends string>(record: SimpleDBRecord<Flag>, flags: Flag[]): SimpleDBRecord<Flag>[Flag];
+declare type DynamicDBRecord<Flag extends string> = ({
+    dynamicField: number;
+} | {
+    dynamicField: string;
+}) & DBBoolTable<Flag>;
+declare function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]): DynamicDBRecord<Flag>[Flag];

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -651,25 +651,26 @@ function f51<T, K extends keyof T>(k: K, s: string) {
 >k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 184, 35))
 }
 
-function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {
+function f52<T>(obj: { [x: string]: boolean }, k: Exclude<keyof T, symbol>, s: string, n: number) {
 >f52 : Symbol(f52, Decl(keyofAndIndexedAccess.ts, 187, 1))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 189, 13))
 >obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 189, 16))
 >x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 189, 24))
 >k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 189, 46))
+>Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 189, 13))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 189, 58))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 189, 69))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 189, 75))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 189, 86))
 
     const x1 = obj[s];
 >x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 190, 9))
 >obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 189, 16))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 189, 58))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 189, 75))
 
     const x2 = obj[n];
 >x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 191, 9))
 >obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 189, 16))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 189, 69))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 189, 86))
 
     const x3 = obj[k];
 >x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 192, 9))
@@ -677,32 +678,33 @@ function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number)
 >k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 189, 46))
 }
 
-function f53<T, K extends keyof T>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
+function f53<T, K extends Exclude<keyof T, symbol>>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
 >f53 : Symbol(f53, Decl(keyofAndIndexedAccess.ts, 193, 1))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 195, 13))
 >K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 195, 15))
+>Exclude : Symbol(Exclude, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 195, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 195, 35))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 195, 43))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 195, 65))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 195, 52))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 195, 60))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 195, 82))
 >K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 195, 15))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 195, 71))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 195, 82))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 195, 88))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 195, 99))
 
     const x1 = obj[s];
 >x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 196, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 195, 35))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 195, 71))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 195, 52))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 195, 88))
 
     const x2 = obj[n];
 >x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 197, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 195, 35))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 195, 82))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 195, 52))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 195, 99))
 
     const x3 = obj[k];
 >x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 198, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 195, 35))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 195, 65))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 195, 52))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 195, 82))
 }
 
 function f54<T>(obj: T, key: keyof T) {
@@ -1963,31 +1965,32 @@ new AnotherSampleClass({});
 >AnotherSampleClass : Symbol(AnotherSampleClass, Decl(keyofAndIndexedAccess.ts, 540, 54))
 
 // Positive repro from #17166
-function f3<T, K extends keyof T>(t: T, k: K, tk: T[K]): void {
+function f3<T, K extends Extract<keyof T, string>>(t: T, k: K, tk: T[K]): void {
 >f3 : Symbol(f3, Decl(keyofAndIndexedAccess.ts, 552, 27))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 555, 12))
 >K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 555, 14))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 555, 12))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 34))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 51))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 555, 12))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 555, 39))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 555, 56))
 >K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 555, 14))
->tk : Symbol(tk, Decl(keyofAndIndexedAccess.ts, 555, 45))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccess.ts, 555, 62))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 555, 12))
 >K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 555, 14))
 
     for (let key in t) {
 >key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 556, 12))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 34))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 51))
 
         key = k // ok, K ==> keyof T
 >key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 556, 12))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 555, 39))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 555, 56))
 
         t[key] = tk; // ok, T[K] ==> T[keyof T]
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 34))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 51))
 >key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 556, 12))
->tk : Symbol(tk, Decl(keyofAndIndexedAccess.ts, 555, 45))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccess.ts, 555, 62))
     }
 }
 

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -2007,3 +2007,65 @@ type Predicates<TaggedRecord> = {
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 564, 3))
 }
 
+
+// Repro from #23618
+
+type DBBoolTable<K extends string> = { [k in K]: 0 | 1 } 
+>DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 565, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 570, 17))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 570, 40))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 570, 17))
+
+enum Flag {
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 570, 56))
+
+    FLAG_1 = "flag_1",
+>FLAG_1 : Symbol(Flag.FLAG_1, Decl(keyofAndIndexedAccess.ts, 571, 11))
+
+    FLAG_2 = "flag_2"
+>FLAG_2 : Symbol(Flag.FLAG_2, Decl(keyofAndIndexedAccess.ts, 572, 22))
+}
+
+type SimpleDBRecord<Flag extends string> = { staticField: number } & DBBoolTable<Flag>
+>SimpleDBRecord : Symbol(SimpleDBRecord, Decl(keyofAndIndexedAccess.ts, 574, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 576, 20))
+>staticField : Symbol(staticField, Decl(keyofAndIndexedAccess.ts, 576, 44))
+>DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 565, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 576, 20))
+
+function getFlagsFromSimpleRecord<Flag extends string>(record: SimpleDBRecord<Flag>, flags: Flag[]) {
+>getFlagsFromSimpleRecord : Symbol(getFlagsFromSimpleRecord, Decl(keyofAndIndexedAccess.ts, 576, 86))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 577, 34))
+>record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 577, 55))
+>SimpleDBRecord : Symbol(SimpleDBRecord, Decl(keyofAndIndexedAccess.ts, 574, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 577, 34))
+>flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 577, 84))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 577, 34))
+
+    return record[flags[0]];
+>record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 577, 55))
+>flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 577, 84))
+}
+
+type DynamicDBRecord<Flag extends string> = ({ dynamicField: number } | { dynamicField: string }) & DBBoolTable<Flag>
+>DynamicDBRecord : Symbol(DynamicDBRecord, Decl(keyofAndIndexedAccess.ts, 579, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 581, 21))
+>dynamicField : Symbol(dynamicField, Decl(keyofAndIndexedAccess.ts, 581, 46))
+>dynamicField : Symbol(dynamicField, Decl(keyofAndIndexedAccess.ts, 581, 73))
+>DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 565, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 581, 21))
+
+function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]) {
+>getFlagsFromDynamicRecord : Symbol(getFlagsFromDynamicRecord, Decl(keyofAndIndexedAccess.ts, 581, 117))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 582, 35))
+>record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 582, 56))
+>DynamicDBRecord : Symbol(DynamicDBRecord, Decl(keyofAndIndexedAccess.ts, 579, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 582, 35))
+>flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 582, 86))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 582, 35))
+
+    return record[flags[0]];
+>record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 582, 56))
+>flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 582, 86))
+}
+

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -888,11 +888,11 @@ function f60<T>(source: T, target: T) {
 }
 
 function f70(func: <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void) {
->f70 : (func: <T, U>(k1: keyof (T | U), k2: keyof T | keyof U) => void) => void
->func : <T, U>(k1: keyof (T | U), k2: keyof T | keyof U) => void
+>f70 : (func: <T, U>(k1: keyof T & keyof U, k2: keyof T | keyof U) => void) => void
+>func : <T, U>(k1: keyof T & keyof U, k2: keyof T | keyof U) => void
 >T : T
 >U : U
->k1 : keyof (T | U)
+>k1 : keyof T & keyof U
 >T : T
 >U : U
 >k2 : keyof T | keyof U
@@ -901,7 +901,7 @@ function f70(func: <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void) {
 
     func<{ a: any, b: any }, { a: any, c: any }>('a', 'a');
 >func<{ a: any, b: any }, { a: any, c: any }>('a', 'a') : void
->func : <T, U>(k1: keyof (T | U), k2: keyof T | keyof U) => void
+>func : <T, U>(k1: keyof T & keyof U, k2: keyof T | keyof U) => void
 >a : any
 >b : any
 >a : any
@@ -911,7 +911,7 @@ function f70(func: <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void) {
 
     func<{ a: any, b: any }, { a: any, c: any }>('a', 'b');
 >func<{ a: any, b: any }, { a: any, c: any }>('a', 'b') : void
->func : <T, U>(k1: keyof (T | U), k2: keyof T | keyof U) => void
+>func : <T, U>(k1: keyof T & keyof U, k2: keyof T | keyof U) => void
 >a : any
 >b : any
 >a : any
@@ -921,7 +921,7 @@ function f70(func: <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void) {
 
     func<{ a: any, b: any }, { a: any, c: any }>('a', 'c');
 >func<{ a: any, b: any }, { a: any, c: any }>('a', 'c') : void
->func : <T, U>(k1: keyof (T | U), k2: keyof T | keyof U) => void
+>func : <T, U>(k1: keyof T & keyof U, k2: keyof T | keyof U) => void
 >a : any
 >b : any
 >a : any
@@ -1095,8 +1095,8 @@ function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[
 }
 
 function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[K]) {
->f74 : (func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[K]) => void
->func : <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[K]
+>f74 : (func: <T, U, K extends keyof T & keyof U>(x: T, y: U, k: K) => (T | U)[K]) => void
+>func : <T, U, K extends keyof T & keyof U>(x: T, y: U, k: K) => (T | U)[K]
 >T : T
 >U : U
 >K : K
@@ -1115,7 +1115,7 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
     let a = func({ a: 1, b: "hello" }, { a: 2, b: true }, 'a');  // number
 >a : number
 >func({ a: 1, b: "hello" }, { a: 2, b: true }, 'a') : number
->func : <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[K]
+>func : <T, U, K extends keyof T & keyof U>(x: T, y: U, k: K) => (T | U)[K]
 >{ a: 1, b: "hello" } : { a: number; b: string; }
 >a : number
 >1 : 1
@@ -1131,7 +1131,7 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
     let b = func({ a: 1, b: "hello" }, { a: 2, b: true }, 'b');  // string | boolean
 >b : string | boolean
 >func({ a: 1, b: "hello" }, { a: 2, b: true }, 'b') : string | boolean
->func : <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[K]
+>func : <T, U, K extends keyof T & keyof U>(x: T, y: U, k: K) => (T | U)[K]
 >{ a: 1, b: "hello" } : { a: number; b: string; }
 >a : number
 >1 : 1
@@ -2340,5 +2340,75 @@ type Predicates<TaggedRecord> = {
 >variant : any
 >TaggedRecord : TaggedRecord
 >T : T
+}
+
+
+// Repro from #23618
+
+type DBBoolTable<K extends string> = { [k in K]: 0 | 1 } 
+>DBBoolTable : DBBoolTable<K>
+>K : K
+>k : k
+>K : K
+
+enum Flag {
+>Flag : Flag
+
+    FLAG_1 = "flag_1",
+>FLAG_1 : Flag.FLAG_1
+>"flag_1" : "flag_1"
+
+    FLAG_2 = "flag_2"
+>FLAG_2 : Flag.FLAG_2
+>"flag_2" : "flag_2"
+}
+
+type SimpleDBRecord<Flag extends string> = { staticField: number } & DBBoolTable<Flag>
+>SimpleDBRecord : SimpleDBRecord<Flag>
+>Flag : Flag
+>staticField : number
+>DBBoolTable : DBBoolTable<K>
+>Flag : Flag
+
+function getFlagsFromSimpleRecord<Flag extends string>(record: SimpleDBRecord<Flag>, flags: Flag[]) {
+>getFlagsFromSimpleRecord : <Flag extends string>(record: SimpleDBRecord<Flag>, flags: Flag[]) => SimpleDBRecord<Flag>[Flag]
+>Flag : Flag
+>record : SimpleDBRecord<Flag>
+>SimpleDBRecord : SimpleDBRecord<Flag>
+>Flag : Flag
+>flags : Flag[]
+>Flag : Flag
+
+    return record[flags[0]];
+>record[flags[0]] : SimpleDBRecord<Flag>[Flag]
+>record : SimpleDBRecord<Flag>
+>flags[0] : Flag
+>flags : Flag[]
+>0 : 0
+}
+
+type DynamicDBRecord<Flag extends string> = ({ dynamicField: number } | { dynamicField: string }) & DBBoolTable<Flag>
+>DynamicDBRecord : DynamicDBRecord<Flag>
+>Flag : Flag
+>dynamicField : number
+>dynamicField : string
+>DBBoolTable : DBBoolTable<K>
+>Flag : Flag
+
+function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]) {
+>getFlagsFromDynamicRecord : <Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]) => DynamicDBRecord<Flag>[Flag]
+>Flag : Flag
+>record : DynamicDBRecord<Flag>
+>DynamicDBRecord : DynamicDBRecord<Flag>
+>Flag : Flag
+>flags : Flag[]
+>Flag : Flag
+
+    return record[flags[0]];
+>record[flags[0]] : DynamicDBRecord<Flag>[Flag]
+>record : DynamicDBRecord<Flag>
+>flags[0] : Flag
+>flags : Flag[]
+>0 : 0
 }
 

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -59,10 +59,10 @@ const enum E { A, B, C }
 >C : E.C
 
 type K00 = keyof any;  // string
->K00 : string
+>K00 : string | number | symbol
 
 type K01 = keyof string;  // "toString" | "charAt" | ...
->K01 : "length" | "toString" | "concat" | "slice" | "indexOf" | "lastIndexOf" | "charAt" | "charCodeAt" | "localeCompare" | "match" | "replace" | "search" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
+>K01 : number | "length" | "toString" | "concat" | "slice" | "indexOf" | "lastIndexOf" | "charAt" | "charCodeAt" | "localeCompare" | "match" | "replace" | "search" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
 
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
 >K02 : "toString" | "toLocaleString" | "valueOf" | "toFixed" | "toExponential" | "toPrecision"
@@ -88,11 +88,11 @@ type K10 = keyof Shape;  // "name" | "width" | "height" | "visible"
 >Shape : Shape
 
 type K11 = keyof Shape[];  // "length" | "toString" | ...
->K11 : "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
+>K11 : number | "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
 >Shape : Shape
 
 type K12 = keyof Dictionary<Shape>;  // string
->K12 : string
+>K12 : string | number
 >Dictionary : Dictionary<T>
 >Shape : Shape
 
@@ -108,7 +108,7 @@ type K15 = keyof E;  // "toString" | "toFixed" | "toExponential" | ...
 >E : E
 
 type K16 = keyof [string, number];  // "0" | "1" | "length" | "toString" | ...
->K16 : "0" | "1" | "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
+>K16 : number | "0" | "1" | "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
 
 type K17 = keyof (Shape | Item);  // "name"
 >K17 : "name"
@@ -121,7 +121,7 @@ type K18 = keyof (Shape & Item);  // "name" | "width" | "height" | "visible" | "
 >Item : Item
 
 type K19 = keyof NumericallyIndexed<Shape> // never
->K19 : never
+>K19 : number
 >NumericallyIndexed : NumericallyIndexed<T>
 >Shape : Shape
 
@@ -136,7 +136,7 @@ type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
 >Shape : Shape
 
 type K21 = KeyOf<Dictionary<Shape>>;  // string
->K21 : string
+>K21 : string | number
 >KeyOf : keyof T
 >Dictionary : Dictionary<T>
 >Shape : Shape
@@ -756,12 +756,13 @@ function f51<T, K extends keyof T>(k: K, s: string) {
 >k : K
 }
 
-function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {
->f52 : <T>(obj: { [x: string]: boolean; }, k: keyof T, s: string, n: number) => void
+function f52<T>(obj: { [x: string]: boolean }, k: Exclude<keyof T, symbol>, s: string, n: number) {
+>f52 : <T>(obj: { [x: string]: boolean; }, k: Exclude<keyof T, symbol>, s: string, n: number) => void
 >T : T
 >obj : { [x: string]: boolean; }
 >x : string
->k : keyof T
+>k : Exclude<keyof T, symbol>
+>Exclude : Exclude<T, U>
 >T : T
 >s : string
 >n : number
@@ -779,16 +780,17 @@ function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number)
 >n : number
 
     const x3 = obj[k];
->x3 : { [x: string]: boolean; }[keyof T]
->obj[k] : { [x: string]: boolean; }[keyof T]
+>x3 : { [x: string]: boolean; }[Exclude<keyof T, symbol>]
+>obj[k] : { [x: string]: boolean; }[Exclude<keyof T, symbol>]
 >obj : { [x: string]: boolean; }
->k : keyof T
+>k : Exclude<keyof T, symbol>
 }
 
-function f53<T, K extends keyof T>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
->f53 : <T, K extends keyof T>(obj: { [x: string]: boolean; }, k: K, s: string, n: number) => void
+function f53<T, K extends Exclude<keyof T, symbol>>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
+>f53 : <T, K extends Exclude<keyof T, symbol>>(obj: { [x: string]: boolean; }, k: K, s: string, n: number) => void
 >T : T
 >K : K
+>Exclude : Exclude<T, U>
 >T : T
 >obj : { [x: string]: boolean; }
 >x : string
@@ -825,7 +827,7 @@ function f54<T>(obj: T, key: keyof T) {
 >T : T
 
     for (let s in obj[key]) {
->s : keyof T[keyof T]
+>s : Extract<keyof T[keyof T], string>
 >obj[key] : T[keyof T]
 >obj : T
 >key : keyof T
@@ -850,7 +852,7 @@ function f55<T, K extends keyof T>(obj: T, key: K) {
 >K : K
 
     for (let s in obj[key]) {
->s : keyof T[K]
+>s : Extract<keyof T[K], string>
 >obj[key] : T[K]
 >obj : T
 >key : K
@@ -873,17 +875,17 @@ function f60<T>(source: T, target: T) {
 >T : T
 
     for (let k in source) {
->k : keyof T
+>k : Extract<keyof T, string>
 >source : T
 
         target[k] = source[k];
->target[k] = source[k] : T[keyof T]
->target[k] : T[keyof T]
+>target[k] = source[k] : T[Extract<keyof T, string>]
+>target[k] : T[Extract<keyof T, string>]
 >target : T
->k : keyof T
->source[k] : T[keyof T]
+>k : Extract<keyof T, string>
+>source[k] : T[Extract<keyof T, string>]
 >source : T
->k : keyof T
+>k : Extract<keyof T, string>
     }
 }
 
@@ -2295,10 +2297,11 @@ new AnotherSampleClass({});
 >{} : {}
 
 // Positive repro from #17166
-function f3<T, K extends keyof T>(t: T, k: K, tk: T[K]): void {
->f3 : <T, K extends keyof T>(t: T, k: K, tk: T[K]) => void
+function f3<T, K extends Extract<keyof T, string>>(t: T, k: K, tk: T[K]): void {
+>f3 : <T, K extends Extract<keyof T, string>>(t: T, k: K, tk: T[K]) => void
 >T : T
 >K : K
+>Extract : Extract<T, U>
 >T : T
 >t : T
 >T : T
@@ -2309,19 +2312,19 @@ function f3<T, K extends keyof T>(t: T, k: K, tk: T[K]): void {
 >K : K
 
     for (let key in t) {
->key : keyof T
+>key : Extract<keyof T, string>
 >t : T
 
         key = k // ok, K ==> keyof T
 >key = k : K
->key : keyof T
+>key : Extract<keyof T, string>
 >k : K
 
         t[key] = tk; // ok, T[K] ==> T[keyof T]
 >t[key] = tk : T[K]
->t[key] : T[keyof T]
+>t[key] : T[Extract<keyof T, string>]
 >t : T
->key : keyof T
+>key : Extract<keyof T, string>
 >tk : T[K]
     }
 }

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -22,27 +22,35 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(64,33): error
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(66,24): error TS2345: Argument of type '"size"' is not assignable to parameter of type '"name" | "width" | "height" | "visible"'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(67,24): error TS2345: Argument of type '"name" | "size"' is not assignable to parameter of type '"name" | "width" | "height" | "visible"'.
   Type '"size"' is not assignable to type '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(72,5): error TS2536: Type 'keyof T | keyof U' cannot be used to index type 'T | U'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(76,5): error TS2322: Type 'T | U' is not assignable to type 'T & U'.
-  Type 'T' is not assignable to type 'T & U'.
-    Type 'T' is not assignable to type 'U'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(77,5): error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof (T | U)'.
-  Type 'keyof T' is not assignable to type 'keyof (T | U)'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(86,9): error TS2322: Type 'keyof T' is not assignable to type 'K'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(88,9): error TS2322: Type 'T[keyof T]' is not assignable to type 'T[K]'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(73,5): error TS2536: Type 'keyof T | keyof U' cannot be used to index type 'T | U'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(74,5): error TS2536: Type 'keyof T | keyof U' cannot be used to index type 'T | U'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(82,5): error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
+  Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
+    Type 'keyof T' is not assignable to type 'keyof U'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(83,5): error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
+  Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
+    Type 'keyof T' is not assignable to type 'keyof U'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(86,5): error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
+  Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
+    Type 'keyof T' is not assignable to type 'keyof U'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(87,5): error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
+  Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
+    Type 'keyof T' is not assignable to type 'keyof U'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(103,9): error TS2322: Type 'keyof T' is not assignable to type 'K'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(105,9): error TS2322: Type 'T[keyof T]' is not assignable to type 'T[K]'.
   Type 'keyof T' is not assignable to type 'K'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(91,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(108,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
   Type 'T' is not assignable to type 'U'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(94,5): error TS2322: Type 'T[J]' is not assignable to type 'U[J]'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(111,5): error TS2322: Type 'T[J]' is not assignable to type 'U[J]'.
   Type 'T' is not assignable to type 'U'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(97,5): error TS2322: Type 'T[K]' is not assignable to type 'T[J]'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(114,5): error TS2322: Type 'T[K]' is not assignable to type 'T[J]'.
   Type 'K' is not assignable to type 'J'.
     Type 'keyof T' is not assignable to type 'J'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(100,5): error TS2322: Type 'T[K]' is not assignable to type 'U[J]'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error TS2322: Type 'T[K]' is not assignable to type 'U[J]'.
   Type 'T' is not assignable to type 'U'.
 
 
-==== tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts (31 errors) ====
+==== tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts (34 errors) ====
     class Shape {
         name: string;
         width: number;
@@ -158,24 +166,52 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(100,5): error
 !!! error TS2345:   Type '"size"' is not assignable to type '"name" | "width" | "height" | "visible"'.
     }
     
-    function f20<T, U>(k1: keyof (T | U), k2: keyof (T & U), o1: T | U, o2: T & U) {
-        o1[k1];
-        o1[k2];   // Error
-        ~~~~~~
+    function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U, k3: keyof (T & U), k4: keyof T | keyof U) {
+        x[k1];
+        x[k2];
+        x[k3];  // Error
+        ~~~~~
 !!! error TS2536: Type 'keyof T | keyof U' cannot be used to index type 'T | U'.
-        o2[k1];
-        o2[k2];
-        o1 = o2;
-        o2 = o1;  // Error
+        x[k4];  // Error
+        ~~~~~
+!!! error TS2536: Type 'keyof T | keyof U' cannot be used to index type 'T | U'.
+    
+        y[k1];
+        y[k2];
+        y[k3];
+        y[k4];
+    
+        k1 = k2;
+        k1 = k3;  // Error
         ~~
-!!! error TS2322: Type 'T | U' is not assignable to type 'T & U'.
-!!! error TS2322:   Type 'T' is not assignable to type 'T & U'.
-!!! error TS2322:     Type 'T' is not assignable to type 'U'.
-        k1 = k2;  // Error
+!!! error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:   Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:     Type 'keyof T' is not assignable to type 'keyof U'.
+        k1 = k4;  // Error
         ~~
-!!! error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof (T | U)'.
-!!! error TS2322:   Type 'keyof T' is not assignable to type 'keyof (T | U)'.
+!!! error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:   Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:     Type 'keyof T' is not assignable to type 'keyof U'.
+    
         k2 = k1;
+        k2 = k3;  // Error
+        ~~
+!!! error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:   Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:     Type 'keyof T' is not assignable to type 'keyof U'.
+        k2 = k4;  // Error
+        ~~
+!!! error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:   Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:     Type 'keyof T' is not assignable to type 'keyof U'.
+    
+        k3 = k1;
+        k3 = k2;
+        k3 = k4;
+    
+        k4 = k1;
+        k4 = k2;
+        k4 = k3;
     }
     
     // Repro from #17166

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -26,7 +26,12 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(73,5): error 
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(74,5): error TS2536: Type 'keyof T | keyof U' cannot be used to index type 'T | U'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(82,5): error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
   Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
-    Type 'keyof T' is not assignable to type 'keyof U'.
+    Type 'string | number | symbol' is not assignable to type 'keyof T & keyof U'.
+      Type 'string' is not assignable to type 'keyof T & keyof U'.
+        Type 'string' is not assignable to type 'keyof T'.
+          Type 'keyof T' is not assignable to type 'keyof U'.
+            Type 'string | number | symbol' is not assignable to type 'keyof U'.
+              Type 'string' is not assignable to type 'keyof U'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(83,5): error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
   Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
     Type 'keyof T' is not assignable to type 'keyof U'.
@@ -36,16 +41,20 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(86,5): error 
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(87,5): error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
   Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
     Type 'keyof T' is not assignable to type 'keyof U'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(103,9): error TS2322: Type 'keyof T' is not assignable to type 'K'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(105,9): error TS2322: Type 'T[keyof T]' is not assignable to type 'T[K]'.
-  Type 'keyof T' is not assignable to type 'K'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(103,9): error TS2322: Type 'Extract<keyof T, string>' is not assignable to type 'K'.
+  Type 'string & keyof T' is not assignable to type 'K'.
+    Type 'string' is not assignable to type 'K'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(105,9): error TS2322: Type 'T[Extract<keyof T, string>]' is not assignable to type 'T[K]'.
+  Type 'Extract<keyof T, string>' is not assignable to type 'K'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(108,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
   Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(111,5): error TS2322: Type 'T[J]' is not assignable to type 'U[J]'.
   Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(114,5): error TS2322: Type 'T[K]' is not assignable to type 'T[J]'.
   Type 'K' is not assignable to type 'J'.
-    Type 'keyof T' is not assignable to type 'J'.
+    Type 'Extract<keyof T, string>' is not assignable to type 'J'.
+      Type 'string & keyof T' is not assignable to type 'J'.
+        Type 'string' is not assignable to type 'J'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error TS2322: Type 'T[K]' is not assignable to type 'U[J]'.
   Type 'T' is not assignable to type 'U'.
 
@@ -186,7 +195,12 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error
         ~~
 !!! error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
 !!! error TS2322:   Type 'keyof T' is not assignable to type 'keyof T & keyof U'.
-!!! error TS2322:     Type 'keyof T' is not assignable to type 'keyof U'.
+!!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:       Type 'string' is not assignable to type 'keyof T & keyof U'.
+!!! error TS2322:         Type 'string' is not assignable to type 'keyof T'.
+!!! error TS2322:           Type 'keyof T' is not assignable to type 'keyof U'.
+!!! error TS2322:             Type 'string | number | symbol' is not assignable to type 'keyof U'.
+!!! error TS2322:               Type 'string' is not assignable to type 'keyof U'.
         k1 = k4;  // Error
         ~~
 !!! error TS2322: Type 'keyof T | keyof U' is not assignable to type 'keyof T & keyof U'.
@@ -215,18 +229,20 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error
     }
     
     // Repro from #17166
-    function f3<T, K extends keyof T, U extends T, J extends K>(
+    function f3<T, K extends Extract<keyof T, string>, U extends T, J extends K>(
         t: T, k: K, tk: T[K], u: U, j: J, uk: U[K], tj: T[J], uj: U[J]): void {
         for (let key in t) {
             key = k // ok, K ==> keyof T
             k = key // error, keyof T =/=> K
             ~
-!!! error TS2322: Type 'keyof T' is not assignable to type 'K'.
+!!! error TS2322: Type 'Extract<keyof T, string>' is not assignable to type 'K'.
+!!! error TS2322:   Type 'string & keyof T' is not assignable to type 'K'.
+!!! error TS2322:     Type 'string' is not assignable to type 'K'.
             t[key] = tk; // ok, T[K] ==> T[keyof T]
             tk = t[key]; // error, T[keyof T] =/=> T[K]
             ~~
-!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'T[K]'.
-!!! error TS2322:   Type 'keyof T' is not assignable to type 'K'.
+!!! error TS2322: Type 'T[Extract<keyof T, string>]' is not assignable to type 'T[K]'.
+!!! error TS2322:   Type 'Extract<keyof T, string>' is not assignable to type 'K'.
         }
         tk = uk;
         uk = tk; // error
@@ -245,7 +261,9 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error
         ~~
 !!! error TS2322: Type 'T[K]' is not assignable to type 'T[J]'.
 !!! error TS2322:   Type 'K' is not assignable to type 'J'.
-!!! error TS2322:     Type 'keyof T' is not assignable to type 'J'.
+!!! error TS2322:     Type 'Extract<keyof T, string>' is not assignable to type 'J'.
+!!! error TS2322:       Type 'string & keyof T' is not assignable to type 'J'.
+!!! error TS2322:         Type 'string' is not assignable to type 'J'.
     
         tk = uj;
         uj = tk; // error

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.js
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.js
@@ -97,7 +97,7 @@ function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U,
 }
 
 // Repro from #17166
-function f3<T, K extends keyof T, U extends T, J extends K>(
+function f3<T, K extends Extract<keyof T, string>, U extends T, J extends K>(
     t: T, k: K, tk: T[K], u: U, j: J, uk: U[K], tj: T[J], uj: U[J]): void {
     for (let key in t) {
         key = k // ok, K ==> keyof T

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.js
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.js
@@ -68,15 +68,32 @@ function f10(shape: Shape) {
     setProperty(shape, cond ? "name" : "size", 10);  // Error
 }
 
-function f20<T, U>(k1: keyof (T | U), k2: keyof (T & U), o1: T | U, o2: T & U) {
-    o1[k1];
-    o1[k2];   // Error
-    o2[k1];
-    o2[k2];
-    o1 = o2;
-    o2 = o1;  // Error
-    k1 = k2;  // Error
+function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U, k3: keyof (T & U), k4: keyof T | keyof U) {
+    x[k1];
+    x[k2];
+    x[k3];  // Error
+    x[k4];  // Error
+
+    y[k1];
+    y[k2];
+    y[k3];
+    y[k4];
+
+    k1 = k2;
+    k1 = k3;  // Error
+    k1 = k4;  // Error
+
     k2 = k1;
+    k2 = k3;  // Error
+    k2 = k4;  // Error
+
+    k3 = k1;
+    k3 = k2;
+    k3 = k4;
+
+    k4 = k1;
+    k4 = k2;
+    k4 = k3;
 }
 
 // Repro from #17166
@@ -122,15 +139,27 @@ function f10(shape) {
     setProperty(shape, "size", 10); // Error
     setProperty(shape, cond ? "name" : "size", 10); // Error
 }
-function f20(k1, k2, o1, o2) {
-    o1[k1];
-    o1[k2]; // Error
-    o2[k1];
-    o2[k2];
-    o1 = o2;
-    o2 = o1; // Error
-    k1 = k2; // Error
+function f20(x, y, k1, k2, k3, k4) {
+    x[k1];
+    x[k2];
+    x[k3]; // Error
+    x[k4]; // Error
+    y[k1];
+    y[k2];
+    y[k3];
+    y[k4];
+    k1 = k2;
+    k1 = k3; // Error
+    k1 = k4; // Error
     k2 = k1;
+    k2 = k3; // Error
+    k2 = k4; // Error
+    k3 = k1;
+    k3 = k2;
+    k3 = k4;
+    k4 = k1;
+    k4 = k2;
+    k4 = k3;
 }
 // Repro from #17166
 function f3(t, k, tk, u, j, uk, tj, uj) {

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.symbols
@@ -324,18 +324,19 @@ function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U,
 }
 
 // Repro from #17166
-function f3<T, K extends keyof T, U extends T, J extends K>(
+function f3<T, K extends Extract<keyof T, string>, U extends T, J extends K>(
 >f3 : Symbol(f3, Decl(keyofAndIndexedAccessErrors.ts, 95, 1))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
 >K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
+>Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
->U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 33))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 50))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
->J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 46))
+>J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 63))
 >K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
 
     t: T, k: K, tk: T[K], u: U, j: J, uk: U[K], tj: T[J], uj: U[J]): void {
->t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 60))
+>t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 77))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
 >k : Symbol(k, Decl(keyofAndIndexedAccessErrors.ts, 99, 9))
 >K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
@@ -343,22 +344,22 @@ function f3<T, K extends keyof T, U extends T, J extends K>(
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
 >K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
 >u : Symbol(u, Decl(keyofAndIndexedAccessErrors.ts, 99, 25))
->U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 33))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 50))
 >j : Symbol(j, Decl(keyofAndIndexedAccessErrors.ts, 99, 31))
->J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 46))
+>J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 63))
 >uk : Symbol(uk, Decl(keyofAndIndexedAccessErrors.ts, 99, 37))
->U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 33))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 50))
 >K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
 >tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 99, 47))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
->J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 46))
+>J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 63))
 >uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 99, 57))
->U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 33))
->J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 46))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 50))
+>J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 63))
 
     for (let key in t) {
 >key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
->t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 60))
+>t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 77))
 
         key = k // ok, K ==> keyof T
 >key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
@@ -369,13 +370,13 @@ function f3<T, K extends keyof T, U extends T, J extends K>(
 >key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
 
         t[key] = tk; // ok, T[K] ==> T[keyof T]
->t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 60))
+>t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 77))
 >key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
 >tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
 
         tk = t[key]; // error, T[keyof T] =/=> T[K]
 >tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
->t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 60))
+>t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 77))
 >key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
     }
     tk = uk;

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.symbols
@@ -219,141 +219,195 @@ function f10(shape: Shape) {
 >cond : Symbol(cond, Decl(keyofAndIndexedAccessErrors.ts, 50, 11))
 }
 
-function f20<T, U>(k1: keyof (T | U), k2: keyof (T & U), o1: T | U, o2: T & U) {
+function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U, k3: keyof (T & U), k4: keyof T | keyof U) {
 >f20 : Symbol(f20, Decl(keyofAndIndexedAccessErrors.ts, 67, 1))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 69, 13))
 >U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 69, 15))
->k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 69, 13))
 >U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 69, 15))
->k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 37))
+>y : Symbol(y, Decl(keyofAndIndexedAccessErrors.ts, 69, 28))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 69, 13))
 >U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 69, 15))
->o1 : Symbol(o1, Decl(keyofAndIndexedAccessErrors.ts, 69, 56))
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 69, 13))
 >U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 69, 15))
->o2 : Symbol(o2, Decl(keyofAndIndexedAccessErrors.ts, 69, 67))
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 69, 13))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 69, 15))
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 69, 13))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 69, 15))
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
 >T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 69, 13))
 >U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 69, 15))
 
-    o1[k1];
->o1 : Symbol(o1, Decl(keyofAndIndexedAccessErrors.ts, 69, 56))
->k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
+    x[k1];
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
 
-    o1[k2];   // Error
->o1 : Symbol(o1, Decl(keyofAndIndexedAccessErrors.ts, 69, 56))
->k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 37))
+    x[k2];
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
 
-    o2[k1];
->o2 : Symbol(o2, Decl(keyofAndIndexedAccessErrors.ts, 69, 67))
->k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
+    x[k3];  // Error
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
 
-    o2[k2];
->o2 : Symbol(o2, Decl(keyofAndIndexedAccessErrors.ts, 69, 67))
->k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 37))
+    x[k4];  // Error
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
 
-    o1 = o2;
->o1 : Symbol(o1, Decl(keyofAndIndexedAccessErrors.ts, 69, 56))
->o2 : Symbol(o2, Decl(keyofAndIndexedAccessErrors.ts, 69, 67))
+    y[k1];
+>y : Symbol(y, Decl(keyofAndIndexedAccessErrors.ts, 69, 28))
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
 
-    o2 = o1;  // Error
->o2 : Symbol(o2, Decl(keyofAndIndexedAccessErrors.ts, 69, 67))
->o1 : Symbol(o1, Decl(keyofAndIndexedAccessErrors.ts, 69, 56))
+    y[k2];
+>y : Symbol(y, Decl(keyofAndIndexedAccessErrors.ts, 69, 28))
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
 
-    k1 = k2;  // Error
->k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
->k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 37))
+    y[k3];
+>y : Symbol(y, Decl(keyofAndIndexedAccessErrors.ts, 69, 28))
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
+
+    y[k4];
+>y : Symbol(y, Decl(keyofAndIndexedAccessErrors.ts, 69, 28))
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
+
+    k1 = k2;
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
+
+    k1 = k3;  // Error
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
+
+    k1 = k4;  // Error
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
 
     k2 = k1;
->k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 37))
->k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 19))
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
+
+    k2 = k3;  // Error
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
+
+    k2 = k4;  // Error
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
+
+    k3 = k1;
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
+
+    k3 = k2;
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
+
+    k3 = k4;
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
+
+    k4 = k1;
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
+>k1 : Symbol(k1, Decl(keyofAndIndexedAccessErrors.ts, 69, 38))
+
+    k4 = k2;
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
+>k2 : Symbol(k2, Decl(keyofAndIndexedAccessErrors.ts, 69, 57))
+
+    k4 = k3;
+>k4 : Symbol(k4, Decl(keyofAndIndexedAccessErrors.ts, 69, 99))
+>k3 : Symbol(k3, Decl(keyofAndIndexedAccessErrors.ts, 69, 80))
 }
 
 // Repro from #17166
 function f3<T, K extends keyof T, U extends T, J extends K>(
->f3 : Symbol(f3, Decl(keyofAndIndexedAccessErrors.ts, 78, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 81, 12))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 81, 14))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 81, 12))
->U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 81, 33))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 81, 12))
->J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 81, 46))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 81, 14))
+>f3 : Symbol(f3, Decl(keyofAndIndexedAccessErrors.ts, 95, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 33))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
+>J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 46))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
 
     t: T, k: K, tk: T[K], u: U, j: J, uk: U[K], tj: T[J], uj: U[J]): void {
->t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 81, 60))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 81, 12))
->k : Symbol(k, Decl(keyofAndIndexedAccessErrors.ts, 82, 9))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 81, 14))
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 81, 12))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 81, 14))
->u : Symbol(u, Decl(keyofAndIndexedAccessErrors.ts, 82, 25))
->U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 81, 33))
->j : Symbol(j, Decl(keyofAndIndexedAccessErrors.ts, 82, 31))
->J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 81, 46))
->uk : Symbol(uk, Decl(keyofAndIndexedAccessErrors.ts, 82, 37))
->U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 81, 33))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 81, 14))
->tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 82, 47))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 81, 12))
->J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 81, 46))
->uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 82, 57))
->U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 81, 33))
->J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 81, 46))
+>t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 60))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
+>k : Symbol(k, Decl(keyofAndIndexedAccessErrors.ts, 99, 9))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
+>u : Symbol(u, Decl(keyofAndIndexedAccessErrors.ts, 99, 25))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 33))
+>j : Symbol(j, Decl(keyofAndIndexedAccessErrors.ts, 99, 31))
+>J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 46))
+>uk : Symbol(uk, Decl(keyofAndIndexedAccessErrors.ts, 99, 37))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 33))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 98, 14))
+>tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 99, 47))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 98, 12))
+>J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 46))
+>uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 99, 57))
+>U : Symbol(U, Decl(keyofAndIndexedAccessErrors.ts, 98, 33))
+>J : Symbol(J, Decl(keyofAndIndexedAccessErrors.ts, 98, 46))
 
     for (let key in t) {
->key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 83, 12))
->t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 81, 60))
+>key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
+>t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 60))
 
         key = k // ok, K ==> keyof T
->key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 83, 12))
->k : Symbol(k, Decl(keyofAndIndexedAccessErrors.ts, 82, 9))
+>key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
+>k : Symbol(k, Decl(keyofAndIndexedAccessErrors.ts, 99, 9))
 
         k = key // error, keyof T =/=> K
->k : Symbol(k, Decl(keyofAndIndexedAccessErrors.ts, 82, 9))
->key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 83, 12))
+>k : Symbol(k, Decl(keyofAndIndexedAccessErrors.ts, 99, 9))
+>key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
 
         t[key] = tk; // ok, T[K] ==> T[keyof T]
->t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 81, 60))
->key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 83, 12))
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
+>t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 60))
+>key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
 
         tk = t[key]; // error, T[keyof T] =/=> T[K]
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
->t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 81, 60))
->key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 83, 12))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
+>t : Symbol(t, Decl(keyofAndIndexedAccessErrors.ts, 98, 60))
+>key : Symbol(key, Decl(keyofAndIndexedAccessErrors.ts, 100, 12))
     }
     tk = uk;
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
->uk : Symbol(uk, Decl(keyofAndIndexedAccessErrors.ts, 82, 37))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
+>uk : Symbol(uk, Decl(keyofAndIndexedAccessErrors.ts, 99, 37))
 
     uk = tk; // error
->uk : Symbol(uk, Decl(keyofAndIndexedAccessErrors.ts, 82, 37))
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
+>uk : Symbol(uk, Decl(keyofAndIndexedAccessErrors.ts, 99, 37))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
 
     tj = uj;
->tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 82, 47))
->uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 82, 57))
+>tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 99, 47))
+>uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 99, 57))
 
     uj = tj; // error
->uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 82, 57))
->tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 82, 47))
+>uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 99, 57))
+>tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 99, 47))
 
     tk = tj;
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
->tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 82, 47))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
+>tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 99, 47))
 
     tj = tk; // error
->tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 82, 47))
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
+>tj : Symbol(tj, Decl(keyofAndIndexedAccessErrors.ts, 99, 47))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
 
     tk = uj;
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
->uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 82, 57))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
+>uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 99, 57))
 
     uj = tk; // error
->uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 82, 57))
->tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 82, 15))
+>uj : Symbol(uj, Decl(keyofAndIndexedAccessErrors.ts, 99, 57))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccessErrors.ts, 99, 15))
 }
 

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.types
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.types
@@ -22,7 +22,7 @@ type Dictionary<T> = { [x: string]: T };
 >T : T
 
 type T00 = keyof K0;  // Error
->T00 : string
+>T00 : string | number | symbol
 >K0 : No type information available!
 
 type T01 = keyof Object;
@@ -30,23 +30,23 @@ type T01 = keyof Object;
 >Object : Object
 
 type T02 = keyof keyof Object;
->T02 : "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
+>T02 : number | "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
 >Object : Object
 
 type T03 = keyof keyof keyof Object;
->T03 : "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
+>T03 : "toString" | "valueOf"
 >Object : Object
 
 type T04 = keyof keyof keyof keyof Object;
->T04 : "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
+>T04 : number | "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
 >Object : Object
 
 type T05 = keyof keyof keyof keyof keyof Object;
->T05 : "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
+>T05 : "toString" | "valueOf"
 >Object : Object
 
 type T06 = keyof keyof keyof keyof keyof keyof Object;
->T06 : "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
+>T06 : number | "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
 >Object : Object
 
 type T10 = Shape["name"];
@@ -367,10 +367,11 @@ function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U,
 }
 
 // Repro from #17166
-function f3<T, K extends keyof T, U extends T, J extends K>(
->f3 : <T, K extends keyof T, U extends T, J extends K>(t: T, k: K, tk: T[K], u: U, j: J, uk: U[K], tj: T[J], uj: U[J]) => void
+function f3<T, K extends Extract<keyof T, string>, U extends T, J extends K>(
+>f3 : <T, K extends Extract<keyof T, string>, U extends T, J extends K>(t: T, k: K, tk: T[K], u: U, j: J, uk: U[K], tj: T[J], uj: U[J]) => void
 >T : T
 >K : K
+>Extract : Extract<T, U>
 >T : T
 >U : U
 >T : T
@@ -400,32 +401,32 @@ function f3<T, K extends keyof T, U extends T, J extends K>(
 >J : J
 
     for (let key in t) {
->key : keyof T
+>key : Extract<keyof T, string>
 >t : T
 
         key = k // ok, K ==> keyof T
 >key = k : K
->key : keyof T
+>key : Extract<keyof T, string>
 >k : K
 
         k = key // error, keyof T =/=> K
->k = key : keyof T
+>k = key : Extract<keyof T, string>
 >k : K
->key : keyof T
+>key : Extract<keyof T, string>
 
         t[key] = tk; // ok, T[K] ==> T[keyof T]
 >t[key] = tk : T[K]
->t[key] : T[keyof T]
+>t[key] : T[Extract<keyof T, string>]
 >t : T
->key : keyof T
+>key : Extract<keyof T, string>
 >tk : T[K]
 
         tk = t[key]; // error, T[keyof T] =/=> T[K]
->tk = t[key] : T[keyof T]
+>tk = t[key] : T[Extract<keyof T, string>]
 >tk : T[K]
->t[key] : T[keyof T]
+>t[key] : T[Extract<keyof T, string>]
 >t : T
->key : keyof T
+>key : Extract<keyof T, string>
     }
     tk = uk;
 >tk = uk : U[K]

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.types
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.types
@@ -242,62 +242,128 @@ function f10(shape: Shape) {
 >10 : 10
 }
 
-function f20<T, U>(k1: keyof (T | U), k2: keyof (T & U), o1: T | U, o2: T & U) {
->f20 : <T, U>(k1: keyof (T | U), k2: keyof T | keyof U, o1: T | U, o2: T & U) => void
+function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U, k3: keyof (T & U), k4: keyof T | keyof U) {
+>f20 : <T, U>(x: T | U, y: T & U, k1: keyof T & keyof U, k2: keyof T & keyof U, k3: keyof T | keyof U, k4: keyof T | keyof U) => void
 >T : T
 >U : U
->k1 : keyof (T | U)
+>x : T | U
 >T : T
 >U : U
->k2 : keyof T | keyof U
+>y : T & U
 >T : T
 >U : U
->o1 : T | U
+>k1 : keyof T & keyof U
 >T : T
 >U : U
->o2 : T & U
+>k2 : keyof T & keyof U
+>T : T
+>U : U
+>k3 : keyof T | keyof U
+>T : T
+>U : U
+>k4 : keyof T | keyof U
 >T : T
 >U : U
 
-    o1[k1];
->o1[k1] : (T | U)[keyof (T | U)]
->o1 : T | U
->k1 : keyof (T | U)
+    x[k1];
+>x[k1] : (T | U)[keyof T & keyof U]
+>x : T | U
+>k1 : keyof T & keyof U
 
-    o1[k2];   // Error
->o1[k2] : (T | U)[keyof T | keyof U]
->o1 : T | U
->k2 : keyof T | keyof U
+    x[k2];
+>x[k2] : (T | U)[keyof T & keyof U]
+>x : T | U
+>k2 : keyof T & keyof U
 
-    o2[k1];
->o2[k1] : (T & U)[keyof (T | U)]
->o2 : T & U
->k1 : keyof (T | U)
+    x[k3];  // Error
+>x[k3] : (T | U)[keyof T | keyof U]
+>x : T | U
+>k3 : keyof T | keyof U
 
-    o2[k2];
->o2[k2] : (T & U)[keyof T | keyof U]
->o2 : T & U
->k2 : keyof T | keyof U
+    x[k4];  // Error
+>x[k4] : (T | U)[keyof T | keyof U]
+>x : T | U
+>k4 : keyof T | keyof U
 
-    o1 = o2;
->o1 = o2 : T & U
->o1 : T | U
->o2 : T & U
+    y[k1];
+>y[k1] : (T & U)[keyof T & keyof U]
+>y : T & U
+>k1 : keyof T & keyof U
 
-    o2 = o1;  // Error
->o2 = o1 : T | U
->o2 : T & U
->o1 : T | U
+    y[k2];
+>y[k2] : (T & U)[keyof T & keyof U]
+>y : T & U
+>k2 : keyof T & keyof U
 
-    k1 = k2;  // Error
->k1 = k2 : keyof T | keyof U
->k1 : keyof (T | U)
->k2 : keyof T | keyof U
+    y[k3];
+>y[k3] : (T & U)[keyof T | keyof U]
+>y : T & U
+>k3 : keyof T | keyof U
+
+    y[k4];
+>y[k4] : (T & U)[keyof T | keyof U]
+>y : T & U
+>k4 : keyof T | keyof U
+
+    k1 = k2;
+>k1 = k2 : keyof T & keyof U
+>k1 : keyof T & keyof U
+>k2 : keyof T & keyof U
+
+    k1 = k3;  // Error
+>k1 = k3 : keyof T | keyof U
+>k1 : keyof T & keyof U
+>k3 : keyof T | keyof U
+
+    k1 = k4;  // Error
+>k1 = k4 : keyof T | keyof U
+>k1 : keyof T & keyof U
+>k4 : keyof T | keyof U
 
     k2 = k1;
->k2 = k1 : keyof (T | U)
->k2 : keyof T | keyof U
->k1 : keyof (T | U)
+>k2 = k1 : keyof T & keyof U
+>k2 : keyof T & keyof U
+>k1 : keyof T & keyof U
+
+    k2 = k3;  // Error
+>k2 = k3 : keyof T | keyof U
+>k2 : keyof T & keyof U
+>k3 : keyof T | keyof U
+
+    k2 = k4;  // Error
+>k2 = k4 : keyof T | keyof U
+>k2 : keyof T & keyof U
+>k4 : keyof T | keyof U
+
+    k3 = k1;
+>k3 = k1 : keyof T & keyof U
+>k3 : keyof T | keyof U
+>k1 : keyof T & keyof U
+
+    k3 = k2;
+>k3 = k2 : keyof T & keyof U
+>k3 : keyof T | keyof U
+>k2 : keyof T & keyof U
+
+    k3 = k4;
+>k3 = k4 : keyof T | keyof U
+>k3 : keyof T | keyof U
+>k4 : keyof T | keyof U
+
+    k4 = k1;
+>k4 = k1 : keyof T & keyof U
+>k4 : keyof T | keyof U
+>k1 : keyof T & keyof U
+
+    k4 = k2;
+>k4 = k2 : keyof T & keyof U
+>k4 : keyof T | keyof U
+>k2 : keyof T & keyof U
+
+    k4 = k3;
+>k4 = k3 : keyof T | keyof U
+>k4 : keyof T | keyof U
+>k3 : keyof T | keyof U
 }
 
 // Repro from #17166

--- a/tests/baselines/reference/library_ObjectPrototypeProperties.types
+++ b/tests/baselines/reference/library_ObjectPrototypeProperties.types
@@ -34,11 +34,11 @@ Object.prototype.valueOf();
 
 Object.prototype.hasOwnProperty("string");
 >Object.prototype.hasOwnProperty("string") : boolean
->Object.prototype.hasOwnProperty : (v: string) => boolean
+>Object.prototype.hasOwnProperty : (v: string | number | symbol) => boolean
 >Object.prototype : Object
 >Object : ObjectConstructor
 >prototype : Object
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >"string" : "string"
 
 Object.prototype.isPrototypeOf(Object);
@@ -52,10 +52,10 @@ Object.prototype.isPrototypeOf(Object);
 
 Object.prototype.propertyIsEnumerable("string");
 >Object.prototype.propertyIsEnumerable("string") : boolean
->Object.prototype.propertyIsEnumerable : (v: string) => boolean
+>Object.prototype.propertyIsEnumerable : (v: string | number | symbol) => boolean
 >Object.prototype : Object
 >Object : ObjectConstructor
 >prototype : Object
->propertyIsEnumerable : (v: string) => boolean
+>propertyIsEnumerable : (v: string | number | symbol) => boolean
 >"string" : "string"
 

--- a/tests/baselines/reference/limitDeepInstantiations.errors.txt
+++ b/tests/baselines/reference/limitDeepInstantiations.errors.txt
@@ -1,8 +1,7 @@
 tests/cases/compiler/limitDeepInstantiations.ts(3,35): error TS2502: '"true"' is referenced directly or indirectly in its own type annotation.
-tests/cases/compiler/limitDeepInstantiations.ts(5,13): error TS2344: Type '"false"' does not satisfy the constraint '"true"'.
 
 
-==== tests/cases/compiler/limitDeepInstantiations.ts (2 errors) ====
+==== tests/cases/compiler/limitDeepInstantiations.ts (1 errors) ====
     // Repro from #14837
     
     type Foo<T extends "true", B> = { "true": Foo<T, Foo<T, B>> }[T];
@@ -10,6 +9,4 @@ tests/cases/compiler/limitDeepInstantiations.ts(5,13): error TS2344: Type '"fals
 !!! error TS2502: '"true"' is referenced directly or indirectly in its own type annotation.
     let f1: Foo<"true", {}>;
     let f2: Foo<"false", {}>;
-                ~~~~~~~
-!!! error TS2344: Type '"false"' does not satisfy the constraint '"true"'.
     

--- a/tests/baselines/reference/mappedTypeErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(19,20): error TS2313: Type parameter 'P' has a circular constraint.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(20,20): error TS2322: Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(21,20): error TS2322: Type 'Date' is not assignable to type 'string'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(22,19): error TS2344: Type 'Date' does not satisfy the constraint 'string'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(21,20): error TS2322: Type 'Date' is not assignable to type 'string | number | symbol'.
+  Type 'Date' is not assignable to type 'symbol'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(22,19): error TS2344: Type 'Date' does not satisfy the constraint 'string | number | symbol'.
+  Type 'Date' is not assignable to type 'symbol'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(25,24): error TS2344: Type '"foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(26,24): error TS2344: Type '"name" | "foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type '"foo"' is not assignable to type '"name" | "width" | "height" | "visible"'.
@@ -45,11 +46,12 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(129,5): error TS2322: T
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(130,5): error TS2322: Type '{ a: string; }' is not assignable to type '{ [x: string]: any; a?: number | undefined; }'.
   Types of property 'a' are incompatible.
     Type 'string' is not assignable to type 'number | undefined'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,16): error TS2322: Type 'T' is not assignable to type 'string'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,16): error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
+  Type 'T' is not assignable to type 'symbol'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,21): error TS2536: Type 'P' cannot be used to index type 'T'.
 
 
-==== tests/cases/conformance/types/mapped/mappedTypeErrors.ts (26 errors) ====
+==== tests/cases/conformance/types/mapped/mappedTypeErrors.ts (25 errors) ====
     interface Shape {
         name: string;
         width: number;
@@ -72,14 +74,14 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,21): error TS2536: 
                        ~
 !!! error TS2313: Type parameter 'P' has a circular constraint.
     type T01 = { [P in number]: string };  // Error
-                       ~~~~~~
-!!! error TS2322: Type 'number' is not assignable to type 'string'.
     type T02 = { [P in Date]: number };  // Error
                        ~~~~
-!!! error TS2322: Type 'Date' is not assignable to type 'string'.
+!!! error TS2322: Type 'Date' is not assignable to type 'string | number | symbol'.
+!!! error TS2322:   Type 'Date' is not assignable to type 'symbol'.
     type T03 = Record<Date, number>;  // Error
                       ~~~~
-!!! error TS2344: Type 'Date' does not satisfy the constraint 'string'.
+!!! error TS2344: Type 'Date' does not satisfy the constraint 'string | number | symbol'.
+!!! error TS2344:   Type 'Date' is not assignable to type 'symbol'.
     
     type T10 = Pick<Shape, "name">;
     type T11 = Pick<Shape, "foo">;  // Error
@@ -258,7 +260,8 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,21): error TS2536: 
         pf: {[P in F]?: T[P]},
         pt: {[P in T]?: T[P]}, // note: should be in keyof T
                    ~
-!!! error TS2322: Type 'T' is not assignable to type 'string'.
+!!! error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
+!!! error TS2322:   Type 'T' is not assignable to type 'symbol'.
                         ~~~~
 !!! error TS2536: Type 'P' cannot be used to index type 'T'.
     };

--- a/tests/baselines/reference/mappedTypeErrors.types
+++ b/tests/baselines/reference/mappedTypeErrors.types
@@ -373,17 +373,17 @@ function setState<T, K extends keyof T>(obj: T, props: Pick<T, K>) {
 >K : K
 
     for (let k in props) {
->k : K
+>k : Extract<K, string>
 >props : Pick<T, K>
 
         obj[k] = props[k];
->obj[k] = props[k] : Pick<T, K>[K]
->obj[k] : T[K]
+>obj[k] = props[k] : Pick<T, K>[Extract<K, string>]
+>obj[k] : T[Extract<K, string>]
 >obj : T
->k : K
->props[k] : Pick<T, K>[K]
+>k : Extract<K, string>
+>props[k] : Pick<T, K>[Extract<K, string>]
 >props : Pick<T, K>
->k : K
+>k : Extract<K, string>
     }
 }
 
@@ -468,19 +468,19 @@ class C<T> {
 >K : K
 
         for (let k in props) {
->k : K
+>k : Extract<K, string>
 >props : Pick<T, K>
 
             this.state[k] = props[k];
->this.state[k] = props[k] : Pick<T, K>[K]
->this.state[k] : T[K]
+>this.state[k] = props[k] : Pick<T, K>[Extract<K, string>]
+>this.state[k] : T[Extract<K, string>]
 >this.state : T
 >this : this
 >state : T
->k : K
->props[k] : Pick<T, K>[K]
+>k : Extract<K, string>
+>props[k] : Pick<T, K>[Extract<K, string>]
 >props : Pick<T, K>
->k : K
+>k : Extract<K, string>
         }
     }
 }

--- a/tests/baselines/reference/mappedTypeErrors2.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors2.errors.txt
@@ -1,10 +1,13 @@
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(9,30): error TS2536: Type 'K' cannot be used to index type 'T1<K>'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(13,30): error TS2536: Type 'K' cannot be used to index type 'T3'.
+tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,38): error TS2536: Type 'S' cannot be used to index type '{ [key in AB[S]]: true; }'.
+tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,47): error TS2322: Type 'AB[S]' is not assignable to type 'string | number | symbol'.
+  Type 'AB[S]' is not assignable to type 'symbol'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,47): error TS2536: Type 'S' cannot be used to index type 'AB'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(17,49): error TS2536: Type 'L' cannot be used to index type '{ [key in AB[S]]: true; }'.
 
 
-==== tests/cases/conformance/types/mapped/mappedTypeErrors2.ts (4 errors) ====
+==== tests/cases/conformance/types/mapped/mappedTypeErrors2.ts (6 errors) ====
     // Repros from #17238
     
     type AB = {
@@ -24,6 +27,11 @@ tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(17,49): error TS2536: 
 !!! error TS2536: Type 'K' cannot be used to index type 'T3'.
     
     type T5<S extends 'a'|'b'|'extra'> = {[key in AB[S]]: true}[S]; // Error
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2536: Type 'S' cannot be used to index type '{ [key in AB[S]]: true; }'.
+                                                  ~~~~~
+!!! error TS2322: Type 'AB[S]' is not assignable to type 'string | number | symbol'.
+!!! error TS2322:   Type 'AB[S]' is not assignable to type 'symbol'.
                                                   ~~~~~
 !!! error TS2536: Type 'S' cannot be used to index type 'AB'.
     

--- a/tests/baselines/reference/mappedTypeRelationships.errors.txt
+++ b/tests/baselines/reference/mappedTypeRelationships.errors.txt
@@ -10,29 +10,27 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(25,5): error TS2
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(26,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
   Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(26,12): error TS2536: Type 'K' cannot be used to index type 'T'.
-tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(30,5): error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'T[keyof T]'.
-  Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
-    Type 'undefined' is not assignable to type 'T[keyof T]'.
-tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(35,5): error TS2322: Type 'Partial<T>[K]' is not assignable to type 'T[K]'.
-  Type 'T[K] | undefined' is not assignable to type 'T[K]'.
-    Type 'undefined' is not assignable to type 'T[K]'.
-tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(40,5): error TS2322: Type 'Partial<U>[keyof T]' is not assignable to type 'T[keyof T]'.
-  Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
-    Type 'undefined' is not assignable to type 'T[keyof T]'.
-tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(45,5): error TS2322: Type 'Partial<U>[K]' is not assignable to type 'T[K]'.
-  Type 'U[K] | undefined' is not assignable to type 'T[K]'.
-    Type 'undefined' is not assignable to type 'T[K]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(30,5): error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
+  Type 'undefined' is not assignable to type 'T[keyof T]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(35,5): error TS2322: Type 'T[K] | undefined' is not assignable to type 'T[K]'.
+  Type 'undefined' is not assignable to type 'T[K]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(40,5): error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
+  Type 'undefined' is not assignable to type 'T[keyof T]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(41,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
+  Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+    Type 'T' is not assignable to type 'U'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(45,5): error TS2322: Type 'U[K] | undefined' is not assignable to type 'T[K]'.
+  Type 'undefined' is not assignable to type 'T[K]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(46,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K] | undefined'.
+  Type 'T[K]' is not assignable to type 'U[K]'.
+    Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(51,5): error TS2542: Index signature in type 'Readonly<T>' only permits reading.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(56,5): error TS2542: Index signature in type 'Readonly<T>' only permits reading.
-tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(61,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'Readonly<U>[keyof T]'.
-  Type 'T' is not assignable to type 'Readonly<U>'.
-    Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
-      Type 'T' is not assignable to type 'U'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(61,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+  Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(61,5): error TS2542: Index signature in type 'Readonly<U>' only permits reading.
-tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(66,5): error TS2322: Type 'T[K]' is not assignable to type 'Readonly<U>[K]'.
-  Type 'T' is not assignable to type 'Readonly<U>'.
-    Type 'T[K]' is not assignable to type 'U[K]'.
-      Type 'T' is not assignable to type 'U'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(66,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
+  Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(66,5): error TS2542: Index signature in type 'Readonly<U>' only permits reading.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(72,5): error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(78,5): error TS2322: Type 'Partial<Thing>' is not assignable to type 'Partial<T>'.
@@ -43,18 +41,26 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(143,5): error TS
     Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(148,5): error TS2322: Type '{ [P in keyof T]: T[P]; }' is not assignable to type '{ [P in keyof U]: U[P]; }'.
   Type 'keyof U' is not assignable to type 'keyof T'.
+    Type 'string | number | symbol' is not assignable to type 'keyof T'.
+      Type 'string' is not assignable to type 'keyof T'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(153,5): error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof T]: T[P]; }'.
   Type 'keyof T' is not assignable to type 'K'.
+    Type 'string | number | symbol' is not assignable to type 'K'.
+      Type 'string' is not assignable to type 'K'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(158,5): error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof U]: U[P]; }'.
   Type 'keyof U' is not assignable to type 'K'.
+    Type 'string | number | symbol' is not assignable to type 'K'.
+      Type 'string' is not assignable to type 'K'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(163,5): error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof T]: U[P]; }'.
   Type 'keyof T' is not assignable to type 'K'.
+    Type 'string | number | symbol' is not assignable to type 'K'.
+      Type 'string' is not assignable to type 'K'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in K]: U[P]; }'.
   Type 'T[P]' is not assignable to type 'U[P]'.
     Type 'T' is not assignable to type 'U'.
 
 
-==== tests/cases/conformance/types/mapped/mappedTypeRelationships.ts (28 errors) ====
+==== tests/cases/conformance/types/mapped/mappedTypeRelationships.ts (30 errors) ====
     function f1<T>(x: T, k: keyof T) {
         return x[k];
     }
@@ -106,37 +112,41 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
     function f10<T>(x: T, y: Partial<T>, k: keyof T) {
         x[k] = y[k];  // Error
         ~~~~
-!!! error TS2322: Type 'Partial<T>[keyof T]' is not assignable to type 'T[keyof T]'.
-!!! error TS2322:   Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
-!!! error TS2322:     Type 'undefined' is not assignable to type 'T[keyof T]'.
+!!! error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'T[keyof T]'.
         y[k] = x[k];
     }
     
     function f11<T, K extends keyof T>(x: T, y: Partial<T>, k: K) {
         x[k] = y[k];  // Error
         ~~~~
-!!! error TS2322: Type 'Partial<T>[K]' is not assignable to type 'T[K]'.
-!!! error TS2322:   Type 'T[K] | undefined' is not assignable to type 'T[K]'.
-!!! error TS2322:     Type 'undefined' is not assignable to type 'T[K]'.
+!!! error TS2322: Type 'T[K] | undefined' is not assignable to type 'T[K]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'T[K]'.
         y[k] = x[k];
     }
     
     function f12<T, U extends T>(x: T, y: Partial<U>, k: keyof T) {
         x[k] = y[k];  // Error
         ~~~~
-!!! error TS2322: Type 'Partial<U>[keyof T]' is not assignable to type 'T[keyof T]'.
-!!! error TS2322:   Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
-!!! error TS2322:     Type 'undefined' is not assignable to type 'T[keyof T]'.
+!!! error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'T[keyof T]'.
         y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
+!!! error TS2322:   Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+!!! error TS2322:     Type 'T' is not assignable to type 'U'.
     }
     
     function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K) {
         x[k] = y[k];  // Error
         ~~~~
-!!! error TS2322: Type 'Partial<U>[K]' is not assignable to type 'T[K]'.
-!!! error TS2322:   Type 'U[K] | undefined' is not assignable to type 'T[K]'.
-!!! error TS2322:     Type 'undefined' is not assignable to type 'T[K]'.
+!!! error TS2322: Type 'U[K] | undefined' is not assignable to type 'T[K]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'T[K]'.
         y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'T[K]' is not assignable to type 'U[K] | undefined'.
+!!! error TS2322:   Type 'T[K]' is not assignable to type 'U[K]'.
+!!! error TS2322:     Type 'T' is not assignable to type 'U'.
     }
     
     function f20<T>(x: T, y: Readonly<T>, k: keyof T) {
@@ -157,10 +167,8 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
         x[k] = y[k];
         y[k] = x[k];  // Error
         ~~~~
-!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'Readonly<U>[keyof T]'.
-!!! error TS2322:   Type 'T' is not assignable to type 'Readonly<U>'.
-!!! error TS2322:     Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
-!!! error TS2322:       Type 'T' is not assignable to type 'U'.
+!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'U'.
         ~~~~
 !!! error TS2542: Index signature in type 'Readonly<U>' only permits reading.
     }
@@ -169,10 +177,8 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
         x[k] = y[k];
         y[k] = x[k];  // Error
         ~~~~
-!!! error TS2322: Type 'T[K]' is not assignable to type 'Readonly<U>[K]'.
-!!! error TS2322:   Type 'T' is not assignable to type 'Readonly<U>'.
-!!! error TS2322:     Type 'T[K]' is not assignable to type 'U[K]'.
-!!! error TS2322:       Type 'T' is not assignable to type 'U'.
+!!! error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'U'.
         ~~~~
 !!! error TS2542: Index signature in type 'Readonly<U>' only permits reading.
     }
@@ -272,6 +278,8 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
         ~
 !!! error TS2322: Type '{ [P in keyof T]: T[P]; }' is not assignable to type '{ [P in keyof U]: U[P]; }'.
 !!! error TS2322:   Type 'keyof U' is not assignable to type 'keyof T'.
+!!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'keyof T'.
+!!! error TS2322:       Type 'string' is not assignable to type 'keyof T'.
     }
     
     function f73<T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in keyof T]: T[P] }) {
@@ -280,6 +288,8 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
         ~
 !!! error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof T]: T[P]; }'.
 !!! error TS2322:   Type 'keyof T' is not assignable to type 'K'.
+!!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'K'.
+!!! error TS2322:       Type 'string' is not assignable to type 'K'.
     }
     
     function f74<T, U extends T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in keyof U]: U[P] }) {
@@ -288,6 +298,8 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
         ~
 !!! error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof U]: U[P]; }'.
 !!! error TS2322:   Type 'keyof U' is not assignable to type 'K'.
+!!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'K'.
+!!! error TS2322:       Type 'string' is not assignable to type 'K'.
     }
     
     function f75<T, U extends T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in keyof T]: U[P] }) {
@@ -296,6 +308,8 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
         ~
 !!! error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof T]: U[P]; }'.
 !!! error TS2322:   Type 'keyof T' is not assignable to type 'K'.
+!!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'K'.
+!!! error TS2322:       Type 'string' is not assignable to type 'K'.
     }
     
     function f76<T, U extends T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in K]: U[P] }) {

--- a/tests/baselines/reference/mappedTypeWithAny.types
+++ b/tests/baselines/reference/mappedTypeWithAny.types
@@ -11,7 +11,7 @@ type ItemMap<T> = { [P in keyof T]: Item };
 >Item : Item
 
 declare let x0: keyof any;
->x0 : string
+>x0 : string | number | symbol
 
 declare let x1: { [P in any]: Item };
 >x1 : { [x: string]: Item; }

--- a/tests/baselines/reference/mappedTypes4.types
+++ b/tests/baselines/reference/mappedTypes4.types
@@ -40,19 +40,19 @@ function boxify<T>(obj: T): Boxified<T> {
 >T : T
 
         for (let k in obj) {
->k : keyof T
+>k : Extract<keyof T, string>
 >obj : T
 
             result[k] = { value: obj[k] };
->result[k] = { value: obj[k] } : { value: T[keyof T]; }
->result[k] : Boxified<T>[keyof T]
+>result[k] = { value: obj[k] } : { value: T[Extract<keyof T, string>]; }
+>result[k] : Boxified<T>[Extract<keyof T, string>]
 >result : Boxified<T>
->k : keyof T
->{ value: obj[k] } : { value: T[keyof T]; }
->value : T[keyof T]
->obj[k] : T[keyof T]
+>k : Extract<keyof T, string>
+>{ value: obj[k] } : { value: T[Extract<keyof T, string>]; }
+>value : T[Extract<keyof T, string>]
+>obj[k] : T[Extract<keyof T, string>]
 >obj : T
->k : keyof T
+>k : Extract<keyof T, string>
         }
         return result;
 >result : Boxified<T>

--- a/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6ArrayWithOnlyES6ArrayLib.errors.txt
+++ b/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6ArrayWithOnlyES6ArrayLib.errors.txt
@@ -1,12 +1,14 @@
 error TS2318: Cannot find global type 'Boolean'.
 error TS2318: Cannot find global type 'IArguments'.
 error TS2318: Cannot find global type 'Number'.
+error TS2318: Cannot find global type 'Object'.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6ArrayWithOnlyES6ArrayLib.ts(3,12): error TS2693: 'Array' only refers to a type, but is being used as a value here.
 
 
 !!! error TS2318: Cannot find global type 'Boolean'.
 !!! error TS2318: Cannot find global type 'IArguments'.
 !!! error TS2318: Cannot find global type 'Number'.
+!!! error TS2318: Cannot find global type 'Object'.
 ==== tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6ArrayWithOnlyES6ArrayLib.ts (1 errors) ====
     // Error missing basic JavaScript objects
     function f(x: number, y: number, z: number) {

--- a/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.types
+++ b/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.types
@@ -80,9 +80,9 @@ var o = {
 };
 o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty(Symbol.hasInstance) : boolean
->o.hasOwnProperty : (v: string) => boolean
+>o.hasOwnProperty : (v: string | number | symbol) => boolean
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >Symbol.hasInstance : any
 >Symbol : any
 >hasInstance : any

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.symbols
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.symbols
@@ -100,9 +100,9 @@ var o = {
     }
 };
 o.hasOwnProperty(Symbol.hasInstance);
->o.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>o.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >o : Symbol(o, Decl(modularizeLibrary_NoErrorDuplicateLibOptions1.ts, 38, 3))
->hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.types
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.types
@@ -124,9 +124,9 @@ var o = {
 };
 o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty(Symbol.hasInstance) : boolean
->o.hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
+>o.hasOwnProperty : (v: string | number | symbol) => boolean
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
->hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >Symbol.hasInstance : symbol
 >Symbol : SymbolConstructor
 >hasInstance : symbol

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.symbols
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.symbols
@@ -100,9 +100,9 @@ var o = {
     }
 };
 o.hasOwnProperty(Symbol.hasInstance);
->o.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>o.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >o : Symbol(o, Decl(modularizeLibrary_NoErrorDuplicateLibOptions2.ts, 38, 3))
->hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.types
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.types
@@ -124,9 +124,9 @@ var o = {
 };
 o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty(Symbol.hasInstance) : boolean
->o.hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
+>o.hasOwnProperty : (v: string | number | symbol) => boolean
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
->hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >Symbol.hasInstance : symbol
 >Symbol : SymbolConstructor
 >hasInstance : symbol

--- a/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.symbols
+++ b/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.symbols
@@ -100,9 +100,9 @@ var o = {
     }
 };
 o.hasOwnProperty(Symbol.hasInstance);
->o.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>o.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >o : Symbol(o, Decl(modularizeLibrary_TargetES5UsingES6Lib.ts, 38, 3))
->hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))

--- a/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.types
+++ b/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.types
@@ -124,9 +124,9 @@ var o = {
 };
 o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty(Symbol.hasInstance) : boolean
->o.hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
+>o.hasOwnProperty : (v: string | number | symbol) => boolean
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
->hasOwnProperty : { (v: PropertyKey): boolean; (v: string): boolean; }
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >Symbol.hasInstance : symbol
 >Symbol : SymbolConstructor
 >hasInstance : symbol

--- a/tests/baselines/reference/modularizeLibrary_TargetES6UsingES6Lib.symbols
+++ b/tests/baselines/reference/modularizeLibrary_TargetES6UsingES6Lib.symbols
@@ -65,9 +65,9 @@ var o = {
     }
 };
 o.hasOwnProperty(Symbol.hasInstance);
->o.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>o.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >o : Symbol(o, Decl(modularizeLibrary_TargetES6UsingES6Lib.ts, 21, 3))
->hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))

--- a/tests/baselines/reference/modularizeLibrary_TargetES6UsingES6Lib.types
+++ b/tests/baselines/reference/modularizeLibrary_TargetES6UsingES6Lib.types
@@ -79,9 +79,9 @@ var o = {
 };
 o.hasOwnProperty(Symbol.hasInstance);
 >o.hasOwnProperty(Symbol.hasInstance) : boolean
->o.hasOwnProperty : { (v: string): boolean; (v: PropertyKey): boolean; }
+>o.hasOwnProperty : (v: string | number | symbol) => boolean
 >o : { a: number; [Symbol.hasInstance](value: any): boolean; }
->hasOwnProperty : { (v: string): boolean; (v: PropertyKey): boolean; }
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >Symbol.hasInstance : symbol
 >Symbol : SymbolConstructor
 >hasInstance : symbol

--- a/tests/baselines/reference/modularizeLibrary_UsingES5LibAndES6FeatureLibs.types
+++ b/tests/baselines/reference/modularizeLibrary_UsingES5LibAndES6FeatureLibs.types
@@ -16,10 +16,10 @@ var p = new Proxy(t, {});
 >{} : {}
 
 Reflect.ownKeys({});
->Reflect.ownKeys({}) : PropertyKey[]
->Reflect.ownKeys : (target: object) => PropertyKey[]
+>Reflect.ownKeys({}) : (string | number | symbol)[]
+>Reflect.ownKeys : (target: object) => (string | number | symbol)[]
 >Reflect : typeof Reflect
->ownKeys : (target: object) => PropertyKey[]
+>ownKeys : (target: object) => (string | number | symbol)[]
 >{} : {}
 
 function* idGen() {

--- a/tests/baselines/reference/numberPropertyAccess.types
+++ b/tests/baselines/reference/numberPropertyAccess.types
@@ -13,9 +13,9 @@ var a = x.toExponential();
 var b = x.hasOwnProperty('toFixed');
 >b : boolean
 >x.hasOwnProperty('toFixed') : boolean
->x.hasOwnProperty : (v: string) => boolean
+>x.hasOwnProperty : (v: string | number | symbol) => boolean
 >x : number
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >'toFixed' : "toFixed"
 
 var c = x['toExponential']();
@@ -28,7 +28,7 @@ var c = x['toExponential']();
 var d = x['hasOwnProperty']('toFixed');
 >d : boolean
 >x['hasOwnProperty']('toFixed') : boolean
->x['hasOwnProperty'] : (v: string) => boolean
+>x['hasOwnProperty'] : (v: string | number | symbol) => boolean
 >x : number
 >'hasOwnProperty' : "hasOwnProperty"
 >'toFixed' : "toFixed"

--- a/tests/baselines/reference/objectLitGetterSetter.types
+++ b/tests/baselines/reference/objectLitGetterSetter.types
@@ -5,9 +5,9 @@
 
             Object.defineProperty(obj, "accProperty", <PropertyDescriptor>({
 >Object.defineProperty(obj, "accProperty", <PropertyDescriptor>({                get: function () {                    eval("public = 1;");                    return 11;                },                set: function (v) {                }            })) : any
->Object.defineProperty : (o: any, p: string, attributes: PropertyDescriptor & ThisType<any>) => any
+>Object.defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
 >Object : ObjectConstructor
->defineProperty : (o: any, p: string, attributes: PropertyDescriptor & ThisType<any>) => any
+>defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
 >obj : {}
 >"accProperty" : "accProperty"
 ><PropertyDescriptor>({                get: function () {                    eval("public = 1;");                    return 11;                },                set: function (v) {                }            }) : PropertyDescriptor

--- a/tests/baselines/reference/objectLiteralNormalization.symbols
+++ b/tests/baselines/reference/objectLiteralNormalization.symbols
@@ -15,14 +15,14 @@ a1.a;  // number
 >a : Symbol(a, Decl(objectLiteralNormalization.ts, 1, 11), Decl(objectLiteralNormalization.ts, 1, 21), Decl(objectLiteralNormalization.ts, 1, 39))
 
 a1.b;  // string | undefined
->a1.b : Symbol(b, Decl(objectLiteralNormalization.ts, 1, 27), Decl(objectLiteralNormalization.ts, 1, 45))
+>a1.b : Symbol(b, Decl(objectLiteralNormalization.ts, 1, 45), Decl(objectLiteralNormalization.ts, 1, 27), Decl(objectLiteralNormalization.ts, 1, 45))
 >a1 : Symbol(a1, Decl(objectLiteralNormalization.ts, 1, 3))
->b : Symbol(b, Decl(objectLiteralNormalization.ts, 1, 27), Decl(objectLiteralNormalization.ts, 1, 45))
+>b : Symbol(b, Decl(objectLiteralNormalization.ts, 1, 45), Decl(objectLiteralNormalization.ts, 1, 27), Decl(objectLiteralNormalization.ts, 1, 45))
 
 a1.c;  // boolean | undefined
->a1.c : Symbol(c, Decl(objectLiteralNormalization.ts, 1, 53))
+>a1.c : Symbol(c, Decl(objectLiteralNormalization.ts, 1, 53), Decl(objectLiteralNormalization.ts, 1, 53))
 >a1 : Symbol(a1, Decl(objectLiteralNormalization.ts, 1, 3))
->c : Symbol(c, Decl(objectLiteralNormalization.ts, 1, 53))
+>c : Symbol(c, Decl(objectLiteralNormalization.ts, 1, 53), Decl(objectLiteralNormalization.ts, 1, 53))
 
 a1 = { a: 1 };
 >a1 : Symbol(a1, Decl(objectLiteralNormalization.ts, 1, 3))
@@ -48,14 +48,14 @@ let a2 = [{ a: 1, b: 2 }, { a: "abc" }, {}][0];
 >a : Symbol(a, Decl(objectLiteralNormalization.ts, 10, 27))
 
 a2.a;  // string | number | undefined
->a2.a : Symbol(a, Decl(objectLiteralNormalization.ts, 10, 11), Decl(objectLiteralNormalization.ts, 10, 27))
+>a2.a : Symbol(a, Decl(objectLiteralNormalization.ts, 10, 11), Decl(objectLiteralNormalization.ts, 10, 27), Decl(objectLiteralNormalization.ts, 10, 27))
 >a2 : Symbol(a2, Decl(objectLiteralNormalization.ts, 10, 3))
->a : Symbol(a, Decl(objectLiteralNormalization.ts, 10, 11), Decl(objectLiteralNormalization.ts, 10, 27))
+>a : Symbol(a, Decl(objectLiteralNormalization.ts, 10, 11), Decl(objectLiteralNormalization.ts, 10, 27), Decl(objectLiteralNormalization.ts, 10, 27))
 
 a2.b;  // number | undefined
->a2.b : Symbol(b, Decl(objectLiteralNormalization.ts, 10, 17))
+>a2.b : Symbol(b, Decl(objectLiteralNormalization.ts, 10, 17), Decl(objectLiteralNormalization.ts, 1, 45))
 >a2 : Symbol(a2, Decl(objectLiteralNormalization.ts, 10, 3))
->b : Symbol(b, Decl(objectLiteralNormalization.ts, 10, 17))
+>b : Symbol(b, Decl(objectLiteralNormalization.ts, 10, 17), Decl(objectLiteralNormalization.ts, 1, 45))
 
 a2 = { a: 10, b: 20 };
 >a2 : Symbol(a2, Decl(objectLiteralNormalization.ts, 10, 3))
@@ -144,32 +144,32 @@ d1.pos;
 >pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
 
 d1.pos.x;
->d1.pos.x : Symbol(x, Decl(objectLiteralNormalization.ts, 33, 29))
+>d1.pos.x : Symbol(x, Decl(objectLiteralNormalization.ts, 33, 29), Decl(objectLiteralNormalization.ts, 33, 29))
 >d1.pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
 >d1 : Symbol(d1, Decl(objectLiteralNormalization.ts, 33, 3))
 >pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
->x : Symbol(x, Decl(objectLiteralNormalization.ts, 33, 29))
+>x : Symbol(x, Decl(objectLiteralNormalization.ts, 33, 29), Decl(objectLiteralNormalization.ts, 33, 29))
 
 d1.pos.y;
->d1.pos.y : Symbol(y, Decl(objectLiteralNormalization.ts, 33, 35))
+>d1.pos.y : Symbol(y, Decl(objectLiteralNormalization.ts, 33, 35), Decl(objectLiteralNormalization.ts, 33, 35))
 >d1.pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
 >d1 : Symbol(d1, Decl(objectLiteralNormalization.ts, 33, 3))
 >pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
->y : Symbol(y, Decl(objectLiteralNormalization.ts, 33, 35))
+>y : Symbol(y, Decl(objectLiteralNormalization.ts, 33, 35), Decl(objectLiteralNormalization.ts, 33, 35))
 
 d1.pos.a;
->d1.pos.a : Symbol(a, Decl(objectLiteralNormalization.ts, 33, 73))
+>d1.pos.a : Symbol(a, Decl(objectLiteralNormalization.ts, 10, 27), Decl(objectLiteralNormalization.ts, 33, 73))
 >d1.pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
 >d1 : Symbol(d1, Decl(objectLiteralNormalization.ts, 33, 3))
 >pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
->a : Symbol(a, Decl(objectLiteralNormalization.ts, 33, 73))
+>a : Symbol(a, Decl(objectLiteralNormalization.ts, 10, 27), Decl(objectLiteralNormalization.ts, 33, 73))
 
 d1.pos.b;
->d1.pos.b : Symbol(b, Decl(objectLiteralNormalization.ts, 33, 86))
+>d1.pos.b : Symbol(b, Decl(objectLiteralNormalization.ts, 1, 45), Decl(objectLiteralNormalization.ts, 33, 86))
 >d1.pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
 >d1 : Symbol(d1, Decl(objectLiteralNormalization.ts, 33, 3))
 >pos : Symbol(pos, Decl(objectLiteralNormalization.ts, 33, 22), Decl(objectLiteralNormalization.ts, 33, 58))
->b : Symbol(b, Decl(objectLiteralNormalization.ts, 33, 86))
+>b : Symbol(b, Decl(objectLiteralNormalization.ts, 1, 45), Decl(objectLiteralNormalization.ts, 33, 86))
 
 declare function f<T>(...items: T[]): T;
 >f : Symbol(f, Decl(objectLiteralNormalization.ts, 39, 9))

--- a/tests/baselines/reference/objectTypeHidingMembersOfExtendedObject.errors.txt
+++ b/tests/baselines/reference/objectTypeHidingMembersOfExtendedObject.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'constructor' of type 'Function' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'data' of type 'A' is not assignable to string index type 'Object'.
-tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'hasOwnProperty' of type '(v: string) => boolean' is not assignable to string index type 'Object'.
+tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'hasOwnProperty' of type '(v: string | number | symbol) => boolean' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'isPrototypeOf' of type '(v: Object) => boolean' is not assignable to string index type 'Object'.
-tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'propertyIsEnumerable' of type '(v: string) => boolean' is not assignable to string index type 'Object'.
+tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'propertyIsEnumerable' of type '(v: string | number | symbol) => boolean' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'toLocaleString' of type '() => string' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'toString' of type '() => string' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(11,5): error TS2411: Property 'valueOf' of type '() => Object' is not assignable to string index type 'Object'.
@@ -25,11 +25,11 @@ tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2411: Property 'data' of type 'A' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2411: Property 'hasOwnProperty' of type '(v: string) => boolean' is not assignable to string index type 'Object'.
+!!! error TS2411: Property 'hasOwnProperty' of type '(v: string | number | symbol) => boolean' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2411: Property 'isPrototypeOf' of type '(v: Object) => boolean' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2411: Property 'propertyIsEnumerable' of type '(v: string) => boolean' is not assignable to string index type 'Object'.
+!!! error TS2411: Property 'propertyIsEnumerable' of type '(v: string | number | symbol) => boolean' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2411: Property 'toLocaleString' of type '() => string' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/objectTypeWithStringIndexerHidingObjectIndexer.errors.txt
+++ b/tests/baselines/reference/objectTypeWithStringIndexerHidingObjectIndexer.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'constructor' of type 'Function' is not assignable to string index type 'Object'.
-tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'hasOwnProperty' of type '(v: string) => boolean' is not assignable to string index type 'Object'.
+tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'hasOwnProperty' of type '(v: string | number | symbol) => boolean' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'isPrototypeOf' of type '(v: Object) => boolean' is not assignable to string index type 'Object'.
-tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'propertyIsEnumerable' of type '(v: string) => boolean' is not assignable to string index type 'Object'.
+tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'propertyIsEnumerable' of type '(v: string | number | symbol) => boolean' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'toLocaleString' of type '() => string' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'toString' of type '() => string' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts(5,5): error TS2411: Property 'valueOf' of type '() => Object' is not assignable to string index type 'Object'.
@@ -16,11 +16,11 @@ tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectInd
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2411: Property 'constructor' of type 'Function' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2411: Property 'hasOwnProperty' of type '(v: string) => boolean' is not assignable to string index type 'Object'.
+!!! error TS2411: Property 'hasOwnProperty' of type '(v: string | number | symbol) => boolean' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2411: Property 'isPrototypeOf' of type '(v: Object) => boolean' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2411: Property 'propertyIsEnumerable' of type '(v: string) => boolean' is not assignable to string index type 'Object'.
+!!! error TS2411: Property 'propertyIsEnumerable' of type '(v: string | number | symbol) => boolean' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2411: Property 'toLocaleString' of type '() => string' is not assignable to string index type 'Object'.
         ~~~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/parserComputedPropertyName41.types
+++ b/tests/baselines/reference/parserComputedPropertyName41.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName41.ts ===
 var v = {
->v : { [x: string]: boolean; }
->{    [0 in []]: true} : { [x: string]: boolean; }
+>v : {}
+>{    [0 in []]: true} : {}
 
     [0 in []]: true
 >[0 in []] : boolean

--- a/tests/baselines/reference/parserUsingConstructorAsIdentifier.types
+++ b/tests/baselines/reference/parserUsingConstructorAsIdentifier.types
@@ -90,9 +90,9 @@
 
                 Object.defineProperty(constructor.prototype, "constructor", { value: constructor, writable: true, configurable: true, enumerable: true });
 >Object.defineProperty(constructor.prototype, "constructor", { value: constructor, writable: true, configurable: true, enumerable: true }) : any
->Object.defineProperty : (o: any, p: string, attributes: PropertyDescriptor & ThisType<any>) => any
+>Object.defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
 >Object : ObjectConstructor
->defineProperty : (o: any, p: string, attributes: PropertyDescriptor & ThisType<any>) => any
+>defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
 >constructor.prototype : any
 >constructor : any
 >prototype : any

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -2810,11 +2810,11 @@ module Harness {
 
                     if (this.fileCollection.hasOwnProperty(p)) {
 >this.fileCollection.hasOwnProperty(p) : boolean
->this.fileCollection.hasOwnProperty : (v: string) => boolean
+>this.fileCollection.hasOwnProperty : (v: string | number | symbol) => boolean
 >this.fileCollection : {}
 >this : this
 >fileCollection : {}
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >p : string
 
                         var current = <Harness.Compiler.WriterAggregator>this.fileCollection[p];

--- a/tests/baselines/reference/propertyAccess.types
+++ b/tests/baselines/reference/propertyAccess.types
@@ -139,10 +139,10 @@ var aa = obj.x;
 
 // Dotted property access of property that exists on value's apparent type
 var bb = obj.hasOwnProperty;
->bb : (v: string) => boolean
->obj.hasOwnProperty : (v: string) => boolean
+>bb : (v: string | number | symbol) => boolean
+>obj.hasOwnProperty : (v: string | number | symbol) => boolean
 >obj : { 10: string; x: string; y: number; z: { n: string; m: number; o: () => boolean; }; 'literal property': number; }
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 
 // Dotted property access of property that doesn't exist on value's apparent type
 var cc = obj.qqq; // error

--- a/tests/baselines/reference/recursiveTypeRelations.errors.txt
+++ b/tests/baselines/reference/recursiveTypeRelations.errors.txt
@@ -6,7 +6,7 @@ tests/cases/compiler/recursiveTypeRelations.ts(27,61): error TS2304: Cannot find
 ==== tests/cases/compiler/recursiveTypeRelations.ts (3 errors) ====
     // Repro from #14896
     
-    type Attributes<Keys extends string> = {
+    type Attributes<Keys extends keyof any> = {
         [Key in Keys]: string;
     }
     

--- a/tests/baselines/reference/recursiveTypeRelations.js
+++ b/tests/baselines/reference/recursiveTypeRelations.js
@@ -1,7 +1,7 @@
 //// [recursiveTypeRelations.ts]
 // Repro from #14896
 
-type Attributes<Keys extends string> = {
+type Attributes<Keys extends keyof any> = {
     [Key in Keys]: string;
 }
 

--- a/tests/baselines/reference/recursiveTypeRelations.symbols
+++ b/tests/baselines/reference/recursiveTypeRelations.symbols
@@ -1,7 +1,7 @@
 === tests/cases/compiler/recursiveTypeRelations.ts ===
 // Repro from #14896
 
-type Attributes<Keys extends string> = {
+type Attributes<Keys extends keyof any> = {
 >Attributes : Symbol(Attributes, Decl(recursiveTypeRelations.ts, 0, 0))
 >Keys : Symbol(Keys, Decl(recursiveTypeRelations.ts, 2, 16))
 

--- a/tests/baselines/reference/recursiveTypeRelations.types
+++ b/tests/baselines/reference/recursiveTypeRelations.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/recursiveTypeRelations.ts ===
 // Repro from #14896
 
-type Attributes<Keys extends string> = {
+type Attributes<Keys extends keyof any> = {
 >Attributes : { [Key in Keys]: string; }
 >Keys : Keys
 
@@ -97,7 +97,7 @@ export function css<S extends { [K in keyof S]: string }>(styles: S, ...classNam
     if (typeof arg == "object") {
 >typeof arg == "object" : boolean
 >typeof arg : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
->arg : object & { [K in keyof S]?: boolean; }
+>arg : keyof S | (object & { [K in keyof S]?: boolean; })
 >"object" : "object"
 
       return Object.keys(arg).reduce<ClassNameObject>((obj: ClassNameObject, key: keyof S) => {

--- a/tests/baselines/reference/staticInstanceResolution2.types
+++ b/tests/baselines/reference/staticInstanceResolution2.types
@@ -4,9 +4,9 @@ class A { }
 
 A.hasOwnProperty('foo');
 >A.hasOwnProperty('foo') : boolean
->A.hasOwnProperty : (v: string) => boolean
+>A.hasOwnProperty : (v: string | number | symbol) => boolean
 >A : typeof A
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >'foo' : "foo"
 
 class B {
@@ -16,9 +16,9 @@ class B {
 }
 B.hasOwnProperty('foo');
 >B.hasOwnProperty('foo') : boolean
->B.hasOwnProperty : (v: string) => boolean
+>B.hasOwnProperty : (v: string | number | symbol) => boolean
 >B : typeof B
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >'foo' : "foo"
 
 

--- a/tests/baselines/reference/stringPropertyAccess.types
+++ b/tests/baselines/reference/stringPropertyAccess.types
@@ -14,9 +14,9 @@ var a = x.charAt(0);
 var b = x.hasOwnProperty('charAt');
 >b : boolean
 >x.hasOwnProperty('charAt') : boolean
->x.hasOwnProperty : (v: string) => boolean
+>x.hasOwnProperty : (v: string | number | symbol) => boolean
 >x : string
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >'charAt' : "charAt"
 
 var c = x['charAt'](0);
@@ -30,7 +30,7 @@ var c = x['charAt'](0);
 var e = x['hasOwnProperty']('toFixed');
 >e : boolean
 >x['hasOwnProperty']('toFixed') : boolean
->x['hasOwnProperty'] : (v: string) => boolean
+>x['hasOwnProperty'] : (v: string | number | symbol) => boolean
 >x : string
 >'hasOwnProperty' : "hasOwnProperty"
 >'toFixed' : "toFixed"

--- a/tests/baselines/reference/switchCaseWithIntersectionTypes01.errors.txt
+++ b/tests/baselines/reference/switchCaseWithIntersectionTypes01.errors.txt
@@ -1,10 +1,7 @@
-tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts(18,10): error TS2678: Type '(number & true) | (number & false)' is not comparable to type 'string & number'.
-  Type 'number & false' is not comparable to type 'string & number'.
-    Type 'number & false' is not comparable to type 'string'.
 tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts(22,10): error TS2678: Type 'boolean' is not comparable to type 'string & number'.
 
 
-==== tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts (2 errors) ====
+==== tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts (1 errors) ====
     var strAndNum: string & number;
     var numAndBool: number & boolean;
     var str: string;
@@ -23,10 +20,6 @@ tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithInterse
     
         // Overlap in constituents
         case numAndBool:
-             ~~~~~~~~~~
-!!! error TS2678: Type '(number & true) | (number & false)' is not comparable to type 'string & number'.
-!!! error TS2678:   Type 'number & false' is not comparable to type 'string & number'.
-!!! error TS2678:     Type 'number & false' is not comparable to type 'string'.
             break;
     
         // No relation

--- a/tests/baselines/reference/switchCaseWithIntersectionTypes01.types
+++ b/tests/baselines/reference/switchCaseWithIntersectionTypes01.types
@@ -3,7 +3,7 @@ var strAndNum: string & number;
 >strAndNum : string & number
 
 var numAndBool: number & boolean;
->numAndBool : (number & true) | (number & false)
+>numAndBool : never
 
 var str: string;
 >str : string
@@ -34,7 +34,7 @@ switch (strAndNum) {
 
     // Overlap in constituents
     case numAndBool:
->numAndBool : (number & true) | (number & false)
+>numAndBool : never
 
         break;
 

--- a/tests/baselines/reference/symbolProperty3.types
+++ b/tests/baselines/reference/symbolProperty3.types
@@ -4,8 +4,8 @@ var s = Symbol;
 >Symbol : SymbolConstructor
 
 var x = {
->x : { [x: string]: number | (() => void); }
->{    [s]: 0,    [s]() { },    get [s]() {        return 0;    }} : { [x: string]: number | (() => void); }
+>x : {}
+>{    [s]: 0,    [s]() { },    get [s]() {        return 0;    }} : {}
 
     [s]: 0,
 >[s] : number

--- a/tests/baselines/reference/symbolType1.symbols
+++ b/tests/baselines/reference/symbolType1.symbols
@@ -9,7 +9,7 @@ Symbol instanceof Symbol();
 
 (Symbol() || {}) instanceof Object; // This one should be okay, it's a valid way of distinguishing types
 >Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 Symbol instanceof (Symbol() || {});
 >Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))

--- a/tests/baselines/reference/typeGuardsTypeParameters.types
+++ b/tests/baselines/reference/typeGuardsTypeParameters.types
@@ -80,19 +80,19 @@ function fun<T>(item: { [P in keyof T]: T[P] }) {
 >[] : never[]
 
     for (const key in item) {
->key : keyof T
+>key : Extract<keyof T, string>
 >item : { [P in keyof T]: T[P]; }
 
         const value = item[key];
->value : { [P in keyof T]: T[P]; }[keyof T]
->item[key] : { [P in keyof T]: T[P]; }[keyof T]
+>value : { [P in keyof T]: T[P]; }[Extract<keyof T, string>]
+>item[key] : { [P in keyof T]: T[P]; }[Extract<keyof T, string>]
 >item : { [P in keyof T]: T[P]; }
->key : keyof T
+>key : Extract<keyof T, string>
 
         if (typeof value === "string") {
 >typeof value === "string" : boolean
 >typeof value : "string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"
->value : { [P in keyof T]: T[P]; }[keyof T]
+>value : { [P in keyof T]: T[P]; }[Extract<keyof T, string>]
 >"string" : "string"
 
             strings.push(value);
@@ -100,7 +100,7 @@ function fun<T>(item: { [P in keyof T]: T[P] }) {
 >strings.push : (...items: string[]) => number
 >strings : string[]
 >push : (...items: string[]) => number
->value : { [P in keyof T]: T[P]; }[keyof T] & string
+>value : { [P in keyof T]: T[P]; }[Extract<keyof T, string>] & string
         }
     }
 }

--- a/tests/baselines/reference/typeGuardsWithInstanceOf.types
+++ b/tests/baselines/reference/typeGuardsWithInstanceOf.types
@@ -25,7 +25,7 @@ if (!(result instanceof RegExp)) {
 
 } else if (!result.global) {
 >!result.global : boolean
->result.global : (string & true) | (string & false)
+>result.global : never
 >result : I & RegExp
->global : (string & true) | (string & false)
+>global : never
 }

--- a/tests/baselines/reference/typePredicateStructuralMatch.types
+++ b/tests/baselines/reference/typePredicateStructuralMatch.types
@@ -46,9 +46,9 @@ function isResponseInData<T>(value: T | { data: T}): value is { data: T } {
 
     return value.hasOwnProperty('data');
 >value.hasOwnProperty('data') : boolean
->value.hasOwnProperty : (v: string) => boolean
+>value.hasOwnProperty : (v: string | number | symbol) => boolean
 >value : T | { data: T; }
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >'data' : "data"
 }
 
@@ -84,9 +84,9 @@ function isPlainResponse<T>(value: T | { data: T}): value is T {
     return !value.hasOwnProperty('data');
 >!value.hasOwnProperty('data') : boolean
 >value.hasOwnProperty('data') : boolean
->value.hasOwnProperty : (v: string) => boolean
+>value.hasOwnProperty : (v: string | number | symbol) => boolean
 >value : T | { data: T; }
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >'data' : "data"
 }
 

--- a/tests/baselines/reference/uniqueSymbols.types
+++ b/tests/baselines/reference/uniqueSymbols.types
@@ -402,8 +402,8 @@ const constInitToLReadonlyNestedTypeWithIndexedAccess: L["nested"]["readonlyNest
 
 // type argument inference
 const promiseForConstCall = Promise.resolve(constCall);
->promiseForConstCall : Promise<symbol>
->Promise.resolve(constCall) : Promise<symbol>
+>promiseForConstCall : Promise<unique symbol>
+>Promise.resolve(constCall) : Promise<unique symbol>
 >Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
 >Promise : PromiseConstructor
 >resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
@@ -454,19 +454,19 @@ declare function g(x: typeof N.s): void;
 
 // argument inference
 f(s);
->f(s) : symbol
+>f(s) : unique symbol
 >f : <T>(x: T) => T
 >s : unique symbol
 
 f(N.s);
->f(N.s) : symbol
+>f(N.s) : unique symbol
 >f : <T>(x: T) => T
 >N.s : unique symbol
 >N : typeof N
 >s : unique symbol
 
 f(N["s"]);
->f(N["s"]) : symbol
+>f(N["s"]) : unique symbol
 >f : <T>(x: T) => T
 >N["s"] : unique symbol
 >N : typeof N

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.js
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.js
@@ -482,7 +482,7 @@ declare const constInitToLReadonlyTypeWithTypeQuery: typeof l.readonlyType;
 declare const constInitToLReadonlyNestedTypeWithTypeQuery: typeof l.nested.readonlyNestedType;
 declare const constInitToLReadonlyTypeWithIndexedAccess: L["readonlyType"];
 declare const constInitToLReadonlyNestedTypeWithIndexedAccess: L["nested"]["readonlyNestedType"];
-declare const promiseForConstCall: Promise<symbol>;
+declare const promiseForConstCall: Promise<typeof constCall>;
 declare const arrayOfConstCall: symbol[];
 declare const s: unique symbol;
 declare namespace N {

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.types
@@ -402,8 +402,8 @@ const constInitToLReadonlyNestedTypeWithIndexedAccess: L["nested"]["readonlyNest
 
 // type argument inference
 const promiseForConstCall = Promise.resolve(constCall);
->promiseForConstCall : Promise<symbol>
->Promise.resolve(constCall) : Promise<symbol>
+>promiseForConstCall : Promise<unique symbol>
+>Promise.resolve(constCall) : Promise<unique symbol>
 >Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
 >Promise : PromiseConstructor
 >resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
@@ -454,19 +454,19 @@ declare function g(x: typeof N.s): void;
 
 // argument inference
 f(s);
->f(s) : symbol
+>f(s) : unique symbol
 >f : <T>(x: T) => T
 >s : unique symbol
 
 f(N.s);
->f(N.s) : symbol
+>f(N.s) : unique symbol
 >f : <T>(x: T) => T
 >N.s : unique symbol
 >N : typeof N
 >s : unique symbol
 
 f(N["s"]);
->f(N["s"]) : symbol
+>f(N["s"]) : unique symbol
 >f : <T>(x: T) => T
 >N["s"] : unique symbol
 >N : typeof N

--- a/tests/baselines/reference/unspecializedConstraints.types
+++ b/tests/baselines/reference/unspecializedConstraints.types
@@ -464,12 +464,12 @@ module ts {
 
    
     var hasOwnProperty = Object.prototype.hasOwnProperty;
->hasOwnProperty : (v: string) => boolean
->Object.prototype.hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
+>Object.prototype.hasOwnProperty : (v: string | number | symbol) => boolean
 >Object.prototype : Object
 >Object : ObjectConstructor
 >prototype : Object
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 
     function getProperty<T>(map: Map<T>, key: string): T {
 >getProperty : <T>(map: Map<T>, key: string) => T
@@ -484,7 +484,7 @@ module ts {
 >!hasOwnProperty.call(map, key) : boolean
 >hasOwnProperty.call(map, key) : any
 >hasOwnProperty.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >map : Map<T>
 >key : string
@@ -507,7 +507,7 @@ module ts {
         return hasOwnProperty.call(map, key);
 >hasOwnProperty.call(map, key) : any
 >hasOwnProperty.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->hasOwnProperty : (v: string) => boolean
+>hasOwnProperty : (v: string | number | symbol) => boolean
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >map : Map<T>
 >key : string

--- a/tests/baselines/reference/useObjectValuesAndEntries3.symbols
+++ b/tests/baselines/reference/useObjectValuesAndEntries3.symbols
@@ -6,7 +6,7 @@ var o = { a: 1, b: 2 };
 
 for (var x of Object.values(o)) {
 >x : Symbol(x, Decl(useObjectValuesAndEntries3.ts, 2, 8))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >o : Symbol(o, Decl(useObjectValuesAndEntries3.ts, 0, 3))
 
     let y = x;
@@ -16,6 +16,6 @@ for (var x of Object.values(o)) {
 
 var entries = Object.entries(o);
 >entries : Symbol(entries, Decl(useObjectValuesAndEntries3.ts, 6, 3))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >o : Symbol(o, Decl(useObjectValuesAndEntries3.ts, 0, 3))
 

--- a/tests/baselines/reference/useObjectValuesAndEntries4.symbols
+++ b/tests/baselines/reference/useObjectValuesAndEntries4.symbols
@@ -7,7 +7,7 @@ var o = { a: 1, b: 2 };
 for (var x of Object.values(o)) {
 >x : Symbol(x, Decl(useObjectValuesAndEntries4.ts, 2, 8))
 >Object.values : Symbol(ObjectConstructor.values, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >values : Symbol(ObjectConstructor.values, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
 >o : Symbol(o, Decl(useObjectValuesAndEntries4.ts, 0, 3))
 
@@ -19,7 +19,7 @@ for (var x of Object.values(o)) {
 var entries = Object.entries(o);
 >entries : Symbol(entries, Decl(useObjectValuesAndEntries4.ts, 6, 3))
 >Object.entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
->Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
 >o : Symbol(o, Decl(useObjectValuesAndEntries4.ts, 0, 3))
 

--- a/tests/cases/compiler/deeplyNestedCheck.ts
+++ b/tests/cases/compiler/deeplyNestedCheck.ts
@@ -5,5 +5,5 @@ interface DataSnapshot<X = {}> {
 }
 
 interface Snapshot<T> extends DataSnapshot {
-  child<U extends keyof T>(path: U): Snapshot<T[U]>;
+  child<U extends Extract<keyof T, string>>(path: U): Snapshot<T[U]>;
 }

--- a/tests/cases/compiler/deferredLookupTypeResolution.ts
+++ b/tests/cases/compiler/deferredLookupTypeResolution.ts
@@ -8,7 +8,7 @@ type StringContains<S extends string, L extends string> = (
     { [key: string]: 'false' }
   )[L]
 
-type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>
+type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>
 
 type First<T> = ObjectHasKey<T, '0'>;  // Should be deferred
 

--- a/tests/cases/compiler/deferredLookupTypeResolution2.ts
+++ b/tests/cases/compiler/deferredLookupTypeResolution2.ts
@@ -5,7 +5,7 @@
 
 type StringContains<S extends string, L extends string> = ({ [K in S]: 'true' } & { [key: string]: 'false'})[L];
 
-type ObjectHasKey<O, L extends string> = StringContains<keyof O, L>;
+type ObjectHasKey<O, L extends string> = StringContains<Extract<keyof O, string>, L>;
 
 type A<T> = ObjectHasKey<T, '0'>;
 

--- a/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts
+++ b/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts
@@ -1,4 +1,4 @@
-type Diff<T extends string, U extends string> =
+type Diff<T extends keyof any, U extends keyof any> =
     ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
 type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>
 type Omit1<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;

--- a/tests/cases/compiler/keyofDoesntContainSymbols.ts
+++ b/tests/cases/compiler/keyofDoesntContainSymbols.ts
@@ -1,4 +1,6 @@
 // @lib: es6
+// @keyofStringsOnly: true
+
 const sym = Symbol();
 const num = 0;
 const obj = { num: 0, str: 's', [num]: num as 0, [sym]: sym };

--- a/tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts
+++ b/tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts
@@ -1,3 +1,5 @@
+// @keyofStringsOnly: true
+
 declare const fooProp: unique symbol;
 declare const barProp: unique symbol;
 

--- a/tests/cases/compiler/recursiveTypeRelations.ts
+++ b/tests/cases/compiler/recursiveTypeRelations.ts
@@ -1,6 +1,6 @@
 // Repro from #14896
 
-type Attributes<Keys extends string> = {
+type Attributes<Keys extends keyof any> = {
     [Key in Keys]: string;
 }
 

--- a/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes1.ts
@@ -303,7 +303,7 @@ function f50() {
 
 // Repro from #21862
 
-type OldDiff<T extends string, U extends string> = (
+type OldDiff<T extends keyof any, U extends keyof any> = (
     & { [P in T]: P; }
     & { [P in U]: never; }
     & { [x: string]: never; }

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -567,3 +567,22 @@ function f3<T, K extends keyof T>(t: T, k: K, tk: T[K]): void {
 type Predicates<TaggedRecord> = {
   [T in keyof TaggedRecord]: (variant: TaggedRecord[keyof TaggedRecord]) => variant is TaggedRecord[T]
 }
+
+
+// Repro from #23618
+
+type DBBoolTable<K extends string> = { [k in K]: 0 | 1 } 
+enum Flag {
+    FLAG_1 = "flag_1",
+    FLAG_2 = "flag_2"
+}
+
+type SimpleDBRecord<Flag extends string> = { staticField: number } & DBBoolTable<Flag>
+function getFlagsFromSimpleRecord<Flag extends string>(record: SimpleDBRecord<Flag>, flags: Flag[]) {
+    return record[flags[0]];
+}
+
+type DynamicDBRecord<Flag extends string> = ({ dynamicField: number } | { dynamicField: string }) & DBBoolTable<Flag>
+function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]) {
+    return record[flags[0]];
+}

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -190,13 +190,13 @@ function f51<T, K extends keyof T>(k: K, s: string) {
     const x2 = k as string;
 }
 
-function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {
+function f52<T>(obj: { [x: string]: boolean }, k: Exclude<keyof T, symbol>, s: string, n: number) {
     const x1 = obj[s];
     const x2 = obj[n];
     const x3 = obj[k];
 }
 
-function f53<T, K extends keyof T>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
+function f53<T, K extends Exclude<keyof T, symbol>>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
     const x1 = obj[s];
     const x2 = obj[n];
     const x3 = obj[k];
@@ -556,7 +556,7 @@ class AnotherSampleClass<T> extends SampleClass<T & Foo> {
 new AnotherSampleClass({});
 
 // Positive repro from #17166
-function f3<T, K extends keyof T>(t: T, k: K, tk: T[K]): void {
+function f3<T, K extends Extract<keyof T, string>>(t: T, k: K, tk: T[K]): void {
     for (let key in t) {
         key = k // ok, K ==> keyof T
         t[key] = tk; // ok, T[K] ==> T[keyof T]

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
@@ -96,7 +96,7 @@ function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U,
 }
 
 // Repro from #17166
-function f3<T, K extends keyof T, U extends T, J extends K>(
+function f3<T, K extends Extract<keyof T, string>, U extends T, J extends K>(
     t: T, k: K, tk: T[K], u: U, j: J, uk: U[K], tj: T[J], uj: U[J]): void {
     for (let key in t) {
         key = k // ok, K ==> keyof T

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
@@ -67,15 +67,32 @@ function f10(shape: Shape) {
     setProperty(shape, cond ? "name" : "size", 10);  // Error
 }
 
-function f20<T, U>(k1: keyof (T | U), k2: keyof (T & U), o1: T | U, o2: T & U) {
-    o1[k1];
-    o1[k2];   // Error
-    o2[k1];
-    o2[k2];
-    o1 = o2;
-    o2 = o1;  // Error
-    k1 = k2;  // Error
+function f20<T, U>(x: T | U, y: T & U, k1: keyof (T | U), k2: keyof T & keyof U, k3: keyof (T & U), k4: keyof T | keyof U) {
+    x[k1];
+    x[k2];
+    x[k3];  // Error
+    x[k4];  // Error
+
+    y[k1];
+    y[k2];
+    y[k3];
+    y[k4];
+
+    k1 = k2;
+    k1 = k3;  // Error
+    k1 = k4;  // Error
+
     k2 = k1;
+    k2 = k3;  // Error
+    k2 = k4;  // Error
+
+    k3 = k1;
+    k3 = k2;
+    k3 = k4;
+
+    k4 = k1;
+    k4 = k2;
+    k4 = k3;
 }
 
 // Repro from #17166

--- a/tests/cases/fourslash/completionsImport_details_withMisspelledName.ts
+++ b/tests/cases/fourslash/completionsImport_details_withMisspelledName.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+////export const abc = 0;
+
+// @Filename: /b.ts
+////acb/**/;
+
+goTo.marker("");
+verify.applyCodeActionFromCompletion("", {
+    name: "abc",
+    source: "/a",
+    description: `Import 'abc' from module "./a"`,
+    newFileContent: `import { abc } from "./a";
+
+acb;`,
+});

--- a/tests/cases/fourslash/getEditsForFileRename.ts
+++ b/tests/cases/fourslash/getEditsForFileRename.ts
@@ -12,6 +12,9 @@
 /////// <reference path="../old.ts" />
 ////import old from "../old";
 
+// @Filename: /tsconfig.json
+////{ "files": ["/a.ts", "/src/a.ts", "/src/foo/a.ts", "/src/old.ts"] }
+
 verify.getEditsForFileRename({
     oldPath: "/src/old.ts",
     newPath: "/src/new.ts",
@@ -19,5 +22,6 @@ verify.getEditsForFileRename({
         "/a.ts": '/// <reference path="./src/new.ts" />\nimport old from "./src/new";',
         "/src/a.ts": '/// <reference path="./new.ts" />\nimport old from "./new";',
         "/src/foo/a.ts": '/// <reference path="../new.ts" />\nimport old from "../new";',
+        "/tsconfig.json": '{ "files": ["/a.ts", "/src/a.ts", "/src/foo/a.ts", "/src/new.ts"] }',
     },
 });


### PR DESCRIPTION
With this PR we transform `keyof` applied to a union type to an intersection of `keyof` applied to each union constituent. In other words, we rewrite types of the form `keyof (A | B)` to `keyof A & keyof B`.

Some examples:

```ts
type A = { a: string, c: string };
type B = { b: string, c: string };

type T1 = keyof (A | B);  // "c"
type T2<T> = keyof (T | B);  // (keyof T & "b") | (keyof T & "c")
type T3<U> = keyof (A | U);  // ("a" | keyof U) | ("c" & keyof U)
type T4<T, U> = keyof (T | U);  // keyof T & keyof U
type T5 = T2<A>;  // "c"
type T6 = T3<B>;  // "c"
type T7 = T4<A, B>;  // "c"
```

This PR is the mirror image of #22300 and finally brings symmetry to the type eqivalences:

```ts
keyof (A & B) <==> keyof A | keyof B
keyof (A | B) <==> keyof A & keyof B
```

Why it took so long to figure out I don't know!

Fixes #23618.