### PR TITLE
Fix crash in recursive declared type resolution

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5641,6 +5641,10 @@ namespace ts {
                 const symbol = type.symbol;
                 const members = getMembersOfSymbol(symbol);
                 (<InterfaceTypeWithDeclaredMembers>type).declaredProperties = getNamedMembers(members);
+                // Start with signatures at empty array in case of recursive types
+                (<InterfaceTypeWithDeclaredMembers>type).declaredCallSignatures = emptyArray;
+                (<InterfaceTypeWithDeclaredMembers>type).declaredConstructSignatures = emptyArray;
+
                 (<InterfaceTypeWithDeclaredMembers>type).declaredCallSignatures = getSignaturesOfSymbol(members.get(InternalSymbolName.Call));
                 (<InterfaceTypeWithDeclaredMembers>type).declaredConstructSignatures = getSignaturesOfSymbol(members.get(InternalSymbolName.New));
                 (<InterfaceTypeWithDeclaredMembers>type).declaredStringIndexInfo = getIndexInfoOfSymbol(symbol, IndexKind.String);
@@ -7033,7 +7037,7 @@ namespace ts {
                     for (let i = numTypeArguments; i < numTypeParameters; i++) {
                         const mapper = createTypeMapper(typeParameters, typeArguments);
                         let defaultType = getDefaultFromTypeParameter(typeParameters[i]);
-                        if (defaultType && isTypeIdenticalTo(defaultType, emptyObjectType) && isJavaScriptImplicitAny) {
+                        if (isJavaScriptImplicitAny && defaultType && isTypeIdenticalTo(defaultType, emptyObjectType)) {
                             defaultType = anyType;
                         }
                         typeArguments[i] = defaultType ? instantiateType(defaultType, mapper) : getDefaultTypeArgumentType(isJavaScriptImplicitAny);

--- a/tests/baselines/reference/recursiveResolveDeclaredMembers.symbols
+++ b/tests/baselines/reference/recursiveResolveDeclaredMembers.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/types.ts ===
+// #23025
+export interface F {
+>F : Symbol(F, Decl(types.ts, 0, 0))
+
+    (): E;
+>E : Symbol(E, Decl(other.js, 0, 4))
+}
+export interface D<T extends F = F> {}
+>D : Symbol(D, Decl(types.ts, 3, 1))
+>T : Symbol(T, Decl(types.ts, 4, 19))
+>F : Symbol(F, Decl(types.ts, 0, 0))
+>F : Symbol(F, Decl(types.ts, 0, 0))
+
+=== tests/cases/compiler/other.js ===
+/** @typedef {import("./types").D} E */
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/recursiveResolveDeclaredMembers.types
+++ b/tests/baselines/reference/recursiveResolveDeclaredMembers.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/types.ts ===
+// #23025
+export interface F {
+>F : F
+
+    (): E;
+>E : D<any>
+}
+export interface D<T extends F = F> {}
+>D : D<T>
+>T : T
+>F : F
+>F : F
+
+=== tests/cases/compiler/other.js ===
+/** @typedef {import("./types").D} E */
+No type information for this code.
+No type information for this code.

--- a/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
+++ b/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
@@ -1,0 +1,12 @@
+// #23025
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: types.ts
+export interface F {
+    (): E;
+}
+export interface D<T extends F = F> {}
+
+// @Filename: other.js
+/** @typedef {import("./types").D} E */


### PR DESCRIPTION
... when one type has a type parameter with a default. 

This occurs because declaredCallSignatures and declaredConstructSignatures are undefined before getSignaturesOfSymbol returns, which can be observed if these properties are read during the execution of getSignaturesOfSymbol. This happens with the following example, which has mutually recursive interfaces, one of which has a type parameter with a default.

```ts
interface F { (): E }
interface D<T extends F = F> {}
type E = D
```

The simplest fix for the above program is to check whether we are in a javascript file immediately in fillMissingTypeArguments. But this doesn't work when the type alias is in a Javascript file (as shown in the test case for this PR), and in any case the recursive type resolution might fail in other ways in the future.

Fixes #23025