### PR TITLE
Remove verify.referencesAre, verify.referencesOf, verify.rangesReferenceEachOther

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -119,7 +119,7 @@ namespace ts.FindAllReferences {
                     const { node } = def;
                     const symbol = checker.getSymbolAtLocation(node);
                     const displayParts = symbol && SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(
-                        checker, symbol, node.getSourceFile(), getContainerNode(node), node).displayParts;
+                        checker, symbol, node.getSourceFile(), getContainerNode(node), node).displayParts || [textPart("this")];
                     return { node, name: "this", kind: ScriptElementKind.variableElement, displayParts };
                 }
                 case "string": {

--- a/tests/cases/fourslash/esModuleInteropFindAllReferences.ts
+++ b/tests/cases/fourslash/esModuleInteropFindAllReferences.ts
@@ -4,11 +4,11 @@
 
 // @Filename: /abc.d.ts
 ////declare module "a" {
-////    export const [|x|]: number;
+////    export const [|{| "isWriteAccess": true, "isDefinition": true |}x|]: number;
 ////}
 
 // @Filename: /b.ts
 ////import a from "a";
 ////a.[|x|];
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("const x: number");

--- a/tests/cases/fourslash/esModuleInteropFindAllReferences2.ts
+++ b/tests/cases/fourslash/esModuleInteropFindAllReferences2.ts
@@ -6,10 +6,10 @@
 
 // @Filename: /a.d.ts
 ////export as namespace abc;
-////export const [|x|]: number;
+////export const [|{| "isWriteAccess": true, "isDefinition": true |}x|]: number;
 
 // @Filename: /b.ts
 ////import a from "./a";
 ////a.[|x|];
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup('const x: number');

--- a/tests/cases/fourslash/findAllReferPropertyAccessExpressionHeritageClause.ts
+++ b/tests/cases/fourslash/findAllReferPropertyAccessExpressionHeritageClause.ts
@@ -2,12 +2,9 @@
 
 //// class B {}
 //// function foo() {
-////     return {[|B|]: B};
+////     return {[|{| "isWriteAccess": true, "isDefinition": true |}B|]: B};
 //// }
 //// class C extends (foo()).[|B|] {}
 //// class C1 extends foo().[|B|] {}
 
-const ranges = test.ranges();
-for (const range of ranges) {
-  verify.referencesOf(range, ranges);
-}
+verify.singleReferenceGroup("(property) B: typeof B");

--- a/tests/cases/fourslash/findAllReferencesDynamicImport1.ts
+++ b/tests/cases/fourslash/findAllReferencesDynamicImport1.ts
@@ -6,4 +6,4 @@
 //// import("[|./foo|]")
 //// var x = import("[|./foo|]")
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup('module "/tests/cases/fourslash/foo"');

--- a/tests/cases/fourslash/findAllReferencesDynamicImport2.ts
+++ b/tests/cases/fourslash/findAllReferencesDynamicImport2.ts
@@ -1,12 +1,12 @@
 ﻿/// <reference path='fourslash.ts' />
 
 // @Filename: foo.ts
-//// export function [|bar|]() { return "bar"; }
+//// export function [|{| "isWriteAccess": true, "isDefinition": true |}bar|]() { return "bar"; }
 
 //// var x = import("./foo");
 //// x.then(foo => {
-////     foo.[|bar|](); 
+////     foo.[|bar|]();
 //// })
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("function bar(): string");
 verify.rangesAreRenameLocations();

--- a/tests/cases/fourslash/findAllReferencesJsDocTypeLiteral.ts
+++ b/tests/cases/fourslash/findAllReferencesJsDocTypeLiteral.ts
@@ -13,4 +13,4 @@
 //// */
 //// function f(o) { return o.nested.[|great|]; }
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("(property) great: boolean");

--- a/tests/cases/fourslash/findAllRefsBadImport.ts
+++ b/tests/cases/fourslash/findAllRefsBadImport.ts
@@ -1,7 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
-////import { [|ab|] as [|cd|] } from "doesNotExist";
+////import { [|ab|] as [|{| "isWriteAccess": true, "isDefinition": true |}cd|] } from "doesNotExist";
 
 const [r0, r1]  = test.ranges();
-verify.referencesOf(r0, [r1]);
-verify.referencesOf(r1, [r1]);
+verify.referenceGroups([r0, r1], [{ definition: "import cd", ranges: [r1] }]);

--- a/tests/cases/fourslash/findAllRefsThisKeyword.ts
+++ b/tests/cases/fourslash/findAllRefsThisKeyword.ts
@@ -25,7 +25,7 @@
 ////x.[|this|];
 
 const [global, f0, f1, g0, g1, x, y, constructor, method, propDef, propUse] = test.ranges();
-verify.referencesOf(global, [global]);
+verify.singleReferenceGroup("this", [global]);
 verify.referenceGroups(f0, [{ definition: "(parameter) this: any", ranges: [f0, f1] }]);
 verify.referenceGroups(f1, [{ definition: "this: any", ranges: [f0, f1] }]);
 verify.referenceGroups(g0, [{ definition: "(parameter) this: any", ranges: [g0, g1] }]);

--- a/tests/cases/fourslash/findAllRefsThisKeywordMultipleFiles.ts
+++ b/tests/cases/fourslash/findAllRefsThisKeywordMultipleFiles.ts
@@ -12,4 +12,4 @@
 //// // different 'this'
 //// function f(this) { return this; }
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("this");

--- a/tests/cases/fourslash/findAllRefsTypedef.ts
+++ b/tests/cases/fourslash/findAllRefsTypedef.ts
@@ -5,11 +5,11 @@
 // @Filename: /a.js
 /////**
 //// * @typedef I {Object}
-//// * @prop [|p|] {number}
+//// * @prop [|{| "isWriteAccess": true, "isDefinition": true |}p|] {number}
 //// */
 ////
 /////** @type {I} */
 ////let x;
 ////x.[|p|];
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("(property) p: number");

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -254,12 +254,6 @@ declare namespace FourSlashInterface {
         symbolAtLocation(startRange: Range, ...declarationRanges: Range[]): void;
         typeOfSymbolAtLocation(range: Range, symbol: any, expected: string): void;
         /**
-         * @deprecated, prefer 'referenceGroups'
-         * Like `referencesAre`, but goes to `start` first.
-         * `start` should be included in `references`.
-         */
-        referencesOf(start: Range, references: Range[]): void;
-        /**
          * For each of starts, asserts the ranges that are referenced from there.
          * This uses the 'findReferences' command instead of 'getReferencesAtPosition', so references are grouped by their definition.
          */
@@ -268,11 +262,6 @@ declare namespace FourSlashInterface {
         rangesAreOccurrences(isWriteAccess?: boolean): void;
         rangesWithSameTextAreRenameLocations(): void;
         rangesAreRenameLocations(options?: Range[] | { findInStrings?: boolean, findInComments?: boolean, ranges?: Range[] });
-        /**
-         * Performs `referencesOf` for every range on the whole set.
-         * If `ranges` is omitted, this is `test.ranges()`.
-         */
-        rangesReferenceEachOther(ranges?: Range[]): void;
         findReferencesDefinitionDisplayPartsAtCaretAre(expected: ts.SymbolDisplayPart[]): void;
         currentParameterHelpArgumentNameIs(name: string): void;
         currentParameterSpanIs(parameter: string): void;

--- a/tests/cases/fourslash/server/references01.ts
+++ b/tests/cases/fourslash/server/references01.ts
@@ -2,14 +2,22 @@
 
 // Global class reference.
 
-// @Filename: referencesForGlobals_1.ts
-////class [|globalClass|] {
+// @Filename: /referencesForGlobals_1.ts
+////class [|{| "isWriteAccess": true, "isDefinition": true |}globalClass|] {
 ////    public f() { }
 ////}
 
-// @Filename: referencesForGlobals_2.ts
+// @Filename: /referencesForGlobals_2.ts
 ///////<reference path="referencesForGlobals_1.ts" />
 ////var c = [|globalClass|]();
 
-// Must reverse ranges so that referencesForGlobals_2 goes first -- otherwise referencesForGlobals_1 won't pick it up.
-verify.rangesReferenceEachOther(test.ranges().reverse());
+const [r0, r1] = test.ranges();
+goTo.rangeStart(r1);
+verify.getReferencesForServerTest([
+    { fileName: "/referencesForGlobals_1.ts", isDefinition: true, isWriteAccess: true, textSpan: toSpan(r0) },
+    { fileName: "/referencesForGlobals_2.ts", isDefinition: false, isWriteAccess: false, textSpan: toSpan(r1) },
+]);
+
+function toSpan(r: FourSlashInterface.Range) {
+    return { start: r.pos, length: r.end - r.pos };
+}

--- a/tests/cases/fourslash/server/referencesInConfiguredProject.ts
+++ b/tests/cases/fourslash/server/referencesInConfiguredProject.ts
@@ -2,15 +2,24 @@
 
 // Global class reference.
 
-// @Filename: referencesForGlobals_1.ts
+// @Filename: /referencesForGlobals_1.ts
 ////class [|globalClass|] {
 ////    public f() { }
 ////}
 
-// @Filename: referencesForGlobals_2.ts
+// @Filename: /referencesForGlobals_2.ts
 ////var c = [|globalClass|]();
 
-// @Filename: tsconfig.json
+// @Filename: /tsconfig.json
 ////{ "files": ["referencesForGlobals_1.ts", "referencesForGlobals_2.ts"] }
 
-verify.rangesReferenceEachOther();
+const [r0, r1] = test.ranges();
+goTo.rangeStart(r1);
+verify.getReferencesForServerTest([
+    { fileName: "/referencesForGlobals_1.ts", isDefinition: true, isWriteAccess: true, textSpan: toSpan(r0) },
+    { fileName: "/referencesForGlobals_2.ts", isDefinition: false, isWriteAccess: false, textSpan: toSpan(r1) },
+]);
+
+function toSpan(r: FourSlashInterface.Range) {
+    return { start: r.pos, length: r.end - r.pos };
+}

--- a/tests/cases/fourslash/tsxFindAllReferences1.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences1.ts
@@ -4,7 +4,7 @@
 //// declare module JSX {
 ////     interface Element { }
 ////     interface IntrinsicElements {
-////         [|div|]: {
+////         [|{| "isWriteAccess": true, "isDefinition": true |}div|]: {
 ////             name?: string;
 ////             isOpen?: boolean;
 ////         };
@@ -13,4 +13,7 @@
 //// }
 //// var x = <[|div|] />;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup(`(property) JSX.IntrinsicElements.div: {
+    name?: string;
+    isOpen?: boolean;
+}`);

--- a/tests/cases/fourslash/tsxFindAllReferences10.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences10.ts
@@ -15,7 +15,7 @@
 ////     className?: string;
 //// }
 //// interface ButtonProps extends ClickableProps {
-////     [|onClick|](event?: React.MouseEvent<HTMLButtonElement>): void;
+////     [|{| "isWriteAccess": true, "isDefinition": true |}onClick|](event?: React.MouseEvent<HTMLButtonElement>): void;
 //// }
 //// interface LinkProps extends ClickableProps {
 ////     goTo: string;
@@ -25,9 +25,9 @@
 //// declare function MainButton(props: ButtonProps | LinkProps): JSX.Element;
 //// let opt = <MainButton />;
 //// let opt = <MainButton children="chidlren" />;
-//// let opt = <MainButton [|onClick|]={()=>{}} />;
-//// let opt = <MainButton [|onClick|]={()=>{}} ignore-prop />;
+//// let opt = <MainButton [|{| "isWriteAccess": true, "isDefinition": true |}onClick|]={()=>{}} />;
+//// let opt = <MainButton [|{| "isWriteAccess": true, "isDefinition": true |}onClick|]={()=>{}} ignore-prop />;
 //// let opt = <MainButton goTo="goTo" />;
 //// let opt = <MainButton wrong />;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("(method) ButtonProps.onClick(event?: any): void");

--- a/tests/cases/fourslash/tsxFindAllReferences11.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences11.ts
@@ -23,7 +23,6 @@
 //// declare function MainButton(buttonProps: ButtonProps): JSX.Element;
 //// declare function MainButton(linkProps: LinkProps): JSX.Element;
 //// declare function MainButton(props: ButtonProps | LinkProps): JSX.Element;
-//// let opt = <MainButton [|wrong|] />;  // r1
+//// let opt = <MainButton [|{| "isWriteAccess": true, "isDefinition": true |}wrong|] />;
 
-const [r1] = test.ranges();
-verify.referencesOf(r1, [r1]);
+verify.singleReferenceGroup("(property) wrong: true");

--- a/tests/cases/fourslash/tsxFindAllReferences2.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences2.ts
@@ -5,12 +5,12 @@
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////         div: {
-////             [|name|]?: string;
+////             [|{| "isWriteAccess": true, "isDefinition": true |}name|]?: string;
 ////             isOpen?: boolean;
 ////         };
 ////         span: { n: string; };
 ////     }
 //// }
-//// var x = <div [|name|]="hello" />;
+//// var x = <div [|{| "isWriteAccess": true, "isDefinition": true |}name|]="hello" />;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("(property) name?: string");

--- a/tests/cases/fourslash/tsxFindAllReferences3.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences3.ts
@@ -9,11 +9,11 @@
 //// }
 //// class MyClass {
 ////   props: {
-////     [|name|]?: string;
+////     [|{| "isWriteAccess": true, "isDefinition": true |}name|]?: string;
 ////     size?: number;
 //// }
-//// 
-//// 
-//// var x = <MyClass [|name|]='hello'/>;
+////
+////
+//// var x = <MyClass [|{| "isWriteAccess": true, "isDefinition": true |}name|]='hello'/>;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("(property) name?: string");

--- a/tests/cases/fourslash/tsxFindAllReferences4.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences4.ts
@@ -7,13 +7,13 @@
 ////     }
 ////     interface ElementAttributesProperty { props }
 //// }
-//// class [|MyClass|] {
+//// class [|{| "isWriteAccess": true, "isDefinition": true |}MyClass|] {
 ////   props: {
 ////     name?: string;
 ////     size?: number;
 //// }
-//// 
-//// 
+////
+////
 //// var x = <[|MyClass|] name='hello'></[|MyClass|]>;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("class MyClass");

--- a/tests/cases/fourslash/tsxFindAllReferences5.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences5.ts
@@ -15,11 +15,11 @@
 ////     propString: string
 ////     optional?: boolean
 //// }
-//// declare function [|Opt|](attributes: OptionPropBag): JSX.Element;
+//// declare function [|{| "isWriteAccess": true, "isDefinition": true |}Opt|](attributes: OptionPropBag): JSX.Element;
 //// let opt = <[|Opt|] />;
 //// let opt1 = <[|Opt|] propx={100} propString />;
 //// let opt2 = <[|Opt|] propx={100} optional/>;
 //// let opt3 = <[|Opt|] wrong />;
 //// let opt4 = <[|Opt|] propx={100} propString="hi" />;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("function Opt(attributes: OptionPropBag): JSX.Element");

--- a/tests/cases/fourslash/tsxFindAllReferences6.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences6.ts
@@ -17,7 +17,6 @@
 ////     optional?: boolean
 //// }
 //// declare function Opt(attributes: OptionPropBag): JSX.Element;
-//// let opt = <Opt [|wrong|] />;  //r1
+//// let opt = <Opt [|{| "isWriteAccess": true, "isDefinition": true |}wrong|] />;
 
-const [r1] = test.ranges();
-verify.referencesOf(r1, [r1]);
+verify.singleReferenceGroup("(property) wrong: true");

--- a/tests/cases/fourslash/tsxFindAllReferences7.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences7.ts
@@ -11,14 +11,14 @@
 ////     interface ElementAttributesProperty { props; }
 //// }
 //// interface OptionPropBag {
-////     [|propx|]: number
+////     [|{| "isWriteAccess": true, "isDefinition": true |}propx|]: number
 ////     propString: string
 ////     optional?: boolean
 //// }
 //// declare function Opt(attributes: OptionPropBag): JSX.Element;
 //// let opt = <Opt />;
-//// let opt1 = <Opt [|propx|]={100} propString />;
-//// let opt2 = <Opt [|propx|]={100} optional/>;
+//// let opt1 = <Opt [|{| "isWriteAccess": true, "isDefinition": true |}propx|]={100} propString />;
+//// let opt2 = <Opt [|{| "isWriteAccess": true, "isDefinition": true |}propx|]={100} optional/>;
 //// let opt3 = <Opt wrong />;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("(property) OptionPropBag.propx: number");

--- a/tests/cases/fourslash/tsxFindAllReferences8.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences8.ts
@@ -20,9 +20,9 @@
 //// interface LinkProps extends ClickableProps {
 ////     goTo: string;
 //// }
-//// declare function [|MainButton|](buttonProps: ButtonProps): JSX.Element;
-//// declare function [|MainButton|](linkProps: LinkProps): JSX.Element;
-//// declare function [|MainButton|](props: ButtonProps | LinkProps): JSX.Element;
+//// declare function [|{| "isWriteAccess": true, "isDefinition": true |}MainButton|](buttonProps: ButtonProps): JSX.Element;
+//// declare function [|{| "isWriteAccess": true, "isDefinition": true |}MainButton|](linkProps: LinkProps): JSX.Element;
+//// declare function [|{| "isWriteAccess": true, "isDefinition": true |}MainButton|](props: ButtonProps | LinkProps): JSX.Element;
 //// let opt = <[|MainButton|] />;
 //// let opt = <[|MainButton|] children="chidlren" />;
 //// let opt = <[|MainButton|] onClick={()=>{}} />;
@@ -30,4 +30,4 @@
 //// let opt = <[|MainButton|] goTo="goTo" />;
 //// let opt = <[|MainButton|] wrong />;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("function MainButton(buttonProps: ButtonProps): JSX.Element (+2 overloads)");

--- a/tests/cases/fourslash/tsxFindAllReferences9.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences9.ts
@@ -18,7 +18,7 @@
 ////     onClick(event?: React.MouseEvent<HTMLButtonElement>): void;
 //// }
 //// interface LinkProps extends ClickableProps {
-////     [|goTo|]: string;
+////     [|{| "isWriteAccess": true, "isDefinition": true |}goTo|]: string;
 //// }
 //// declare function MainButton(buttonProps: ButtonProps): JSX.Element;
 //// declare function MainButton(linkProps: LinkProps): JSX.Element;
@@ -27,8 +27,8 @@
 //// let opt = <MainButton children="chidlren" />;
 //// let opt = <MainButton onClick={()=>{}} />;
 //// let opt = <MainButton onClick={()=>{}} ignore-prop />;
-//// let opt = <MainButton [|goTo|]="goTo" />;
-//// let opt = <MainButton [|goTo|] />;
+//// let opt = <MainButton [|{| "isWriteAccess": true, "isDefinition": true |}goTo|]="goTo" />;
+//// let opt = <MainButton [|{| "isWriteAccess": true, "isDefinition": true |}goTo|] />;
 //// let opt = <MainButton wrong />;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("(property) LinkProps.goTo: string");

--- a/tests/cases/fourslash/tsxFindAllReferencesUnionElementType1.ts
+++ b/tests/cases/fourslash/tsxFindAllReferencesUnionElementType1.ts
@@ -18,7 +18,11 @@
 ////     return <h1>World </h1>;
 //// }
 
-//// var [|SFCComp|] = SFC1 || SFC2;
+//// var [|{| "isWriteAccess": true, "isDefinition": true |}SFCComp|] = SFC1 || SFC2;
 //// <[|SFCComp|] x={ "hi" } />
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup(`var SFCComp: ((prop: {
+    x: number;
+}) => JSX.Element) | ((prop: {
+    x: boolean;
+}) => JSX.Element)`);

--- a/tests/cases/fourslash/tsxFindAllReferencesUnionElementType2.ts
+++ b/tests/cases/fourslash/tsxFindAllReferencesUnionElementType2.ts
@@ -17,7 +17,7 @@
 ////     private method() { }
 //// }
 
-//// var [|RCComp|] = RC1 || RC2;
+//// var [|{| "isWriteAccess": true, "isDefinition": true |}RCComp|] = RC1 || RC2;
 //// <[|RCComp|] />
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("var RCComp: typeof RC1");


### PR DESCRIPTION
We get stricter checking with `verify.referenceGroups` (and `verify.singleReferenceGroup` which delegates to it), so removing these older testing methods. Specifically, we now test for the definition text and `isWriteAccess`/`isDefinition`.