### PR TITLE
Make new harness fake host more performant in large complications

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2223,6 +2223,7 @@ namespace ts {
         const reduced = [components[0]];
         for (let i = 1; i < components.length; i++) {
             const component = components[i];
+            if (!component) continue;
             if (component === ".") continue;
             if (component === "..") {
                 if (reduced.length > 1) {

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -119,7 +119,12 @@ namespace ts {
     export function readJson(path: string, host: { readFile(fileName: string): string | undefined }): object {
         try {
             const jsonText = host.readFile(path);
-            return jsonText ? JSON.parse(jsonText) : {};
+            if (!jsonText) return {};
+            const result = parseConfigFileTextToJson(path, jsonText);
+            if (result.error) {
+                return {};
+            }
+            return result.config;
         }
         catch (e) {
             // gracefully handle if readFile fails or returns not JSON

--- a/src/harness/utils.ts
+++ b/src/harness/utils.ts
@@ -2,31 +2,6 @@
  * Common utilities
  */
 namespace utils {
-    const leadingCommentRegExp = /^(\s*\/\*[^]*?\*\/\s*|\s*\/\/[^\r\n\u2028\u2029]*[\r\n\u2028\u2029]*)+/;
-    const trailingCommentRegExp = /(\s*\/\*[^]*?\*\/\s*|\s*\/\/[^\r\n\u2028\u2029]*[\r\n\u2028\u2029]*)+$/;
-    const leadingAndTrailingCommentRegExp = /^(\s*\/\*[^]*?\*\/\s*|\s*\/\/[^\r\n\u2028\u2029]*[\r\n\u2028\u2029]*)+|(\s*\/\*[^]*?\*\/\s*|\s*\/\/[^\r\n\u2028\u2029]*[\r\n\u2028\u2029]*)+$/g;
-    const allCommentRegExp = /(['"])(?:(?!\1).|\\[^])*\1|(\/\*[^]*?\*\/|\/\/[^\r\n\u2028\u2029]*[\r\n\u2028\u2029]*)/g;
-
-    export const enum CommentRemoval {
-        leading,
-        trailing,
-        leadingAndTrailing,
-        all
-    }
-
-    export function removeComments(text: string, removal: CommentRemoval) {
-        switch (removal) {
-            case CommentRemoval.leading:
-                return text.replace(leadingCommentRegExp, "");
-            case CommentRemoval.trailing:
-                return text.replace(trailingCommentRegExp, "");
-            case CommentRemoval.leadingAndTrailing:
-                return text.replace(leadingAndTrailingCommentRegExp, "");
-            case CommentRemoval.all:
-                return text.replace(allCommentRegExp, (match, quote) => quote ? match : "");
-        }
-    }
-
     const testPathPrefixRegExp = /(?:(file:\/{3})|\/)\.(ts|lib|src)\//g;
     export function removeTestPathPrefixes(text: string, retainTrailingDirectorySeparator?: boolean) {
         return text !== undefined ? text.replace(testPathPrefixRegExp, (_, scheme) => scheme || (retainTrailingDirectorySeparator ? "/" : "")) : undefined;


### PR DESCRIPTION
This fixes some of the issues our RWC suite has with the new vfs-backed test harness. 
The changes include:
First: empty path segments will now be collapsed by our path handling logic (as they were before). We had tests exhibiting a dependence on paths like `../..//site/SomeFile.ts` resolving correctly.

Second: Do not attempt to regex away comments from `.json` files inside `vfs.System`. Instead, just use `parseConfigFileTextToJson` in the `moduleNameResolver` to allow for comments in parsed `package.json`s (after all, we handle them in every other json document we parse, so why not there) - the regex used for finding comments and stripping them at the system layer had a catastrophic bad case in the RWC suite; our own parser should be more predictable (and more importantly, if it exhibits similar problems in the future, must be fixed).

Third: Replaces `outputs` in the `fakes.CompilerHost` with a canonicalized map and ordered list of names - linerarly searching for the insertion index in the output list took _forever_ when there was > 2000 files in the output (as shown by our largest RWC tests) - this remedies that pathological case.

I think the VFS is still the root cause of some other RWC failures related to being unable to find a `tsconfig`, but I haven't gotten a chance to look into that yet, so that'll probably be separate.