### PR TITLE
Lint to ensure use of emptyArray where possible

### DIFF
--- a/scripts/tslint/rules/emptyArrayRule.ts
+++ b/scripts/tslint/rules/emptyArrayRule.ts
@@ -1,0 +1,29 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+
+export class Rule extends Lint.Rules.TypedRule {
+    public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, ctx => walk(ctx, program.getTypeChecker()));
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
+    ctx.sourceFile.forEachChild(function cb(node) {
+        if (ts.isArrayLiteralExpression(node) && node.elements.length === 0) {
+            const ct = checker.getContextualType(node);
+            if (ct) {
+                const str = checker.typeToString(ct);
+                if (str.startsWith("ReadonlyArray<") && str.endsWith(">")) {
+                    ctx.addFailureAtNode(node, "Use `emptyArray` instead", Lint.Replacement.replaceNode(node, "emptyArray"));
+                }
+            }
+            else {
+                // Allow `const x = [];` as this is almost certain to be pushed to
+                if (!ts.isVariableDeclaration(node.parent)) {
+                    ctx.addFailureAtNode(node, "Array literal has no contextual type -- not sure if this should be `emptyArray`.");
+                }
+            }
+        }
+        node.forEachChild(cb);
+    });
+}

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -680,7 +680,7 @@ namespace ts {
                 buildDisplayForParametersAndDelimiters(thisParameter, parameters, writer, enclosing?, originalFlags?) {
                     const printer = createPrinter({ removeComments: true });
                     const flags = NodeBuilderFlags.OmitParameterModifiers | NodeBuilderFlags.IgnoreErrors | toNodeBuilderFlags(originalFlags);
-                    const thisParameterArray = thisParameter ? [nodeBuilder.symbolToParameterDeclaration(thisParameter, enclosing, flags)] : [];
+                    const thisParameterArray = thisParameter ? [nodeBuilder.symbolToParameterDeclaration(thisParameter, enclosing, flags)] : emptyArray;
                     const params = createNodeArray([...thisParameterArray, ...map(parameters, param => nodeBuilder.symbolToParameterDeclaration(param, enclosing, flags))]);
                     printer.writeList(ListFormat.CallExpressionArguments, params, getSourceFileOfNode(getParseTreeNode(enclosing)), emitTextWriterWrapper(writer));
                 },
@@ -3310,7 +3310,7 @@ namespace ts {
                             }
                         }
                         if (context.encounteredError || (context.flags & NodeBuilderFlags.AllowEmptyTuple)) {
-                            return createTupleTypeNode([]);
+                            return createTupleTypeNode(emptyArray);
                         }
                         context.encounteredError = true;
                         return undefined;
@@ -9257,7 +9257,7 @@ namespace ts {
                     const item = items[i];
                     const mapped = instantiator(item, mapper);
                     if (item !== mapped) {
-                        const result = i === 0 ? [] : items.slice(0, i);
+                        const result: T[] = i === 0 ? [] : items.slice(0, i);
                         result.push(mapped);
                         for (i++; i < items.length; i++) {
                             result.push(instantiator(items[i], mapper));

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1409,7 +1409,7 @@ namespace ts {
                 case "string":
                     return option.isFilePath ? "./" : "";
                 case "list":
-                    return [];
+                    return emptyArray;
                 case "object":
                     return {};
                 default:
@@ -1551,7 +1551,7 @@ namespace ts {
         existingOptions: CompilerOptions = {},
         configFileName?: string,
         resolutionStack: Path[] = [],
-        extraFileExtensions: ReadonlyArray<FileExtensionInfo> = [],
+        extraFileExtensions: ReadonlyArray<FileExtensionInfo> = emptyArray,
     ): ParsedCommandLine {
         Debug.assert((json === undefined && sourceFile !== undefined) || (json !== undefined && sourceFile === undefined));
         const errors: Diagnostic[] = [];
@@ -2149,7 +2149,7 @@ namespace ts {
      * @param extraFileExtensions optionaly file extra file extension information from host
      */
     /* @internal */
-    export function getFileNamesFromConfigSpecs(spec: ConfigFileSpecs, basePath: string, options: CompilerOptions, host: ParseConfigHost, extraFileExtensions: ReadonlyArray<FileExtensionInfo> = []): ExpandResult {
+    export function getFileNamesFromConfigSpecs(spec: ConfigFileSpecs, basePath: string, options: CompilerOptions, host: ParseConfigHost, extraFileExtensions: ReadonlyArray<FileExtensionInfo> = emptyArray): ExpandResult {
         basePath = normalizePath(basePath);
 
         const keyMapper = host.useCaseSensitiveFileNames ? identity : toLowerCase;

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -751,7 +751,7 @@ namespace ts {
     /**
      * Deduplicates an array that has already been sorted.
      */
-    function deduplicateSorted<T>(array: ReadonlyArray<T>, comparer: EqualityComparer<T> | Comparer<T>) {
+    function deduplicateSorted<T>(array: ReadonlyArray<T>, comparer: EqualityComparer<T> | Comparer<T>): T[] {
         if (!array) return undefined;
         if (array.length === 0) return [];
 
@@ -790,7 +790,7 @@ namespace ts {
         }
     }
 
-    export function sortAndDeduplicate<T>(array: ReadonlyArray<T>, comparer: Comparer<T>, equalityComparer?: EqualityComparer<T>) {
+    export function sortAndDeduplicate<T>(array: ReadonlyArray<T>, comparer: Comparer<T>, equalityComparer?: EqualityComparer<T>): T[] {
         return deduplicateSorted(sort(array, comparer), equalityComparer || comparer);
     }
 
@@ -2222,7 +2222,7 @@ namespace ts {
      * Reduce an array of path components to a more simplified path by navigating any
      * `"."` or `".."` entries in the path.
      */
-    export function reducePathComponents(components: ReadonlyArray<string>) {
+    export function reducePathComponents(components: ReadonlyArray<string>): string[] {
         if (!some(components)) return [];
         const reduced = [components[0]];
         for (let i = 1; i < components.length; i++) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -95,7 +95,7 @@ namespace ts {
 
     /*@internal*/
     // targetSourceFile is when users only want one file in entire project to be emitted. This is used in compileOnSave feature
-    export function emitFiles(resolver: EmitResolver, host: EmitHost, targetSourceFile: SourceFile, emitOnlyDtsFiles?: boolean, transformers?: TransformerFactory<SourceFile | Bundle>[]): EmitResult {
+    export function emitFiles(resolver: EmitResolver, host: EmitHost, targetSourceFile: SourceFile, emitOnlyDtsFiles?: boolean, transformers?: ReadonlyArray<TransformerFactory<SourceFile | Bundle>>): EmitResult {
         const compilerOptions = host.getCompilerOptions();
         const sourceMapDataList: SourceMapData[] = (compilerOptions.sourceMap || compilerOptions.inlineSourceMap || getAreDeclarationMapsEnabled(compilerOptions)) ? [] : undefined;
         const emittedFilesList: string[] = compilerOptions.listEmittedFiles ? [] : undefined;
@@ -2552,7 +2552,7 @@ namespace ts {
         }
 
         function emitSyntheticTripleSlashReferencesIfNeeded(node: Bundle) {
-            emitTripleSlashDirectives(node.hasNoDefaultLib, node.syntheticFileReferences || [], node.syntheticTypeReferences || []);
+            emitTripleSlashDirectives(node.hasNoDefaultLib, node.syntheticFileReferences || emptyArray, node.syntheticTypeReferences || emptyArray);
         }
 
         function emitTripleSlashDirectivesIfNeeded(node: SourceFile) {

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -21,14 +21,11 @@ namespace ts {
      * Make `elements` into a `NodeArray<T>`. If `elements` is `undefined`, returns an empty `NodeArray<T>`.
      */
     export function createNodeArray<T extends Node>(elements?: ReadonlyArray<T>, hasTrailingComma?: boolean): NodeArray<T> {
-        if (!elements || elements === emptyArray) {
-            elements = [];
-        }
-        else if (isNodeArray(elements)) {
+        if (elements && isNodeArray(elements)) {
             return elements;
         }
 
-        const array = <NodeArray<T>>elements;
+        const array = !elements || elements === emptyArray ? <NodeArray<T>><any>[] : <NodeArray<T>>elements;
         array.pos = -1;
         array.end = -1;
         array.hasTrailingComma = hasTrailingComma;
@@ -2600,12 +2597,12 @@ namespace ts {
                 /*asteriskToken*/ undefined,
                 /*name*/ undefined,
                 /*typeParameters*/ undefined,
-                /*parameters*/ param ? [param] : [],
+                /*parameters*/ param ? [param] : emptyArray,
                 /*type*/ undefined,
                 createBlock(statements, /*multiLine*/ true)
             ),
             /*typeArguments*/ undefined,
-            /*argumentsArray*/ paramValue ? [paramValue] : []
+            /*argumentsArray*/ paramValue ? [paramValue] : emptyArray
         );
     }
 
@@ -2616,13 +2613,13 @@ namespace ts {
             createArrowFunction(
                 /*modifiers*/ undefined,
                 /*typeParameters*/ undefined,
-                /*parameters*/ param ? [param] : [],
+                /*parameters*/ param ? [param] : emptyArray,
                 /*type*/ undefined,
                 /*equalsGreaterThanToken*/ undefined,
                 createBlock(statements, /*multiLine*/ true)
             ),
             /*typeArguments*/ undefined,
-            /*argumentsArray*/ paramValue ? [paramValue] : []
+            /*argumentsArray*/ paramValue ? [paramValue] : emptyArray
         );
     }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1245,7 +1245,7 @@ namespace ts {
         }
 
         function emitWorker(program: Program, sourceFile: SourceFile, writeFileCallback: WriteFileCallback, cancellationToken: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult {
-            let declarationDiagnostics: ReadonlyArray<Diagnostic> = [];
+            let declarationDiagnostics: ReadonlyArray<Diagnostic> = emptyArray;
 
             if (!emitOnlyDtsFiles) {
                 if (options.noEmit) {
@@ -1290,7 +1290,7 @@ namespace ts {
 
             performance.mark("beforeEmit");
 
-            const transformers = emitOnlyDtsFiles ? [] : getTransformers(options, customTransformers);
+            const transformers = emitOnlyDtsFiles ? emptyArray : getTransformers(options, customTransformers);
             const emitResult = emitFiles(
                 emitResolver,
                 getEmitHost(writeFileCallback),
@@ -1931,7 +1931,7 @@ namespace ts {
             if (refFile) {
                 const redirect = getProjectReferenceRedirect(fileName);
                 if (redirect) {
-                    ((refFile.redirectedReferences || (refFile.redirectedReferences = [])) as string[]).push(fileName);
+                    ((refFile.redirectedReferences || (refFile.redirectedReferences = [] as string[])) as string[]).push(fileName);
                     fileName = redirect;
                     // Once we start redirecting to a file, we can potentially come back to it
                     // via a back-reference from another file in the .d.ts folder. If that happens we'll

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -152,27 +152,28 @@ namespace ts {
                             needsDeclare = false;
                             const statements = visitNodes(sourceFile.statements, visitDeclarationStatements);
                             const newFile = updateSourceFileNode(sourceFile, [createModuleDeclaration(
-                                [],
+                                emptyArray,
                                 [createModifier(SyntaxKind.DeclareKeyword)],
                                 createLiteral(getResolvedExternalModuleName(context.getEmitHost(), sourceFile)),
                                 createModuleBlock(setTextRange(createNodeArray(filterCandidateImports(statements)), sourceFile.statements))
-                            )], /*isDeclarationFile*/ true, /*referencedFiles*/ [], /*typeReferences*/ [], /*hasNoDefaultLib*/ false);
+                            )], /*isDeclarationFile*/ true, /*referencedFiles*/ emptyArray, /*typeReferences*/ emptyArray, /*hasNoDefaultLib*/ false);
                             return newFile;
                         }
                         needsDeclare = true;
                         const updated = visitNodes(sourceFile.statements, visitDeclarationStatements);
-                        return updateSourceFileNode(sourceFile, filterCandidateImports(updated), /*isDeclarationFile*/ true, /*referencedFiles*/ [], /*typeReferences*/ [], /*hasNoDefaultLib*/ false);
+                        return updateSourceFileNode(sourceFile, filterCandidateImports(updated), /*isDeclarationFile*/ true, /*referencedFiles*/ emptyArray, /*typeReferences*/ emptyArray, /*hasNoDefaultLib*/ false);
                     }
                 ), mapDefined(node.prepends, prepend => {
                     if (prepend.kind === SyntaxKind.InputFiles) {
                         return createUnparsedSourceFile(prepend.declarationText);
                     }
                 }));
-                bundle.syntheticFileReferences = [];
+                const syntheticFileReferences: FileReference[] = [];
+                bundle.syntheticFileReferences = syntheticFileReferences;
                 bundle.syntheticTypeReferences = getFileReferencesForUsedTypeReferences();
                 bundle.hasNoDefaultLib = hasNoDefaultLib;
                 const outputFilePath = getDirectoryPath(normalizeSlashes(getOutputPathsFor(node, host, /*forceDtsPaths*/ true).declarationFilePath));
-                const referenceVisitor = mapReferencesIntoArray(bundle.syntheticFileReferences as FileReference[], outputFilePath);
+                const referenceVisitor = mapReferencesIntoArray(syntheticFileReferences, outputFilePath);
                 refs.forEach(referenceVisitor);
                 return bundle;
             }
@@ -199,13 +200,13 @@ namespace ts {
             let combinedStatements = setTextRange(createNodeArray(filterCandidateImports(statements)), node.statements);
             const emittedImports = filter(combinedStatements, isAnyImportSyntax);
             if (isExternalModule(node) && (!resultHasExternalModuleIndicator || (needsScopeFixMarker && !resultHasScopeMarker))) {
-                combinedStatements = setTextRange(createNodeArray([...combinedStatements, createExportDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, createNamedExports([]), /*moduleSpecifier*/ undefined)]), combinedStatements);
+                combinedStatements = setTextRange(createNodeArray([...combinedStatements, createExportDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, createNamedExports(emptyArray), /*moduleSpecifier*/ undefined)]), combinedStatements);
             }
             const updated = updateSourceFileNode(node, combinedStatements, /*isDeclarationFile*/ true, references, getFileReferencesForUsedTypeReferences(), node.hasNoDefaultLib);
             return updated;
 
-            function getFileReferencesForUsedTypeReferences() {
-                return necessaryTypeRefernces ? mapDefined(arrayFrom(necessaryTypeRefernces.keys()), getFileReferenceForTypeName) : [];
+            function getFileReferencesForUsedTypeReferences(): ReadonlyArray<FileReference> {
+                return necessaryTypeRefernces ? mapDefined(arrayFrom(necessaryTypeRefernces.keys()), getFileReferenceForTypeName) : emptyArray;
             }
 
             function getFileReferenceForTypeName(typeName: string): FileReference | undefined {
@@ -862,7 +863,7 @@ namespace ts {
                             errorNode: input
                         });
                         const varDecl = createVariableDeclaration(newId, resolver.createTypeOfExpression(input.expression, input, declarationEmitNodeBuilderFlags, symbolTracker), /*initializer*/ undefined);
-                        const statement = createVariableStatement(needsDeclare ? [createModifier(SyntaxKind.DeclareKeyword)] : [], createVariableDeclarationList([varDecl], NodeFlags.Const));
+                        const statement = createVariableStatement(needsDeclare ? [createModifier(SyntaxKind.DeclareKeyword)] : emptyArray, createVariableDeclarationList([varDecl], NodeFlags.Const));
                         return [statement, updateExportAssignment(input, input.decorators, input.modifiers, newId)];
                     }
                 }
@@ -1020,7 +1021,7 @@ namespace ts {
                             typeName: input.name
                         });
                         const varDecl = createVariableDeclaration(newId, resolver.createTypeOfExpression(extendsClause.expression, input, declarationEmitNodeBuilderFlags, symbolTracker), /*initializer*/ undefined);
-                        const statement = createVariableStatement(needsDeclare ? [createModifier(SyntaxKind.DeclareKeyword)] : [], createVariableDeclarationList([varDecl], NodeFlags.Const));
+                        const statement = createVariableStatement(needsDeclare ? [createModifier(SyntaxKind.DeclareKeyword)] : emptyArray, createVariableDeclarationList([varDecl], NodeFlags.Const));
                         const heritageClauses = createNodeArray(map(input.heritageClauses, clause => {
                             if (clause.token === SyntaxKind.ExtendsKeyword) {
                                 const oldDiag = getSymbolAccessibilityDiagnostic;

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -775,7 +775,7 @@ namespace ts {
                 /*asteriskToken*/ undefined,
                 /*name*/ undefined,
                 /*typeParameters*/ undefined,
-                extendsClauseElement ? [createParameter(/*decorators*/ undefined, /*modifiers*/ undefined, /*dotDotDotToken*/ undefined, createFileLevelUniqueName("_super"))] : [],
+                extendsClauseElement ? [createParameter(/*decorators*/ undefined, /*modifiers*/ undefined, /*dotDotDotToken*/ undefined, createFileLevelUniqueName("_super"))] : emptyArray,
                 /*type*/ undefined,
                 transformClassBody(node, extendsClauseElement)
             );
@@ -801,7 +801,7 @@ namespace ts {
                     /*typeArguments*/ undefined,
                     extendsClauseElement
                         ? [visitNode(extendsClauseElement.expression, visitor, isExpression)]
-                        : []
+                        : emptyArray
                 )
             );
             addSyntheticLeadingComment(result, SyntaxKind.MultiLineCommentTrivia, "* @class ");
@@ -1377,7 +1377,7 @@ namespace ts {
                                 createVariableDeclaration(
                                     declarationName,
                                     /*type*/ undefined,
-                                    createArrayLiteral([])
+                                    createArrayLiteral(emptyArray)
                                 )
                             ])
                         ),
@@ -2446,7 +2446,7 @@ namespace ts {
             const catchVariable = getGeneratedNameForNode(errorRecord);
             const returnMethod = createTempVariable(/*recordTempVariable*/ undefined);
             const values = createValuesHelper(context, expression, node.expression);
-            const next = createCall(createPropertyAccess(iterator, "next"), /*typeArguments*/ undefined, []);
+            const next = createCall(createPropertyAccess(iterator, "next"), /*typeArguments*/ undefined, emptyArray);
 
             hoistVariableDeclaration(errorRecord);
             hoistVariableDeclaration(returnMethod);
@@ -2518,7 +2518,7 @@ namespace ts {
                                         )
                                     ),
                                     createStatement(
-                                        createFunctionCall(returnMethod, iterator, [])
+                                        createFunctionCall(returnMethod, iterator, emptyArray)
                                     )
                                 ),
                                 EmitFlags.SingleLine
@@ -3517,7 +3517,7 @@ namespace ts {
                         transformAndSpreadElements(createNodeArray([createVoidZero(), ...node.arguments]), /*needsUniqueCopy*/ false, /*multiLine*/ false, /*hasTrailingComma*/ false)
                     ),
                     /*typeArguments*/ undefined,
-                    []
+                    emptyArray
                 );
             }
             return visitEachChild(node, visitor, context);

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -642,7 +642,7 @@ namespace ts {
             createToken(SyntaxKind.AsteriskToken),
             /*name*/ undefined,
             /*typeParameters*/ undefined,
-            /*parameters*/ [],
+            /*parameters*/ emptyArray,
             /*type*/ undefined,
             body
         );

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -372,10 +372,10 @@ namespace ts {
             const catchVariable = getGeneratedNameForNode(errorRecord);
             const returnMethod = createTempVariable(/*recordTempVariable*/ undefined);
             const callValues = createAsyncValuesHelper(context, expression, /*location*/ node.expression);
-            const callNext = createCall(createPropertyAccess(iterator, "next"), /*typeArguments*/ undefined, []);
+            const callNext = createCall(createPropertyAccess(iterator, "next"), /*typeArguments*/ undefined, emptyArray);
             const getDone = createPropertyAccess(result, "done");
             const getValue = createPropertyAccess(result, "value");
-            const callReturn = createFunctionCall(returnMethod, iterator, []);
+            const callReturn = createFunctionCall(returnMethod, iterator, emptyArray);
 
             hoistVariableDeclaration(errorRecord);
             hoistVariableDeclaration(returnMethod);
@@ -634,7 +634,7 @@ namespace ts {
                             createToken(SyntaxKind.AsteriskToken),
                             node.name && getGeneratedNameForNode(node.name),
                             /*typeParameters*/ undefined,
-                            /*parameters*/ [],
+                            /*parameters*/ emptyArray,
                             /*type*/ undefined,
                             updateBlock(
                                 node.body,

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -1160,7 +1160,7 @@ namespace ts {
                                 )
                             ),
                             /*typeArguments*/ undefined,
-                            []
+                            emptyArray
                         ),
                         node
                     ),
@@ -2146,7 +2146,7 @@ namespace ts {
             exception.catchVariable = name;
             exception.catchLabel = catchLabel;
 
-            emitAssignment(name, createCall(createPropertyAccess(state, "sent"), /*typeArguments*/ undefined, []));
+            emitAssignment(name, createCall(createPropertyAccess(state, "sent"), /*typeArguments*/ undefined, emptyArray));
             emitNop();
         }
 
@@ -2481,7 +2481,7 @@ namespace ts {
                 createCall(
                     createPropertyAccess(state, "sent"),
                     /*typeArguments*/ undefined,
-                    []
+                    emptyArray
                 ),
                 location
             );
@@ -2812,7 +2812,7 @@ namespace ts {
             clauses.push(
                 createCaseClause(
                     createLiteral(labelNumber),
-                    statements || []
+                    statements || emptyArray
                 )
             );
 

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -153,7 +153,7 @@ namespace ts {
                                 /*typeArguments*/ undefined,
                                 [
                                     // Add the module name (if provided).
-                                    ...(moduleName ? [moduleName] : []),
+                                    ...(moduleName ? [moduleName] : emptyArray),
 
                                     // Add the dependency array argument:
                                     //
@@ -262,7 +262,7 @@ namespace ts {
                                                 /*typeArguments*/ undefined,
                                                 [
                                                     // Add the module name (if provided).
-                                                    ...(moduleName ? [moduleName] : []),
+                                                    ...(moduleName ? [moduleName] : emptyArray),
                                                     createArrayLiteral([
                                                         createLiteral("require"),
                                                         createLiteral("exports"),
@@ -703,8 +703,8 @@ namespace ts {
             // Promise.resolve().then(function () { return require(x); }) /*CommonJs Require*/
             // We have to wrap require in then callback so that require is done in asynchronously
             // if we simply do require in resolve callback in Promise constructor. We will execute the loading immediately
-            const promiseResolveCall = createCall(createPropertyAccess(createIdentifier("Promise"), "resolve"), /*typeArguments*/ undefined, /*argumentsArray*/ []);
-            let requireCall = createCall(createIdentifier("require"), /*typeArguments*/ undefined, arg ? [arg] : []);
+            const promiseResolveCall = createCall(createPropertyAccess(createIdentifier("Promise"), "resolve"), /*typeArguments*/ undefined, /*argumentsArray*/ emptyArray);
+            let requireCall = createCall(createIdentifier("require"), /*typeArguments*/ undefined, arg ? [arg] : emptyArray);
             if (compilerOptions.esModuleInterop) {
                 context.requestEmitHelper(importStarHelper);
                 requireCall = createCall(getHelperName("__importStar"), /*typeArguments*/ undefined, [requireCall]);
@@ -715,7 +715,7 @@ namespace ts {
                 func = createArrowFunction(
                     /*modifiers*/ undefined,
                     /*typeParameters*/ undefined,
-                    /*parameters*/ [],
+                    /*parameters*/ emptyArray,
                     /*type*/ undefined,
                     /*equalsGreaterThanToken*/ undefined,
                     requireCall);
@@ -726,7 +726,7 @@ namespace ts {
                     /*asteriskToken*/ undefined,
                     /*name*/ undefined,
                     /*typeParameters*/ undefined,
-                    /*parameters*/ [],
+                    /*parameters*/ emptyArray,
                     /*type*/ undefined,
                     createBlock([createReturn(requireCall)]));
 

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -270,7 +270,7 @@ namespace ts {
                         /*asteriskToken*/ undefined,
                         /*name*/ undefined,
                         /*typeParameters*/ undefined,
-                        /*parameters*/ [],
+                        /*parameters*/ emptyArray,
                         /*type*/ undefined,
                         createBlock(executeStatements, /*multiLine*/ true)
                     )
@@ -415,7 +415,7 @@ namespace ts {
                             createVariableDeclaration(
                                 exports,
                                 /*type*/ undefined,
-                                createObjectLiteral([])
+                                createObjectLiteral(emptyArray)
                             )
                         ])
                     ),
@@ -1499,7 +1499,7 @@ namespace ts {
                     createIdentifier("import")
                 ),
                 /*typeArguments*/ undefined,
-                some(node.arguments) ? [visitNode(node.arguments[0], destructuringAndImportCallVisitor)] : []
+                some(node.arguments) ? [visitNode(node.arguments[0], destructuringAndImportCallVisitor)] : emptyArray
             );
         }
 

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1674,13 +1674,13 @@ namespace ts {
             if (compilerOptions.emitDecoratorMetadata) {
                 let properties: ObjectLiteralElementLike[];
                 if (shouldAddTypeMetadata(node)) {
-                    (properties || (properties = [])).push(createPropertyAssignment("type", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, [], /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeTypeOfNode(node))));
+                    (properties || (properties = [])).push(createPropertyAssignment("type", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, emptyArray, /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeTypeOfNode(node))));
                 }
                 if (shouldAddParamTypesMetadata(node)) {
-                    (properties || (properties = [])).push(createPropertyAssignment("paramTypes", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, [], /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeParameterTypesOfNode(node, container))));
+                    (properties || (properties = [])).push(createPropertyAssignment("paramTypes", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, emptyArray, /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeParameterTypesOfNode(node, container))));
                 }
                 if (shouldAddReturnTypeMetadata(node)) {
-                    (properties || (properties = [])).push(createPropertyAssignment("returnType", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, [], /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeReturnTypeOfNode(node))));
+                    (properties || (properties = [])).push(createPropertyAssignment("returnType", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, emptyArray, /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeReturnTypeOfNode(node))));
                 }
                 if (properties) {
                     decoratorExpressions.push(createMetadataHelper(context, "design:typeinfo", createObjectLiteral(properties, /*multiLine*/ true)));
@@ -2296,7 +2296,7 @@ namespace ts {
                 visitPropertyNameOfClassElement(node),
                 visitParameterList(node.parameters, visitor, context),
                 /*type*/ undefined,
-                visitFunctionBody(node.body, visitor, context) || createBlock([])
+                visitFunctionBody(node.body, visitor, context) || createBlock(emptyArray)
             );
             if (updated !== node) {
                 // While we emit the source map for the node after skipping decorators and modifiers,
@@ -2326,7 +2326,7 @@ namespace ts {
                 visitNodes(node.modifiers, modifierVisitor, isModifier),
                 visitPropertyNameOfClassElement(node),
                 visitParameterList(node.parameters, visitor, context),
-                visitFunctionBody(node.body, visitor, context) || createBlock([])
+                visitFunctionBody(node.body, visitor, context) || createBlock(emptyArray)
             );
             if (updated !== node) {
                 // While we emit the source map for the node after skipping decorators and modifiers,
@@ -2360,7 +2360,7 @@ namespace ts {
                 /*typeParameters*/ undefined,
                 visitParameterList(node.parameters, visitor, context),
                 /*type*/ undefined,
-                visitFunctionBody(node.body, visitor, context) || createBlock([])
+                visitFunctionBody(node.body, visitor, context) || createBlock(emptyArray)
             );
             if (isExportOfNamespace(node)) {
                 const statements: Statement[] = [updated];
@@ -2390,7 +2390,7 @@ namespace ts {
                 /*typeParameters*/ undefined,
                 visitParameterList(node.parameters, visitor, context),
                 /*type*/ undefined,
-                visitFunctionBody(node.body, visitor, context) || createBlock([])
+                visitFunctionBody(node.body, visitor, context) || createBlock(emptyArray)
             );
             return updated;
         }

--- a/src/harness/compiler.ts
+++ b/src/harness/compiler.ts
@@ -240,7 +240,7 @@ namespace compiler {
         if (compilerOptions.skipDefaultLibCheck === undefined) compilerOptions.skipDefaultLibCheck = true;
         if (compilerOptions.noErrorTruncation === undefined) compilerOptions.noErrorTruncation = true;
 
-        const program = ts.createProgram(rootFiles || [], compilerOptions, host);
+        const program = ts.createProgram(rootFiles || ts.emptyArray, compilerOptions, host);
         const emitResult = program.emit();
         const errors = ts.getPreEmitDiagnostics(program);
         return new CompilationResult(host, compilerOptions, program, emitResult, errors);

--- a/src/harness/documents.ts
+++ b/src/harness/documents.ts
@@ -64,9 +64,9 @@ namespace documents {
         public readonly version: number;
         public readonly file: string;
         public readonly sourceRoot: string | undefined;
-        public readonly sources: ReadonlyArray<string> = [];
+        public readonly sources: ReadonlyArray<string> = ts.emptyArray;
         public readonly sourcesContent: ReadonlyArray<string> | undefined;
-        public readonly mappings: ReadonlyArray<Mapping> = [];
+        public readonly mappings: ReadonlyArray<Mapping> = ts.emptyArray;
         public readonly names: ReadonlyArray<string> | undefined;
 
         private static readonly _mappingRegExp = /([A-Za-z0-9+/]+),?|(;)|./g;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -691,7 +691,7 @@ namespace FourSlash {
             let testName: string;
 
             if (!defs || ts.isArray(defs)) {
-                definitions = defs as ts.DefinitionInfo[] || [];
+                definitions = defs as ts.DefinitionInfo[] || ts.emptyArray;
                 testName = "goToDefinitions";
             }
             else {
@@ -2957,7 +2957,7 @@ Actual: ${stringify(fullActual)}`);
             for (const fileName of fileNames) {
                 const expectedRangesInFile = expectedRanges.filter(r => ts.normalizePath(r.fileName) === fileName);
                 const highlights = ts.find(documentHighlights, dh => dh.fileName === fileName);
-                const spansInFile = highlights ? highlights.highlightSpans.sort((s1, s2) => s1.textSpan.start - s2.textSpan.start) : [];
+                const spansInFile = highlights ? highlights.highlightSpans.sort((s1, s2) => s1.textSpan.start - s2.textSpan.start) : ts.emptyArray;
 
                 if (expectedRangesInFile.length !== spansInFile.length) {
                     this.raiseError(`verifyDocumentHighlights failed - In ${fileName}, expected ${expectedRangesInFile.length} highlights, got ${spansInFile.length}`);

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -605,7 +605,7 @@ namespace Harness {
                 return { files, directories };
             }
             catch (e) {
-                return { files: [], directories: [] };
+                return { files: ts.emptyArray, directories: ts.emptyArray };
             }
         }
 
@@ -935,7 +935,7 @@ namespace Harness {
 
         function getAccessibleFileSystemEntries(dirname: string): ts.FileSystemEntries {
             const response = send(HttpRequestMessage.post(new URL("/api/getAccessibleFileSystemEntries", serverRoot), HttpContent.text(dirname)));
-            return hasJsonContent(response) ? JSON.parse(response.content.content) : { files: [], directories: [] };
+            return hasJsonContent(response) ? JSON.parse(response.content.content) : { files: ts.emptyArray, directories: ts.emptyArray };
         }
 
         function hasJsonContent(response: HttpResponseMessage): response is HttpResponseMessage & { content: HttpContent } {

--- a/src/harness/unittests/configurationExtension.ts
+++ b/src/harness/unittests/configurationExtension.ts
@@ -57,13 +57,13 @@ namespace ts {
                     "dev/missing.json": JSON.stringify({
                         extends: "./missing2",
                         compilerOptions: {
-                            types: []
+                            types: emptyArray,
                         }
                     }),
                     "dev/failure.json": JSON.stringify({
                         extends: "./failure2.json",
                         compilerOptions: {
-                            typeRoots: []
+                            typeRoots: emptyArray,
                         }
                     }),
                     "dev/failure2.json": JSON.stringify({

--- a/src/harness/unittests/convertCompilerOptionsFromJson.ts
+++ b/src/harness/unittests/convertCompilerOptionsFromJson.ts
@@ -377,7 +377,7 @@ namespace ts {
                         target: "es5",
                         noImplicitAny: false,
                         sourceMap: false,
-                        lib: []
+                        lib: emptyArray,
                     }
                 }, "tsconfig.json",
                 {
@@ -386,9 +386,9 @@ namespace ts {
                         target: ScriptTarget.ES5,
                         noImplicitAny: false,
                         sourceMap: false,
-                        lib: []
+                        lib: emptyArray,
                     },
-                    errors: []
+                    errors: emptyArray,
                 }
             );
         });

--- a/src/harness/unittests/organizeImports.ts
+++ b/src/harness/unittests/organizeImports.ts
@@ -32,7 +32,7 @@ namespace ts {
 
         describe("Coalesce imports", () => {
             it("No imports", () => {
-                assert.isEmpty(OrganizeImports.coalesceImports([]));
+                assert.isEmpty(OrganizeImports.coalesceImports(emptyArray));
             });
 
             it("Sort specifiers", () => {

--- a/src/harness/unittests/paths.ts
+++ b/src/harness/unittests/paths.ts
@@ -214,7 +214,7 @@ describe("core paths", () => {
         assert.deepEqual(ts.getPathComponents("http://server/path"), ["http://server/", "path"]);
     });
     it("reducePathComponents", () => {
-        assert.deepEqual(ts.reducePathComponents([]), []);
+        assert.deepEqual(ts.reducePathComponents(ts.emptyArray), ts.emptyArray);
         assert.deepEqual(ts.reducePathComponents([""]), [""]);
         assert.deepEqual(ts.reducePathComponents(["", "."]), [""]);
         assert.deepEqual(ts.reducePathComponents(["", ".", "a"]), ["", "a"]);

--- a/src/harness/unittests/printer.ts
+++ b/src/harness/unittests/printer.ts
@@ -188,7 +188,7 @@ namespace ts {
                             /*name*/ createIdentifier("method"),
                             /*questionToken*/ createToken(SyntaxKind.QuestionToken),
                             /*typeParameters*/ undefined,
-                            [],
+                            emptyArray,
                             /*type*/ createKeywordTypeNode(SyntaxKind.VoidKeyword),
                             /*body*/ undefined
                         ),
@@ -268,7 +268,7 @@ namespace ts {
                             /*decorators*/ undefined,
                             /*modifiers*/ undefined,
                             /*dotDotDotToken*/ undefined,
-                            createObjectBindingPattern([])
+                            createObjectBindingPattern(emptyArray)
                         )],
                         createKeywordTypeNode(SyntaxKind.AnyKeyword)
                     ),

--- a/src/harness/unittests/programMissingFiles.ts
+++ b/src/harness/unittests/programMissingFiles.ts
@@ -46,7 +46,7 @@ namespace ts {
         it("handles no missing root files", () => {
             const program = createProgram([emptyFileRelativePath], options, testCompilerHost);
             const missing = program.getMissingFilePaths();
-            verifyMissingFilePaths(missing, []);
+            verifyMissingFilePaths(missing, emptyArray);
         });
 
         it("handles missing root file", () => {

--- a/src/harness/unittests/projectErrors.ts
+++ b/src/harness/unittests/projectErrors.ts
@@ -138,7 +138,7 @@ namespace ts.projectSystem {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
                 assert.isTrue(configuredProject !== undefined, "should find configured project");
-                checkProjectErrors(configuredProject, []);
+                checkProjectErrors(configuredProject, emptyArray);
                 const projectErrors = configuredProjectAt(projectService, 0).getAllProjectErrors();
                 checkProjectErrorsWorker(projectErrors, [
                     "'{' expected."
@@ -152,9 +152,9 @@ namespace ts.projectSystem {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
                 assert.isTrue(configuredProject !== undefined, "should find configured project");
-                checkProjectErrors(configuredProject, []);
+                checkProjectErrors(configuredProject, emptyArray);
                 const projectErrors = configuredProjectAt(projectService, 0).getAllProjectErrors();
-                checkProjectErrorsWorker(projectErrors, []);
+                checkProjectErrorsWorker(projectErrors, emptyArray);
             }
         });
 
@@ -183,9 +183,9 @@ namespace ts.projectSystem {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
                 assert.isTrue(configuredProject !== undefined, "should find configured project");
-                checkProjectErrors(configuredProject, []);
+                checkProjectErrors(configuredProject, emptyArray);
                 const projectErrors = configuredProjectAt(projectService, 0).getAllProjectErrors();
-                checkProjectErrorsWorker(projectErrors, []);
+                checkProjectErrorsWorker(projectErrors, emptyArray);
             }
             // break config and trigger watcher
             host.reloadFS([file1, file2, corruptedConfig]);
@@ -193,7 +193,7 @@ namespace ts.projectSystem {
                 projectService.checkNumberOfProjects({ configuredProjects: 1 });
                 const configuredProject = forEach(projectService.synchronizeProjectList([]), f => f.info.projectName === corruptedConfig.path && f);
                 assert.isTrue(configuredProject !== undefined, "should find configured project");
-                checkProjectErrors(configuredProject, []);
+                checkProjectErrors(configuredProject, emptyArray);
                 const projectErrors = configuredProjectAt(projectService, 0).getAllProjectErrors();
                 checkProjectErrorsWorker(projectErrors, [
                     "'{' expected."

--- a/src/harness/unittests/projectReferences.ts
+++ b/src/harness/unittests/projectReferences.ts
@@ -56,7 +56,7 @@ namespace ts {
                     outDir: "bin",
                     ...sp.options
                 },
-                references: (sp.references || []).map(r => {
+                references: (sp.references || emptyArray).map(r => {
                     if (typeof r === "string") {
                         return { path: r };
                     }
@@ -104,7 +104,7 @@ namespace ts {
             const spec: TestSpecification = {
                 "/primary": {
                     files: { "/primary/a.ts": emptyModule },
-                    references: []
+                    references: emptyArray
                 },
                 "/reference": {
                     files: { "/secondary/b.ts": moduleImporting("../primary/a") },
@@ -126,7 +126,7 @@ namespace ts {
             const spec: TestSpecification = {
                 "/primary": {
                     files: { "/primary/a.ts": emptyModule },
-                    references: [],
+                    references: emptyArray,
                     options: {
                         declaration: false
                     }
@@ -143,7 +143,7 @@ namespace ts {
             const spec: TestSpecification = {
                 "/primary": {
                     files: { "/primary/a.ts": emptyModule },
-                    references: [],
+                    references: emptyArray,
                     options: {
                         composite: false
                     }
@@ -233,7 +233,7 @@ namespace ts {
             const spec: TestSpecification = {
                 "/alpha": {
                     files: { "/alpha/a.ts": "export const m: number = 3;" },
-                    references: [],
+                    references: emptyArray,
                     outputFiles: { "a.d.ts": emptyModule }
                 },
                 "/beta": {
@@ -253,7 +253,7 @@ namespace ts {
             const spec: TestSpecification = {
                 "/alpha": {
                     files: { "/alpha/a.ts": "export const m: number = 3;" },
-                    references: []
+                    references: emptyArray,
                 },
                 "/beta": {
                     files: { "/beta/b.ts": "import { m } from '../alpha/a'" },
@@ -278,7 +278,7 @@ namespace ts {
                         declaration: true,
                         outDir: "bin"
                     },
-                    references: []
+                    references: emptyArray,
                 }
             };
             testProjectReferences(spec, "/alpha/tsconfig.json", (program, host) => {

--- a/src/harness/unittests/reuseProgramStructure.ts
+++ b/src/harness/unittests/reuseProgramStructure.ts
@@ -873,14 +873,14 @@ namespace ts {
                     updateProgramText(files, bxPackage, JSON.stringify({ name: "x", version: "1.2.3" }));
                 });
                 assert.equal(program1.structureIsReused, StructureIsReused.Not);
-                assert.deepEqual(program2.getSemanticDiagnostics(), []);
+                assert.deepEqual(program2.getSemanticDiagnostics(), emptyArray);
             });
         });
     });
 
     describe("host is optional", () => {
         it("should work if host is not provided", () => {
-            createProgram([], {});
+            createProgram(emptyArray, {});
         });
     });
 

--- a/src/harness/unittests/telemetry.ts
+++ b/src/harness/unittests/telemetry.ts
@@ -196,7 +196,7 @@ namespace ts.projectSystem {
                     enable: true,
                     enableAutoDiscovery: false,
                     include: ["hunter2", "hunter3"],
-                    exclude: [],
+                    exclude: emptyArray,
                 },
             });
             const et = new TestServerEventManager([jsconfig, file]);

--- a/src/harness/unittests/transform.ts
+++ b/src/harness/unittests/transform.ts
@@ -243,8 +243,8 @@ namespace ts {
                 };
                 function visitNode(sf: SourceFile) {
                     // produce `class Foo { @Bar baz() {} }`;
-                    const classDecl = createClassDeclaration([], [], "Foo", /*typeParameters*/ undefined, /*heritageClauses*/ undefined, [
-                        createMethod([createDecorator(createIdentifier("Bar"))], [], /**/ undefined, "baz", /**/ undefined, /**/ undefined, [], /**/ undefined, createBlock([]))
+                    const classDecl = createClassDeclaration(emptyArray, emptyArray, "Foo", /*typeParameters*/ undefined, /*heritageClauses*/ undefined, [
+                        createMethod([createDecorator(createIdentifier("Bar"))], emptyArray, /**/ undefined, "baz", /**/ undefined, /**/ undefined, emptyArray, /**/ undefined, createBlock(emptyArray))
                     ]);
                     return updateSourceFileNode(sf, [classDecl]);
                 }

--- a/src/harness/unittests/tscWatchMode.ts
+++ b/src/harness/unittests/tscWatchMode.ts
@@ -908,7 +908,7 @@ namespace ts.tscWatch {
             };
             const config = {
                 path: "/a/b/tsconfig.json",
-                content: JSON.stringify({ compilerOptions: { types: ["node"], typeRoots: [] } })
+                content: JSON.stringify({ compilerOptions: { types: ["node"], typeRoots: emptyArray } })
             };
             const node = {
                 path: "/a/b/node_modules/@types/node/index.d.ts",
@@ -1047,7 +1047,7 @@ namespace ts.tscWatch {
                 path: "/a/tsconfig.json",
                 content: JSON.stringify({
                     compiler: {},
-                    files: []
+                    files: emptyArray
                 })
             };
             const t1 = {
@@ -1163,13 +1163,13 @@ namespace ts.tscWatch {
                 noUnusedLocals: true
             });
             checkProgramActualFiles(watch(), files.map(file => file.path));
-            checkOutputErrorsInitial(host, []);
+            checkOutputErrorsInitial(host, emptyArray);
 
             file.content = getFileContent(/*asModule*/ true);
             host.reloadFS(files);
             host.runQueuedTimeoutCallbacks();
             checkProgramActualFiles(watch(), files.map(file => file.path));
-            checkOutputErrorsIncremental(host, []);
+            checkOutputErrorsIncremental(host, emptyArray);
         });
 
         it("watched files when file is deleted and new file is added as part of change", () => {
@@ -1203,7 +1203,7 @@ namespace ts.tscWatch {
 
     describe("tsc-watch emit with outFile or out setting", () => {
         function createWatchForOut(out?: string, outFile?: string) {
-            const host = createWatchedSystem([]);
+            const host = createWatchedSystem(emptyArray);
             const config: FileOrFolderEmit = {
                 path: "/a/tsconfig.json",
                 content: JSON.stringify({
@@ -1341,7 +1341,7 @@ namespace ts.tscWatch {
             firstReloadFileList?: string[];
         }
         function getInitialState({ configObj = {}, firstCompilationEmitFiles, getEmitLine, getAdditionalFileOrFolder, firstReloadFileList }: InitialStateParams = {}) {
-            const host = createWatchedSystem([]);
+            const host = createWatchedSystem(emptyArray);
             const getOutputName = getEmitLine ? (file: FileOrFolder) => getEmitLine(file, host) :
                 (file: FileOrFolder) => getEmittedLineForMultiFileOutput(file, host);
 
@@ -1372,7 +1372,7 @@ namespace ts.tscWatch {
 
             const additionalFiles = getAdditionalFileOrFolder ?
                 map(getAdditionalFileOrFolder(), file => getFileOrFolderEmit(file, getOutputName)) :
-                [];
+                emptyArray;
 
             (configObj.compilerOptions || (configObj.compilerOptions = {})).listEmittedFiles = true;
             const configFile = getFileOrFolderEmit({
@@ -1686,7 +1686,7 @@ namespace ts.tscWatch {
 
         function verifyEmittedFileContents(newLine: string, inputFiles: FileOrFolder[], initialEmittedFileContents: string[],
             modifyFiles: (files: FileOrFolderEmit[], emitedFiles: EmittedFile[]) => FileOrFolderEmit[], configFile?: FileOrFolder) {
-            const host = createWatchedSystem([], { newLine });
+            const host = createWatchedSystem(emptyArray, { newLine });
             const files = concatenate(
                 map(inputFiles, file => getFileOrFolderEmit(file, fileToConvert => getEmittedLineForMultiFileOutput(fileToConvert, host))),
                 configFile ? [libFile, configFile] : [libFile]

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -480,7 +480,7 @@ namespace ts.projectSystem {
         checkNthEvent(session, server.toEvent(eventName, diagnostics), 0, isMostRecent);
     }
 
-    function createDiagnostic(start: protocol.Location, end: protocol.Location, message: DiagnosticMessage, args: ReadonlyArray<string> = [], category = diagnosticCategoryName(message), reportsUnnecessary?: {}): protocol.Diagnostic {
+    function createDiagnostic(start: protocol.Location, end: protocol.Location, message: DiagnosticMessage, args: ReadonlyArray<string> = emptyArray, category = diagnosticCategoryName(message), reportsUnnecessary?: {}): protocol.Diagnostic {
         return { start, end, text: formatStringFromArgs(message.message, args), code: message.code, category, reportsUnnecessary, source: undefined };
     }
 
@@ -560,7 +560,7 @@ namespace ts.projectSystem {
             const config = {
                 path: "/a/b/tsconfig.json",
                 content: JSON.stringify({
-                    include: []
+                    include: emptyArray,
                 })
             };
 
@@ -1255,7 +1255,7 @@ namespace ts.projectSystem {
         it("external project for dynamic file", () => {
             const externalProjectName = "^ScriptDocument1 file1.ts";
             const externalFiles = toExternalFiles(["^ScriptDocument1 file1.ts"]);
-            const host = createServerHost([]);
+            const host = createServerHost(emptyArray);
             const projectService = createProjectService(host);
             projectService.openExternalProject({
                 rootFiles: externalFiles,
@@ -2029,7 +2029,7 @@ namespace ts.projectSystem {
                 scriptKind: "JS" as "JS"
             };
 
-            const host = createServerHost([]);
+            const host = createServerHost(emptyArray);
             const projectService = createProjectService(host);
             projectService.applyChangesInOpenFiles([tsFile], [], []);
             const projs = projectService.synchronizeProjectList([]);
@@ -4264,7 +4264,7 @@ namespace ts.projectSystem {
             };
             const config = {
                 path: "/a/b/tsconfig.json",
-                content: JSON.stringify({ compilerOptions: { types: ["node"], typeRoots: [] } })
+                content: JSON.stringify({ compilerOptions: { types: ["node"], typeRoots: emptyArray } })
             };
             const node = {
                 path: "/a/b/node_modules/@types/node/index.d.ts",
@@ -4945,7 +4945,7 @@ namespace ts.projectSystem {
                 path: "/a/tsconfig.json",
                 content: JSON.stringify({
                     compiler: {},
-                    files: []
+                    files: emptyArray,
                 })
             };
             const t1 = {
@@ -7050,7 +7050,7 @@ namespace ts.projectSystem {
                         content: `interface GlobalFoo { age: number }`
                     };
 
-                    const additionalFiles = getAdditionalFileOrFolder ? getAdditionalFileOrFolder() : [];
+                    const additionalFiles = getAdditionalFileOrFolder ? getAdditionalFileOrFolder() : emptyArray;
                     const configFile = {
                         path: configFilePath,
                         content: JSON.stringify(configObj || { compilerOptions: {} })
@@ -7315,7 +7315,7 @@ namespace ts.projectSystem {
                     };
                     const configFile: FileOrFolder = {
                         path: rootFolder + "a/b/project/tsconfig.json",
-                        content: JSON.stringify({ compilerOptions: { typeRoots: [] } })
+                        content: JSON.stringify({ compilerOptions: { typeRoots: emptyArray } })
                     };
 
                     const projectFiles = [file1, file3, libFile, configFile];

--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1031,7 +1031,7 @@ namespace ts.projectSystem {
         });
 
         it("cached unresolved typings are not recomputed if program structure did not change", () => {
-            const host = createServerHost([]);
+            const host = createServerHost(emptyArray);
             const session = createSession(host);
             const f = {
                 path: "/a/app.js",
@@ -1356,7 +1356,7 @@ namespace ts.projectSystem {
             const host = createServerHost([app, a, b]);
             const cache = createMap<JsTyping.CachedTyping>();
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(<Path>app.path), emptySafeList, cache, { enable: true }, /*unresolvedImports*/ [], emptyMap);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path], getDirectoryPath(<Path>app.path), emptySafeList, cache, { enable: true }, /*unresolvedImports*/ emptyArray, emptyMap);
             assert.deepEqual(logger.finish(), [
                 'Searching for typing names in /node_modules; all files: ["/node_modules/a/package.json"]',
                 '    Found package names: ["a"]',

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -631,7 +631,7 @@ namespace ts.server {
             return emptyArray;
         }
 
-        getFileNames(excludeFilesFromExternalLibraries?: boolean, excludeConfigFiles?: boolean) {
+        getFileNames(excludeFilesFromExternalLibraries?: boolean, excludeConfigFiles?: boolean): NormalizedPath[] {
             if (!this.program) {
                 return [];
             }
@@ -1487,7 +1487,7 @@ namespace ts.server {
      * These are created only if a host explicitly calls `openExternalProject`.
      */
     export class ExternalProject extends Project {
-        excludedFiles: ReadonlyArray<NormalizedPath> = [];
+        excludedFiles: ReadonlyArray<NormalizedPath> = emptyArray;
         private typeAcquisition: TypeAcquisition;
         /*@internal*/
         constructor(public externalProjectName: string,

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -733,7 +733,7 @@ namespace ts.server {
             return childIndex;
         }
 
-        insertAt(child: LineCollection, nodes: LineCollection[]) {
+        insertAt(child: LineCollection, nodes: LineCollection[]): LineNode[] {
             let childIndex = this.findChildIndex(child);
             const clen = this.children.length;
             const nodeCount = nodes.length;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -835,15 +835,14 @@ namespace ts.server {
             return this.getProjectInfoWorker(args.file, args.projectFileName, args.needFileNameList, /*excludeConfigFiles*/ false);
         }
 
-        private getProjectInfoWorker(uncheckedFileName: string, projectFileName: string, needFileNameList: boolean, excludeConfigFiles: boolean) {
+        private getProjectInfoWorker(uncheckedFileName: string, projectFileName: string, needFileNameList: boolean, excludeConfigFiles: boolean): protocol.ProjectInfo & { fileNames: NormalizedPath[] } {
             const { project } = this.getFileAndProjectWorker(uncheckedFileName, projectFileName);
             project.updateGraph();
-            const projectInfo = {
+            return {
                 configFileName: project.getProjectName(),
                 languageServiceDisabled: !project.languageServiceEnabled,
                 fileNames: needFileNameList ? project.getFileNames(/*excludeFilesFromExternalLibraries*/ false, excludeConfigFiles) : undefined
             };
-            return projectInfo;
         }
 
         private getRenameInfo(args: protocol.FileLocationRequestArgs) {
@@ -1783,7 +1782,7 @@ namespace ts.server {
             }
 
             // No need to analyze lib.d.ts
-            const fileNamesInProject = fileNames.filter(value => !stringContains(value, "lib.d.ts"));
+            const fileNamesInProject = filter<NormalizedPath>(fileNames, value => !stringContains(value, "lib.d.ts"));
             if (fileNamesInProject.length === 0) {
                 return;
             }

--- a/src/services/codefixes/annotateWithTypeFromJSDoc.ts
+++ b/src/services/codefixes/annotateWithTypeFromJSDoc.ts
@@ -160,7 +160,7 @@ namespace ts.codefix {
             /*dotDotDotToken*/ undefined,
             node.typeArguments[0].kind === SyntaxKind.NumberKeyword ? "n" : "s",
             /*questionToken*/ undefined,
-            createTypeReferenceNode(node.typeArguments[0].kind === SyntaxKind.NumberKeyword ? "number" : "string", []),
+            createTypeReferenceNode(node.typeArguments[0].kind === SyntaxKind.NumberKeyword ? "number" : "string", emptyArray),
             /*initializer*/ undefined);
         const indexSignature = createTypeLiteralNode([createIndexSignature(/*decorators*/ undefined, /*modifiers*/ undefined, [index], node.typeArguments[1])]);
         setEmitFlags(indexSignature, EmitFlags.SingleLine);

--- a/src/services/codefixes/convertFunctionToEs6Class.ts
+++ b/src/services/codefixes/convertFunctionToEs6Class.ts
@@ -118,7 +118,7 @@ namespace ts.codefix {
                 deleteNode(nodeToDelete);
 
                 if (!assignmentBinaryExpression.right) {
-                    return createProperty([], modifiers, symbol.name, /*questionToken*/ undefined,
+                    return createProperty(emptyArray, modifiers, symbol.name, /*questionToken*/ undefined,
                         /*type*/ undefined, /*initializer*/ undefined);
                 }
 

--- a/src/services/codefixes/convertToEs6Module.ts
+++ b/src/services/codefixes/convertToEs6Module.ts
@@ -134,7 +134,7 @@ namespace ts.codefix {
                 if (isExportsOrModuleExportsOrAlias(sourceFile, initializer)) {
                     // `const alias = module.exports;` can be removed.
                     foundImport = true;
-                    return [];
+                    return emptyArray;
                 }
                 else if (isRequireCall(initializer, /*checkArgumentIsStringLiteralLike*/ true)) {
                     foundImport = true;

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -212,7 +212,7 @@ namespace ts.DocumentHighlights {
             case SyntaxKind.Constructor:
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.FunctionDeclaration: {
-                return [...container.parameters, ...(isClassLike(container.parent) ? container.parent.members : [])];
+                return [...container.parameters, ...(isClassLike(container.parent) ? container.parent.members : emptyArray)];
             }
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.ClassExpression:

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -368,7 +368,7 @@ namespace ts.formatting {
         return typeof arg === "number" ? tokenRangeFrom([arg]) : isArray(arg) ? tokenRangeFrom(arg) : arg;
     }
 
-    function tokenRangeFromRange(from: SyntaxKind, to: SyntaxKind, except: ReadonlyArray<SyntaxKind> = []): TokenRange {
+    function tokenRangeFromRange(from: SyntaxKind, to: SyntaxKind, except: ReadonlyArray<SyntaxKind> = emptyArray): TokenRange {
         const tokens: SyntaxKind[] = [];
         for (let token = from; token <= to; token++) {
             if (!contains(except, token)) {

--- a/src/services/patternMatcher.ts
+++ b/src/services/patternMatcher.ts
@@ -124,7 +124,7 @@ namespace ts {
             return undefined;
         }
 
-        candidateContainers = candidateContainers || [];
+        candidateContainers = candidateContainers || emptyArray;
 
         // -1 because the last part was checked against the name, and only the rest
         // of the parts are checked against the container.

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -369,7 +369,7 @@ namespace ts.SignatureHelp {
                 signatureHelpParameters = typeParameters && typeParameters.length > 0 ? map(typeParameters, createSignatureHelpParameterForTypeParameter) : emptyArray;
                 suffixDisplayParts.push(punctuationPart(SyntaxKind.GreaterThanToken));
                 const parameterParts = mapToDisplayParts(writer => {
-                    const thisParameter = candidateSignature.thisParameter ? [typeChecker.symbolToParameterDeclaration(candidateSignature.thisParameter, invocation, signatureHelpNodeBuilderFlags)] : [];
+                    const thisParameter = candidateSignature.thisParameter ? [typeChecker.symbolToParameterDeclaration(candidateSignature.thisParameter, invocation, signatureHelpNodeBuilderFlags)] : emptyArray;
                     const params = createNodeArray([...thisParameter, ...map(candidateSignature.parameters, param => typeChecker.symbolToParameterDeclaration(param, invocation, signatureHelpNodeBuilderFlags))]);
                     printer.writeList(ListFormat.CallExpressionArguments, params, getSourceFileOfNode(getParseTreeNode(invocation)), writer);
                 });

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
     "rulesDirectory": "built/local/tslint/rules",
     "rules": {
         "no-unnecessary-type-assertion-2": true,
+        "empty-array": true,
 
         "array-type": [true, "array"],
         "ban-types": {


### PR DESCRIPTION
Ensures we choose `emptyArray` over `[]` when the contextual type is `ReadonlyArray`.