### PR TITLE
Add createRegularExpressionLiteral and expose createStringLiteral

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -93,8 +93,14 @@ namespace ts {
         return node;
     }
 
-    function createStringLiteral(text: string): StringLiteral {
+    export function createStringLiteral(text: string): StringLiteral {
         const node = <StringLiteral>createSynthesizedNode(SyntaxKind.StringLiteral);
+        node.text = text;
+        return node;
+    }
+
+    export function createRegularExpressionLiteral(text: string): RegularExpressionLiteral {
+        const node = <RegularExpressionLiteral>createSynthesizedNode(SyntaxKind.RegularExpressionLiteral);
         node.text = text;
         return node;
     }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3484,6 +3484,8 @@ declare namespace ts {
     function createLiteral(value: boolean): BooleanLiteral;
     function createLiteral(value: string | number | boolean): PrimaryExpression;
     function createNumericLiteral(value: string): NumericLiteral;
+    function createStringLiteral(text: string): StringLiteral;
+    function createRegularExpressionLiteral(text: string): RegularExpressionLiteral;
     function createIdentifier(text: string): Identifier;
     function updateIdentifier(node: Identifier): Identifier;
     /** Create a unique temporary variable. */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3484,6 +3484,8 @@ declare namespace ts {
     function createLiteral(value: boolean): BooleanLiteral;
     function createLiteral(value: string | number | boolean): PrimaryExpression;
     function createNumericLiteral(value: string): NumericLiteral;
+    function createStringLiteral(text: string): StringLiteral;
+    function createRegularExpressionLiteral(text: string): RegularExpressionLiteral;
     function createIdentifier(text: string): Identifier;
     function updateIdentifier(node: Identifier): Identifier;
     /** Create a unique temporary variable. */


### PR DESCRIPTION
Fixes: #23992

I also wanted to add it to the convenience function `createLiteral`:

```ts
if (value instanceof RegExp) {
    return createRegularExpressionLiteral(`/${value.source}/${value.flags}`);
}
```
 Unfortunately that's not possible because RegExp#flags was introduced in ES2015.

Is there a reason the TypeScript compiler doesn't use `lib: ["ES2015"]`? It already declares ES2015 interfaces like `Map` and `Iterator`.