### PR TITLE
Always parse an argument for an ElementAccessExpression

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -23,6 +23,10 @@
         "category": "Error",
         "code": 1010
     },
+    "An element access expression should take an argument.": {
+        "category": "Error",
+        "code": 1011
+    },
     "Unexpected token.": {
         "category": "Error",
         "code": 1012

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1240,7 +1240,7 @@ namespace ts {
             if (reportAtCurrentPosition) {
                 parseErrorAtPosition(scanner.getStartPos(), 0, diagnosticMessage, arg0);
             }
-            else {
+            else if (diagnosticMessage) {
                 parseErrorAtCurrentToken(diagnosticMessage, arg0);
             }
 
@@ -4348,14 +4348,15 @@ namespace ts {
                     const indexedAccess = <ElementAccessExpression>createNode(SyntaxKind.ElementAccessExpression, expression.pos);
                     indexedAccess.expression = expression;
 
-                    // It's not uncommon for a user to write: "new Type[]".
-                    // Check for that common pattern and report a better error message.
-                    if (token() !== SyntaxKind.CloseBracketToken) {
-                        indexedAccess.argumentExpression = allowInAnd(parseExpression);
-                        if (indexedAccess.argumentExpression.kind === SyntaxKind.StringLiteral || indexedAccess.argumentExpression.kind === SyntaxKind.NumericLiteral) {
-                            const literal = <LiteralExpression>indexedAccess.argumentExpression;
-                            literal.text = internIdentifier(literal.text);
+                    if (token() === SyntaxKind.CloseBracketToken) {
+                        indexedAccess.argumentExpression = createMissingNode(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, Diagnostics.An_element_access_expression_should_take_an_argument);
+                    }
+                    else {
+                        const argument = allowInAnd(parseExpression);
+                        if (isStringOrNumericLiteral(argument)) {
+                            argument.text = internIdentifier(argument.text);
                         }
+                        indexedAccess.argumentExpression = argument;
                     }
 
                     parseExpected(SyntaxKind.CloseBracketToken);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1685,7 +1685,7 @@ namespace ts {
     export interface ElementAccessExpression extends MemberExpression {
         kind: SyntaxKind.ElementAccessExpression;
         expression: LeftHandSideExpression;
-        argumentExpression?: Expression;
+        argumentExpression: Expression;
     }
 
     export interface SuperElementAccessExpression extends ElementAccessExpression {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1019,7 +1019,7 @@ declare namespace ts {
     interface ElementAccessExpression extends MemberExpression {
         kind: SyntaxKind.ElementAccessExpression;
         expression: LeftHandSideExpression;
-        argumentExpression?: Expression;
+        argumentExpression: Expression;
     }
     interface SuperElementAccessExpression extends ElementAccessExpression {
         expression: SuperExpression;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1019,7 +1019,7 @@ declare namespace ts {
     interface ElementAccessExpression extends MemberExpression {
         kind: SyntaxKind.ElementAccessExpression;
         expression: LeftHandSideExpression;
-        argumentExpression?: Expression;
+        argumentExpression: Expression;
     }
     interface SuperElementAccessExpression extends ElementAccessExpression {
         expression: SuperExpression;

--- a/tests/baselines/reference/badArrayIndex.errors.txt
+++ b/tests/baselines/reference/badArrayIndex.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/compiler/badArrayIndex.ts(1,15): error TS2693: 'number' only refers to a type, but is being used as a value here.
-tests/cases/compiler/badArrayIndex.ts(1,22): error TS1109: Expression expected.
+tests/cases/compiler/badArrayIndex.ts(1,22): error TS1011: An element access expression should take an argument.
 
 
 ==== tests/cases/compiler/badArrayIndex.ts (2 errors) ====
     var results = number[];
                   ~~~~~~
 !!! error TS2693: 'number' only refers to a type, but is being used as a value here.
-                         ~
-!!! error TS1109: Expression expected.
+                         
+!!! error TS1011: An element access expression should take an argument.

--- a/tests/baselines/reference/badArrayIndex.types
+++ b/tests/baselines/reference/badArrayIndex.types
@@ -3,4 +3,5 @@ var results = number[];
 >results : any
 >number[] : any
 >number : any
+> : any
 

--- a/tests/baselines/reference/badArraySyntax.errors.txt
+++ b/tests/baselines/reference/badArraySyntax.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/badArraySyntax.ts(6,15): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
-tests/cases/compiler/badArraySyntax.ts(7,15): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
-tests/cases/compiler/badArraySyntax.ts(8,20): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
-tests/cases/compiler/badArraySyntax.ts(9,20): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
-tests/cases/compiler/badArraySyntax.ts(10,36): error TS1109: Expression expected.
-tests/cases/compiler/badArraySyntax.ts(10,40): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/badArraySyntax.ts(6,16): error TS1011: An element access expression should take an argument.
+tests/cases/compiler/badArraySyntax.ts(7,16): error TS1011: An element access expression should take an argument.
+tests/cases/compiler/badArraySyntax.ts(8,21): error TS1011: An element access expression should take an argument.
+tests/cases/compiler/badArraySyntax.ts(9,21): error TS1011: An element access expression should take an argument.
+tests/cases/compiler/badArraySyntax.ts(10,30): error TS1011: An element access expression should take an argument.
+tests/cases/compiler/badArraySyntax.ts(10,41): error TS1011: An element access expression should take an argument.
 
 
 ==== tests/cases/compiler/badArraySyntax.ts (6 errors) ====
@@ -13,20 +13,20 @@ tests/cases/compiler/badArraySyntax.ts(10,40): error TS1150: 'new T[]' cannot be
     
     var a1: Z[] = [];
     var a2 = new Z[];
-                  ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                   
+!!! error TS1011: An element access expression should take an argument.
     var a3 = new Z[]();
-                  ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                   
+!!! error TS1011: An element access expression should take an argument.
     var a4: Z[] = new Z[];
-                       ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                        
+!!! error TS1011: An element access expression should take an argument.
     var a5: Z[] = new Z[]();
-                       ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                        
+!!! error TS1011: An element access expression should take an argument.
     var a6: Z[][] = new   Z     [      ]   [  ];
-                                       ~
-!!! error TS1109: Expression expected.
-                                           ~~~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                 
+!!! error TS1011: An element access expression should take an argument.
+                                            
+!!! error TS1011: An element access expression should take an argument.
     

--- a/tests/baselines/reference/badArraySyntax.types
+++ b/tests/baselines/reference/badArraySyntax.types
@@ -17,12 +17,14 @@ var a2 = new Z[];
 >new Z[] : any
 >Z[] : any
 >Z : typeof Z
+> : any
 
 var a3 = new Z[]();
 >a3 : any
 >new Z[]() : any
 >Z[] : any
 >Z : typeof Z
+> : any
 
 var a4: Z[] = new Z[];
 >a4 : Z[]
@@ -30,6 +32,7 @@ var a4: Z[] = new Z[];
 >new Z[] : any
 >Z[] : any
 >Z : typeof Z
+> : any
 
 var a5: Z[] = new Z[]();
 >a5 : Z[]
@@ -37,6 +40,7 @@ var a5: Z[] = new Z[]();
 >new Z[]() : any
 >Z[] : any
 >Z : typeof Z
+> : any
 
 var a6: Z[][] = new   Z     [      ]   [  ];
 >a6 : Z[][]
@@ -45,4 +49,6 @@ var a6: Z[][] = new   Z     [      ]   [  ];
 >Z     [      ]   [  ] : any
 >Z     [      ] : any
 >Z : typeof Z
+> : any
+> : any
 

--- a/tests/baselines/reference/cannotInvokeNewOnErrorExpression.errors.txt
+++ b/tests/baselines/reference/cannotInvokeNewOnErrorExpression.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/cannotInvokeNewOnErrorExpression.ts(5,15): error TS2339: Property 'ClassA' does not exist on type 'typeof M'.
-tests/cases/compiler/cannotInvokeNewOnErrorExpression.ts(5,21): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/cannotInvokeNewOnErrorExpression.ts(5,22): error TS1011: An element access expression should take an argument.
 
 
 ==== tests/cases/compiler/cannotInvokeNewOnErrorExpression.ts (2 errors) ====
@@ -10,5 +10,5 @@ tests/cases/compiler/cannotInvokeNewOnErrorExpression.ts(5,21): error TS1150: 'n
     var t = new M.ClassA[];
                   ~~~~~~
 !!! error TS2339: Property 'ClassA' does not exist on type 'typeof M'.
-                        ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                         
+!!! error TS1011: An element access expression should take an argument.

--- a/tests/baselines/reference/cannotInvokeNewOnErrorExpression.types
+++ b/tests/baselines/reference/cannotInvokeNewOnErrorExpression.types
@@ -12,4 +12,5 @@ var t = new M.ClassA[];
 >M.ClassA : any
 >M : typeof M
 >ClassA : any
+> : any
 

--- a/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
+++ b/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
@@ -77,6 +77,7 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(257,33): error T
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(257,35): error TS2693: 'string' only refers to a type, but is being used as a value here.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(257,43): error TS1109: Expression expected.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(257,52): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(257,59): error TS1011: An element access expression should take an argument.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(257,60): error TS1005: ';' expected.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(257,65): error TS1109: Expression expected.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(259,9): error TS2304: Cannot find name 'public'.
@@ -89,7 +90,7 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(259,55): error T
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(261,1): error TS1128: Declaration or statement expected.
 
 
-==== tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts (89 errors) ====
+==== tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts (90 errors) ====
     declare module "fs" {
         export class File {
             constructor(filename: string);
@@ -508,6 +509,8 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(261,1): error TS
 !!! error TS1109: Expression expected.
                                                        ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                                                              
+!!! error TS1011: An element access expression should take an argument.
                                                                ~
 !!! error TS1005: ';' expected.
                                                                     ~

--- a/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.types
+++ b/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.types
@@ -929,6 +929,7 @@ module TypeScriptAllInOne {
 >rest : any
 >string[] : any
 >string : any
+> : any
 >&         public : number
 > : any
 

--- a/tests/baselines/reference/createArray.errors.txt
+++ b/tests/baselines/reference/createArray.errors.txt
@@ -1,35 +1,35 @@
 tests/cases/compiler/createArray.ts(1,12): error TS2693: 'number' only refers to a type, but is being used as a value here.
-tests/cases/compiler/createArray.ts(1,18): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
-tests/cases/compiler/createArray.ts(6,6): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/createArray.ts(1,19): error TS1011: An element access expression should take an argument.
+tests/cases/compiler/createArray.ts(6,7): error TS1011: An element access expression should take an argument.
 tests/cases/compiler/createArray.ts(7,12): error TS2693: 'boolean' only refers to a type, but is being used as a value here.
-tests/cases/compiler/createArray.ts(7,19): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/createArray.ts(7,20): error TS1011: An element access expression should take an argument.
 tests/cases/compiler/createArray.ts(8,12): error TS2693: 'string' only refers to a type, but is being used as a value here.
-tests/cases/compiler/createArray.ts(8,18): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/createArray.ts(8,19): error TS1011: An element access expression should take an argument.
 
 
 ==== tests/cases/compiler/createArray.ts (7 errors) ====
     var na=new number[];
                ~~~~~~
 !!! error TS2693: 'number' only refers to a type, but is being used as a value here.
-                     ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                      
+!!! error TS1011: An element access expression should take an argument.
     
     class C {
     }
     
     new C[];
-         ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+          
+!!! error TS1011: An element access expression should take an argument.
     var ba=new boolean[];
                ~~~~~~~
 !!! error TS2693: 'boolean' only refers to a type, but is being used as a value here.
-                      ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                       
+!!! error TS1011: An element access expression should take an argument.
     var sa=new string[];
                ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-                     ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                      
+!!! error TS1011: An element access expression should take an argument.
     function f(s:string):number { return 0;
     }
     if (ba[14]) {

--- a/tests/baselines/reference/createArray.types
+++ b/tests/baselines/reference/createArray.types
@@ -4,6 +4,7 @@ var na=new number[];
 >new number[] : any
 >number[] : any
 >number : any
+> : any
 
 class C {
 >C : C
@@ -13,18 +14,21 @@ new C[];
 >new C[] : any
 >C[] : any
 >C : typeof C
+> : any
 
 var ba=new boolean[];
 >ba : any
 >new boolean[] : any
 >boolean[] : any
 >boolean : any
+> : any
 
 var sa=new string[];
 >sa : any
 >new string[] : any
 >string[] : any
 >string : any
+> : any
 
 function f(s:string):number { return 0;
 >f : (s: string) => number

--- a/tests/baselines/reference/libMembers.errors.txt
+++ b/tests/baselines/reference/libMembers.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/libMembers.ts(4,3): error TS2339: Property 'subby' does not exist on type 'string'.
-tests/cases/compiler/libMembers.ts(9,16): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/libMembers.ts(9,17): error TS1011: An element access expression should take an argument.
 tests/cases/compiler/libMembers.ts(12,15): error TS2339: Property 'prototype' does not exist on type 'C'.
 
 
@@ -15,8 +15,8 @@ tests/cases/compiler/libMembers.ts(12,15): error TS2339: Property 'prototype' do
         export class C {
         }
         var a=new C[];
-                   ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                    
+!!! error TS1011: An element access expression should take an argument.
         a.length;
         a.push(new C());
         (new C()).prototype;

--- a/tests/baselines/reference/libMembers.types
+++ b/tests/baselines/reference/libMembers.types
@@ -43,6 +43,7 @@ module M {
 >new C[] : any
 >C[] : any
 >C : typeof C
+> : any
 
     a.length;
 >a.length : any

--- a/tests/baselines/reference/newOperator.errors.txt
+++ b/tests/baselines/reference/newOperator.errors.txt
@@ -3,16 +3,15 @@ tests/cases/compiler/newOperator.ts(10,10): error TS2351: Cannot use 'new' with 
 tests/cases/compiler/newOperator.ts(11,10): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/compiler/newOperator.ts(12,5): error TS2693: 'string' only refers to a type, but is being used as a value here.
 tests/cases/compiler/newOperator.ts(18,14): error TS2693: 'string' only refers to a type, but is being used as a value here.
-tests/cases/compiler/newOperator.ts(18,20): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/newOperator.ts(18,21): error TS1011: An element access expression should take an argument.
 tests/cases/compiler/newOperator.ts(21,1): error TS2693: 'string' only refers to a type, but is being used as a value here.
-tests/cases/compiler/newOperator.ts(22,1): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/newOperator.ts(22,2): error TS1011: An element access expression should take an argument.
 tests/cases/compiler/newOperator.ts(28,13): error TS2304: Cannot find name 'q'.
 tests/cases/compiler/newOperator.ts(31,10): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
-tests/cases/compiler/newOperator.ts(44,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/newOperator.ts(45,23): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/compiler/newOperator.ts(45,24): error TS1011: An element access expression should take an argument.
 
 
-==== tests/cases/compiler/newOperator.ts (12 errors) ====
+==== tests/cases/compiler/newOperator.ts (11 errors) ====
     interface ifc { }
     // Attempting to 'new' an interface yields poor error
     var i = new ifc();
@@ -41,18 +40,17 @@ tests/cases/compiler/newOperator.ts(45,23): error TS1150: 'new T[]' cannot be us
     var t3 = new string[]( );
                  ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-                       ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                        
+!!! error TS1011: An element access expression should take an argument.
     var t4 =
     new
     string
     ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
     [
-    ~
+     
+!!! error TS1011: An element access expression should take an argument.
         ]
-    ~~~~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
         (
             );
     
@@ -78,11 +76,9 @@ tests/cases/compiler/newOperator.ts(45,23): error TS1150: 'new T[]' cannot be us
     
     class S {
         public get xs(): M.T[] {
-                   ~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             return new M.T[];
-                          ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                           
+!!! error TS1011: An element access expression should take an argument.
         }
     }
     

--- a/tests/baselines/reference/newOperator.types
+++ b/tests/baselines/reference/newOperator.types
@@ -49,6 +49,7 @@ var t3 = new string[]( );
 >new string[]( ) : any
 >string[] : any
 >string : any
+> : any
 
 var t4 =
 >t4 : any
@@ -62,6 +63,8 @@ string
 
 [
     ]
+> : any
+
     (
         );
 
@@ -109,6 +112,7 @@ class S {
 >M.T : typeof M.T
 >M : typeof M
 >T : typeof M.T
+> : any
     }
 }
 

--- a/tests/baselines/reference/objectLitArrayDeclNoNew.errors.txt
+++ b/tests/baselines/reference/objectLitArrayDeclNoNew.errors.txt
@@ -1,7 +1,8 @@
+tests/cases/compiler/objectLitArrayDeclNoNew.ts(22,20): error TS1011: An element access expression should take an argument.
 tests/cases/compiler/objectLitArrayDeclNoNew.ts(27,1): error TS1128: Declaration or statement expected.
 
 
-==== tests/cases/compiler/objectLitArrayDeclNoNew.ts (1 errors) ====
+==== tests/cases/compiler/objectLitArrayDeclNoNew.ts (2 errors) ====
     declare var console;
     "use strict";
     module Test {
@@ -24,6 +25,8 @@ tests/cases/compiler/objectLitArrayDeclNoNew.ts(27,1): error TS1128: Declaration
           var state:IState= null;
           return {
            tokens: Gar[],//IToken[],  // Missing new. Correct syntax is: tokens: new IToken[]
+                       
+!!! error TS1011: An element access expression should take an argument.
            endState: state
           };
          }

--- a/tests/baselines/reference/objectLitArrayDeclNoNew.types
+++ b/tests/baselines/reference/objectLitArrayDeclNoNew.types
@@ -52,6 +52,7 @@ module Test {
 >tokens : any
 >Gar[] : any
 >Gar : typeof Gar
+> : any
 
        endState: state
 >endState : IState

--- a/tests/baselines/reference/parserObjectCreationArrayLiteral1.errors.txt
+++ b/tests/baselines/reference/parserObjectCreationArrayLiteral1.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral1.ts(1,5): error TS2304: Cannot find name 'Foo'.
-tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral1.ts(1,8): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral1.ts(1,9): error TS1011: An element access expression should take an argument.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral1.ts (2 errors) ====
     new Foo[];
         ~~~
 !!! error TS2304: Cannot find name 'Foo'.
-           ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+            
+!!! error TS1011: An element access expression should take an argument.

--- a/tests/baselines/reference/parserObjectCreationArrayLiteral1.types
+++ b/tests/baselines/reference/parserObjectCreationArrayLiteral1.types
@@ -3,4 +3,5 @@ new Foo[];
 >new Foo[] : any
 >Foo[] : any
 >Foo : any
+> : any
 

--- a/tests/baselines/reference/parserObjectCreationArrayLiteral3.errors.txt
+++ b/tests/baselines/reference/parserObjectCreationArrayLiteral3.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral3.ts(1,5): error TS2304: Cannot find name 'Foo'.
-tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral3.ts(1,8): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral3.ts(1,9): error TS1011: An element access expression should take an argument.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral3.ts (2 errors) ====
     new Foo[]();
         ~~~
 !!! error TS2304: Cannot find name 'Foo'.
-           ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+            
+!!! error TS1011: An element access expression should take an argument.

--- a/tests/baselines/reference/parserObjectCreationArrayLiteral3.types
+++ b/tests/baselines/reference/parserObjectCreationArrayLiteral3.types
@@ -3,4 +3,5 @@ new Foo[]();
 >new Foo[]() : any
 >Foo[] : any
 >Foo : any
+> : any
 

--- a/tests/baselines/reference/parserRealSource10.errors.txt
+++ b/tests/baselines/reference/parserRealSource10.errors.txt
@@ -1,12 +1,12 @@
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(127,33): error TS2449: Class 'TokenInfo' used before its declaration.
-tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(127,42): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(127,43): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(128,36): error TS2693: 'string' only refers to a type, but is being used as a value here.
-tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(128,42): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(128,43): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(129,41): error TS2693: 'number' only refers to a type, but is being used as a value here.
-tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(129,47): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(129,48): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(130,35): error TS2693: 'boolean' only refers to a type, but is being used as a value here.
-tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(130,42): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(130,43): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(179,54): error TS2304: Cannot find name 'ErrorRecoverySet'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(184,28): error TS2304: Cannot find name 'ErrorRecoverySet'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(188,34): error TS2304: Cannot find name 'NodeType'.
@@ -340,7 +340,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(312,128): error
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(312,149): error TS2304: Cannot find name 'ErrorRecoverySet'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(355,52): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(356,53): error TS2304: Cannot find name 'NodeType'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(449,40): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(449,41): error TS1011: An element access expression should take an argument.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts (343 errors) ====
@@ -475,23 +475,23 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(449,40): error 
         export var tokenTable = new TokenInfo[];
                                     ~~~~~~~~~
 !!! error TS2449: Class 'TokenInfo' used before its declaration.
-                                             ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                              
+!!! error TS1011: An element access expression should take an argument.
         export var nodeTypeTable = new string[];
                                        ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
-                                             ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                              
+!!! error TS1011: An element access expression should take an argument.
         export var nodeTypeToTokTable = new number[];
                                             ~~~~~~
 !!! error TS2693: 'number' only refers to a type, but is being used as a value here.
-                                                  ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                                   
+!!! error TS1011: An element access expression should take an argument.
         export var noRegexTable = new boolean[];
                                       ~~~~~~~
 !!! error TS2693: 'boolean' only refers to a type, but is being used as a value here.
-                                             ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                              
+!!! error TS1011: An element access expression should take an argument.
     
         noRegexTable[TokenID.Identifier] = true;
         noRegexTable[TokenID.StringLiteral] = true;
@@ -1477,8 +1477,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(449,40): error 
     
         // TODO: new with length TokenID.LimFixed
         export var staticTokens = new Token[];
-                                           ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                            
+!!! error TS1011: An element access expression should take an argument.
         export function initializeStaticTokens() {
             for (var i = 0; i <= TokenID.LimFixed; i++) {
                 staticTokens[i] = new Token(i);

--- a/tests/baselines/reference/parserRealSource10.types
+++ b/tests/baselines/reference/parserRealSource10.types
@@ -365,24 +365,28 @@ module TypeScript {
 >new TokenInfo[] : any
 >TokenInfo[] : any
 >TokenInfo : typeof TokenInfo
+> : any
 
     export var nodeTypeTable = new string[];
 >nodeTypeTable : any
 >new string[] : any
 >string[] : any
 >string : any
+> : any
 
     export var nodeTypeToTokTable = new number[];
 >nodeTypeToTokTable : any
 >new number[] : any
 >number[] : any
 >number : any
+> : any
 
     export var noRegexTable = new boolean[];
 >noRegexTable : any
 >new boolean[] : any
 >boolean[] : any
 >boolean : any
+> : any
 
     noRegexTable[TokenID.Identifier] = true;
 >noRegexTable[TokenID.Identifier] = true : true
@@ -3949,6 +3953,7 @@ module TypeScript {
 >new Token[] : any
 >Token[] : any
 >Token : typeof Token
+> : any
 
     export function initializeStaticTokens() {
 >initializeStaticTokens : () => void

--- a/tests/baselines/reference/parserRealSource11.errors.txt
+++ b/tests/baselines/reference/parserRealSource11.errors.txt
@@ -40,7 +40,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(151,57): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(155,26): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(184,19): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(192,32): error TS2304: Cannot find name 'SymbolScope'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(193,40): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(193,41): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(196,19): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(199,42): error TS2304: Cannot find name 'ControlFlowContext'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(219,33): error TS2304: Cannot find name 'NodeType'.
@@ -215,7 +215,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(838,24): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(841,61): error TS2304: Cannot find name 'TypeSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(850,52): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(863,36): error TS2304: Cannot find name 'TypeFlow'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(867,29): error TS1015: Parameter cannot have question mark and initializer.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(868,38): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(877,40): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(891,27): error TS2304: Cannot find name 'VarFlags'.
@@ -252,9 +251,9 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1004,44): error
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1004,67): error TS2304: Cannot find name 'FncFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1005,57): error TS2304: Cannot find name 'FncFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1007,47): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1009,45): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1009,46): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1022,32): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1024,47): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1024,48): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1032,36): error TS2304: Cannot find name 'ControlFlowContext'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1033,29): error TS2304: Cannot find name 'BasicBlock'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1034,28): error TS2304: Cannot find name 'BasicBlock'.
@@ -517,7 +516,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,30): error
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error TS2304: Cannot find name 'TokenID'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts (517 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts (516 errors) ====
     // Copyright (c) Microsoft. All rights reserved. Licensed under the Apache License, Version 2.0. 
     // See LICENSE.txt in the project root for complete license information.
     
@@ -795,8 +794,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                                    ~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SymbolScope'.
             public members: AST[] = new AST[];
-                                           ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                            
+!!! error TS1011: An element access expression should take an argument.
     
             constructor () {
                 super(NodeType.List);
@@ -1819,8 +1818,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
             }
     
             public getAliasName(aliasAST?: AST = this.alias) : string {
-                                ~~~~~~~~
-!!! error TS1015: Parameter cannot have question mark and initializer.
                 if (aliasAST.nodeType == NodeType.Name) {
                                          ~~~~~~~~
 !!! error TS2304: Cannot find name 'NodeType'.
@@ -2035,8 +2032,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
 !!! error TS2304: Cannot find name 'Symbol'.
                 if (this.envids == null) {
                     this.envids = new Identifier[];
-                                                ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                                 
+!!! error TS1011: An element access expression should take an argument.
                 }
                 this.envids[this.envids.length] = id;
                 var outerFnc = this.enclosingFnc;
@@ -2054,8 +2051,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
 !!! error TS2304: Cannot find name 'Symbol'.
                 if (this.jumpRefs == null) {
                     this.jumpRefs = new Identifier[];
-                                                  ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                                   
+!!! error TS1011: An element access expression should take an argument.
                 }
                 var id = new Identifier(sym.name);
                 this.jumpRefs[this.jumpRefs.length] = id;

--- a/tests/baselines/reference/parserRealSource11.types
+++ b/tests/baselines/reference/parserRealSource11.types
@@ -853,6 +853,7 @@ module TypeScript {
 >new AST[] : any
 >AST[] : any
 >AST : typeof AST
+> : any
 
         constructor () {
             super(NodeType.List);
@@ -4642,6 +4643,7 @@ module TypeScript {
 >new Identifier[] : any
 >Identifier[] : any
 >Identifier : typeof Identifier
+> : any
             }
             this.envids[this.envids.length] = id;
 >this.envids[this.envids.length] = id : Identifier
@@ -4724,6 +4726,7 @@ module TypeScript {
 >new Identifier[] : any
 >Identifier[] : any
 >Identifier : typeof Identifier
+> : any
             }
             var id = new Identifier(sym.name);
 >id : Identifier

--- a/tests/baselines/reference/parserRealSource4.errors.txt
+++ b/tests/baselines/reference/parserRealSource4.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
-tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts(195,37): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts(195,38): error TS1011: An element access expression should take an argument.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts (2 errors) ====
@@ -200,8 +200,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts(195,37): error T
         export class HashTable {
             public itemCount: number = 0;
             public table = new HashEntry[];
-                                        ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                         
+!!! error TS1011: An element access expression should take an argument.
     
             constructor (public size: number, public hashFn: (key) =>number,
                         public equalsFn: (key1, key2) =>boolean) {

--- a/tests/baselines/reference/parserRealSource4.types
+++ b/tests/baselines/reference/parserRealSource4.types
@@ -748,6 +748,7 @@ module TypeScript {
 >new HashEntry[] : any
 >HashEntry[] : any
 >HashEntry : typeof HashEntry
+> : any
 
         constructor (public size: number, public hashFn: (key) =>number,
 >size : number

--- a/tests/baselines/reference/parserRealSource7.errors.txt
+++ b/tests/baselines/reference/parserRealSource7.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(4,21): error TS6
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(12,38): error TS2304: Cannot find name 'ASTList'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(12,62): error TS2304: Cannot find name 'TypeLink'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(16,37): error TS2552: Cannot find name 'TypeLink'. Did you mean 'typeLink'?
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(16,45): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(16,46): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(21,36): error TS2552: Cannot find name 'TypeLink'. Did you mean 'typeLink'?
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(29,29): error TS2304: Cannot find name 'Type'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(29,45): error TS2304: Cannot find name 'TypeDeclaration'.
@@ -328,8 +328,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
                     baseTypeLinks = new TypeLink[];
                                         ~~~~~~~~
 !!! error TS2552: Cannot find name 'TypeLink'. Did you mean 'typeLink'?
-                                                ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                                 
+!!! error TS1011: An element access expression should take an argument.
                 }
                 for (var i = 0; i < len; i++) {
                     var baseExpr = bases.members[i];

--- a/tests/baselines/reference/parserRealSource7.types
+++ b/tests/baselines/reference/parserRealSource7.types
@@ -48,6 +48,7 @@ module TypeScript {
 >new TypeLink[] : any
 >TypeLink[] : any
 >TypeLink : any
+> : any
             }
             for (var i = 0; i < len; i++) {
 >i : number

--- a/tests/baselines/reference/parserRealSource9.errors.txt
+++ b/tests/baselines/reference/parserRealSource9.errors.txt
@@ -4,7 +4,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(9,48): error TS2
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(9,67): error TS2304: Cannot find name 'SymbolScope'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(10,30): error TS2304: Cannot find name 'Type'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(12,35): error TS2304: Cannot find name 'Type'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(12,39): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(12,40): error TS1011: An element access expression should take an argument.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(29,36): error TS2304: Cannot find name 'SymbolScope'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(29,55): error TS2304: Cannot find name 'Type'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(67,54): error TS2304: Cannot find name 'SignatureGroup'.
@@ -58,8 +58,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(200,48): error T
                     extendsList = new Type[];
                                       ~~~~
 !!! error TS2304: Cannot find name 'Type'.
-                                          ~~
-!!! error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
+                                           
+!!! error TS1011: An element access expression should take an argument.
                     for (var i = 0, len = typeLinks.length; i < len; i++) {
                         var typeLink = typeLinks[i];
                         this.checker.resolvingBases = true;

--- a/tests/baselines/reference/parserRealSource9.types
+++ b/tests/baselines/reference/parserRealSource9.types
@@ -35,6 +35,7 @@ module TypeScript {
 >new Type[] : any
 >Type[] : any
 >Type : any
+> : any
 
                 for (var i = 0, len = typeLinks.length; i < len; i++) {
 >i : number


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/pull/22088#discussion_r184111510