### PR TITLE
Fix #16675: Better error message for dynamic import with ES2015 modules

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28103,7 +28103,7 @@ namespace ts {
 
         function checkGrammarImportCallExpression(node: ImportCall): boolean {
             if (moduleKind === ModuleKind.ES2015) {
-                return grammarErrorOnNode(node, Diagnostics.Dynamic_import_cannot_be_used_when_targeting_ECMAScript_2015_modules);
+                return grammarErrorOnNode(node, Diagnostics.Dynamic_import_cannot_be_used_when_targeting_ECMAScript_2015_modules_Please_use_esnext_or_commonjs_as_module_compiler_option);
             }
 
             if (node.typeArguments) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -895,7 +895,7 @@
         "category": "Error",
         "code": 1322
     },
-    "Dynamic import cannot be used when targeting ECMAScript 2015 modules.": {
+    "Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.": {
         "category": "Error",
         "code": 1323
     },

--- a/tests/baselines/reference/importCallExpressionErrorInES2015.errors.txt
+++ b/tests/baselines/reference/importCallExpressionErrorInES2015.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/dynamicImport/1.ts(1,1): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
-tests/cases/conformance/dynamicImport/1.ts(2,10): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
-tests/cases/conformance/dynamicImport/1.ts(8,16): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+tests/cases/conformance/dynamicImport/1.ts(1,1): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
+tests/cases/conformance/dynamicImport/1.ts(2,10): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
+tests/cases/conformance/dynamicImport/1.ts(8,16): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
 
 
 ==== tests/cases/conformance/dynamicImport/0.ts (0 errors) ====
@@ -9,10 +9,10 @@ tests/cases/conformance/dynamicImport/1.ts(8,16): error TS1323: Dynamic import c
 ==== tests/cases/conformance/dynamicImport/1.ts (3 errors) ====
     import("./0");
     ~~~~~~~~~~~~~
-!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
     var p1 = import("./0");
              ~~~~~~~~~~~~~
-!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
     p1.then(zero => {
         return zero.foo();
     })
@@ -20,5 +20,5 @@ tests/cases/conformance/dynamicImport/1.ts(8,16): error TS1323: Dynamic import c
     function foo() {
         const p2 = import("./0");
                    ~~~~~~~~~~~~~
-!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
     }

--- a/tests/baselines/reference/importCallExpressionNestedES2015.errors.txt
+++ b/tests/baselines/reference/importCallExpressionNestedES2015.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/dynamicImport/index.ts(2,18): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
-tests/cases/conformance/dynamicImport/index.ts(2,32): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+tests/cases/conformance/dynamicImport/index.ts(2,18): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
+tests/cases/conformance/dynamicImport/index.ts(2,32): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
 
 
 ==== tests/cases/conformance/dynamicImport/foo.ts (0 errors) ====
@@ -9,7 +9,7 @@ tests/cases/conformance/dynamicImport/index.ts(2,32): error TS1323: Dynamic impo
     async function foo() {
         return await import((await import("./foo")).default);
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
                                    ~~~~~~~~~~~~~~~
-!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
     }

--- a/tests/baselines/reference/importCallExpressionNestedES20152.errors.txt
+++ b/tests/baselines/reference/importCallExpressionNestedES20152.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/dynamicImport/index.ts(2,18): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
-tests/cases/conformance/dynamicImport/index.ts(2,32): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+tests/cases/conformance/dynamicImport/index.ts(2,18): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
+tests/cases/conformance/dynamicImport/index.ts(2,32): error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
 
 
 ==== tests/cases/conformance/dynamicImport/foo.ts (0 errors) ====
@@ -9,7 +9,7 @@ tests/cases/conformance/dynamicImport/index.ts(2,32): error TS1323: Dynamic impo
     async function foo() {
         return await import((await import("./foo")).default);
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
                                    ~~~~~~~~~~~~~~~
-!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules.
+!!! error TS1323: Dynamic import cannot be used when targeting ECMAScript 2015 modules. Please use 'esnext' or 'commonjs' as module compiler option.
     }


### PR DESCRIPTION
Fixes #16675. Following the suggestions in this ticket this PR improves the error message when users try to use dynamic imports while having ES2015 as module in the compiler options.
