### PR TITLE
Don't close runtests-browser server when browser-launcher closes

### DIFF
--- a/tests/webTestServer.ts
+++ b/tests/webTestServer.ts
@@ -780,7 +780,6 @@ function startClient(server: http.Server) {
     const child = child_process.spawn(browserPath, [`http://localhost:${port}/tests/webTestResults.html${queryString}`], {
         stdio: "inherit"
     });
-    child.on("exit", () => server.close());
 }
 
 function printHelp() {


### PR DESCRIPTION
This was causing problems if Chrome was already open, since the process will open a new tab in the existing process and close immediately.