### PR TITLE
Fix RWC tsconfig and lib paths

### DIFF
--- a/src/harness/compiler.ts
+++ b/src/harness/compiler.ts
@@ -10,8 +10,7 @@ namespace compiler {
 
     export function readProject(host: fakes.ParseConfigHost, project: string | undefined, existingOptions?: ts.CompilerOptions): Project | undefined {
         if (project) {
-            project = host.vfs.stringComparer(vpath.basename(project), "tsconfig.json") === 0 ? project :
-                vpath.combine(project, "tsconfig.json");
+            project = utils.isTsConfigFile({path: project}) ? project : vpath.combine(project, "tsconfig.json");
         }
         else {
             [project] = host.vfs.scanSync(".", "ancestors-or-self", {

--- a/src/harness/compiler.ts
+++ b/src/harness/compiler.ts
@@ -10,7 +10,7 @@ namespace compiler {
 
     export function readProject(host: fakes.ParseConfigHost, project: string | undefined, existingOptions?: ts.CompilerOptions): Project | undefined {
         if (project) {
-            project = utils.isTsConfigFile({path: project}) ? project : vpath.combine(project, "tsconfig.json");
+            project = utils.isTsConfigFile({ path: project }) ? project : vpath.combine(project, "tsconfig.json");
         }
         else {
             [project] = host.vfs.scanSync(".", "ancestors-or-self", {

--- a/src/harness/compiler.ts
+++ b/src/harness/compiler.ts
@@ -10,7 +10,7 @@ namespace compiler {
 
     export function readProject(host: fakes.ParseConfigHost, project: string | undefined, existingOptions?: ts.CompilerOptions): Project | undefined {
         if (project) {
-            project = utils.isTsConfigFile({ path: project }) ? project : vpath.combine(project, "tsconfig.json");
+            project = vpath.isTsConfigFile(project) ? project : vpath.combine(project, "tsconfig.json");
         }
         else {
             [project] = host.vfs.scanSync(".", "ancestors-or-self", {

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -68,7 +68,7 @@ namespace RWC {
                 let fileNames = opts.fileNames;
 
                 runWithIOLog(ioLog, () => {
-                    const tsconfigFile = ts.forEach(ioLog.filesRead, f => utils.isTsConfigFile(f) ? f : undefined);
+                    const tsconfigFile = ts.forEach(ioLog.filesRead, f => vpath.isTsConfigFile(f.path) ? f : undefined);
                     if (tsconfigFile) {
                         const tsconfigFileContents = getHarnessCompilerInputUnit(tsconfigFile.path);
                         tsconfigFiles.push({ unitName: tsconfigFile.path, content: tsconfigFileContents.content });

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -21,10 +21,6 @@ namespace RWC {
         }
     }
 
-    function isTsConfigFile(file: { path: string }): boolean {
-        return file.path.indexOf("tsconfig") !== -1 && file.path.indexOf("json") !== -1;
-    }
-
     export function runRWCTest(jsonPath: string) {
         describe("Testing a rwc project: " + jsonPath, () => {
             let inputFiles: Harness.Compiler.TestFile[] = [];
@@ -69,11 +65,10 @@ namespace RWC {
                     // we will set noEmitOnError flag to be false.
                     opts.options.noEmitOnError = false;
                 });
+                let fileNames = opts.fileNames;
 
-                runWithIOLog(ioLog, oldIO => {
-                    let fileNames = opts.fileNames;
-
-                    const tsconfigFile = ts.forEach(ioLog.filesRead, f => isTsConfigFile(f) ? f : undefined);
+                runWithIOLog(ioLog, () => {
+                    const tsconfigFile = ts.forEach(ioLog.filesRead, f => utils.isTsConfigFile(f) ? f : undefined);
                     if (tsconfigFile) {
                         const tsconfigFileContents = getHarnessCompilerInputUnit(tsconfigFile.path);
                         tsconfigFiles.push({ unitName: tsconfigFile.path, content: tsconfigFileContents.content });
@@ -103,55 +98,40 @@ namespace RWC {
                     }
 
                     // Add files to compilation
-                    const isInInputList = (resolvedPath: string) => (inputFile: { unitName: string; content: string; }) => inputFile.unitName === resolvedPath;
                     for (const fileRead of ioLog.filesRead) {
-                        // Check if the file is already added into the set of input files.
-                        const resolvedPath = ts.normalizeSlashes(Harness.IO.resolvePath(fileRead.path));
-                        const inInputList = ts.forEach(inputFiles, isInInputList(resolvedPath));
-
-                        if (isTsConfigFile(fileRead)) {
-                            continue;
-                        }
-
-                        if (!Harness.isDefaultLibraryFile(fileRead.path)) {
-                            if (inInputList) {
-                                continue;
-                            }
+                        const normalized = ts.normalizeSlashes(fileRead.path);
+                        if (!uniqueNames.has(normalized) && !Harness.isDefaultLibraryFile(fileRead.path)) {
+                            uniqueNames.set(normalized, true);
                             otherFiles.push(getHarnessCompilerInputUnit(fileRead.path));
                         }
-                        else if (!opts.options.noLib && Harness.isDefaultLibraryFile(fileRead.path)) {
-                            if (!inInputList) {
-                                // If useCustomLibraryFile is true, we will use lib.d.ts from json object
-                                // otherwise use the lib.d.ts from built/local
-                                // Majority of RWC code will be using built/local/lib.d.ts instead of
-                                // lib.d.ts inside json file. However, some RWC cases will still use
-                                // their own version of lib.d.ts because they have customized lib.d.ts
-                                if (useCustomLibraryFile) {
-                                    inputFiles.push(getHarnessCompilerInputUnit(fileRead.path));
-                                }
-                                else {
-                                    // set the flag to put default library to the beginning of the list
-                                    inputFiles.unshift(Harness.getDefaultLibraryFile(fileRead.path, oldIO));
-                                }
-                            }
+                        else if (!opts.options.noLib && Harness.isDefaultLibraryFile(fileRead.path) && !uniqueNames.has(normalized) && useCustomLibraryFile) {
+                            // If useCustomLibraryFile is true, we will use lib.d.ts from json object
+                            // otherwise use the lib.d.ts from built/local
+                            // Majority of RWC code will be using built/local/lib.d.ts instead of
+                            // lib.d.ts inside json file. However, some RWC cases will still use
+                            // their own version of lib.d.ts because they have customized lib.d.ts
+                            uniqueNames.set(normalized, true)
+                            inputFiles.push(getHarnessCompilerInputUnit(fileRead.path));
                         }
                     }
+                });
 
+                if (useCustomLibraryFile) {
                     // do not use lib since we already read it in above
                     opts.options.lib = undefined;
                     opts.options.noLib = true;
+                }
 
-                    // Emit the results
-                    compilerResult = Harness.Compiler.compileFiles(
-                        inputFiles,
-                        otherFiles,
-                        /* harnessOptions */ undefined,
-                        opts.options,
-                        // Since each RWC json file specifies its current directory in its json file, we need
-                        // to pass this information in explicitly instead of acquiring it from the process.
-                        currentDirectory);
-                    compilerOptions = compilerResult.options;
-                });
+                // Emit the results
+                compilerResult = Harness.Compiler.compileFiles(
+                    inputFiles,
+                    otherFiles,
+                    /* harnessOptions */ undefined,
+                    opts.options,
+                    // Since each RWC json file specifies its current directory in its json file, we need
+                    // to pass this information in explicitly instead of acquiring it from the process.
+                    currentDirectory);
+                compilerOptions = compilerResult.options;
 
                 function getHarnessCompilerInputUnit(fileName: string): Harness.Compiler.TestFile {
                     const unitName = ts.normalizeSlashes(Harness.IO.resolvePath(fileName));

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -110,7 +110,7 @@ namespace RWC {
                             // Majority of RWC code will be using built/local/lib.d.ts instead of
                             // lib.d.ts inside json file. However, some RWC cases will still use
                             // their own version of lib.d.ts because they have customized lib.d.ts
-                            uniqueNames.set(normalized, true)
+                            uniqueNames.set(normalized, true);
                             inputFiles.push(getHarnessCompilerInputUnit(fileRead.path));
                         }
                     }

--- a/src/harness/utils.ts
+++ b/src/harness/utils.ts
@@ -86,8 +86,4 @@ namespace utils {
     export function addUTF8ByteOrderMark(text: string) {
         return getByteOrderMarkLength(text) === 0 ? "\u00EF\u00BB\u00BF" + text : text;
     }
-
-    export function isTsConfigFile(file: { path: string }): boolean {
-        return file.path.indexOf("tsconfig") !== -1 && file.path.indexOf("json") !== -1;
-    }
 }

--- a/src/harness/utils.ts
+++ b/src/harness/utils.ts
@@ -86,4 +86,8 @@ namespace utils {
     export function addUTF8ByteOrderMark(text: string) {
         return getByteOrderMarkLength(text) === 0 ? "\u00EF\u00BB\u00BF" + text : text;
     }
+
+    export function isTsConfigFile(file: { path: string }): boolean {
+        return file.path.indexOf("tsconfig") !== -1 && file.path.indexOf("json") !== -1;
+    }
 }

--- a/src/harness/vpath.ts
+++ b/src/harness/vpath.ts
@@ -124,4 +124,8 @@ namespace vpath {
         return isDeclaration(path)
             && basename(path).startsWith("lib.");
     }
+
+    export function isTsConfigFile(path: string): boolean {
+        return path.indexOf("tsconfig") !== -1 && path.indexOf("json") !== -1;
+    }
 }


### PR DESCRIPTION
The vfs's `readProject` had a different special casing logic than `rwc`, this aligns them. It was also neglecting to actually place tsconfigs into the vfs - now it does. This should fix the last of our harness-related RWC failures. The fixed libs also revealed https://github.com/Microsoft/TypeScript/issues/23977.