### PR TITLE
Named Type Arguments & Partial Type Argument Inference

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20130,7 +20130,7 @@ namespace ts {
         }
 
         function getContextNode(node: Expression): Node {
-            if (node.kind === SyntaxKind.JsxAttributes) {
+            if (node.kind === SyntaxKind.JsxAttributes && node.parent.kind === SyntaxKind.JsxOpeningElement) {
                 return node.parent.parent; // Needs to be the root JsxElement, so it encompasses the attributes _and_ the children (which are essentially part of the attributes)
             }
             return node;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9004,9 +9004,10 @@ namespace ts {
             return links.resolvedType;
         }
 
-        function getSyntheticInferTypeForName(targetName: __String, targetConstraint: Type | undefined): Type {
+        function getSyntheticInferType(targetName: __String, targetConstraint: Type | undefined, targetDefault: Type | undefined): Type {
             const param = createType(TypeFlags.TypeParameter) as TypeParameter;
             param.constraint = targetConstraint || noConstraintType;
+            param.default = targetDefault || noConstraintType;
             const symbol = createSymbol(SymbolFlags.TypeParameter, targetName, CheckFlags.ImpliedInferDecl);
             param.symbol = symbol;
             symbol.declaredType = param;
@@ -9029,18 +9030,18 @@ namespace ts {
                 const positionalCount = results.length;
                 const remainingTargets = targets.slice(positionalCount);
                 for (const target of remainingTargets) {
-                    let targetName: __String;
-                    let targetConstraint: Type;
+                    let param: TypeParameter;
                     if (((target as Node).kind && isTypeParameterDeclaration(target as Node))) {
-                        targetName = (target as TypeParameterDeclaration).name.escapedText;
-                        targetConstraint = getConstraintFromTypeParameter(getDeclaredTypeOfTypeParameter((target as TypeParameterDeclaration).symbol));
+                        param = getDeclaredTypeOfTypeParameter((target as TypeParameterDeclaration).symbol);
                     }
                     else {
-                        targetName = (target as TypeParameter).symbol.escapedName;
-                        targetConstraint = getConstraintFromTypeParameter((target as TypeParameter));
+                        param = target as TypeParameter;
                     }
+                    const targetName = param.symbol.escapedName;
+                    const targetConstraint = getConstraintFromTypeParameter(param);
+                    const targetDefault = getResolvedTypeParameterDefault(param);
                     const provided = named.get(targetName);
-                    results.push(provided ? getTypeFromTypeNode(provided.type) : getSyntheticInferTypeForName(targetName, targetConstraint));
+                    results.push(provided ? getTypeFromTypeNode(provided.type) : getSyntheticInferType(targetName, targetConstraint, targetDefault));
                 }
             }
             return results;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -971,6 +971,34 @@
         "category": "Error",
         "code": 1342
     },
+    "Positional type arguments cannot follow named type arguments.": {
+        "category": "Error",
+        "code": 1343
+    },
+    "Named type argument conflicts with positional type argument at index '{0}'.": {
+        "category": "Error",
+        "code": 1344
+    },
+    "Positional type argument conflicts with named type argument '{0}'.": {
+        "category": "Error",
+        "code": 1345
+    },
+    "Signature has no type argument named '{0}'.": {
+        "category": "Error",
+        "code": 1346
+    },
+    "No signature has all named type arguments.": {
+        "category": "Error",
+        "code": 1347
+    },
+    "No signature matches all named and positional type arguments.": {
+        "category": "Error",
+        "code": 1348
+    },
+    "No signature has a type argument named '{0}'.": {
+        "category": "Error",
+        "code": 1349
+    },
 
     "Duplicate identifier '{0}'.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -566,6 +566,8 @@ namespace ts {
                     return emitCallSignature(<CallSignatureDeclaration>node);
                 case SyntaxKind.ConstructSignature:
                     return emitConstructSignature(<ConstructSignatureDeclaration>node);
+                case SyntaxKind.NamedTypeArgument:
+                    return emitNamedTypeArgument(<NamedTypeArgument>node);
                 case SyntaxKind.IndexSignature:
                     return emitIndexSignature(<IndexSignatureDeclaration>node);
 
@@ -975,7 +977,7 @@ namespace ts {
         function emitIdentifier(node: Identifier) {
             const writeText = node.symbol ? writeSymbol : write;
             writeText(getTextOfNode(node, /*includeTrivia*/ false), node.symbol);
-            emitList(node, node.typeArguments, ListFormat.TypeParameters); // Call emitList directly since it could be an array of TypeParameterDeclarations _or_ type arguments
+            emitTypeParameters(node, node.typeParameters);
         }
 
         //
@@ -1123,6 +1125,14 @@ namespace ts {
             emitParameters(node, node.parameters);
             emitTypeAnnotation(node.type);
             writeSemicolon();
+        }
+
+        function emitNamedTypeArgument(node: NamedTypeArgument) {
+            emit(node.name);
+            writeSpace();
+            writePunctuation("=");
+            writeSpace();
+            emit(node.type);
         }
 
         function emitIndexSignature(node: IndexSignatureDeclaration) {
@@ -2674,12 +2684,12 @@ namespace ts {
             emitList(parentNode, decorators, ListFormat.Decorators);
         }
 
-        function emitTypeArguments(parentNode: Node, typeArguments: NodeArray<TypeNode>) {
+        function emitTypeArguments(parentNode: Node, typeArguments: NodeArray<TypeArgument>) {
             emitList(parentNode, typeArguments, ListFormat.TypeArguments);
         }
 
-        function emitTypeParameters(parentNode: SignatureDeclaration | InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | ClassExpression, typeParameters: NodeArray<TypeParameterDeclaration>) {
-            if (isFunctionLike(parentNode) && parentNode.typeArguments) { // Quick info uses type arguments in place of type parameters on instantiated signatures
+        function emitTypeParameters(parentNode: SignatureDeclaration | InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | ClassExpression | Identifier, typeParameters: NodeArray<TypeParameterDeclaration>) {
+            if ((isFunctionLike(parentNode) || isIdentifier(parentNode)) && parentNode.typeArguments) { // Quick info uses type arguments in place of type parameters on instantiated signatures
                 return emitTypeArguments(parentNode, parentNode.typeArguments);
             }
             emitList(parentNode, typeParameters, ListFormat.TypeParameters);

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -112,26 +112,30 @@ namespace ts {
 
     export function createIdentifier(text: string): Identifier;
     /* @internal */
-    export function createIdentifier(text: string, typeArguments: ReadonlyArray<TypeNode | TypeParameterDeclaration>): Identifier; // tslint:disable-line unified-signatures
-    export function createIdentifier(text: string, typeArguments?: ReadonlyArray<TypeNode | TypeParameterDeclaration>): Identifier {
+    export function createIdentifier(text: string, typeArguments: ReadonlyArray<TypeArgument>, typeParameters: ReadonlyArray<TypeParameterDeclaration>): Identifier; // tslint:disable-line unified-signatures
+    export function createIdentifier(text: string, typeArguments?: ReadonlyArray<TypeArgument>, typeParameters?: ReadonlyArray<TypeParameterDeclaration>): Identifier {
         const node = <Identifier>createSynthesizedNode(SyntaxKind.Identifier);
         node.escapedText = escapeLeadingUnderscores(text);
         node.originalKeywordKind = text ? stringToToken(text) : SyntaxKind.Unknown;
         node.autoGenerateFlags = GeneratedIdentifierFlags.None;
         node.autoGenerateId = 0;
         if (typeArguments) {
-            node.typeArguments = createNodeArray(typeArguments as ReadonlyArray<TypeNode>);
+            node.typeArguments = createNodeArray(typeArguments);
+        }
+        if (typeParameters) {
+            node.typeParameters = createNodeArray(typeParameters);
         }
         return node;
     }
 
     export function updateIdentifier(node: Identifier): Identifier;
     /* @internal */
-    export function updateIdentifier(node: Identifier, typeArguments: NodeArray<TypeNode | TypeParameterDeclaration> | undefined): Identifier; // tslint:disable-line unified-signatures
-    export function updateIdentifier(node: Identifier, typeArguments?: NodeArray<TypeNode | TypeParameterDeclaration> | undefined): Identifier {
-        return node.typeArguments !== typeArguments
-        ? updateNode(createIdentifier(idText(node), typeArguments), node)
-        : node;
+    export function updateIdentifier(node: Identifier, typeArguments: NodeArray<TypeArgument> | undefined, typeParameters: NodeArray<TypeParameterDeclaration> | undefined): Identifier; // tslint:disable-line unified-signatures
+    export function updateIdentifier(node: Identifier, typeArguments?: NodeArray<TypeArgument> | undefined, typeParameters?: NodeArray<TypeParameterDeclaration> | undefined): Identifier {
+        return node.typeArguments !== typeArguments ||
+            node.typeParameters !== typeParameters
+            ? updateNode(createIdentifier(idText(node), typeArguments, typeParameters), node)
+            : node;
     }
 
     let nextAutoGenerateId = 0;
@@ -605,6 +609,20 @@ namespace ts {
         return updateSignatureDeclaration(node, typeParameters, parameters, type);
     }
 
+    export function createNamedTypeArgument(name: string | Identifier, type: TypeNode) {
+        const node = createSynthesizedNode(SyntaxKind.NamedTypeArgument) as NamedTypeArgument;
+        node.name = asName(name);
+        node.type = type;
+        return node;
+    }
+
+    export function updateNamedTypeArgument(node: NamedTypeArgument, name: Identifier, type: TypeNode) {
+        return node.name !== name ||
+            node.type !== type
+            ? updateNode(createNamedTypeArgument(name, type), node)
+            : node;
+    }
+
     export function createIndexSignature(
         decorators: ReadonlyArray<Decorator> | undefined,
         modifiers: ReadonlyArray<Modifier> | undefined,
@@ -670,14 +688,14 @@ namespace ts {
             : node;
     }
 
-    export function createTypeReferenceNode(typeName: string | EntityName, typeArguments: ReadonlyArray<TypeNode> | undefined) {
+    export function createTypeReferenceNode(typeName: string | EntityName, typeArguments: ReadonlyArray<TypeArgument> | undefined) {
         const node = createSynthesizedNode(SyntaxKind.TypeReference) as TypeReferenceNode;
         node.typeName = asName(typeName);
         node.typeArguments = typeArguments && parenthesizeTypeParameters(typeArguments);
         return node;
     }
 
-    export function updateTypeReferenceNode(node: TypeReferenceNode, typeName: EntityName, typeArguments: NodeArray<TypeNode> | undefined) {
+    export function updateTypeReferenceNode(node: TypeReferenceNode, typeName: EntityName, typeArguments: NodeArray<TypeArgument> | undefined) {
         return node.typeName !== typeName
             || node.typeArguments !== typeArguments
             ? updateNode(createTypeReferenceNode(typeName, typeArguments), node)
@@ -806,7 +824,7 @@ namespace ts {
             : node;
     }
 
-    export function createImportTypeNode(argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeNode>, isTypeOf?: boolean) {
+    export function createImportTypeNode(argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeArgument>, isTypeOf?: boolean) {
         const node = <ImportTypeNode>createSynthesizedNode(SyntaxKind.ImportType);
         node.argument = argument;
         node.qualifier = qualifier;
@@ -815,7 +833,7 @@ namespace ts {
         return node;
     }
 
-    export function updateImportTypeNode(node: ImportTypeNode, argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeNode>, isTypeOf?: boolean) {
+    export function updateImportTypeNode(node: ImportTypeNode, argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeArgument>, isTypeOf?: boolean) {
         return node.argument !== argument
             || node.qualifier !== qualifier
             || node.typeArguments !== typeArguments
@@ -1000,7 +1018,7 @@ namespace ts {
             : node;
     }
 
-    export function createCall(expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression>) {
+    export function createCall(expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression>) {
         const node = <CallExpression>createSynthesizedNode(SyntaxKind.CallExpression);
         node.expression = parenthesizeForAccess(expression);
         node.typeArguments = asNodeArray(typeArguments);
@@ -1008,7 +1026,7 @@ namespace ts {
         return node;
     }
 
-    export function updateCall(node: CallExpression, expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression>) {
+    export function updateCall(node: CallExpression, expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression>) {
         return node.expression !== expression
             || node.typeArguments !== typeArguments
             || node.arguments !== argumentsArray
@@ -1016,7 +1034,7 @@ namespace ts {
             : node;
     }
 
-    export function createNew(expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined) {
+    export function createNew(expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined) {
         const node = <NewExpression>createSynthesizedNode(SyntaxKind.NewExpression);
         node.expression = parenthesizeForNew(expression);
         node.typeArguments = asNodeArray(typeArguments);
@@ -1024,7 +1042,7 @@ namespace ts {
         return node;
     }
 
-    export function updateNew(node: NewExpression, expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined) {
+    export function updateNew(node: NewExpression, expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined) {
         return node.expression !== expression
             || node.typeArguments !== typeArguments
             || node.arguments !== argumentsArray
@@ -1033,14 +1051,14 @@ namespace ts {
     }
 
     export function createTaggedTemplate(tag: Expression, template: TemplateLiteral): TaggedTemplateExpression;
-    export function createTaggedTemplate(tag: Expression, typeArguments: ReadonlyArray<TypeNode>, template: TemplateLiteral): TaggedTemplateExpression;
+    export function createTaggedTemplate(tag: Expression, typeArguments: ReadonlyArray<TypeArgument>, template: TemplateLiteral): TaggedTemplateExpression;
     /** @internal */
-    export function createTaggedTemplate(tag: Expression, typeArgumentsOrTemplate: ReadonlyArray<TypeNode> | TemplateLiteral, template?: TemplateLiteral): TaggedTemplateExpression;
-    export function createTaggedTemplate(tag: Expression, typeArgumentsOrTemplate: ReadonlyArray<TypeNode> | TemplateLiteral, template?: TemplateLiteral) {
+    export function createTaggedTemplate(tag: Expression, typeArgumentsOrTemplate: ReadonlyArray<TypeArgument> | TemplateLiteral, template?: TemplateLiteral): TaggedTemplateExpression;
+    export function createTaggedTemplate(tag: Expression, typeArgumentsOrTemplate: ReadonlyArray<TypeArgument> | TemplateLiteral, template?: TemplateLiteral) {
         const node = <TaggedTemplateExpression>createSynthesizedNode(SyntaxKind.TaggedTemplateExpression);
         node.tag = parenthesizeForAccess(tag);
         if (template) {
-            node.typeArguments = asNodeArray(typeArgumentsOrTemplate as ReadonlyArray<TypeNode>);
+            node.typeArguments = asNodeArray(typeArgumentsOrTemplate as ReadonlyArray<TypeArgument>);
             node.template = template!;
         }
         else {
@@ -1051,8 +1069,8 @@ namespace ts {
     }
 
     export function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, template: TemplateLiteral): TaggedTemplateExpression;
-    export function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, typeArguments: ReadonlyArray<TypeNode>, template: TemplateLiteral): TaggedTemplateExpression;
-    export function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, typeArgumentsOrTemplate: ReadonlyArray<TypeNode> | TemplateLiteral, template?: TemplateLiteral) {
+    export function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, typeArguments: ReadonlyArray<TypeArgument>, template: TemplateLiteral): TaggedTemplateExpression;
+    export function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, typeArgumentsOrTemplate: ReadonlyArray<TypeArgument> | TemplateLiteral, template?: TemplateLiteral) {
         return node.tag !== tag
             || (template
                 ? node.typeArguments !== typeArgumentsOrTemplate || node.template !== template
@@ -1422,14 +1440,14 @@ namespace ts {
         return <OmittedExpression>createSynthesizedNode(SyntaxKind.OmittedExpression);
     }
 
-    export function createExpressionWithTypeArguments(typeArguments: ReadonlyArray<TypeNode>, expression: Expression) {
+    export function createExpressionWithTypeArguments(typeArguments: ReadonlyArray<TypeArgument>, expression: Expression) {
         const node = <ExpressionWithTypeArguments>createSynthesizedNode(SyntaxKind.ExpressionWithTypeArguments);
         node.expression = parenthesizeForAccess(expression);
         node.typeArguments = asNodeArray(typeArguments);
         return node;
     }
 
-    export function updateExpressionWithTypeArguments(node: ExpressionWithTypeArguments, typeArguments: ReadonlyArray<TypeNode>, expression: Expression) {
+    export function updateExpressionWithTypeArguments(node: ExpressionWithTypeArguments, typeArguments: ReadonlyArray<TypeArgument>, expression: Expression) {
         return node.typeArguments !== typeArguments
             || node.expression !== expression
             ? updateNode(createExpressionWithTypeArguments(typeArguments, expression), node)
@@ -2197,7 +2215,7 @@ namespace ts {
             : node;
     }
 
-    export function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes) {
+    export function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes) {
         const node = <JsxSelfClosingElement>createSynthesizedNode(SyntaxKind.JsxSelfClosingElement);
         node.tagName = tagName;
         node.typeArguments = typeArguments && createNodeArray(typeArguments);
@@ -2205,7 +2223,7 @@ namespace ts {
         return node;
     }
 
-    export function updateJsxSelfClosingElement(node: JsxSelfClosingElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes) {
+    export function updateJsxSelfClosingElement(node: JsxSelfClosingElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes) {
         return node.tagName !== tagName
             || node.typeArguments !== typeArguments
             || node.attributes !== attributes
@@ -2213,7 +2231,7 @@ namespace ts {
             : node;
     }
 
-    export function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes) {
+    export function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes) {
         const node = <JsxOpeningElement>createSynthesizedNode(SyntaxKind.JsxOpeningElement);
         node.tagName = tagName;
         node.typeArguments = typeArguments && createNodeArray(typeArguments);
@@ -2221,7 +2239,7 @@ namespace ts {
         return node;
     }
 
-    export function updateJsxOpeningElement(node: JsxOpeningElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes) {
+    export function updateJsxOpeningElement(node: JsxOpeningElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes) {
         return node.tagName !== tagName
             || node.typeArguments !== typeArguments
             || node.attributes !== attributes
@@ -4242,11 +4260,17 @@ namespace ts {
         return createNodeArray(sameMap(members, parenthesizeElementTypeMember));
     }
 
-    export function parenthesizeTypeParameters(typeParameters: ReadonlyArray<TypeNode>) {
+    export function parenthesizeTypeParameters(typeParameters: ReadonlyArray<TypeNode>): MutableNodeArray<TypeNode>;
+    export function parenthesizeTypeParameters(typeParameters: ReadonlyArray<TypeArgument>): MutableNodeArray<TypeArgument>;
+    export function parenthesizeTypeParameters(typeParameters: ReadonlyArray<TypeNode> | ReadonlyArray<TypeArgument>): MutableNodeArray<TypeNode> | MutableNodeArray<TypeArgument> {
         if (some(typeParameters)) {
-            const params: TypeNode[] = [];
+            const params: TypeArgument[] = [];
             for (let i = 0; i < typeParameters.length; ++i) {
                 const entry = typeParameters[i];
+                if (isNamedTypeArgument(entry)) {
+                    params.push(entry);
+                    continue;
+                }
                 params.push(i === 0 && isFunctionOrConstructorTypeNode(entry) && entry.typeParameters ?
                     createParenthesizedType(entry) :
                     entry);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -264,6 +264,7 @@ namespace ts {
         SetAccessor,
         CallSignature,
         ConstructSignature,
+        NamedTypeArgument,
         IndexSignature,
         // Type
         TypePredicate,
@@ -720,7 +721,8 @@ namespace ts {
         /*@internal*/ autoGenerateFlags?: GeneratedIdentifierFlags; // Specifies whether to auto-generate the text for an identifier.
         /*@internal*/ autoGenerateId?: number;                    // Ensures unique generated identifiers get unique names, but clones get the same name.
         isInJSDocNamespace?: boolean;                             // if the node is a member in a JSDoc namespace
-        /*@internal*/ typeArguments?: NodeArray<TypeNode | TypeParameterDeclaration>; // Only defined on synthesized nodes. Though not syntactically valid, used in emitting diagnostics, quickinfo, and signature help.
+        /*@internal*/ typeArguments?: NodeArray<TypeArgument>;    // Only defined on synthesized nodes. Though not syntactically valid, used in emitting diagnostics, quickinfo, and signature help.
+        /*@internal*/ typeParameters?: NodeArray<TypeParameterDeclaration>; // Same as above, but for parameters
         /*@internal*/ jsdocDotPos?: number;                       // Identifier occurs in JSDoc-style generic: Id.<T>
     }
 
@@ -804,7 +806,7 @@ namespace ts {
         typeParameters?: NodeArray<TypeParameterDeclaration>;
         parameters: NodeArray<ParameterDeclaration>;
         type: TypeNode | undefined;
-        /* @internal */ typeArguments?: NodeArray<TypeNode>; // Used for quick info, replaces typeParameters for instantiated signatures
+        /* @internal */ typeArguments?: NodeArray<TypeArgument>; // Used for quick info, replaces typeParameters for instantiated signatures
     }
 
     export type SignatureDeclaration =
@@ -1055,6 +1057,14 @@ namespace ts {
         _typeNodeBrand: any;
     }
 
+    export interface NamedTypeArgument extends Node {
+        kind: SyntaxKind.NamedTypeArgument;
+        name: Identifier;
+        type: TypeNode;
+    }
+
+    export type TypeArgument = TypeNode | NamedTypeArgument;
+
     export interface KeywordTypeNode extends TypeNode {
         kind: SyntaxKind.AnyKeyword
             | SyntaxKind.NumberKeyword
@@ -1094,7 +1104,7 @@ namespace ts {
     }
 
     export interface NodeWithTypeArguments extends TypeNode {
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
     }
 
     export type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
@@ -1698,7 +1708,7 @@ namespace ts {
     export interface CallExpression extends LeftHandSideExpression, Declaration {
         kind: SyntaxKind.CallExpression;
         expression: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         arguments: NodeArray<Expression>;
     }
 
@@ -1720,14 +1730,14 @@ namespace ts {
     export interface NewExpression extends PrimaryExpression, Declaration {
         kind: SyntaxKind.NewExpression;
         expression: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         arguments?: NodeArray<Expression>;
     }
 
     export interface TaggedTemplateExpression extends MemberExpression {
         kind: SyntaxKind.TaggedTemplateExpression;
         tag: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         template: TemplateLiteral;
     }
 
@@ -1784,7 +1794,7 @@ namespace ts {
         kind: SyntaxKind.JsxOpeningElement;
         parent?: JsxElement;
         tagName: JsxTagNameExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         attributes: JsxAttributes;
     }
 
@@ -1792,7 +1802,7 @@ namespace ts {
     export interface JsxSelfClosingElement extends PrimaryExpression {
         kind: SyntaxKind.JsxSelfClosingElement;
         tagName: JsxTagNameExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         attributes: JsxAttributes;
     }
 
@@ -2826,7 +2836,7 @@ namespace ts {
         typeToTypeNode(type: Type, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): TypeNode;
         /* @internal */ typeToTypeNode(type: Type, enclosingDeclaration?: Node, flags?: NodeBuilderFlags, tracker?: SymbolTracker): TypeNode; // tslint:disable-line unified-signatures
         /** Note that the resulting nodes cannot be checked. */
-        signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): SignatureDeclaration & {typeArguments?: NodeArray<TypeNode>} | undefined;
+        signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): SignatureDeclaration & {typeArguments?: NodeArray<TypeArgument>} | undefined;
         /** Note that the resulting nodes cannot be checked. */
         indexInfoToIndexSignatureDeclaration(indexInfo: IndexInfo, kind: IndexKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): IndexSignatureDeclaration | undefined;
         /** Note that the resulting nodes cannot be checked. */
@@ -3441,6 +3451,7 @@ namespace ts {
         ContainsStatic    = 1 << 9,         // Synthetic property with static constituent(s)
         Late              = 1 << 10,        // Late-bound symbol for a computed property with a dynamic name
         ReverseMapped     = 1 << 11,        // property of reverse-inferred homomorphic mapped type.
+        ImpliedInferDecl  = 1 << 12,        // Transitent symbol is for an implied `infer` type
         Synthetic = SyntheticProperty | SyntheticMethod
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -961,7 +961,13 @@ namespace ts {
             return (<ArrayTypeNode>node).elementType;
         }
         else if (node && node.kind === SyntaxKind.TypeReference) {
-            return singleOrUndefined((<TypeReferenceNode>node).typeArguments);
+            const argumentNode = singleOrUndefined((<TypeReferenceNode>node).typeArguments);
+            if (isNamedTypeArgument(argumentNode)) {
+                return argumentNode.type;
+            }
+            else {
+                return argumentNode;
+            }
         }
         else {
             return undefined;
@@ -1474,6 +1480,7 @@ namespace ts {
             isIdentifier(node.typeName) &&
             node.typeName.escapedText === "Object" &&
             node.typeArguments && node.typeArguments.length === 2 &&
+            node.typeArguments[1].kind !== SyntaxKind.NamedTypeArgument &&
             (node.typeArguments[0].kind === SyntaxKind.StringKeyword || node.typeArguments[0].kind === SyntaxKind.NumberKeyword);
     }
 
@@ -4851,6 +4858,10 @@ namespace ts {
         return node.kind === SyntaxKind.ConstructSignature;
     }
 
+    export function isNamedTypeArgument(node: Node): node is NamedTypeArgument {
+        return node.kind === SyntaxKind.NamedTypeArgument;
+    }
+
     export function isIndexSignatureDeclaration(node: Node): node is IndexSignatureDeclaration {
         return node.kind === SyntaxKind.IndexSignature;
     }
@@ -5693,6 +5704,10 @@ namespace ts {
      */
     export function isTypeNode(node: Node): node is TypeNode {
         return isTypeNodeKind(node.kind);
+    }
+
+    export function isTypeArgument(node: Node): node is TypeArgument {
+        return isTypeNodeKind(node.kind) || isNamedTypeArgument(node);
     }
 
     export function isFunctionOrConstructorTypeNode(node: Node): node is FunctionTypeNode | ConstructorTypeNode {

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -1,6 +1,4 @@
 namespace ts {
-    const isTypeNodeOrTypeParameterDeclaration = or(isTypeNode, isTypeParameterDeclaration);
-
     /**
      * Visits a Node using the supplied visitor, possibly returning a new Node in its place.
      *
@@ -220,7 +218,9 @@ namespace ts {
             // Names
 
             case SyntaxKind.Identifier:
-                return updateIdentifier(<Identifier>node, nodesVisitor((<Identifier>node).typeArguments, visitor, isTypeNodeOrTypeParameterDeclaration));
+                return updateIdentifier(<Identifier>node,
+                    nodesVisitor((<Identifier>node).typeArguments, visitor, isTypeArgument),
+                    nodesVisitor((<Identifier>node).typeParameters, visitor, isTypeParameterDeclaration));
 
             case SyntaxKind.QualifiedName:
                 return updateQualifiedName(<QualifiedName>node,
@@ -328,6 +328,11 @@ namespace ts {
                     nodesVisitor((<ConstructSignatureDeclaration>node).parameters, visitor, isParameterDeclaration),
                     visitNode((<ConstructSignatureDeclaration>node).type, visitor, isTypeNode));
 
+            case SyntaxKind.NamedTypeArgument:
+                    return updateNamedTypeArgument(<NamedTypeArgument>node,
+                        visitNode((<NamedTypeArgument>node).name, visitor, isIdentifier),
+                        visitNode((<NamedTypeArgument>node).type, visitor, isTypeNode));
+
             case SyntaxKind.IndexSignature:
                 return updateIndexSignature(<IndexSignatureDeclaration>node,
                     nodesVisitor((<IndexSignatureDeclaration>node).decorators, visitor, isDecorator),
@@ -345,7 +350,7 @@ namespace ts {
             case SyntaxKind.TypeReference:
                 return updateTypeReferenceNode(<TypeReferenceNode>node,
                     visitNode((<TypeReferenceNode>node).typeName, visitor, isEntityName),
-                    nodesVisitor((<TypeReferenceNode>node).typeArguments, visitor, isTypeNode));
+                    nodesVisitor((<TypeReferenceNode>node).typeArguments, visitor, isTypeArgument));
 
             case SyntaxKind.FunctionType:
                 return updateFunctionTypeNode(<FunctionTypeNode>node,
@@ -398,7 +403,7 @@ namespace ts {
                 return updateImportTypeNode(<ImportTypeNode>node,
                     visitNode((<ImportTypeNode>node).argument, visitor, isTypeNode),
                     visitNode((<ImportTypeNode>node).qualifier, visitor, isEntityName),
-                    visitNodes((<ImportTypeNode>node).typeArguments, visitor, isTypeNode),
+                    visitNodes((<ImportTypeNode>node).typeArguments, visitor, isTypeArgument),
                     (<ImportTypeNode>node).isTypeOf
                 );
 
@@ -466,19 +471,19 @@ namespace ts {
             case SyntaxKind.CallExpression:
                 return updateCall(<CallExpression>node,
                     visitNode((<CallExpression>node).expression, visitor, isExpression),
-                    nodesVisitor((<CallExpression>node).typeArguments, visitor, isTypeNode),
+                    nodesVisitor((<CallExpression>node).typeArguments, visitor, isTypeArgument),
                     nodesVisitor((<CallExpression>node).arguments, visitor, isExpression));
 
             case SyntaxKind.NewExpression:
                 return updateNew(<NewExpression>node,
                     visitNode((<NewExpression>node).expression, visitor, isExpression),
-                    nodesVisitor((<NewExpression>node).typeArguments, visitor, isTypeNode),
+                    nodesVisitor((<NewExpression>node).typeArguments, visitor, isTypeArgument),
                     nodesVisitor((<NewExpression>node).arguments, visitor, isExpression));
 
             case SyntaxKind.TaggedTemplateExpression:
                 return updateTaggedTemplate(<TaggedTemplateExpression>node,
                     visitNode((<TaggedTemplateExpression>node).tag, visitor, isExpression),
-                    visitNodes((<TaggedTemplateExpression>node).typeArguments, visitor, isExpression),
+                    visitNodes((<TaggedTemplateExpression>node).typeArguments, visitor, isTypeArgument),
                     visitNode((<TaggedTemplateExpression>node).template, visitor, isTemplateLiteral));
 
             case SyntaxKind.TypeAssertionExpression:
@@ -571,7 +576,7 @@ namespace ts {
 
             case SyntaxKind.ExpressionWithTypeArguments:
                 return updateExpressionWithTypeArguments(<ExpressionWithTypeArguments>node,
-                    nodesVisitor((<ExpressionWithTypeArguments>node).typeArguments, visitor, isTypeNode),
+                    nodesVisitor((<ExpressionWithTypeArguments>node).typeArguments, visitor, isTypeArgument),
                     visitNode((<ExpressionWithTypeArguments>node).expression, visitor, isExpression));
 
             case SyntaxKind.AsExpression:
@@ -826,13 +831,13 @@ namespace ts {
             case SyntaxKind.JsxSelfClosingElement:
                 return updateJsxSelfClosingElement(<JsxSelfClosingElement>node,
                     visitNode((<JsxSelfClosingElement>node).tagName, visitor, isJsxTagNameExpression),
-                    nodesVisitor((<JsxSelfClosingElement>node).typeArguments, visitor, isTypeNode),
+                    nodesVisitor((<JsxSelfClosingElement>node).typeArguments, visitor, isTypeArgument),
                     visitNode((<JsxSelfClosingElement>node).attributes, visitor, isJsxAttributes));
 
             case SyntaxKind.JsxOpeningElement:
                 return updateJsxOpeningElement(<JsxOpeningElement>node,
                     visitNode((<JsxOpeningElement>node).tagName, visitor, isJsxTagNameExpression),
-                    nodesVisitor((<JsxSelfClosingElement>node).typeArguments, visitor, isTypeNode),
+                    nodesVisitor((<JsxSelfClosingElement>node).typeArguments, visitor, isTypeArgument),
                     visitNode((<JsxOpeningElement>node).attributes, visitor, isJsxAttributes));
 
             case SyntaxKind.JsxClosingElement:

--- a/src/services/codefixes/annotateWithTypeFromJSDoc.ts
+++ b/src/services/codefixes/annotateWithTypeFromJSDoc.ts
@@ -162,7 +162,8 @@ namespace ts.codefix {
             /*questionToken*/ undefined,
             createTypeReferenceNode(node.typeArguments[0].kind === SyntaxKind.NumberKeyword ? "number" : "string", []),
             /*initializer*/ undefined);
-        const indexSignature = createTypeLiteralNode([createIndexSignature(/*decorators*/ undefined, /*modifiers*/ undefined, [index], node.typeArguments[1])]);
+        Debug.assert(!node.typeArguments[1] || isTypeNode(node.typeArguments[1]));
+        const indexSignature = createTypeLiteralNode([createIndexSignature(/*decorators*/ undefined, /*modifiers*/ undefined, [index], node.typeArguments[1] as TypeNode)]);
         setEmitFlags(indexSignature, EmitFlags.SingleLine);
         return indexSignature;
     }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -221,148 +221,149 @@ declare namespace ts {
         SetAccessor = 156,
         CallSignature = 157,
         ConstructSignature = 158,
-        IndexSignature = 159,
-        TypePredicate = 160,
-        TypeReference = 161,
-        FunctionType = 162,
-        ConstructorType = 163,
-        TypeQuery = 164,
-        TypeLiteral = 165,
-        ArrayType = 166,
-        TupleType = 167,
-        UnionType = 168,
-        IntersectionType = 169,
-        ConditionalType = 170,
-        InferType = 171,
-        ParenthesizedType = 172,
-        ThisType = 173,
-        TypeOperator = 174,
-        IndexedAccessType = 175,
-        MappedType = 176,
-        LiteralType = 177,
-        ImportType = 178,
-        ObjectBindingPattern = 179,
-        ArrayBindingPattern = 180,
-        BindingElement = 181,
-        ArrayLiteralExpression = 182,
-        ObjectLiteralExpression = 183,
-        PropertyAccessExpression = 184,
-        ElementAccessExpression = 185,
-        CallExpression = 186,
-        NewExpression = 187,
-        TaggedTemplateExpression = 188,
-        TypeAssertionExpression = 189,
-        ParenthesizedExpression = 190,
-        FunctionExpression = 191,
-        ArrowFunction = 192,
-        DeleteExpression = 193,
-        TypeOfExpression = 194,
-        VoidExpression = 195,
-        AwaitExpression = 196,
-        PrefixUnaryExpression = 197,
-        PostfixUnaryExpression = 198,
-        BinaryExpression = 199,
-        ConditionalExpression = 200,
-        TemplateExpression = 201,
-        YieldExpression = 202,
-        SpreadElement = 203,
-        ClassExpression = 204,
-        OmittedExpression = 205,
-        ExpressionWithTypeArguments = 206,
-        AsExpression = 207,
-        NonNullExpression = 208,
-        MetaProperty = 209,
-        TemplateSpan = 210,
-        SemicolonClassElement = 211,
-        Block = 212,
-        VariableStatement = 213,
-        EmptyStatement = 214,
-        ExpressionStatement = 215,
-        IfStatement = 216,
-        DoStatement = 217,
-        WhileStatement = 218,
-        ForStatement = 219,
-        ForInStatement = 220,
-        ForOfStatement = 221,
-        ContinueStatement = 222,
-        BreakStatement = 223,
-        ReturnStatement = 224,
-        WithStatement = 225,
-        SwitchStatement = 226,
-        LabeledStatement = 227,
-        ThrowStatement = 228,
-        TryStatement = 229,
-        DebuggerStatement = 230,
-        VariableDeclaration = 231,
-        VariableDeclarationList = 232,
-        FunctionDeclaration = 233,
-        ClassDeclaration = 234,
-        InterfaceDeclaration = 235,
-        TypeAliasDeclaration = 236,
-        EnumDeclaration = 237,
-        ModuleDeclaration = 238,
-        ModuleBlock = 239,
-        CaseBlock = 240,
-        NamespaceExportDeclaration = 241,
-        ImportEqualsDeclaration = 242,
-        ImportDeclaration = 243,
-        ImportClause = 244,
-        NamespaceImport = 245,
-        NamedImports = 246,
-        ImportSpecifier = 247,
-        ExportAssignment = 248,
-        ExportDeclaration = 249,
-        NamedExports = 250,
-        ExportSpecifier = 251,
-        MissingDeclaration = 252,
-        ExternalModuleReference = 253,
-        JsxElement = 254,
-        JsxSelfClosingElement = 255,
-        JsxOpeningElement = 256,
-        JsxClosingElement = 257,
-        JsxFragment = 258,
-        JsxOpeningFragment = 259,
-        JsxClosingFragment = 260,
-        JsxAttribute = 261,
-        JsxAttributes = 262,
-        JsxSpreadAttribute = 263,
-        JsxExpression = 264,
-        CaseClause = 265,
-        DefaultClause = 266,
-        HeritageClause = 267,
-        CatchClause = 268,
-        PropertyAssignment = 269,
-        ShorthandPropertyAssignment = 270,
-        SpreadAssignment = 271,
-        EnumMember = 272,
-        SourceFile = 273,
-        Bundle = 274,
-        JSDocTypeExpression = 275,
-        JSDocAllType = 276,
-        JSDocUnknownType = 277,
-        JSDocNullableType = 278,
-        JSDocNonNullableType = 279,
-        JSDocOptionalType = 280,
-        JSDocFunctionType = 281,
-        JSDocVariadicType = 282,
-        JSDocComment = 283,
-        JSDocTypeLiteral = 284,
-        JSDocTag = 285,
-        JSDocAugmentsTag = 286,
-        JSDocClassTag = 287,
-        JSDocParameterTag = 288,
-        JSDocReturnTag = 289,
-        JSDocTypeTag = 290,
-        JSDocTemplateTag = 291,
-        JSDocTypedefTag = 292,
-        JSDocPropertyTag = 293,
-        SyntaxList = 294,
-        NotEmittedStatement = 295,
-        PartiallyEmittedExpression = 296,
-        CommaListExpression = 297,
-        MergeDeclarationMarker = 298,
-        EndOfDeclarationMarker = 299,
-        Count = 300,
+        NamedTypeArgument = 159,
+        IndexSignature = 160,
+        TypePredicate = 161,
+        TypeReference = 162,
+        FunctionType = 163,
+        ConstructorType = 164,
+        TypeQuery = 165,
+        TypeLiteral = 166,
+        ArrayType = 167,
+        TupleType = 168,
+        UnionType = 169,
+        IntersectionType = 170,
+        ConditionalType = 171,
+        InferType = 172,
+        ParenthesizedType = 173,
+        ThisType = 174,
+        TypeOperator = 175,
+        IndexedAccessType = 176,
+        MappedType = 177,
+        LiteralType = 178,
+        ImportType = 179,
+        ObjectBindingPattern = 180,
+        ArrayBindingPattern = 181,
+        BindingElement = 182,
+        ArrayLiteralExpression = 183,
+        ObjectLiteralExpression = 184,
+        PropertyAccessExpression = 185,
+        ElementAccessExpression = 186,
+        CallExpression = 187,
+        NewExpression = 188,
+        TaggedTemplateExpression = 189,
+        TypeAssertionExpression = 190,
+        ParenthesizedExpression = 191,
+        FunctionExpression = 192,
+        ArrowFunction = 193,
+        DeleteExpression = 194,
+        TypeOfExpression = 195,
+        VoidExpression = 196,
+        AwaitExpression = 197,
+        PrefixUnaryExpression = 198,
+        PostfixUnaryExpression = 199,
+        BinaryExpression = 200,
+        ConditionalExpression = 201,
+        TemplateExpression = 202,
+        YieldExpression = 203,
+        SpreadElement = 204,
+        ClassExpression = 205,
+        OmittedExpression = 206,
+        ExpressionWithTypeArguments = 207,
+        AsExpression = 208,
+        NonNullExpression = 209,
+        MetaProperty = 210,
+        TemplateSpan = 211,
+        SemicolonClassElement = 212,
+        Block = 213,
+        VariableStatement = 214,
+        EmptyStatement = 215,
+        ExpressionStatement = 216,
+        IfStatement = 217,
+        DoStatement = 218,
+        WhileStatement = 219,
+        ForStatement = 220,
+        ForInStatement = 221,
+        ForOfStatement = 222,
+        ContinueStatement = 223,
+        BreakStatement = 224,
+        ReturnStatement = 225,
+        WithStatement = 226,
+        SwitchStatement = 227,
+        LabeledStatement = 228,
+        ThrowStatement = 229,
+        TryStatement = 230,
+        DebuggerStatement = 231,
+        VariableDeclaration = 232,
+        VariableDeclarationList = 233,
+        FunctionDeclaration = 234,
+        ClassDeclaration = 235,
+        InterfaceDeclaration = 236,
+        TypeAliasDeclaration = 237,
+        EnumDeclaration = 238,
+        ModuleDeclaration = 239,
+        ModuleBlock = 240,
+        CaseBlock = 241,
+        NamespaceExportDeclaration = 242,
+        ImportEqualsDeclaration = 243,
+        ImportDeclaration = 244,
+        ImportClause = 245,
+        NamespaceImport = 246,
+        NamedImports = 247,
+        ImportSpecifier = 248,
+        ExportAssignment = 249,
+        ExportDeclaration = 250,
+        NamedExports = 251,
+        ExportSpecifier = 252,
+        MissingDeclaration = 253,
+        ExternalModuleReference = 254,
+        JsxElement = 255,
+        JsxSelfClosingElement = 256,
+        JsxOpeningElement = 257,
+        JsxClosingElement = 258,
+        JsxFragment = 259,
+        JsxOpeningFragment = 260,
+        JsxClosingFragment = 261,
+        JsxAttribute = 262,
+        JsxAttributes = 263,
+        JsxSpreadAttribute = 264,
+        JsxExpression = 265,
+        CaseClause = 266,
+        DefaultClause = 267,
+        HeritageClause = 268,
+        CatchClause = 269,
+        PropertyAssignment = 270,
+        ShorthandPropertyAssignment = 271,
+        SpreadAssignment = 272,
+        EnumMember = 273,
+        SourceFile = 274,
+        Bundle = 275,
+        JSDocTypeExpression = 276,
+        JSDocAllType = 277,
+        JSDocUnknownType = 278,
+        JSDocNullableType = 279,
+        JSDocNonNullableType = 280,
+        JSDocOptionalType = 281,
+        JSDocFunctionType = 282,
+        JSDocVariadicType = 283,
+        JSDocComment = 284,
+        JSDocTypeLiteral = 285,
+        JSDocTag = 286,
+        JSDocAugmentsTag = 287,
+        JSDocClassTag = 288,
+        JSDocParameterTag = 289,
+        JSDocReturnTag = 290,
+        JSDocTypeTag = 291,
+        JSDocTemplateTag = 292,
+        JSDocTypedefTag = 293,
+        JSDocPropertyTag = 294,
+        SyntaxList = 295,
+        NotEmittedStatement = 296,
+        PartiallyEmittedExpression = 297,
+        CommaListExpression = 298,
+        MergeDeclarationMarker = 299,
+        EndOfDeclarationMarker = 300,
+        Count = 301,
         FirstAssignment = 58,
         LastAssignment = 70,
         FirstCompoundAssignment = 59,
@@ -373,8 +374,8 @@ declare namespace ts {
         LastKeyword = 144,
         FirstFutureReservedWord = 108,
         LastFutureReservedWord = 116,
-        FirstTypeNode = 160,
-        LastTypeNode = 178,
+        FirstTypeNode = 161,
+        LastTypeNode = 179,
         FirstPunctuation = 17,
         LastPunctuation = 70,
         FirstToken = 0,
@@ -388,10 +389,10 @@ declare namespace ts {
         FirstBinaryOperator = 27,
         LastBinaryOperator = 70,
         FirstNode = 145,
-        FirstJSDocNode = 275,
-        LastJSDocNode = 293,
-        FirstJSDocTagNode = 285,
-        LastJSDocTagNode = 293
+        FirstJSDocNode = 276,
+        LastJSDocNode = 294,
+        FirstJSDocTagNode = 286,
+        LastJSDocTagNode = 294
     }
     enum NodeFlags {
         None = 0,
@@ -696,6 +697,12 @@ declare namespace ts {
     interface TypeNode extends Node {
         _typeNodeBrand: any;
     }
+    interface NamedTypeArgument extends Node {
+        kind: SyntaxKind.NamedTypeArgument;
+        name: Identifier;
+        type: TypeNode;
+    }
+    type TypeArgument = TypeNode | NamedTypeArgument;
     interface KeywordTypeNode extends TypeNode {
         kind: SyntaxKind.AnyKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.StringKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.ThisKeyword | SyntaxKind.VoidKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.NullKeyword | SyntaxKind.NeverKeyword;
     }
@@ -716,7 +723,7 @@ declare namespace ts {
         kind: SyntaxKind.ConstructorType;
     }
     interface NodeWithTypeArguments extends TypeNode {
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
     }
     type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
     interface TypeReferenceNode extends NodeWithTypeArguments {
@@ -1028,7 +1035,7 @@ declare namespace ts {
     interface CallExpression extends LeftHandSideExpression, Declaration {
         kind: SyntaxKind.CallExpression;
         expression: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         arguments: NodeArray<Expression>;
     }
     interface SuperCall extends CallExpression {
@@ -1045,13 +1052,13 @@ declare namespace ts {
     interface NewExpression extends PrimaryExpression, Declaration {
         kind: SyntaxKind.NewExpression;
         expression: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         arguments?: NodeArray<Expression>;
     }
     interface TaggedTemplateExpression extends MemberExpression {
         kind: SyntaxKind.TaggedTemplateExpression;
         tag: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         template: TemplateLiteral;
     }
     type CallLikeExpression = CallExpression | NewExpression | TaggedTemplateExpression | Decorator | JsxOpeningLikeElement;
@@ -1091,13 +1098,13 @@ declare namespace ts {
         kind: SyntaxKind.JsxOpeningElement;
         parent?: JsxElement;
         tagName: JsxTagNameExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         attributes: JsxAttributes;
     }
     interface JsxSelfClosingElement extends PrimaryExpression {
         kind: SyntaxKind.JsxSelfClosingElement;
         tagName: JsxTagNameExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         attributes: JsxAttributes;
     }
     interface JsxFragment extends PrimaryExpression {
@@ -1768,7 +1775,7 @@ declare namespace ts {
         typeToTypeNode(type: Type, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): TypeNode;
         /** Note that the resulting nodes cannot be checked. */
         signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): (SignatureDeclaration & {
-            typeArguments?: NodeArray<TypeNode>;
+            typeArguments?: NodeArray<TypeArgument>;
         }) | undefined;
         /** Note that the resulting nodes cannot be checked. */
         indexInfoToIndexSignatureDeclaration(indexInfo: IndexInfo, kind: IndexKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): IndexSignatureDeclaration | undefined;
@@ -3159,6 +3166,7 @@ declare namespace ts {
     function isSetAccessorDeclaration(node: Node): node is SetAccessorDeclaration;
     function isCallSignatureDeclaration(node: Node): node is CallSignatureDeclaration;
     function isConstructSignatureDeclaration(node: Node): node is ConstructSignatureDeclaration;
+    function isNamedTypeArgument(node: Node): node is NamedTypeArgument;
     function isIndexSignatureDeclaration(node: Node): node is IndexSignatureDeclaration;
     function isTypePredicateNode(node: Node): node is TypePredicateNode;
     function isTypeReferenceNode(node: Node): node is TypeReferenceNode;
@@ -3325,6 +3333,7 @@ declare namespace ts {
      * of a TypeNode.
      */
     function isTypeNode(node: Node): node is TypeNode;
+    function isTypeArgument(node: Node): node is TypeArgument;
     function isFunctionOrConstructorTypeNode(node: Node): node is FunctionTypeNode | ConstructorTypeNode;
     function isPropertyAccessOrQualifiedName(node: Node): node is PropertyAccessExpression | QualifiedName;
     function isCallLikeExpression(node: Node): node is CallLikeExpression;
@@ -3472,13 +3481,15 @@ declare namespace ts {
     function updateCallSignature(node: CallSignatureDeclaration, typeParameters: NodeArray<TypeParameterDeclaration> | undefined, parameters: NodeArray<ParameterDeclaration>, type: TypeNode | undefined): CallSignatureDeclaration;
     function createConstructSignature(typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode | undefined): ConstructSignatureDeclaration;
     function updateConstructSignature(node: ConstructSignatureDeclaration, typeParameters: NodeArray<TypeParameterDeclaration> | undefined, parameters: NodeArray<ParameterDeclaration>, type: TypeNode | undefined): ConstructSignatureDeclaration;
+    function createNamedTypeArgument(name: string | Identifier, type: TypeNode): NamedTypeArgument;
+    function updateNamedTypeArgument(node: NamedTypeArgument, name: Identifier, type: TypeNode): NamedTypeArgument;
     function createIndexSignature(decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode): IndexSignatureDeclaration;
     function updateIndexSignature(node: IndexSignatureDeclaration, decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode): IndexSignatureDeclaration;
     function createKeywordTypeNode(kind: KeywordTypeNode["kind"]): KeywordTypeNode;
     function createTypePredicateNode(parameterName: Identifier | ThisTypeNode | string, type: TypeNode): TypePredicateNode;
     function updateTypePredicateNode(node: TypePredicateNode, parameterName: Identifier | ThisTypeNode, type: TypeNode): TypePredicateNode;
-    function createTypeReferenceNode(typeName: string | EntityName, typeArguments: ReadonlyArray<TypeNode> | undefined): TypeReferenceNode;
-    function updateTypeReferenceNode(node: TypeReferenceNode, typeName: EntityName, typeArguments: NodeArray<TypeNode> | undefined): TypeReferenceNode;
+    function createTypeReferenceNode(typeName: string | EntityName, typeArguments: ReadonlyArray<TypeArgument> | undefined): TypeReferenceNode;
+    function updateTypeReferenceNode(node: TypeReferenceNode, typeName: EntityName, typeArguments: NodeArray<TypeArgument> | undefined): TypeReferenceNode;
     function createFunctionTypeNode(typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode | undefined): FunctionTypeNode;
     function updateFunctionTypeNode(node: FunctionTypeNode, typeParameters: NodeArray<TypeParameterDeclaration> | undefined, parameters: NodeArray<ParameterDeclaration>, type: TypeNode | undefined): FunctionTypeNode;
     function createConstructorTypeNode(typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode | undefined): ConstructorTypeNode;
@@ -3500,8 +3511,8 @@ declare namespace ts {
     function updateConditionalTypeNode(node: ConditionalTypeNode, checkType: TypeNode, extendsType: TypeNode, trueType: TypeNode, falseType: TypeNode): ConditionalTypeNode;
     function createInferTypeNode(typeParameter: TypeParameterDeclaration): InferTypeNode;
     function updateInferTypeNode(node: InferTypeNode, typeParameter: TypeParameterDeclaration): InferTypeNode;
-    function createImportTypeNode(argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeNode>, isTypeOf?: boolean): ImportTypeNode;
-    function updateImportTypeNode(node: ImportTypeNode, argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeNode>, isTypeOf?: boolean): ImportTypeNode;
+    function createImportTypeNode(argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeArgument>, isTypeOf?: boolean): ImportTypeNode;
+    function updateImportTypeNode(node: ImportTypeNode, argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeArgument>, isTypeOf?: boolean): ImportTypeNode;
     function createParenthesizedType(type: TypeNode): ParenthesizedTypeNode;
     function updateParenthesizedType(node: ParenthesizedTypeNode, type: TypeNode): ParenthesizedTypeNode;
     function createThisTypeNode(): ThisTypeNode;
@@ -3528,14 +3539,14 @@ declare namespace ts {
     function updatePropertyAccess(node: PropertyAccessExpression, expression: Expression, name: Identifier): PropertyAccessExpression;
     function createElementAccess(expression: Expression, index: number | Expression): ElementAccessExpression;
     function updateElementAccess(node: ElementAccessExpression, expression: Expression, argumentExpression: Expression): ElementAccessExpression;
-    function createCall(expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression>): CallExpression;
-    function updateCall(node: CallExpression, expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression>): CallExpression;
-    function createNew(expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined): NewExpression;
-    function updateNew(node: NewExpression, expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined): NewExpression;
+    function createCall(expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression>): CallExpression;
+    function updateCall(node: CallExpression, expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression>): CallExpression;
+    function createNew(expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined): NewExpression;
+    function updateNew(node: NewExpression, expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined): NewExpression;
     function createTaggedTemplate(tag: Expression, template: TemplateLiteral): TaggedTemplateExpression;
-    function createTaggedTemplate(tag: Expression, typeArguments: ReadonlyArray<TypeNode>, template: TemplateLiteral): TaggedTemplateExpression;
+    function createTaggedTemplate(tag: Expression, typeArguments: ReadonlyArray<TypeArgument>, template: TemplateLiteral): TaggedTemplateExpression;
     function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, template: TemplateLiteral): TaggedTemplateExpression;
-    function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, typeArguments: ReadonlyArray<TypeNode>, template: TemplateLiteral): TaggedTemplateExpression;
+    function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, typeArguments: ReadonlyArray<TypeArgument>, template: TemplateLiteral): TaggedTemplateExpression;
     function createTypeAssertion(type: TypeNode, expression: Expression): TypeAssertion;
     function updateTypeAssertion(node: TypeAssertion, type: TypeNode, expression: Expression): TypeAssertion;
     function createParen(expression: Expression): ParenthesizedExpression;
@@ -3577,8 +3588,8 @@ declare namespace ts {
     function createClassExpression(modifiers: ReadonlyArray<Modifier> | undefined, name: string | Identifier | undefined, typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, heritageClauses: ReadonlyArray<HeritageClause>, members: ReadonlyArray<ClassElement>): ClassExpression;
     function updateClassExpression(node: ClassExpression, modifiers: ReadonlyArray<Modifier> | undefined, name: Identifier | undefined, typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, heritageClauses: ReadonlyArray<HeritageClause>, members: ReadonlyArray<ClassElement>): ClassExpression;
     function createOmittedExpression(): OmittedExpression;
-    function createExpressionWithTypeArguments(typeArguments: ReadonlyArray<TypeNode>, expression: Expression): ExpressionWithTypeArguments;
-    function updateExpressionWithTypeArguments(node: ExpressionWithTypeArguments, typeArguments: ReadonlyArray<TypeNode>, expression: Expression): ExpressionWithTypeArguments;
+    function createExpressionWithTypeArguments(typeArguments: ReadonlyArray<TypeArgument>, expression: Expression): ExpressionWithTypeArguments;
+    function updateExpressionWithTypeArguments(node: ExpressionWithTypeArguments, typeArguments: ReadonlyArray<TypeArgument>, expression: Expression): ExpressionWithTypeArguments;
     function createAsExpression(expression: Expression, type: TypeNode): AsExpression;
     function updateAsExpression(node: AsExpression, expression: Expression, type: TypeNode): AsExpression;
     function createNonNullExpression(expression: Expression): NonNullExpression;
@@ -3670,10 +3681,10 @@ declare namespace ts {
     function updateExternalModuleReference(node: ExternalModuleReference, expression: Expression): ExternalModuleReference;
     function createJsxElement(openingElement: JsxOpeningElement, children: ReadonlyArray<JsxChild>, closingElement: JsxClosingElement): JsxElement;
     function updateJsxElement(node: JsxElement, openingElement: JsxOpeningElement, children: ReadonlyArray<JsxChild>, closingElement: JsxClosingElement): JsxElement;
-    function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
-    function updateJsxSelfClosingElement(node: JsxSelfClosingElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
-    function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes): JsxOpeningElement;
-    function updateJsxOpeningElement(node: JsxOpeningElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes): JsxOpeningElement;
+    function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
+    function updateJsxSelfClosingElement(node: JsxSelfClosingElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
+    function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes): JsxOpeningElement;
+    function updateJsxOpeningElement(node: JsxOpeningElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes): JsxOpeningElement;
     function createJsxClosingElement(tagName: JsxTagNameExpression): JsxClosingElement;
     function updateJsxClosingElement(node: JsxClosingElement, tagName: JsxTagNameExpression): JsxClosingElement;
     function createJsxFragment(openingFragment: JsxOpeningFragment, children: ReadonlyArray<JsxChild>, closingFragment: JsxClosingFragment): JsxFragment;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -221,148 +221,149 @@ declare namespace ts {
         SetAccessor = 156,
         CallSignature = 157,
         ConstructSignature = 158,
-        IndexSignature = 159,
-        TypePredicate = 160,
-        TypeReference = 161,
-        FunctionType = 162,
-        ConstructorType = 163,
-        TypeQuery = 164,
-        TypeLiteral = 165,
-        ArrayType = 166,
-        TupleType = 167,
-        UnionType = 168,
-        IntersectionType = 169,
-        ConditionalType = 170,
-        InferType = 171,
-        ParenthesizedType = 172,
-        ThisType = 173,
-        TypeOperator = 174,
-        IndexedAccessType = 175,
-        MappedType = 176,
-        LiteralType = 177,
-        ImportType = 178,
-        ObjectBindingPattern = 179,
-        ArrayBindingPattern = 180,
-        BindingElement = 181,
-        ArrayLiteralExpression = 182,
-        ObjectLiteralExpression = 183,
-        PropertyAccessExpression = 184,
-        ElementAccessExpression = 185,
-        CallExpression = 186,
-        NewExpression = 187,
-        TaggedTemplateExpression = 188,
-        TypeAssertionExpression = 189,
-        ParenthesizedExpression = 190,
-        FunctionExpression = 191,
-        ArrowFunction = 192,
-        DeleteExpression = 193,
-        TypeOfExpression = 194,
-        VoidExpression = 195,
-        AwaitExpression = 196,
-        PrefixUnaryExpression = 197,
-        PostfixUnaryExpression = 198,
-        BinaryExpression = 199,
-        ConditionalExpression = 200,
-        TemplateExpression = 201,
-        YieldExpression = 202,
-        SpreadElement = 203,
-        ClassExpression = 204,
-        OmittedExpression = 205,
-        ExpressionWithTypeArguments = 206,
-        AsExpression = 207,
-        NonNullExpression = 208,
-        MetaProperty = 209,
-        TemplateSpan = 210,
-        SemicolonClassElement = 211,
-        Block = 212,
-        VariableStatement = 213,
-        EmptyStatement = 214,
-        ExpressionStatement = 215,
-        IfStatement = 216,
-        DoStatement = 217,
-        WhileStatement = 218,
-        ForStatement = 219,
-        ForInStatement = 220,
-        ForOfStatement = 221,
-        ContinueStatement = 222,
-        BreakStatement = 223,
-        ReturnStatement = 224,
-        WithStatement = 225,
-        SwitchStatement = 226,
-        LabeledStatement = 227,
-        ThrowStatement = 228,
-        TryStatement = 229,
-        DebuggerStatement = 230,
-        VariableDeclaration = 231,
-        VariableDeclarationList = 232,
-        FunctionDeclaration = 233,
-        ClassDeclaration = 234,
-        InterfaceDeclaration = 235,
-        TypeAliasDeclaration = 236,
-        EnumDeclaration = 237,
-        ModuleDeclaration = 238,
-        ModuleBlock = 239,
-        CaseBlock = 240,
-        NamespaceExportDeclaration = 241,
-        ImportEqualsDeclaration = 242,
-        ImportDeclaration = 243,
-        ImportClause = 244,
-        NamespaceImport = 245,
-        NamedImports = 246,
-        ImportSpecifier = 247,
-        ExportAssignment = 248,
-        ExportDeclaration = 249,
-        NamedExports = 250,
-        ExportSpecifier = 251,
-        MissingDeclaration = 252,
-        ExternalModuleReference = 253,
-        JsxElement = 254,
-        JsxSelfClosingElement = 255,
-        JsxOpeningElement = 256,
-        JsxClosingElement = 257,
-        JsxFragment = 258,
-        JsxOpeningFragment = 259,
-        JsxClosingFragment = 260,
-        JsxAttribute = 261,
-        JsxAttributes = 262,
-        JsxSpreadAttribute = 263,
-        JsxExpression = 264,
-        CaseClause = 265,
-        DefaultClause = 266,
-        HeritageClause = 267,
-        CatchClause = 268,
-        PropertyAssignment = 269,
-        ShorthandPropertyAssignment = 270,
-        SpreadAssignment = 271,
-        EnumMember = 272,
-        SourceFile = 273,
-        Bundle = 274,
-        JSDocTypeExpression = 275,
-        JSDocAllType = 276,
-        JSDocUnknownType = 277,
-        JSDocNullableType = 278,
-        JSDocNonNullableType = 279,
-        JSDocOptionalType = 280,
-        JSDocFunctionType = 281,
-        JSDocVariadicType = 282,
-        JSDocComment = 283,
-        JSDocTypeLiteral = 284,
-        JSDocTag = 285,
-        JSDocAugmentsTag = 286,
-        JSDocClassTag = 287,
-        JSDocParameterTag = 288,
-        JSDocReturnTag = 289,
-        JSDocTypeTag = 290,
-        JSDocTemplateTag = 291,
-        JSDocTypedefTag = 292,
-        JSDocPropertyTag = 293,
-        SyntaxList = 294,
-        NotEmittedStatement = 295,
-        PartiallyEmittedExpression = 296,
-        CommaListExpression = 297,
-        MergeDeclarationMarker = 298,
-        EndOfDeclarationMarker = 299,
-        Count = 300,
+        NamedTypeArgument = 159,
+        IndexSignature = 160,
+        TypePredicate = 161,
+        TypeReference = 162,
+        FunctionType = 163,
+        ConstructorType = 164,
+        TypeQuery = 165,
+        TypeLiteral = 166,
+        ArrayType = 167,
+        TupleType = 168,
+        UnionType = 169,
+        IntersectionType = 170,
+        ConditionalType = 171,
+        InferType = 172,
+        ParenthesizedType = 173,
+        ThisType = 174,
+        TypeOperator = 175,
+        IndexedAccessType = 176,
+        MappedType = 177,
+        LiteralType = 178,
+        ImportType = 179,
+        ObjectBindingPattern = 180,
+        ArrayBindingPattern = 181,
+        BindingElement = 182,
+        ArrayLiteralExpression = 183,
+        ObjectLiteralExpression = 184,
+        PropertyAccessExpression = 185,
+        ElementAccessExpression = 186,
+        CallExpression = 187,
+        NewExpression = 188,
+        TaggedTemplateExpression = 189,
+        TypeAssertionExpression = 190,
+        ParenthesizedExpression = 191,
+        FunctionExpression = 192,
+        ArrowFunction = 193,
+        DeleteExpression = 194,
+        TypeOfExpression = 195,
+        VoidExpression = 196,
+        AwaitExpression = 197,
+        PrefixUnaryExpression = 198,
+        PostfixUnaryExpression = 199,
+        BinaryExpression = 200,
+        ConditionalExpression = 201,
+        TemplateExpression = 202,
+        YieldExpression = 203,
+        SpreadElement = 204,
+        ClassExpression = 205,
+        OmittedExpression = 206,
+        ExpressionWithTypeArguments = 207,
+        AsExpression = 208,
+        NonNullExpression = 209,
+        MetaProperty = 210,
+        TemplateSpan = 211,
+        SemicolonClassElement = 212,
+        Block = 213,
+        VariableStatement = 214,
+        EmptyStatement = 215,
+        ExpressionStatement = 216,
+        IfStatement = 217,
+        DoStatement = 218,
+        WhileStatement = 219,
+        ForStatement = 220,
+        ForInStatement = 221,
+        ForOfStatement = 222,
+        ContinueStatement = 223,
+        BreakStatement = 224,
+        ReturnStatement = 225,
+        WithStatement = 226,
+        SwitchStatement = 227,
+        LabeledStatement = 228,
+        ThrowStatement = 229,
+        TryStatement = 230,
+        DebuggerStatement = 231,
+        VariableDeclaration = 232,
+        VariableDeclarationList = 233,
+        FunctionDeclaration = 234,
+        ClassDeclaration = 235,
+        InterfaceDeclaration = 236,
+        TypeAliasDeclaration = 237,
+        EnumDeclaration = 238,
+        ModuleDeclaration = 239,
+        ModuleBlock = 240,
+        CaseBlock = 241,
+        NamespaceExportDeclaration = 242,
+        ImportEqualsDeclaration = 243,
+        ImportDeclaration = 244,
+        ImportClause = 245,
+        NamespaceImport = 246,
+        NamedImports = 247,
+        ImportSpecifier = 248,
+        ExportAssignment = 249,
+        ExportDeclaration = 250,
+        NamedExports = 251,
+        ExportSpecifier = 252,
+        MissingDeclaration = 253,
+        ExternalModuleReference = 254,
+        JsxElement = 255,
+        JsxSelfClosingElement = 256,
+        JsxOpeningElement = 257,
+        JsxClosingElement = 258,
+        JsxFragment = 259,
+        JsxOpeningFragment = 260,
+        JsxClosingFragment = 261,
+        JsxAttribute = 262,
+        JsxAttributes = 263,
+        JsxSpreadAttribute = 264,
+        JsxExpression = 265,
+        CaseClause = 266,
+        DefaultClause = 267,
+        HeritageClause = 268,
+        CatchClause = 269,
+        PropertyAssignment = 270,
+        ShorthandPropertyAssignment = 271,
+        SpreadAssignment = 272,
+        EnumMember = 273,
+        SourceFile = 274,
+        Bundle = 275,
+        JSDocTypeExpression = 276,
+        JSDocAllType = 277,
+        JSDocUnknownType = 278,
+        JSDocNullableType = 279,
+        JSDocNonNullableType = 280,
+        JSDocOptionalType = 281,
+        JSDocFunctionType = 282,
+        JSDocVariadicType = 283,
+        JSDocComment = 284,
+        JSDocTypeLiteral = 285,
+        JSDocTag = 286,
+        JSDocAugmentsTag = 287,
+        JSDocClassTag = 288,
+        JSDocParameterTag = 289,
+        JSDocReturnTag = 290,
+        JSDocTypeTag = 291,
+        JSDocTemplateTag = 292,
+        JSDocTypedefTag = 293,
+        JSDocPropertyTag = 294,
+        SyntaxList = 295,
+        NotEmittedStatement = 296,
+        PartiallyEmittedExpression = 297,
+        CommaListExpression = 298,
+        MergeDeclarationMarker = 299,
+        EndOfDeclarationMarker = 300,
+        Count = 301,
         FirstAssignment = 58,
         LastAssignment = 70,
         FirstCompoundAssignment = 59,
@@ -373,8 +374,8 @@ declare namespace ts {
         LastKeyword = 144,
         FirstFutureReservedWord = 108,
         LastFutureReservedWord = 116,
-        FirstTypeNode = 160,
-        LastTypeNode = 178,
+        FirstTypeNode = 161,
+        LastTypeNode = 179,
         FirstPunctuation = 17,
         LastPunctuation = 70,
         FirstToken = 0,
@@ -388,10 +389,10 @@ declare namespace ts {
         FirstBinaryOperator = 27,
         LastBinaryOperator = 70,
         FirstNode = 145,
-        FirstJSDocNode = 275,
-        LastJSDocNode = 293,
-        FirstJSDocTagNode = 285,
-        LastJSDocTagNode = 293
+        FirstJSDocNode = 276,
+        LastJSDocNode = 294,
+        FirstJSDocTagNode = 286,
+        LastJSDocTagNode = 294
     }
     enum NodeFlags {
         None = 0,
@@ -696,6 +697,12 @@ declare namespace ts {
     interface TypeNode extends Node {
         _typeNodeBrand: any;
     }
+    interface NamedTypeArgument extends Node {
+        kind: SyntaxKind.NamedTypeArgument;
+        name: Identifier;
+        type: TypeNode;
+    }
+    type TypeArgument = TypeNode | NamedTypeArgument;
     interface KeywordTypeNode extends TypeNode {
         kind: SyntaxKind.AnyKeyword | SyntaxKind.NumberKeyword | SyntaxKind.ObjectKeyword | SyntaxKind.BooleanKeyword | SyntaxKind.StringKeyword | SyntaxKind.SymbolKeyword | SyntaxKind.ThisKeyword | SyntaxKind.VoidKeyword | SyntaxKind.UndefinedKeyword | SyntaxKind.NullKeyword | SyntaxKind.NeverKeyword;
     }
@@ -716,7 +723,7 @@ declare namespace ts {
         kind: SyntaxKind.ConstructorType;
     }
     interface NodeWithTypeArguments extends TypeNode {
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
     }
     type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
     interface TypeReferenceNode extends NodeWithTypeArguments {
@@ -1028,7 +1035,7 @@ declare namespace ts {
     interface CallExpression extends LeftHandSideExpression, Declaration {
         kind: SyntaxKind.CallExpression;
         expression: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         arguments: NodeArray<Expression>;
     }
     interface SuperCall extends CallExpression {
@@ -1045,13 +1052,13 @@ declare namespace ts {
     interface NewExpression extends PrimaryExpression, Declaration {
         kind: SyntaxKind.NewExpression;
         expression: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         arguments?: NodeArray<Expression>;
     }
     interface TaggedTemplateExpression extends MemberExpression {
         kind: SyntaxKind.TaggedTemplateExpression;
         tag: LeftHandSideExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         template: TemplateLiteral;
     }
     type CallLikeExpression = CallExpression | NewExpression | TaggedTemplateExpression | Decorator | JsxOpeningLikeElement;
@@ -1091,13 +1098,13 @@ declare namespace ts {
         kind: SyntaxKind.JsxOpeningElement;
         parent?: JsxElement;
         tagName: JsxTagNameExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         attributes: JsxAttributes;
     }
     interface JsxSelfClosingElement extends PrimaryExpression {
         kind: SyntaxKind.JsxSelfClosingElement;
         tagName: JsxTagNameExpression;
-        typeArguments?: NodeArray<TypeNode>;
+        typeArguments?: NodeArray<TypeArgument>;
         attributes: JsxAttributes;
     }
     interface JsxFragment extends PrimaryExpression {
@@ -1768,7 +1775,7 @@ declare namespace ts {
         typeToTypeNode(type: Type, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): TypeNode;
         /** Note that the resulting nodes cannot be checked. */
         signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): (SignatureDeclaration & {
-            typeArguments?: NodeArray<TypeNode>;
+            typeArguments?: NodeArray<TypeArgument>;
         }) | undefined;
         /** Note that the resulting nodes cannot be checked. */
         indexInfoToIndexSignatureDeclaration(indexInfo: IndexInfo, kind: IndexKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): IndexSignatureDeclaration | undefined;
@@ -3159,6 +3166,7 @@ declare namespace ts {
     function isSetAccessorDeclaration(node: Node): node is SetAccessorDeclaration;
     function isCallSignatureDeclaration(node: Node): node is CallSignatureDeclaration;
     function isConstructSignatureDeclaration(node: Node): node is ConstructSignatureDeclaration;
+    function isNamedTypeArgument(node: Node): node is NamedTypeArgument;
     function isIndexSignatureDeclaration(node: Node): node is IndexSignatureDeclaration;
     function isTypePredicateNode(node: Node): node is TypePredicateNode;
     function isTypeReferenceNode(node: Node): node is TypeReferenceNode;
@@ -3325,6 +3333,7 @@ declare namespace ts {
      * of a TypeNode.
      */
     function isTypeNode(node: Node): node is TypeNode;
+    function isTypeArgument(node: Node): node is TypeArgument;
     function isFunctionOrConstructorTypeNode(node: Node): node is FunctionTypeNode | ConstructorTypeNode;
     function isPropertyAccessOrQualifiedName(node: Node): node is PropertyAccessExpression | QualifiedName;
     function isCallLikeExpression(node: Node): node is CallLikeExpression;
@@ -3472,13 +3481,15 @@ declare namespace ts {
     function updateCallSignature(node: CallSignatureDeclaration, typeParameters: NodeArray<TypeParameterDeclaration> | undefined, parameters: NodeArray<ParameterDeclaration>, type: TypeNode | undefined): CallSignatureDeclaration;
     function createConstructSignature(typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode | undefined): ConstructSignatureDeclaration;
     function updateConstructSignature(node: ConstructSignatureDeclaration, typeParameters: NodeArray<TypeParameterDeclaration> | undefined, parameters: NodeArray<ParameterDeclaration>, type: TypeNode | undefined): ConstructSignatureDeclaration;
+    function createNamedTypeArgument(name: string | Identifier, type: TypeNode): NamedTypeArgument;
+    function updateNamedTypeArgument(node: NamedTypeArgument, name: Identifier, type: TypeNode): NamedTypeArgument;
     function createIndexSignature(decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode): IndexSignatureDeclaration;
     function updateIndexSignature(node: IndexSignatureDeclaration, decorators: ReadonlyArray<Decorator> | undefined, modifiers: ReadonlyArray<Modifier> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode): IndexSignatureDeclaration;
     function createKeywordTypeNode(kind: KeywordTypeNode["kind"]): KeywordTypeNode;
     function createTypePredicateNode(parameterName: Identifier | ThisTypeNode | string, type: TypeNode): TypePredicateNode;
     function updateTypePredicateNode(node: TypePredicateNode, parameterName: Identifier | ThisTypeNode, type: TypeNode): TypePredicateNode;
-    function createTypeReferenceNode(typeName: string | EntityName, typeArguments: ReadonlyArray<TypeNode> | undefined): TypeReferenceNode;
-    function updateTypeReferenceNode(node: TypeReferenceNode, typeName: EntityName, typeArguments: NodeArray<TypeNode> | undefined): TypeReferenceNode;
+    function createTypeReferenceNode(typeName: string | EntityName, typeArguments: ReadonlyArray<TypeArgument> | undefined): TypeReferenceNode;
+    function updateTypeReferenceNode(node: TypeReferenceNode, typeName: EntityName, typeArguments: NodeArray<TypeArgument> | undefined): TypeReferenceNode;
     function createFunctionTypeNode(typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode | undefined): FunctionTypeNode;
     function updateFunctionTypeNode(node: FunctionTypeNode, typeParameters: NodeArray<TypeParameterDeclaration> | undefined, parameters: NodeArray<ParameterDeclaration>, type: TypeNode | undefined): FunctionTypeNode;
     function createConstructorTypeNode(typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, parameters: ReadonlyArray<ParameterDeclaration>, type: TypeNode | undefined): ConstructorTypeNode;
@@ -3500,8 +3511,8 @@ declare namespace ts {
     function updateConditionalTypeNode(node: ConditionalTypeNode, checkType: TypeNode, extendsType: TypeNode, trueType: TypeNode, falseType: TypeNode): ConditionalTypeNode;
     function createInferTypeNode(typeParameter: TypeParameterDeclaration): InferTypeNode;
     function updateInferTypeNode(node: InferTypeNode, typeParameter: TypeParameterDeclaration): InferTypeNode;
-    function createImportTypeNode(argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeNode>, isTypeOf?: boolean): ImportTypeNode;
-    function updateImportTypeNode(node: ImportTypeNode, argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeNode>, isTypeOf?: boolean): ImportTypeNode;
+    function createImportTypeNode(argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeArgument>, isTypeOf?: boolean): ImportTypeNode;
+    function updateImportTypeNode(node: ImportTypeNode, argument: TypeNode, qualifier?: EntityName, typeArguments?: ReadonlyArray<TypeArgument>, isTypeOf?: boolean): ImportTypeNode;
     function createParenthesizedType(type: TypeNode): ParenthesizedTypeNode;
     function updateParenthesizedType(node: ParenthesizedTypeNode, type: TypeNode): ParenthesizedTypeNode;
     function createThisTypeNode(): ThisTypeNode;
@@ -3528,14 +3539,14 @@ declare namespace ts {
     function updatePropertyAccess(node: PropertyAccessExpression, expression: Expression, name: Identifier): PropertyAccessExpression;
     function createElementAccess(expression: Expression, index: number | Expression): ElementAccessExpression;
     function updateElementAccess(node: ElementAccessExpression, expression: Expression, argumentExpression: Expression): ElementAccessExpression;
-    function createCall(expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression>): CallExpression;
-    function updateCall(node: CallExpression, expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression>): CallExpression;
-    function createNew(expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined): NewExpression;
-    function updateNew(node: NewExpression, expression: Expression, typeArguments: ReadonlyArray<TypeNode> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined): NewExpression;
+    function createCall(expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression>): CallExpression;
+    function updateCall(node: CallExpression, expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression>): CallExpression;
+    function createNew(expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined): NewExpression;
+    function updateNew(node: NewExpression, expression: Expression, typeArguments: ReadonlyArray<TypeArgument> | undefined, argumentsArray: ReadonlyArray<Expression> | undefined): NewExpression;
     function createTaggedTemplate(tag: Expression, template: TemplateLiteral): TaggedTemplateExpression;
-    function createTaggedTemplate(tag: Expression, typeArguments: ReadonlyArray<TypeNode>, template: TemplateLiteral): TaggedTemplateExpression;
+    function createTaggedTemplate(tag: Expression, typeArguments: ReadonlyArray<TypeArgument>, template: TemplateLiteral): TaggedTemplateExpression;
     function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, template: TemplateLiteral): TaggedTemplateExpression;
-    function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, typeArguments: ReadonlyArray<TypeNode>, template: TemplateLiteral): TaggedTemplateExpression;
+    function updateTaggedTemplate(node: TaggedTemplateExpression, tag: Expression, typeArguments: ReadonlyArray<TypeArgument>, template: TemplateLiteral): TaggedTemplateExpression;
     function createTypeAssertion(type: TypeNode, expression: Expression): TypeAssertion;
     function updateTypeAssertion(node: TypeAssertion, type: TypeNode, expression: Expression): TypeAssertion;
     function createParen(expression: Expression): ParenthesizedExpression;
@@ -3577,8 +3588,8 @@ declare namespace ts {
     function createClassExpression(modifiers: ReadonlyArray<Modifier> | undefined, name: string | Identifier | undefined, typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, heritageClauses: ReadonlyArray<HeritageClause>, members: ReadonlyArray<ClassElement>): ClassExpression;
     function updateClassExpression(node: ClassExpression, modifiers: ReadonlyArray<Modifier> | undefined, name: Identifier | undefined, typeParameters: ReadonlyArray<TypeParameterDeclaration> | undefined, heritageClauses: ReadonlyArray<HeritageClause>, members: ReadonlyArray<ClassElement>): ClassExpression;
     function createOmittedExpression(): OmittedExpression;
-    function createExpressionWithTypeArguments(typeArguments: ReadonlyArray<TypeNode>, expression: Expression): ExpressionWithTypeArguments;
-    function updateExpressionWithTypeArguments(node: ExpressionWithTypeArguments, typeArguments: ReadonlyArray<TypeNode>, expression: Expression): ExpressionWithTypeArguments;
+    function createExpressionWithTypeArguments(typeArguments: ReadonlyArray<TypeArgument>, expression: Expression): ExpressionWithTypeArguments;
+    function updateExpressionWithTypeArguments(node: ExpressionWithTypeArguments, typeArguments: ReadonlyArray<TypeArgument>, expression: Expression): ExpressionWithTypeArguments;
     function createAsExpression(expression: Expression, type: TypeNode): AsExpression;
     function updateAsExpression(node: AsExpression, expression: Expression, type: TypeNode): AsExpression;
     function createNonNullExpression(expression: Expression): NonNullExpression;
@@ -3670,10 +3681,10 @@ declare namespace ts {
     function updateExternalModuleReference(node: ExternalModuleReference, expression: Expression): ExternalModuleReference;
     function createJsxElement(openingElement: JsxOpeningElement, children: ReadonlyArray<JsxChild>, closingElement: JsxClosingElement): JsxElement;
     function updateJsxElement(node: JsxElement, openingElement: JsxOpeningElement, children: ReadonlyArray<JsxChild>, closingElement: JsxClosingElement): JsxElement;
-    function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
-    function updateJsxSelfClosingElement(node: JsxSelfClosingElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
-    function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes): JsxOpeningElement;
-    function updateJsxOpeningElement(node: JsxOpeningElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeNode> | undefined, attributes: JsxAttributes): JsxOpeningElement;
+    function createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
+    function updateJsxSelfClosingElement(node: JsxSelfClosingElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
+    function createJsxOpeningElement(tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes): JsxOpeningElement;
+    function updateJsxOpeningElement(node: JsxOpeningElement, tagName: JsxTagNameExpression, typeArguments: ReadonlyArray<TypeArgument> | undefined, attributes: JsxAttributes): JsxOpeningElement;
     function createJsxClosingElement(tagName: JsxTagNameExpression): JsxClosingElement;
     function updateJsxClosingElement(node: JsxClosingElement, tagName: JsxTagNameExpression): JsxClosingElement;
     function createJsxFragment(openingFragment: JsxOpeningFragment, children: ReadonlyArray<JsxChild>, closingFragment: JsxClosingFragment): JsxFragment;

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.errors.txt
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(20,31): error TS2326: Types of property 'children' are incompatible.
-  Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: IntrinsicAttributes & LitProps<"x">) => "x"'.
+  Type '(p: LitProps<"x">) => "y"' is not assignable to type '(x: IntrinsicAttributes & LitProps<"x">) => "x"'.
     Type '"y"' is not assignable to type '"x"'.
 tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(21,19): error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
   Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
@@ -41,7 +41,7 @@ tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,21): error TS2322:
     const arg = <ElemLit prop="x" children={p => "y"} />
                                   ~~~~~~~~~~~~~~~~~~~
 !!! error TS2326: Types of property 'children' are incompatible.
-!!! error TS2326:   Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: IntrinsicAttributes & LitProps<"x">) => "x"'.
+!!! error TS2326:   Type '(p: LitProps<"x">) => "y"' is not assignable to type '(x: IntrinsicAttributes & LitProps<"x">) => "x"'.
 !!! error TS2326:     Type '"y"' is not assignable to type '"x"'.
     const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
                       ~~~~~~~

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.types
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.types
@@ -139,9 +139,9 @@ const arg = <ElemLit prop="x" children={p => "y"} />
 ><ElemLit prop="x" children={p => "y"} /> : JSX.Element
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
 >prop : "x"
->children : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "y"
->p => "y" : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "y"
->p : JSX.IntrinsicAttributes & LitProps<"x">
+>children : (p: LitProps<"x">) => "y"
+>p => "y" : (p: LitProps<"x">) => "y"
+>p : LitProps<"x">
 >"y" : "y"
 
 const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>

--- a/tests/baselines/reference/typeArgumentListWithNamedTypeArgumentsAndDefaults.js
+++ b/tests/baselines/reference/typeArgumentListWithNamedTypeArgumentsAndDefaults.js
@@ -1,0 +1,23 @@
+//// [typeArgumentListWithNamedTypeArgumentsAndDefaults.ts]
+class Foo<A extends {x: string} = {x: string, y: number}, B = number> {
+    constructor(public a?: A, public b?: B) {}
+}
+
+const x = new Foo<B = string>();
+x.a.x;
+x.a.y;
+x.b;
+
+
+//// [typeArgumentListWithNamedTypeArgumentsAndDefaults.js]
+var Foo = /** @class */ (function () {
+    function Foo(a, b) {
+        this.a = a;
+        this.b = b;
+    }
+    return Foo;
+}());
+var x = new Foo();
+x.a.x;
+x.a.y;
+x.b;

--- a/tests/baselines/reference/typeArgumentListWithNamedTypeArgumentsAndDefaults.symbols
+++ b/tests/baselines/reference/typeArgumentListWithNamedTypeArgumentsAndDefaults.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListWithNamedTypeArgumentsAndDefaults.ts ===
+class Foo<A extends {x: string} = {x: string, y: number}, B = number> {
+>Foo : Symbol(Foo, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 0))
+>A : Symbol(A, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 10))
+>x : Symbol(x, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 21))
+>x : Symbol(x, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 35))
+>y : Symbol(y, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 45))
+>B : Symbol(B, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 57))
+
+    constructor(public a?: A, public b?: B) {}
+>a : Symbol(Foo.a, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 1, 16))
+>A : Symbol(A, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 10))
+>b : Symbol(Foo.b, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 1, 29))
+>B : Symbol(B, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 57))
+}
+
+const x = new Foo<B = string>();
+>x : Symbol(x, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 4, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 0))
+
+x.a.x;
+>x.a.x : Symbol(x, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 35))
+>x.a : Symbol(Foo.a, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 1, 16))
+>x : Symbol(x, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 4, 5))
+>a : Symbol(Foo.a, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 1, 16))
+>x : Symbol(x, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 35))
+
+x.a.y;
+>x.a.y : Symbol(y, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 45))
+>x.a : Symbol(Foo.a, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 1, 16))
+>x : Symbol(x, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 4, 5))
+>a : Symbol(Foo.a, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 1, 16))
+>y : Symbol(y, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 0, 45))
+
+x.b;
+>x.b : Symbol(Foo.b, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 1, 29))
+>x : Symbol(x, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 4, 5))
+>b : Symbol(Foo.b, Decl(typeArgumentListWithNamedTypeArgumentsAndDefaults.ts, 1, 29))
+

--- a/tests/baselines/reference/typeArgumentListWithNamedTypeArgumentsAndDefaults.types
+++ b/tests/baselines/reference/typeArgumentListWithNamedTypeArgumentsAndDefaults.types
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListWithNamedTypeArgumentsAndDefaults.ts ===
+class Foo<A extends {x: string} = {x: string, y: number}, B = number> {
+>Foo : Foo<A, B>
+>A : A
+>x : string
+>x : string
+>y : number
+>B : B
+
+    constructor(public a?: A, public b?: B) {}
+>a : A
+>A : A
+>b : B
+>B : B
+}
+
+const x = new Foo<B = string>();
+>x : Foo<{ x: string; y: number; }, string>
+>new Foo<B = string>() : Foo<{ x: string; y: number; }, string>
+>Foo : typeof Foo
+>B : any
+
+x.a.x;
+>x.a.x : string
+>x.a : { x: string; y: number; }
+>x : Foo<{ x: string; y: number; }, string>
+>a : { x: string; y: number; }
+>x : string
+
+x.a.y;
+>x.a.y : number
+>x.a : { x: string; y: number; }
+>x : Foo<{ x: string; y: number; }, string>
+>a : { x: string; y: number; }
+>y : number
+
+x.b;
+>x.b : string
+>x : Foo<{ x: string; y: number; }, string>
+>b : string
+

--- a/tests/baselines/reference/typeArgumentListsWithNamedTypeArgumentErrors.errors.txt
+++ b/tests/baselines/reference/typeArgumentListsWithNamedTypeArgumentErrors.errors.txt
@@ -1,0 +1,199 @@
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(28,35): error TS1346: Signature has no type argument named 'Q'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(29,29): error TS1346: Signature has no type argument named 'Q'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(30,29): error TS1346: Signature has no type argument named 'Q'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(31,33): error TS1346: Signature has no type argument named 'Q'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(32,22): error TS1346: Signature has no type argument named 'Q'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(36,27): error TS1345: Positional type argument conflicts with named type argument 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(36,35): error TS1344: Named type argument conflicts with positional type argument at index '0'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(37,21): error TS1345: Positional type argument conflicts with named type argument 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(37,29): error TS1344: Named type argument conflicts with positional type argument at index '0'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(38,21): error TS1345: Positional type argument conflicts with named type argument 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(38,29): error TS1344: Named type argument conflicts with positional type argument at index '0'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(39,25): error TS1345: Positional type argument conflicts with named type argument 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(39,33): error TS1344: Named type argument conflicts with positional type argument at index '0'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(40,14): error TS1345: Positional type argument conflicts with named type argument 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(40,22): error TS1344: Named type argument conflicts with positional type argument at index '0'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(44,27): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(44,39): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(44,51): error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(45,21): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(45,33): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(45,45): error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(46,21): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(46,33): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(47,25): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(47,37): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(47,61): error TS2326: Types of property 'cb' are incompatible.
+  Type '(props: ComponentProps<string, string>) => any' is not assignable to type '(props: ComponentProps<number, string>) => void'.
+    Types of parameters 'props' and 'props' are incompatible.
+      Type 'ComponentProps<number, string>' is not assignable to type 'ComponentProps<string, string>'.
+        Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(47,88): error TS2339: Property 'toFixed' does not exist on type 'string'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(48,14): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(48,26): error TS2300: Duplicate identifier 'T'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(52,27): error TS2558: Expected 0-2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(53,21): error TS2558: Expected 0-2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(54,21): error TS2558: Expected 0-2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(55,25): error TS2558: Expected 0-2 type arguments, but got 3.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(56,10): error TS2314: Generic type 'Foo<T, U>' requires 2 type argument(s).
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(60,39): error TS1343: Positional type arguments cannot follow named type arguments.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(61,33): error TS1343: Positional type arguments cannot follow named type arguments.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(62,33): error TS1343: Positional type arguments cannot follow named type arguments.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(63,37): error TS1343: Positional type arguments cannot follow named type arguments.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(64,26): error TS1343: Positional type arguments cannot follow named type arguments.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx(67,10): error TS2314: Generic type 'Foo<T, U>' requires 2 type argument(s).
+
+
+==== tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx (40 errors) ====
+    declare module JSX {
+        interface Element {}
+    }
+    declare namespace React {
+        export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+    }
+    
+    class Foo<T, U> {
+        constructor(public prop1: T, public prop2: U) {}
+    }
+    
+    function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+    
+    function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+    
+    interface ComponentProps<T, U> {
+        x: T;
+        y: U;
+        cb(props: this): void;
+    }
+    
+    function Component<T, U>(x: ComponentProps<T, U>) {
+        return <h></h>;
+    }
+    
+    // Does not reference valid param
+    
+    const instance1 = new Foo<number, Q = string>(0, "");
+                                      ~
+!!! error TS1346: Signature has no type argument named 'Q'.
+    const result1 = foo<number, Q = string>(0, "");
+                                ~
+!!! error TS1346: Signature has no type argument named 'Q'.
+    const tagged1 = tag<number, Q = string>`tags ${12} ${""}`;
+                                ~
+!!! error TS1346: Signature has no type argument named 'Q'.
+    const jsx1 = <Component<number, Q = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+                                    ~
+!!! error TS1346: Signature has no type argument named 'Q'.
+    type A = Foo<number, Q = string>;
+                         ~
+!!! error TS1346: Signature has no type argument named 'Q'.
+    
+    // Duplicates positional
+    
+    const instance2 = new Foo<number, T = string>(0, "");
+                              ~~~~~~
+!!! error TS1345: Positional type argument conflicts with named type argument 'T'.
+                                      ~
+!!! error TS1344: Named type argument conflicts with positional type argument at index '0'.
+    const result2 = foo<number, T = string>(0, "");
+                        ~~~~~~
+!!! error TS1345: Positional type argument conflicts with named type argument 'T'.
+                                ~
+!!! error TS1344: Named type argument conflicts with positional type argument at index '0'.
+    const tagged2 = tag<number, T = string>`tags ${12} ${""}`;
+                        ~~~~~~
+!!! error TS1345: Positional type argument conflicts with named type argument 'T'.
+                                ~
+!!! error TS1344: Named type argument conflicts with positional type argument at index '0'.
+    const jsx2 = <Component<number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+                            ~~~~~~
+!!! error TS1345: Positional type argument conflicts with named type argument 'T'.
+                                    ~
+!!! error TS1344: Named type argument conflicts with positional type argument at index '0'.
+    type B = Foo<number, T = string>;
+                 ~~~~~~
+!!! error TS1345: Positional type argument conflicts with named type argument 'T'.
+                         ~
+!!! error TS1344: Named type argument conflicts with positional type argument at index '0'.
+    
+    // Duplicates other named
+    
+    const instance3 = new Foo<T = number, T = string>(0, "");
+                              ~
+!!! error TS2300: Duplicate identifier 'T'.
+                                          ~
+!!! error TS2300: Duplicate identifier 'T'.
+                                                      ~
+!!! error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
+    const result3 = foo<T = number, T = string>(0, "");
+                        ~
+!!! error TS2300: Duplicate identifier 'T'.
+                                    ~
+!!! error TS2300: Duplicate identifier 'T'.
+                                                ~
+!!! error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
+    const tagged3 = tag<T = number, T = string>`tags ${12} ${""}`;
+                        ~
+!!! error TS2300: Duplicate identifier 'T'.
+                                    ~
+!!! error TS2300: Duplicate identifier 'T'.
+    const jsx3 = <Component<T = number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+                            ~
+!!! error TS2300: Duplicate identifier 'T'.
+                                        ~
+!!! error TS2300: Duplicate identifier 'T'.
+                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2326: Types of property 'cb' are incompatible.
+!!! error TS2326:   Type '(props: ComponentProps<string, string>) => any' is not assignable to type '(props: ComponentProps<number, string>) => void'.
+!!! error TS2326:     Types of parameters 'props' and 'props' are incompatible.
+!!! error TS2326:       Type 'ComponentProps<number, string>' is not assignable to type 'ComponentProps<string, string>'.
+!!! error TS2326:         Type 'number' is not assignable to type 'string'.
+                                                                                           ~~~~~~~
+!!! error TS2339: Property 'toFixed' does not exist on type 'string'.
+    type C = Foo<T = number, T = string>;
+                 ~
+!!! error TS2300: Duplicate identifier 'T'.
+                             ~
+!!! error TS2300: Duplicate identifier 'T'.
+    
+    // Too many arguments
+    
+    const instance4 = new Foo<T = number, U = string, W = never>(0, "");
+                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2558: Expected 0-2 type arguments, but got 3.
+    const result4 = foo<T = number, U = string, W = never>(0, "");
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2558: Expected 0-2 type arguments, but got 3.
+    const tagged4 = tag<T = number, U = string, W = never>`tags ${12} ${""}`;
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2558: Expected 0-2 type arguments, but got 3.
+    const jsx4 = <Component<T = number, U = string, W = never> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2558: Expected 0-2 type arguments, but got 3.
+    type D = Foo<T = number, U = string, W = never>;
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2314: Generic type 'Foo<T, U>' requires 2 type argument(s).
+    
+    // Positional after named
+    
+    const instance5 = new Foo<U = string, number>(0, "");
+                                          ~~~~~~
+!!! error TS1343: Positional type arguments cannot follow named type arguments.
+    const result5 = foo<U = string, number>(0, "");
+                                    ~~~~~~
+!!! error TS1343: Positional type arguments cannot follow named type arguments.
+    const tagged5 = tag<U = string, number>`tags ${12} ${""}`;
+                                    ~~~~~~
+!!! error TS1343: Positional type arguments cannot follow named type arguments.
+    const jsx5 = <Component<U = string, number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+                                        ~~~~~~
+!!! error TS1343: Positional type arguments cannot follow named type arguments.
+    type E = Foo<U = string, number>;
+                             ~~~~~~
+!!! error TS1343: Positional type arguments cannot follow named type arguments.
+    
+    // Typespace only - does not provide enough arguments
+    type F = Foo<U = number>;
+             ~~~~~~~~~~~~~~~
+!!! error TS2314: Generic type 'Foo<T, U>' requires 2 type argument(s).
+    

--- a/tests/baselines/reference/typeArgumentListsWithNamedTypeArgumentErrors.js
+++ b/tests/baselines/reference/typeArgumentListsWithNamedTypeArgumentErrors.js
@@ -1,0 +1,118 @@
+//// [typeArgumentListsWithNamedTypeArgumentErrors.tsx]
+declare module JSX {
+    interface Element {}
+}
+declare namespace React {
+    export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+}
+
+class Foo<T, U> {
+    constructor(public prop1: T, public prop2: U) {}
+}
+
+function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+
+function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+
+interface ComponentProps<T, U> {
+    x: T;
+    y: U;
+    cb(props: this): void;
+}
+
+function Component<T, U>(x: ComponentProps<T, U>) {
+    return <h></h>;
+}
+
+// Does not reference valid param
+
+const instance1 = new Foo<number, Q = string>(0, "");
+const result1 = foo<number, Q = string>(0, "");
+const tagged1 = tag<number, Q = string>`tags ${12} ${""}`;
+const jsx1 = <Component<number, Q = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type A = Foo<number, Q = string>;
+
+// Duplicates positional
+
+const instance2 = new Foo<number, T = string>(0, "");
+const result2 = foo<number, T = string>(0, "");
+const tagged2 = tag<number, T = string>`tags ${12} ${""}`;
+const jsx2 = <Component<number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type B = Foo<number, T = string>;
+
+// Duplicates other named
+
+const instance3 = new Foo<T = number, T = string>(0, "");
+const result3 = foo<T = number, T = string>(0, "");
+const tagged3 = tag<T = number, T = string>`tags ${12} ${""}`;
+const jsx3 = <Component<T = number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type C = Foo<T = number, T = string>;
+
+// Too many arguments
+
+const instance4 = new Foo<T = number, U = string, W = never>(0, "");
+const result4 = foo<T = number, U = string, W = never>(0, "");
+const tagged4 = tag<T = number, U = string, W = never>`tags ${12} ${""}`;
+const jsx4 = <Component<T = number, U = string, W = never> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type D = Foo<T = number, U = string, W = never>;
+
+// Positional after named
+
+const instance5 = new Foo<U = string, number>(0, "");
+const result5 = foo<U = string, number>(0, "");
+const tagged5 = tag<U = string, number>`tags ${12} ${""}`;
+const jsx5 = <Component<U = string, number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type E = Foo<U = string, number>;
+
+// Typespace only - does not provide enough arguments
+type F = Foo<U = number>;
+
+
+//// [typeArgumentListsWithNamedTypeArgumentErrors.js]
+var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+};
+var Foo = /** @class */ (function () {
+    function Foo(prop1, prop2) {
+        this.prop1 = prop1;
+        this.prop2 = prop2;
+    }
+    return Foo;
+}());
+function foo(x, y) { return [x, y]; }
+function tag(x) {
+    var args = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        args[_i - 1] = arguments[_i];
+    }
+    return args;
+}
+function Component(x) {
+    return React.createElement("h", null);
+}
+// Does not reference valid param
+var instance1 = new Foo(0, "");
+var result1 = foo(0, "");
+var tagged1 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx1 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });
+// Duplicates positional
+var instance2 = new Foo(0, "");
+var result2 = foo(0, "");
+var tagged2 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx2 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });
+// Duplicates other named
+var instance3 = new Foo(0, "");
+var result3 = foo(0, "");
+var tagged3 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx3 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });
+// Too many arguments
+var instance4 = new Foo(0, "");
+var result4 = foo(0, "");
+var tagged4 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx4 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });
+// Positional after named
+var instance5 = new Foo(0, "");
+var result5 = foo(0, "");
+var tagged5 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx5 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });

--- a/tests/baselines/reference/typeArgumentListsWithNamedTypeArgumentErrors.symbols
+++ b/tests/baselines/reference/typeArgumentListsWithNamedTypeArgumentErrors.symbols
@@ -1,0 +1,268 @@
+=== tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx ===
+declare module JSX {
+>JSX : Symbol(JSX, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 0, 0))
+
+    interface Element {}
+>Element : Symbol(Element, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 0, 20))
+}
+declare namespace React {
+>React : Symbol(React, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 2, 1))
+
+    export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+>createElement : Symbol(createElement, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 3, 25))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 4, 34))
+>p : Symbol(p, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 4, 41))
+>children : Symbol(children, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 4, 49))
+>JSX : Symbol(JSX, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 0, 0))
+>Element : Symbol(JSX.Element, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 0, 20))
+}
+
+class Foo<T, U> {
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 7, 10))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 7, 12))
+
+    constructor(public prop1: T, public prop2: U) {}
+>prop1 : Symbol(Foo.prop1, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 8, 16))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 7, 10))
+>prop2 : Symbol(Foo.prop2, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 8, 32))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 7, 12))
+}
+
+function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+>foo : Symbol(foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 9, 1))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 13))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 15))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 19))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 13))
+>y : Symbol(y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 24))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 15))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 13))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 15))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 19))
+>y : Symbol(y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 24))
+
+function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+>tag : Symbol(tag, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 57))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 13))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 15))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 19))
+>TemplateStringsArray : Symbol(TemplateStringsArray, Decl(lib.d.ts, --, --))
+>args : Symbol(args, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 43))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 13))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 15))
+>args : Symbol(args, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 43))
+
+interface ComponentProps<T, U> {
+>ComponentProps : Symbol(ComponentProps, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 80))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 25))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 27))
+
+    x: T;
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 25))
+
+    y: U;
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 27))
+
+    cb(props: this): void;
+>cb : Symbol(ComponentProps.cb, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 17, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 18, 7))
+}
+
+function Component<T, U>(x: ComponentProps<T, U>) {
+>Component : Symbol(Component, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 19, 1))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 21, 19))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 21, 21))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 21, 25))
+>ComponentProps : Symbol(ComponentProps, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 13, 80))
+>T : Symbol(T, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 21, 19))
+>U : Symbol(U, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 21, 21))
+
+    return <h></h>;
+}
+
+// Does not reference valid param
+
+const instance1 = new Foo<number, Q = string>(0, "");
+>instance1 : Symbol(instance1, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 27, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+const result1 = foo<number, Q = string>(0, "");
+>result1 : Symbol(result1, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 28, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 9, 1))
+
+const tagged1 = tag<number, Q = string>`tags ${12} ${""}`;
+>tagged1 : Symbol(tagged1, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 29, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 57))
+
+const jsx1 = <Component<number, Q = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx1 : Symbol(jsx1, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 30, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 30, 43))
+>y : Symbol(y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 30, 50))
+>cb : Symbol(cb, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 30, 55))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 30, 60))
+>props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 30, 60))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 30, 60))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+
+type A = Foo<number, Q = string>;
+>A : Symbol(A, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 30, 122))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+// Duplicates positional
+
+const instance2 = new Foo<number, T = string>(0, "");
+>instance2 : Symbol(instance2, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 35, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+const result2 = foo<number, T = string>(0, "");
+>result2 : Symbol(result2, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 36, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 9, 1))
+
+const tagged2 = tag<number, T = string>`tags ${12} ${""}`;
+>tagged2 : Symbol(tagged2, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 37, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 57))
+
+const jsx2 = <Component<number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx2 : Symbol(jsx2, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 38, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 38, 43))
+>y : Symbol(y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 38, 50))
+>cb : Symbol(cb, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 38, 55))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 38, 60))
+>props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 38, 60))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 38, 60))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+
+type B = Foo<number, T = string>;
+>B : Symbol(B, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 38, 122))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+// Duplicates other named
+
+const instance3 = new Foo<T = number, T = string>(0, "");
+>instance3 : Symbol(instance3, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 43, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+const result3 = foo<T = number, T = string>(0, "");
+>result3 : Symbol(result3, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 44, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 9, 1))
+
+const tagged3 = tag<T = number, T = string>`tags ${12} ${""}`;
+>tagged3 : Symbol(tagged3, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 45, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 57))
+
+const jsx3 = <Component<T = number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx3 : Symbol(jsx3, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 46, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 46, 47))
+>y : Symbol(y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 46, 54))
+>cb : Symbol(cb, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 46, 59))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 46, 64))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 46, 64))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 46, 64))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+
+type C = Foo<T = number, T = string>;
+>C : Symbol(C, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 46, 126))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+// Too many arguments
+
+const instance4 = new Foo<T = number, U = string, W = never>(0, "");
+>instance4 : Symbol(instance4, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 51, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+const result4 = foo<T = number, U = string, W = never>(0, "");
+>result4 : Symbol(result4, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 52, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 9, 1))
+
+const tagged4 = tag<T = number, U = string, W = never>`tags ${12} ${""}`;
+>tagged4 : Symbol(tagged4, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 53, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 57))
+
+const jsx4 = <Component<T = number, U = string, W = never> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx4 : Symbol(jsx4, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 54, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 54, 58))
+>y : Symbol(y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 54, 65))
+>cb : Symbol(cb, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 54, 70))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 54, 75))
+>props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 54, 75))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 54, 75))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+
+type D = Foo<T = number, U = string, W = never>;
+>D : Symbol(D, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 54, 137))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+// Positional after named
+
+const instance5 = new Foo<U = string, number>(0, "");
+>instance5 : Symbol(instance5, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 59, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+const result5 = foo<U = string, number>(0, "");
+>result5 : Symbol(result5, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 60, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 9, 1))
+
+const tagged5 = tag<U = string, number>`tags ${12} ${""}`;
+>tagged5 : Symbol(tagged5, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 61, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 11, 57))
+
+const jsx5 = <Component<U = string, number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx5 : Symbol(jsx5, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 62, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 62, 43))
+>y : Symbol(y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 62, 50))
+>cb : Symbol(cb, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 62, 55))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 62, 60))
+>props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 62, 60))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 15, 32))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 62, 60))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+
+type E = Foo<U = string, number>;
+>E : Symbol(E, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 62, 122))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+
+// Typespace only - does not provide enough arguments
+type F = Foo<U = number>;
+>F : Symbol(F, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 63, 33))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithNamedTypeArgumentErrors.tsx, 5, 1))
+

--- a/tests/baselines/reference/typeArgumentListsWithNamedTypeArgumentErrors.types
+++ b/tests/baselines/reference/typeArgumentListsWithNamedTypeArgumentErrors.types
@@ -1,0 +1,405 @@
+=== tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx ===
+declare module JSX {
+>JSX : any
+
+    interface Element {}
+>Element : Element
+}
+declare namespace React {
+>React : typeof React
+
+    export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+>createElement : (x: any, p: any, ...children: any[]) => JSX.Element
+>x : any
+>p : any
+>children : any[]
+>JSX : any
+>Element : JSX.Element
+}
+
+class Foo<T, U> {
+>Foo : Foo<T, U>
+>T : T
+>U : U
+
+    constructor(public prop1: T, public prop2: U) {}
+>prop1 : T
+>T : T
+>prop2 : U
+>U : U
+}
+
+function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+>foo : <T, U>(x: T, y: U) => [T, U]
+>T : T
+>U : U
+>x : T
+>T : T
+>y : U
+>U : U
+>T : T
+>U : U
+>[x, y] : [T, U]
+>x : T
+>y : U
+
+function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>T : T
+>U : U
+>x : TemplateStringsArray
+>TemplateStringsArray : TemplateStringsArray
+>args : (T | U)[]
+>T : T
+>U : U
+>args : (T | U)[]
+
+interface ComponentProps<T, U> {
+>ComponentProps : ComponentProps<T, U>
+>T : T
+>U : U
+
+    x: T;
+>x : T
+>T : T
+
+    y: U;
+>y : U
+>U : U
+
+    cb(props: this): void;
+>cb : (props: this) => void
+>props : this
+}
+
+function Component<T, U>(x: ComponentProps<T, U>) {
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>T : T
+>U : U
+>x : ComponentProps<T, U>
+>ComponentProps : ComponentProps<T, U>
+>T : T
+>U : U
+
+    return <h></h>;
+><h></h> : JSX.Element
+>h : any
+>h : any
+}
+
+// Does not reference valid param
+
+const instance1 = new Foo<number, Q = string>(0, "");
+>instance1 : any
+>new Foo<number, Q = string>(0, "") : any
+>Foo : typeof Foo
+>Q : any
+>0 : 0
+>"" : ""
+
+const result1 = foo<number, Q = string>(0, "");
+>result1 : any
+>foo<number, Q = string>(0, "") : any
+>foo : <T, U>(x: T, y: U) => [T, U]
+>Q : any
+>0 : 0
+>"" : ""
+
+const tagged1 = tag<number, Q = string>`tags ${12} ${""}`;
+>tagged1 : any
+>tag<number, Q = string>`tags ${12} ${""}` : any
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>Q : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx1 = <Component<number, Q = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx1 : JSX.Element
+><Component<number, Q = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>Q : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<number, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<number, string>) => any
+>props : ComponentProps<number, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : string
+>props.x.toFixed : (fractionDigits?: number) => string
+>props.x : number
+>props : ComponentProps<number, string>
+>x : number
+>toFixed : (fractionDigits?: number) => string
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<number, string>
+>y : string
+>toUpperCase : () => string
+
+type A = Foo<number, Q = string>;
+>A : Foo<number, U>
+>Foo : Foo<T, U>
+>Q : any
+
+// Duplicates positional
+
+const instance2 = new Foo<number, T = string>(0, "");
+>instance2 : any
+>new Foo<number, T = string>(0, "") : any
+>Foo : typeof Foo
+>T : any
+>0 : 0
+>"" : ""
+
+const result2 = foo<number, T = string>(0, "");
+>result2 : any
+>foo<number, T = string>(0, "") : any
+>foo : <T, U>(x: T, y: U) => [T, U]
+>T : any
+>0 : 0
+>"" : ""
+
+const tagged2 = tag<number, T = string>`tags ${12} ${""}`;
+>tagged2 : any
+>tag<number, T = string>`tags ${12} ${""}` : any
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>T : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx2 = <Component<number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx2 : JSX.Element
+><Component<number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>T : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<number, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<number, string>) => any
+>props : ComponentProps<number, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : string
+>props.x.toFixed : (fractionDigits?: number) => string
+>props.x : number
+>props : ComponentProps<number, string>
+>x : number
+>toFixed : (fractionDigits?: number) => string
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<number, string>
+>y : string
+>toUpperCase : () => string
+
+type B = Foo<number, T = string>;
+>B : Foo<number, U>
+>Foo : Foo<T, U>
+>T : any
+
+// Duplicates other named
+
+const instance3 = new Foo<T = number, T = string>(0, "");
+>instance3 : any
+>new Foo<T = number, T = string>(0, "") : any
+>Foo : typeof Foo
+>T : any
+>T : any
+>0 : 0
+>"" : ""
+
+const result3 = foo<T = number, T = string>(0, "");
+>result3 : any
+>foo<T = number, T = string>(0, "") : any
+>foo : <T, U>(x: T, y: U) => [T, U]
+>T : any
+>T : any
+>0 : 0
+>"" : ""
+
+const tagged3 = tag<T = number, T = string>`tags ${12} ${""}`;
+>tagged3 : (string | number)[]
+>tag<T = number, T = string>`tags ${12} ${""}` : (string | number)[]
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>T : any
+>T : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx3 = <Component<T = number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx3 : JSX.Element
+><Component<T = number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>T : any
+>T : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<string, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<string, string>) => any
+>props : ComponentProps<string, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : any
+>props.x.toFixed : any
+>props.x : string
+>props : ComponentProps<string, string>
+>x : string
+>toFixed : any
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<string, string>
+>y : string
+>toUpperCase : () => string
+
+type C = Foo<T = number, T = string>;
+>C : Foo<string, U>
+>Foo : Foo<T, U>
+>T : any
+>T : any
+
+// Too many arguments
+
+const instance4 = new Foo<T = number, U = string, W = never>(0, "");
+>instance4 : any
+>new Foo<T = number, U = string, W = never>(0, "") : any
+>Foo : typeof Foo
+>T : any
+>U : any
+>W : any
+>0 : 0
+>"" : ""
+
+const result4 = foo<T = number, U = string, W = never>(0, "");
+>result4 : any
+>foo<T = number, U = string, W = never>(0, "") : any
+>foo : <T, U>(x: T, y: U) => [T, U]
+>T : any
+>U : any
+>W : any
+>0 : 0
+>"" : ""
+
+const tagged4 = tag<T = number, U = string, W = never>`tags ${12} ${""}`;
+>tagged4 : any
+>tag<T = number, U = string, W = never>`tags ${12} ${""}` : any
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>T : any
+>U : any
+>W : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx4 = <Component<T = number, U = string, W = never> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx4 : JSX.Element
+><Component<T = number, U = string, W = never> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>T : any
+>U : any
+>W : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<number, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<number, string>) => any
+>props : ComponentProps<number, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : string
+>props.x.toFixed : (fractionDigits?: number) => string
+>props.x : number
+>props : ComponentProps<number, string>
+>x : number
+>toFixed : (fractionDigits?: number) => string
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<number, string>
+>y : string
+>toUpperCase : () => string
+
+type D = Foo<T = number, U = string, W = never>;
+>D : any
+>Foo : Foo<T, U>
+>T : any
+>U : any
+>W : any
+
+// Positional after named
+
+const instance5 = new Foo<U = string, number>(0, "");
+>instance5 : Foo<number, string>
+>new Foo<U = string, number>(0, "") : Foo<number, string>
+>Foo : typeof Foo
+>U : any
+>0 : 0
+>"" : ""
+
+const result5 = foo<U = string, number>(0, "");
+>result5 : [number, string]
+>foo<U = string, number>(0, "") : [number, string]
+>foo : <T, U>(x: T, y: U) => [T, U]
+>U : any
+>0 : 0
+>"" : ""
+
+const tagged5 = tag<U = string, number>`tags ${12} ${""}`;
+>tagged5 : (string | number)[]
+>tag<U = string, number>`tags ${12} ${""}` : (string | number)[]
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>U : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx5 = <Component<U = string, number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx5 : JSX.Element
+><Component<U = string, number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>U : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<number, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<number, string>) => any
+>props : ComponentProps<number, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : string
+>props.x.toFixed : (fractionDigits?: number) => string
+>props.x : number
+>props : ComponentProps<number, string>
+>x : number
+>toFixed : (fractionDigits?: number) => string
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<number, string>
+>y : string
+>toUpperCase : () => string
+
+type E = Foo<U = string, number>;
+>E : Foo<number, string>
+>Foo : Foo<T, U>
+>U : any
+
+// Typespace only - does not provide enough arguments
+type F = Foo<U = number>;
+>F : any
+>Foo : Foo<T, U>
+>U : any
+

--- a/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.js
+++ b/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.js
@@ -1,0 +1,91 @@
+//// [typeArgumentListsWithnamedTypeArguments.tsx]
+declare module JSX {
+    interface Element {}
+}
+declare namespace React {
+    export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+}
+
+class Foo<T, U> {
+    constructor(public prop1: T, public prop2: U) {}
+}
+
+function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+
+function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+
+interface ComponentProps<T, U> {
+    x: T;
+    y: U;
+    cb: (props: this) => void;
+}
+
+function Component<T, U>(x: ComponentProps<T, U>) {
+    return <h></h>;
+}
+
+// In order
+
+const instance1 = new Foo<T = number, U = string>(0, "");
+const result1 = foo<T = number, U = string>(0, "");
+const tagged1 = tag<T = number, U = string>`tags ${12} ${""}`;
+const jsx1 = <Component<T = number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+
+
+// Out of order
+
+const instance2 = new Foo<U = string, T = number>(0, "");
+const result2 = foo<U = string, T = number>(0, "");
+const tagged2 = tag<U = string, T = number>`tags ${12} ${""}`;
+const jsx2 = <Component<U = string, T = number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+
+// With positional
+
+const instance3 = new Foo<number, U = string>(0, "");
+const result3 = foo<number, U = string>(0, "");
+const tagged3 = tag<number, U = string>`tags ${12} ${""}`;
+const jsx3 = <Component<number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+
+// With partial inference
+
+
+
+//// [typeArgumentListsWithnamedTypeArguments.js]
+var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+};
+var Foo = /** @class */ (function () {
+    function Foo(prop1, prop2) {
+        this.prop1 = prop1;
+        this.prop2 = prop2;
+    }
+    return Foo;
+}());
+function foo(x, y) { return [x, y]; }
+function tag(x) {
+    var args = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        args[_i - 1] = arguments[_i];
+    }
+    return args;
+}
+function Component(x) {
+    return React.createElement("h", null);
+}
+// In order
+var instance1 = new Foo(0, "");
+var result1 = foo(0, "");
+var tagged1 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx1 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });
+// Out of order
+var instance2 = new Foo(0, "");
+var result2 = foo(0, "");
+var tagged2 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx2 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });
+// With positional
+var instance3 = new Foo(0, "");
+var result3 = foo(0, "");
+var tagged3 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx3 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });
+// With partial inference

--- a/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.js
+++ b/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.js
@@ -17,7 +17,7 @@ function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
 interface ComponentProps<T, U> {
     x: T;
     y: U;
-    cb: (props: this) => void;
+    cb(props: this): void;
 }
 
 function Component<T, U>(x: ComponentProps<T, U>) {
@@ -30,7 +30,6 @@ const instance1 = new Foo<T = number, U = string>(0, "");
 const result1 = foo<T = number, U = string>(0, "");
 const tagged1 = tag<T = number, U = string>`tags ${12} ${""}`;
 const jsx1 = <Component<T = number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
-
 
 // Out of order
 
@@ -48,6 +47,10 @@ const jsx3 = <Component<number, U = string> x={12} y="" cb={props => void (props
 
 // With partial inference
 
+const instance4 = new Foo<U = string>(0, "");
+const result4 = foo<U = string>(0, "");
+const tagged4 = tag<U = string>`tags ${12} ${""}`;
+const jsx4 = <Component<U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
 
 
 //// [typeArgumentListsWithnamedTypeArguments.js]
@@ -89,3 +92,7 @@ var result3 = foo(0, "");
 var tagged3 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
 var jsx3 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });
 // With partial inference
+var instance4 = new Foo(0, "");
+var result4 = foo(0, "");
+var tagged4 = tag(__makeTemplateObject(["tags ", " ", ""], ["tags ", " ", ""]), 12, "");
+var jsx4 = React.createElement(Component, { x: 12, y: "", cb: function (props) { return void (props.x.toFixed() + props.y.toUpperCase()); } });

--- a/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.symbols
+++ b/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.symbols
@@ -66,9 +66,9 @@ interface ComponentProps<T, U> {
 >y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
 >U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 27))
 
-    cb: (props: this) => void;
+    cb(props: this): void;
 >cb : Symbol(ComponentProps.cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 17, 9))
->props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 18, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 18, 7))
 }
 
 function Component<T, U>(x: ComponentProps<T, U>) {
@@ -115,71 +115,99 @@ const jsx1 = <Component<T = number, U = string> x={12} y="" cb={props => void (p
 >y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
 >toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
 
-
 // Out of order
 
 const instance2 = new Foo<U = string, T = number>(0, "");
->instance2 : Symbol(instance2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 35, 5))
+>instance2 : Symbol(instance2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 34, 5))
 >Foo : Symbol(Foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 5, 1))
 
 const result2 = foo<U = string, T = number>(0, "");
->result2 : Symbol(result2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 36, 5))
+>result2 : Symbol(result2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 35, 5))
 >foo : Symbol(foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 9, 1))
 
 const tagged2 = tag<U = string, T = number>`tags ${12} ${""}`;
->tagged2 : Symbol(tagged2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 5))
+>tagged2 : Symbol(tagged2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 36, 5))
 >tag : Symbol(tag, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 57))
 
 const jsx2 = <Component<U = string, T = number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
->jsx2 : Symbol(jsx2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 5))
+>jsx2 : Symbol(jsx2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 5))
 >Component : Symbol(Component, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 19, 1))
->x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 47))
->y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 54))
->cb : Symbol(cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 59))
->props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 64))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 47))
+>y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 54))
+>cb : Symbol(cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 59))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 64))
 >props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 >props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
->props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 64))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 64))
 >x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
 >toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 >props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
 >props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
->props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 64))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 64))
 >y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
 >toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
 
 // With positional
 
 const instance3 = new Foo<number, U = string>(0, "");
->instance3 : Symbol(instance3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 42, 5))
+>instance3 : Symbol(instance3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 41, 5))
 >Foo : Symbol(Foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 5, 1))
 
 const result3 = foo<number, U = string>(0, "");
->result3 : Symbol(result3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 43, 5))
+>result3 : Symbol(result3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 42, 5))
 >foo : Symbol(foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 9, 1))
 
 const tagged3 = tag<number, U = string>`tags ${12} ${""}`;
->tagged3 : Symbol(tagged3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 5))
+>tagged3 : Symbol(tagged3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 43, 5))
 >tag : Symbol(tag, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 57))
 
 const jsx3 = <Component<number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
->jsx3 : Symbol(jsx3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 5))
+>jsx3 : Symbol(jsx3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 5))
 >Component : Symbol(Component, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 19, 1))
->x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 43))
->y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 50))
->cb : Symbol(cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 55))
->props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 60))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 43))
+>y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 50))
+>cb : Symbol(cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 55))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 60))
 >props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 >props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
->props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 60))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 60))
 >x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
 >toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
 >props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
 >props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
->props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 60))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 60))
 >y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
 >toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
 
 // With partial inference
 
+const instance4 = new Foo<U = string>(0, "");
+>instance4 : Symbol(instance4, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 48, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 5, 1))
+
+const result4 = foo<U = string>(0, "");
+>result4 : Symbol(result4, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 49, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 9, 1))
+
+const tagged4 = tag<U = string>`tags ${12} ${""}`;
+>tagged4 : Symbol(tagged4, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 50, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 57))
+
+const jsx4 = <Component<U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx4 : Symbol(jsx4, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 51, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 51, 35))
+>y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 51, 42))
+>cb : Symbol(cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 51, 47))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 51, 52))
+>props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 51, 52))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 51, 52))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
 

--- a/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.symbols
+++ b/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.symbols
@@ -1,0 +1,185 @@
+=== tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithnamedTypeArguments.tsx ===
+declare module JSX {
+>JSX : Symbol(JSX, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 0, 0))
+
+    interface Element {}
+>Element : Symbol(Element, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 0, 20))
+}
+declare namespace React {
+>React : Symbol(React, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 2, 1))
+
+    export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+>createElement : Symbol(createElement, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 3, 25))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 4, 34))
+>p : Symbol(p, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 4, 41))
+>children : Symbol(children, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 4, 49))
+>JSX : Symbol(JSX, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 0, 0))
+>Element : Symbol(JSX.Element, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 0, 20))
+}
+
+class Foo<T, U> {
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 5, 1))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 7, 10))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 7, 12))
+
+    constructor(public prop1: T, public prop2: U) {}
+>prop1 : Symbol(Foo.prop1, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 8, 16))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 7, 10))
+>prop2 : Symbol(Foo.prop2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 8, 32))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 7, 12))
+}
+
+function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+>foo : Symbol(foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 9, 1))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 13))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 15))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 19))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 13))
+>y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 24))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 15))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 13))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 15))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 19))
+>y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 24))
+
+function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+>tag : Symbol(tag, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 57))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 13))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 15))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 19))
+>TemplateStringsArray : Symbol(TemplateStringsArray, Decl(lib.d.ts, --, --))
+>args : Symbol(args, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 43))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 13))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 15))
+>args : Symbol(args, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 43))
+
+interface ComponentProps<T, U> {
+>ComponentProps : Symbol(ComponentProps, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 80))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 25))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 27))
+
+    x: T;
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 25))
+
+    y: U;
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 27))
+
+    cb: (props: this) => void;
+>cb : Symbol(ComponentProps.cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 17, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 18, 9))
+}
+
+function Component<T, U>(x: ComponentProps<T, U>) {
+>Component : Symbol(Component, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 19, 1))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 21, 19))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 21, 21))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 21, 25))
+>ComponentProps : Symbol(ComponentProps, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 13, 80))
+>T : Symbol(T, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 21, 19))
+>U : Symbol(U, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 21, 21))
+
+    return <h></h>;
+}
+
+// In order
+
+const instance1 = new Foo<T = number, U = string>(0, "");
+>instance1 : Symbol(instance1, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 27, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 5, 1))
+
+const result1 = foo<T = number, U = string>(0, "");
+>result1 : Symbol(result1, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 28, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 9, 1))
+
+const tagged1 = tag<T = number, U = string>`tags ${12} ${""}`;
+>tagged1 : Symbol(tagged1, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 29, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 57))
+
+const jsx1 = <Component<T = number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx1 : Symbol(jsx1, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 30, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 30, 47))
+>y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 30, 54))
+>cb : Symbol(cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 30, 59))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 30, 64))
+>props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 30, 64))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 30, 64))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+
+
+// Out of order
+
+const instance2 = new Foo<U = string, T = number>(0, "");
+>instance2 : Symbol(instance2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 35, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 5, 1))
+
+const result2 = foo<U = string, T = number>(0, "");
+>result2 : Symbol(result2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 36, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 9, 1))
+
+const tagged2 = tag<U = string, T = number>`tags ${12} ${""}`;
+>tagged2 : Symbol(tagged2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 37, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 57))
+
+const jsx2 = <Component<U = string, T = number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx2 : Symbol(jsx2, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 47))
+>y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 54))
+>cb : Symbol(cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 59))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 64))
+>props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 64))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 38, 64))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+
+// With positional
+
+const instance3 = new Foo<number, U = string>(0, "");
+>instance3 : Symbol(instance3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 42, 5))
+>Foo : Symbol(Foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 5, 1))
+
+const result3 = foo<number, U = string>(0, "");
+>result3 : Symbol(result3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 43, 5))
+>foo : Symbol(foo, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 9, 1))
+
+const tagged3 = tag<number, U = string>`tags ${12} ${""}`;
+>tagged3 : Symbol(tagged3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 44, 5))
+>tag : Symbol(tag, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 11, 57))
+
+const jsx3 = <Component<number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx3 : Symbol(jsx3, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 5))
+>Component : Symbol(Component, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 19, 1))
+>x : Symbol(x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 43))
+>y : Symbol(y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 50))
+>cb : Symbol(cb, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 55))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 60))
+>props.x.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 60))
+>x : Symbol(ComponentProps.x, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 15, 32))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>props.y.toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+>props.y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>props : Symbol(props, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 45, 60))
+>y : Symbol(ComponentProps.y, Decl(typeArgumentListsWithnamedTypeArguments.tsx, 16, 9))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.d.ts, --, --))
+
+// With partial inference
+
+

--- a/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.types
+++ b/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.types
@@ -67,7 +67,7 @@ interface ComponentProps<T, U> {
 >y : U
 >U : U
 
-    cb: (props: this) => void;
+    cb(props: this): void;
 >cb : (props: this) => void
 >props : this
 }
@@ -144,7 +144,6 @@ const jsx1 = <Component<T = number, U = string> x={12} y="" cb={props => void (p
 >props : ComponentProps<number, string>
 >y : string
 >toUpperCase : () => string
-
 
 // Out of order
 
@@ -260,4 +259,55 @@ const jsx3 = <Component<number, U = string> x={12} y="" cb={props => void (props
 
 // With partial inference
 
+const instance4 = new Foo<U = string>(0, "");
+>instance4 : Foo<number, string>
+>new Foo<U = string>(0, "") : Foo<number, string>
+>Foo : typeof Foo
+>U : any
+>0 : 0
+>"" : ""
+
+const result4 = foo<U = string>(0, "");
+>result4 : [number, string]
+>foo<U = string>(0, "") : [number, string]
+>foo : <T, U>(x: T, y: U) => [T, U]
+>U : any
+>0 : 0
+>"" : ""
+
+const tagged4 = tag<U = string>`tags ${12} ${""}`;
+>tagged4 : (string | number)[]
+>tag<U = string>`tags ${12} ${""}` : (string | number)[]
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>U : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx4 = <Component<U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx4 : JSX.Element
+><Component<U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>U : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<number, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<number, string>) => any
+>props : ComponentProps<number, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : string
+>props.x.toFixed : (fractionDigits?: number) => string
+>props.x : number
+>props : ComponentProps<number, string>
+>x : number
+>toFixed : (fractionDigits?: number) => string
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<number, string>
+>y : string
+>toUpperCase : () => string
 

--- a/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.types
+++ b/tests/baselines/reference/typeArgumentListsWithnamedTypeArguments.types
@@ -1,0 +1,263 @@
+=== tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithnamedTypeArguments.tsx ===
+declare module JSX {
+>JSX : any
+
+    interface Element {}
+>Element : Element
+}
+declare namespace React {
+>React : typeof React
+
+    export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+>createElement : (x: any, p: any, ...children: any[]) => JSX.Element
+>x : any
+>p : any
+>children : any[]
+>JSX : any
+>Element : JSX.Element
+}
+
+class Foo<T, U> {
+>Foo : Foo<T, U>
+>T : T
+>U : U
+
+    constructor(public prop1: T, public prop2: U) {}
+>prop1 : T
+>T : T
+>prop2 : U
+>U : U
+}
+
+function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+>foo : <T, U>(x: T, y: U) => [T, U]
+>T : T
+>U : U
+>x : T
+>T : T
+>y : U
+>U : U
+>T : T
+>U : U
+>[x, y] : [T, U]
+>x : T
+>y : U
+
+function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>T : T
+>U : U
+>x : TemplateStringsArray
+>TemplateStringsArray : TemplateStringsArray
+>args : (T | U)[]
+>T : T
+>U : U
+>args : (T | U)[]
+
+interface ComponentProps<T, U> {
+>ComponentProps : ComponentProps<T, U>
+>T : T
+>U : U
+
+    x: T;
+>x : T
+>T : T
+
+    y: U;
+>y : U
+>U : U
+
+    cb: (props: this) => void;
+>cb : (props: this) => void
+>props : this
+}
+
+function Component<T, U>(x: ComponentProps<T, U>) {
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>T : T
+>U : U
+>x : ComponentProps<T, U>
+>ComponentProps : ComponentProps<T, U>
+>T : T
+>U : U
+
+    return <h></h>;
+><h></h> : JSX.Element
+>h : any
+>h : any
+}
+
+// In order
+
+const instance1 = new Foo<T = number, U = string>(0, "");
+>instance1 : Foo<number, string>
+>new Foo<T = number, U = string>(0, "") : Foo<number, string>
+>Foo : typeof Foo
+>T : any
+>U : any
+>0 : 0
+>"" : ""
+
+const result1 = foo<T = number, U = string>(0, "");
+>result1 : [number, string]
+>foo<T = number, U = string>(0, "") : [number, string]
+>foo : <T, U>(x: T, y: U) => [T, U]
+>T : any
+>U : any
+>0 : 0
+>"" : ""
+
+const tagged1 = tag<T = number, U = string>`tags ${12} ${""}`;
+>tagged1 : (string | number)[]
+>tag<T = number, U = string>`tags ${12} ${""}` : (string | number)[]
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>T : any
+>U : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx1 = <Component<T = number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx1 : JSX.Element
+><Component<T = number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>T : any
+>U : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<number, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<number, string>) => any
+>props : ComponentProps<number, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : string
+>props.x.toFixed : (fractionDigits?: number) => string
+>props.x : number
+>props : ComponentProps<number, string>
+>x : number
+>toFixed : (fractionDigits?: number) => string
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<number, string>
+>y : string
+>toUpperCase : () => string
+
+
+// Out of order
+
+const instance2 = new Foo<U = string, T = number>(0, "");
+>instance2 : Foo<number, string>
+>new Foo<U = string, T = number>(0, "") : Foo<number, string>
+>Foo : typeof Foo
+>U : any
+>T : any
+>0 : 0
+>"" : ""
+
+const result2 = foo<U = string, T = number>(0, "");
+>result2 : [number, string]
+>foo<U = string, T = number>(0, "") : [number, string]
+>foo : <T, U>(x: T, y: U) => [T, U]
+>U : any
+>T : any
+>0 : 0
+>"" : ""
+
+const tagged2 = tag<U = string, T = number>`tags ${12} ${""}`;
+>tagged2 : (string | number)[]
+>tag<U = string, T = number>`tags ${12} ${""}` : (string | number)[]
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>U : any
+>T : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx2 = <Component<U = string, T = number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx2 : JSX.Element
+><Component<U = string, T = number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>U : any
+>T : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<number, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<number, string>) => any
+>props : ComponentProps<number, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : string
+>props.x.toFixed : (fractionDigits?: number) => string
+>props.x : number
+>props : ComponentProps<number, string>
+>x : number
+>toFixed : (fractionDigits?: number) => string
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<number, string>
+>y : string
+>toUpperCase : () => string
+
+// With positional
+
+const instance3 = new Foo<number, U = string>(0, "");
+>instance3 : Foo<number, string>
+>new Foo<number, U = string>(0, "") : Foo<number, string>
+>Foo : typeof Foo
+>U : any
+>0 : 0
+>"" : ""
+
+const result3 = foo<number, U = string>(0, "");
+>result3 : [number, string]
+>foo<number, U = string>(0, "") : [number, string]
+>foo : <T, U>(x: T, y: U) => [T, U]
+>U : any
+>0 : 0
+>"" : ""
+
+const tagged3 = tag<number, U = string>`tags ${12} ${""}`;
+>tagged3 : (string | number)[]
+>tag<number, U = string>`tags ${12} ${""}` : (string | number)[]
+>tag : <T, U>(x: TemplateStringsArray, ...args: (T | U)[]) => (T | U)[]
+>U : any
+>`tags ${12} ${""}` : string
+>12 : 12
+>"" : ""
+
+const jsx3 = <Component<number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+>jsx3 : JSX.Element
+><Component<number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} /> : JSX.Element
+>Component : <T, U>(x: ComponentProps<T, U>) => JSX.Element
+>U : any
+>x : number
+>12 : 12
+>y : string
+>cb : (props: ComponentProps<number, string>) => any
+>props => void (props.x.toFixed() + props.y.toUpperCase()) : (props: ComponentProps<number, string>) => any
+>props : ComponentProps<number, string>
+>void (props.x.toFixed() + props.y.toUpperCase()) : undefined
+>(props.x.toFixed() + props.y.toUpperCase()) : string
+>props.x.toFixed() + props.y.toUpperCase() : string
+>props.x.toFixed() : string
+>props.x.toFixed : (fractionDigits?: number) => string
+>props.x : number
+>props : ComponentProps<number, string>
+>x : number
+>toFixed : (fractionDigits?: number) => string
+>props.y.toUpperCase() : string
+>props.y.toUpperCase : () => string
+>props.y : string
+>props : ComponentProps<number, string>
+>y : string
+>toUpperCase : () => string
+
+// With partial inference
+
+

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListWithNamedTypeArgumentsAndDefaults.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListWithNamedTypeArgumentsAndDefaults.ts
@@ -1,0 +1,8 @@
+class Foo<A extends {x: string} = {x: string, y: number}, B = number> {
+    constructor(public a?: A, public b?: B) {}
+}
+
+const x = new Foo<B = string>();
+x.a.x;
+x.a.y;
+x.b;

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithNamedTypeArgumentErrors.tsx
@@ -1,0 +1,68 @@
+// @jsx: react
+declare module JSX {
+    interface Element {}
+}
+declare namespace React {
+    export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+}
+
+class Foo<T, U> {
+    constructor(public prop1: T, public prop2: U) {}
+}
+
+function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+
+function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+
+interface ComponentProps<T, U> {
+    x: T;
+    y: U;
+    cb(props: this): void;
+}
+
+function Component<T, U>(x: ComponentProps<T, U>) {
+    return <h></h>;
+}
+
+// Does not reference valid param
+
+const instance1 = new Foo<number, Q = string>(0, "");
+const result1 = foo<number, Q = string>(0, "");
+const tagged1 = tag<number, Q = string>`tags ${12} ${""}`;
+const jsx1 = <Component<number, Q = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type A = Foo<number, Q = string>;
+
+// Duplicates positional
+
+const instance2 = new Foo<number, T = string>(0, "");
+const result2 = foo<number, T = string>(0, "");
+const tagged2 = tag<number, T = string>`tags ${12} ${""}`;
+const jsx2 = <Component<number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type B = Foo<number, T = string>;
+
+// Duplicates other named
+
+const instance3 = new Foo<T = number, T = string>(0, "");
+const result3 = foo<T = number, T = string>(0, "");
+const tagged3 = tag<T = number, T = string>`tags ${12} ${""}`;
+const jsx3 = <Component<T = number, T = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type C = Foo<T = number, T = string>;
+
+// Too many arguments
+
+const instance4 = new Foo<T = number, U = string, W = never>(0, "");
+const result4 = foo<T = number, U = string, W = never>(0, "");
+const tagged4 = tag<T = number, U = string, W = never>`tags ${12} ${""}`;
+const jsx4 = <Component<T = number, U = string, W = never> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type D = Foo<T = number, U = string, W = never>;
+
+// Positional after named
+
+const instance5 = new Foo<U = string, number>(0, "");
+const result5 = foo<U = string, number>(0, "");
+const tagged5 = tag<U = string, number>`tags ${12} ${""}`;
+const jsx5 = <Component<U = string, number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+type E = Foo<U = string, number>;
+
+// Typespace only - does not provide enough arguments
+type F = Foo<U = number>;

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithnamedTypeArguments.tsx
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeArgumentListsWithNamedTypeArguments/typeArgumentListsWithnamedTypeArguments.tsx
@@ -1,0 +1,53 @@
+// @jsx: react
+declare module JSX {
+    interface Element {}
+}
+declare namespace React {
+    export function createElement(x: any, p: any, ...children: any[]): JSX.Element;
+}
+
+class Foo<T, U> {
+    constructor(public prop1: T, public prop2: U) {}
+}
+
+function foo<T, U>(x: T, y: U): [T, U] { return [x, y]; }
+
+function tag<T, U>(x: TemplateStringsArray, ...args: (T | U)[]) { return args; }
+
+interface ComponentProps<T, U> {
+    x: T;
+    y: U;
+    cb(props: this): void;
+}
+
+function Component<T, U>(x: ComponentProps<T, U>) {
+    return <h></h>;
+}
+
+// In order
+
+const instance1 = new Foo<T = number, U = string>(0, "");
+const result1 = foo<T = number, U = string>(0, "");
+const tagged1 = tag<T = number, U = string>`tags ${12} ${""}`;
+const jsx1 = <Component<T = number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+
+// Out of order
+
+const instance2 = new Foo<U = string, T = number>(0, "");
+const result2 = foo<U = string, T = number>(0, "");
+const tagged2 = tag<U = string, T = number>`tags ${12} ${""}`;
+const jsx2 = <Component<U = string, T = number> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+
+// With positional
+
+const instance3 = new Foo<number, U = string>(0, "");
+const result3 = foo<number, U = string>(0, "");
+const tagged3 = tag<number, U = string>`tags ${12} ${""}`;
+const jsx3 = <Component<number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
+
+// With partial inference
+
+const instance4 = new Foo<U = string>(0, "");
+const result4 = foo<U = string>(0, "");
+const tagged4 = tag<U = string>`tags ${12} ${""}`;
+const jsx4 = <Component<U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;


### PR DESCRIPTION
With this PR, we allow named type arguments, of the form `Identifier = Type` anywhere a type argument is expected. This looks like so:

```ts
const instance1 = new Foo<T = number, U = string>(0, "");
const result1 = foo<T = number, U = string>(0, "");
const tagged1 = tag<T = number, U = string>`tags ${12} ${""}`;
const jsx1 = <Component<T = number, U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
type A = Foo<T = number, U = string>;
```

These arguments do not need to come in any particular order, but _must_ come after all positional type arguments. When you've used a named type argument, you may elide any other type arguments you wish. When you do so, the missing arguments will be _inferred_ (and will not cause an error to be issued even if they do not have a default)

```ts
const instance4 = new Foo<U = string>(0, "");
const result4 = foo<U = string>(0, "");
const tagged4 = tag<U = string>`tags ${12} ${""}`;
const jsx4 = <Component<U = string> x={12} y="" cb={props => void (props.x.toFixed() + props.y.toUpperCase())} />;
```

(This is not valid for typespace references such as type references - those still have strict arity checks as there is no inference source)

Fixes #22631
Fixes #20122
Fixes #10571

🚲 🏠: Should named type argument assignments use a `=` (as they do in this PR now), or a `:` (as #22631 proposed)?

