### PR TITLE
Move symbol instance type to es5 to follow PropertyKey

### DIFF
--- a/src/lib/es2015.symbol.d.ts
+++ b/src/lib/es2015.symbol.d.ts
@@ -1,11 +1,3 @@
-interface Symbol {
-    /** Returns a string representation of an object. */
-    toString(): string;
-
-    /** Returns the primitive value of the specified object. */
-    valueOf(): symbol;
-}
-
 interface SymbolConstructor {
     /**
      * A reference to the prototype.

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -74,6 +74,14 @@ declare function escape(string: string): string;
   */
 declare function unescape(string: string): string;
 
+interface Symbol {
+  /** Returns a string representation of an object. */
+  toString(): string;
+
+  /** Returns the primitive value of the specified object. */
+  valueOf(): symbol;
+}
+
 declare type PropertyKey = string | number | symbol;
 
 interface PropertyDescriptor {

--- a/tests/baselines/reference/ES5For-ofTypeCheck10.errors.txt
+++ b/tests/baselines/reference/ES5For-ofTypeCheck10.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(9,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(9,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(14,15): error TS2569: Type 'StringIterator' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.
 
 
@@ -13,7 +13,7 @@ tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(14,1
         }
         [Symbol.iterator]() {
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
             return this;
         }
     }

--- a/tests/baselines/reference/ES5SymbolProperty1.symbols
+++ b/tests/baselines/reference/ES5SymbolProperty1.symbols
@@ -6,7 +6,7 @@ interface SymbolConstructor {
 >foo : Symbol(SymbolConstructor.foo, Decl(ES5SymbolProperty1.ts, 0, 29))
 }
 var Symbol: SymbolConstructor;
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty1.ts, 3, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty1.ts, 3, 3))
 >SymbolConstructor : Symbol(SymbolConstructor, Decl(ES5SymbolProperty1.ts, 0, 0))
 
 var obj = {
@@ -15,13 +15,13 @@ var obj = {
     [Symbol.foo]: 0
 >[Symbol.foo] : Symbol([Symbol.foo], Decl(ES5SymbolProperty1.ts, 5, 11))
 >Symbol.foo : Symbol(SymbolConstructor.foo, Decl(ES5SymbolProperty1.ts, 0, 29))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty1.ts, 3, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty1.ts, 3, 3))
 >foo : Symbol(SymbolConstructor.foo, Decl(ES5SymbolProperty1.ts, 0, 29))
 }
 
 obj[Symbol.foo];
 >obj : Symbol(obj, Decl(ES5SymbolProperty1.ts, 5, 3))
 >Symbol.foo : Symbol(SymbolConstructor.foo, Decl(ES5SymbolProperty1.ts, 0, 29))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty1.ts, 3, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty1.ts, 3, 3))
 >foo : Symbol(SymbolConstructor.foo, Decl(ES5SymbolProperty1.ts, 0, 29))
 

--- a/tests/baselines/reference/ES5SymbolProperty2.errors.txt
+++ b/tests/baselines/reference/ES5SymbolProperty2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/Symbols/ES5SymbolProperty2.ts(5,10): error TS2471: A computed property name of the form 'Symbol.iterator' must be of type 'symbol'.
-tests/cases/conformance/Symbols/ES5SymbolProperty2.ts(10,11): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/Symbols/ES5SymbolProperty2.ts(10,11): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/Symbols/ES5SymbolProperty2.ts (2 errors) ====
@@ -16,4 +16,4 @@ tests/cases/conformance/Symbols/ES5SymbolProperty2.ts(10,11): error TS2304: Cann
     
     (new M.C)[Symbol.iterator];
               ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.

--- a/tests/baselines/reference/ES5SymbolProperty3.symbols
+++ b/tests/baselines/reference/ES5SymbolProperty3.symbols
@@ -1,16 +1,16 @@
 === tests/cases/conformance/Symbols/ES5SymbolProperty3.ts ===
 var Symbol: any;
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty3.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty3.ts, 0, 3))
 
 class C {
 >C : Symbol(C, Decl(ES5SymbolProperty3.ts, 0, 16))
 
     [Symbol.iterator]() { }
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(ES5SymbolProperty3.ts, 2, 9))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty3.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty3.ts, 0, 3))
 }
 
 (new C)[Symbol.iterator]
 >C : Symbol(C, Decl(ES5SymbolProperty3.ts, 0, 16))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty3.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty3.ts, 0, 3))
 

--- a/tests/baselines/reference/ES5SymbolProperty4.symbols
+++ b/tests/baselines/reference/ES5SymbolProperty4.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/Symbols/ES5SymbolProperty4.ts ===
 var Symbol: { iterator: string };
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty4.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty4.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty4.ts, 0, 13))
 
 class C {
@@ -9,13 +9,13 @@ class C {
     [Symbol.iterator]() { }
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(ES5SymbolProperty4.ts, 2, 9))
 >Symbol.iterator : Symbol(iterator, Decl(ES5SymbolProperty4.ts, 0, 13))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty4.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty4.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty4.ts, 0, 13))
 }
 
 (new C)[Symbol.iterator]
 >C : Symbol(C, Decl(ES5SymbolProperty4.ts, 0, 33))
 >Symbol.iterator : Symbol(iterator, Decl(ES5SymbolProperty4.ts, 0, 13))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty4.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty4.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty4.ts, 0, 13))
 

--- a/tests/baselines/reference/ES5SymbolProperty5.symbols
+++ b/tests/baselines/reference/ES5SymbolProperty5.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/Symbols/ES5SymbolProperty5.ts ===
 var Symbol: { iterator: symbol };
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty5.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty5.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty5.ts, 0, 13))
 
 class C {
@@ -9,13 +9,13 @@ class C {
     [Symbol.iterator]() { }
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(ES5SymbolProperty5.ts, 2, 9))
 >Symbol.iterator : Symbol(iterator, Decl(ES5SymbolProperty5.ts, 0, 13))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty5.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty5.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty5.ts, 0, 13))
 }
 
 (new C)[Symbol.iterator](0) // Should error
 >C : Symbol(C, Decl(ES5SymbolProperty5.ts, 0, 33))
 >Symbol.iterator : Symbol(iterator, Decl(ES5SymbolProperty5.ts, 0, 13))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty5.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty5.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty5.ts, 0, 13))
 

--- a/tests/baselines/reference/ES5SymbolProperty6.errors.txt
+++ b/tests/baselines/reference/ES5SymbolProperty6.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/conformance/Symbols/ES5SymbolProperty6.ts(2,6): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/Symbols/ES5SymbolProperty6.ts(5,9): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/Symbols/ES5SymbolProperty6.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
+tests/cases/conformance/Symbols/ES5SymbolProperty6.ts(5,9): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/Symbols/ES5SymbolProperty6.ts (2 errors) ====
     class C {
         [Symbol.iterator]() { }
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }
     
     (new C)[Symbol.iterator]
             ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.

--- a/tests/baselines/reference/ES5SymbolProperty7.symbols
+++ b/tests/baselines/reference/ES5SymbolProperty7.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/Symbols/ES5SymbolProperty7.ts ===
 var Symbol: { iterator: any };
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty7.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty7.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty7.ts, 0, 13))
 
 class C {
@@ -9,13 +9,13 @@ class C {
     [Symbol.iterator]() { }
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(ES5SymbolProperty7.ts, 2, 9))
 >Symbol.iterator : Symbol(iterator, Decl(ES5SymbolProperty7.ts, 0, 13))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty7.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty7.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty7.ts, 0, 13))
 }
 
 (new C)[Symbol.iterator]
 >C : Symbol(C, Decl(ES5SymbolProperty7.ts, 0, 30))
 >Symbol.iterator : Symbol(iterator, Decl(ES5SymbolProperty7.ts, 0, 13))
->Symbol : Symbol(Symbol, Decl(ES5SymbolProperty7.ts, 0, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(ES5SymbolProperty7.ts, 0, 3))
 >iterator : Symbol(iterator, Decl(ES5SymbolProperty7.ts, 0, 13))
 

--- a/tests/baselines/reference/ES5SymbolType1.symbols
+++ b/tests/baselines/reference/ES5SymbolType1.symbols
@@ -3,7 +3,7 @@ var s: symbol;
 >s : Symbol(s, Decl(ES5SymbolType1.ts, 0, 3))
 
 s.toString();
->s.toString : Symbol(Object.toString, Decl(lib.d.ts, --, --))
+>s.toString : Symbol(Symbol.toString, Decl(lib.d.ts, --, --))
 >s : Symbol(s, Decl(ES5SymbolType1.ts, 0, 3))
->toString : Symbol(Object.toString, Decl(lib.d.ts, --, --))
+>toString : Symbol(Symbol.toString, Decl(lib.d.ts, --, --))
 

--- a/tests/baselines/reference/argumentsObjectIterator02_ES5.errors.txt
+++ b/tests/baselines/reference/argumentsObjectIterator02_ES5.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/argumentsObjectIterator02_ES5.ts(2,26): error TS2304: Cannot find name 'Symbol'.
+tests/cases/compiler/argumentsObjectIterator02_ES5.ts(2,26): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/compiler/argumentsObjectIterator02_ES5.ts (1 errors) ====
     function doubleAndReturnAsArray(x: number, y: number, z: number): [number, number, number] {
         let blah = arguments[Symbol.iterator];
                              ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     
         let result = [];
         for (let arg of blah()) {

--- a/tests/baselines/reference/argumentsObjectIterator02_ES6.symbols
+++ b/tests/baselines/reference/argumentsObjectIterator02_ES6.symbols
@@ -9,7 +9,7 @@ function doubleAndReturnAsArray(x: number, y: number, z: number): [number, numbe
 >blah : Symbol(blah, Decl(argumentsObjectIterator02_ES6.ts, 1, 7))
 >arguments : Symbol(arguments)
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     let result = [];

--- a/tests/baselines/reference/classDeclarationShouldBeOutOfScopeInComputedNames.symbols
+++ b/tests/baselines/reference/classDeclarationShouldBeOutOfScopeInComputedNames.symbols
@@ -4,11 +4,11 @@ class A {
 
     static readonly p1 = Symbol();
 >p1 : Symbol(A.p1, Decl(classDeclarationShouldBeOutOfScopeInComputedNames.ts, 0, 9))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     static readonly p2 = Symbol();
 >p2 : Symbol(A.p2, Decl(classDeclarationShouldBeOutOfScopeInComputedNames.ts, 1, 34))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     // All of the below should be out of scope or TDZ - `A` has not finished being constructed as they are executed
     static readonly [A.p1] = 0;

--- a/tests/baselines/reference/complexRecursiveCollections.symbols
+++ b/tests/baselines/reference/complexRecursiveCollections.symbols
@@ -1910,7 +1910,7 @@ declare module Immutable {
       [Symbol.iterator](): IterableIterator<[keyof T, T[keyof T]]>;
 >[Symbol.iterator] : Symbol(Instance[Symbol.iterator], Decl(immutable.ts, 256, 46))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >IterableIterator : Symbol(IterableIterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >T : Symbol(T, Decl(immutable.ts, 219, 30))
@@ -2737,7 +2737,7 @@ declare module Immutable {
       [Symbol.iterator](): IterableIterator<[K, V]>;
 >[Symbol.iterator] : Symbol(Keyed[Symbol.iterator], Decl(immutable.ts, 353, 84))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >IterableIterator : Symbol(IterableIterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >K : Symbol(K, Decl(immutable.ts, 340, 27))
@@ -2981,7 +2981,7 @@ declare module Immutable {
       [Symbol.iterator](): IterableIterator<T>;
 >[Symbol.iterator] : Symbol(Indexed[Symbol.iterator], Decl(immutable.ts, 385, 91))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >IterableIterator : Symbol(IterableIterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >T : Symbol(T, Decl(immutable.ts, 358, 29))
@@ -3091,7 +3091,7 @@ declare module Immutable {
       [Symbol.iterator](): IterableIterator<T>;
 >[Symbol.iterator] : Symbol(Set[Symbol.iterator], Decl(immutable.ts, 399, 88))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >IterableIterator : Symbol(IterableIterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >T : Symbol(T, Decl(immutable.ts, 390, 25))

--- a/tests/baselines/reference/declarationEmitPrivateNameCausesError.symbols
+++ b/tests/baselines/reference/declarationEmitPrivateNameCausesError.symbols
@@ -1,7 +1,7 @@
 === tests/cases/compiler/file.ts ===
 const IGNORE_EXTRA_VARIABLES = Symbol(); //Notice how this is unexported
 >IGNORE_EXTRA_VARIABLES : Symbol(IGNORE_EXTRA_VARIABLES, Decl(file.ts, 0, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 //This is exported
 export function ignoreExtraVariables<CtorT extends {new(...args:any[]):{}}> (ctor : CtorT) {

--- a/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.symbols
+++ b/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.symbols
@@ -1,7 +1,7 @@
 === tests/cases/compiler/a.ts ===
 export const x = Symbol();
 >x : Symbol(x, Decl(a.ts, 0, 12))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 === tests/cases/compiler/b.ts ===
 import { x } from "./a";

--- a/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.symbols
+++ b/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.symbols
@@ -1,7 +1,7 @@
 === tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.ts ===
 const _data = Symbol('data');
 >_data : Symbol(_data, Decl(declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.ts, 0, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 export class User {
 >User : Symbol(User, Decl(declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.ts, 0, 29))

--- a/tests/baselines/reference/decoratorsOnComputedProperties.symbols
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.symbols
@@ -33,7 +33,7 @@ class A {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(A[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 9, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -45,7 +45,7 @@ class A {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(A[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 11, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -55,7 +55,7 @@ class A {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(A[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 13, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -65,7 +65,7 @@ class A {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(A[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 15, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -109,7 +109,7 @@ void class B {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(B[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 26, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -121,7 +121,7 @@ void class B {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(B[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 28, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -131,7 +131,7 @@ void class B {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(B[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 30, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -141,7 +141,7 @@ void class B {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(B[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 32, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -186,7 +186,7 @@ class C {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(C[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 43, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -198,7 +198,7 @@ class C {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 45, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -208,7 +208,7 @@ class C {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(C[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 47, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -218,7 +218,7 @@ class C {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(C[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 49, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -265,7 +265,7 @@ void class D {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(D[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 61, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -277,7 +277,7 @@ void class D {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(D[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 63, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -287,7 +287,7 @@ void class D {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(D[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 65, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -297,7 +297,7 @@ void class D {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(D[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 67, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -345,7 +345,7 @@ class E {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(E[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 79, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -357,7 +357,7 @@ class E {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(E[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 81, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -367,7 +367,7 @@ class E {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(E[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 83, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -377,7 +377,7 @@ class E {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(E[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 85, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -424,7 +424,7 @@ void class F {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(F[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 97, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -436,7 +436,7 @@ void class F {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(F[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 99, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -446,7 +446,7 @@ void class F {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(F[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 101, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -456,7 +456,7 @@ void class F {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(F[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 103, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -504,7 +504,7 @@ class G {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(G[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 115, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -516,7 +516,7 @@ class G {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(G[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 117, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -526,7 +526,7 @@ class G {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(G[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 119, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -536,7 +536,7 @@ class G {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(G[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 121, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -586,7 +586,7 @@ void class H {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(H[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 134, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -598,7 +598,7 @@ void class H {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(H[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 136, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -608,7 +608,7 @@ void class H {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(H[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 138, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -618,7 +618,7 @@ void class H {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(H[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 140, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -669,7 +669,7 @@ class I {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(I[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 153, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -681,7 +681,7 @@ class I {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 155, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -691,7 +691,7 @@ class I {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(I[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 157, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -701,7 +701,7 @@ class I {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(I[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 159, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;
@@ -752,7 +752,7 @@ void class J {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.toStringTag] : Symbol(J[Symbol.toStringTag], Decl(decoratorsOnComputedProperties.ts, 172, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     @x ["property2"]: any = 2;
@@ -764,7 +764,7 @@ void class J {
 >x : Symbol(x, Decl(decoratorsOnComputedProperties.ts, 0, 0))
 >[Symbol.iterator] : Symbol(J[Symbol.iterator], Decl(decoratorsOnComputedProperties.ts, 174, 30))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     ["property3"]: any;
@@ -774,7 +774,7 @@ void class J {
     [Symbol.isConcatSpreadable]: any;
 >[Symbol.isConcatSpreadable] : Symbol(J[Symbol.isConcatSpreadable], Decl(decoratorsOnComputedProperties.ts, 176, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     ["property4"]: any = 2;
@@ -784,7 +784,7 @@ void class J {
     [Symbol.match]: any = null;
 >[Symbol.match] : Symbol(J[Symbol.match], Decl(decoratorsOnComputedProperties.ts, 178, 27))
 >Symbol.match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >match : Symbol(SymbolConstructor.match, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [foo()]: any;

--- a/tests/baselines/reference/destructuredLateBoundNameHasCorrectTypes.symbols
+++ b/tests/baselines/reference/destructuredLateBoundNameHasCorrectTypes.symbols
@@ -1,7 +1,7 @@
 === tests/cases/compiler/destructuredLateBoundNameHasCorrectTypes.ts ===
 let { [Symbol.iterator]: destructured } = [];
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >destructured : Symbol(destructured, Decl(destructuredLateBoundNameHasCorrectTypes.ts, 0, 5))
 

--- a/tests/baselines/reference/dynamicNames.symbols
+++ b/tests/baselines/reference/dynamicNames.symbols
@@ -7,7 +7,7 @@ export const c1 = 1;
 
 export const s0 = Symbol();
 >s0 : Symbol(s0, Decl(module.ts, 2, 12))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 export interface T0 {
 >T0 : Symbol(T0, Decl(module.ts, 2, 27))

--- a/tests/baselines/reference/dynamicNamesErrors.symbols
+++ b/tests/baselines/reference/dynamicNamesErrors.symbols
@@ -62,19 +62,19 @@ t2 = t1;
 
 const x = Symbol();
 >x : Symbol(x, Decl(dynamicNamesErrors.ts, 26, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 const y = Symbol();
 >y : Symbol(y, Decl(dynamicNamesErrors.ts, 27, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 const z = Symbol();
 >z : Symbol(z, Decl(dynamicNamesErrors.ts, 28, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 const w = Symbol();
 >w : Symbol(w, Decl(dynamicNamesErrors.ts, 29, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 export interface InterfaceMemberVisibility {
 >InterfaceMemberVisibility : Symbol(InterfaceMemberVisibility, Decl(dynamicNamesErrors.ts, 29, 19))

--- a/tests/baselines/reference/for-of15.symbols
+++ b/tests/baselines/reference/for-of15.symbols
@@ -10,7 +10,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of15.ts, 3, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of16.symbols
+++ b/tests/baselines/reference/for-of16.symbols
@@ -5,7 +5,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of16.ts, 0, 22))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of17.symbols
+++ b/tests/baselines/reference/for-of17.symbols
@@ -17,7 +17,7 @@ class NumberIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(NumberIterator[Symbol.iterator], Decl(for-of17.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of18.symbols
+++ b/tests/baselines/reference/for-of18.symbols
@@ -17,7 +17,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of18.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of19.symbols
+++ b/tests/baselines/reference/for-of19.symbols
@@ -21,7 +21,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(for-of19.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of20.symbols
+++ b/tests/baselines/reference/for-of20.symbols
@@ -21,7 +21,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(for-of20.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of21.symbols
+++ b/tests/baselines/reference/for-of21.symbols
@@ -21,7 +21,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(for-of21.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of22.symbols
+++ b/tests/baselines/reference/for-of22.symbols
@@ -21,7 +21,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(for-of22.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of23.symbols
+++ b/tests/baselines/reference/for-of23.symbols
@@ -21,7 +21,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(for-of23.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of25.symbols
+++ b/tests/baselines/reference/for-of25.symbols
@@ -5,7 +5,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of25.ts, 0, 22))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return x;

--- a/tests/baselines/reference/for-of26.symbols
+++ b/tests/baselines/reference/for-of26.symbols
@@ -11,7 +11,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of26.ts, 3, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of27.symbols
+++ b/tests/baselines/reference/for-of27.symbols
@@ -5,7 +5,7 @@ class StringIterator {
     [Symbol.iterator]: any;
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of27.ts, 0, 22))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 }
 

--- a/tests/baselines/reference/for-of28.symbols
+++ b/tests/baselines/reference/for-of28.symbols
@@ -8,7 +8,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of28.ts, 1, 14))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of29.symbols
+++ b/tests/baselines/reference/for-of29.symbols
@@ -5,7 +5,7 @@ var iterableWithOptionalIterator: {
     [Symbol.iterator]?(): Iterator<string>
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(for-of29.ts, 0, 35))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >Iterator : Symbol(Iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 

--- a/tests/baselines/reference/for-of30.symbols
+++ b/tests/baselines/reference/for-of30.symbols
@@ -20,7 +20,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of30.ts, 8, 15))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of31.symbols
+++ b/tests/baselines/reference/for-of31.symbols
@@ -15,7 +15,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of31.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of33.symbols
+++ b/tests/baselines/reference/for-of33.symbols
@@ -5,7 +5,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of33.ts, 0, 22))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return v;

--- a/tests/baselines/reference/for-of34.symbols
+++ b/tests/baselines/reference/for-of34.symbols
@@ -12,7 +12,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of34.ts, 3, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of35.symbols
+++ b/tests/baselines/reference/for-of35.symbols
@@ -18,7 +18,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(for-of35.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/for-of44.symbols
+++ b/tests/baselines/reference/for-of44.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of44.ts ===
 var array: [number, string | boolean | symbol][] = [[0, ""], [0, true], [1, Symbol()]]
 >array : Symbol(array, Decl(for-of44.ts, 0, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 for (var [num, strBoolSym] of array) {
 >num : Symbol(num, Decl(for-of44.ts, 1, 10))

--- a/tests/baselines/reference/generatorES6_6.symbols
+++ b/tests/baselines/reference/generatorES6_6.symbols
@@ -5,7 +5,7 @@ class C {
   *[Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(generatorES6_6.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     let a = yield 1;

--- a/tests/baselines/reference/generatorTypeCheck28.symbols
+++ b/tests/baselines/reference/generatorTypeCheck28.symbols
@@ -8,7 +8,7 @@ function* g(): IterableIterator<(x: string) => number> {
         *[Symbol.iterator]() {
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(generatorTypeCheck28.ts, 1, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
             yield x => x.length;

--- a/tests/baselines/reference/generatorTypeCheck46.symbols
+++ b/tests/baselines/reference/generatorTypeCheck46.symbols
@@ -23,7 +23,7 @@ foo("", function* () {
         *[Symbol.iterator]() {
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(generatorTypeCheck46.ts, 3, 12))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
             yield x => x.length

--- a/tests/baselines/reference/indirectUniqueSymbolDeclarationEmit.symbols
+++ b/tests/baselines/reference/indirectUniqueSymbolDeclarationEmit.symbols
@@ -1,11 +1,11 @@
 === tests/cases/compiler/indirectUniqueSymbolDeclarationEmit.ts ===
 export const x = Symbol();
 >x : Symbol(x, Decl(indirectUniqueSymbolDeclarationEmit.ts, 0, 12))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 export const y = Symbol();
 >y : Symbol(y, Decl(indirectUniqueSymbolDeclarationEmit.ts, 1, 12))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 declare function rand(): boolean;
 >rand : Symbol(rand, Decl(indirectUniqueSymbolDeclarationEmit.ts, 1, 26))

--- a/tests/baselines/reference/intersectionTypeInference3.symbols
+++ b/tests/baselines/reference/intersectionTypeInference3.symbols
@@ -10,7 +10,7 @@ type Nominal<Kind extends string, Type> = Type & {
     [Symbol.species]: Kind;
 >[Symbol.species] : Symbol([Symbol.species], Decl(intersectionTypeInference3.ts, 2, 50))
 >Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Kind : Symbol(Kind, Decl(intersectionTypeInference3.ts, 2, 13))
 

--- a/tests/baselines/reference/iterableArrayPattern1.symbols
+++ b/tests/baselines/reference/iterableArrayPattern1.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iterableArrayPattern1.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iterableArrayPattern1.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iterableArrayPattern1.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern10.symbols
+++ b/tests/baselines/reference/iterableArrayPattern10.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern10.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern11.symbols
+++ b/tests/baselines/reference/iterableArrayPattern11.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern11.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern12.symbols
+++ b/tests/baselines/reference/iterableArrayPattern12.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern12.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern13.symbols
+++ b/tests/baselines/reference/iterableArrayPattern13.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern13.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern14.symbols
+++ b/tests/baselines/reference/iterableArrayPattern14.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern14.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern15.symbols
+++ b/tests/baselines/reference/iterableArrayPattern15.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern15.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern16.symbols
+++ b/tests/baselines/reference/iterableArrayPattern16.symbols
@@ -39,7 +39,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern16.ts, 10, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;
@@ -67,7 +67,7 @@ class FooIteratorIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIteratorIterator[Symbol.iterator], Decl(iterableArrayPattern16.ts, 23, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern17.symbols
+++ b/tests/baselines/reference/iterableArrayPattern17.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern17.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern18.symbols
+++ b/tests/baselines/reference/iterableArrayPattern18.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern18.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern19.symbols
+++ b/tests/baselines/reference/iterableArrayPattern19.symbols
@@ -28,7 +28,7 @@ class FooArrayIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooArrayIterator[Symbol.iterator], Decl(iterableArrayPattern19.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern2.symbols
+++ b/tests/baselines/reference/iterableArrayPattern2.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iterableArrayPattern2.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iterableArrayPattern2.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iterableArrayPattern2.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern20.symbols
+++ b/tests/baselines/reference/iterableArrayPattern20.symbols
@@ -28,7 +28,7 @@ class FooArrayIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooArrayIterator[Symbol.iterator], Decl(iterableArrayPattern20.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern3.symbols
+++ b/tests/baselines/reference/iterableArrayPattern3.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern3.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern4.symbols
+++ b/tests/baselines/reference/iterableArrayPattern4.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern4.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern5.symbols
+++ b/tests/baselines/reference/iterableArrayPattern5.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern5.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern6.symbols
+++ b/tests/baselines/reference/iterableArrayPattern6.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern6.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern7.symbols
+++ b/tests/baselines/reference/iterableArrayPattern7.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern7.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern8.symbols
+++ b/tests/baselines/reference/iterableArrayPattern8.symbols
@@ -28,7 +28,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern8.ts, 8, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iterableArrayPattern9.symbols
+++ b/tests/baselines/reference/iterableArrayPattern9.symbols
@@ -34,7 +34,7 @@ class FooIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(FooIterator[Symbol.iterator], Decl(iterableArrayPattern9.ts, 9, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInArray.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInArray.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray10.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray10.symbols
@@ -5,7 +5,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray10.ts, 0, 22))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray2.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray2.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInArray2.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInArray2.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray2.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;
@@ -46,7 +46,7 @@ class NumberIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(NumberIterator[Symbol.iterator], Decl(iteratorSpreadInArray2.ts, 19, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray3.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray3.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInArray3.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInArray3.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray3.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray4.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray4.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInArray4.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInArray4.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray4.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray5.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray5.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInArray5.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInArray5.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray5.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray6.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray6.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInArray6.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInArray6.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray6.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray7.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray7.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInArray7.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInArray7.ts, 3, 28))
@@ -19,7 +19,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray7.ts, 6, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInArray8.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray8.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInArray8.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInArray8.ts, 3, 28))

--- a/tests/baselines/reference/iteratorSpreadInArray9.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray9.symbols
@@ -8,7 +8,7 @@ class SymbolIterator {
         return {
             value: Symbol()
 >value : Symbol(value, Decl(iteratorSpreadInArray9.ts, 2, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
         };
     }
@@ -16,7 +16,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInArray9.ts, 5, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall.symbols
@@ -12,7 +12,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall.ts, 4, 28))
@@ -23,7 +23,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall10.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall10.symbols
@@ -15,7 +15,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall10.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall10.ts, 4, 28))
@@ -26,7 +26,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall10.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall11.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall11.symbols
@@ -15,7 +15,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall11.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall11.ts, 4, 28))
@@ -26,7 +26,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall11.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall12.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall12.symbols
@@ -17,7 +17,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall12.ts, 6, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall12.ts, 7, 28))
@@ -28,7 +28,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall12.ts, 10, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;
@@ -55,7 +55,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(iteratorSpreadInCall12.ts, 23, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall2.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall2.symbols
@@ -12,7 +12,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall2.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall2.ts, 4, 28))
@@ -23,7 +23,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall2.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall3.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall3.symbols
@@ -12,7 +12,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall3.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall3.ts, 4, 28))
@@ -23,7 +23,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall3.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall4.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall4.symbols
@@ -13,7 +13,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall4.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall4.ts, 4, 28))
@@ -24,7 +24,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall4.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall5.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall5.symbols
@@ -12,7 +12,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall5.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall5.ts, 4, 28))
@@ -23,7 +23,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall5.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;
@@ -50,7 +50,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(iteratorSpreadInCall5.ts, 20, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall6.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall6.symbols
@@ -12,7 +12,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall6.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall6.ts, 4, 28))
@@ -23,7 +23,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall6.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;
@@ -50,7 +50,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(iteratorSpreadInCall6.ts, 20, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall7.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall7.symbols
@@ -15,7 +15,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall7.ts, 3, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall7.ts, 4, 28))
@@ -26,7 +26,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall7.ts, 7, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;
@@ -53,7 +53,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(iteratorSpreadInCall7.ts, 20, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall8.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall8.symbols
@@ -17,7 +17,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall8.ts, 6, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall8.ts, 7, 28))
@@ -28,7 +28,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall8.ts, 10, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;
@@ -55,7 +55,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(iteratorSpreadInCall8.ts, 23, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/iteratorSpreadInCall9.symbols
+++ b/tests/baselines/reference/iteratorSpreadInCall9.symbols
@@ -17,7 +17,7 @@ class SymbolIterator {
         return {
             value: Symbol(),
 >value : Symbol(value, Decl(iteratorSpreadInCall9.ts, 6, 16))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
             done: false
 >done : Symbol(done, Decl(iteratorSpreadInCall9.ts, 7, 28))
@@ -28,7 +28,7 @@ class SymbolIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(SymbolIterator[Symbol.iterator], Decl(iteratorSpreadInCall9.ts, 10, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;
@@ -55,7 +55,7 @@ class StringIterator {
     [Symbol.iterator]() {
 >[Symbol.iterator] : Symbol(StringIterator[Symbol.iterator], Decl(iteratorSpreadInCall9.ts, 23, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
         return this;

--- a/tests/baselines/reference/keyofDoesntContainSymbols.symbols
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.symbols
@@ -1,7 +1,7 @@
 === tests/cases/compiler/keyofDoesntContainSymbols.ts ===
 const sym = Symbol();
 >sym : Symbol(sym, Decl(keyofDoesntContainSymbols.ts, 0, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 const num = 0;
 >num : Symbol(num, Decl(keyofDoesntContainSymbols.ts, 1, 5))

--- a/tests/baselines/reference/lateBoundDestructuringImplicitAnyError.symbols
+++ b/tests/baselines/reference/lateBoundDestructuringImplicitAnyError.symbols
@@ -23,11 +23,11 @@ let numed = 6;
 
 const symed = Symbol();
 >symed : Symbol(symed, Decl(lateBoundDestructuringImplicitAnyError.ts, 9, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 let symed2 = Symbol();
 >symed2 : Symbol(symed2, Decl(lateBoundDestructuringImplicitAnyError.ts, 10, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 let {[named]: prop2} = numIndexed;
 >named : Symbol(named, Decl(lateBoundDestructuringImplicitAnyError.ts, 0, 3))

--- a/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.errors.txt
+++ b/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.errors.txt
@@ -2,14 +2,14 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.t
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(10,13): error TS2304: Cannot find name 'Map'.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(17,5): error TS2339: Property 'name' does not exist on type '() => void'.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(20,6): error TS2551: Property 'sign' does not exist on type 'Math'. Did you mean 'sin'?
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(25,6): error TS2304: Cannot find name 'Symbol'.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(29,18): error TS2304: Cannot find name 'Symbol'.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(25,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(29,18): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(33,13): error TS2304: Cannot find name 'Proxy'.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(36,1): error TS2304: Cannot find name 'Reflect'.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(40,5): error TS2339: Property 'flags' does not exist on type 'RegExp'.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(44,5): error TS2339: Property 'includes' does not exist on type 'string'.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(47,9): error TS2304: Cannot find name 'Symbol'.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(51,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(47,9): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(51,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts (12 errors) ====
@@ -47,13 +47,13 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.t
         a: 2,
         [Symbol.hasInstance](value: any) {
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
             return false;
         }
     };
     o.hasOwnProperty(Symbol.hasInstance);
                      ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     
     // Using Es6 proxy
     var t = {}
@@ -81,13 +81,13 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.t
     // Using ES6 symbol
     var s = Symbol();
             ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     
     // Using ES6 wellknown-symbol
     const o1 = {
         [Symbol.hasInstance](value: any) {
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
             return false;
         }
     }

--- a/tests/baselines/reference/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.errors.txt
+++ b/tests/baselines/reference/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts(7,1): error TS2322: Type 'false' is not assignable to type 'string'.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts(7,3): error TS2304: Cannot find name 'Symbol'.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts(7,3): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts (2 errors) ====
@@ -13,4 +13,4 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6We
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'false' is not assignable to type 'string'.
       ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.symbols
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions1.symbols
@@ -92,7 +92,7 @@ var o = {
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : Symbol([Symbol.hasInstance], Decl(modularizeLibrary_NoErrorDuplicateLibOptions1.ts, 39, 9))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >value : Symbol(value, Decl(modularizeLibrary_NoErrorDuplicateLibOptions1.ts, 40, 25))
 
@@ -104,7 +104,7 @@ o.hasOwnProperty(Symbol.hasInstance);
 >o : Symbol(o, Decl(modularizeLibrary_NoErrorDuplicateLibOptions1.ts, 38, 3))
 >hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 // Using ES6 promise
@@ -167,7 +167,7 @@ str.includes("hello", 0);
 // Using ES6 symbol
 var s = Symbol();
 >s : Symbol(s, Decl(modularizeLibrary_NoErrorDuplicateLibOptions1.ts, 72, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 // Using ES6 wellknown-symbol
 const o1 = {
@@ -176,7 +176,7 @@ const o1 = {
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : Symbol([Symbol.hasInstance], Decl(modularizeLibrary_NoErrorDuplicateLibOptions1.ts, 75, 12))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >value : Symbol(value, Decl(modularizeLibrary_NoErrorDuplicateLibOptions1.ts, 76, 25))
 

--- a/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.symbols
+++ b/tests/baselines/reference/modularizeLibrary_NoErrorDuplicateLibOptions2.symbols
@@ -92,7 +92,7 @@ var o = {
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : Symbol([Symbol.hasInstance], Decl(modularizeLibrary_NoErrorDuplicateLibOptions2.ts, 39, 9))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >value : Symbol(value, Decl(modularizeLibrary_NoErrorDuplicateLibOptions2.ts, 40, 25))
 
@@ -104,7 +104,7 @@ o.hasOwnProperty(Symbol.hasInstance);
 >o : Symbol(o, Decl(modularizeLibrary_NoErrorDuplicateLibOptions2.ts, 38, 3))
 >hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 // Using ES6 promise
@@ -167,7 +167,7 @@ str.includes("hello", 0);
 // Using ES6 symbol
 var s = Symbol();
 >s : Symbol(s, Decl(modularizeLibrary_NoErrorDuplicateLibOptions2.ts, 72, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 // Using ES6 wellknown-symbol
 const o1 = {
@@ -176,7 +176,7 @@ const o1 = {
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : Symbol([Symbol.hasInstance], Decl(modularizeLibrary_NoErrorDuplicateLibOptions2.ts, 75, 12))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >value : Symbol(value, Decl(modularizeLibrary_NoErrorDuplicateLibOptions2.ts, 76, 25))
 

--- a/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.symbols
+++ b/tests/baselines/reference/modularizeLibrary_TargetES5UsingES6Lib.symbols
@@ -92,7 +92,7 @@ var o = {
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : Symbol([Symbol.hasInstance], Decl(modularizeLibrary_TargetES5UsingES6Lib.ts, 39, 9))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >value : Symbol(value, Decl(modularizeLibrary_TargetES5UsingES6Lib.ts, 40, 25))
 
@@ -104,7 +104,7 @@ o.hasOwnProperty(Symbol.hasInstance);
 >o : Symbol(o, Decl(modularizeLibrary_TargetES5UsingES6Lib.ts, 38, 3))
 >hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 // Using ES6 promise
@@ -167,7 +167,7 @@ str.includes("hello", 0);
 // Using ES6 symbol
 var s = Symbol();
 >s : Symbol(s, Decl(modularizeLibrary_TargetES5UsingES6Lib.ts, 72, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 // Using ES6 wellknown-symbol
 const o1 = {
@@ -176,7 +176,7 @@ const o1 = {
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : Symbol([Symbol.hasInstance], Decl(modularizeLibrary_TargetES5UsingES6Lib.ts, 75, 12))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >value : Symbol(value, Decl(modularizeLibrary_TargetES5UsingES6Lib.ts, 76, 25))
 

--- a/tests/baselines/reference/modularizeLibrary_TargetES6UsingES6Lib.symbols
+++ b/tests/baselines/reference/modularizeLibrary_TargetES6UsingES6Lib.symbols
@@ -57,7 +57,7 @@ var o = {
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : Symbol([Symbol.hasInstance], Decl(modularizeLibrary_TargetES6UsingES6Lib.ts, 22, 9))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >value : Symbol(value, Decl(modularizeLibrary_TargetES6UsingES6Lib.ts, 23, 25))
 
@@ -69,7 +69,7 @@ o.hasOwnProperty(Symbol.hasInstance);
 >o : Symbol(o, Decl(modularizeLibrary_TargetES6UsingES6Lib.ts, 21, 3))
 >hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 // Using Es6 proxy
@@ -109,7 +109,7 @@ str.includes("hello", 0);
 // Using ES6 symbol
 var s = Symbol();
 >s : Symbol(s, Decl(modularizeLibrary_TargetES6UsingES6Lib.ts, 45, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 // Using ES6 wellknown-symbol
 const o1 = {
@@ -118,7 +118,7 @@ const o1 = {
     [Symbol.hasInstance](value: any) {
 >[Symbol.hasInstance] : Symbol([Symbol.hasInstance], Decl(modularizeLibrary_TargetES6UsingES6Lib.ts, 48, 12))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >value : Symbol(value, Decl(modularizeLibrary_TargetES6UsingES6Lib.ts, 49, 25))
 

--- a/tests/baselines/reference/modularizeLibrary_UsingES5LibAndES6FeatureLibs.symbols
+++ b/tests/baselines/reference/modularizeLibrary_UsingES5LibAndES6FeatureLibs.symbols
@@ -1,7 +1,7 @@
 === tests/cases/compiler/modularizeLibrary_UsingES5LibAndES6FeatureLibs.ts ===
 var s = Symbol();
 >s : Symbol(s, Decl(modularizeLibrary_UsingES5LibAndES6FeatureLibs.ts, 0, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 var t = {};
 >t : Symbol(t, Decl(modularizeLibrary_UsingES5LibAndES6FeatureLibs.ts, 1, 3))

--- a/tests/baselines/reference/modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.symbols
+++ b/tests/baselines/reference/modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.symbols
@@ -21,6 +21,6 @@ let a = ['c', 'd'];
 a[Symbol.isConcatSpreadable] = false;
 >a : Symbol(a, Decl(modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.ts, 5, 3))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/nativeToBoxedTypes.errors.txt
+++ b/tests/baselines/reference/nativeToBoxedTypes.errors.txt
@@ -4,7 +4,8 @@ tests/cases/compiler/nativeToBoxedTypes.ts(7,1): error TS2322: Type 'String' is 
   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 tests/cases/compiler/nativeToBoxedTypes.ts(11,1): error TS2322: Type 'Boolean' is not assignable to type 'boolean'.
   'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.
-tests/cases/compiler/nativeToBoxedTypes.ts(14,10): error TS2304: Cannot find name 'Symbol'.
+tests/cases/compiler/nativeToBoxedTypes.ts(15,1): error TS2322: Type 'Symbol' is not assignable to type 'symbol'.
+  'symbol' is a primitive, but 'Symbol' is a wrapper object. Prefer using 'symbol' when possible.
 
 
 ==== tests/cases/compiler/nativeToBoxedTypes.ts (4 errors) ====
@@ -31,6 +32,7 @@ tests/cases/compiler/nativeToBoxedTypes.ts(14,10): error TS2304: Cannot find nam
     
     var sym: symbol; 
     var Sym: Symbol;
-             ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
     sym = Sym;
+    ~~~
+!!! error TS2322: Type 'Symbol' is not assignable to type 'symbol'.
+!!! error TS2322:   'symbol' is a primitive, but 'Symbol' is a wrapper object. Prefer using 'symbol' when possible.

--- a/tests/baselines/reference/nativeToBoxedTypes.symbols
+++ b/tests/baselines/reference/nativeToBoxedTypes.symbols
@@ -37,6 +37,7 @@ var sym: symbol;
 
 var Sym: Symbol;
 >Sym : Symbol(Sym, Decl(nativeToBoxedTypes.ts, 13, 3))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
 sym = Sym;
 >sym : Symbol(sym, Decl(nativeToBoxedTypes.ts, 12, 3))

--- a/tests/baselines/reference/nativeToBoxedTypes.types
+++ b/tests/baselines/reference/nativeToBoxedTypes.types
@@ -45,11 +45,11 @@ var sym: symbol;
 >sym : symbol
 
 var Sym: Symbol;
->Sym : any
->Symbol : No type information available!
+>Sym : Symbol
+>Symbol : Symbol
 
 sym = Sym;
->sym = Sym : any
+>sym = Sym : Symbol
 >sym : symbol
->Sym : any
+>Sym : Symbol
 

--- a/tests/baselines/reference/newNamesInGlobalAugmentations1.symbols
+++ b/tests/baselines/reference/newNamesInGlobalAugmentations1.symbols
@@ -35,7 +35,7 @@ declare global {
 === tests/cases/compiler/main.ts ===
 Symbol.observable;
 >Symbol.observable : Symbol(SymbolConstructor.observable, Decl(f1.d.ts, 6, 33))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >observable : Symbol(SymbolConstructor.observable, Decl(f1.d.ts, 6, 33))
 
 new Cls().x

--- a/tests/baselines/reference/noUnusedLocals_writeOnlyProperty_dynamicNames.symbols
+++ b/tests/baselines/reference/noUnusedLocals_writeOnlyProperty_dynamicNames.symbols
@@ -1,11 +1,11 @@
 === tests/cases/compiler/noUnusedLocals_writeOnlyProperty_dynamicNames.ts ===
 const x = Symbol("x");
 >x : Symbol(x, Decl(noUnusedLocals_writeOnlyProperty_dynamicNames.ts, 0, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 const y = Symbol("y");
 >y : Symbol(y, Decl(noUnusedLocals_writeOnlyProperty_dynamicNames.ts, 1, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 class C {
 >C : Symbol(C, Decl(noUnusedLocals_writeOnlyProperty_dynamicNames.ts, 1, 22))

--- a/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.symbols
+++ b/tests/baselines/reference/objectLiteralPropertyImplicitlyAny.symbols
@@ -2,7 +2,7 @@
 const foo = Symbol.for("foo");
 >foo : Symbol(foo, Decl(objectLiteralPropertyImplicitlyAny.ts, 0, 5))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 const o = { [foo]: undefined };

--- a/tests/baselines/reference/parserES5SymbolProperty1.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty1.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts (1 errors) ====
     interface I {
         [Symbol.iterator]: string;
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty2.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts (1 errors) ====
     interface I {
         [Symbol.unscopables](): string;
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty3.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty3.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts (1 errors) ====
     declare class C {
         [Symbol.unscopables](): string;
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty4.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty4.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts (1 errors) ====
     declare class C {
         [Symbol.isRegExp]: string;
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty5.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty5.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts (1 errors) ====
     class C {
         [Symbol.isRegExp]: string;
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty6.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty6.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts (1 errors) ====
     class C {
         [Symbol.toStringTag]: string = "";
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty7.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty7.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty7.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty7.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty7.ts (1 errors) ====
     class C {
         [Symbol.toStringTag](): void { }
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty8.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty8.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts (1 errors) ====
     var x: {
         [Symbol.toPrimitive](): string
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty9.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty9.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts(2,6): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts(2,6): error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts (1 errors) ====
     var x: {
         [Symbol.toPrimitive]: string
          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
+!!! error TS2693: 'Symbol' only refers to a type, but is being used as a value here.
     }

--- a/tests/baselines/reference/parserRealSource11.errors.txt
+++ b/tests/baselines/reference/parserRealSource11.errors.txt
@@ -35,7 +35,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(137,17): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(138,24): error TS2304: Cannot find name 'nodeTypeTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(141,30): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(145,42): error TS2304: Cannot find name 'ControlFlowContext'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(151,39): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(151,57): error TS2304: Cannot find name 'StringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(155,26): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(184,19): error TS2304: Cannot find name 'NodeType'.
@@ -48,7 +47,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(231,30): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(231,48): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(233,52): error TS2304: Cannot find name 'TokenID'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(237,36): error TS2304: Cannot find name 'TypeFlow'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(251,21): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(268,19): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(298,36): error TS2304: Cannot find name 'TypeFlow'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(302,30): error TS2304: Cannot find name 'Emitter'.
@@ -218,7 +216,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(863,36): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(868,38): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(877,40): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(891,27): error TS2304: Cannot find name 'VarFlags'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(892,21): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(894,55): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(900,37): error TS2304: Cannot find name 'hasFlag'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(900,60): error TS2304: Cannot find name 'VarFlags'.
@@ -243,17 +240,15 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(946,48): error 
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(959,27): error TS2304: Cannot find name 'FncFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(961,25): error TS2304: Cannot find name 'IHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(963,27): error TS2304: Cannot find name 'Signature'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(969,31): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(977,32): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(981,27): error TS2304: Cannot find name 'Type'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(985,29): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1004,44): error TS2304: Cannot find name 'hasFlag'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1004,67): error TS2304: Cannot find name 'FncFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1005,57): error TS2304: Cannot find name 'FncFlags'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1007,47): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1009,46): error TS1011: An element access expression should take an argument.
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1022,32): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1014,65): error TS2339: Property 'container' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1024,48): error TS1011: An element access expression should take an argument.
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1026,41): error TS2339: Property 'name' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1032,36): error TS2304: Cannot find name 'ControlFlowContext'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1033,29): error TS2304: Cannot find name 'BasicBlock'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(1034,28): error TS2304: Cannot find name 'BasicBlock'.
@@ -516,7 +511,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,30): error
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error TS2304: Cannot find name 'TokenID'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts (516 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts (511 errors) ====
     // Copyright (c) Microsoft. All rights reserved. Licensed under the Apache License, Version 2.0. 
     // See LICENSE.txt in the project root for complete license information.
     
@@ -742,8 +737,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
             }
     
             public netFreeUses(container: Symbol, freeUses: StringHashTable) {
-                                          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
                                                             ~~~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'StringHashTable'.
             }
@@ -868,8 +861,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
     
         export class Identifier extends AST {
             public sym: Symbol = null;
-                        ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             public cloId = -1;
             public text: string;
     
@@ -1849,8 +1840,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                               ~~~~~~~~
 !!! error TS2304: Cannot find name 'VarFlags'.
             public sym: Symbol = null;
-                        ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
     
             constructor (public id: Identifier, nodeType: NodeType, public nestingLevel: number) {
                                                           ~~~~~~~~
@@ -1976,8 +1965,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
             public tmp1Declared = false;
             public enclosingFnc: FuncDecl = null;
             public freeVariables: Symbol[] = [];
-                                  ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             public unitIndex = -1;
             public classDecl: NamedDeclaration = null;
             public boundToProperty: VarDecl = null;
@@ -1986,8 +1973,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
             public isTargetTypedAsMethod = false;
             public isInlineCallLiteral = false;
             public accessorSymbol: Symbol = null;
-                                   ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             public leftCurlyCount = 0;
             public rightCurlyCount = 0;
             public returnStatementsWithExpressions: ReturnStatement[] = [];
@@ -2028,8 +2013,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
 !!! error TS2304: Cannot find name 'FncFlags'.
     
             public addCloRef(id: Identifier, sym: Symbol): number {
-                                                  ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
                 if (this.envids == null) {
                     this.envids = new Identifier[];
                                                  
@@ -2039,6 +2022,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
                 var outerFnc = this.enclosingFnc;
                 if (sym) {
                     while (outerFnc && (outerFnc.type.symbol != sym.container)) {
+                                                                    ~~~~~~~~~
+!!! error TS2339: Property 'container' does not exist on type 'Symbol'.
                         outerFnc.addJumpRef(sym);
                         outerFnc = outerFnc.enclosingFnc;
                     }
@@ -2047,14 +2032,14 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
             }
     
             public addJumpRef(sym: Symbol): void {
-                                   ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
                 if (this.jumpRefs == null) {
                     this.jumpRefs = new Identifier[];
                                                    
 !!! error TS1011: An element access expression should take an argument.
                 }
                 var id = new Identifier(sym.name);
+                                            ~~~~
+!!! error TS2339: Property 'name' does not exist on type 'Symbol'.
                 this.jumpRefs[this.jumpRefs.length] = id;
                 id.sym = sym;
                 id.cloId = this.addCloRef(id, null);

--- a/tests/baselines/reference/parserRealSource11.symbols
+++ b/tests/baselines/reference/parserRealSource11.symbols
@@ -367,6 +367,7 @@ module TypeScript {
         public netFreeUses(container: Symbol, freeUses: StringHashTable) {
 >netFreeUses : Symbol(AST.netFreeUses, Decl(parserRealSource11.ts, 148, 9))
 >container : Symbol(container, Decl(parserRealSource11.ts, 150, 27))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 >freeUses : Symbol(freeUses, Decl(parserRealSource11.ts, 150, 45))
         }
 
@@ -694,6 +695,7 @@ module TypeScript {
 
         public sym: Symbol = null;
 >sym : Symbol(Identifier.sym, Decl(parserRealSource11.ts, 249, 41))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         public cloId = -1;
 >cloId : Symbol(Identifier.cloId, Decl(parserRealSource11.ts, 250, 34))
@@ -2477,6 +2479,7 @@ module TypeScript {
 
         public sym: Symbol = null;
 >sym : Symbol(BoundDecl.sym, Decl(parserRealSource11.ts, 890, 40))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         constructor (public id: Identifier, nodeType: NodeType, public nestingLevel: number) {
 >id : Symbol(BoundDecl.id, Decl(parserRealSource11.ts, 893, 21))
@@ -2703,6 +2706,7 @@ module TypeScript {
 
         public freeVariables: Symbol[] = [];
 >freeVariables : Symbol(FuncDecl.freeVariables, Decl(parserRealSource11.ts, 967, 45))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         public unitIndex = -1;
 >unitIndex : Symbol(FuncDecl.unitIndex, Decl(parserRealSource11.ts, 968, 44))
@@ -2730,6 +2734,7 @@ module TypeScript {
 
         public accessorSymbol: Symbol = null;
 >accessorSymbol : Symbol(FuncDecl.accessorSymbol, Decl(parserRealSource11.ts, 975, 43))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         public leftCurlyCount = 0;
 >leftCurlyCount : Symbol(FuncDecl.leftCurlyCount, Decl(parserRealSource11.ts, 976, 45))
@@ -2827,6 +2832,7 @@ module TypeScript {
 >id : Symbol(id, Decl(parserRealSource11.ts, 1006, 25))
 >Identifier : Symbol(Identifier, Decl(parserRealSource11.ts, 247, 5))
 >sym : Symbol(sym, Decl(parserRealSource11.ts, 1006, 40))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
             if (this.envids == null) {
 >this.envids : Symbol(FuncDecl.envids, Decl(parserRealSource11.ts, 962, 36))
@@ -2890,6 +2896,7 @@ module TypeScript {
         public addJumpRef(sym: Symbol): void {
 >addJumpRef : Symbol(FuncDecl.addJumpRef, Decl(parserRealSource11.ts, 1019, 9))
 >sym : Symbol(sym, Decl(parserRealSource11.ts, 1021, 26))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
             if (this.jumpRefs == null) {
 >this.jumpRefs : Symbol(FuncDecl.jumpRefs, Decl(parserRealSource11.ts, 963, 36))

--- a/tests/baselines/reference/parserRealSource11.types
+++ b/tests/baselines/reference/parserRealSource11.types
@@ -669,9 +669,9 @@ module TypeScript {
         }
 
         public netFreeUses(container: Symbol, freeUses: StringHashTable) {
->netFreeUses : (container: any, freeUses: any) => void
->container : any
->Symbol : No type information available!
+>netFreeUses : (container: Symbol, freeUses: any) => void
+>container : Symbol
+>Symbol : Symbol
 >freeUses : any
 >StringHashTable : No type information available!
         }
@@ -1123,8 +1123,8 @@ module TypeScript {
 >AST : AST
 
         public sym: Symbol = null;
->sym : any
->Symbol : No type information available!
+>sym : Symbol
+>Symbol : Symbol
 >null : null
 
         public cloId = -1;
@@ -3869,21 +3869,21 @@ module TypeScript {
 >isDynamicImport : boolean
 >(this.id.sym && !(<TypeSymbol>this.id.sym).onlyReferencedAsTypeRef) : boolean
 >this.id.sym && !(<TypeSymbol>this.id.sym).onlyReferencedAsTypeRef : boolean
->this.id.sym : any
+>this.id.sym : Symbol
 >this.id : Identifier
 >this : this
 >id : Identifier
->sym : any
+>sym : Symbol
 >!(<TypeSymbol>this.id.sym).onlyReferencedAsTypeRef : boolean
 >(<TypeSymbol>this.id.sym).onlyReferencedAsTypeRef : any
 >(<TypeSymbol>this.id.sym) : any
 ><TypeSymbol>this.id.sym : any
 >TypeSymbol : No type information available!
->this.id.sym : any
+>this.id.sym : Symbol
 >this.id : Identifier
 >this : this
 >id : Identifier
->sym : any
+>sym : Symbol
 >onlyReferencedAsTypeRef : any
 
                 var prevModAliasId = emitter.modAliasId;
@@ -4143,8 +4143,8 @@ module TypeScript {
 >None : any
 
         public sym: Symbol = null;
->sym : any
->Symbol : No type information available!
+>sym : Symbol
+>Symbol : Symbol
 >null : null
 
         constructor (public id: Identifier, nodeType: NodeType, public nestingLevel: number) {
@@ -4463,8 +4463,8 @@ module TypeScript {
 >null : null
 
         public freeVariables: Symbol[] = [];
->freeVariables : any[]
->Symbol : No type information available!
+>freeVariables : Symbol[]
+>Symbol : Symbol
 >[] : undefined[]
 
         public unitIndex = -1;
@@ -4500,8 +4500,8 @@ module TypeScript {
 >false : false
 
         public accessorSymbol: Symbol = null;
->accessorSymbol : any
->Symbol : No type information available!
+>accessorSymbol : Symbol
+>Symbol : Symbol
 >null : null
 
         public leftCurlyCount = 0;
@@ -4622,11 +4622,11 @@ module TypeScript {
 >HasSelfReference : any
 
         public addCloRef(id: Identifier, sym: Symbol): number {
->addCloRef : (id: Identifier, sym: any) => number
+>addCloRef : (id: Identifier, sym: Symbol) => number
 >id : Identifier
 >Identifier : Identifier
->sym : any
->Symbol : No type information available!
+>sym : Symbol
+>Symbol : Symbol
 
             if (this.envids == null) {
 >this.envids == null : boolean
@@ -4665,7 +4665,7 @@ module TypeScript {
 >enclosingFnc : FuncDecl
 
             if (sym) {
->sym : any
+>sym : Symbol
 
                 while (outerFnc && (outerFnc.type.symbol != sym.container)) {
 >outerFnc && (outerFnc.type.symbol != sym.container) : boolean
@@ -4678,15 +4678,15 @@ module TypeScript {
 >type : any
 >symbol : any
 >sym.container : any
->sym : any
+>sym : Symbol
 >container : any
 
                     outerFnc.addJumpRef(sym);
 >outerFnc.addJumpRef(sym) : void
->outerFnc.addJumpRef : (sym: any) => void
+>outerFnc.addJumpRef : (sym: Symbol) => void
 >outerFnc : FuncDecl
->addJumpRef : (sym: any) => void
->sym : any
+>addJumpRef : (sym: Symbol) => void
+>sym : Symbol
 
                     outerFnc = outerFnc.enclosingFnc;
 >outerFnc = outerFnc.enclosingFnc : FuncDecl
@@ -4707,9 +4707,9 @@ module TypeScript {
         }
 
         public addJumpRef(sym: Symbol): void {
->addJumpRef : (sym: any) => void
->sym : any
->Symbol : No type information available!
+>addJumpRef : (sym: Symbol) => void
+>sym : Symbol
+>Symbol : Symbol
 
             if (this.jumpRefs == null) {
 >this.jumpRefs == null : boolean
@@ -4733,7 +4733,7 @@ module TypeScript {
 >new Identifier(sym.name) : Identifier
 >Identifier : typeof Identifier
 >sym.name : any
->sym : any
+>sym : Symbol
 >name : any
 
             this.jumpRefs[this.jumpRefs.length] = id;
@@ -4750,11 +4750,11 @@ module TypeScript {
 >id : Identifier
 
             id.sym = sym;
->id.sym = sym : any
->id.sym : any
+>id.sym = sym : Symbol
+>id.sym : Symbol
 >id : Identifier
->sym : any
->sym : any
+>sym : Symbol
+>sym : Symbol
 
             id.cloId = this.addCloRef(id, null);
 >id.cloId = this.addCloRef(id, null) : number
@@ -4762,9 +4762,9 @@ module TypeScript {
 >id : Identifier
 >cloId : number
 >this.addCloRef(id, null) : number
->this.addCloRef : (id: Identifier, sym: any) => number
+>this.addCloRef : (id: Identifier, sym: Symbol) => number
 >this : this
->addCloRef : (id: Identifier, sym: any) => number
+>addCloRef : (id: Identifier, sym: Symbol) => number
 >id : Identifier
 >null : null
         }
@@ -11105,11 +11105,11 @@ module TypeScript {
             }
             this.param.sym = exceptVar.symbol;
 >this.param.sym = exceptVar.symbol : any
->this.param.sym : any
+>this.param.sym : Symbol
 >this.param : VarDecl
 >this : this
 >param : VarDecl
->sym : any
+>sym : Symbol
 >exceptVar.symbol : any
 >exceptVar : any
 >symbol : any

--- a/tests/baselines/reference/parserRealSource6.errors.txt
+++ b/tests/baselines/reference/parserRealSource6.errors.txt
@@ -27,7 +27,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(79,45): error TS
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(79,58): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(79,71): error TS2304: Cannot find name 'IAstWalker'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(81,13): error TS2304: Cannot find name 'hasFlag'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(92,56): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(93,23): error TS2304: Cannot find name 'ScopedMembers'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(94,30): error TS2304: Cannot find name 'ScopedMembers'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(95,24): error TS2304: Cannot find name 'ScopedMembers'.
@@ -61,7 +60,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(212,81): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(215,20): error TS2339: Property 'getAstWalkerFactory' does not exist on type 'typeof TypeScript'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts (61 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts (60 errors) ====
     // Copyright (c) Microsoft. All rights reserved. Licensed under the Apache License, Version 2.0. 
     // See LICENSE.txt in the project root for complete license information.
     
@@ -212,8 +211,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(215,20): error T
         }
     
         export function pushTypeCollectionScope(container: Symbol,
-                                                           ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             valueMembers: ScopedMembers,
                           ~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'ScopedMembers'.

--- a/tests/baselines/reference/parserRealSource6.symbols
+++ b/tests/baselines/reference/parserRealSource6.symbols
@@ -259,6 +259,7 @@ module TypeScript {
     export function pushTypeCollectionScope(container: Symbol,
 >pushTypeCollectionScope : Symbol(pushTypeCollectionScope, Decl(parserRealSource6.ts, 89, 5))
 >container : Symbol(container, Decl(parserRealSource6.ts, 91, 44))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         valueMembers: ScopedMembers,
 >valueMembers : Symbol(valueMembers, Decl(parserRealSource6.ts, 91, 62))

--- a/tests/baselines/reference/parserRealSource6.types
+++ b/tests/baselines/reference/parserRealSource6.types
@@ -354,9 +354,9 @@ module TypeScript {
     }
 
     export function pushTypeCollectionScope(container: Symbol,
->pushTypeCollectionScope : (container: any, valueMembers: any, ambientValueMembers: any, enclosedTypes: any, ambientEnclosedTypes: any, context: TypeCollectionContext, thisType: any, classType: any, moduleDecl: any) => void
->container : any
->Symbol : No type information available!
+>pushTypeCollectionScope : (container: Symbol, valueMembers: any, ambientValueMembers: any, enclosedTypes: any, ambientEnclosedTypes: any, context: TypeCollectionContext, thisType: any, classType: any, moduleDecl: any) => void
+>container : Symbol
+>Symbol : Symbol
 
         valueMembers: ScopedMembers,
 >valueMembers : any
@@ -399,14 +399,14 @@ module TypeScript {
 >enclosedTypes : any
 >ambientEnclosedTypes : any
 >null : null
->container : any
+>container : Symbol
 
         var chain: ScopeChain = new ScopeChain(container, context.scopeChain, builder);
 >chain : any
 >ScopeChain : No type information available!
 >new ScopeChain(container, context.scopeChain, builder) : any
 >ScopeChain : any
->container : any
+>container : Symbol
 >context.scopeChain : any
 >context : TypeCollectionContext
 >scopeChain : any

--- a/tests/baselines/reference/parserRealSource7.errors.txt
+++ b/tests/baselines/reference/parserRealSource7.errors.txt
@@ -28,15 +28,14 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(83,24): error TS
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(84,18): error TS2304: Cannot find name 'IHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(85,20): error TS2304: Cannot find name 'TypeCollectionContext'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(88,67): error TS2304: Cannot find name 'ScopeChain'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(88,80): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(98,41): error TS2304: Cannot find name 'AST'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(98,76): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(99,21): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(101,18): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(102,30): error TS2304: Cannot find name 'Identifier'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(103,33): error TS2304: Cannot find name 'isQuoted'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(123,18): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(124,35): error TS2304: Cannot find name 'BinaryExpression'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(127,38): error TS2339: Property 'getType' does not exist on type 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(138,34): error TS2339: Property 'getType' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(150,48): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(150,61): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(150,75): error TS2304: Cannot find name 'TypeCollectionContext'.
@@ -45,6 +44,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(153,22): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(154,27): error TS2304: Cannot find name 'ImportDeclaration'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(155,26): error TS2304: Cannot find name 'hasFlag'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(155,55): error TS2304: Cannot find name 'VarFlags'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(162,51): error TS2339: Property 'getType' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(165,28): error TS2304: Cannot find name 'ModuleType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(169,26): error TS2304: Cannot find name 'TypeSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(186,48): error TS2304: Cannot find name 'AST'.
@@ -452,8 +452,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
         function findTypeSymbolInScopeChain(name: string, scopeChain: ScopeChain): Symbol {
                                                                       ~~~~~~~~~~
 !!! error TS2304: Cannot find name 'ScopeChain'.
-                                                                                   ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             var symbol = scopeChain.scope.find(name, false, true);
     
             if (symbol == null && scopeChain.previous) {
@@ -466,11 +464,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
         function findSymbolFromAlias(alias: AST, context: IAliasScopeContext): Symbol {
                                             ~~~
 !!! error TS2304: Cannot find name 'AST'.
-                                                                               ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             var symbol: Symbol = null;
-                        ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             switch (alias.nodeType) {
                 case NodeType.Name:
                      ~~~~~~~~
@@ -509,6 +503,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
                     var op1Sym = findSymbolFromAlias(dottedExpr.operand1, context);
     
                     if (op1Sym && op1Sym.getType()) {
+                                         ~~~~~~~
+!!! error TS2339: Property 'getType' does not exist on type 'Symbol'.
                         symbol = findSymbolFromAlias(dottedExpr.operand2, context);
                     }
     
@@ -520,6 +516,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
     
             if (symbol) {
                 var symType = symbol.getType();
+                                     ~~~~~~~
+!!! error TS2339: Property 'getType' does not exist on type 'Symbol'.
                 if (symType) {
                     var members = symType.members;
                     if (members) {
@@ -560,6 +558,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
     
             if (aliasedModSymbol) {
                 var aliasedModType = aliasedModSymbol.getType();
+                                                      ~~~~~~~
+!!! error TS2339: Property 'getType' does not exist on type 'Symbol'.
     
                 if (aliasedModType) {
                     modType = <ModuleType>aliasedModType;

--- a/tests/baselines/reference/parserRealSource7.symbols
+++ b/tests/baselines/reference/parserRealSource7.symbols
@@ -240,6 +240,7 @@ module TypeScript {
 >findTypeSymbolInScopeChain : Symbol(findTypeSymbolInScopeChain, Decl(parserRealSource7.ts, 85, 5))
 >name : Symbol(name, Decl(parserRealSource7.ts, 87, 40))
 >scopeChain : Symbol(scopeChain, Decl(parserRealSource7.ts, 87, 53))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         var symbol = scopeChain.scope.find(name, false, true);
 >symbol : Symbol(symbol, Decl(parserRealSource7.ts, 88, 11))
@@ -266,9 +267,11 @@ module TypeScript {
 >alias : Symbol(alias, Decl(parserRealSource7.ts, 97, 33))
 >context : Symbol(context, Decl(parserRealSource7.ts, 97, 44))
 >IAliasScopeContext : Symbol(IAliasScopeContext, Decl(parserRealSource7.ts, 79, 34))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         var symbol: Symbol = null;
 >symbol : Symbol(symbol, Decl(parserRealSource7.ts, 98, 11))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         switch (alias.nodeType) {
 >alias : Symbol(alias, Decl(parserRealSource7.ts, 97, 33))

--- a/tests/baselines/reference/parserRealSource7.types
+++ b/tests/baselines/reference/parserRealSource7.types
@@ -455,11 +455,11 @@ module TypeScript {
     }
 
     function findTypeSymbolInScopeChain(name: string, scopeChain: ScopeChain): Symbol {
->findTypeSymbolInScopeChain : (name: string, scopeChain: any) => any
+>findTypeSymbolInScopeChain : (name: string, scopeChain: any) => Symbol
 >name : string
 >scopeChain : any
 >ScopeChain : No type information available!
->Symbol : No type information available!
+>Symbol : Symbol
 
         var symbol = scopeChain.scope.find(name, false, true);
 >symbol : any
@@ -483,10 +483,10 @@ module TypeScript {
 >previous : any
 
             symbol = findTypeSymbolInScopeChain(name, scopeChain.previous);
->symbol = findTypeSymbolInScopeChain(name, scopeChain.previous) : any
+>symbol = findTypeSymbolInScopeChain(name, scopeChain.previous) : Symbol
 >symbol : any
->findTypeSymbolInScopeChain(name, scopeChain.previous) : any
->findTypeSymbolInScopeChain : (name: string, scopeChain: any) => any
+>findTypeSymbolInScopeChain(name, scopeChain.previous) : Symbol
+>findTypeSymbolInScopeChain : (name: string, scopeChain: any) => Symbol
 >name : string
 >scopeChain.previous : any
 >scopeChain : any
@@ -498,16 +498,16 @@ module TypeScript {
     }
 
     function findSymbolFromAlias(alias: AST, context: IAliasScopeContext): Symbol {
->findSymbolFromAlias : (alias: any, context: IAliasScopeContext) => any
+>findSymbolFromAlias : (alias: any, context: IAliasScopeContext) => Symbol
 >alias : any
 >AST : No type information available!
 >context : IAliasScopeContext
 >IAliasScopeContext : IAliasScopeContext
->Symbol : No type information available!
+>Symbol : Symbol
 
         var symbol: Symbol = null;
->symbol : any
->Symbol : No type information available!
+>symbol : Symbol
+>Symbol : Symbol
 >null : null
 
         switch (alias.nodeType) {
@@ -556,8 +556,8 @@ module TypeScript {
                     }
                     else {
                         return findTypeSymbolInScopeChain(name, context.topLevelScope);
->findTypeSymbolInScopeChain(name, context.topLevelScope) : any
->findTypeSymbolInScopeChain : (name: string, scopeChain: any) => any
+>findTypeSymbolInScopeChain(name, context.topLevelScope) : Symbol
+>findTypeSymbolInScopeChain : (name: string, scopeChain: any) => Symbol
 >name : any
 >context.topLevelScope : any
 >context : IAliasScopeContext
@@ -570,7 +570,7 @@ module TypeScript {
 
                     symbol = context.tcContext.checker.findSymbolForDynamicModule(name, context.tcContext.script.locationInfo.filename, findSym);
 >symbol = context.tcContext.checker.findSymbolForDynamicModule(name, context.tcContext.script.locationInfo.filename, findSym) : any
->symbol : any
+>symbol : Symbol
 >context.tcContext.checker.findSymbolForDynamicModule(name, context.tcContext.script.locationInfo.filename, findSym) : any
 >context.tcContext.checker.findSymbolForDynamicModule : any
 >context.tcContext.checker : any
@@ -594,7 +594,7 @@ module TypeScript {
                 else {
                     symbol = findSym(name);
 >symbol = findSym(name) : any
->symbol : any
+>symbol : Symbol
 >findSym(name) : any
 >findSym : (id: string) => any
 >name : any
@@ -614,9 +614,9 @@ module TypeScript {
 >alias : any
 
                 var op1Sym = findSymbolFromAlias(dottedExpr.operand1, context);
->op1Sym : any
->findSymbolFromAlias(dottedExpr.operand1, context) : any
->findSymbolFromAlias : (alias: any, context: IAliasScopeContext) => any
+>op1Sym : Symbol
+>findSymbolFromAlias(dottedExpr.operand1, context) : Symbol
+>findSymbolFromAlias : (alias: any, context: IAliasScopeContext) => Symbol
 >dottedExpr.operand1 : any
 >dottedExpr : any
 >operand1 : any
@@ -624,17 +624,17 @@ module TypeScript {
 
                 if (op1Sym && op1Sym.getType()) {
 >op1Sym && op1Sym.getType() : any
->op1Sym : any
+>op1Sym : Symbol
 >op1Sym.getType() : any
 >op1Sym.getType : any
->op1Sym : any
+>op1Sym : Symbol
 >getType : any
 
                     symbol = findSymbolFromAlias(dottedExpr.operand2, context);
->symbol = findSymbolFromAlias(dottedExpr.operand2, context) : any
->symbol : any
->findSymbolFromAlias(dottedExpr.operand2, context) : any
->findSymbolFromAlias : (alias: any, context: IAliasScopeContext) => any
+>symbol = findSymbolFromAlias(dottedExpr.operand2, context) : Symbol
+>symbol : Symbol
+>findSymbolFromAlias(dottedExpr.operand2, context) : Symbol
+>findSymbolFromAlias : (alias: any, context: IAliasScopeContext) => Symbol
 >dottedExpr.operand2 : any
 >dottedExpr : any
 >operand2 : any
@@ -648,13 +648,13 @@ module TypeScript {
         }
 
         if (symbol) {
->symbol : any
+>symbol : Symbol
 
             var symType = symbol.getType();
 >symType : any
 >symbol.getType() : any
 >symbol.getType : any
->symbol : any
+>symbol : Symbol
 >getType : any
 
             if (symType) {
@@ -682,7 +682,7 @@ module TypeScript {
         }
 
         return symbol;
->symbol : any
+>symbol : Symbol
     }
 
     export function preCollectImportTypes(ast: AST, parent: AST, context: TypeCollectionContext) {
@@ -729,9 +729,9 @@ module TypeScript {
 
         // REVIEW: technically, this call isn't strictly necessary, since we'll find the type during the call to resolveTypeMembers
         var aliasedModSymbol = findSymbolFromAlias(importDecl.alias, { topLevelScope: scopeChain, members: null, tcContext: context });
->aliasedModSymbol : any
->findSymbolFromAlias(importDecl.alias, { topLevelScope: scopeChain, members: null, tcContext: context }) : any
->findSymbolFromAlias : (alias: any, context: IAliasScopeContext) => any
+>aliasedModSymbol : Symbol
+>findSymbolFromAlias(importDecl.alias, { topLevelScope: scopeChain, members: null, tcContext: context }) : Symbol
+>findSymbolFromAlias : (alias: any, context: IAliasScopeContext) => Symbol
 >importDecl.alias : any
 >importDecl : any
 >alias : any
@@ -758,13 +758,13 @@ module TypeScript {
 >gloMod : any
 
         if (aliasedModSymbol) {
->aliasedModSymbol : any
+>aliasedModSymbol : Symbol
 
             var aliasedModType = aliasedModSymbol.getType();
 >aliasedModType : any
 >aliasedModSymbol.getType() : any
 >aliasedModSymbol.getType : any
->aliasedModSymbol : any
+>aliasedModSymbol : Symbol
 >getType : any
 
             if (aliasedModType) {

--- a/tests/baselines/reference/parserRealSource8.errors.txt
+++ b/tests/baselines/reference/parserRealSource8.errors.txt
@@ -7,15 +7,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(17,15): error TS
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(18,20): error TS2304: Cannot find name 'Type'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(19,14): error TS2304: Cannot find name 'FuncDecl'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(21,25): error TS2304: Cannot find name 'ScopeChain'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(32,40): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(32,51): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(41,43): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(47,41): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(47,52): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(47,62): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(48,46): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(50,24): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(56,26): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(33,33): error TS2339: Property 'isInstanceProperty' does not exist on type 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(42,18): error TS2339: Property 'isInstanceProperty' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(69,48): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(70,27): error TS2304: Cannot find name 'ModuleDeclaration'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(71,26): error TS2304: Cannot find name 'SymbolTableScope'.
@@ -51,8 +44,6 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(163,30): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(170,40): error TS2339: Property 'SymbolScopeBuilder' does not exist on type 'typeof TypeScript'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(176,50): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(177,25): error TS2304: Cannot find name 'FuncDecl'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(179,24): error TS2304: Cannot find name 'Symbol'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(180,29): error TS2304: Cannot find name 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(185,24): error TS2304: Cannot find name 'hasFlag'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(185,51): error TS2304: Cannot find name 'FncFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(195,41): error TS2304: Cannot find name 'hasFlag'.
@@ -66,12 +57,17 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(231,38): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(231,74): error TS2304: Cannot find name 'SymbolFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(237,27): error TS2304: Cannot find name 'FuncDecl'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(239,24): error TS2304: Cannot find name 'TypeSymbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(245,64): error TS2339: Property 'getType' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(246,47): error TS2304: Cannot find name 'SymbolScopeBuilder'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(246,68): error TS2304: Cannot find name 'TypeSymbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(255,31): error TS2339: Property 'declAST' does not exist on type 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(256,31): error TS2339: Property 'declAST' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(256,51): error TS2304: Cannot find name 'NodeType'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(257,23): error TS2304: Cannot find name 'FuncDecl'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(257,42): error TS2339: Property 'declAST' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(284,38): error TS2304: Cannot find name 'FncFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(286,55): error TS2304: Cannot find name 'NodeType'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(289,116): error TS2339: Property 'getType' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(292,43): error TS2304: Cannot find name 'SymbolFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(309,29): error TS2304: Cannot find name 'StringHashTable'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(310,31): error TS2304: Cannot find name 'ScopedMembers'.
@@ -134,7 +130,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(453,38): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error TS2304: Cannot find name 'Catch'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts (134 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts (130 errors) ====
     // Copyright (c) Microsoft. All rights reserved. Licensed under the Apache License, Version 2.0. 
     // See LICENSE.txt in the project root for complete license information.
     
@@ -185,11 +181,9 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error T
         }
     
         export function instanceCompare(a: Symbol, b: Symbol) {
-                                           ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
-                                                      ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             if (((a == null) || (!a.isInstanceProperty()))) {
+                                    ~~~~~~~~~~~~~~~~~~
+!!! error TS2339: Property 'isInstanceProperty' does not exist on type 'Symbol'.
                 return b;
             }
             else {
@@ -198,35 +192,23 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error T
         }
     
         export function instanceFilterStop(s: Symbol) {
-                                              ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             return s.isInstanceProperty();
+                     ~~~~~~~~~~~~~~~~~~
+!!! error TS2339: Property 'isInstanceProperty' does not exist on type 'Symbol'.
         }
     
         export class ScopeSearchFilter {
     
             constructor (public select: (a: Symbol, b: Symbol) =>Symbol,
-                                            ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
-                                                       ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
-                                                                 ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
                                 public stop: (s: Symbol) =>boolean) { }
-                                                 ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
     
             public result: Symbol = null;
-                           ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
     
             public reset() {
                 this.result = null;
             }
     
             public update(b: Symbol): boolean {
-                             ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
                 this.result = this.select(this.result, b);
                 if (this.result) {
                     return this.stop(this.result);
@@ -420,11 +402,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error T
 !!! error TS2304: Cannot find name 'FuncDecl'.
     
             var container: Symbol = null;
-                           ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             var localContainer: Symbol = null;
-                                ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
             if (funcDecl.type) {
                 localContainer = ast.type.symbol;
             }
@@ -516,6 +494,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error T
                     // to copy it over.  We don't set this by default because having a non-null member list will throw off assignment
                     // compatibility tests
                     if (outerFnc.type.members == null && container.getType().memberScope) {
+                                                                   ~~~~~~~
+!!! error TS2339: Property 'getType' does not exist on type 'Symbol'.
                         outerFnc.type.members = (<SymbolScopeBuilder>(<TypeSymbol>container).type.memberScope).valueMembers;
                                                   ~~~~~~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SymbolScopeBuilder'.
@@ -530,12 +510,18 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error T
                     if (!funcDecl.isConstructor &&
                         container &&
                         container.declAST &&
+                                  ~~~~~~~
+!!! error TS2339: Property 'declAST' does not exist on type 'Symbol'.
                         container.declAST.nodeType == NodeType.FuncDecl &&
+                                  ~~~~~~~
+!!! error TS2339: Property 'declAST' does not exist on type 'Symbol'.
                                                       ~~~~~~~~
 !!! error TS2304: Cannot find name 'NodeType'.
                         (<FuncDecl>container.declAST).isConstructor &&
                           ~~~~~~~~
 !!! error TS2304: Cannot find name 'FuncDecl'.
+                                             ~~~~~~~
+!!! error TS2339: Property 'declAST' does not exist on type 'Symbol'.
                         !funcDecl.isMethod()) {
                         funcScope = context.scopeChain.thisType.constructorScope;//locals;
                     }
@@ -572,6 +558,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error T
                         (fgSym && fgSym.isAccessor())) 
                 {
                     funcDecl.accessorSymbol = context.typeFlow.checker.createAccessorSymbol(funcDecl, fgSym, container.getType(), (funcDecl.isMethod() && isStatic), true, funcScope, container);
+                                                                                                                       ~~~~~~~
+!!! error TS2339: Property 'getType' does not exist on type 'Symbol'.
                 }
     
                 funcDecl.type.symbol.flags |= SymbolFlags.TypeSetDuringScopeAssignment;

--- a/tests/baselines/reference/parserRealSource8.symbols
+++ b/tests/baselines/reference/parserRealSource8.symbols
@@ -81,7 +81,9 @@ module TypeScript {
     export function instanceCompare(a: Symbol, b: Symbol) {
 >instanceCompare : Symbol(instanceCompare, Decl(parserRealSource8.ts, 29, 5))
 >a : Symbol(a, Decl(parserRealSource8.ts, 31, 36))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 >b : Symbol(b, Decl(parserRealSource8.ts, 31, 46))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         if (((a == null) || (!a.isInstanceProperty()))) {
 >a : Symbol(a, Decl(parserRealSource8.ts, 31, 36))
@@ -99,6 +101,7 @@ module TypeScript {
     export function instanceFilterStop(s: Symbol) {
 >instanceFilterStop : Symbol(instanceFilterStop, Decl(parserRealSource8.ts, 38, 5))
 >s : Symbol(s, Decl(parserRealSource8.ts, 40, 39))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         return s.isInstanceProperty();
 >s : Symbol(s, Decl(parserRealSource8.ts, 40, 39))
@@ -110,14 +113,19 @@ module TypeScript {
         constructor (public select: (a: Symbol, b: Symbol) =>Symbol,
 >select : Symbol(ScopeSearchFilter.select, Decl(parserRealSource8.ts, 46, 21))
 >a : Symbol(a, Decl(parserRealSource8.ts, 46, 37))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 >b : Symbol(b, Decl(parserRealSource8.ts, 46, 47))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
                             public stop: (s: Symbol) =>boolean) { }
 >stop : Symbol(ScopeSearchFilter.stop, Decl(parserRealSource8.ts, 46, 68))
 >s : Symbol(s, Decl(parserRealSource8.ts, 47, 42))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         public result: Symbol = null;
 >result : Symbol(ScopeSearchFilter.result, Decl(parserRealSource8.ts, 47, 67))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         public reset() {
 >reset : Symbol(ScopeSearchFilter.reset, Decl(parserRealSource8.ts, 49, 37))
@@ -131,6 +139,7 @@ module TypeScript {
         public update(b: Symbol): boolean {
 >update : Symbol(ScopeSearchFilter.update, Decl(parserRealSource8.ts, 53, 9))
 >b : Symbol(b, Decl(parserRealSource8.ts, 55, 22))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
             this.result = this.select(this.result, b);
 >this.result : Symbol(ScopeSearchFilter.result, Decl(parserRealSource8.ts, 47, 67))
@@ -524,9 +533,11 @@ module TypeScript {
 
         var container: Symbol = null;
 >container : Symbol(container, Decl(parserRealSource8.ts, 178, 11))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         var localContainer: Symbol = null;
 >localContainer : Symbol(localContainer, Decl(parserRealSource8.ts, 179, 11))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
         if (funcDecl.type) {
 >funcDecl : Symbol(funcDecl, Decl(parserRealSource8.ts, 176, 11))

--- a/tests/baselines/reference/parserRealSource8.types
+++ b/tests/baselines/reference/parserRealSource8.types
@@ -102,44 +102,44 @@ module TypeScript {
     }
 
     export function instanceCompare(a: Symbol, b: Symbol) {
->instanceCompare : (a: any, b: any) => any
->a : any
->Symbol : No type information available!
->b : any
->Symbol : No type information available!
+>instanceCompare : (a: Symbol, b: Symbol) => Symbol
+>a : Symbol
+>Symbol : Symbol
+>b : Symbol
+>Symbol : Symbol
 
         if (((a == null) || (!a.isInstanceProperty()))) {
 >((a == null) || (!a.isInstanceProperty())) : boolean
 >(a == null) || (!a.isInstanceProperty()) : boolean
 >(a == null) : boolean
 >a == null : boolean
->a : any
+>a : Symbol
 >null : null
 >(!a.isInstanceProperty()) : boolean
 >!a.isInstanceProperty() : boolean
 >a.isInstanceProperty() : any
 >a.isInstanceProperty : any
->a : any
+>a : Symbol
 >isInstanceProperty : any
 
             return b;
->b : any
+>b : Symbol
         }
         else {
             return a;
->a : any
+>a : Symbol
         }
     }
 
     export function instanceFilterStop(s: Symbol) {
->instanceFilterStop : (s: any) => any
->s : any
->Symbol : No type information available!
+>instanceFilterStop : (s: Symbol) => any
+>s : Symbol
+>Symbol : Symbol
 
         return s.isInstanceProperty();
 >s.isInstanceProperty() : any
 >s.isInstanceProperty : any
->s : any
+>s : Symbol
 >isInstanceProperty : any
     }
 
@@ -147,21 +147,21 @@ module TypeScript {
 >ScopeSearchFilter : ScopeSearchFilter
 
         constructor (public select: (a: Symbol, b: Symbol) =>Symbol,
->select : (a: any, b: any) => any
->a : any
->Symbol : No type information available!
->b : any
->Symbol : No type information available!
->Symbol : No type information available!
+>select : (a: Symbol, b: Symbol) => Symbol
+>a : Symbol
+>Symbol : Symbol
+>b : Symbol
+>Symbol : Symbol
+>Symbol : Symbol
 
                             public stop: (s: Symbol) =>boolean) { }
->stop : (s: any) => boolean
->s : any
->Symbol : No type information available!
+>stop : (s: Symbol) => boolean
+>s : Symbol
+>Symbol : Symbol
 
         public result: Symbol = null;
->result : any
->Symbol : No type information available!
+>result : Symbol
+>Symbol : Symbol
 >null : null
 
         public reset() {
@@ -169,44 +169,44 @@ module TypeScript {
 
             this.result = null;
 >this.result = null : null
->this.result : any
+>this.result : Symbol
 >this : this
->result : any
+>result : Symbol
 >null : null
         }
 
         public update(b: Symbol): boolean {
->update : (b: any) => boolean
->b : any
->Symbol : No type information available!
+>update : (b: Symbol) => boolean
+>b : Symbol
+>Symbol : Symbol
 
             this.result = this.select(this.result, b);
->this.result = this.select(this.result, b) : any
->this.result : any
+>this.result = this.select(this.result, b) : Symbol
+>this.result : Symbol
 >this : this
->result : any
->this.select(this.result, b) : any
->this.select : (a: any, b: any) => any
+>result : Symbol
+>this.select(this.result, b) : Symbol
+>this.select : (a: Symbol, b: Symbol) => Symbol
 >this : this
->select : (a: any, b: any) => any
->this.result : any
+>select : (a: Symbol, b: Symbol) => Symbol
+>this.result : Symbol
 >this : this
->result : any
->b : any
+>result : Symbol
+>b : Symbol
 
             if (this.result) {
->this.result : any
+>this.result : Symbol
 >this : this
->result : any
+>result : Symbol
 
                 return this.stop(this.result);
 >this.stop(this.result) : boolean
->this.stop : (s: any) => boolean
+>this.stop : (s: Symbol) => boolean
 >this : this
->stop : (s: any) => boolean
->this.result : any
+>stop : (s: Symbol) => boolean
+>this.result : Symbol
 >this : this
->result : any
+>result : Symbol
             }
             else {
                 return false;
@@ -219,8 +219,8 @@ module TypeScript {
 >instanceFilter : ScopeSearchFilter
 >new ScopeSearchFilter(instanceCompare, instanceFilterStop) : ScopeSearchFilter
 >ScopeSearchFilter : typeof ScopeSearchFilter
->instanceCompare : (a: any, b: any) => any
->instanceFilterStop : (s: any) => any
+>instanceCompare : (a: Symbol, b: Symbol) => Symbol
+>instanceFilterStop : (s: Symbol) => any
 
     export function preAssignModuleScopes(ast: AST, context: AssignScopeContext) {
 >preAssignModuleScopes : (ast: any, context: AssignScopeContext) => void
@@ -868,13 +868,13 @@ module TypeScript {
 >ast : any
 
         var container: Symbol = null;
->container : any
->Symbol : No type information available!
+>container : Symbol
+>Symbol : Symbol
 >null : null
 
         var localContainer: Symbol = null;
->localContainer : any
->Symbol : No type information available!
+>localContainer : Symbol
+>Symbol : Symbol
 >null : null
 
         if (funcDecl.type) {
@@ -884,7 +884,7 @@ module TypeScript {
 
             localContainer = ast.type.symbol;
 >localContainer = ast.type.symbol : any
->localContainer : any
+>localContainer : Symbol
 >ast.type.symbol : any
 >ast.type : any
 >ast : any
@@ -1123,7 +1123,7 @@ module TypeScript {
             }
             container = instType.symbol;
 >container = instType.symbol : any
->container : any
+>container : Symbol
 >instType.symbol : any
 >instType : any
 >symbol : any
@@ -1142,7 +1142,7 @@ module TypeScript {
             // sets the container to the class type's symbol (which is shared by the instance type)
             container = context.scopeChain.thisType.symbol;
 >container = context.scopeChain.thisType.symbol : any
->container : any
+>container : Symbol
 >context.scopeChain.thisType.symbol : any
 >context.scopeChain.thisType : any
 >context.scopeChain : any
@@ -1189,7 +1189,7 @@ module TypeScript {
 
                 container = context.scopeChain.fnc.type.symbol;
 >container = context.scopeChain.fnc.type.symbol : any
->container : any
+>container : Symbol
 >context.scopeChain.fnc.type.symbol : any
 >context.scopeChain.fnc.type : any
 >context.scopeChain.fnc : any
@@ -1250,7 +1250,7 @@ module TypeScript {
 >container.getType().memberScope : any
 >container.getType() : any
 >container.getType : any
->container : any
+>container : Symbol
 >getType : any
 >memberScope : any
 
@@ -1270,7 +1270,7 @@ module TypeScript {
 >(<TypeSymbol>container) : any
 ><TypeSymbol>container : any
 >TypeSymbol : No type information available!
->container : any
+>container : Symbol
 >type : any
 >memberScope : any
 >valueMembers : any
@@ -1308,25 +1308,25 @@ module TypeScript {
 >!funcDecl.isConstructor &&                    container &&                    container.declAST &&                    container.declAST.nodeType == NodeType.FuncDecl &&                    (<FuncDecl>container.declAST).isConstructor : any
 >!funcDecl.isConstructor &&                    container &&                    container.declAST &&                    container.declAST.nodeType == NodeType.FuncDecl : boolean
 >!funcDecl.isConstructor &&                    container &&                    container.declAST : any
->!funcDecl.isConstructor &&                    container : any
+>!funcDecl.isConstructor &&                    container : Symbol
 >!funcDecl.isConstructor : boolean
 >funcDecl.isConstructor : any
 >funcDecl : any
 >isConstructor : any
 
                     container &&
->container : any
+>container : Symbol
 
                     container.declAST &&
 >container.declAST : any
->container : any
+>container : Symbol
 >declAST : any
 
                     container.declAST.nodeType == NodeType.FuncDecl &&
 >container.declAST.nodeType == NodeType.FuncDecl : boolean
 >container.declAST.nodeType : any
 >container.declAST : any
->container : any
+>container : Symbol
 >declAST : any
 >nodeType : any
 >NodeType.FuncDecl : any
@@ -1339,7 +1339,7 @@ module TypeScript {
 ><FuncDecl>container.declAST : any
 >FuncDecl : No type information available!
 >container.declAST : any
->container : any
+>container : Symbol
 >declAST : any
 >isConstructor : any
 
@@ -1428,7 +1428,7 @@ module TypeScript {
 >checker : any
 >createFunctionSignature : any
 >funcDecl : any
->container : any
+>container : Symbol
 
                                                             funcScope, fgSym, fgSym == null);
 >funcScope : any
@@ -1441,7 +1441,7 @@ module TypeScript {
             if (!funcDecl.accessorSymbol && 
 >!funcDecl.accessorSymbol &&                 (funcDecl.fncFlags & FncFlags.ClassMethod) &&                container &&                 ((!fgSym || fgSym.declAST.nodeType != NodeType.FuncDecl) && funcDecl.isAccessor()) ||                     (fgSym && fgSym.isAccessor()) : any
 >!funcDecl.accessorSymbol &&                 (funcDecl.fncFlags & FncFlags.ClassMethod) &&                container &&                 ((!fgSym || fgSym.declAST.nodeType != NodeType.FuncDecl) && funcDecl.isAccessor()) : any
->!funcDecl.accessorSymbol &&                 (funcDecl.fncFlags & FncFlags.ClassMethod) &&                container : any
+>!funcDecl.accessorSymbol &&                 (funcDecl.fncFlags & FncFlags.ClassMethod) &&                container : Symbol
 >!funcDecl.accessorSymbol &&                 (funcDecl.fncFlags & FncFlags.ClassMethod) : number
 >!funcDecl.accessorSymbol : boolean
 >funcDecl.accessorSymbol : any
@@ -1459,7 +1459,7 @@ module TypeScript {
 >ClassMethod : any
 
                 container && 
->container : any
+>container : Symbol
 
                 ((!fgSym || fgSym.declAST.nodeType != NodeType.FuncDecl) && funcDecl.isAccessor()) || 
 >((!fgSym || fgSym.declAST.nodeType != NodeType.FuncDecl) && funcDecl.isAccessor()) : any
@@ -1508,7 +1508,7 @@ module TypeScript {
 >fgSym : any
 >container.getType() : any
 >container.getType : any
->container : any
+>container : Symbol
 >getType : any
 >(funcDecl.isMethod() && isStatic) : any
 >funcDecl.isMethod() && isStatic : any
@@ -1519,7 +1519,7 @@ module TypeScript {
 >isStatic : any
 >true : true
 >funcScope : any
->container : any
+>container : Symbol
             }
 
             funcDecl.type.symbol.flags |= SymbolFlags.TypeSetDuringScopeAssignment;
@@ -1665,7 +1665,7 @@ module TypeScript {
 >null : null
 >null : null
 >parentScope : any
->localContainer : any
+>localContainer : Symbol
 
         var statics = new SymbolScopeBuilder(funcStaticMembers, ambientFuncStaticMembers, null, null, parentScope, null);
 >statics : any

--- a/tests/baselines/reference/parserRealSource9.errors.txt
+++ b/tests/baselines/reference/parserRealSource9.errors.txt
@@ -18,8 +18,13 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(103,39): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(104,31): error TS2304: Cannot find name 'SymbolAggregateScope'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(110,52): error TS2304: Cannot find name 'ModuleDeclaration'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(145,34): error TS2304: Cannot find name 'SymbolScope'.
-tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(145,55): error TS2304: Cannot find name 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(146,25): error TS2339: Property 'bound' does not exist on type 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(148,53): error TS2339: Property 'unitIndex' does not exist on type 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(148,80): error TS2339: Property 'unitIndex' does not exist on type 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(149,75): error TS2339: Property 'unitIndex' does not exist on type 'Symbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(151,32): error TS2339: Property 'kind' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(152,26): error TS2304: Cannot find name 'SymbolKind'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(154,36): error TS2339: Property 'flags' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(154,44): error TS2304: Cannot find name 'SymbolFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(158,43): error TS2304: Cannot find name 'TypeSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(159,45): error TS2304: Cannot find name 'SymbolFlags'.
@@ -29,11 +34,12 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(185,26): error T
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(186,63): error TS2304: Cannot find name 'FieldSymbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(189,26): error TS2304: Cannot find name 'SymbolKind'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(191,51): error TS2304: Cannot find name 'ParameterSymbol'.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(197,20): error TS2339: Property 'bound' does not exist on type 'Symbol'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(200,28): error TS2304: Cannot find name 'SymbolScope'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(200,48): error TS2304: Cannot find name 'IHashTable'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts (33 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts (39 errors) ====
     // Copyright (c) Microsoft. All rights reserved. Licensed under the Apache License, Version 2.0. 
     // See LICENSE.txt in the project root for complete license information.
     
@@ -219,19 +225,29 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(200,48): error T
             public bindSymbol(scope: SymbolScope, symbol: Symbol) {
                                      ~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SymbolScope'.
-                                                          ~~~~~~
-!!! error TS2304: Cannot find name 'Symbol'.
                 if (!symbol.bound) {
+                            ~~~~~
+!!! error TS2339: Property 'bound' does not exist on type 'Symbol'.
                     var prevLocationInfo = this.checker.locationInfo;
                     if ((this.checker.units) && (symbol.unitIndex >= 0) && (symbol.unitIndex < this.checker.units.length)) {
+                                                        ~~~~~~~~~
+!!! error TS2339: Property 'unitIndex' does not exist on type 'Symbol'.
+                                                                                   ~~~~~~~~~
+!!! error TS2339: Property 'unitIndex' does not exist on type 'Symbol'.
                         this.checker.locationInfo = this.checker.units[symbol.unitIndex];
+                                                                              ~~~~~~~~~
+!!! error TS2339: Property 'unitIndex' does not exist on type 'Symbol'.
                     }
                     switch (symbol.kind()) {
+                                   ~~~~
+!!! error TS2339: Property 'kind' does not exist on type 'Symbol'.
                         case SymbolKind.Type:
                              ~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SymbolKind'.
     
                             if (symbol.flags & SymbolFlags.Bound) {
+                                       ~~~~~
+!!! error TS2339: Property 'flags' does not exist on type 'Symbol'.
                                                ~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SymbolFlags'.
                                 break;
@@ -293,6 +309,8 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(200,48): error T
                     this.checker.locationInfo = prevLocationInfo;
                 }
                 symbol.bound = true;
+                       ~~~~~
+!!! error TS2339: Property 'bound' does not exist on type 'Symbol'.
             }
     
             public bind(scope: SymbolScope, table: IHashTable) {

--- a/tests/baselines/reference/parserRealSource9.symbols
+++ b/tests/baselines/reference/parserRealSource9.symbols
@@ -478,6 +478,7 @@ module TypeScript {
 >bindSymbol : Symbol(Binder.bindSymbol, Decl(parserRealSource9.ts, 142, 9))
 >scope : Symbol(scope, Decl(parserRealSource9.ts, 144, 26))
 >symbol : Symbol(symbol, Decl(parserRealSource9.ts, 144, 45))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --))
 
             if (!symbol.bound) {
 >symbol : Symbol(symbol, Decl(parserRealSource9.ts, 144, 45))

--- a/tests/baselines/reference/parserRealSource9.types
+++ b/tests/baselines/reference/parserRealSource9.types
@@ -432,9 +432,9 @@ module TypeScript {
 
                     this.bindSymbol(scope, signature.parameters[j]);
 >this.bindSymbol(scope, signature.parameters[j]) : void
->this.bindSymbol : (scope: any, symbol: any) => void
+>this.bindSymbol : (scope: any, symbol: Symbol) => void
 >this : this
->bindSymbol : (scope: any, symbol: any) => void
+>bindSymbol : (scope: any, symbol: Symbol) => void
 >scope : any
 >signature.parameters[j] : any
 >signature.parameters : any
@@ -805,16 +805,16 @@ module TypeScript {
         }
 
         public bindSymbol(scope: SymbolScope, symbol: Symbol) {
->bindSymbol : (scope: any, symbol: any) => void
+>bindSymbol : (scope: any, symbol: Symbol) => void
 >scope : any
 >SymbolScope : No type information available!
->symbol : any
->Symbol : No type information available!
+>symbol : Symbol
+>Symbol : Symbol
 
             if (!symbol.bound) {
 >!symbol.bound : boolean
 >symbol.bound : any
->symbol : any
+>symbol : Symbol
 >bound : any
 
                 var prevLocationInfo = this.checker.locationInfo;
@@ -837,13 +837,13 @@ module TypeScript {
 >(symbol.unitIndex >= 0) : boolean
 >symbol.unitIndex >= 0 : boolean
 >symbol.unitIndex : any
->symbol : any
+>symbol : Symbol
 >unitIndex : any
 >0 : 0
 >(symbol.unitIndex < this.checker.units.length) : boolean
 >symbol.unitIndex < this.checker.units.length : boolean
 >symbol.unitIndex : any
->symbol : any
+>symbol : Symbol
 >unitIndex : any
 >this.checker.units.length : any
 >this.checker.units : any
@@ -867,13 +867,13 @@ module TypeScript {
 >checker : any
 >units : any
 >symbol.unitIndex : any
->symbol : any
+>symbol : Symbol
 >unitIndex : any
                 }
                 switch (symbol.kind()) {
 >symbol.kind() : any
 >symbol.kind : any
->symbol : any
+>symbol : Symbol
 >kind : any
 
                     case SymbolKind.Type:
@@ -884,7 +884,7 @@ module TypeScript {
                         if (symbol.flags & SymbolFlags.Bound) {
 >symbol.flags & SymbolFlags.Bound : number
 >symbol.flags : any
->symbol : any
+>symbol : Symbol
 >flags : any
 >SymbolFlags.Bound : any
 >SymbolFlags : any
@@ -897,7 +897,7 @@ module TypeScript {
 >typeSymbol : any
 ><TypeSymbol>symbol : any
 >TypeSymbol : No type information available!
->symbol : any
+>symbol : Symbol
 
                         typeSymbol.flags |= SymbolFlags.Bound;
 >typeSymbol.flags |= SymbolFlags.Bound : number
@@ -1075,7 +1075,7 @@ module TypeScript {
 >(<FieldSymbol>symbol) : any
 ><FieldSymbol>symbol : any
 >FieldSymbol : No type information available!
->symbol : any
+>symbol : Symbol
 >field : any
 >typeLink : any
 
@@ -1103,7 +1103,7 @@ module TypeScript {
 >(<ParameterSymbol>symbol) : any
 ><ParameterSymbol>symbol : any
 >ParameterSymbol : No type information available!
->symbol : any
+>symbol : Symbol
 >parameter : any
 >typeLink : any
 
@@ -1124,7 +1124,7 @@ module TypeScript {
             symbol.bound = true;
 >symbol.bound = true : true
 >symbol.bound : any
->symbol : any
+>symbol : Symbol
 >bound : any
 >true : true
         }

--- a/tests/baselines/reference/parserSymbolProperty1.symbols
+++ b/tests/baselines/reference/parserSymbolProperty1.symbols
@@ -5,6 +5,6 @@ interface I {
     [Symbol.iterator]: string;
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(parserSymbolProperty1.ts, 0, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 }

--- a/tests/baselines/reference/parserSymbolProperty2.symbols
+++ b/tests/baselines/reference/parserSymbolProperty2.symbols
@@ -5,6 +5,6 @@ interface I {
     [Symbol.unscopables](): string;
 >[Symbol.unscopables] : Symbol(I[Symbol.unscopables], Decl(parserSymbolProperty2.ts, 0, 13))
 >Symbol.unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/parserSymbolProperty3.symbols
+++ b/tests/baselines/reference/parserSymbolProperty3.symbols
@@ -5,6 +5,6 @@ declare class C {
     [Symbol.unscopables](): string;
 >[Symbol.unscopables] : Symbol(C[Symbol.unscopables], Decl(parserSymbolProperty3.ts, 0, 17))
 >Symbol.unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/parserSymbolProperty4.symbols
+++ b/tests/baselines/reference/parserSymbolProperty4.symbols
@@ -5,6 +5,6 @@ declare class C {
     [Symbol.toPrimitive]: string;
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(parserSymbolProperty4.ts, 0, 17))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/parserSymbolProperty5.symbols
+++ b/tests/baselines/reference/parserSymbolProperty5.symbols
@@ -5,6 +5,6 @@ class C {
     [Symbol.toPrimitive]: string;
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(parserSymbolProperty5.ts, 0, 9))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/parserSymbolProperty6.symbols
+++ b/tests/baselines/reference/parserSymbolProperty6.symbols
@@ -5,6 +5,6 @@ class C {
     [Symbol.toStringTag]: string = "";
 >[Symbol.toStringTag] : Symbol(C[Symbol.toStringTag], Decl(parserSymbolProperty6.ts, 0, 9))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/parserSymbolProperty7.symbols
+++ b/tests/baselines/reference/parserSymbolProperty7.symbols
@@ -5,6 +5,6 @@ class C {
     [Symbol.toStringTag](): void { }
 >[Symbol.toStringTag] : Symbol(C[Symbol.toStringTag], Decl(parserSymbolProperty7.ts, 0, 9))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/parserSymbolProperty8.symbols
+++ b/tests/baselines/reference/parserSymbolProperty8.symbols
@@ -5,6 +5,6 @@ var x: {
     [Symbol.toPrimitive](): string
 >[Symbol.toPrimitive] : Symbol([Symbol.toPrimitive], Decl(parserSymbolProperty8.ts, 0, 8))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/parserSymbolProperty9.symbols
+++ b/tests/baselines/reference/parserSymbolProperty9.symbols
@@ -5,6 +5,6 @@ var x: {
     [Symbol.toPrimitive]: string
 >[Symbol.toPrimitive] : Symbol([Symbol.toPrimitive], Decl(parserSymbolProperty9.ts, 0, 8))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/recursiveComplicatedClasses.symbols
+++ b/tests/baselines/reference/recursiveComplicatedClasses.symbols
@@ -10,13 +10,13 @@ class Signature {
 function aEnclosesB(a: Symbol) {
 >aEnclosesB : Symbol(aEnclosesB, Decl(recursiveComplicatedClasses.ts, 2, 1))
 >a : Symbol(a, Decl(recursiveComplicatedClasses.ts, 4, 20))
->Symbol : Symbol(Symbol, Decl(recursiveComplicatedClasses.ts, 6, 1))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(recursiveComplicatedClasses.ts, 6, 1))
 
     return true;
 }
 
 class Symbol {
->Symbol : Symbol(Symbol, Decl(recursiveComplicatedClasses.ts, 6, 1))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(recursiveComplicatedClasses.ts, 6, 1))
 
     public bound: boolean;
 >bound : Symbol(Symbol.bound, Decl(recursiveComplicatedClasses.ts, 8, 14))
@@ -36,7 +36,7 @@ class Symbol {
 }
 class InferenceSymbol extends Symbol {
 >InferenceSymbol : Symbol(InferenceSymbol, Decl(recursiveComplicatedClasses.ts, 15, 1))
->Symbol : Symbol(Symbol, Decl(recursiveComplicatedClasses.ts, 6, 1))
+>Symbol : Symbol(Symbol, Decl(lib.d.ts, --, --), Decl(recursiveComplicatedClasses.ts, 6, 1))
 }
 
 class ParameterSymbol extends InferenceSymbol {

--- a/tests/baselines/reference/superSymbolIndexedAccess1.symbols
+++ b/tests/baselines/reference/superSymbolIndexedAccess1.symbols
@@ -2,7 +2,7 @@
 var symbol = Symbol.for('myThing');
 >symbol : Symbol(symbol, Decl(superSymbolIndexedAccess1.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 class Foo {

--- a/tests/baselines/reference/superSymbolIndexedAccess2.symbols
+++ b/tests/baselines/reference/superSymbolIndexedAccess2.symbols
@@ -5,7 +5,7 @@ class Foo {
     [Symbol.isConcatSpreadable]() {
 >[Symbol.isConcatSpreadable] : Symbol(Foo[Symbol.isConcatSpreadable], Decl(superSymbolIndexedAccess2.ts, 0, 11))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return 0;
@@ -19,13 +19,13 @@ class Bar extends Foo {
     [Symbol.isConcatSpreadable]() {
 >[Symbol.isConcatSpreadable] : Symbol(Bar[Symbol.isConcatSpreadable], Decl(superSymbolIndexedAccess2.ts, 6, 23))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return super[Symbol.isConcatSpreadable]();
 >super : Symbol(Foo, Decl(superSymbolIndexedAccess2.ts, 0, 0))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
     }
 }

--- a/tests/baselines/reference/superSymbolIndexedAccess3.symbols
+++ b/tests/baselines/reference/superSymbolIndexedAccess3.symbols
@@ -2,7 +2,7 @@
 var symbol = Symbol.for('myThing');
 >symbol : Symbol(symbol, Decl(superSymbolIndexedAccess3.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 class Foo {

--- a/tests/baselines/reference/superSymbolIndexedAccess4.symbols
+++ b/tests/baselines/reference/superSymbolIndexedAccess4.symbols
@@ -2,7 +2,7 @@
 var symbol = Symbol.for('myThing');
 >symbol : Symbol(symbol, Decl(superSymbolIndexedAccess4.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 class Bar {

--- a/tests/baselines/reference/symbolDeclarationEmit1.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit1.symbols
@@ -5,6 +5,6 @@ class C {
     [Symbol.toPrimitive]: number;
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit1.ts, 0, 9))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit10.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit10.symbols
@@ -5,13 +5,13 @@ var obj = {
     get [Symbol.isConcatSpreadable]() { return '' },
 >[Symbol.isConcatSpreadable] : Symbol([Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit10.ts, 0, 11), Decl(symbolDeclarationEmit10.ts, 1, 52))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     set [Symbol.isConcatSpreadable](x) { }
 >[Symbol.isConcatSpreadable] : Symbol([Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit10.ts, 0, 11), Decl(symbolDeclarationEmit10.ts, 1, 52))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit10.ts, 2, 36))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit11.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit11.symbols
@@ -5,25 +5,25 @@ class C {
     static [Symbol.iterator] = 0;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolDeclarationEmit11.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     static [Symbol.isConcatSpreadable]() { }
 >[Symbol.isConcatSpreadable] : Symbol(C[Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit11.ts, 1, 33))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     static get [Symbol.toPrimitive]() { return ""; }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit11.ts, 2, 44), Decl(symbolDeclarationEmit11.ts, 3, 52))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     static set [Symbol.toPrimitive](x) { }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit11.ts, 2, 44), Decl(symbolDeclarationEmit11.ts, 3, 52))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit11.ts, 4, 36))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit12.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit12.symbols
@@ -11,14 +11,14 @@ module M {
         [Symbol.iterator]: I;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolDeclarationEmit12.ts, 2, 20))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >I : Symbol(I, Decl(symbolDeclarationEmit12.ts, 0, 10))
 
         [Symbol.toPrimitive](x: I) { }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 3, 29))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit12.ts, 4, 29))
 >I : Symbol(I, Decl(symbolDeclarationEmit12.ts, 0, 10))
@@ -26,7 +26,7 @@ module M {
         [Symbol.isConcatSpreadable](): I {
 >[Symbol.isConcatSpreadable] : Symbol(C[Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit12.ts, 4, 38))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >I : Symbol(I, Decl(symbolDeclarationEmit12.ts, 0, 10))
 
@@ -36,14 +36,14 @@ module M {
         get [Symbol.toPrimitive]() { return undefined; }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 7, 9))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >undefined : Symbol(undefined)
 
         set [Symbol.toPrimitive](x: I) { }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 8, 56))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit12.ts, 9, 33))
 >I : Symbol(I, Decl(symbolDeclarationEmit12.ts, 0, 10))

--- a/tests/baselines/reference/symbolDeclarationEmit13.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit13.symbols
@@ -5,13 +5,13 @@ class C {
     get [Symbol.toPrimitive]() { return ""; }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit13.ts, 0, 9))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     set [Symbol.toStringTag](x) { }
 >[Symbol.toStringTag] : Symbol(C[Symbol.toStringTag], Decl(symbolDeclarationEmit13.ts, 1, 45))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit13.ts, 2, 29))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit14.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit14.symbols
@@ -5,12 +5,12 @@ class C {
     get [Symbol.toPrimitive]() { return ""; }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit14.ts, 0, 9))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     get [Symbol.toStringTag]() { return ""; }
 >[Symbol.toStringTag] : Symbol(C[Symbol.toStringTag], Decl(symbolDeclarationEmit14.ts, 1, 45))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit2.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit2.symbols
@@ -5,6 +5,6 @@ class C {
     [Symbol.toPrimitive] = "";
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit2.ts, 0, 9))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit3.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit3.symbols
@@ -5,21 +5,21 @@ class C {
     [Symbol.toPrimitive](x: number);
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit3.ts, 0, 9), Decl(symbolDeclarationEmit3.ts, 1, 36), Decl(symbolDeclarationEmit3.ts, 2, 36))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit3.ts, 1, 25))
 
     [Symbol.toPrimitive](x: string);
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit3.ts, 0, 9), Decl(symbolDeclarationEmit3.ts, 1, 36), Decl(symbolDeclarationEmit3.ts, 2, 36))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit3.ts, 2, 25))
 
     [Symbol.toPrimitive](x: any) { }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit3.ts, 0, 9), Decl(symbolDeclarationEmit3.ts, 1, 36), Decl(symbolDeclarationEmit3.ts, 2, 36))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit3.ts, 3, 25))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit4.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit4.symbols
@@ -5,13 +5,13 @@ class C {
     get [Symbol.toPrimitive]() { return ""; }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit4.ts, 0, 9), Decl(symbolDeclarationEmit4.ts, 1, 45))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     set [Symbol.toPrimitive](x) { }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit4.ts, 0, 9), Decl(symbolDeclarationEmit4.ts, 1, 45))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolDeclarationEmit4.ts, 2, 29))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit5.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit5.symbols
@@ -5,6 +5,6 @@ interface I {
     [Symbol.isConcatSpreadable](): string;
 >[Symbol.isConcatSpreadable] : Symbol(I[Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit5.ts, 0, 13))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit6.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit6.symbols
@@ -5,6 +5,6 @@ interface I {
     [Symbol.isConcatSpreadable]: string;
 >[Symbol.isConcatSpreadable] : Symbol(I[Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit6.ts, 0, 13))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit7.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit7.symbols
@@ -5,6 +5,6 @@ var obj: {
     [Symbol.isConcatSpreadable]: string;
 >[Symbol.isConcatSpreadable] : Symbol([Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit7.ts, 0, 10))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit8.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit8.symbols
@@ -5,6 +5,6 @@ var obj = {
     [Symbol.isConcatSpreadable]: 0
 >[Symbol.isConcatSpreadable] : Symbol([Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit8.ts, 0, 11))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolDeclarationEmit9.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit9.symbols
@@ -5,6 +5,6 @@ var obj = {
     [Symbol.isConcatSpreadable]() { }
 >[Symbol.isConcatSpreadable] : Symbol([Symbol.isConcatSpreadable], Decl(symbolDeclarationEmit9.ts, 0, 11))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolProperty10.symbols
+++ b/tests/baselines/reference/symbolProperty10.symbols
@@ -5,7 +5,7 @@ class C {
     [Symbol.iterator]: { x; y };
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty10.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty10.ts, 1, 24))
 >y : Symbol(y, Decl(symbolProperty10.ts, 1, 27))
@@ -16,7 +16,7 @@ interface I {
     [Symbol.iterator]?: { x };
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty10.ts, 3, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty10.ts, 4, 25))
 }

--- a/tests/baselines/reference/symbolProperty11.symbols
+++ b/tests/baselines/reference/symbolProperty11.symbols
@@ -8,7 +8,7 @@ interface I {
     [Symbol.iterator]?: { x };
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty11.ts, 1, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty11.ts, 2, 25))
 }

--- a/tests/baselines/reference/symbolProperty12.symbols
+++ b/tests/baselines/reference/symbolProperty12.symbols
@@ -5,7 +5,7 @@ class C {
     private [Symbol.iterator]: { x };
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty12.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty12.ts, 1, 32))
 }
@@ -15,7 +15,7 @@ interface I {
     [Symbol.iterator]: { x };
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty12.ts, 3, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty12.ts, 4, 24))
 }

--- a/tests/baselines/reference/symbolProperty13.symbols
+++ b/tests/baselines/reference/symbolProperty13.symbols
@@ -5,7 +5,7 @@ class C {
     [Symbol.iterator]: { x; y };
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty13.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty13.ts, 1, 24))
 >y : Symbol(y, Decl(symbolProperty13.ts, 1, 27))
@@ -16,7 +16,7 @@ interface I {
     [Symbol.iterator]: { x };
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty13.ts, 3, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty13.ts, 4, 24))
 }

--- a/tests/baselines/reference/symbolProperty14.symbols
+++ b/tests/baselines/reference/symbolProperty14.symbols
@@ -5,7 +5,7 @@ class C {
     [Symbol.iterator]: { x; y };
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty14.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty14.ts, 1, 24))
 >y : Symbol(y, Decl(symbolProperty14.ts, 1, 27))
@@ -16,7 +16,7 @@ interface I {
     [Symbol.iterator]?: { x };
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty14.ts, 3, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty14.ts, 4, 25))
 }

--- a/tests/baselines/reference/symbolProperty15.symbols
+++ b/tests/baselines/reference/symbolProperty15.symbols
@@ -8,7 +8,7 @@ interface I {
     [Symbol.iterator]?: { x };
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty15.ts, 1, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty15.ts, 2, 25))
 }

--- a/tests/baselines/reference/symbolProperty16.symbols
+++ b/tests/baselines/reference/symbolProperty16.symbols
@@ -5,7 +5,7 @@ class C {
     private [Symbol.iterator]: { x };
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty16.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty16.ts, 1, 32))
 }
@@ -15,7 +15,7 @@ interface I {
     [Symbol.iterator]: { x };
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty16.ts, 3, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty16.ts, 4, 24))
 }

--- a/tests/baselines/reference/symbolProperty17.symbols
+++ b/tests/baselines/reference/symbolProperty17.symbols
@@ -5,7 +5,7 @@ interface I {
     [Symbol.iterator]: number;
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty17.ts, 0, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     [s: symbol]: string;
@@ -23,6 +23,6 @@ var it = i[Symbol.iterator];
 >it : Symbol(it, Decl(symbolProperty17.ts, 7, 3))
 >i : Symbol(i, Decl(symbolProperty17.ts, 6, 3))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty18.symbols
+++ b/tests/baselines/reference/symbolProperty18.symbols
@@ -5,19 +5,19 @@ var i = {
     [Symbol.iterator]: 0,
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(symbolProperty18.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     [Symbol.toStringTag]() { return "" },
 >[Symbol.toStringTag] : Symbol([Symbol.toStringTag], Decl(symbolProperty18.ts, 1, 25))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     set [Symbol.toPrimitive](p: boolean) { }
 >[Symbol.toPrimitive] : Symbol([Symbol.toPrimitive], Decl(symbolProperty18.ts, 2, 41))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >p : Symbol(p, Decl(symbolProperty18.ts, 3, 29))
 }
@@ -26,19 +26,19 @@ var it = i[Symbol.iterator];
 >it : Symbol(it, Decl(symbolProperty18.ts, 6, 3))
 >i : Symbol(i, Decl(symbolProperty18.ts, 0, 3))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 var str = i[Symbol.toStringTag]();
 >str : Symbol(str, Decl(symbolProperty18.ts, 7, 3))
 >i : Symbol(i, Decl(symbolProperty18.ts, 0, 3))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 i[Symbol.toPrimitive] = false;
 >i : Symbol(i, Decl(symbolProperty18.ts, 0, 3))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty19.symbols
+++ b/tests/baselines/reference/symbolProperty19.symbols
@@ -5,14 +5,14 @@ var i = {
     [Symbol.iterator]: { p: null },
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(symbolProperty19.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >p : Symbol(p, Decl(symbolProperty19.ts, 1, 24))
 
     [Symbol.toStringTag]() { return { p: undefined }; }
 >[Symbol.toStringTag] : Symbol([Symbol.toStringTag], Decl(symbolProperty19.ts, 1, 35))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >p : Symbol(p, Decl(symbolProperty19.ts, 2, 37))
 >undefined : Symbol(undefined)
@@ -22,13 +22,13 @@ var it = i[Symbol.iterator];
 >it : Symbol(it, Decl(symbolProperty19.ts, 5, 3))
 >i : Symbol(i, Decl(symbolProperty19.ts, 0, 3))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 var str = i[Symbol.toStringTag]();
 >str : Symbol(str, Decl(symbolProperty19.ts, 6, 3))
 >i : Symbol(i, Decl(symbolProperty19.ts, 0, 3))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty2.symbols
+++ b/tests/baselines/reference/symbolProperty2.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/Symbols/symbolProperty2.ts ===
 var s = Symbol();
 >s : Symbol(s, Decl(symbolProperty2.ts, 0, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 var x = {
 >x : Symbol(x, Decl(symbolProperty2.ts, 1, 3))

--- a/tests/baselines/reference/symbolProperty20.symbols
+++ b/tests/baselines/reference/symbolProperty20.symbols
@@ -5,14 +5,14 @@ interface I {
     [Symbol.iterator]: (s: string) => string;
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty20.ts, 0, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >s : Symbol(s, Decl(symbolProperty20.ts, 1, 24))
 
     [Symbol.toStringTag](s: number): number;
 >[Symbol.toStringTag] : Symbol(I[Symbol.toStringTag], Decl(symbolProperty20.ts, 1, 45))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >s : Symbol(s, Decl(symbolProperty20.ts, 2, 25))
 }
@@ -24,7 +24,7 @@ var i: I = {
     [Symbol.iterator]: s => s,
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(symbolProperty20.ts, 5, 12))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >s : Symbol(s, Decl(symbolProperty20.ts, 6, 22))
 >s : Symbol(s, Decl(symbolProperty20.ts, 6, 22))
@@ -32,7 +32,7 @@ var i: I = {
     [Symbol.toStringTag](n) { return n; }
 >[Symbol.toStringTag] : Symbol([Symbol.toStringTag], Decl(symbolProperty20.ts, 6, 30))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >n : Symbol(n, Decl(symbolProperty20.ts, 7, 25))
 >n : Symbol(n, Decl(symbolProperty20.ts, 7, 25))

--- a/tests/baselines/reference/symbolProperty21.symbols
+++ b/tests/baselines/reference/symbolProperty21.symbols
@@ -7,14 +7,14 @@ interface I<T, U> {
     [Symbol.unscopables]: T;
 >[Symbol.unscopables] : Symbol(I[Symbol.unscopables], Decl(symbolProperty21.ts, 0, 19))
 >Symbol.unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >T : Symbol(T, Decl(symbolProperty21.ts, 0, 12))
 
     [Symbol.isConcatSpreadable]: U;
 >[Symbol.isConcatSpreadable] : Symbol(I[Symbol.isConcatSpreadable], Decl(symbolProperty21.ts, 1, 28))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >U : Symbol(U, Decl(symbolProperty21.ts, 0, 14))
 }
@@ -38,19 +38,19 @@ foo({
     [Symbol.isConcatSpreadable]: "",
 >[Symbol.isConcatSpreadable] : Symbol([Symbol.isConcatSpreadable], Decl(symbolProperty21.ts, 7, 5))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [Symbol.toPrimitive]: 0,
 >[Symbol.toPrimitive] : Symbol([Symbol.toPrimitive], Decl(symbolProperty21.ts, 8, 36))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [Symbol.unscopables]: true
 >[Symbol.unscopables] : Symbol([Symbol.unscopables], Decl(symbolProperty21.ts, 9, 28))
 >Symbol.unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 });

--- a/tests/baselines/reference/symbolProperty22.symbols
+++ b/tests/baselines/reference/symbolProperty22.symbols
@@ -7,7 +7,7 @@ interface I<T, U> {
     [Symbol.unscopables](x: T): U;
 >[Symbol.unscopables] : Symbol(I[Symbol.unscopables], Decl(symbolProperty22.ts, 0, 19))
 >Symbol.unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty22.ts, 1, 25))
 >T : Symbol(T, Decl(symbolProperty22.ts, 0, 12))
@@ -30,7 +30,7 @@ foo("", { [Symbol.unscopables]: s => s.length });
 >foo : Symbol(foo, Decl(symbolProperty22.ts, 2, 1))
 >[Symbol.unscopables] : Symbol([Symbol.unscopables], Decl(symbolProperty22.ts, 6, 9))
 >Symbol.unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >s : Symbol(s, Decl(symbolProperty22.ts, 6, 31))
 >s.length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))

--- a/tests/baselines/reference/symbolProperty23.symbols
+++ b/tests/baselines/reference/symbolProperty23.symbols
@@ -5,7 +5,7 @@ interface I {
     [Symbol.toPrimitive]: () => boolean;
 >[Symbol.toPrimitive] : Symbol(I[Symbol.toPrimitive], Decl(symbolProperty23.ts, 0, 13))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }
 
@@ -16,7 +16,7 @@ class C implements I {
     [Symbol.toPrimitive]() {
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolProperty23.ts, 4, 22))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return true;

--- a/tests/baselines/reference/symbolProperty24.symbols
+++ b/tests/baselines/reference/symbolProperty24.symbols
@@ -5,7 +5,7 @@ interface I {
     [Symbol.toPrimitive]: () => boolean;
 >[Symbol.toPrimitive] : Symbol(I[Symbol.toPrimitive], Decl(symbolProperty24.ts, 0, 13))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }
 
@@ -16,7 +16,7 @@ class C implements I {
     [Symbol.toPrimitive]() {
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolProperty24.ts, 4, 22))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";

--- a/tests/baselines/reference/symbolProperty25.symbols
+++ b/tests/baselines/reference/symbolProperty25.symbols
@@ -5,7 +5,7 @@ interface I {
     [Symbol.toPrimitive]: () => boolean;
 >[Symbol.toPrimitive] : Symbol(I[Symbol.toPrimitive], Decl(symbolProperty25.ts, 0, 13))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }
 
@@ -16,7 +16,7 @@ class C implements I {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C[Symbol.toStringTag], Decl(symbolProperty25.ts, 4, 22))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";

--- a/tests/baselines/reference/symbolProperty26.symbols
+++ b/tests/baselines/reference/symbolProperty26.symbols
@@ -5,7 +5,7 @@ class C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty26.ts, 0, 10))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";
@@ -19,7 +19,7 @@ class C2 extends C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C2[Symbol.toStringTag], Decl(symbolProperty26.ts, 6, 21))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";

--- a/tests/baselines/reference/symbolProperty27.symbols
+++ b/tests/baselines/reference/symbolProperty27.symbols
@@ -5,7 +5,7 @@ class C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty27.ts, 0, 10))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return {};
@@ -19,7 +19,7 @@ class C2 extends C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C2[Symbol.toStringTag], Decl(symbolProperty27.ts, 6, 21))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";

--- a/tests/baselines/reference/symbolProperty28.symbols
+++ b/tests/baselines/reference/symbolProperty28.symbols
@@ -5,7 +5,7 @@ class C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty28.ts, 0, 10))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return { x: "" };
@@ -26,7 +26,7 @@ var obj = c[Symbol.toStringTag]().x;
 >c[Symbol.toStringTag]().x : Symbol(x, Decl(symbolProperty28.ts, 2, 16))
 >c : Symbol(c, Decl(symbolProperty28.ts, 8, 3))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty28.ts, 2, 16))
 

--- a/tests/baselines/reference/symbolProperty29.symbols
+++ b/tests/baselines/reference/symbolProperty29.symbols
@@ -5,7 +5,7 @@ class C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty29.ts, 0, 10))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return { x: "" };

--- a/tests/baselines/reference/symbolProperty3.symbols
+++ b/tests/baselines/reference/symbolProperty3.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/Symbols/symbolProperty3.ts ===
 var s = Symbol;
 >s : Symbol(s, Decl(symbolProperty3.ts, 0, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 var x = {
 >x : Symbol(x, Decl(symbolProperty3.ts, 1, 3))

--- a/tests/baselines/reference/symbolProperty30.symbols
+++ b/tests/baselines/reference/symbolProperty30.symbols
@@ -5,7 +5,7 @@ class C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty30.ts, 0, 10))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return { x: "" };

--- a/tests/baselines/reference/symbolProperty31.symbols
+++ b/tests/baselines/reference/symbolProperty31.symbols
@@ -5,7 +5,7 @@ class C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty31.ts, 0, 10))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return { x: "" };

--- a/tests/baselines/reference/symbolProperty32.symbols
+++ b/tests/baselines/reference/symbolProperty32.symbols
@@ -5,7 +5,7 @@ class C1 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty32.ts, 0, 10))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return { x: "" };

--- a/tests/baselines/reference/symbolProperty33.symbols
+++ b/tests/baselines/reference/symbolProperty33.symbols
@@ -6,7 +6,7 @@ class C1 extends C2 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty33.ts, 0, 21))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return { x: "" };

--- a/tests/baselines/reference/symbolProperty34.symbols
+++ b/tests/baselines/reference/symbolProperty34.symbols
@@ -6,7 +6,7 @@ class C1 extends C2 {
     [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C1[Symbol.toStringTag], Decl(symbolProperty34.ts, 0, 21))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return { x: "" };

--- a/tests/baselines/reference/symbolProperty35.symbols
+++ b/tests/baselines/reference/symbolProperty35.symbols
@@ -5,7 +5,7 @@ interface I1 {
     [Symbol.toStringTag](): { x: string }
 >[Symbol.toStringTag] : Symbol(I1[Symbol.toStringTag], Decl(symbolProperty35.ts, 0, 14))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty35.ts, 1, 29))
 }
@@ -15,7 +15,7 @@ interface I2 {
     [Symbol.toStringTag](): { x: number }
 >[Symbol.toStringTag] : Symbol(I2[Symbol.toStringTag], Decl(symbolProperty35.ts, 3, 14))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty35.ts, 4, 29))
 }

--- a/tests/baselines/reference/symbolProperty36.symbols
+++ b/tests/baselines/reference/symbolProperty36.symbols
@@ -5,12 +5,12 @@ var x = {
     [Symbol.isConcatSpreadable]: 0,
 >[Symbol.isConcatSpreadable] : Symbol([Symbol.isConcatSpreadable], Decl(symbolProperty36.ts, 0, 9), Decl(symbolProperty36.ts, 1, 35))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [Symbol.isConcatSpreadable]: 1
 >[Symbol.isConcatSpreadable] : Symbol([Symbol.isConcatSpreadable], Decl(symbolProperty36.ts, 0, 9), Decl(symbolProperty36.ts, 1, 35))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolProperty37.symbols
+++ b/tests/baselines/reference/symbolProperty37.symbols
@@ -5,12 +5,12 @@ interface I {
     [Symbol.isConcatSpreadable]: string;
 >[Symbol.isConcatSpreadable] : Symbol(I[Symbol.isConcatSpreadable], Decl(symbolProperty37.ts, 0, 13), Decl(symbolProperty37.ts, 1, 40))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [Symbol.isConcatSpreadable]: string;
 >[Symbol.isConcatSpreadable] : Symbol(I[Symbol.isConcatSpreadable], Decl(symbolProperty37.ts, 0, 13), Decl(symbolProperty37.ts, 1, 40))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolProperty38.symbols
+++ b/tests/baselines/reference/symbolProperty38.symbols
@@ -5,7 +5,7 @@ interface I {
     [Symbol.isConcatSpreadable]: string;
 >[Symbol.isConcatSpreadable] : Symbol(I[Symbol.isConcatSpreadable], Decl(symbolProperty38.ts, 0, 13), Decl(symbolProperty38.ts, 3, 13))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }
 interface I {
@@ -14,6 +14,6 @@ interface I {
     [Symbol.isConcatSpreadable]: string;
 >[Symbol.isConcatSpreadable] : Symbol(I[Symbol.isConcatSpreadable], Decl(symbolProperty38.ts, 0, 13), Decl(symbolProperty38.ts, 3, 13))
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolProperty39.symbols
+++ b/tests/baselines/reference/symbolProperty39.symbols
@@ -5,21 +5,21 @@ class C {
     [Symbol.iterator](x: string): string;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty39.ts, 0, 9), Decl(symbolProperty39.ts, 1, 41), Decl(symbolProperty39.ts, 2, 41), Decl(symbolProperty39.ts, 5, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty39.ts, 1, 22))
 
     [Symbol.iterator](x: number): number;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty39.ts, 0, 9), Decl(symbolProperty39.ts, 1, 41), Decl(symbolProperty39.ts, 2, 41), Decl(symbolProperty39.ts, 5, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty39.ts, 2, 22))
 
     [Symbol.iterator](x: any) {
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty39.ts, 0, 9), Decl(symbolProperty39.ts, 1, 41), Decl(symbolProperty39.ts, 2, 41), Decl(symbolProperty39.ts, 5, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty39.ts, 3, 22))
 
@@ -29,7 +29,7 @@ class C {
     [Symbol.iterator](x: any) {
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty39.ts, 0, 9), Decl(symbolProperty39.ts, 1, 41), Decl(symbolProperty39.ts, 2, 41), Decl(symbolProperty39.ts, 5, 5))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty39.ts, 6, 22))
 

--- a/tests/baselines/reference/symbolProperty4.symbols
+++ b/tests/baselines/reference/symbolProperty4.symbols
@@ -4,15 +4,15 @@ var x = {
 
     [Symbol()]: 0,
 >[Symbol()] : Symbol([Symbol()], Decl(symbolProperty4.ts, 0, 9))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     [Symbol()]() { },
 >[Symbol()] : Symbol([Symbol()], Decl(symbolProperty4.ts, 1, 18))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     get [Symbol()]() {
 >[Symbol()] : Symbol([Symbol()], Decl(symbolProperty4.ts, 2, 21))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
         return 0;
     }

--- a/tests/baselines/reference/symbolProperty40.symbols
+++ b/tests/baselines/reference/symbolProperty40.symbols
@@ -5,21 +5,21 @@ class C {
     [Symbol.iterator](x: string): string;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty40.ts, 0, 9), Decl(symbolProperty40.ts, 1, 41), Decl(symbolProperty40.ts, 2, 41))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty40.ts, 1, 22))
 
     [Symbol.iterator](x: number): number;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty40.ts, 0, 9), Decl(symbolProperty40.ts, 1, 41), Decl(symbolProperty40.ts, 2, 41))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty40.ts, 2, 22))
 
     [Symbol.iterator](x: any) {
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty40.ts, 0, 9), Decl(symbolProperty40.ts, 1, 41), Decl(symbolProperty40.ts, 2, 41))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty40.ts, 3, 22))
 
@@ -35,12 +35,12 @@ var c = new C;
 c[Symbol.iterator]("");
 >c : Symbol(c, Decl(symbolProperty40.ts, 8, 3))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 c[Symbol.iterator](0);
 >c : Symbol(c, Decl(symbolProperty40.ts, 8, 3))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty41.symbols
+++ b/tests/baselines/reference/symbolProperty41.symbols
@@ -5,7 +5,7 @@ class C {
     [Symbol.iterator](x: string): { x: string };
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty41.ts, 0, 9), Decl(symbolProperty41.ts, 1, 48), Decl(symbolProperty41.ts, 2, 64))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty41.ts, 1, 22))
 >x : Symbol(x, Decl(symbolProperty41.ts, 1, 35))
@@ -13,7 +13,7 @@ class C {
     [Symbol.iterator](x: "hello"): { x: string; hello: string };
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty41.ts, 0, 9), Decl(symbolProperty41.ts, 1, 48), Decl(symbolProperty41.ts, 2, 64))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty41.ts, 2, 22))
 >x : Symbol(x, Decl(symbolProperty41.ts, 2, 36))
@@ -22,7 +22,7 @@ class C {
     [Symbol.iterator](x: any) {
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty41.ts, 0, 9), Decl(symbolProperty41.ts, 1, 48), Decl(symbolProperty41.ts, 2, 64))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty41.ts, 3, 22))
 
@@ -38,12 +38,12 @@ var c = new C;
 c[Symbol.iterator]("");
 >c : Symbol(c, Decl(symbolProperty41.ts, 8, 3))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 c[Symbol.iterator]("hello");
 >c : Symbol(c, Decl(symbolProperty41.ts, 8, 3))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty42.symbols
+++ b/tests/baselines/reference/symbolProperty42.symbols
@@ -5,21 +5,21 @@ class C {
     [Symbol.iterator](x: string): string;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty42.ts, 0, 9), Decl(symbolProperty42.ts, 2, 48))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty42.ts, 1, 22))
 
     static [Symbol.iterator](x: number): number;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty42.ts, 1, 41))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty42.ts, 2, 29))
 
     [Symbol.iterator](x: any) {
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty42.ts, 0, 9), Decl(symbolProperty42.ts, 2, 48))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty42.ts, 3, 22))
 

--- a/tests/baselines/reference/symbolProperty43.symbols
+++ b/tests/baselines/reference/symbolProperty43.symbols
@@ -5,14 +5,14 @@ class C {
     [Symbol.iterator](x: string): string;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty43.ts, 0, 9), Decl(symbolProperty43.ts, 1, 41))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty43.ts, 1, 22))
 
     [Symbol.iterator](x: number): number;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty43.ts, 0, 9), Decl(symbolProperty43.ts, 1, 41))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty43.ts, 2, 22))
 }

--- a/tests/baselines/reference/symbolProperty44.symbols
+++ b/tests/baselines/reference/symbolProperty44.symbols
@@ -5,7 +5,7 @@ class C {
     get [Symbol.hasInstance]() {
 >[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty44.ts, 0, 9))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";
@@ -13,7 +13,7 @@ class C {
     get [Symbol.hasInstance]() {
 >[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty44.ts, 3, 5))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";

--- a/tests/baselines/reference/symbolProperty45.symbols
+++ b/tests/baselines/reference/symbolProperty45.symbols
@@ -5,7 +5,7 @@ class C {
     get [Symbol.hasInstance]() {
 >[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty45.ts, 0, 9))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";
@@ -13,7 +13,7 @@ class C {
     get [Symbol.toPrimitive]() {
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolProperty45.ts, 3, 5))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";

--- a/tests/baselines/reference/symbolProperty46.symbols
+++ b/tests/baselines/reference/symbolProperty46.symbols
@@ -5,7 +5,7 @@ class C {
     get [Symbol.hasInstance]() {
 >[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty46.ts, 0, 9), Decl(symbolProperty46.ts, 3, 5))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";
@@ -14,7 +14,7 @@ class C {
     set [Symbol.hasInstance](x) {
 >[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty46.ts, 0, 9), Decl(symbolProperty46.ts, 3, 5))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty46.ts, 5, 29))
     }
@@ -23,12 +23,12 @@ class C {
 (new C)[Symbol.hasInstance] = 0;
 >C : Symbol(C, Decl(symbolProperty46.ts, 0, 0))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 (new C)[Symbol.hasInstance] = "";
 >C : Symbol(C, Decl(symbolProperty46.ts, 0, 0))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty47.symbols
+++ b/tests/baselines/reference/symbolProperty47.symbols
@@ -5,7 +5,7 @@ class C {
     get [Symbol.hasInstance]() {
 >[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty47.ts, 0, 9), Decl(symbolProperty47.ts, 3, 5))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return "";
@@ -14,7 +14,7 @@ class C {
     set [Symbol.hasInstance](x: number) {
 >[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty47.ts, 0, 9), Decl(symbolProperty47.ts, 3, 5))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty47.ts, 5, 29))
     }
@@ -23,12 +23,12 @@ class C {
 (new C)[Symbol.hasInstance] = 0;
 >C : Symbol(C, Decl(symbolProperty47.ts, 0, 0))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 (new C)[Symbol.hasInstance] = "";
 >C : Symbol(C, Decl(symbolProperty47.ts, 0, 0))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty5.symbols
+++ b/tests/baselines/reference/symbolProperty5.symbols
@@ -5,19 +5,19 @@ var x = {
     [Symbol.iterator]: 0,
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(symbolProperty5.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     [Symbol.toPrimitive]() { },
 >[Symbol.toPrimitive] : Symbol([Symbol.toPrimitive], Decl(symbolProperty5.ts, 1, 25))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     get [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol([Symbol.toStringTag], Decl(symbolProperty5.ts, 2, 31))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return 0;

--- a/tests/baselines/reference/symbolProperty50.symbols
+++ b/tests/baselines/reference/symbolProperty50.symbols
@@ -11,7 +11,7 @@ module M {
         [Symbol.iterator]() { }
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty50.ts, 3, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
     }
 }

--- a/tests/baselines/reference/symbolProperty51.symbols
+++ b/tests/baselines/reference/symbolProperty51.symbols
@@ -11,7 +11,7 @@ module M {
         [Symbol.iterator]() { }
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty51.ts, 3, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
     }
 }

--- a/tests/baselines/reference/symbolProperty52.symbols
+++ b/tests/baselines/reference/symbolProperty52.symbols
@@ -4,7 +4,7 @@ var obj = {
 
     [Symbol.nonsense]: 0
 >[Symbol.nonsense] : Symbol([Symbol.nonsense], Decl(symbolProperty52.ts, 0, 11))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 };
 
@@ -13,5 +13,5 @@ obj = {};
 
 obj[Symbol.nonsense];
 >obj : Symbol(obj, Decl(symbolProperty52.ts, 0, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty53.symbols
+++ b/tests/baselines/reference/symbolProperty53.symbols
@@ -5,7 +5,7 @@ var obj = {
     [Symbol.for]: 0
 >[Symbol.for] : Symbol([Symbol.for], Decl(symbolProperty53.ts, 0, 11))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 };
@@ -13,6 +13,6 @@ var obj = {
 obj[Symbol.for];
 >obj : Symbol(obj, Decl(symbolProperty53.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty54.symbols
+++ b/tests/baselines/reference/symbolProperty54.symbols
@@ -5,7 +5,7 @@ var obj = {
     [Symbol.prototype]: 0
 >[Symbol.prototype] : Symbol([Symbol.prototype], Decl(symbolProperty54.ts, 0, 11))
 >Symbol.prototype : Symbol(SymbolConstructor.prototype, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >prototype : Symbol(SymbolConstructor.prototype, Decl(lib.es2015.symbol.d.ts, --, --))
 
 };

--- a/tests/baselines/reference/symbolProperty55.symbols
+++ b/tests/baselines/reference/symbolProperty55.symbols
@@ -5,7 +5,7 @@ var obj = {
     [Symbol.iterator]: 0
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(symbolProperty55.ts, 0, 11))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 };

--- a/tests/baselines/reference/symbolProperty56.symbols
+++ b/tests/baselines/reference/symbolProperty56.symbols
@@ -5,7 +5,7 @@ var obj = {
     [Symbol.iterator]: 0
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(symbolProperty56.ts, 0, 11))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 };

--- a/tests/baselines/reference/symbolProperty57.symbols
+++ b/tests/baselines/reference/symbolProperty57.symbols
@@ -5,7 +5,7 @@ var obj = {
     [Symbol.iterator]: 0
 >[Symbol.iterator] : Symbol([Symbol.iterator], Decl(symbolProperty57.ts, 0, 11))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 };
@@ -13,5 +13,5 @@ var obj = {
 // Should give type 'any'.
 obj[Symbol["nonsense"]];
 >obj : Symbol(obj, Decl(symbolProperty57.ts, 0, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolProperty58.symbols
+++ b/tests/baselines/reference/symbolProperty58.symbols
@@ -12,6 +12,6 @@ var obj = {
     [Symbol.foo]: 0
 >[Symbol.foo] : Symbol([Symbol.foo], Decl(symbolProperty58.ts, 4, 11))
 >Symbol.foo : Symbol(SymbolConstructor.foo, Decl(symbolProperty58.ts, 0, 29))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >foo : Symbol(SymbolConstructor.foo, Decl(symbolProperty58.ts, 0, 29))
 }

--- a/tests/baselines/reference/symbolProperty59.symbols
+++ b/tests/baselines/reference/symbolProperty59.symbols
@@ -5,6 +5,6 @@ interface I {
     [Symbol.keyFor]: string;
 >[Symbol.keyFor] : Symbol(I[Symbol.keyFor], Decl(symbolProperty59.ts, 0, 13))
 >Symbol.keyFor : Symbol(SymbolConstructor.keyFor, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >keyFor : Symbol(SymbolConstructor.keyFor, Decl(lib.es2015.symbol.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolProperty6.symbols
+++ b/tests/baselines/reference/symbolProperty6.symbols
@@ -5,25 +5,25 @@ class C {
     [Symbol.iterator] = 0;
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty6.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
     [Symbol.unscopables]: number;
 >[Symbol.unscopables] : Symbol(C[Symbol.unscopables], Decl(symbolProperty6.ts, 1, 26))
 >Symbol.unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [Symbol.toPrimitive]() { }
 >[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolProperty6.ts, 2, 33))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     get [Symbol.toStringTag]() {
 >[Symbol.toStringTag] : Symbol(C[Symbol.toStringTag], Decl(symbolProperty6.ts, 3, 30))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
         return 0;

--- a/tests/baselines/reference/symbolProperty60.symbols
+++ b/tests/baselines/reference/symbolProperty60.symbols
@@ -6,7 +6,7 @@ interface I1 {
     [Symbol.toStringTag]: string;
 >[Symbol.toStringTag] : Symbol(I1[Symbol.toStringTag], Decl(symbolProperty60.ts, 1, 14))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [key: string]: number;
@@ -19,7 +19,7 @@ interface I2 {
     [Symbol.toStringTag]: string;
 >[Symbol.toStringTag] : Symbol(I2[Symbol.toStringTag], Decl(symbolProperty60.ts, 6, 14))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [key: number]: boolean;

--- a/tests/baselines/reference/symbolProperty7.symbols
+++ b/tests/baselines/reference/symbolProperty7.symbols
@@ -4,19 +4,19 @@ class C {
 
     [Symbol()] = 0;
 >[Symbol()] : Symbol(C[Symbol()], Decl(symbolProperty7.ts, 0, 9))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     [Symbol()]: number;
 >[Symbol()] : Symbol(C[Symbol()], Decl(symbolProperty7.ts, 1, 19))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     [Symbol()]() { }
 >[Symbol()] : Symbol(C[Symbol()], Decl(symbolProperty7.ts, 2, 23))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     get [Symbol()]() {
 >[Symbol()] : Symbol(C[Symbol()], Decl(symbolProperty7.ts, 3, 20))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
         return 0;
     }

--- a/tests/baselines/reference/symbolProperty8.symbols
+++ b/tests/baselines/reference/symbolProperty8.symbols
@@ -5,12 +5,12 @@ interface I {
     [Symbol.unscopables]: number;
 >[Symbol.unscopables] : Symbol(I[Symbol.unscopables], Decl(symbolProperty8.ts, 0, 13))
 >Symbol.unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >unscopables : Symbol(SymbolConstructor.unscopables, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     [Symbol.toPrimitive]();
 >[Symbol.toPrimitive] : Symbol(I[Symbol.toPrimitive], Decl(symbolProperty8.ts, 1, 33))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/symbolProperty9.symbols
+++ b/tests/baselines/reference/symbolProperty9.symbols
@@ -5,7 +5,7 @@ class C {
     [Symbol.iterator]: { x; y };
 >[Symbol.iterator] : Symbol(C[Symbol.iterator], Decl(symbolProperty9.ts, 0, 9))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty9.ts, 1, 24))
 >y : Symbol(y, Decl(symbolProperty9.ts, 1, 27))
@@ -16,7 +16,7 @@ interface I {
     [Symbol.iterator]: { x };
 >[Symbol.iterator] : Symbol(I[Symbol.iterator], Decl(symbolProperty9.ts, 3, 13))
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 >x : Symbol(x, Decl(symbolProperty9.ts, 4, 24))
 }

--- a/tests/baselines/reference/symbolType1.symbols
+++ b/tests/baselines/reference/symbolType1.symbols
@@ -1,17 +1,17 @@
 === tests/cases/conformance/es6/Symbols/symbolType1.ts ===
 Symbol() instanceof Symbol;
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 Symbol instanceof Symbol();
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 (Symbol() || {}) instanceof Object; // This one should be okay, it's a valid way of distinguishing types
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 Symbol instanceof (Symbol() || {});
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolType10.symbols
+++ b/tests/baselines/reference/symbolType10.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("bitwise");
 >s : Symbol(s, Decl(symbolType10.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 s & s;

--- a/tests/baselines/reference/symbolType11.symbols
+++ b/tests/baselines/reference/symbolType11.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("logical");
 >s : Symbol(s, Decl(symbolType11.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 s && s;

--- a/tests/baselines/reference/symbolType12.symbols
+++ b/tests/baselines/reference/symbolType12.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("assign");
 >s : Symbol(s, Decl(symbolType12.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 var str = "";

--- a/tests/baselines/reference/symbolType13.symbols
+++ b/tests/baselines/reference/symbolType13.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/Symbols/symbolType13.ts ===
 var s = Symbol();
 >s : Symbol(s, Decl(symbolType13.ts, 0, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 var x: any;
 >x : Symbol(x, Decl(symbolType13.ts, 1, 3))

--- a/tests/baselines/reference/symbolType14.symbols
+++ b/tests/baselines/reference/symbolType14.symbols
@@ -1,4 +1,4 @@
 === tests/cases/conformance/es6/Symbols/symbolType14.ts ===
 new Symbol();
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolType15.symbols
+++ b/tests/baselines/reference/symbolType15.symbols
@@ -4,7 +4,7 @@ var sym: symbol;
 
 var symObj: Symbol;
 >symObj : Symbol(symObj, Decl(symbolType15.ts, 1, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 symObj = sym;
 >symObj : Symbol(symObj, Decl(symbolType15.ts, 1, 3))

--- a/tests/baselines/reference/symbolType16.symbols
+++ b/tests/baselines/reference/symbolType16.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/Symbols/symbolType16.ts ===
 interface Symbol {
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(symbolType16.ts, 0, 0))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(symbolType16.ts, 0, 0))
 
     newSymbolProp: number;
 >newSymbolProp : Symbol(Symbol.newSymbolProp, Decl(symbolType16.ts, 0, 18))

--- a/tests/baselines/reference/symbolType2.symbols
+++ b/tests/baselines/reference/symbolType2.symbols
@@ -1,11 +1,11 @@
 === tests/cases/conformance/es6/Symbols/symbolType2.ts ===
 Symbol.isConcatSpreadable in {};
 >Symbol.isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >isConcatSpreadable : Symbol(SymbolConstructor.isConcatSpreadable, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 "" in Symbol.toPrimitive;
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolType3.symbols
+++ b/tests/baselines/reference/symbolType3.symbols
@@ -1,21 +1,21 @@
 === tests/cases/conformance/es6/Symbols/symbolType3.ts ===
 var s = Symbol();
 >s : Symbol(s, Decl(symbolType3.ts, 0, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 delete Symbol.iterator;
 >Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 void Symbol.toPrimitive;
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 typeof Symbol.toStringTag;
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 ++s;
@@ -25,17 +25,17 @@ typeof Symbol.toStringTag;
 >s : Symbol(s, Decl(symbolType3.ts, 0, 3))
 
 + Symbol();
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 - Symbol();
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 ~ Symbol();
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 ! Symbol();
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 +(Symbol() || 0);
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 

--- a/tests/baselines/reference/symbolType4.symbols
+++ b/tests/baselines/reference/symbolType4.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("postfix");
 >s : Symbol(s, Decl(symbolType4.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 s++;

--- a/tests/baselines/reference/symbolType5.symbols
+++ b/tests/baselines/reference/symbolType5.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("multiply");
 >s : Symbol(s, Decl(symbolType5.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 s * s;

--- a/tests/baselines/reference/symbolType6.symbols
+++ b/tests/baselines/reference/symbolType6.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("add");
 >s : Symbol(s, Decl(symbolType6.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 var a: any;

--- a/tests/baselines/reference/symbolType7.symbols
+++ b/tests/baselines/reference/symbolType7.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("shift");
 >s : Symbol(s, Decl(symbolType7.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 s << s;

--- a/tests/baselines/reference/symbolType8.symbols
+++ b/tests/baselines/reference/symbolType8.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("compare");
 >s : Symbol(s, Decl(symbolType8.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 s < s;

--- a/tests/baselines/reference/symbolType9.symbols
+++ b/tests/baselines/reference/symbolType9.symbols
@@ -2,7 +2,7 @@
 var s = Symbol.for("equal");
 >s : Symbol(s, Decl(symbolType9.ts, 0, 3))
 >Symbol.for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >for : Symbol(SymbolConstructor.for, Decl(lib.es2015.symbol.d.ts, --, --))
 
 s == s;

--- a/tests/baselines/reference/uniqueSymbolAllowsIndexInObjectWithIndexSignature.symbols
+++ b/tests/baselines/reference/uniqueSymbolAllowsIndexInObjectWithIndexSignature.symbols
@@ -2,7 +2,7 @@
 // https://github.com/Microsoft/TypeScript/issues/21962
 export const SYM = Symbol('a unique symbol');
 >SYM : Symbol(SYM, Decl(uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts, 1, 12))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 export interface I {
 >I : Symbol(I, Decl(uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts, 1, 45))

--- a/tests/baselines/reference/uniqueSymbols.symbols
+++ b/tests/baselines/reference/uniqueSymbols.symbols
@@ -2,15 +2,15 @@
 // declarations with call initializer
 const constCall = Symbol();
 >constCall : Symbol(constCall, Decl(uniqueSymbols.ts, 1, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 let letCall = Symbol();
 >letCall : Symbol(letCall, Decl(uniqueSymbols.ts, 2, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 var varCall = Symbol();
 >varCall : Symbol(varCall, Decl(uniqueSymbols.ts, 3, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 // ambient declaration with type
 declare const constType: unique symbol;
@@ -19,7 +19,7 @@ declare const constType: unique symbol;
 // declaration with type and call initializer
 const constTypeAndCall: unique symbol = Symbol();
 >constTypeAndCall : Symbol(constTypeAndCall, Decl(uniqueSymbols.ts, 9, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 // declaration from initializer
 const constInitToConstCall = constCall;
@@ -152,26 +152,26 @@ class C {
 
     static readonly readonlyStaticCall = Symbol();
 >readonlyStaticCall : Symbol(C.readonlyStaticCall, Decl(uniqueSymbols.ts, 56, 9))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     static readonly readonlyStaticType: unique symbol;
 >readonlyStaticType : Symbol(C.readonlyStaticType, Decl(uniqueSymbols.ts, 57, 50))
 
     static readonly readonlyStaticTypeAndCall: unique symbol = Symbol();
 >readonlyStaticTypeAndCall : Symbol(C.readonlyStaticTypeAndCall, Decl(uniqueSymbols.ts, 58, 54))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     static readwriteStaticCall = Symbol();
 >readwriteStaticCall : Symbol(C.readwriteStaticCall, Decl(uniqueSymbols.ts, 59, 72))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     readonly readonlyCall = Symbol();
 >readonlyCall : Symbol(C.readonlyCall, Decl(uniqueSymbols.ts, 60, 42))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     readwriteCall = Symbol();
 >readwriteCall : Symbol(C.readwriteCall, Decl(uniqueSymbols.ts, 62, 37))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 }
 declare const c: C;
 >c : Symbol(c, Decl(uniqueSymbols.ts, 65, 13))

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.symbols
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.symbols
@@ -2,15 +2,15 @@
 // declarations with call initializer
 const constCall = Symbol();
 >constCall : Symbol(constCall, Decl(uniqueSymbolsDeclarations.ts, 1, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 let letCall = Symbol();
 >letCall : Symbol(letCall, Decl(uniqueSymbolsDeclarations.ts, 2, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 var varCall = Symbol();
 >varCall : Symbol(varCall, Decl(uniqueSymbolsDeclarations.ts, 3, 3))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 // ambient declaration with type
 declare const constType: unique symbol;
@@ -19,7 +19,7 @@ declare const constType: unique symbol;
 // declaration with type and call initializer
 const constTypeAndCall: unique symbol = Symbol();
 >constTypeAndCall : Symbol(constTypeAndCall, Decl(uniqueSymbolsDeclarations.ts, 9, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
 // declaration from initializer
 const constInitToConstCall = constCall;
@@ -152,26 +152,26 @@ class C {
 
     static readonly readonlyStaticCall = Symbol();
 >readonlyStaticCall : Symbol(C.readonlyStaticCall, Decl(uniqueSymbolsDeclarations.ts, 56, 9))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     static readonly readonlyStaticType: unique symbol;
 >readonlyStaticType : Symbol(C.readonlyStaticType, Decl(uniqueSymbolsDeclarations.ts, 57, 50))
 
     static readonly readonlyStaticTypeAndCall: unique symbol = Symbol();
 >readonlyStaticTypeAndCall : Symbol(C.readonlyStaticTypeAndCall, Decl(uniqueSymbolsDeclarations.ts, 58, 54))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     static readwriteStaticCall = Symbol();
 >readwriteStaticCall : Symbol(C.readwriteStaticCall, Decl(uniqueSymbolsDeclarations.ts, 59, 72))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     readonly readonlyCall = Symbol();
 >readonlyCall : Symbol(C.readonlyCall, Decl(uniqueSymbolsDeclarations.ts, 60, 42))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 
     readwriteCall = Symbol();
 >readwriteCall : Symbol(C.readwriteCall, Decl(uniqueSymbolsDeclarations.ts, 62, 37))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 }
 declare const c: C;
 >c : Symbol(c, Decl(uniqueSymbolsDeclarations.ts, 65, 13))

--- a/tests/baselines/reference/uniqueSymbolsErrors.symbols
+++ b/tests/baselines/reference/uniqueSymbolsErrors.symbols
@@ -238,5 +238,5 @@ declare const invalidIntersection: unique symbol | unique symbol;
 // https://github.com/Microsoft/TypeScript/issues/21584
 const shouldNotBeAssignable: string = Symbol();
 >shouldNotBeAssignable : Symbol(shouldNotBeAssignable, Decl(uniqueSymbolsErrors.ts, 86, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 

--- a/tests/baselines/reference/useSharedArrayBuffer4.symbols
+++ b/tests/baselines/reference/useSharedArrayBuffer4.symbols
@@ -13,14 +13,14 @@ var species = foge[Symbol.species];
 >species : Symbol(species, Decl(useSharedArrayBuffer4.ts, 2, 3))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer4.ts, 0, 3))
 >Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 var stringTag = foge[Symbol.toStringTag];
 >stringTag : Symbol(stringTag, Decl(useSharedArrayBuffer4.ts, 3, 3))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer4.ts, 0, 3))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 var len = foge.byteLength;

--- a/tests/baselines/reference/useSharedArrayBuffer5.symbols
+++ b/tests/baselines/reference/useSharedArrayBuffer5.symbols
@@ -7,13 +7,13 @@ var species = foge[Symbol.species];
 >species : Symbol(species, Decl(useSharedArrayBuffer5.ts, 1, 3))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer5.ts, 0, 3))
 >Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 var stringTag = foge[Symbol.toStringTag];
 >stringTag : Symbol(stringTag, Decl(useSharedArrayBuffer5.ts, 2, 3))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer5.ts, 0, 3))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/useSharedArrayBuffer6.symbols
+++ b/tests/baselines/reference/useSharedArrayBuffer6.symbols
@@ -7,13 +7,13 @@ var species = foge[Symbol.species];
 >species : Symbol(species, Decl(useSharedArrayBuffer6.ts, 1, 3))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer6.ts, 0, 3))
 >Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 var stringTag = foge[Symbol.toStringTag];
 >stringTag : Symbol(stringTag, Decl(useSharedArrayBuffer6.ts, 2, 3))
 >foge : Symbol(foge, Decl(useSharedArrayBuffer6.ts, 0, 3))
 >Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.symbols
+++ b/tests/baselines/reference/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.symbols
@@ -1,7 +1,7 @@
 === tests/cases/compiler/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.ts ===
 const key = Symbol(), value = 12;
 >key : Symbol(key, Decl(variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.ts, 0, 5))
->Symbol : Symbol(Symbol, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
 >value : Symbol(value, Decl(variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.ts, 0, 21))
 
 export class Foo {


### PR DESCRIPTION
Fixes #23778

I've moved the entire thing (rather than making an empty interface) so that `PropertyKey` can still be `toString` and `valueOf`'d.

Our test harness can't test the change because the error is triggered while checking the lib and we don't record lib errors. ☹️  (But I can verify it fixes the issue from manual testing)