### PR TITLE
Replace `verify.rangesReferenceEachOther` with `verify.singleReferenceGroup`

### DIFF
--- a/tests/cases/fourslash/findAllRefsImportType.ts
+++ b/tests/cases/fourslash/findAllRefsImportType.ts
@@ -9,4 +9,4 @@
 // @Filename: /b.js
 ////type T = import("./a").[|N|];
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("type N = number");

--- a/tests/cases/fourslash/findAllRefsTypedef_importType.ts
+++ b/tests/cases/fourslash/findAllRefsTypedef_importType.ts
@@ -11,4 +11,4 @@
 /////** @type {import('./a').[|Foo|]} */
 ////const x = 0;
 
-verify.rangesReferenceEachOther();
+verify.singleReferenceGroup("type Foo = number");

--- a/tests/cases/fourslash/findAllRefs_importType_meaningAtLocation.ts
+++ b/tests/cases/fourslash/findAllRefs_importType_meaningAtLocation.ts
@@ -9,5 +9,5 @@
 ////const x: typeof import("./a").[|T|] = 0;
 
 const [r0, r1, r2, r3] = test.ranges();
-verify.rangesReferenceEachOther([r0, r2]);
-verify.rangesReferenceEachOther([r1, r3]);
+verify.singleReferenceGroup("type T = 0\nconst T: 0", [r0, r2]);
+verify.singleReferenceGroup("type T = 0\nconst T: 0", [r1, r3]);


### PR DESCRIPTION
Fixes semantic merge conflict between #23881 and #23900