### PR TITLE
--pretty by default in tsc.exe (the ChakraCore tsc host)

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -500,6 +500,7 @@ namespace ts {
         executingFile: string;
         newLine?: string;
         useCaseSensitiveFileNames?: boolean;
+        echoIsTTY?: boolean;
         echo(s: string): void;
         quit(exitCode?: number): void;
         fileExists(path: string): boolean;
@@ -1085,6 +1086,9 @@ namespace ts {
                 newLine: ChakraHost.newLine || "\r\n",
                 args: ChakraHost.args,
                 useCaseSensitiveFileNames: !!ChakraHost.useCaseSensitiveFileNames,
+                writeOutputIsTTY() {
+                    return !!ChakraHost.echoIsTTY;
+                },
                 write: ChakraHost.echo,
                 readFile(path: string, _encoding?: string) {
                     // encoding is automatically handled by the implementation in ChakraHost


### PR DESCRIPTION
Supports `--pretty` by default in `tsc.exe` given anticipated internal changes.

# Background

@kpreisser recommended fixing terminal escapes on https://github.com/Microsoft/TypeScript/pull/23408#issuecomment-383494419. Using the same logic to detect support for terminal escapes, we can determine whether we are outputting to a pseudoterminal device.

Within `tsc.js`, we just need to look for the member which specifies as much.