### PR TITLE
Fix duplicate completions bugs

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -858,8 +858,7 @@ namespace FourSlash {
             const actualByName = ts.createMap<ts.CompletionEntry>();
             for (const entry of actualCompletions.entries) {
                 if (actualByName.has(entry.name)) {
-                    // TODO: GH#23587
-                    if (entry.name !== "undefined" && entry.name !== "require") this.raiseError(`Duplicate completions for ${entry.name}`);
+                    this.raiseError(`Duplicate completions for ${entry.name}`);
                 }
                 else {
                     actualByName.set(entry.name, entry);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2059,8 +2059,9 @@ namespace ts.Completions {
             const kind = stringToToken(entry.name);
             switch (keywordFilter) {
                 case KeywordCompletionFilters.None:
-                    // "undefined" is a global variable, so don't need a keyword completion for it.
-                    return kind !== SyntaxKind.UndefinedKeyword;
+                    // TODO: GH#23631 Includes type keywords because `Array<numb/**/` is treaded as a value location currently.
+                    return !isContextualKeyword(kind) && !isClassMemberCompletionKeyword(kind) || kind === SyntaxKind.DeclareKeyword || kind === SyntaxKind.ModuleKeyword
+                        || isTypeKeyword(kind) && kind !== SyntaxKind.UndefinedKeyword;
                 case KeywordCompletionFilters.ClassElementKeywords:
                     return isClassMemberCompletionKeyword(kind);
                 case KeywordCompletionFilters.InterfaceElementKeywords:
@@ -2068,7 +2069,7 @@ namespace ts.Completions {
                 case KeywordCompletionFilters.ConstructorParameterKeywords:
                     return isParameterPropertyModifier(kind);
                 case KeywordCompletionFilters.FunctionLikeBodyKeywords:
-                    return !isClassMemberCompletionKeyword(kind);
+                    return !isContextualKeyword(kind) && !isClassMemberCompletionKeyword(kind);
                 case KeywordCompletionFilters.TypeKeywords:
                     return isTypeKeyword(kind);
                 default:

--- a/tests/cases/fourslash/completionEntryForPrimitive.ts
+++ b/tests/cases/fourslash/completionEntryForPrimitive.ts
@@ -1,8 +1,0 @@
-///<reference path="fourslash.ts" />
-
-////var x = Object.create(/**/
-
-goTo.marker();
-verify.not.completionListIsEmpty();
-edit.insert("nu");
-verify.completionListContains("number", undefined, undefined, "keyword");

--- a/tests/cases/fourslash/completionListKeywords.ts
+++ b/tests/cases/fourslash/completionListKeywords.ts
@@ -1,48 +1,42 @@
 /// <reference path="fourslash.ts"/>
 
-/////**/
+////
 
-goTo.marker();
-verify.completionListContains("break");
-verify.completionListContains("case");
-verify.completionListContains("catch");
-verify.completionListContains("class");
-verify.completionListContains("constructor");
-verify.completionListContains("continue");
-verify.completionListContains("debugger");
-verify.completionListContains("declare");
-verify.completionListContains("default");
-verify.completionListContains("delete");
-verify.completionListContains("do");
-verify.completionListContains("else");
-verify.completionListContains("enum");
-verify.completionListContains("export");
-verify.completionListContains("extends");
-verify.completionListContains("false");
-verify.completionListContains("finally");
-verify.completionListContains("for");
-verify.completionListContains("function");
-verify.completionListContains("get");
-verify.completionListContains("if");
-verify.completionListContains("implements");
-verify.completionListContains("import");
-verify.completionListContains("in");
-verify.completionListContains("instanceof");
-verify.completionListContains("interface");
-verify.completionListContains("module");
-verify.completionListContains("new");
-verify.completionListContains("private");
-verify.completionListContains("public");
-verify.completionListContains("return");
-verify.completionListContains("set");
-verify.completionListContains("static");
-verify.completionListContains("super");
-verify.completionListContains("switch");
-verify.completionListContains("this");
-verify.completionListContains("throw");
-verify.completionListContains("true");
-verify.completionListContains("try");
-verify.completionListContains("typeof");
-verify.completionListContains("var");
-verify.completionListContains("while");
-verify.completionListContains("with");
+verify.completions({
+    includes: [
+        "break",
+        "case",
+        "catch",
+        "class",
+        "continue",
+        "debugger",
+        "declare",
+        "default",
+        "delete",
+        "do",
+        "else",
+        "enum",
+        "export",
+        "extends",
+        "false",
+        "finally",
+        "for",
+        "function",
+        "if",
+        "instanceof",
+        "interface",
+        "module",
+        "new",
+        "return",
+        "super",
+        "switch",
+        "this",
+        "throw",
+        "true",
+        "try",
+        "typeof",
+        "var",
+        "while",
+        "with",
+    ],
+});

--- a/tests/cases/fourslash/completionListPrimitives.ts
+++ b/tests/cases/fourslash/completionListPrimitives.ts
@@ -1,5 +1,0 @@
-/// <reference path="fourslash.ts"/>
-
-////
-
-verify.completions({ includes: ["any", "boolean", "null", "number", "string", "undefined", "void"] })


### PR DESCRIPTION
Fixes #23587

Will rebase against master after #23591 is in.
Also removes the "constructor", "get", "set", "private", "public", and "static" contextual keywords from global completions.
(Also removes two tests that are already covered by `completionListKeywords.ts`.)