### PR TITLE
Remove unnecessary filtering of tsx completions

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -899,7 +899,7 @@ namespace FourSlash {
                         }
                         else {
                             const found = actualByName.get(exclude.name);
-                            if (found.source === exclude.source) {
+                            if (found && found.source === exclude.source) {
                                 this.raiseError(`Did not expect to get a completion named ${exclude.name} with source ${exclude.source}`);
                             }
                         }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -972,12 +972,8 @@ namespace ts.Completions {
         }
         else if (isRightOfOpenTag) {
             const tagSymbols = Debug.assertEachDefined(typeChecker.getJsxIntrinsicTagNamesAt(location), "getJsxIntrinsicTagNames() should all be defined");
-            if (tryGetGlobalSymbols()) {
-                symbols = tagSymbols.concat(symbols.filter(s => !!(s.flags & (SymbolFlags.Value | SymbolFlags.Alias))));
-            }
-            else {
-                symbols = tagSymbols;
-            }
+            tryGetGlobalSymbols();
+            symbols = tagSymbols.concat(symbols);
             completionKind = CompletionKind.MemberLike;
         }
         else if (isStartingCloseTag) {
@@ -1298,7 +1294,7 @@ namespace ts.Completions {
                 const exportedSymbols = typeChecker.getExportsOfModule(symbol);
                 // If the exported symbols contains type,
                 // symbol can be referenced at locations where type is allowed
-                return forEach(exportedSymbols, symbolCanBeReferencedAtTypeLocation);
+                return exportedSymbols.some(symbolCanBeReferencedAtTypeLocation);
             }
         }
 

--- a/tests/cases/fourslash/completionsImport_tsx.ts
+++ b/tests/cases/fourslash/completionsImport_tsx.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @noLib: true
+// @nolib: true
+// @jsx: preserve
+
+// @Filename: /a.tsx
+////export type Bar = 0;
+////export default function Foo() {};
+
+// @Filename: /b.tsx
+////<Fo/**/ />;
+
+verify.completions({
+    marker: "",
+    includes: { name: "Foo", source: "/a.tsx", hasAction: true },
+    excludes: "Bar",
+    preferences: {
+        includeCompletionsForModuleExports: true,
+    },
+});


### PR DESCRIPTION
Fixes #23014

The `filter` call didn't need to be here -- we filter by symbol meaning in `filterGlobalCompletion` already. It was filtering out a default exported function that only had `SymbolFlags.ExportValue` set.
