### PR TITLE
Fix #21441: Add WSH as an alias for WScript in scripthost.d.ts

### DIFF
--- a/src/lib/scripthost.d.ts
+++ b/src/lib/scripthost.d.ts
@@ -202,6 +202,11 @@ declare var WScript: {
 };
 
 /**
+ * WSH is an alias for WScript under Windows Script Host
+ */
+declare var WSH: typeof WScript;
+
+/**
  * Represents an Automation SAFEARRAY
  */
 declare class SafeArray<T = any> {


### PR DESCRIPTION
This PR adds WSH as an alias for WScript in `src/lib/scripthost.d.ts`.

This exact change was proposed by Daniel Rosenwasser in issue #21441. 

I have not added tests for this as I could not find any tests for the scripthost.d.ts type declaration file.