### PR TITLE
Dont consider global argumentation top-level members as having the export modifier

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21319,7 +21319,7 @@ namespace ts {
                 n.parent.kind !== SyntaxKind.ClassDeclaration &&
                 n.parent.kind !== SyntaxKind.ClassExpression &&
                 n.flags & NodeFlags.Ambient) {
-                if (!(flags & ModifierFlags.Ambient)) {
+                if (!(flags & ModifierFlags.Ambient) && !(isModuleBlock(n.parent) && isModuleDeclaration(n.parent.parent) && isGlobalScopeAugmentation(n.parent.parent))) {
                     // It is nested in an ambient context, which means it is automatically exported
                     flags |= ModifierFlags.Export;
                 }

--- a/tests/baselines/reference/globalFunctionAugmentationOverload.js
+++ b/tests/baselines/reference/globalFunctionAugmentationOverload.js
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/globalFunctionAugmentationOverload.ts] ////
+
+//// [mod.d.ts]
+declare function expect(spy: Function): void;
+declare function expect<T>(actual: ArrayLike<T>): void;
+declare module "mod" {
+    class mod {}
+    export = mod;
+}
+//// [mine.ts]
+import "mod";
+
+declare global {
+    function expect(element: string): void;
+}
+//// [index.d.ts]
+declare function expect(spy: Function): void;
+
+//// [mine.js]
+"use strict";
+exports.__esModule = true;
+require("mod");

--- a/tests/baselines/reference/globalFunctionAugmentationOverload.symbols
+++ b/tests/baselines/reference/globalFunctionAugmentationOverload.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/mod.d.ts ===
+declare function expect(spy: Function): void;
+>expect : Symbol(expect, Decl(mod.d.ts, 0, 0), Decl(mod.d.ts, 0, 45), Decl(index.d.ts, 0, 0), Decl(mine.ts, 2, 16))
+>spy : Symbol(spy, Decl(mod.d.ts, 0, 24))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+declare function expect<T>(actual: ArrayLike<T>): void;
+>expect : Symbol(expect, Decl(mod.d.ts, 0, 0), Decl(mod.d.ts, 0, 45), Decl(index.d.ts, 0, 0), Decl(mine.ts, 2, 16))
+>T : Symbol(T, Decl(mod.d.ts, 1, 24))
+>actual : Symbol(actual, Decl(mod.d.ts, 1, 27))
+>ArrayLike : Symbol(ArrayLike, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mod.d.ts, 1, 24))
+
+declare module "mod" {
+>"mod" : Symbol("mod", Decl(mod.d.ts, 1, 55))
+
+    class mod {}
+>mod : Symbol(mod, Decl(mod.d.ts, 2, 22))
+
+    export = mod;
+>mod : Symbol(mod, Decl(mod.d.ts, 2, 22))
+}
+=== tests/cases/compiler/mine.ts ===
+import "mod";
+
+declare global {
+>global : Symbol(global, Decl(mine.ts, 0, 13))
+
+    function expect(element: string): void;
+>expect : Symbol(expect, Decl(mod.d.ts, 0, 0), Decl(mod.d.ts, 0, 45), Decl(index.d.ts, 0, 0), Decl(mine.ts, 2, 16))
+>element : Symbol(element, Decl(mine.ts, 3, 20))
+}
+=== tests/cases/compiler/index.d.ts ===
+declare function expect(spy: Function): void;
+>expect : Symbol(expect, Decl(mod.d.ts, 0, 0), Decl(mod.d.ts, 0, 45), Decl(index.d.ts, 0, 0), Decl(mine.ts, 2, 16))
+>spy : Symbol(spy, Decl(index.d.ts, 0, 24))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/globalFunctionAugmentationOverload.types
+++ b/tests/baselines/reference/globalFunctionAugmentationOverload.types
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/mod.d.ts ===
+declare function expect(spy: Function): void;
+>expect : { (spy: Function): void; <T>(actual: ArrayLike<T>): void; (spy: Function): void; (element: string): void; }
+>spy : Function
+>Function : Function
+
+declare function expect<T>(actual: ArrayLike<T>): void;
+>expect : { (spy: Function): void; <T>(actual: ArrayLike<T>): void; (spy: Function): void; (element: string): void; }
+>T : T
+>actual : ArrayLike<T>
+>ArrayLike : ArrayLike<T>
+>T : T
+
+declare module "mod" {
+>"mod" : typeof import("mod")
+
+    class mod {}
+>mod : mod
+
+    export = mod;
+>mod : mod
+}
+=== tests/cases/compiler/mine.ts ===
+import "mod";
+
+declare global {
+>global : typeof global
+
+    function expect(element: string): void;
+>expect : { (spy: Function): void; <T>(actual: ArrayLike<T>): void; (spy: Function): void; (element: string): void; }
+>element : string
+}
+=== tests/cases/compiler/index.d.ts ===
+declare function expect(spy: Function): void;
+>expect : { (spy: Function): void; <T>(actual: ArrayLike<T>): void; (spy: Function): void; (element: string): void; }
+>spy : Function
+>Function : Function
+

--- a/tests/cases/compiler/globalFunctionAugmentationOverload.ts
+++ b/tests/cases/compiler/globalFunctionAugmentationOverload.ts
@@ -1,0 +1,15 @@
+// @filename: mod.d.ts
+declare function expect(spy: Function): void;
+declare function expect<T>(actual: ArrayLike<T>): void;
+declare module "mod" {
+    class mod {}
+    export = mod;
+}
+// @filename: mine.ts
+import "mod";
+
+declare global {
+    function expect(element: string): void;
+}
+// @filename: index.d.ts
+declare function expect(spy: Function): void;


### PR DESCRIPTION
Fixes #23796
