### PR TITLE
Type relationships for intersections with union constraints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7917,8 +7917,13 @@ namespace ts {
             return binarySearch(types, type, getTypeId, compareValues) >= 0;
         }
 
-        // Return true if the given intersection type contains (a) more than one unit type or (b) an object
-        // type and a nullable type (null or undefined).
+        // Return true if the given intersection type contains
+        // more than one unit type or,
+        // an object type and a nullable type (null or undefined), or
+        // a string-like type and a non-string-like primitive type, or
+        // a number-like type and a non-number-like primitive type, or
+        // a symbol-like type and a non-symbol-like primitive type, or
+        // a void-like type and a non-void-like primitive type.
         function isEmptyIntersectionType(type: IntersectionType) {
             let combined: TypeFlags = 0;
             for (const t of type.types) {
@@ -7926,7 +7931,11 @@ namespace ts {
                     return true;
                 }
                 combined |= t.flags;
-                if (combined & TypeFlags.Nullable && combined & (TypeFlags.Object | TypeFlags.NonPrimitive)) {
+                if (combined & TypeFlags.Nullable && combined & (TypeFlags.Object | TypeFlags.NonPrimitive) ||
+                    combined & TypeFlags.StringLike && combined & (TypeFlags.Primitive & ~TypeFlags.StringLike) ||
+                    combined & TypeFlags.NumberLike && combined & (TypeFlags.Primitive & ~TypeFlags.NumberLike) ||
+                    combined & TypeFlags.ESSymbolLike && combined & (TypeFlags.Primitive & ~TypeFlags.ESSymbolLike) ||
+                    combined & TypeFlags.VoidLike && combined & (TypeFlags.Primitive & ~TypeFlags.VoidLike)) {
                     return true;
                 }
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3613,6 +3613,7 @@ namespace ts {
         BooleanLike = Boolean | BooleanLiteral,
         EnumLike = Enum | EnumLiteral,
         ESSymbolLike = ESSymbol | UniqueESSymbol,
+        VoidLike = Void | Undefined,
         UnionOrIntersection = Union | Intersection,
         StructuredType = Object | Union | Intersection,
         TypeVariable = TypeParameter | IndexedAccess,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3614,6 +3614,8 @@ namespace ts {
         EnumLike = Enum | EnumLiteral,
         ESSymbolLike = ESSymbol | UniqueESSymbol,
         VoidLike = Void | Undefined,
+        /* @internal */
+        DisjointDomains = NonPrimitive | StringLike | NumberLike | BooleanLike | ESSymbolLike | VoidLike | Null,
         UnionOrIntersection = Union | Intersection,
         StructuredType = Object | Union | Intersection,
         TypeVariable = TypeParameter | IndexedAccess,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2105,6 +2105,7 @@ declare namespace ts {
         BooleanLike = 136,
         EnumLike = 272,
         ESSymbolLike = 1536,
+        VoidLike = 6144,
         UnionOrIntersection = 393216,
         StructuredType = 458752,
         TypeVariable = 1081344,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2105,6 +2105,7 @@ declare namespace ts {
         BooleanLike = 136,
         EnumLike = 272,
         ESSymbolLike = 1536,
+        VoidLike = 6144,
         UnionOrIntersection = 393216,
         StructuredType = 458752,
         TypeVariable = 1081344,

--- a/tests/baselines/reference/errorMessagesIntersectionTypes04.errors.txt
+++ b/tests/baselines/reference/errorMessagesIntersectionTypes04.errors.txt
@@ -1,11 +1,9 @@
 tests/cases/compiler/errorMessagesIntersectionTypes04.ts(17,5): error TS2322: Type 'A & B' is not assignable to type 'number'.
 tests/cases/compiler/errorMessagesIntersectionTypes04.ts(18,5): error TS2322: Type 'A & B' is not assignable to type 'boolean'.
 tests/cases/compiler/errorMessagesIntersectionTypes04.ts(19,5): error TS2322: Type 'A & B' is not assignable to type 'string'.
-tests/cases/compiler/errorMessagesIntersectionTypes04.ts(21,5): error TS2322: Type '(number & true) | (number & false)' is not assignable to type 'string'.
-  Type 'number & true' is not assignable to type 'string'.
 
 
-==== tests/cases/compiler/errorMessagesIntersectionTypes04.ts (4 errors) ====
+==== tests/cases/compiler/errorMessagesIntersectionTypes04.ts (3 errors) ====
     interface A {
         a;
     }
@@ -33,7 +31,4 @@ tests/cases/compiler/errorMessagesIntersectionTypes04.ts(21,5): error TS2322: Ty
 !!! error TS2322: Type 'A & B' is not assignable to type 'string'.
     
         str = num_and_bool;
-        ~~~
-!!! error TS2322: Type '(number & true) | (number & false)' is not assignable to type 'string'.
-!!! error TS2322:   Type 'number & true' is not assignable to type 'string'.
     }

--- a/tests/baselines/reference/errorMessagesIntersectionTypes04.types
+++ b/tests/baselines/reference/errorMessagesIntersectionTypes04.types
@@ -36,7 +36,7 @@ function f<T, U extends A, V extends U>(): void {
 >B : B
 
     let num_and_bool: number & boolean;
->num_and_bool : (number & true) | (number & false)
+>num_and_bool : never
 
     num = a_and_b;
 >num = a_and_b : A & B
@@ -54,7 +54,7 @@ function f<T, U extends A, V extends U>(): void {
 >a_and_b : A & B
 
     str = num_and_bool;
->str = num_and_bool : (number & true) | (number & false)
+>str = num_and_bool : never
 >str : string
->num_and_bool : (number & true) | (number & false)
+>num_and_bool : never
 }

--- a/tests/baselines/reference/intersectionWithUnionConstraint.errors.txt
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.errors.txt
@@ -62,6 +62,18 @@ tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(12
     
     type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
     
+    function f3<T extends string | number | undefined>(x: T & (number | object | undefined)) {
+        const y: number | undefined = x;
+    }
+    
+    function f4<T extends string | number>(x: T & (number | object)) {
+        const y: number = x;
+    }
+    
+    function f5<T, U extends keyof T>(x: keyof T & U) {
+        let y: keyof any = x;
+    }
+    
     // Repro from #23648
     
     type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }

--- a/tests/baselines/reference/intersectionWithUnionConstraint.errors.txt
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.errors.txt
@@ -1,0 +1,71 @@
+tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(7,9): error TS2322: Type 'T & U' is not assignable to type 'string | number'.
+  Type 'string | undefined' is not assignable to type 'string | number'.
+    Type 'undefined' is not assignable to type 'string | number'.
+      Type 'T & U' is not assignable to type 'number'.
+tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(8,9): error TS2322: Type 'T & U' is not assignable to type 'string | null'.
+  Type 'string | undefined' is not assignable to type 'string | null'.
+    Type 'undefined' is not assignable to type 'string | null'.
+      Type 'T & U' is not assignable to type 'string'.
+tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(10,9): error TS2322: Type 'T & U' is not assignable to type 'number | null'.
+  Type 'string | undefined' is not assignable to type 'number | null'.
+    Type 'undefined' is not assignable to type 'number | null'.
+      Type 'T & U' is not assignable to type 'number'.
+tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(11,9): error TS2322: Type 'T & U' is not assignable to type 'number | undefined'.
+  Type 'string | undefined' is not assignable to type 'number | undefined'.
+    Type 'string' is not assignable to type 'number | undefined'.
+      Type 'T & U' is not assignable to type 'number'.
+tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(12,9): error TS2322: Type 'T & U' is not assignable to type 'null | undefined'.
+  Type 'string | undefined' is not assignable to type 'null | undefined'.
+    Type 'string' is not assignable to type 'null | undefined'.
+      Type 'T & U' is not assignable to type 'null'.
+
+
+==== tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts (5 errors) ====
+    function f1<T extends string | number, U extends string | number>(x: T & U) {
+        // Combined constraint of 'T & U' is 'string | number'
+        let y: string | number = x;
+    }
+    
+    function f2<T extends string | number | undefined, U extends string | null | undefined>(x: T & U) {
+        let y1: string | number = x;     // Error
+            ~~
+!!! error TS2322: Type 'T & U' is not assignable to type 'string | number'.
+!!! error TS2322:   Type 'string | undefined' is not assignable to type 'string | number'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'string | number'.
+!!! error TS2322:       Type 'T & U' is not assignable to type 'number'.
+        let y2: string | null = x;       // Error
+            ~~
+!!! error TS2322: Type 'T & U' is not assignable to type 'string | null'.
+!!! error TS2322:   Type 'string | undefined' is not assignable to type 'string | null'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'string | null'.
+!!! error TS2322:       Type 'T & U' is not assignable to type 'string'.
+        let y3: string | undefined = x;
+        let y4: number | null = x;       // Error
+            ~~
+!!! error TS2322: Type 'T & U' is not assignable to type 'number | null'.
+!!! error TS2322:   Type 'string | undefined' is not assignable to type 'number | null'.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'number | null'.
+!!! error TS2322:       Type 'T & U' is not assignable to type 'number'.
+        let y5: number | undefined = x;  // Error
+            ~~
+!!! error TS2322: Type 'T & U' is not assignable to type 'number | undefined'.
+!!! error TS2322:   Type 'string | undefined' is not assignable to type 'number | undefined'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number | undefined'.
+!!! error TS2322:       Type 'T & U' is not assignable to type 'number'.
+        let y6: null | undefined = x;    // Error
+            ~~
+!!! error TS2322: Type 'T & U' is not assignable to type 'null | undefined'.
+!!! error TS2322:   Type 'string | undefined' is not assignable to type 'null | undefined'.
+!!! error TS2322:     Type 'string' is not assignable to type 'null | undefined'.
+!!! error TS2322:       Type 'T & U' is not assignable to type 'null'.
+    }
+    
+    type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
+    
+    // Repro from #23648
+    
+    type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }
+    
+    type UnexpectedError<T extends PropertyKey> = T
+    type NoErrorHere<T extends PropertyKey> = T
+    

--- a/tests/baselines/reference/intersectionWithUnionConstraint.js
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.js
@@ -15,6 +15,18 @@ function f2<T extends string | number | undefined, U extends string | null | und
 
 type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
 
+function f3<T extends string | number | undefined>(x: T & (number | object | undefined)) {
+    const y: number | undefined = x;
+}
+
+function f4<T extends string | number>(x: T & (number | object)) {
+    const y: number = x;
+}
+
+function f5<T, U extends keyof T>(x: keyof T & U) {
+    let y: keyof any = x;
+}
+
 // Repro from #23648
 
 type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }
@@ -36,4 +48,13 @@ function f2(x) {
     var y4 = x; // Error
     var y5 = x; // Error
     var y6 = x; // Error
+}
+function f3(x) {
+    var y = x;
+}
+function f4(x) {
+    var y = x;
+}
+function f5(x) {
+    var y = x;
 }

--- a/tests/baselines/reference/intersectionWithUnionConstraint.js
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.js
@@ -1,0 +1,39 @@
+//// [intersectionWithUnionConstraint.ts]
+function f1<T extends string | number, U extends string | number>(x: T & U) {
+    // Combined constraint of 'T & U' is 'string | number'
+    let y: string | number = x;
+}
+
+function f2<T extends string | number | undefined, U extends string | null | undefined>(x: T & U) {
+    let y1: string | number = x;     // Error
+    let y2: string | null = x;       // Error
+    let y3: string | undefined = x;
+    let y4: number | null = x;       // Error
+    let y5: number | undefined = x;  // Error
+    let y6: null | undefined = x;    // Error
+}
+
+type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
+
+// Repro from #23648
+
+type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }
+
+type UnexpectedError<T extends PropertyKey> = T
+type NoErrorHere<T extends PropertyKey> = T
+
+
+//// [intersectionWithUnionConstraint.js]
+"use strict";
+function f1(x) {
+    // Combined constraint of 'T & U' is 'string | number'
+    var y = x;
+}
+function f2(x) {
+    var y1 = x; // Error
+    var y2 = x; // Error
+    var y3 = x;
+    var y4 = x; // Error
+    var y5 = x; // Error
+    var y6 = x; // Error
+}

--- a/tests/baselines/reference/intersectionWithUnionConstraint.symbols
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.symbols
@@ -1,0 +1,78 @@
+=== tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts ===
+function f1<T extends string | number, U extends string | number>(x: T & U) {
+>f1 : Symbol(f1, Decl(intersectionWithUnionConstraint.ts, 0, 0))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 0, 12))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 0, 38))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 0, 66))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 0, 12))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 0, 38))
+
+    // Combined constraint of 'T & U' is 'string | number'
+    let y: string | number = x;
+>y : Symbol(y, Decl(intersectionWithUnionConstraint.ts, 2, 7))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 0, 66))
+}
+
+function f2<T extends string | number | undefined, U extends string | null | undefined>(x: T & U) {
+>f2 : Symbol(f2, Decl(intersectionWithUnionConstraint.ts, 3, 1))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 5, 12))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 5, 50))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 5, 88))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 5, 12))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 5, 50))
+
+    let y1: string | number = x;     // Error
+>y1 : Symbol(y1, Decl(intersectionWithUnionConstraint.ts, 6, 7))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 5, 88))
+
+    let y2: string | null = x;       // Error
+>y2 : Symbol(y2, Decl(intersectionWithUnionConstraint.ts, 7, 7))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 5, 88))
+
+    let y3: string | undefined = x;
+>y3 : Symbol(y3, Decl(intersectionWithUnionConstraint.ts, 8, 7))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 5, 88))
+
+    let y4: number | null = x;       // Error
+>y4 : Symbol(y4, Decl(intersectionWithUnionConstraint.ts, 9, 7))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 5, 88))
+
+    let y5: number | undefined = x;  // Error
+>y5 : Symbol(y5, Decl(intersectionWithUnionConstraint.ts, 10, 7))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 5, 88))
+
+    let y6: null | undefined = x;    // Error
+>y6 : Symbol(y6, Decl(intersectionWithUnionConstraint.ts, 11, 7))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 5, 88))
+}
+
+type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
+>T1 : Symbol(T1, Decl(intersectionWithUnionConstraint.ts, 12, 1))
+
+// Repro from #23648
+
+type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }
+>Example : Symbol(Example, Decl(intersectionWithUnionConstraint.ts, 14, 70))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 18, 13))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 18, 15))
+>K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 18, 24))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 18, 13))
+>K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 18, 24))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 18, 15))
+>UnexpectedError : Symbol(UnexpectedError, Decl(intersectionWithUnionConstraint.ts, 18, 96))
+>K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 18, 24))
+>NoErrorHere : Symbol(NoErrorHere, Decl(intersectionWithUnionConstraint.ts, 20, 47))
+>K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 18, 24))
+
+type UnexpectedError<T extends PropertyKey> = T
+>UnexpectedError : Symbol(UnexpectedError, Decl(intersectionWithUnionConstraint.ts, 18, 96))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 20, 21))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 20, 21))
+
+type NoErrorHere<T extends PropertyKey> = T
+>NoErrorHere : Symbol(NoErrorHere, Decl(intersectionWithUnionConstraint.ts, 20, 47))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 21, 17))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 21, 17))
+

--- a/tests/baselines/reference/intersectionWithUnionConstraint.symbols
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.symbols
@@ -49,30 +49,66 @@ function f2<T extends string | number | undefined, U extends string | null | und
 type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
 >T1 : Symbol(T1, Decl(intersectionWithUnionConstraint.ts, 12, 1))
 
+function f3<T extends string | number | undefined>(x: T & (number | object | undefined)) {
+>f3 : Symbol(f3, Decl(intersectionWithUnionConstraint.ts, 14, 70))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 16, 12))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 16, 51))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 16, 12))
+
+    const y: number | undefined = x;
+>y : Symbol(y, Decl(intersectionWithUnionConstraint.ts, 17, 9))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 16, 51))
+}
+
+function f4<T extends string | number>(x: T & (number | object)) {
+>f4 : Symbol(f4, Decl(intersectionWithUnionConstraint.ts, 18, 1))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 20, 12))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 20, 39))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 20, 12))
+
+    const y: number = x;
+>y : Symbol(y, Decl(intersectionWithUnionConstraint.ts, 21, 9))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 20, 39))
+}
+
+function f5<T, U extends keyof T>(x: keyof T & U) {
+>f5 : Symbol(f5, Decl(intersectionWithUnionConstraint.ts, 22, 1))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 24, 12))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 24, 14))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 24, 12))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 24, 34))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 24, 12))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 24, 14))
+
+    let y: keyof any = x;
+>y : Symbol(y, Decl(intersectionWithUnionConstraint.ts, 25, 7))
+>x : Symbol(x, Decl(intersectionWithUnionConstraint.ts, 24, 34))
+}
+
 // Repro from #23648
 
 type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }
->Example : Symbol(Example, Decl(intersectionWithUnionConstraint.ts, 14, 70))
->T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 18, 13))
->U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 18, 15))
->K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 18, 24))
->T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 18, 13))
->K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 18, 24))
->U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 18, 15))
->UnexpectedError : Symbol(UnexpectedError, Decl(intersectionWithUnionConstraint.ts, 18, 96))
->K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 18, 24))
->NoErrorHere : Symbol(NoErrorHere, Decl(intersectionWithUnionConstraint.ts, 20, 47))
->K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 18, 24))
+>Example : Symbol(Example, Decl(intersectionWithUnionConstraint.ts, 26, 1))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 30, 13))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 30, 15))
+>K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 30, 24))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 30, 13))
+>K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 30, 24))
+>U : Symbol(U, Decl(intersectionWithUnionConstraint.ts, 30, 15))
+>UnexpectedError : Symbol(UnexpectedError, Decl(intersectionWithUnionConstraint.ts, 30, 96))
+>K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 30, 24))
+>NoErrorHere : Symbol(NoErrorHere, Decl(intersectionWithUnionConstraint.ts, 32, 47))
+>K : Symbol(K, Decl(intersectionWithUnionConstraint.ts, 30, 24))
 
 type UnexpectedError<T extends PropertyKey> = T
->UnexpectedError : Symbol(UnexpectedError, Decl(intersectionWithUnionConstraint.ts, 18, 96))
->T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 20, 21))
+>UnexpectedError : Symbol(UnexpectedError, Decl(intersectionWithUnionConstraint.ts, 30, 96))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 32, 21))
 >PropertyKey : Symbol(PropertyKey, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 20, 21))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 32, 21))
 
 type NoErrorHere<T extends PropertyKey> = T
->NoErrorHere : Symbol(NoErrorHere, Decl(intersectionWithUnionConstraint.ts, 20, 47))
->T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 21, 17))
+>NoErrorHere : Symbol(NoErrorHere, Decl(intersectionWithUnionConstraint.ts, 32, 47))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 33, 17))
 >PropertyKey : Symbol(PropertyKey, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 21, 17))
+>T : Symbol(T, Decl(intersectionWithUnionConstraint.ts, 33, 17))
 

--- a/tests/baselines/reference/intersectionWithUnionConstraint.types
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.types
@@ -1,0 +1,83 @@
+=== tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts ===
+function f1<T extends string | number, U extends string | number>(x: T & U) {
+>f1 : <T extends string | number, U extends string | number>(x: T & U) => void
+>T : T
+>U : U
+>x : T & U
+>T : T
+>U : U
+
+    // Combined constraint of 'T & U' is 'string | number'
+    let y: string | number = x;
+>y : string | number
+>x : T & U
+}
+
+function f2<T extends string | number | undefined, U extends string | null | undefined>(x: T & U) {
+>f2 : <T extends string | number | undefined, U extends string | null | undefined>(x: T & U) => void
+>T : T
+>U : U
+>null : null
+>x : T & U
+>T : T
+>U : U
+
+    let y1: string | number = x;     // Error
+>y1 : string | number
+>x : T & U
+
+    let y2: string | null = x;       // Error
+>y2 : string | null
+>null : null
+>x : T & U
+
+    let y3: string | undefined = x;
+>y3 : string | undefined
+>x : T & U
+
+    let y4: number | null = x;       // Error
+>y4 : number | null
+>null : null
+>x : T & U
+
+    let y5: number | undefined = x;  // Error
+>y5 : number | undefined
+>x : T & U
+
+    let y6: null | undefined = x;    // Error
+>y6 : null | undefined
+>null : null
+>x : T & U
+}
+
+type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
+>T1 : string | undefined
+>null : null
+
+// Repro from #23648
+
+type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }
+>Example : Example<T, U>
+>T : T
+>U : U
+>K : K
+>T : T
+>K : K
+>U : U
+>UnexpectedError : T
+>K : K
+>NoErrorHere : T
+>K : K
+
+type UnexpectedError<T extends PropertyKey> = T
+>UnexpectedError : T
+>T : T
+>PropertyKey : string | number | symbol
+>T : T
+
+type NoErrorHere<T extends PropertyKey> = T
+>NoErrorHere : T
+>T : T
+>PropertyKey : string | number | symbol
+>T : T
+

--- a/tests/baselines/reference/intersectionWithUnionConstraint.types
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.types
@@ -54,6 +54,42 @@ type T1 = (string | number | undefined) & (string | null | undefined);  // strin
 >T1 : string | undefined
 >null : null
 
+function f3<T extends string | number | undefined>(x: T & (number | object | undefined)) {
+>f3 : <T extends string | number | undefined>(x: (T & undefined) | (T & number) | (T & object)) => void
+>T : T
+>x : (T & undefined) | (T & number) | (T & object)
+>T : T
+
+    const y: number | undefined = x;
+>y : number | undefined
+>x : (T & undefined) | (T & number) | (T & object)
+}
+
+function f4<T extends string | number>(x: T & (number | object)) {
+>f4 : <T extends string | number>(x: (T & number) | (T & object)) => void
+>T : T
+>x : (T & number) | (T & object)
+>T : T
+
+    const y: number = x;
+>y : number
+>x : (T & number) | (T & object)
+}
+
+function f5<T, U extends keyof T>(x: keyof T & U) {
+>f5 : <T, U extends keyof T>(x: keyof T & U) => void
+>T : T
+>U : U
+>T : T
+>x : keyof T & U
+>T : T
+>U : U
+
+    let y: keyof any = x;
+>y : string | number | symbol
+>x : keyof T & U
+}
+
 // Repro from #23648
 
 type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -44,6 +44,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(87,5): error 
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(103,9): error TS2322: Type 'Extract<keyof T, string>' is not assignable to type 'K'.
   Type 'string & keyof T' is not assignable to type 'K'.
     Type 'string' is not assignable to type 'K'.
+      Type 'string' is not assignable to type 'K'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(105,9): error TS2322: Type 'T[Extract<keyof T, string>]' is not assignable to type 'T[K]'.
   Type 'Extract<keyof T, string>' is not assignable to type 'K'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(108,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
@@ -55,6 +56,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(114,5): error
     Type 'Extract<keyof T, string>' is not assignable to type 'J'.
       Type 'string & keyof T' is not assignable to type 'J'.
         Type 'string' is not assignable to type 'J'.
+          Type 'string' is not assignable to type 'J'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error TS2322: Type 'T[K]' is not assignable to type 'U[J]'.
   Type 'T' is not assignable to type 'U'.
 
@@ -238,6 +240,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error
 !!! error TS2322: Type 'Extract<keyof T, string>' is not assignable to type 'K'.
 !!! error TS2322:   Type 'string & keyof T' is not assignable to type 'K'.
 !!! error TS2322:     Type 'string' is not assignable to type 'K'.
+!!! error TS2322:       Type 'string' is not assignable to type 'K'.
             t[key] = tk; // ok, T[K] ==> T[keyof T]
             tk = t[key]; // error, T[keyof T] =/=> T[K]
             ~~
@@ -264,6 +267,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error
 !!! error TS2322:     Type 'Extract<keyof T, string>' is not assignable to type 'J'.
 !!! error TS2322:       Type 'string & keyof T' is not assignable to type 'J'.
 !!! error TS2322:         Type 'string' is not assignable to type 'J'.
+!!! error TS2322:           Type 'string' is not assignable to type 'J'.
     
         tk = uj;
         uj = tk; // error

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.types
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.types
@@ -34,19 +34,19 @@ type T02 = keyof keyof Object;
 >Object : Object
 
 type T03 = keyof keyof keyof Object;
->T03 : "toString" | "valueOf" | ("toString" & number) | ("toLocaleString" & number) | ("valueOf" & number) | ("toFixed" & number) | ("toExponential" & number) | ("toPrecision" & number)
+>T03 : "toString" | "valueOf"
 >Object : Object
 
 type T04 = keyof keyof keyof keyof Object;
->T04 : number | "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | ("toString" & number) | ("valueOf" & number) | (number & "length") | (number & "toString") | (number & "toLocaleString") | (number & "valueOf") | (number & "charAt") | (number & "charCodeAt") | (number & "concat") | (number & "indexOf") | (number & "lastIndexOf") | (number & "localeCompare") | (number & "match") | (number & "replace") | (number & "search") | (number & "slice") | (number & "split") | (number & "substring") | (number & "toLowerCase") | (number & "toLocaleLowerCase") | (number & "toUpperCase") | (number & "toLocaleUpperCase") | (number & "trim") | (number & "substr") | (number & "toFixed") | (number & "toExponential") | (number & "toPrecision") | ("length" & number) | ("charAt" & number) | ("charCodeAt" & number) | ("concat" & number) | ("indexOf" & number) | ("lastIndexOf" & number) | ("localeCompare" & number) | ("match" & number) | ("replace" & number) | ("search" & number) | ("slice" & number) | ("split" & number) | ("substring" & number) | ("toLowerCase" & number) | ("toLocaleLowerCase" & number) | ("toUpperCase" & number) | ("toLocaleUpperCase" & number) | ("trim" & number) | ("substr" & number)
+>T04 : number | "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
 >Object : Object
 
 type T05 = keyof keyof keyof keyof keyof Object;
->T05 : "toString" | "valueOf" | ("toString" & number) | ("toLocaleString" & number) | ("valueOf" & number) | ("toFixed" & number) | ("toExponential" & number) | ("toPrecision" & number)
+>T05 : "toString" | "valueOf"
 >Object : Object
 
 type T06 = keyof keyof keyof keyof keyof keyof Object;
->T06 : number | "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | ("toString" & number) | ("valueOf" & number) | (number & "length") | (number & "toString") | (number & "toLocaleString") | (number & "valueOf") | (number & "charAt") | (number & "charCodeAt") | (number & "concat") | (number & "indexOf") | (number & "lastIndexOf") | (number & "localeCompare") | (number & "match") | (number & "replace") | (number & "search") | (number & "slice") | (number & "split") | (number & "substring") | (number & "toLowerCase") | (number & "toLocaleLowerCase") | (number & "toUpperCase") | (number & "toLocaleUpperCase") | (number & "trim") | (number & "substr") | (number & "toFixed") | (number & "toExponential") | (number & "toPrecision") | ("length" & number) | ("charAt" & number) | ("charCodeAt" & number) | ("concat" & number) | ("indexOf" & number) | ("lastIndexOf" & number) | ("localeCompare" & number) | ("match" & number) | ("replace" & number) | ("search" & number) | ("slice" & number) | ("split" & number) | ("substring" & number) | ("toLowerCase" & number) | ("toLocaleLowerCase" & number) | ("toUpperCase" & number) | ("toLocaleUpperCase" & number) | ("trim" & number) | ("substr" & number)
+>T06 : number | "length" | "toString" | "valueOf" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr"
 >Object : Object
 
 type T10 = Shape["name"];

--- a/tests/baselines/reference/switchCaseWithIntersectionTypes01.errors.txt
+++ b/tests/baselines/reference/switchCaseWithIntersectionTypes01.errors.txt
@@ -1,10 +1,7 @@
-tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts(18,10): error TS2678: Type '(number & true) | (number & false)' is not comparable to type 'string & number'.
-  Type 'number & false' is not comparable to type 'string & number'.
-    Type 'number & false' is not comparable to type 'string'.
 tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts(22,10): error TS2678: Type 'boolean' is not comparable to type 'string & number'.
 
 
-==== tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts (2 errors) ====
+==== tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts (1 errors) ====
     var strAndNum: string & number;
     var numAndBool: number & boolean;
     var str: string;
@@ -23,10 +20,6 @@ tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithInterse
     
         // Overlap in constituents
         case numAndBool:
-             ~~~~~~~~~~
-!!! error TS2678: Type '(number & true) | (number & false)' is not comparable to type 'string & number'.
-!!! error TS2678:   Type 'number & false' is not comparable to type 'string & number'.
-!!! error TS2678:     Type 'number & false' is not comparable to type 'string'.
             break;
     
         // No relation

--- a/tests/baselines/reference/switchCaseWithIntersectionTypes01.types
+++ b/tests/baselines/reference/switchCaseWithIntersectionTypes01.types
@@ -3,7 +3,7 @@ var strAndNum: string & number;
 >strAndNum : string & number
 
 var numAndBool: number & boolean;
->numAndBool : (number & true) | (number & false)
+>numAndBool : never
 
 var str: string;
 >str : string
@@ -34,7 +34,7 @@ switch (strAndNum) {
 
     // Overlap in constituents
     case numAndBool:
->numAndBool : (number & true) | (number & false)
+>numAndBool : never
 
         break;
 

--- a/tests/baselines/reference/typeGuardsWithInstanceOf.types
+++ b/tests/baselines/reference/typeGuardsWithInstanceOf.types
@@ -25,7 +25,7 @@ if (!(result instanceof RegExp)) {
 
 } else if (!result.global) {
 >!result.global : boolean
->result.global : (string & true) | (string & false)
+>result.global : never
 >result : I & RegExp
->global : (string & true) | (string & false)
+>global : never
 }

--- a/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts
+++ b/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts
@@ -1,0 +1,24 @@
+// @strict: true
+
+function f1<T extends string | number, U extends string | number>(x: T & U) {
+    // Combined constraint of 'T & U' is 'string | number'
+    let y: string | number = x;
+}
+
+function f2<T extends string | number | undefined, U extends string | null | undefined>(x: T & U) {
+    let y1: string | number = x;     // Error
+    let y2: string | null = x;       // Error
+    let y3: string | undefined = x;
+    let y4: number | null = x;       // Error
+    let y5: number | undefined = x;  // Error
+    let y6: null | undefined = x;    // Error
+}
+
+type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
+
+// Repro from #23648
+
+type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }
+
+type UnexpectedError<T extends PropertyKey> = T
+type NoErrorHere<T extends PropertyKey> = T

--- a/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts
+++ b/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts
@@ -16,6 +16,18 @@ function f2<T extends string | number | undefined, U extends string | null | und
 
 type T1 = (string | number | undefined) & (string | null | undefined);  // string | undefined
 
+function f3<T extends string | number | undefined>(x: T & (number | object | undefined)) {
+    const y: number | undefined = x;
+}
+
+function f4<T extends string | number>(x: T & (number | object)) {
+    const y: number = x;
+}
+
+function f5<T, U extends keyof T>(x: keyof T & U) {
+    let y: keyof any = x;
+}
+
 // Repro from #23648
 
 type Example<T, U> = { [K in keyof T]: K extends keyof U ? UnexpectedError<K> : NoErrorHere<K> }


### PR DESCRIPTION
This PR fixes two issues:

* Type relationships for intersection types with combined constraints that are union types are now handled properly.
* Intersections of primitive types with mutually exclusive value domains (e.g. `string & number`) are now removed from union types. Previously we only removed intersections containing more than one unit type.

An example of an intersection type with a union type constraint:

```ts
function f1<T extends string | number, U extends string | number>(x: T & U) {
    let y: string | number = x;  // Ok, but was error previously
}
```

Fixes #23648.