### PR TITLE
Make symbol display at ExportSpecifier use 'export', not 'import'

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -413,6 +413,9 @@ namespace ts.SymbolDisplay {
                     displayParts.push(spacePart());
                     displayParts.push(keywordPart((symbol.declarations[0] as ExportAssignment).isExportEquals ? SyntaxKind.EqualsToken : SyntaxKind.DefaultKeyword));
                     break;
+                case SyntaxKind.ExportSpecifier:
+                    displayParts.push(keywordPart(SyntaxKind.ExportKeyword));
+                    break;
                 default:
                     displayParts.push(keywordPart(SyntaxKind.ImportKeyword));
             }

--- a/tests/cases/fourslash/completionsImport_ofAlias.ts
+++ b/tests/cases/fourslash/completionsImport_ofAlias.ts
@@ -21,9 +21,7 @@
 
 goTo.marker("");
 const options = { includeExternalModuleExports: true, sourceDisplay: "./a" };
-// TODO: https://github.com/Microsoft/TypeScript/issues/14003
-//TODO: verify that there's only one!
-verify.completionListContains({ name: "foo", source: "/a" }, "(alias) const foo: 0\nimport foo", "", "alias", /*spanIndex*/ undefined, /*hasAction*/ true, options);
+verify.completionListContains({ name: "foo", source: "/a" }, "(alias) const foo: 0\nexport foo", "", "alias", /*spanIndex*/ undefined, /*hasAction*/ true, options);
 verify.not.completionListContains({ name: "foo", source: "/a_reexport" }, undefined, undefined, undefined, undefined, undefined, options);
 verify.not.completionListContains({ name: "foo", source: "/a_reexport_2" }, undefined, undefined, undefined, undefined, undefined, options);
 

--- a/tests/cases/fourslash/findAllRefsForDefaultExport_reExport.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport_reExport.ts
@@ -13,16 +13,16 @@
 const [r0, r1, r2, r3] = test.ranges();
 verify.referenceGroups([r0, r1], [
     { definition: "const foo: 1", ranges: [r0, r1] },
-    { definition: "(alias) const foo: 1\nimport default", ranges: [r2], },
+    { definition: "(alias) const foo: 1\nexport default", ranges: [r2], },
     { definition: "(alias) const fooDefault: 1\nimport fooDefault", ranges: [r3] },
 ]);
 verify.referenceGroups(r2, [
-    { definition: "(alias) const foo: 1\nimport default", ranges: [r2] },
+    { definition: "(alias) const foo: 1\nexport default", ranges: [r2] },
     { definition: "(alias) const fooDefault: 1\nimport fooDefault", ranges: [r3] },
     { definition: "const foo: 1", ranges: [r0, r1] },
 ]);
 verify.referenceGroups(r3, [
     { definition: "(alias) const fooDefault: 1\nimport fooDefault", ranges: [r3] },
-    { definition: "(alias) const foo: 1\nimport default", ranges: [r2] },
+    { definition: "(alias) const foo: 1\nexport default", ranges: [r2] },
     { definition: "const foo: 1", ranges: [r0, r1] },
 ]);

--- a/tests/cases/fourslash/findAllRefsForDefaultExport_reExport_allowSyntheticDefaultImports.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport_reExport_allowSyntheticDefaultImports.ts
@@ -17,16 +17,16 @@ verify.noErrors();
 const [r0, r1, r2, r3] = test.ranges();
 verify.referenceGroups([r0, r1], [
     { definition: "const foo: 1", ranges: [r0, r1] },
-    { definition: "(alias) const foo: 1\nimport default", ranges: [r2], },
+    { definition: "(alias) const foo: 1\nexport default", ranges: [r2], },
     { definition: "(alias) const fooDefault: 1\nimport fooDefault", ranges: [r3] },
 ]);
 verify.referenceGroups(r2, [
-    { definition: "(alias) const foo: 1\nimport default", ranges: [r2] },
+    { definition: "(alias) const foo: 1\nexport default", ranges: [r2] },
     { definition: "(alias) const fooDefault: 1\nimport fooDefault", ranges: [r3] },
     { definition: "const foo: 1", ranges: [r0, r1] },
 ]);
 verify.referenceGroups(r3, [
     { definition: "(alias) const fooDefault: 1\nimport fooDefault", ranges: [r3] },
-    { definition: "(alias) const foo: 1\nimport default", ranges: [r2] },
+    { definition: "(alias) const foo: 1\nexport default", ranges: [r2] },
     { definition: "const foo: 1", ranges: [r0, r1] },
 ]);

--- a/tests/cases/fourslash/findAllRefsOnImportAliases.ts
+++ b/tests/cases/fourslash/findAllRefsOnImportAliases.ts
@@ -16,6 +16,6 @@ const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
 const classes = { definition: "class Class", ranges: [r0] };
 const imports = { definition: "(alias) class Class\nimport Class", ranges: [r1, r2] };
-const reExports = { definition: "(alias) class Class\nimport Class", ranges: [r3] };
+const reExports = { definition: "(alias) class Class\nexport Class", ranges: [r3] };
 verify.referenceGroups(r0, [classes, imports, reExports]);
 verify.referenceGroups([r1, r2], [imports, classes, reExports]);

--- a/tests/cases/fourslash/findAllRefsOnImportAliases2.ts
+++ b/tests/cases/fourslash/findAllRefsOnImportAliases2.ts
@@ -18,7 +18,7 @@ const [c2_0, c2_1] = c2Ranges;
 const c3Ranges = ranges.get("C3");
 const classes = { definition: "class Class", ranges: classRanges };
 const c2s =  { definition: "(alias) class C2\nimport C2", ranges: c2Ranges };
-const c3s = { definition: "(alias) class C3\nimport C3", ranges: c3Ranges };
+const c3s = { definition: "(alias) class C3\nexport C3", ranges: c3Ranges };
 
 verify.referenceGroups(classRanges, [classes, c2s, c3s]);
 

--- a/tests/cases/fourslash/findAllRefsReExportLocal.ts
+++ b/tests/cases/fourslash/findAllRefsReExportLocal.ts
@@ -19,7 +19,7 @@ const bxRanges = [bx0, bx1];
 const byRanges = [by0, by1];
 const axGroup = { definition: "var x: any", ranges: axRanges };
 const bxGroup = { definition: "(alias) var x: any\nimport x", ranges: bxRanges };
-const ayGroup = { definition: "(alias) var y: any\nimport y", ranges: [ay] }
+const ayGroup = { definition: "(alias) var y: any\nexport y", ranges: [ay] }
 const byGroup = { definition: "(alias) var y: any\nimport y", ranges: byRanges }
 
 verify.referenceGroups(axRanges, [axGroup, bxGroup, ayGroup, byGroup]);

--- a/tests/cases/fourslash/findAllRefsReExportRightNameWrongSymbol.ts
+++ b/tests/cases/fourslash/findAllRefsReExportRightNameWrongSymbol.ts
@@ -24,7 +24,7 @@ const cFromAGroup = { definition: "(alias) const x: 0\nimport x", ranges: cFromA
 verify.referenceGroups(a, [aGroup, cFromAGroup]);
 
 const bGroup = { definition: "const x: 0", ranges: [b] };
-const cFromBGroup = { definition: "(alias) const x: 0\nimport x", ranges: [cFromB] };
+const cFromBGroup = { definition: "(alias) const x: 0\nexport x", ranges: [cFromB] };
 const dGroup = { definition: "(alias) const x: 0\nimport x", ranges: [d] };
 verify.referenceGroups(b, [bGroup, cFromBGroup, dGroup]);
 

--- a/tests/cases/fourslash/findAllRefsReExport_broken.ts
+++ b/tests/cases/fourslash/findAllRefsReExport_broken.ts
@@ -3,4 +3,4 @@
 // @Filename: /a.ts
 ////export { [|{| "isWriteAccess": true, "isDefinition": true |}x|] };
 
-verify.singleReferenceGroup("import x");
+verify.singleReferenceGroup("export x");

--- a/tests/cases/fourslash/findAllRefsReExport_broken2.ts
+++ b/tests/cases/fourslash/findAllRefsReExport_broken2.ts
@@ -3,4 +3,4 @@
 // @Filename: /a.ts
 ////export { [|{| "isWriteAccess": true, "isDefinition": true |}x|] } from "nonsense";
 
-verify.singleReferenceGroup("import x");
+verify.singleReferenceGroup("export x");

--- a/tests/cases/fourslash/findAllRefsReExports.ts
+++ b/tests/cases/fourslash/findAllRefsReExports.ts
@@ -22,9 +22,9 @@
 verify.noErrors();
 const [foo0, foo1, bar0, foo2, defaultC, defaultD, bar1, baz0, defaultE, bang0, boom0, bar2, baz1, bang1, boom1] = test.ranges();
 const a = { definition: "function foo(): void", ranges: [foo0, foo1, foo2] };
-const b = { definition: "(alias) function bar(): void\nimport bar", ranges: [bar0] };
-const c = { definition: "(alias) function foo(): void\nimport default", ranges: [defaultC, defaultE] };
-const d = { definition: "(alias) function foo(): void\nimport default", ranges: [defaultD] };
+const b = { definition: "(alias) function bar(): void\nexport bar", ranges: [bar0] };
+const c = { definition: "(alias) function foo(): void\nexport default", ranges: [defaultC, defaultE] };
+const d = { definition: "(alias) function foo(): void\nexport default", ranges: [defaultD] };
 const eBar = { definition: "(alias) function bar(): void\nimport bar", ranges: [bar1, bar2] };
 const eBaz = { definition: "(alias) function baz(): void\nimport baz", ranges: [baz0, baz1] };
 const eBang = { definition: "(alias) function bang(): void\nimport bang", ranges: [bang0, bang1] };

--- a/tests/cases/fourslash/quickInfoImportedTypesWithMergedMeanings.ts
+++ b/tests/cases/fourslash/quickInfoImportedTypesWithMergedMeanings.ts
@@ -17,7 +17,7 @@ verify.quickInfoAt("1", [
     "(alias) function Original(): void",
     "(alias) type Original<T> = () => T",
     "(alias) namespace Original",
-    "import Original",
+    "export Original",
 ].join("\n"), "some docs ");
 
 verify.quickInfoAt("2", [

--- a/tests/cases/fourslash/renameImportOfExportEquals2.ts
+++ b/tests/cases/fourslash/renameImportOfExportEquals2.ts
@@ -25,7 +25,7 @@ const qRanges = [Q0, Q1];
 
 const ns = { definition: "namespace N", ranges: nRanges };
 const os = { definition: "(alias) namespace O\nimport O", ranges: oRanges };
-const ps = { definition: "(alias) namespace P\nimport P", ranges: pRanges };
+const ps = { definition: "(alias) namespace P\nexport P", ranges: pRanges };
 const qs = { definition: "(alias) namespace Q\nimport Q", ranges: qRanges };
 
 verify.referenceGroups(nRanges, [ns, os, ps, qs]);

--- a/tests/cases/fourslash/renameImportOfReExport.ts
+++ b/tests/cases/fourslash/renameImportOfReExport.ts
@@ -20,7 +20,7 @@ const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
 const importRanges = [r2, r3];
 const classes = { definition: "class C", ranges: [r0] };
-const bs = { definition: "(alias) class C\nimport C", ranges: [r1] };
+const bs = { definition: "(alias) class C\nexport C", ranges: [r1] };
 const imports = { definition: "(alias) class C\nimport C", ranges: importRanges };
 verify.referenceGroups(r0, [classes, bs, imports]);
 verify.referenceGroups(r1, [bs, imports, classes]);

--- a/tests/cases/fourslash/renameImportOfReExport2.ts
+++ b/tests/cases/fourslash/renameImportOfReExport2.ts
@@ -18,7 +18,7 @@ const cRanges = ranges.get("C");
 const [d0, d1, d2] = ranges.get("D");
 
 const classes = { definition: "class C", ranges: cRanges };
-const bImports = { definition: "(alias) class D\nimport D", ranges: [d0] };
+const bImports = { definition: "(alias) class D\nexport D", ranges: [d0] };
 const cImports = { definition: "(alias) class D\nimport D", ranges: [d1, d2] };
 verify.referenceGroups(cRanges, [classes, bImports, cImports]);
 

--- a/tests/cases/fourslash/transitiveExportImports3.ts
+++ b/tests/cases/fourslash/transitiveExportImports3.ts
@@ -13,7 +13,7 @@ verify.noErrors();
 const [f0, f1, g0, f2, g1] = test.ranges();
 
 const af = { definition: "function f(): void", ranges: [f0, f1] };
-const g0Group = { definition: "(alias) function g(): void\nimport g", ranges: [g0] };
+const g0Group = { definition: "(alias) function g(): void\nexport g", ranges: [g0] };
 const g1Group = { definition: "(alias) function g(): void\nimport g", ranges: [g1] };
 const bf = { definition: "(alias) function f(): void\nimport f", ranges: [f2] };
 


### PR DESCRIPTION
Fixes #14003

@mhegazy You mentioned removing the `export` part altogether but it seems like that would be a bigger change and shouldn't effect only `ExportSpecifier`.