### PR TITLE
Support '.' as a trigger character

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -957,7 +957,14 @@ namespace FourSlash {
         }
 
         public verifyCompletionsAt(markerName: string | ReadonlyArray<string>, expected: ReadonlyArray<FourSlashInterface.ExpectedCompletionEntry>, options?: FourSlashInterface.CompletionsAtOptions) {
-            this.verifyCompletions({ marker: markerName, exact: expected, isNewIdentifierLocation: options && options.isNewIdentifierLocation, preferences: options, triggerCharacter: options && options.triggerCharacter });
+            this.verifyCompletions({
+                marker: markerName,
+                exact: expected,
+                isNewIdentifierLocation: options && options.isNewIdentifierLocation,
+                preferences: options,
+                // TODO: GH#20090
+                triggerCharacter: (options && options.triggerCharacter) as ts.CompletionsTriggerCharacter | undefined,
+            });
         }
 
         public verifyCompletionListContains(entryId: ts.Completions.CompletionEntryIdentifier, text?: string, documentation?: string, kind?: string | { kind?: string, kindModifiers?: string }, spanIndex?: number, hasAction?: boolean, options?: FourSlashInterface.VerifyCompletionListContainsOptions) {
@@ -4774,7 +4781,7 @@ namespace FourSlashInterface {
         readonly sourceDisplay?: string;
     };
     export interface CompletionsAtOptions extends Partial<ts.UserPreferences> {
-        triggerCharacter?: string;
+        triggerCharacter?: ts.CompletionsTriggerCharacter;
         isNewIdentifierLocation?: boolean;
     }
 
@@ -4785,13 +4792,13 @@ namespace FourSlashInterface {
         readonly includes?: Many<ExpectedCompletionEntry>;
         readonly excludes?: Many<string | { readonly name: string, readonly source: string }>;
         readonly preferences: ts.UserPreferences;
-        readonly triggerCharacter?: string;
+        readonly triggerCharacter?: ts.CompletionsTriggerCharacter;
     }
 
     export type Many<T> = T | ReadonlyArray<T>;
 
     export interface VerifyCompletionListContainsOptions extends ts.UserPreferences {
-        triggerCharacter?: string;
+        triggerCharacter?: ts.CompletionsTriggerCharacter;
         sourceDisplay: string;
         isRecommended?: true;
         insertText?: string;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1773,7 +1773,7 @@ namespace ts.server.protocol {
          * Optional prefix to apply to possible completions.
          */
         prefix?: string;
-        triggerCharacter?: string;
+        triggerCharacter?: "." | "'" | '"' | "`" | "<";
         /**
          * @deprecated Use UserPreferences.includeCompletionsForModuleExports
          */

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1773,7 +1773,7 @@ namespace ts.server.protocol {
          * Optional prefix to apply to possible completions.
          */
         prefix?: string;
-        triggerCharacter?: "." | "'" | '"' | "`" | "<";
+        triggerCharacter?: "." | '"' | "'" | "`" | "/" | "@" | "<";
         /**
          * @deprecated Use UserPreferences.includeCompletionsForModuleExports
          */

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1765,6 +1765,8 @@ namespace ts.server.protocol {
         arguments: FormatOnKeyRequestArgs;
     }
 
+    export type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
+
     /**
      * Arguments for completions messages.
      */
@@ -1773,7 +1775,7 @@ namespace ts.server.protocol {
          * Optional prefix to apply to possible completions.
          */
         prefix?: string;
-        triggerCharacter?: "." | '"' | "'" | "`" | "/" | "@" | "<";
+        triggerCharacter?: CompletionsTriggerCharacter;
         /**
          * @deprecated Use UserPreferences.includeCompletionsForModuleExports
          */

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2211,6 +2211,8 @@ namespace ts.Completions {
     function isValidTrigger(sourceFile: SourceFile, triggerCharacter: CompletionsTriggerCharacter, contextToken: Node, position: number): boolean {
         switch (triggerCharacter) {
             case ".":
+            case "/":
+            case "@":
                 return true;
             case '"':
             case "'":

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2210,6 +2210,8 @@ namespace ts.Completions {
 
     function isValidTrigger(sourceFile: SourceFile, triggerCharacter: string, contextToken: Node, position: number): boolean {
         switch (triggerCharacter) {
+            case ".":
+                return true;
             case '"':
             case "'":
             case "`":

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -25,7 +25,7 @@ namespace ts.Completions {
 
     const enum GlobalsSearch { Continue, Success, Fail }
 
-    export function getCompletionsAtPosition(host: LanguageServiceHost, program: Program, log: Log, sourceFile: SourceFile, position: number, preferences: UserPreferences, triggerCharacter: string | undefined): CompletionInfo | undefined {
+    export function getCompletionsAtPosition(host: LanguageServiceHost, program: Program, log: Log, sourceFile: SourceFile, position: number, preferences: UserPreferences, triggerCharacter: CompletionsTriggerCharacter | undefined): CompletionInfo | undefined {
         const typeChecker = program.getTypeChecker();
         const compilerOptions = program.getCompilerOptions();
         if (isInReferenceComment(sourceFile, position)) {
@@ -2208,7 +2208,7 @@ namespace ts.Completions {
         return !!type.getStringIndexType() || !!type.getNumberIndexType();
     }
 
-    function isValidTrigger(sourceFile: SourceFile, triggerCharacter: string, contextToken: Node, position: number): boolean {
+    function isValidTrigger(sourceFile: SourceFile, triggerCharacter: CompletionsTriggerCharacter, contextToken: Node, position: number): boolean {
         switch (triggerCharacter) {
             case ".":
                 return true;
@@ -2221,7 +2221,7 @@ namespace ts.Completions {
                 // Opening JSX tag
                 return contextToken.kind === SyntaxKind.LessThanToken && contextToken.parent.kind !== SyntaxKind.BinaryExpression;
             default:
-                return Debug.fail(triggerCharacter);
+                return Debug.assertNever(triggerCharacter);
         }
     }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -355,7 +355,7 @@ namespace ts {
 
     export type OrganizeImportsScope = CombinedCodeFixScope;
 
-    export type CompletionsTriggerCharacter = "." | "'" | '"' | "`" | "<";
+    export type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
 
     export interface GetCompletionsAtPositionOptions extends UserPreferences {
         /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -355,9 +355,11 @@ namespace ts {
 
     export type OrganizeImportsScope = CombinedCodeFixScope;
 
+    export type CompletionsTriggerCharacter = "." | "'" | '"' | "`" | "<";
+
     export interface GetCompletionsAtPositionOptions extends UserPreferences {
         /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */
-        triggerCharacter?: string;
+        triggerCharacter?: CompletionsTriggerCharacter;
         /** @deprecated Use includeCompletionsForModuleExports */
         includeExternalModuleExports?: boolean;
         /** @deprecated Use includeCompletionsWithInsertText */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4472,7 +4472,7 @@ declare namespace ts {
         fileName: string;
     }
     type OrganizeImportsScope = CombinedCodeFixScope;
-    type CompletionsTriggerCharacter = "." | "'" | '"' | "`" | "<";
+    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
     interface GetCompletionsAtPositionOptions extends UserPreferences {
         /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */
         triggerCharacter?: CompletionsTriggerCharacter;
@@ -6703,6 +6703,7 @@ declare namespace ts.server.protocol {
         command: CommandTypes.Formatonkey;
         arguments: FormatOnKeyRequestArgs;
     }
+    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
     /**
      * Arguments for completions messages.
      */
@@ -6711,7 +6712,7 @@ declare namespace ts.server.protocol {
          * Optional prefix to apply to possible completions.
          */
         prefix?: string;
-        triggerCharacter?: "." | "'" | '"' | "`" | "<";
+        triggerCharacter?: CompletionsTriggerCharacter;
         /**
          * @deprecated Use UserPreferences.includeCompletionsForModuleExports
          */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4472,9 +4472,10 @@ declare namespace ts {
         fileName: string;
     }
     type OrganizeImportsScope = CombinedCodeFixScope;
+    type CompletionsTriggerCharacter = "." | "'" | '"' | "`" | "<";
     interface GetCompletionsAtPositionOptions extends UserPreferences {
         /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */
-        triggerCharacter?: string;
+        triggerCharacter?: CompletionsTriggerCharacter;
         /** @deprecated Use includeCompletionsForModuleExports */
         includeExternalModuleExports?: boolean;
         /** @deprecated Use includeCompletionsWithInsertText */
@@ -6710,7 +6711,7 @@ declare namespace ts.server.protocol {
          * Optional prefix to apply to possible completions.
          */
         prefix?: string;
-        triggerCharacter?: string;
+        triggerCharacter?: "." | "'" | '"' | "`" | "<";
         /**
          * @deprecated Use UserPreferences.includeCompletionsForModuleExports
          */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4472,9 +4472,10 @@ declare namespace ts {
         fileName: string;
     }
     type OrganizeImportsScope = CombinedCodeFixScope;
+    type CompletionsTriggerCharacter = "." | "'" | '"' | "`" | "<";
     interface GetCompletionsAtPositionOptions extends UserPreferences {
         /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */
-        triggerCharacter?: string;
+        triggerCharacter?: CompletionsTriggerCharacter;
         /** @deprecated Use includeCompletionsForModuleExports */
         includeExternalModuleExports?: boolean;
         /** @deprecated Use includeCompletionsWithInsertText */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4472,7 +4472,7 @@ declare namespace ts {
         fileName: string;
     }
     type OrganizeImportsScope = CombinedCodeFixScope;
-    type CompletionsTriggerCharacter = "." | "'" | '"' | "`" | "<";
+    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
     interface GetCompletionsAtPositionOptions extends UserPreferences {
         /** If the editor is asking for completions because a certain character was typed, and not because the user explicitly requested them, this should be set. */
         triggerCharacter?: CompletionsTriggerCharacter;


### PR DESCRIPTION
The latest vscode is providing trigger characters, but '.' was never included in the list.
@mjbvz Do you have a complete list of trigger characters you send?