### PR TITLE
Look at simplified types when checking distributive conditional constraints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6501,9 +6501,9 @@ namespace ts {
             // over the conditional type and possibly reduced. For example, 'T extends undefined ? never : T'
             // removes 'undefined' from T.
             if (type.root.isDistributive) {
-                const constraint = getConstraintOfType(type.checkType);
+                const constraint = getConstraintOfType(getSimplifiedType(type.checkType));
                 if (constraint) {
-                    const mapper = createTypeMapper([<TypeParameter>type.root.checkType], [constraint]);
+                    const mapper = makeUnaryTypeMapper(type.root.checkType, constraint);
                     const instantiated = getConditionalTypeInstantiation(type, combineTypeMappers(mapper, type.mapper));
                     if (!(instantiated.flags & TypeFlags.Never)) {
                         return instantiated;

--- a/tests/baselines/reference/nonNullMappedType.js
+++ b/tests/baselines/reference/nonNullMappedType.js
@@ -1,0 +1,10 @@
+//// [nonNullMappedType.ts]
+function f<A extends string>(p0: { [key in A]: {} | undefined }, p1: A) {
+    const v: {} = p0[p1]!;
+}
+
+//// [nonNullMappedType.js]
+"use strict";
+function f(p0, p1) {
+    var v = p0[p1];
+}

--- a/tests/baselines/reference/nonNullMappedType.symbols
+++ b/tests/baselines/reference/nonNullMappedType.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/nonNullMappedType.ts ===
+function f<A extends string>(p0: { [key in A]: {} | undefined }, p1: A) {
+>f : Symbol(f, Decl(nonNullMappedType.ts, 0, 0))
+>A : Symbol(A, Decl(nonNullMappedType.ts, 0, 11))
+>p0 : Symbol(p0, Decl(nonNullMappedType.ts, 0, 29))
+>key : Symbol(key, Decl(nonNullMappedType.ts, 0, 36))
+>A : Symbol(A, Decl(nonNullMappedType.ts, 0, 11))
+>p1 : Symbol(p1, Decl(nonNullMappedType.ts, 0, 64))
+>A : Symbol(A, Decl(nonNullMappedType.ts, 0, 11))
+
+    const v: {} = p0[p1]!;
+>v : Symbol(v, Decl(nonNullMappedType.ts, 1, 9))
+>p0 : Symbol(p0, Decl(nonNullMappedType.ts, 0, 29))
+>p1 : Symbol(p1, Decl(nonNullMappedType.ts, 0, 64))
+}

--- a/tests/baselines/reference/nonNullMappedType.types
+++ b/tests/baselines/reference/nonNullMappedType.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/nonNullMappedType.ts ===
+function f<A extends string>(p0: { [key in A]: {} | undefined }, p1: A) {
+>f : <A extends string>(p0: { [key in A]: {} | undefined; }, p1: A) => void
+>A : A
+>p0 : { [key in A]: {} | undefined; }
+>key : key
+>A : A
+>p1 : A
+>A : A
+
+    const v: {} = p0[p1]!;
+>v : {}
+>p0[p1]! : NonNullable<{ [key in A]: {} | undefined; }[A]>
+>p0[p1] : { [key in A]: {} | undefined; }[A]
+>p0 : { [key in A]: {} | undefined; }
+>p1 : A
+}

--- a/tests/cases/compiler/nonNullMappedType.ts
+++ b/tests/cases/compiler/nonNullMappedType.ts
@@ -1,0 +1,4 @@
+// @strict: true
+function f<A extends string>(p0: { [key in A]: {} | undefined }, p1: A) {
+    const v: {} = p0[p1]!;
+}


### PR DESCRIPTION
In https://github.com/Microsoft/TypeScript/pull/23592 we changed the `getConstraintOfType` function to _not_ simplify index types - distributive conditional type constraints rely on the type being simplified to actually have something to iterate over, ergo `getConstraintOfDistributiveConditionalType` must call `getSimplifiedType` itself.

Fixes #23849
