### PR TITLE
Remove readonly from object rest properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4180,7 +4180,7 @@ namespace ts {
                 const isPrivate = getDeclarationModifierFlagsFromSymbol(prop) & (ModifierFlags.Private | ModifierFlags.Protected);
                 const isSetOnlyAccessor = prop.flags & SymbolFlags.SetAccessor && !(prop.flags & SymbolFlags.GetAccessor);
                 if (!inNamesToRemove && !isPrivate && !isClassMethod(prop) && !isSetOnlyAccessor) {
-                    members.set(prop.escapedName, prop);
+                    members.set(prop.escapedName, getNonReadonlySymbol(prop));
                 }
             }
             const stringIndexInfo = getIndexInfoOfType(source, IndexKind.String);

--- a/tests/baselines/reference/objectRestReadonly.js
+++ b/tests/baselines/reference/objectRestReadonly.js
@@ -1,5 +1,5 @@
 //// [objectRestReadonly.ts]
-// #23374
+// #23734
 type ObjType = {
   foo: string
   baz: string

--- a/tests/baselines/reference/objectRestReadonly.js
+++ b/tests/baselines/reference/objectRestReadonly.js
@@ -1,0 +1,36 @@
+//// [objectRestReadonly.ts]
+// #23374
+type ObjType = {
+  foo: string
+  baz: string
+  quux: string
+}
+
+const obj: Readonly<ObjType> = {
+  foo: 'bar',
+  baz: 'qux',
+  quux: 'quuz',
+}
+
+const { foo, ...rest } = obj
+
+delete rest.baz
+
+
+//// [objectRestReadonly.js]
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+            t[p[i]] = s[p[i]];
+    return t;
+};
+var obj = {
+    foo: 'bar',
+    baz: 'qux',
+    quux: 'quuz'
+};
+var foo = obj.foo, rest = __rest(obj, ["foo"]);
+delete rest.baz;

--- a/tests/baselines/reference/objectRestReadonly.symbols
+++ b/tests/baselines/reference/objectRestReadonly.symbols
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/types/rest/objectRestReadonly.ts ===
+// #23374
+type ObjType = {
+>ObjType : Symbol(ObjType, Decl(objectRestReadonly.ts, 0, 0))
+
+  foo: string
+>foo : Symbol(foo, Decl(objectRestReadonly.ts, 1, 16))
+
+  baz: string
+>baz : Symbol(baz, Decl(objectRestReadonly.ts, 2, 13))
+
+  quux: string
+>quux : Symbol(quux, Decl(objectRestReadonly.ts, 3, 13))
+}
+
+const obj: Readonly<ObjType> = {
+>obj : Symbol(obj, Decl(objectRestReadonly.ts, 7, 5))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>ObjType : Symbol(ObjType, Decl(objectRestReadonly.ts, 0, 0))
+
+  foo: 'bar',
+>foo : Symbol(foo, Decl(objectRestReadonly.ts, 7, 32))
+
+  baz: 'qux',
+>baz : Symbol(baz, Decl(objectRestReadonly.ts, 8, 13))
+
+  quux: 'quuz',
+>quux : Symbol(quux, Decl(objectRestReadonly.ts, 9, 13))
+}
+
+const { foo, ...rest } = obj
+>foo : Symbol(foo, Decl(objectRestReadonly.ts, 13, 7))
+>rest : Symbol(rest, Decl(objectRestReadonly.ts, 13, 12))
+>obj : Symbol(obj, Decl(objectRestReadonly.ts, 7, 5))
+
+delete rest.baz
+>rest.baz : Symbol(baz, Decl(objectRestReadonly.ts, 2, 13))
+>rest : Symbol(rest, Decl(objectRestReadonly.ts, 13, 12))
+>baz : Symbol(baz, Decl(objectRestReadonly.ts, 2, 13))
+

--- a/tests/baselines/reference/objectRestReadonly.symbols
+++ b/tests/baselines/reference/objectRestReadonly.symbols
@@ -1,5 +1,5 @@
 === tests/cases/conformance/types/rest/objectRestReadonly.ts ===
-// #23374
+// #23734
 type ObjType = {
 >ObjType : Symbol(ObjType, Decl(objectRestReadonly.ts, 0, 0))
 

--- a/tests/baselines/reference/objectRestReadonly.types
+++ b/tests/baselines/reference/objectRestReadonly.types
@@ -1,0 +1,45 @@
+=== tests/cases/conformance/types/rest/objectRestReadonly.ts ===
+// #23374
+type ObjType = {
+>ObjType : ObjType
+
+  foo: string
+>foo : string
+
+  baz: string
+>baz : string
+
+  quux: string
+>quux : string
+}
+
+const obj: Readonly<ObjType> = {
+>obj : Readonly<ObjType>
+>Readonly : Readonly<T>
+>ObjType : ObjType
+>{  foo: 'bar',  baz: 'qux',  quux: 'quuz',} : { foo: string; baz: string; quux: string; }
+
+  foo: 'bar',
+>foo : string
+>'bar' : "bar"
+
+  baz: 'qux',
+>baz : string
+>'qux' : "qux"
+
+  quux: 'quuz',
+>quux : string
+>'quuz' : "quuz"
+}
+
+const { foo, ...rest } = obj
+>foo : string
+>rest : { baz: string; quux: string; }
+>obj : Readonly<ObjType>
+
+delete rest.baz
+>delete rest.baz : boolean
+>rest.baz : string
+>rest : { baz: string; quux: string; }
+>baz : string
+

--- a/tests/baselines/reference/objectRestReadonly.types
+++ b/tests/baselines/reference/objectRestReadonly.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/types/rest/objectRestReadonly.ts ===
-// #23374
+// #23734
 type ObjType = {
 >ObjType : ObjType
 

--- a/tests/cases/conformance/types/rest/objectRestReadonly.ts
+++ b/tests/cases/conformance/types/rest/objectRestReadonly.ts
@@ -1,0 +1,16 @@
+// #23374
+type ObjType = {
+  foo: string
+  baz: string
+  quux: string
+}
+
+const obj: Readonly<ObjType> = {
+  foo: 'bar',
+  baz: 'qux',
+  quux: 'quuz',
+}
+
+const { foo, ...rest } = obj
+
+delete rest.baz

--- a/tests/cases/conformance/types/rest/objectRestReadonly.ts
+++ b/tests/cases/conformance/types/rest/objectRestReadonly.ts
@@ -1,4 +1,4 @@
-// #23374
+// #23734
 type ObjType = {
   foo: string
   baz: string


### PR DESCRIPTION
Works the same as removing it from object spread properties

Fixes #23734 