### PR TITLE
Fix assignability of unconstrained T[K]

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10670,23 +10670,8 @@ namespace ts {
                     }
                 }
 
-                if (source.flags & TypeFlags.TypeParameter) {
-                    let constraint = getConstraintForRelation(<TypeParameter>source);
-                    // A type parameter with no constraint is not related to the non-primitive object type.
-                    if (constraint || !(target.flags & TypeFlags.NonPrimitive)) {
-                        if (!constraint || constraint.flags & TypeFlags.Any) {
-                            constraint = emptyObjectType;
-                        }
-                        // Report constraint errors only if the constraint is not the empty object type
-                        const reportConstraintErrors = reportErrors && constraint !== emptyObjectType;
-                        if (result = isRelatedTo(constraint, target, reportConstraintErrors)) {
-                            errorInfo = saveErrorInfo;
-                            return result;
-                        }
-                    }
-                }
-                else if (source.flags & TypeFlags.IndexedAccess) {
-                    if (target.flags & TypeFlags.IndexedAccess) {
+                if (source.flags & TypeFlags.TypeVariable) {
+                    if (source.flags & TypeFlags.IndexedAccess && target.flags & TypeFlags.IndexedAccess) {
                         // A type S[K] is related to a type T[J] if S is related to T and K is related to J.
                         if (result = isRelatedTo((<IndexedAccessType>source).objectType, (<IndexedAccessType>target).objectType, reportErrors)) {
                             result &= isRelatedTo((<IndexedAccessType>source).indexType, (<IndexedAccessType>target).indexType, reportErrors);
@@ -10696,11 +10681,15 @@ namespace ts {
                             return result;
                         }
                     }
-                    // A type S[K] is related to a type T if C is related to T, where C is the
-                    // constraint of S[K].
-                    const constraint = getConstraintForRelation(<IndexedAccessType>source);
-                    if (constraint) {
-                        if (result = isRelatedTo(constraint, target, reportErrors)) {
+                    let constraint = getConstraintForRelation(<TypeParameter>source);
+                    // A type variable with no constraint is not related to the non-primitive object type.
+                    if (constraint || !(target.flags & TypeFlags.NonPrimitive)) {
+                        if (!constraint || constraint.flags & TypeFlags.Any) {
+                            constraint = emptyObjectType;
+                        }
+                        // Report constraint errors only if the constraint is not the empty object type
+                        const reportConstraintErrors = reportErrors && constraint !== emptyObjectType;
+                        if (result = isRelatedTo(constraint, target, reportConstraintErrors)) {
                             errorInfo = saveErrorInfo;
                             return result;
                         }

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -319,6 +319,20 @@ function f90<T extends S2, K extends keyof S2>(x1: S2[keyof S2], x2: T[keyof S2]
     x4.length;
 }
 
+function f91<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
+    let a: {};
+    a = x;
+    a = y;
+    a = z;
+}
+
+function f92<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
+    let a: {} | null | undefined;
+    a = x;
+    a = y;
+    a = z;
+}
+
 // Repros from #12011
 
 class Base {
@@ -593,6 +607,27 @@ function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<
     return record[flags[0]];
 }
 
+// Repro from #21368
+
+interface I {
+    foo: string;
+}
+
+declare function take<T>(p: T): void;
+
+function fn<T extends I, K extends keyof T>(o: T, k: K) {
+    take<{} | null | undefined>(o[k]);
+    take<any>(o[k]);
+}
+
+// Repro from #23133
+
+class Unbounded<T> {
+    foo(x: T[keyof T]) {
+        let y: {} | undefined | null = x;
+    }
+}
+
 
 //// [keyofAndIndexedAccess.js]
 var __extends = (this && this.__extends) || (function () {
@@ -830,6 +865,18 @@ function f90(x1, x2, x3, x4) {
     x3.length;
     x4.length;
 }
+function f91(x, y, z) {
+    var a;
+    a = x;
+    a = y;
+    a = z;
+}
+function f92(x, y, z) {
+    var a;
+    a = x;
+    a = y;
+    a = z;
+}
 // Repros from #12011
 var Base = /** @class */ (function () {
     function Base() {
@@ -986,6 +1033,19 @@ function getFlagsFromSimpleRecord(record, flags) {
 function getFlagsFromDynamicRecord(record, flags) {
     return record[flags[0]];
 }
+function fn(o, k) {
+    take(o[k]);
+    take(o[k]);
+}
+// Repro from #23133
+var Unbounded = /** @class */ (function () {
+    function Unbounded() {
+    }
+    Unbounded.prototype.foo = function (x) {
+        var y = x;
+    };
+    return Unbounded;
+}());
 
 
 //// [keyofAndIndexedAccess.d.ts]
@@ -1126,6 +1186,8 @@ declare type S2 = {
     b: string;
 };
 declare function f90<T extends S2, K extends keyof S2>(x1: S2[keyof S2], x2: T[keyof S2], x3: S2[K], x4: T[K]): void;
+declare function f91<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]): void;
+declare function f92<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]): void;
 declare class Base {
     get<K extends keyof this>(prop: K): this[K];
     set<K extends keyof this>(prop: K, value: this[K]): void;
@@ -1298,3 +1360,11 @@ declare type DynamicDBRecord<Flag extends string> = ({
     dynamicField: string;
 }) & DBBoolTable<Flag>;
 declare function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]): DynamicDBRecord<Flag>[Flag];
+interface I {
+    foo: string;
+}
+declare function take<T>(p: T): void;
+declare function fn<T extends I, K extends keyof T>(o: T, k: K): void;
+declare class Unbounded<T> {
+    foo(x: T[keyof T]): void;
+}

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -1239,884 +1239,999 @@ function f90<T extends S2, K extends keyof S2>(x1: S2[keyof S2], x2: T[keyof S2]
 >length : Symbol(String.length, Decl(lib.d.ts, --, --))
 }
 
+function f91<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
+>f91 : Symbol(f91, Decl(keyofAndIndexedAccess.ts, 318, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 320, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 320, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 320, 13))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 320, 35))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 320, 13))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 320, 40))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 320, 13))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 320, 13))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 320, 55))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 320, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 320, 15))
+
+    let a: {};
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 321, 7))
+
+    a = x;
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 321, 7))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 320, 35))
+
+    a = y;
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 321, 7))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 320, 40))
+
+    a = z;
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 321, 7))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 320, 55))
+}
+
+function f92<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
+>f92 : Symbol(f92, Decl(keyofAndIndexedAccess.ts, 325, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 327, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 327, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 327, 13))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 327, 35))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 327, 13))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 327, 40))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 327, 13))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 327, 13))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 327, 55))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 327, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 327, 15))
+
+    let a: {} | null | undefined;
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 328, 7))
+
+    a = x;
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 328, 7))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 327, 35))
+
+    a = y;
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 328, 7))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 327, 40))
+
+    a = z;
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 328, 7))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 327, 55))
+}
+
 // Repros from #12011
 
 class Base {
->Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 318, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 332, 1))
 
     get<K extends keyof this>(prop: K) {
->get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 322, 12))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 323, 8))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 323, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 323, 8))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 336, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 337, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 337, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 337, 8))
 
         return this[prop];
->this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 318, 1))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 323, 30))
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 332, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 337, 30))
     }
     set<K extends keyof this>(prop: K, value: this[K]) {
->set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 325, 5))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 326, 8))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 326, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 326, 8))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 326, 38))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 326, 8))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 339, 5))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 340, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 340, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 340, 8))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 340, 38))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 340, 8))
 
         this[prop] = value;
->this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 318, 1))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 326, 30))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 326, 38))
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 332, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 340, 30))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 340, 38))
     }
 }
 
 class Person extends Base {
->Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 329, 1))
->Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 318, 1))
+>Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 343, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 332, 1))
 
     parts: number;
->parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 331, 27))
+>parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 345, 27))
 
     constructor(parts: number) {
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 333, 16))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 347, 16))
 
         super();
->super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 318, 1))
+>super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 332, 1))
 
         this.set("parts", parts);
->this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 325, 5))
->this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 329, 1))
->set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 325, 5))
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 333, 16))
+>this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 339, 5))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 343, 1))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 339, 5))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 347, 16))
     }
     getParts() {
->getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 336, 5))
+>getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 350, 5))
 
         return this.get("parts")
->this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 322, 12))
->this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 329, 1))
->get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 322, 12))
+>this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 336, 12))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 343, 1))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 336, 12))
     }
 }
 
 class OtherPerson {
->OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 340, 1))
+>OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 354, 1))
 
     parts: number;
->parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 342, 19))
+>parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 356, 19))
 
     constructor(parts: number) {
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 344, 16))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 358, 16))
 
         setProperty(this, "parts", parts);
 >setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 80, 1))
->this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 340, 1))
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 344, 16))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 354, 1))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 358, 16))
     }
     getParts() {
->getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 346, 5))
+>getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 360, 5))
 
         return getProperty(this, "parts")
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 76, 26))
->this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 340, 1))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 354, 1))
     }
 }
 
 // Modified repro from #12544
 
 function path<T, K1 extends keyof T>(obj: T, key1: K1): T[K1];
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 354, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 354, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 354, 14))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 354, 37))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 354, 14))
->key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 354, 44))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 354, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 354, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 354, 16))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 368, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 368, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 368, 14))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 368, 37))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 368, 14))
+>key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 368, 44))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 368, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 368, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 368, 16))
 
 function path<T, K1 extends keyof T, K2 extends keyof T[K1]>(obj: T, key1: K1, key2: K2): T[K1][K2];
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 355, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 355, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 355, 14))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 355, 36))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 355, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 355, 16))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 355, 61))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 355, 14))
->key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 355, 68))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 355, 16))
->key2 : Symbol(key2, Decl(keyofAndIndexedAccess.ts, 355, 78))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 355, 36))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 355, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 355, 16))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 355, 36))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 369, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 369, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 369, 14))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 369, 36))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 369, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 369, 16))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 369, 61))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 369, 14))
+>key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 369, 68))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 369, 16))
+>key2 : Symbol(key2, Decl(keyofAndIndexedAccess.ts, 369, 78))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 369, 36))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 369, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 369, 16))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 369, 36))
 
 function path<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(obj: T, key1: K1, key2: K2, key3: K3): T[K1][K2][K3];
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 356, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 356, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 356, 14))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 356, 36))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 356, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 356, 16))
->K3 : Symbol(K3, Decl(keyofAndIndexedAccess.ts, 356, 60))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 356, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 356, 16))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 356, 36))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 356, 89))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 356, 14))
->key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 356, 96))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 356, 16))
->key2 : Symbol(key2, Decl(keyofAndIndexedAccess.ts, 356, 106))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 356, 36))
->key3 : Symbol(key3, Decl(keyofAndIndexedAccess.ts, 356, 116))
->K3 : Symbol(K3, Decl(keyofAndIndexedAccess.ts, 356, 60))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 356, 14))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 356, 16))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 356, 36))
->K3 : Symbol(K3, Decl(keyofAndIndexedAccess.ts, 356, 60))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 370, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 370, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 370, 14))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 370, 36))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 370, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 370, 16))
+>K3 : Symbol(K3, Decl(keyofAndIndexedAccess.ts, 370, 60))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 370, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 370, 16))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 370, 36))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 370, 89))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 370, 14))
+>key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 370, 96))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 370, 16))
+>key2 : Symbol(key2, Decl(keyofAndIndexedAccess.ts, 370, 106))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 370, 36))
+>key3 : Symbol(key3, Decl(keyofAndIndexedAccess.ts, 370, 116))
+>K3 : Symbol(K3, Decl(keyofAndIndexedAccess.ts, 370, 60))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 370, 14))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 370, 16))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 370, 36))
+>K3 : Symbol(K3, Decl(keyofAndIndexedAccess.ts, 370, 60))
 
 function path(obj: any, ...keys: (string | number)[]): any;
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 357, 14))
->keys : Symbol(keys, Decl(keyofAndIndexedAccess.ts, 357, 23))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 371, 14))
+>keys : Symbol(keys, Decl(keyofAndIndexedAccess.ts, 371, 23))
 
 function path(obj: any, ...keys: (string | number)[]): any {
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 358, 14))
->keys : Symbol(keys, Decl(keyofAndIndexedAccess.ts, 358, 23))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 372, 14))
+>keys : Symbol(keys, Decl(keyofAndIndexedAccess.ts, 372, 23))
 
     let result = obj;
->result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 359, 7))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 358, 14))
+>result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 373, 7))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 372, 14))
 
     for (let k of keys) {
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 360, 12))
->keys : Symbol(keys, Decl(keyofAndIndexedAccess.ts, 358, 23))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 374, 12))
+>keys : Symbol(keys, Decl(keyofAndIndexedAccess.ts, 372, 23))
 
         result = result[k];
->result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 359, 7))
->result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 359, 7))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 360, 12))
+>result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 373, 7))
+>result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 373, 7))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 374, 12))
     }
     return result;
->result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 359, 7))
+>result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 373, 7))
 }
 
 type Thing = {
->Thing : Symbol(Thing, Decl(keyofAndIndexedAccess.ts, 364, 1))
+>Thing : Symbol(Thing, Decl(keyofAndIndexedAccess.ts, 378, 1))
 
     a: { x: number, y: string },
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 366, 14))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 367, 8))
->y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 367, 19))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 380, 14))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 381, 8))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 381, 19))
 
     b: boolean
->b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 367, 32))
+>b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 381, 32))
 
 };
 
 
 function f1(thing: Thing) {
->f1 : Symbol(f1, Decl(keyofAndIndexedAccess.ts, 369, 2))
->thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 372, 12))
->Thing : Symbol(Thing, Decl(keyofAndIndexedAccess.ts, 364, 1))
+>f1 : Symbol(f1, Decl(keyofAndIndexedAccess.ts, 383, 2))
+>thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 386, 12))
+>Thing : Symbol(Thing, Decl(keyofAndIndexedAccess.ts, 378, 1))
 
     let x1 = path(thing, 'a');  // { x: number, y: string }
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 373, 7))
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 372, 12))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 387, 7))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 386, 12))
 
     let x2 = path(thing, 'a', 'y');  // string
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 374, 7))
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 372, 12))
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 388, 7))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 386, 12))
 
     let x3 = path(thing, 'b');  // boolean
->x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 375, 7))
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 372, 12))
+>x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 389, 7))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 386, 12))
 
     let x4 = path(thing, ...['a', 'x']);  // any
->x4 : Symbol(x4, Decl(keyofAndIndexedAccess.ts, 376, 7))
->path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 350, 1), Decl(keyofAndIndexedAccess.ts, 354, 62), Decl(keyofAndIndexedAccess.ts, 355, 100), Decl(keyofAndIndexedAccess.ts, 356, 142), Decl(keyofAndIndexedAccess.ts, 357, 59))
->thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 372, 12))
+>x4 : Symbol(x4, Decl(keyofAndIndexedAccess.ts, 390, 7))
+>path : Symbol(path, Decl(keyofAndIndexedAccess.ts, 364, 1), Decl(keyofAndIndexedAccess.ts, 368, 62), Decl(keyofAndIndexedAccess.ts, 369, 100), Decl(keyofAndIndexedAccess.ts, 370, 142), Decl(keyofAndIndexedAccess.ts, 371, 59))
+>thing : Symbol(thing, Decl(keyofAndIndexedAccess.ts, 386, 12))
 }
 
 // Repro from comment in #12114
 
 const assignTo2 = <T, K1 extends keyof T, K2 extends keyof T[K1]>(object: T, key1: K1, key2: K2) =>
->assignTo2 : Symbol(assignTo2, Decl(keyofAndIndexedAccess.ts, 381, 5))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 381, 19))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 381, 21))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 381, 19))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 381, 41))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 381, 19))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 381, 21))
->object : Symbol(object, Decl(keyofAndIndexedAccess.ts, 381, 66))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 381, 19))
->key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 381, 76))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 381, 21))
->key2 : Symbol(key2, Decl(keyofAndIndexedAccess.ts, 381, 86))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 381, 41))
+>assignTo2 : Symbol(assignTo2, Decl(keyofAndIndexedAccess.ts, 395, 5))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 395, 19))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 395, 21))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 395, 19))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 395, 41))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 395, 19))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 395, 21))
+>object : Symbol(object, Decl(keyofAndIndexedAccess.ts, 395, 66))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 395, 19))
+>key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 395, 76))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 395, 21))
+>key2 : Symbol(key2, Decl(keyofAndIndexedAccess.ts, 395, 86))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 395, 41))
 
     (value: T[K1][K2]) => object[key1][key2] = value;
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 382, 5))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 381, 19))
->K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 381, 21))
->K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 381, 41))
->object : Symbol(object, Decl(keyofAndIndexedAccess.ts, 381, 66))
->key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 381, 76))
->key2 : Symbol(key2, Decl(keyofAndIndexedAccess.ts, 381, 86))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 382, 5))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 396, 5))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 395, 19))
+>K1 : Symbol(K1, Decl(keyofAndIndexedAccess.ts, 395, 21))
+>K2 : Symbol(K2, Decl(keyofAndIndexedAccess.ts, 395, 41))
+>object : Symbol(object, Decl(keyofAndIndexedAccess.ts, 395, 66))
+>key1 : Symbol(key1, Decl(keyofAndIndexedAccess.ts, 395, 76))
+>key2 : Symbol(key2, Decl(keyofAndIndexedAccess.ts, 395, 86))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 396, 5))
 
 // Modified repro from #12573
 
 declare function one<T>(handler: (t: T) => void): T
->one : Symbol(one, Decl(keyofAndIndexedAccess.ts, 382, 53))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 386, 21))
->handler : Symbol(handler, Decl(keyofAndIndexedAccess.ts, 386, 24))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 386, 34))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 386, 21))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 386, 21))
+>one : Symbol(one, Decl(keyofAndIndexedAccess.ts, 396, 53))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 400, 21))
+>handler : Symbol(handler, Decl(keyofAndIndexedAccess.ts, 400, 24))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 400, 34))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 400, 21))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 400, 21))
 
 var empty = one(() => {}) // inferred as {}, expected
->empty : Symbol(empty, Decl(keyofAndIndexedAccess.ts, 387, 3))
->one : Symbol(one, Decl(keyofAndIndexedAccess.ts, 382, 53))
+>empty : Symbol(empty, Decl(keyofAndIndexedAccess.ts, 401, 3))
+>one : Symbol(one, Decl(keyofAndIndexedAccess.ts, 396, 53))
 
 type Handlers<T> = { [K in keyof T]: (t: T[K]) => void }
->Handlers : Symbol(Handlers, Decl(keyofAndIndexedAccess.ts, 387, 25))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 389, 14))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 389, 22))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 389, 14))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 389, 38))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 389, 14))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 389, 22))
+>Handlers : Symbol(Handlers, Decl(keyofAndIndexedAccess.ts, 401, 25))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 403, 14))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 403, 22))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 403, 14))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 403, 38))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 403, 14))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 403, 22))
 
 declare function on<T>(handlerHash: Handlers<T>): T
->on : Symbol(on, Decl(keyofAndIndexedAccess.ts, 389, 56))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 390, 20))
->handlerHash : Symbol(handlerHash, Decl(keyofAndIndexedAccess.ts, 390, 23))
->Handlers : Symbol(Handlers, Decl(keyofAndIndexedAccess.ts, 387, 25))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 390, 20))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 390, 20))
+>on : Symbol(on, Decl(keyofAndIndexedAccess.ts, 403, 56))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 404, 20))
+>handlerHash : Symbol(handlerHash, Decl(keyofAndIndexedAccess.ts, 404, 23))
+>Handlers : Symbol(Handlers, Decl(keyofAndIndexedAccess.ts, 401, 25))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 404, 20))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 404, 20))
 
 var hashOfEmpty1 = on({ test: () => {} });  // {}
->hashOfEmpty1 : Symbol(hashOfEmpty1, Decl(keyofAndIndexedAccess.ts, 391, 3))
->on : Symbol(on, Decl(keyofAndIndexedAccess.ts, 389, 56))
->test : Symbol(test, Decl(keyofAndIndexedAccess.ts, 391, 23))
+>hashOfEmpty1 : Symbol(hashOfEmpty1, Decl(keyofAndIndexedAccess.ts, 405, 3))
+>on : Symbol(on, Decl(keyofAndIndexedAccess.ts, 403, 56))
+>test : Symbol(test, Decl(keyofAndIndexedAccess.ts, 405, 23))
 
 var hashOfEmpty2 = on({ test: (x: boolean) => {} });  // { test: boolean }
->hashOfEmpty2 : Symbol(hashOfEmpty2, Decl(keyofAndIndexedAccess.ts, 392, 3))
->on : Symbol(on, Decl(keyofAndIndexedAccess.ts, 389, 56))
->test : Symbol(test, Decl(keyofAndIndexedAccess.ts, 392, 23))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 392, 31))
+>hashOfEmpty2 : Symbol(hashOfEmpty2, Decl(keyofAndIndexedAccess.ts, 406, 3))
+>on : Symbol(on, Decl(keyofAndIndexedAccess.ts, 403, 56))
+>test : Symbol(test, Decl(keyofAndIndexedAccess.ts, 406, 23))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 406, 31))
 
 // Repro from #12624
 
 interface Options1<Data, Computed> {
->Options1 : Symbol(Options1, Decl(keyofAndIndexedAccess.ts, 392, 52))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 396, 19))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 396, 24))
+>Options1 : Symbol(Options1, Decl(keyofAndIndexedAccess.ts, 406, 52))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 410, 19))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 410, 24))
 
     data?: Data
->data : Symbol(Options1.data, Decl(keyofAndIndexedAccess.ts, 396, 36))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 396, 19))
+>data : Symbol(Options1.data, Decl(keyofAndIndexedAccess.ts, 410, 36))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 410, 19))
 
     computed?: Computed;
->computed : Symbol(Options1.computed, Decl(keyofAndIndexedAccess.ts, 397, 15))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 396, 24))
+>computed : Symbol(Options1.computed, Decl(keyofAndIndexedAccess.ts, 411, 15))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 410, 24))
 }
 
 declare class Component1<Data, Computed> {
->Component1 : Symbol(Component1, Decl(keyofAndIndexedAccess.ts, 399, 1))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 401, 25))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 401, 30))
+>Component1 : Symbol(Component1, Decl(keyofAndIndexedAccess.ts, 413, 1))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 415, 25))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 415, 30))
 
     constructor(options: Options1<Data, Computed>);
->options : Symbol(options, Decl(keyofAndIndexedAccess.ts, 402, 16))
->Options1 : Symbol(Options1, Decl(keyofAndIndexedAccess.ts, 392, 52))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 401, 25))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 401, 30))
+>options : Symbol(options, Decl(keyofAndIndexedAccess.ts, 416, 16))
+>Options1 : Symbol(Options1, Decl(keyofAndIndexedAccess.ts, 406, 52))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 415, 25))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 415, 30))
 
     get<K extends keyof (Data & Computed)>(key: K): (Data & Computed)[K];
->get : Symbol(Component1.get, Decl(keyofAndIndexedAccess.ts, 402, 51))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 403, 8))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 401, 25))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 401, 30))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 403, 43))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 403, 8))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 401, 25))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 401, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 403, 8))
+>get : Symbol(Component1.get, Decl(keyofAndIndexedAccess.ts, 416, 51))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 417, 8))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 415, 25))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 415, 30))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 417, 43))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 417, 8))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 415, 25))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 415, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 417, 8))
 }
 
 let c1 = new Component1({
->c1 : Symbol(c1, Decl(keyofAndIndexedAccess.ts, 406, 3))
->Component1 : Symbol(Component1, Decl(keyofAndIndexedAccess.ts, 399, 1))
+>c1 : Symbol(c1, Decl(keyofAndIndexedAccess.ts, 420, 3))
+>Component1 : Symbol(Component1, Decl(keyofAndIndexedAccess.ts, 413, 1))
 
     data: {
->data : Symbol(data, Decl(keyofAndIndexedAccess.ts, 406, 25))
+>data : Symbol(data, Decl(keyofAndIndexedAccess.ts, 420, 25))
 
         hello: ""
->hello : Symbol(hello, Decl(keyofAndIndexedAccess.ts, 407, 11))
+>hello : Symbol(hello, Decl(keyofAndIndexedAccess.ts, 421, 11))
     }
 });
 
 c1.get("hello");
->c1.get : Symbol(Component1.get, Decl(keyofAndIndexedAccess.ts, 402, 51))
->c1 : Symbol(c1, Decl(keyofAndIndexedAccess.ts, 406, 3))
->get : Symbol(Component1.get, Decl(keyofAndIndexedAccess.ts, 402, 51))
+>c1.get : Symbol(Component1.get, Decl(keyofAndIndexedAccess.ts, 416, 51))
+>c1 : Symbol(c1, Decl(keyofAndIndexedAccess.ts, 420, 3))
+>get : Symbol(Component1.get, Decl(keyofAndIndexedAccess.ts, 416, 51))
 
 // Repro from #12625
 
 interface Options2<Data, Computed> {
->Options2 : Symbol(Options2, Decl(keyofAndIndexedAccess.ts, 412, 16))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 416, 19))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 416, 24))
+>Options2 : Symbol(Options2, Decl(keyofAndIndexedAccess.ts, 426, 16))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 430, 19))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 430, 24))
 
     data?: Data
->data : Symbol(Options2.data, Decl(keyofAndIndexedAccess.ts, 416, 36))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 416, 19))
+>data : Symbol(Options2.data, Decl(keyofAndIndexedAccess.ts, 430, 36))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 430, 19))
 
     computed?: Computed;
->computed : Symbol(Options2.computed, Decl(keyofAndIndexedAccess.ts, 417, 15))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 416, 24))
+>computed : Symbol(Options2.computed, Decl(keyofAndIndexedAccess.ts, 431, 15))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 430, 24))
 }
 
 declare class Component2<Data, Computed> {
->Component2 : Symbol(Component2, Decl(keyofAndIndexedAccess.ts, 419, 1))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 421, 25))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 421, 30))
+>Component2 : Symbol(Component2, Decl(keyofAndIndexedAccess.ts, 433, 1))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 435, 25))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 435, 30))
 
     constructor(options: Options2<Data, Computed>);
->options : Symbol(options, Decl(keyofAndIndexedAccess.ts, 422, 16))
->Options2 : Symbol(Options2, Decl(keyofAndIndexedAccess.ts, 412, 16))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 421, 25))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 421, 30))
+>options : Symbol(options, Decl(keyofAndIndexedAccess.ts, 436, 16))
+>Options2 : Symbol(Options2, Decl(keyofAndIndexedAccess.ts, 426, 16))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 435, 25))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 435, 30))
 
     get<K extends keyof Data | keyof Computed>(key: K): (Data & Computed)[K];
->get : Symbol(Component2.get, Decl(keyofAndIndexedAccess.ts, 422, 51))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 423, 8))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 421, 25))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 421, 30))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 423, 47))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 423, 8))
->Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 421, 25))
->Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 421, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 423, 8))
+>get : Symbol(Component2.get, Decl(keyofAndIndexedAccess.ts, 436, 51))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 437, 8))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 435, 25))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 435, 30))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 437, 47))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 437, 8))
+>Data : Symbol(Data, Decl(keyofAndIndexedAccess.ts, 435, 25))
+>Computed : Symbol(Computed, Decl(keyofAndIndexedAccess.ts, 435, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 437, 8))
 }
 
 // Repro from #12641
 
 interface R {
->R : Symbol(R, Decl(keyofAndIndexedAccess.ts, 424, 1))
+>R : Symbol(R, Decl(keyofAndIndexedAccess.ts, 438, 1))
 
     p: number;
->p : Symbol(R.p, Decl(keyofAndIndexedAccess.ts, 428, 13))
+>p : Symbol(R.p, Decl(keyofAndIndexedAccess.ts, 442, 13))
 }
 
 function f<K extends keyof R>(p: K) {
->f : Symbol(f, Decl(keyofAndIndexedAccess.ts, 430, 1))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 432, 11))
->R : Symbol(R, Decl(keyofAndIndexedAccess.ts, 424, 1))
->p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 432, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 432, 11))
+>f : Symbol(f, Decl(keyofAndIndexedAccess.ts, 444, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 446, 11))
+>R : Symbol(R, Decl(keyofAndIndexedAccess.ts, 438, 1))
+>p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 446, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 446, 11))
 
     let a: any;
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 433, 7))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 447, 7))
 
     a[p].add;  // any
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 433, 7))
->p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 432, 30))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 447, 7))
+>p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 446, 30))
 }
 
 // Repro from #12651
 
 type MethodDescriptor = {
->MethodDescriptor : Symbol(MethodDescriptor, Decl(keyofAndIndexedAccess.ts, 435, 1))
+>MethodDescriptor : Symbol(MethodDescriptor, Decl(keyofAndIndexedAccess.ts, 449, 1))
 
 	name: string;
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 439, 25))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 453, 25))
 
 	args: any[];
->args : Symbol(args, Decl(keyofAndIndexedAccess.ts, 440, 14))
+>args : Symbol(args, Decl(keyofAndIndexedAccess.ts, 454, 14))
 
 	returnValue: any;
->returnValue : Symbol(returnValue, Decl(keyofAndIndexedAccess.ts, 441, 13))
+>returnValue : Symbol(returnValue, Decl(keyofAndIndexedAccess.ts, 455, 13))
 }
 
 declare function dispatchMethod<M extends MethodDescriptor>(name: M['name'], args: M['args']): M['returnValue'];
->dispatchMethod : Symbol(dispatchMethod, Decl(keyofAndIndexedAccess.ts, 443, 1))
->M : Symbol(M, Decl(keyofAndIndexedAccess.ts, 445, 32))
->MethodDescriptor : Symbol(MethodDescriptor, Decl(keyofAndIndexedAccess.ts, 435, 1))
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 445, 60))
->M : Symbol(M, Decl(keyofAndIndexedAccess.ts, 445, 32))
->args : Symbol(args, Decl(keyofAndIndexedAccess.ts, 445, 76))
->M : Symbol(M, Decl(keyofAndIndexedAccess.ts, 445, 32))
->M : Symbol(M, Decl(keyofAndIndexedAccess.ts, 445, 32))
+>dispatchMethod : Symbol(dispatchMethod, Decl(keyofAndIndexedAccess.ts, 457, 1))
+>M : Symbol(M, Decl(keyofAndIndexedAccess.ts, 459, 32))
+>MethodDescriptor : Symbol(MethodDescriptor, Decl(keyofAndIndexedAccess.ts, 449, 1))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 459, 60))
+>M : Symbol(M, Decl(keyofAndIndexedAccess.ts, 459, 32))
+>args : Symbol(args, Decl(keyofAndIndexedAccess.ts, 459, 76))
+>M : Symbol(M, Decl(keyofAndIndexedAccess.ts, 459, 32))
+>M : Symbol(M, Decl(keyofAndIndexedAccess.ts, 459, 32))
 
 type SomeMethodDescriptor = {
->SomeMethodDescriptor : Symbol(SomeMethodDescriptor, Decl(keyofAndIndexedAccess.ts, 445, 112))
+>SomeMethodDescriptor : Symbol(SomeMethodDescriptor, Decl(keyofAndIndexedAccess.ts, 459, 112))
 
 	name: "someMethod";
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 447, 29))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 461, 29))
 
 	args: [string, number];
->args : Symbol(args, Decl(keyofAndIndexedAccess.ts, 448, 20))
+>args : Symbol(args, Decl(keyofAndIndexedAccess.ts, 462, 20))
 
 	returnValue: string[];
->returnValue : Symbol(returnValue, Decl(keyofAndIndexedAccess.ts, 449, 24))
+>returnValue : Symbol(returnValue, Decl(keyofAndIndexedAccess.ts, 463, 24))
 }
 
 let result = dispatchMethod<SomeMethodDescriptor>("someMethod", ["hello", 35]);
->result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 453, 3))
->dispatchMethod : Symbol(dispatchMethod, Decl(keyofAndIndexedAccess.ts, 443, 1))
->SomeMethodDescriptor : Symbol(SomeMethodDescriptor, Decl(keyofAndIndexedAccess.ts, 445, 112))
+>result : Symbol(result, Decl(keyofAndIndexedAccess.ts, 467, 3))
+>dispatchMethod : Symbol(dispatchMethod, Decl(keyofAndIndexedAccess.ts, 457, 1))
+>SomeMethodDescriptor : Symbol(SomeMethodDescriptor, Decl(keyofAndIndexedAccess.ts, 459, 112))
 
 // Repro from #13073
 
 type KeyTypes = "a" | "b"
->KeyTypes : Symbol(KeyTypes, Decl(keyofAndIndexedAccess.ts, 453, 79))
+>KeyTypes : Symbol(KeyTypes, Decl(keyofAndIndexedAccess.ts, 467, 79))
 
 let MyThingy: { [key in KeyTypes]: string[] };
->MyThingy : Symbol(MyThingy, Decl(keyofAndIndexedAccess.ts, 458, 3))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 458, 17))
->KeyTypes : Symbol(KeyTypes, Decl(keyofAndIndexedAccess.ts, 453, 79))
+>MyThingy : Symbol(MyThingy, Decl(keyofAndIndexedAccess.ts, 472, 3))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 472, 17))
+>KeyTypes : Symbol(KeyTypes, Decl(keyofAndIndexedAccess.ts, 467, 79))
 
 function addToMyThingy<S extends KeyTypes>(key: S) {
->addToMyThingy : Symbol(addToMyThingy, Decl(keyofAndIndexedAccess.ts, 458, 46))
->S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 460, 23))
->KeyTypes : Symbol(KeyTypes, Decl(keyofAndIndexedAccess.ts, 453, 79))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 460, 43))
->S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 460, 23))
+>addToMyThingy : Symbol(addToMyThingy, Decl(keyofAndIndexedAccess.ts, 472, 46))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 474, 23))
+>KeyTypes : Symbol(KeyTypes, Decl(keyofAndIndexedAccess.ts, 467, 79))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 474, 43))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 474, 23))
 
     MyThingy[key].push("a");
 >MyThingy[key].push : Symbol(Array.push, Decl(lib.d.ts, --, --))
->MyThingy : Symbol(MyThingy, Decl(keyofAndIndexedAccess.ts, 458, 3))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 460, 43))
+>MyThingy : Symbol(MyThingy, Decl(keyofAndIndexedAccess.ts, 472, 3))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 474, 43))
 >push : Symbol(Array.push, Decl(lib.d.ts, --, --))
 }
 
 // Repro from #13102
 
 type Handler<T> = {
->Handler : Symbol(Handler, Decl(keyofAndIndexedAccess.ts, 462, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 466, 13))
+>Handler : Symbol(Handler, Decl(keyofAndIndexedAccess.ts, 476, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 480, 13))
 
     onChange: (name: keyof T) => void;
->onChange : Symbol(onChange, Decl(keyofAndIndexedAccess.ts, 466, 19))
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 467, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 466, 13))
+>onChange : Symbol(onChange, Decl(keyofAndIndexedAccess.ts, 480, 19))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 481, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 480, 13))
 
 };
 
 function onChangeGenericFunction<T>(handler: Handler<T & {preset: number}>) {
->onChangeGenericFunction : Symbol(onChangeGenericFunction, Decl(keyofAndIndexedAccess.ts, 468, 2))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 470, 33))
->handler : Symbol(handler, Decl(keyofAndIndexedAccess.ts, 470, 36))
->Handler : Symbol(Handler, Decl(keyofAndIndexedAccess.ts, 462, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 470, 33))
->preset : Symbol(preset, Decl(keyofAndIndexedAccess.ts, 470, 58))
+>onChangeGenericFunction : Symbol(onChangeGenericFunction, Decl(keyofAndIndexedAccess.ts, 482, 2))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 484, 33))
+>handler : Symbol(handler, Decl(keyofAndIndexedAccess.ts, 484, 36))
+>Handler : Symbol(Handler, Decl(keyofAndIndexedAccess.ts, 476, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 484, 33))
+>preset : Symbol(preset, Decl(keyofAndIndexedAccess.ts, 484, 58))
 
     handler.onChange('preset')
->handler.onChange : Symbol(onChange, Decl(keyofAndIndexedAccess.ts, 466, 19))
->handler : Symbol(handler, Decl(keyofAndIndexedAccess.ts, 470, 36))
->onChange : Symbol(onChange, Decl(keyofAndIndexedAccess.ts, 466, 19))
+>handler.onChange : Symbol(onChange, Decl(keyofAndIndexedAccess.ts, 480, 19))
+>handler : Symbol(handler, Decl(keyofAndIndexedAccess.ts, 484, 36))
+>onChange : Symbol(onChange, Decl(keyofAndIndexedAccess.ts, 480, 19))
 }
 
 // Repro from #13285
 
 function updateIds<T extends Record<K, string>, K extends string>(
->updateIds : Symbol(updateIds, Decl(keyofAndIndexedAccess.ts, 472, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 476, 19))
+>updateIds : Symbol(updateIds, Decl(keyofAndIndexedAccess.ts, 486, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 490, 19))
 >Record : Symbol(Record, Decl(lib.d.ts, --, --))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 476, 47))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 476, 47))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 490, 47))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 490, 47))
 
     obj: T,
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 476, 66))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 476, 19))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 490, 66))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 490, 19))
 
     idFields: K[],
->idFields : Symbol(idFields, Decl(keyofAndIndexedAccess.ts, 477, 11))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 476, 47))
+>idFields : Symbol(idFields, Decl(keyofAndIndexedAccess.ts, 491, 11))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 490, 47))
 
     idMapping: { [oldId: string]: string }
->idMapping : Symbol(idMapping, Decl(keyofAndIndexedAccess.ts, 478, 18))
->oldId : Symbol(oldId, Decl(keyofAndIndexedAccess.ts, 479, 18))
+>idMapping : Symbol(idMapping, Decl(keyofAndIndexedAccess.ts, 492, 18))
+>oldId : Symbol(oldId, Decl(keyofAndIndexedAccess.ts, 493, 18))
 
 ): Record<K, string> {
 >Record : Symbol(Record, Decl(lib.d.ts, --, --))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 476, 47))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 490, 47))
 
     for (const idField of idFields) {
->idField : Symbol(idField, Decl(keyofAndIndexedAccess.ts, 481, 14))
->idFields : Symbol(idFields, Decl(keyofAndIndexedAccess.ts, 477, 11))
+>idField : Symbol(idField, Decl(keyofAndIndexedAccess.ts, 495, 14))
+>idFields : Symbol(idFields, Decl(keyofAndIndexedAccess.ts, 491, 11))
 
         const newId = idMapping[obj[idField]];
->newId : Symbol(newId, Decl(keyofAndIndexedAccess.ts, 482, 13))
->idMapping : Symbol(idMapping, Decl(keyofAndIndexedAccess.ts, 478, 18))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 476, 66))
->idField : Symbol(idField, Decl(keyofAndIndexedAccess.ts, 481, 14))
+>newId : Symbol(newId, Decl(keyofAndIndexedAccess.ts, 496, 13))
+>idMapping : Symbol(idMapping, Decl(keyofAndIndexedAccess.ts, 492, 18))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 490, 66))
+>idField : Symbol(idField, Decl(keyofAndIndexedAccess.ts, 495, 14))
 
         if (newId) {
->newId : Symbol(newId, Decl(keyofAndIndexedAccess.ts, 482, 13))
+>newId : Symbol(newId, Decl(keyofAndIndexedAccess.ts, 496, 13))
 
             obj[idField] = newId;
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 476, 66))
->idField : Symbol(idField, Decl(keyofAndIndexedAccess.ts, 481, 14))
->newId : Symbol(newId, Decl(keyofAndIndexedAccess.ts, 482, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 490, 66))
+>idField : Symbol(idField, Decl(keyofAndIndexedAccess.ts, 495, 14))
+>newId : Symbol(newId, Decl(keyofAndIndexedAccess.ts, 496, 13))
         }
     }
     return obj;
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 476, 66))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 490, 66))
 }
 
 // Repro from #13285
 
 function updateIds2<T extends { [x: string]: string }, K extends keyof T>(
->updateIds2 : Symbol(updateIds2, Decl(keyofAndIndexedAccess.ts, 488, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 492, 20))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 492, 33))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 492, 54))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 492, 20))
+>updateIds2 : Symbol(updateIds2, Decl(keyofAndIndexedAccess.ts, 502, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 506, 20))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 506, 33))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 506, 54))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 506, 20))
 
     obj: T,
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 492, 74))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 492, 20))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 506, 74))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 506, 20))
 
     key: K,
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 493, 11))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 492, 54))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 507, 11))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 506, 54))
 
     stringMap: { [oldId: string]: string }
->stringMap : Symbol(stringMap, Decl(keyofAndIndexedAccess.ts, 494, 11))
->oldId : Symbol(oldId, Decl(keyofAndIndexedAccess.ts, 495, 18))
+>stringMap : Symbol(stringMap, Decl(keyofAndIndexedAccess.ts, 508, 11))
+>oldId : Symbol(oldId, Decl(keyofAndIndexedAccess.ts, 509, 18))
 
 ) {
     var x = obj[key];
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 497, 7))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 492, 74))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 493, 11))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 511, 7))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 506, 74))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 507, 11))
 
     stringMap[x]; // Should be OK.
->stringMap : Symbol(stringMap, Decl(keyofAndIndexedAccess.ts, 494, 11))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 497, 7))
+>stringMap : Symbol(stringMap, Decl(keyofAndIndexedAccess.ts, 508, 11))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 511, 7))
 }
 
 // Repro from #13514
 
 declare function head<T extends Array<any>>(list: T): T[0];
->head : Symbol(head, Decl(keyofAndIndexedAccess.ts, 499, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 503, 22))
+>head : Symbol(head, Decl(keyofAndIndexedAccess.ts, 513, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 517, 22))
 >Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->list : Symbol(list, Decl(keyofAndIndexedAccess.ts, 503, 44))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 503, 22))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 503, 22))
+>list : Symbol(list, Decl(keyofAndIndexedAccess.ts, 517, 44))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 517, 22))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 517, 22))
 
 // Repro from #13604
 
 class A<T> {
->A : Symbol(A, Decl(keyofAndIndexedAccess.ts, 503, 59))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 507, 8))
+>A : Symbol(A, Decl(keyofAndIndexedAccess.ts, 517, 59))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 521, 8))
 
 	props: T & { foo: string };
->props : Symbol(A.props, Decl(keyofAndIndexedAccess.ts, 507, 12))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 507, 8))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 508, 13))
+>props : Symbol(A.props, Decl(keyofAndIndexedAccess.ts, 521, 12))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 521, 8))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 522, 13))
 }
 
 class B extends A<{ x: number}> {
->B : Symbol(B, Decl(keyofAndIndexedAccess.ts, 509, 1))
->A : Symbol(A, Decl(keyofAndIndexedAccess.ts, 503, 59))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 511, 19))
+>B : Symbol(B, Decl(keyofAndIndexedAccess.ts, 523, 1))
+>A : Symbol(A, Decl(keyofAndIndexedAccess.ts, 517, 59))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 525, 19))
 
 	f(p: this["props"]) {
->f : Symbol(B.f, Decl(keyofAndIndexedAccess.ts, 511, 33))
->p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 512, 3))
+>f : Symbol(B.f, Decl(keyofAndIndexedAccess.ts, 525, 33))
+>p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 526, 3))
 
 		p.x;
->p.x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 511, 19))
->p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 512, 3))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 511, 19))
+>p.x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 525, 19))
+>p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 526, 3))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 525, 19))
 	}
 }
 
 // Repro from #13749
 
 class Form<T> {
->Form : Symbol(Form, Decl(keyofAndIndexedAccess.ts, 515, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 519, 11))
+>Form : Symbol(Form, Decl(keyofAndIndexedAccess.ts, 529, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 533, 11))
 
     private childFormFactories: {[K in keyof T]: (v: T[K]) => Form<T[K]>}
->childFormFactories : Symbol(Form.childFormFactories, Decl(keyofAndIndexedAccess.ts, 519, 15))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 520, 34))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 519, 11))
->v : Symbol(v, Decl(keyofAndIndexedAccess.ts, 520, 50))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 519, 11))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 520, 34))
->Form : Symbol(Form, Decl(keyofAndIndexedAccess.ts, 515, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 519, 11))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 520, 34))
+>childFormFactories : Symbol(Form.childFormFactories, Decl(keyofAndIndexedAccess.ts, 533, 15))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 534, 34))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 533, 11))
+>v : Symbol(v, Decl(keyofAndIndexedAccess.ts, 534, 50))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 533, 11))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 534, 34))
+>Form : Symbol(Form, Decl(keyofAndIndexedAccess.ts, 529, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 533, 11))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 534, 34))
 
     public set<K extends keyof T>(prop: K, value: T[K]) {
->set : Symbol(Form.set, Decl(keyofAndIndexedAccess.ts, 520, 73))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 522, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 519, 11))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 522, 34))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 522, 15))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 522, 42))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 519, 11))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 522, 15))
+>set : Symbol(Form.set, Decl(keyofAndIndexedAccess.ts, 534, 73))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 536, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 533, 11))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 536, 34))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 536, 15))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 536, 42))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 533, 11))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 536, 15))
 
         this.childFormFactories[prop](value)
->this.childFormFactories : Symbol(Form.childFormFactories, Decl(keyofAndIndexedAccess.ts, 519, 15))
->this : Symbol(Form, Decl(keyofAndIndexedAccess.ts, 515, 1))
->childFormFactories : Symbol(Form.childFormFactories, Decl(keyofAndIndexedAccess.ts, 519, 15))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 522, 34))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 522, 42))
+>this.childFormFactories : Symbol(Form.childFormFactories, Decl(keyofAndIndexedAccess.ts, 533, 15))
+>this : Symbol(Form, Decl(keyofAndIndexedAccess.ts, 529, 1))
+>childFormFactories : Symbol(Form.childFormFactories, Decl(keyofAndIndexedAccess.ts, 533, 15))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 536, 34))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 536, 42))
     }
 }
 
 // Repro from #13787
 
 class SampleClass<P> {
->SampleClass : Symbol(SampleClass, Decl(keyofAndIndexedAccess.ts, 525, 1))
->P : Symbol(P, Decl(keyofAndIndexedAccess.ts, 529, 18))
+>SampleClass : Symbol(SampleClass, Decl(keyofAndIndexedAccess.ts, 539, 1))
+>P : Symbol(P, Decl(keyofAndIndexedAccess.ts, 543, 18))
 
     public props: Readonly<P>;
->props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 529, 22))
+>props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 543, 22))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->P : Symbol(P, Decl(keyofAndIndexedAccess.ts, 529, 18))
+>P : Symbol(P, Decl(keyofAndIndexedAccess.ts, 543, 18))
 
     constructor(props: P) {
->props : Symbol(props, Decl(keyofAndIndexedAccess.ts, 531, 16))
->P : Symbol(P, Decl(keyofAndIndexedAccess.ts, 529, 18))
+>props : Symbol(props, Decl(keyofAndIndexedAccess.ts, 545, 16))
+>P : Symbol(P, Decl(keyofAndIndexedAccess.ts, 543, 18))
 
         this.props = Object.freeze(props);
->this.props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 529, 22))
->this : Symbol(SampleClass, Decl(keyofAndIndexedAccess.ts, 525, 1))
->props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 529, 22))
+>this.props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 543, 22))
+>this : Symbol(SampleClass, Decl(keyofAndIndexedAccess.ts, 539, 1))
+>props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 543, 22))
 >Object.freeze : Symbol(ObjectConstructor.freeze, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >freeze : Symbol(ObjectConstructor.freeze, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->props : Symbol(props, Decl(keyofAndIndexedAccess.ts, 531, 16))
+>props : Symbol(props, Decl(keyofAndIndexedAccess.ts, 545, 16))
     }
 }
 
 interface Foo {
->Foo : Symbol(Foo, Decl(keyofAndIndexedAccess.ts, 534, 1))
+>Foo : Symbol(Foo, Decl(keyofAndIndexedAccess.ts, 548, 1))
 
     foo: string;
->foo : Symbol(Foo.foo, Decl(keyofAndIndexedAccess.ts, 536, 15))
+>foo : Symbol(Foo.foo, Decl(keyofAndIndexedAccess.ts, 550, 15))
 }
 
 declare function merge<T, U>(obj1: T, obj2: U): T & U;
->merge : Symbol(merge, Decl(keyofAndIndexedAccess.ts, 538, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 540, 23))
->U : Symbol(U, Decl(keyofAndIndexedAccess.ts, 540, 25))
->obj1 : Symbol(obj1, Decl(keyofAndIndexedAccess.ts, 540, 29))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 540, 23))
->obj2 : Symbol(obj2, Decl(keyofAndIndexedAccess.ts, 540, 37))
->U : Symbol(U, Decl(keyofAndIndexedAccess.ts, 540, 25))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 540, 23))
->U : Symbol(U, Decl(keyofAndIndexedAccess.ts, 540, 25))
+>merge : Symbol(merge, Decl(keyofAndIndexedAccess.ts, 552, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 554, 23))
+>U : Symbol(U, Decl(keyofAndIndexedAccess.ts, 554, 25))
+>obj1 : Symbol(obj1, Decl(keyofAndIndexedAccess.ts, 554, 29))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 554, 23))
+>obj2 : Symbol(obj2, Decl(keyofAndIndexedAccess.ts, 554, 37))
+>U : Symbol(U, Decl(keyofAndIndexedAccess.ts, 554, 25))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 554, 23))
+>U : Symbol(U, Decl(keyofAndIndexedAccess.ts, 554, 25))
 
 class AnotherSampleClass<T> extends SampleClass<T & Foo> {
->AnotherSampleClass : Symbol(AnotherSampleClass, Decl(keyofAndIndexedAccess.ts, 540, 54))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 542, 25))
->SampleClass : Symbol(SampleClass, Decl(keyofAndIndexedAccess.ts, 525, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 542, 25))
->Foo : Symbol(Foo, Decl(keyofAndIndexedAccess.ts, 534, 1))
+>AnotherSampleClass : Symbol(AnotherSampleClass, Decl(keyofAndIndexedAccess.ts, 554, 54))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 556, 25))
+>SampleClass : Symbol(SampleClass, Decl(keyofAndIndexedAccess.ts, 539, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 556, 25))
+>Foo : Symbol(Foo, Decl(keyofAndIndexedAccess.ts, 548, 1))
 
     constructor(props: T) {
->props : Symbol(props, Decl(keyofAndIndexedAccess.ts, 543, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 542, 25))
+>props : Symbol(props, Decl(keyofAndIndexedAccess.ts, 557, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 556, 25))
 
         const foo: Foo = { foo: "bar" };
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 544, 13))
->Foo : Symbol(Foo, Decl(keyofAndIndexedAccess.ts, 534, 1))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 544, 26))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 558, 13))
+>Foo : Symbol(Foo, Decl(keyofAndIndexedAccess.ts, 548, 1))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 558, 26))
 
         super(merge(props, foo));
->super : Symbol(SampleClass, Decl(keyofAndIndexedAccess.ts, 525, 1))
->merge : Symbol(merge, Decl(keyofAndIndexedAccess.ts, 538, 1))
->props : Symbol(props, Decl(keyofAndIndexedAccess.ts, 543, 16))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 544, 13))
+>super : Symbol(SampleClass, Decl(keyofAndIndexedAccess.ts, 539, 1))
+>merge : Symbol(merge, Decl(keyofAndIndexedAccess.ts, 552, 1))
+>props : Symbol(props, Decl(keyofAndIndexedAccess.ts, 557, 16))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 558, 13))
     }
 
     public brokenMethod() {
->brokenMethod : Symbol(AnotherSampleClass.brokenMethod, Decl(keyofAndIndexedAccess.ts, 546, 5))
+>brokenMethod : Symbol(AnotherSampleClass.brokenMethod, Decl(keyofAndIndexedAccess.ts, 560, 5))
 
         this.props.foo.concat;
 >this.props.foo.concat : Symbol(String.concat, Decl(lib.d.ts, --, --))
->this.props.foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 536, 15))
->this.props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 529, 22))
->this : Symbol(AnotherSampleClass, Decl(keyofAndIndexedAccess.ts, 540, 54))
->props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 529, 22))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 536, 15))
+>this.props.foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 550, 15))
+>this.props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 543, 22))
+>this : Symbol(AnotherSampleClass, Decl(keyofAndIndexedAccess.ts, 554, 54))
+>props : Symbol(SampleClass.props, Decl(keyofAndIndexedAccess.ts, 543, 22))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 550, 15))
 >concat : Symbol(String.concat, Decl(lib.d.ts, --, --))
     }
 }
 new AnotherSampleClass({});
->AnotherSampleClass : Symbol(AnotherSampleClass, Decl(keyofAndIndexedAccess.ts, 540, 54))
+>AnotherSampleClass : Symbol(AnotherSampleClass, Decl(keyofAndIndexedAccess.ts, 554, 54))
 
 // Positive repro from #17166
 function f3<T, K extends Extract<keyof T, string>>(t: T, k: K, tk: T[K]): void {
->f3 : Symbol(f3, Decl(keyofAndIndexedAccess.ts, 552, 27))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 555, 12))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 555, 14))
+>f3 : Symbol(f3, Decl(keyofAndIndexedAccess.ts, 566, 27))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 569, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 569, 14))
 >Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 555, 12))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 51))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 555, 12))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 555, 56))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 555, 14))
->tk : Symbol(tk, Decl(keyofAndIndexedAccess.ts, 555, 62))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 555, 12))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 555, 14))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 569, 12))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 569, 51))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 569, 12))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 569, 56))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 569, 14))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccess.ts, 569, 62))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 569, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 569, 14))
 
     for (let key in t) {
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 556, 12))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 51))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 570, 12))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 569, 51))
 
         key = k // ok, K ==> keyof T
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 556, 12))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 555, 56))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 570, 12))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 569, 56))
 
         t[key] = tk; // ok, T[K] ==> T[keyof T]
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 555, 51))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 556, 12))
->tk : Symbol(tk, Decl(keyofAndIndexedAccess.ts, 555, 62))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 569, 51))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 570, 12))
+>tk : Symbol(tk, Decl(keyofAndIndexedAccess.ts, 569, 62))
     }
 }
 
 // # 21185
 type Predicates<TaggedRecord> = {
->Predicates : Symbol(Predicates, Decl(keyofAndIndexedAccess.ts, 560, 1))
->TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 563, 16))
+>Predicates : Symbol(Predicates, Decl(keyofAndIndexedAccess.ts, 574, 1))
+>TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 577, 16))
 
   [T in keyof TaggedRecord]: (variant: TaggedRecord[keyof TaggedRecord]) => variant is TaggedRecord[T]
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 564, 3))
->TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 563, 16))
->variant : Symbol(variant, Decl(keyofAndIndexedAccess.ts, 564, 30))
->TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 563, 16))
->TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 563, 16))
->variant : Symbol(variant, Decl(keyofAndIndexedAccess.ts, 564, 30))
->TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 563, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 564, 3))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 578, 3))
+>TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 577, 16))
+>variant : Symbol(variant, Decl(keyofAndIndexedAccess.ts, 578, 30))
+>TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 577, 16))
+>TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 577, 16))
+>variant : Symbol(variant, Decl(keyofAndIndexedAccess.ts, 578, 30))
+>TaggedRecord : Symbol(TaggedRecord, Decl(keyofAndIndexedAccess.ts, 577, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 578, 3))
 }
 
 // Repros from #23592
 
 type Example<T extends { [K in keyof T]: { prop: any } }> = { [K in keyof T]: T[K]["prop"] };
->Example : Symbol(Example, Decl(keyofAndIndexedAccess.ts, 565, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 569, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 569, 26))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 569, 13))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 569, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 569, 63))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 569, 13))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 569, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 569, 63))
+>Example : Symbol(Example, Decl(keyofAndIndexedAccess.ts, 579, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 583, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 583, 26))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 583, 13))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 583, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 583, 63))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 583, 13))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 583, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 583, 63))
 
 type Result = Example<{ a: { prop: string }; b: { prop: number } }>;
->Result : Symbol(Result, Decl(keyofAndIndexedAccess.ts, 569, 93))
->Example : Symbol(Example, Decl(keyofAndIndexedAccess.ts, 565, 1))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 570, 23))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 570, 28))
->b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 570, 44))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 570, 49))
+>Result : Symbol(Result, Decl(keyofAndIndexedAccess.ts, 583, 93))
+>Example : Symbol(Example, Decl(keyofAndIndexedAccess.ts, 579, 1))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 584, 23))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 584, 28))
+>b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 584, 44))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 584, 49))
 
 type Helper2<T> = { [K in keyof T]: Extract<T[K], { prop: any }> };
->Helper2 : Symbol(Helper2, Decl(keyofAndIndexedAccess.ts, 570, 68))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 572, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 572, 21))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 572, 13))
+>Helper2 : Symbol(Helper2, Decl(keyofAndIndexedAccess.ts, 584, 68))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 586, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 586, 21))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 586, 13))
 >Extract : Symbol(Extract, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 572, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 572, 21))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 572, 51))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 586, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 586, 21))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 586, 51))
 
 type Example2<T> = { [K in keyof Helper2<T>]: Helper2<T>[K]["prop"] };
->Example2 : Symbol(Example2, Decl(keyofAndIndexedAccess.ts, 572, 67))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 573, 14))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 573, 22))
->Helper2 : Symbol(Helper2, Decl(keyofAndIndexedAccess.ts, 570, 68))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 573, 14))
->Helper2 : Symbol(Helper2, Decl(keyofAndIndexedAccess.ts, 570, 68))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 573, 14))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 573, 22))
+>Example2 : Symbol(Example2, Decl(keyofAndIndexedAccess.ts, 586, 67))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 587, 14))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 587, 22))
+>Helper2 : Symbol(Helper2, Decl(keyofAndIndexedAccess.ts, 584, 68))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 587, 14))
+>Helper2 : Symbol(Helper2, Decl(keyofAndIndexedAccess.ts, 584, 68))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 587, 14))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 587, 22))
 
 type Result2 = Example2<{ 1: { prop: string }; 2: { prop: number } }>;
->Result2 : Symbol(Result2, Decl(keyofAndIndexedAccess.ts, 573, 70))
->Example2 : Symbol(Example2, Decl(keyofAndIndexedAccess.ts, 572, 67))
->1 : Symbol(1, Decl(keyofAndIndexedAccess.ts, 574, 25))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 574, 30))
->2 : Symbol(2, Decl(keyofAndIndexedAccess.ts, 574, 46))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 574, 51))
+>Result2 : Symbol(Result2, Decl(keyofAndIndexedAccess.ts, 587, 70))
+>Example2 : Symbol(Example2, Decl(keyofAndIndexedAccess.ts, 586, 67))
+>1 : Symbol(1, Decl(keyofAndIndexedAccess.ts, 588, 25))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 588, 30))
+>2 : Symbol(2, Decl(keyofAndIndexedAccess.ts, 588, 46))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 588, 51))
 
 // Repro from #23618
 
 type DBBoolTable<K extends string> = { [k in K]: 0 | 1 } 
->DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 574, 70))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 578, 17))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 578, 40))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 578, 17))
+>DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 588, 70))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 592, 17))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 592, 40))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 592, 17))
 
 enum Flag {
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 578, 56))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 592, 56))
 
     FLAG_1 = "flag_1",
->FLAG_1 : Symbol(Flag.FLAG_1, Decl(keyofAndIndexedAccess.ts, 579, 11))
+>FLAG_1 : Symbol(Flag.FLAG_1, Decl(keyofAndIndexedAccess.ts, 593, 11))
 
     FLAG_2 = "flag_2"
->FLAG_2 : Symbol(Flag.FLAG_2, Decl(keyofAndIndexedAccess.ts, 580, 22))
+>FLAG_2 : Symbol(Flag.FLAG_2, Decl(keyofAndIndexedAccess.ts, 594, 22))
 }
 
 type SimpleDBRecord<Flag extends string> = { staticField: number } & DBBoolTable<Flag>
->SimpleDBRecord : Symbol(SimpleDBRecord, Decl(keyofAndIndexedAccess.ts, 582, 1))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 584, 20))
->staticField : Symbol(staticField, Decl(keyofAndIndexedAccess.ts, 584, 44))
->DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 574, 70))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 584, 20))
+>SimpleDBRecord : Symbol(SimpleDBRecord, Decl(keyofAndIndexedAccess.ts, 596, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 598, 20))
+>staticField : Symbol(staticField, Decl(keyofAndIndexedAccess.ts, 598, 44))
+>DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 588, 70))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 598, 20))
 
 function getFlagsFromSimpleRecord<Flag extends string>(record: SimpleDBRecord<Flag>, flags: Flag[]) {
->getFlagsFromSimpleRecord : Symbol(getFlagsFromSimpleRecord, Decl(keyofAndIndexedAccess.ts, 584, 86))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 585, 34))
->record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 585, 55))
->SimpleDBRecord : Symbol(SimpleDBRecord, Decl(keyofAndIndexedAccess.ts, 582, 1))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 585, 34))
->flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 585, 84))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 585, 34))
+>getFlagsFromSimpleRecord : Symbol(getFlagsFromSimpleRecord, Decl(keyofAndIndexedAccess.ts, 598, 86))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 599, 34))
+>record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 599, 55))
+>SimpleDBRecord : Symbol(SimpleDBRecord, Decl(keyofAndIndexedAccess.ts, 596, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 599, 34))
+>flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 599, 84))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 599, 34))
 
     return record[flags[0]];
->record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 585, 55))
->flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 585, 84))
+>record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 599, 55))
+>flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 599, 84))
 }
 
 type DynamicDBRecord<Flag extends string> = ({ dynamicField: number } | { dynamicField: string }) & DBBoolTable<Flag>
->DynamicDBRecord : Symbol(DynamicDBRecord, Decl(keyofAndIndexedAccess.ts, 587, 1))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 589, 21))
->dynamicField : Symbol(dynamicField, Decl(keyofAndIndexedAccess.ts, 589, 46))
->dynamicField : Symbol(dynamicField, Decl(keyofAndIndexedAccess.ts, 589, 73))
->DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 574, 70))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 589, 21))
+>DynamicDBRecord : Symbol(DynamicDBRecord, Decl(keyofAndIndexedAccess.ts, 601, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 603, 21))
+>dynamicField : Symbol(dynamicField, Decl(keyofAndIndexedAccess.ts, 603, 46))
+>dynamicField : Symbol(dynamicField, Decl(keyofAndIndexedAccess.ts, 603, 73))
+>DBBoolTable : Symbol(DBBoolTable, Decl(keyofAndIndexedAccess.ts, 588, 70))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 603, 21))
 
 function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]) {
->getFlagsFromDynamicRecord : Symbol(getFlagsFromDynamicRecord, Decl(keyofAndIndexedAccess.ts, 589, 117))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 590, 35))
->record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 590, 56))
->DynamicDBRecord : Symbol(DynamicDBRecord, Decl(keyofAndIndexedAccess.ts, 587, 1))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 590, 35))
->flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 590, 86))
->Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 590, 35))
+>getFlagsFromDynamicRecord : Symbol(getFlagsFromDynamicRecord, Decl(keyofAndIndexedAccess.ts, 603, 117))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 604, 35))
+>record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 604, 56))
+>DynamicDBRecord : Symbol(DynamicDBRecord, Decl(keyofAndIndexedAccess.ts, 601, 1))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 604, 35))
+>flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 604, 86))
+>Flag : Symbol(Flag, Decl(keyofAndIndexedAccess.ts, 604, 35))
 
     return record[flags[0]];
->record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 590, 56))
->flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 590, 86))
+>record : Symbol(record, Decl(keyofAndIndexedAccess.ts, 604, 56))
+>flags : Symbol(flags, Decl(keyofAndIndexedAccess.ts, 604, 86))
+}
+
+// Repro from #21368
+
+interface I {
+>I : Symbol(I, Decl(keyofAndIndexedAccess.ts, 606, 1))
+
+    foo: string;
+>foo : Symbol(I.foo, Decl(keyofAndIndexedAccess.ts, 610, 13))
+}
+
+declare function take<T>(p: T): void;
+>take : Symbol(take, Decl(keyofAndIndexedAccess.ts, 612, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 614, 22))
+>p : Symbol(p, Decl(keyofAndIndexedAccess.ts, 614, 25))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 614, 22))
+
+function fn<T extends I, K extends keyof T>(o: T, k: K) {
+>fn : Symbol(fn, Decl(keyofAndIndexedAccess.ts, 614, 37))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 616, 12))
+>I : Symbol(I, Decl(keyofAndIndexedAccess.ts, 606, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 616, 24))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 616, 12))
+>o : Symbol(o, Decl(keyofAndIndexedAccess.ts, 616, 44))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 616, 12))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 616, 49))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 616, 24))
+
+    take<{} | null | undefined>(o[k]);
+>take : Symbol(take, Decl(keyofAndIndexedAccess.ts, 612, 1))
+>o : Symbol(o, Decl(keyofAndIndexedAccess.ts, 616, 44))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 616, 49))
+
+    take<any>(o[k]);
+>take : Symbol(take, Decl(keyofAndIndexedAccess.ts, 612, 1))
+>o : Symbol(o, Decl(keyofAndIndexedAccess.ts, 616, 44))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 616, 49))
+}
+
+// Repro from #23133
+
+class Unbounded<T> {
+>Unbounded : Symbol(Unbounded, Decl(keyofAndIndexedAccess.ts, 619, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 623, 16))
+
+    foo(x: T[keyof T]) {
+>foo : Symbol(Unbounded.foo, Decl(keyofAndIndexedAccess.ts, 623, 20))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 624, 8))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 623, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 623, 16))
+
+        let y: {} | undefined | null = x;
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 625, 11))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 624, 8))
+    }
 }
 

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -1497,6 +1497,73 @@ function f90<T extends S2, K extends keyof S2>(x1: S2[keyof S2], x2: T[keyof S2]
 >length : number
 }
 
+function f91<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
+>f91 : <T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) => void
+>T : T
+>K : K
+>T : T
+>x : T
+>T : T
+>y : T[keyof T]
+>T : T
+>T : T
+>z : T[K]
+>T : T
+>K : K
+
+    let a: {};
+>a : {}
+
+    a = x;
+>a = x : T
+>a : {}
+>x : T
+
+    a = y;
+>a = y : T[keyof T]
+>a : {}
+>y : T[keyof T]
+
+    a = z;
+>a = z : T[K]
+>a : {}
+>z : T[K]
+}
+
+function f92<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
+>f92 : <T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) => void
+>T : T
+>K : K
+>T : T
+>x : T
+>T : T
+>y : T[keyof T]
+>T : T
+>T : T
+>z : T[K]
+>T : T
+>K : K
+
+    let a: {} | null | undefined;
+>a : {} | null | undefined
+>null : null
+
+    a = x;
+>a = x : T
+>a : {} | null | undefined
+>x : T
+
+    a = y;
+>a = y : T[keyof T]
+>a : {} | null | undefined
+>y : T[keyof T]
+
+    a = z;
+>a = z : T[K]
+>a : {} | null | undefined
+>z : T[K]
+}
+
 // Repros from #12011
 
 class Base {
@@ -2461,5 +2528,66 @@ function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<
 >flags[0] : Flag
 >flags : Flag[]
 >0 : 0
+}
+
+// Repro from #21368
+
+interface I {
+>I : I
+
+    foo: string;
+>foo : string
+}
+
+declare function take<T>(p: T): void;
+>take : <T>(p: T) => void
+>T : T
+>p : T
+>T : T
+
+function fn<T extends I, K extends keyof T>(o: T, k: K) {
+>fn : <T extends I, K extends keyof T>(o: T, k: K) => void
+>T : T
+>I : I
+>K : K
+>T : T
+>o : T
+>T : T
+>k : K
+>K : K
+
+    take<{} | null | undefined>(o[k]);
+>take<{} | null | undefined>(o[k]) : void
+>take : <T>(p: T) => void
+>null : null
+>o[k] : T[K]
+>o : T
+>k : K
+
+    take<any>(o[k]);
+>take<any>(o[k]) : void
+>take : <T>(p: T) => void
+>o[k] : T[K]
+>o : T
+>k : K
+}
+
+// Repro from #23133
+
+class Unbounded<T> {
+>Unbounded : Unbounded<T>
+>T : T
+
+    foo(x: T[keyof T]) {
+>foo : (x: T[keyof T]) => void
+>x : T[keyof T]
+>T : T
+>T : T
+
+        let y: {} | undefined | null = x;
+>y : {} | null | undefined
+>null : null
+>x : T[keyof T]
+    }
 }
 

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -321,6 +321,20 @@ function f90<T extends S2, K extends keyof S2>(x1: S2[keyof S2], x2: T[keyof S2]
     x4.length;
 }
 
+function f91<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
+    let a: {};
+    a = x;
+    a = y;
+    a = z;
+}
+
+function f92<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
+    let a: {} | null | undefined;
+    a = x;
+    a = y;
+    a = z;
+}
+
 // Repros from #12011
 
 class Base {
@@ -593,4 +607,25 @@ function getFlagsFromSimpleRecord<Flag extends string>(record: SimpleDBRecord<Fl
 type DynamicDBRecord<Flag extends string> = ({ dynamicField: number } | { dynamicField: string }) & DBBoolTable<Flag>
 function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]) {
     return record[flags[0]];
+}
+
+// Repro from #21368
+
+interface I {
+    foo: string;
+}
+
+declare function take<T>(p: T): void;
+
+function fn<T extends I, K extends keyof T>(o: T, k: K) {
+    take<{} | null | undefined>(o[k]);
+    take<any>(o[k]);
+}
+
+// Repro from #23133
+
+class Unbounded<T> {
+    foo(x: T[keyof T]) {
+        let y: {} | undefined | null = x;
+    }
 }


### PR DESCRIPTION
This PR changes the assignability of an unconstrained indexed access to be the same as that of an unconstrained type parameter. Specifically, an unconstrained type parameter is assignable to `{}` and with this PR the same is true for an unconstrained indexed access.

```ts
function foo<T, K extends keyof T>(x: T, y: T[keyof T], z: T[K]) {
    let a: {} | null | undefined;
    a = x;  // Ok
    a = y;  // Ok, but was error before this PR
    a = z;  // Ok, but was error before this PR
}
```

Fixes #21368.
Fixes #23133.