### PR TITLE
Default to 'edge' instead of 'IE' for browser tests

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -54,7 +54,7 @@ const cmdLineOptions = minimist(process.argv.slice(2), {
         debug: process.env.debug || process.env["debug-brk"] || process.env.d,
         inspect: process.env.inspect || process.env["inspect-brk"] || process.env.i,
         host: process.env.TYPESCRIPT_HOST || process.env.host || "node",
-        browser: process.env.browser || process.env.b || "IE",
+        browser: process.env.browser || process.env.b || (os.platform() === "win32" ? "edge" : "chrome"),
         timeout: process.env.timeout || 40000,
         tests: process.env.test || process.env.tests || process.env.t,
         runners: process.env.runners || process.env.runner || process.env.ru,

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -922,7 +922,7 @@ desc("Runs the tests using the built run.js file like 'jake runtests'. Syntax is
 task("runtests-browser", ["browserify", nodeServerOutFile], function () {
     cleanTestDirs();
     host = "node";
-    var browser = process.env.browser || process.env.b ||  (os.platform() === "linux" ? "chrome" : "IE");
+    var browser = process.env.browser || process.env.b ||  (os.platform() === "win32" ? "edge" : "chrome");
     var runners = process.env.runners || process.env.runner || process.env.ru;
     var tests = process.env.test || process.env.tests || process.env.t;
     var light = process.env.light || false;


### PR DESCRIPTION
Our default browser for `gulp runtests-browser` is currently IE, however IE does not support ES6 and some of our test dependencies now use ES6 features. This PR has the following changes:

- Switches the default browser from `"IE"` to `"edge"` on Windows
- Sets the default browser to `"chrome"` when on a non-Windows OS
- On Windows, tries to resolve the actual path to Chrome from the registry.