### PR TITLE
Treat 'import("")' as a module reference

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -272,6 +272,8 @@ namespace ts.FindAllReferences.Core {
             case SyntaxKind.ImportDeclaration:
             case SyntaxKind.ExportDeclaration:
                 return true;
+            case SyntaxKind.LiteralType:
+                return isImportTypeNode(node.parent.parent);
             case SyntaxKind.CallExpression:
                 return isRequireCall(node.parent as CallExpression, /*checkArgumentIsStringLiteralLike*/ false) || isImportCall(node.parent as CallExpression);
             default:
@@ -407,7 +409,6 @@ namespace ts.FindAllReferences.Core {
         return firstDefined(symbol.declarations, decl => {
             if (!decl.parent) {
                 // Assertions for GH#21814. We should be handling SourceFile symbols in `getReferencedSymbolsForModule` instead of getting here.
-                Debug.assert(decl.kind === SyntaxKind.SourceFile);
                 Debug.fail(`Unexpected symbol at ${Debug.showSyntaxKind(node)}: ${Debug.showSymbol(symbol)}`);
             }
             return isTypeLiteralNode(decl.parent) && isUnionTypeNode(decl.parent.parent)

--- a/tests/cases/fourslash/findAllRefsImportTypeOfModule.ts
+++ b/tests/cases/fourslash/findAllRefsImportTypeOfModule.ts
@@ -1,11 +1,13 @@
 /// <reference path='fourslash.ts' />
 
+// @Filename: /b.ts
 ////type [|{| "isWriteAccess": true, "isDefinition": true |}T|] = number;
 ////export = [|T|];
 
-////const x: [|import("./b")|] = 0;
+// @Filename: /a.ts
+////const x: import("[|./b|]") = 0;
 
-// TODO: GH#23879 should just verify.rangesReferenceEachOther();
+// TODO: GH#23879 Should be `verify.singleReferenceGroup("type T = number")
 const [r0, r1, r2] = test.ranges();
 verify.referenceGroups([r0, r1], [{ definition: "type T = number", ranges: [r0, r1] }]);
-verify.referenceGroups(r2, undefined);
+verify.referenceGroups(r2, [{ definition: 'module "/b"', ranges: [r2] }]);


### PR DESCRIPTION
Mitigates #23879

It should probably add the `export =` as a reference since that's what it refers to in this context, but this PR is an easy improvement for now.