### PR TITLE
findAllReferences: Treat a nested property in a jsdoc type literal as a definition

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2111,7 +2111,7 @@ namespace ts {
                 }
                 else if (isQualifiedName(name.parent)) {
                     const tag = name.parent.parent;
-                    return isJSDocParameterTag(tag) && tag.name == name.parent;
+                    return isJSDocParameterTag(tag) && tag.name === name.parent;
                 }
                 else {
                     const binExp = name.parent.parent;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2109,8 +2109,14 @@ namespace ts {
                 if (isDeclaration(name.parent)) {
                     return name.parent.name === name;
                 }
-                const binExp = name.parent.parent;
-                return isBinaryExpression(binExp) && getSpecialPropertyAssignmentKind(binExp) !== SpecialPropertyAssignmentKind.None && getNameOfDeclaration(binExp) === name;
+                else if (isQualifiedName(name.parent)) {
+                    const tag = name.parent.parent;
+                    return isJSDocParameterTag(tag) && tag.name == name.parent;
+                }
+                else {
+                    const binExp = name.parent.parent;
+                    return isBinaryExpression(binExp) && getSpecialPropertyAssignmentKind(binExp) !== SpecialPropertyAssignmentKind.None && getNameOfDeclaration(binExp) === name;
+                }
             default:
                 return false;
         }

--- a/tests/cases/fourslash/findAllReferencesJsDocTypeLiteral.ts
+++ b/tests/cases/fourslash/findAllReferencesJsDocTypeLiteral.ts
@@ -8,9 +8,9 @@
 //// * @param {string} o.x - a thing, its ok
 //// * @param {number} o.y - another thing
 //// * @param {Object} o.nested - very nested
-//// * @param {boolean} o.nested.[|great|] - much greatness
+//// * @param {boolean} o.nested.[|{| "isWriteAccess": true, "isDefinition": true |}great|] - much greatness
 //// * @param {number} o.nested.times - twice? probably!??
 //// */
 //// function f(o) { return o.nested.[|great|]; }
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("(property) great: boolean");


### PR DESCRIPTION
Treats `@param {boolean} o.x.y` as a definition location.