### PR TITLE
Add warn that user can not use --strictPropertyInitialization without --strictNullChecks

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2062,6 +2062,10 @@ namespace ts {
         }
 
         function verifyCompilerOptions() {
+            if (options.strictPropertyInitialization && !options.strictNullChecks) {
+                createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "strictPropertyInitialization", "strictNullChecks");
+            }
+
             if (options.isolatedModules) {
                 if (options.declaration) {
                     createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "declaration", "isolatedModules");

--- a/tests/baselines/reference/optionsStrictPropertyInitializationStrictNullChecks.errors.txt
+++ b/tests/baselines/reference/optionsStrictPropertyInitializationStrictNullChecks.errors.txt
@@ -1,0 +1,7 @@
+error TS5052: Option 'strictPropertyInitialization' cannot be specified without specifying option 'strictNullChecks'.
+
+
+!!! error TS5052: Option 'strictPropertyInitialization' cannot be specified without specifying option 'strictNullChecks'.
+==== tests/cases/compiler/optionsStrictPropertyInitializationStrictNullChecks.ts (0 errors) ====
+    var x;
+    

--- a/tests/baselines/reference/optionsStrictPropertyInitializationStrictNullChecks.js
+++ b/tests/baselines/reference/optionsStrictPropertyInitializationStrictNullChecks.js
@@ -1,0 +1,6 @@
+//// [optionsStrictPropertyInitializationStrictNullChecks.ts]
+var x;
+
+
+//// [optionsStrictPropertyInitializationStrictNullChecks.js]
+var x;

--- a/tests/baselines/reference/optionsStrictPropertyInitializationStrictNullChecks.symbols
+++ b/tests/baselines/reference/optionsStrictPropertyInitializationStrictNullChecks.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/optionsStrictPropertyInitializationStrictNullChecks.ts ===
+var x;
+>x : Symbol(x, Decl(optionsStrictPropertyInitializationStrictNullChecks.ts, 0, 3))
+

--- a/tests/baselines/reference/optionsStrictPropertyInitializationStrictNullChecks.types
+++ b/tests/baselines/reference/optionsStrictPropertyInitializationStrictNullChecks.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/optionsStrictPropertyInitializationStrictNullChecks.ts ===
+var x;
+>x : any
+

--- a/tests/cases/compiler/optionsStrictPropertyInitializationStrictNullChecks.ts
+++ b/tests/cases/compiler/optionsStrictPropertyInitializationStrictNullChecks.ts
@@ -1,0 +1,3 @@
+// @strictPropertyInitialization: true
+
+var x;


### PR DESCRIPTION
Fixes part of #23659 
