### PR TITLE
Don't show a definition at a 'require' call

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -31,7 +31,9 @@ namespace ts.GoToDefinition {
             const sigInfo = createDefinitionFromSignatureDeclaration(typeChecker, calledDeclaration);
             // For a function, if this is the original function definition, return just sigInfo.
             // If this is the original constructor definition, parent is the class.
-            return typeChecker.getRootSymbols(symbol).some(s => calledDeclaration.symbol === s || calledDeclaration.symbol.parent === s)
+            return typeChecker.getRootSymbols(symbol).some(s => calledDeclaration.symbol === s || calledDeclaration.symbol.parent === s) ||
+                // TODO: GH#23742 Following check shouldn't be necessary if 'require' is an alias
+                symbol.declarations.some(d => isVariableDeclaration(d) && d.initializer && isRequireCall(d.initializer, /*checkArgumentIsStringLiteralLike*/ false))
                 ? [sigInfo]
                 : [sigInfo, ...getDefinitionFromSymbol(typeChecker, symbol, node)];
         }

--- a/tests/cases/fourslash/goToDefinitionSignatureAlias_require.ts
+++ b/tests/cases/fourslash/goToDefinitionSignatureAlias_require.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts'/>
+
+// @allowJs: true
+
+// @Filename: /a.js
+////module.exports = function /*f*/f() {}
+
+// @Filename: /b.js
+////const f = require("./a");
+////[|/*use*/f|]();
+
+verify.goToDefinition("use", "f");


### PR DESCRIPTION
Mitigates #23742
Was broken by #23657 -- added a special check for the case where the non-signature definition is a 'require()' call.