### PR TITLE
importNameCodeFix: consistently put fixes to use existing imports before fixes for existing imports

### DIFF
--- a/tests/cases/fourslash/importNameCodeFix_order.ts
+++ b/tests/cases/fourslash/importNameCodeFix_order.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+////export const foo: number;
+
+// @Filename: /b.ts
+////export const foo: number;
+////export const bar: number;
+
+// @Filename: /c.ts
+////[|import { bar } from "./b";
+////foo;|]
+
+goTo.file("/c.ts");
+verify.importFixAtPosition([
+`import { bar, foo } from "./b";
+foo;`,
+`import { bar } from "./b";
+import { foo } from "./a";
+foo;`,
+]);


### PR DESCRIPTION
Fixes #23579

Previously this only worked if there was a *single* potential symbol to import from, since we added the fixes in that order for a single symbol. Now we will create separate lists of 'update'/'add-new' fixes and only concatenate them after we've gone over all symbols.