### PR TITLE
convertToEs6Module: Replace 'module.exports =' with 'export default' without replacing nodes

### DIFF
--- a/src/services/codefixes/convertToEs6Module.ts
+++ b/src/services/codefixes/convertToEs6Module.ts
@@ -192,13 +192,17 @@ namespace ts.codefix {
                 changes.deleteNode(sourceFile, assignment.parent);
             }
             else {
-                let newNodes = isObjectLiteralExpression(right) ? tryChangeModuleExportsObject(right) : undefined;
-                let changedToDefaultExport = false;
-                if (!newNodes) {
-                    ([newNodes, changedToDefaultExport] = convertModuleExportsToExportDefault(right, checker));
+                const replacement = isObjectLiteralExpression(right) ? tryChangeModuleExportsObject(right)
+                    : isRequireCall(right, /*checkArgumentIsStringLiteralLike*/ true) ? convertReExportAll(right.arguments[0], checker)
+                    : undefined;
+                if (replacement) {
+                    changes.replaceNodeWithNodes(sourceFile, assignment.parent, replacement[0]);
+                    return replacement[1];
                 }
-                changes.replaceNodeWithNodes(sourceFile, assignment.parent, newNodes);
-                return changedToDefaultExport;
+                else {
+                    changes.replaceRangeWithText(sourceFile, createTextRange(left.getStart(sourceFile), right.pos), "export default");
+                    return true;
+                }
             }
         }
         else if (isExportsOrModuleExportsOrAlias(sourceFile, left.expression)) {
@@ -212,8 +216,8 @@ namespace ts.codefix {
      * Convert `module.exports = { ... }` to individual exports..
      * We can't always do this if the module has interesting members -- then it will be a default export instead.
      */
-    function tryChangeModuleExportsObject(object: ObjectLiteralExpression): ReadonlyArray<Statement> | undefined {
-        return mapAllOrFail(object.properties, prop => {
+    function tryChangeModuleExportsObject(object: ObjectLiteralExpression): [ReadonlyArray<Statement>, ModuleExportsChanged] | undefined {
+        const statements = mapAllOrFail(object.properties, prop => {
             switch (prop.kind) {
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
@@ -229,6 +233,7 @@ namespace ts.codefix {
                     Debug.assertNever(prop);
             }
         });
+        return statements && [statements, true];
     }
 
     function convertNamedExport(
@@ -253,31 +258,6 @@ namespace ts.codefix {
         }
         else {
             convertExportsPropertyAssignment(assignment, sourceFile, changes);
-        }
-    }
-
-    function convertModuleExportsToExportDefault(exported: Expression, checker: TypeChecker): [ReadonlyArray<Statement>, ModuleExportsChanged] {
-        const modifiers = [createToken(SyntaxKind.ExportKeyword), createToken(SyntaxKind.DefaultKeyword)];
-        switch (exported.kind) {
-            case SyntaxKind.FunctionExpression:
-            case SyntaxKind.ArrowFunction: {
-                // `module.exports = function f() {}` --> `export default function f() {}`
-                const fn = exported as FunctionExpression | ArrowFunction;
-                return [[functionExpressionToDeclaration(fn.name && fn.name.text, modifiers, fn)], true];
-            }
-            case SyntaxKind.ClassExpression: {
-                // `module.exports = class C {}` --> `export default class C {}`
-                const cls = exported as ClassExpression;
-                return [[classExpressionToDeclaration(cls.name && cls.name.text, modifiers, cls)], true];
-            }
-            case SyntaxKind.CallExpression:
-                if (isRequireCall(exported, /*checkArgumentIsStringLiteralLike*/ true)) {
-                    return convertReExportAll(exported.arguments[0], checker);
-                }
-                // falls through
-            default:
-                // `module.exports = 0;` --> `export default 0;`
-                return [[createExportAssignment(/*decorators*/ undefined, /*modifiers*/ undefined, /*isExportEquals*/ false, exported)], true];
         }
     }
 

--- a/tests/cases/fourslash/refactorConvertToEs6Module_export_moduleDotExports.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_export_moduleDotExports.ts
@@ -15,11 +15,9 @@
 verify.codeFix({
     description: "Convert to ES6 module",
     newFileContent:
-`export default function() { }
-export default function f() { }
-export default class {
-}
-export default class C {
-}
+`export default function() {}
+export default function f() {}
+export default class {}
+export default class C {}
 export default 0;`,
 });

--- a/tests/cases/fourslash/refactorConvertToEs6Module_foo.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_foo.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @target: esnext
+
+// @Filename: /a.js
+////const b = require("./b");
+////module.exports = class C {
+////	m() {
+////		b.x;
+////	}
+////};
+
+verify.codeFix({
+    description: "Convert to ES6 module",
+    newFileContent:
+`import { x } from "./b";
+export default class C {
+	m() {
+		x;
+	}
+};`,
+});


### PR DESCRIPTION
Fixes #23938 -- there was a conflict in both replacing the `class` node and replacing some references inside it.