### PR TITLE
Fix debug failure from fixUnusedIdentifier

### DIFF
--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -146,25 +146,9 @@ namespace ts.codefix {
                     break;
                 }
 
-                if (isArrowFunction(oldFunction) && oldFunction.parameters.length === 1) {
-                    // Lambdas with exactly one parameter are special because, after removal, there
-                    // must be an empty parameter list (i.e. `()`) and this won't necessarily be the
-                    // case if the parameter is simply removed (e.g. in `x => 1`).
-                    const newFunction = updateArrowFunction(
-                        oldFunction,
-                        oldFunction.modifiers,
-                        oldFunction.typeParameters,
-                        /*parameters*/ undefined,
-                        oldFunction.type,
-                        oldFunction.equalsGreaterThanToken,
-                        oldFunction.body);
-
-                    // Drop leading and trailing trivia of the new function because we're only going
-                    // to replace the span (vs the full span) of the old function - the old leading
-                    // and trailing trivia will remain.
-                    suppressLeadingAndTrailingTrivia(newFunction);
-
-                    changes.replaceNode(sourceFile, oldFunction, newFunction);
+                if (isArrowFunction(oldFunction) && oldFunction.parameters.length === 1 && !findChildOfKind(oldFunction, SyntaxKind.OpenParenToken, sourceFile)) {
+                    // `x => {}` becomes `() => {}`
+                    changes.replaceNodeWithText(sourceFile, oldFunction.parameters[0], "()");
                 }
                 else {
                     changes.deleteNodeInList(sourceFile, parent);

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -315,6 +315,10 @@ namespace ts.textChanges {
             return this.replaceRangeWithNodes(sourceFile, getAdjustedRange(sourceFile, oldNode, oldNode, options), newNodes, options);
         }
 
+        public replaceNodeWithText(sourceFile: SourceFile, oldNode: Node, text: string, options: ChangeNodeOptions = useNonAdjustedPositions) {
+            return this.replaceRangeWithText(sourceFile, getAdjustedRange(sourceFile, oldNode, oldNode, options), text);
+        }
+
         public replaceNodeRangeWithNodes(sourceFile: SourceFile, startNode: Node, endNode: Node, newNodes: ReadonlyArray<Node>, options: ReplaceWithMultipleNodesOptions & ConfigurableStartEnd = useNonAdjustedPositions) {
             return this.replaceRangeWithNodes(sourceFile, getAdjustedRange(sourceFile, startNode, endNode, options), newNodes, options);
         }

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_formatterDebugFailure.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_formatterDebugFailure.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+// Regression test for https://github.com/Microsoft/TypeScript/issues/23942
+
+// @allowJs: true
+// @target: esnext
+
+// @Filename: /a.js
+////(o){"
+
+verify.codeFix({
+    description: "Remove declaration for: 'o'",
+    index: 0,
+    newFileContent: '(){"',
+});

--- a/tests/cases/fourslash/unusedParameterInLambda1.ts
+++ b/tests/cases/fourslash/unusedParameterInLambda1.ts
@@ -4,9 +4,8 @@
 // @noUnusedParameters: true
 ////[|/*~a*/(/*~b*/x/*~c*/:/*~d*/number/*~e*/)/*~f*/ => /*~g*/{/*~h*/}/*~i*/|]
 
-// In a perfect world, /*~f*/ and /*~h*/ would probably be retained.
 verify.codeFix({
     description: "Remove declaration for: 'x'",
     index: 0,
-    newRangeContent: "/*~a*/() => /*~g*/ { }/*~i*/",
+    newRangeContent: "/*~a*/(/*~e*/)/*~f*/ => /*~g*/{/*~h*/}/*~i*/",
 });

--- a/tests/cases/fourslash/unusedParameterInLambda2.ts
+++ b/tests/cases/fourslash/unusedParameterInLambda2.ts
@@ -4,9 +4,8 @@
 // @noUnusedParameters: true
 ////[|/*~a*/x/*~b*/ /*~c*/=>/*~d*/ {/*~e*/}/*~f*/|]
 
-// In a perfect world, /*~c*/ and /*~e*/ would probably be retained.
 verify.codeFix({
     description: "Remove declaration for: 'x'",
     index: 0,
-    newRangeContent: "/*~a*/() => /*~d*/ { }/*~f*/",
+    newRangeContent: "/*~a*/()/*~b*/ /*~c*/=>/*~d*/ {/*~e*/}/*~f*/",
 });


### PR DESCRIPTION
Fixes #23942

Instead of replacing the entire arrow function node, just replace the parameter with the string "()". This avoids reformatting the body, which can contain invalid emitted nodes like `"` (with no closing quote) that trigger formatter assertions. (When we emit it we also emit the closing quote, but we're still using the original positions which end after the opening quote.)