### PR TITLE
Formatting: fix unwanted space between closing parenthesis and string template

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -129,6 +129,9 @@ namespace ts.formatting {
             // template string
             rule("NoSpaceBetweenTagAndTemplateString", SyntaxKind.Identifier, [SyntaxKind.NoSubstitutionTemplateLiteral, SyntaxKind.TemplateHead], [isNonJsxSameLineTokenContext], RuleAction.Delete),
 
+            // No space between closing parenthesis and template string
+            rule("NoSpaceBetweenCloseParenAndTemplateString", SyntaxKind.CloseParenToken, SyntaxKind.NoSubstitutionTemplateLiteral, [isNonJsxSameLineTokenContext], RuleAction.Delete),
+
             // JSX opening elements
             rule("SpaceBeforeJsxAttribute", anyToken, SyntaxKind.Identifier, [isNextTokenParentJsxAttribute, isNonJsxSameLineTokenContext], RuleAction.Space),
             rule("SpaceBeforeSlashInJsxOpeningElement", anyToken, SyntaxKind.SlashToken, [isJsxSelfClosingElementContext, isNonJsxSameLineTokenContext], RuleAction.Space),

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -126,11 +126,8 @@ namespace ts.formatting {
             rule("SpaceBetweenAsyncAndOpenParen", SyntaxKind.AsyncKeyword, SyntaxKind.OpenParenToken, [isArrowFunctionContext, isNonJsxSameLineTokenContext], RuleAction.Space),
             rule("SpaceBetweenAsyncAndFunctionKeyword", SyntaxKind.AsyncKeyword, SyntaxKind.FunctionKeyword, [isNonJsxSameLineTokenContext], RuleAction.Space),
 
-            // template string
-            rule("NoSpaceBetweenTagAndTemplateString", SyntaxKind.Identifier, [SyntaxKind.NoSubstitutionTemplateLiteral, SyntaxKind.TemplateHead], [isNonJsxSameLineTokenContext], RuleAction.Delete),
-
-            // No space between closing parenthesis and template string
-            rule("NoSpaceBetweenCloseParenAndTemplateString", SyntaxKind.CloseParenToken, SyntaxKind.NoSubstitutionTemplateLiteral, [isNonJsxSameLineTokenContext], RuleAction.Delete),
+            // Template string
+            rule("NoSpaceBetweenTagAndTemplateString", [SyntaxKind.Identifier, SyntaxKind.CloseParenToken], [SyntaxKind.NoSubstitutionTemplateLiteral, SyntaxKind.TemplateHead], [isNonJsxSameLineTokenContext], RuleAction.Delete),
 
             // JSX opening elements
             rule("SpaceBeforeJsxAttribute", anyToken, SyntaxKind.Identifier, [isNextTokenParentJsxAttribute, isNonJsxSameLineTokenContext], RuleAction.Space),

--- a/tests/cases/fourslash/formatNoSpaceBetweenClosingParenAndTemplateString.ts
+++ b/tests/cases/fourslash/formatNoSpaceBetweenClosingParenAndTemplateString.ts
@@ -2,9 +2,11 @@
 
 //// foo() `abc`;
 //// bar()`def`;
+//// baz()`a${x}b`;
 
 format.document();
 verify.currentFileContentIs(
 `foo()\`abc\`;
-bar()\`def\`;`
+bar()\`def\`;
+baz()\`a\${x}b\`;`
 );

--- a/tests/cases/fourslash/formatNoSpaceBetweenClosingParenAndTemplateString.ts
+++ b/tests/cases/fourslash/formatNoSpaceBetweenClosingParenAndTemplateString.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts"/>
+
+//// foo() `abc`;
+//// bar()`def`;
+
+format.document();
+verify.currentFileContentIs(
+`foo()\`abc\`;
+bar()\`def\`;`
+);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #23047
