### PR TITLE
Add refreshDiagnostics() method to Project

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -573,7 +573,7 @@ namespace ts.server {
             return this.pendingProjectUpdates.has(project.getProjectName());
         }
 
-        /** Call this function when an event has happened that should cause projects to update. */
+        /* @internal */
         sendProjectsUpdatedInBackgroundEvent() {
             if (!this.eventHandler) {
                 return;

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -573,7 +573,8 @@ namespace ts.server {
             return this.pendingProjectUpdates.has(project.getProjectName());
         }
 
-        private sendProjectsUpdatedInBackgroundEvent() {
+        /** Call this function when an event has happened that should cause projects to update. */
+        sendProjectsUpdatedInBackgroundEvent() {
             if (!this.eventHandler) {
                 return;
             }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -57,7 +57,6 @@ namespace ts.server {
 
     export interface PluginCreateInfo {
         project: Project;
-        projectService: ProjectService;
         languageService: LanguageService;
         languageServiceHost: LanguageServiceHost;
         serverHost: ServerHost;
@@ -1103,6 +1102,11 @@ namespace ts.server {
             this.projectService.logger.info(`Couldn't find ${pluginConfigEntry.name}`);
         }
 
+        /** Starts a new check for diagnostics. Call this if some file has updated that would cause diagnostics to be changed. */
+        refreshDiagnostics() {
+            this.projectService.sendProjectsUpdatedInBackgroundEvent();
+        }
+
         private enableProxy(pluginModuleFactory: PluginModuleFactory, configEntry: PluginImport) {
             try {
                 if (typeof pluginModuleFactory !== "function") {
@@ -1113,7 +1117,6 @@ namespace ts.server {
                 const info: PluginCreateInfo = {
                     config: configEntry,
                     project: this,
-                    projectService: this.projectService,
                     languageService: this.languageService,
                     languageServiceHost: this,
                     serverHost: this.projectService.host

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -57,6 +57,7 @@ namespace ts.server {
 
     export interface PluginCreateInfo {
         project: Project;
+        projectService: ProjectService;
         languageService: LanguageService;
         languageServiceHost: LanguageServiceHost;
         serverHost: ServerHost;
@@ -164,7 +165,7 @@ namespace ts.server {
             return hasOneOrMoreJsAndNoTsFiles(this);
         }
 
-        public static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void): {} {
+        public static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void): {} | undefined {
             const resolvedPath = normalizeSlashes(host.resolvePath(combinePaths(initialDir, "node_modules")));
             log(`Loading ${moduleName} from ${initialDir} (resolved to ${resolvedPath})`);
             const result = host.require(resolvedPath, moduleName);
@@ -1112,6 +1113,7 @@ namespace ts.server {
                 const info: PluginCreateInfo = {
                     config: configEntry,
                     project: this,
+                    projectService: this.projectService,
                     languageService: this.languageService,
                     languageServiceHost: this,
                     serverHost: this.projectService.host

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7647,6 +7647,7 @@ declare namespace ts.server {
     function allFilesAreJsOrDts(project: Project): boolean;
     interface PluginCreateInfo {
         project: Project;
+        projectService: ProjectService;
         languageService: LanguageService;
         languageServiceHost: LanguageServiceHost;
         serverHost: ServerHost;
@@ -7710,7 +7711,7 @@ declare namespace ts.server {
         private readonly cancellationToken;
         isNonTsProject(): boolean;
         isJsOnlyProject(): boolean;
-        static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void): {};
+        static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void): {} | undefined;
         isKnownTypesPackageName(name: string): boolean;
         installPackage(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult>;
         private readonly typingsCache;
@@ -8043,7 +8044,8 @@ declare namespace ts.server {
         updateTypingsForProject(response: SetTypings | InvalidateCachedTypings | PackageInstalledResponse): void;
         private delayEnsureProjectForOpenFiles;
         private delayUpdateProjectGraph;
-        private sendProjectsUpdatedInBackgroundEvent;
+        /** Call this function when an event has happened that should cause projects to update. */
+        sendProjectsUpdatedInBackgroundEvent(): void;
         private delayUpdateProjectGraphs;
         setCompilerOptionsForInferredProjects(projectCompilerOptions: protocol.ExternalProjectCompilerOptions, projectRootPath?: string): void;
         findProject(projectName: string): Project | undefined;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7647,7 +7647,6 @@ declare namespace ts.server {
     function allFilesAreJsOrDts(project: Project): boolean;
     interface PluginCreateInfo {
         project: Project;
-        projectService: ProjectService;
         languageService: LanguageService;
         languageServiceHost: LanguageServiceHost;
         serverHost: ServerHost;
@@ -7792,6 +7791,8 @@ declare namespace ts.server {
         protected removeRoot(info: ScriptInfo): void;
         protected enableGlobalPlugins(): void;
         protected enablePlugin(pluginConfigEntry: PluginImport, searchPaths: string[]): void;
+        /** Starts a new check for diagnostics. Call this if some file has updated that would cause diagnostics to be changed. */
+        refreshDiagnostics(): void;
         private enableProxy;
     }
     /**
@@ -8044,8 +8045,6 @@ declare namespace ts.server {
         updateTypingsForProject(response: SetTypings | InvalidateCachedTypings | PackageInstalledResponse): void;
         private delayEnsureProjectForOpenFiles;
         private delayUpdateProjectGraph;
-        /** Call this function when an event has happened that should cause projects to update. */
-        sendProjectsUpdatedInBackgroundEvent(): void;
         private delayUpdateProjectGraphs;
         setCompilerOptionsForInferredProjects(projectCompilerOptions: protocol.ExternalProjectCompilerOptions, projectRootPath?: string): void;
         findProject(projectName: string): Project | undefined;


### PR DESCRIPTION
Fixes #15914 and #15915

Using this, a plugin should be able to call `sendProjectsUpdatedInBackgroundEvent` on the `ProjectService` when it notices a config file has changed. Then we should request diagnostics again.
(Note: this includes having the plugin watch `tsconfig.json` if it needs to, instead of having the server notify the plugin for that.)
CC @egamma 