### PR TITLE
Prevent infinite js symbol merge in the checker

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -895,7 +895,7 @@ namespace ts {
                 if ((source.flags | target.flags) & SymbolFlags.JSContainer) {
                     const sourceInitializer = getJSInitializerSymbol(source);
                     const targetInitializer = getJSInitializerSymbol(target);
-                    if (sourceInitializer !== source || targetInitializer !== target) {
+                    if (sourceInitializer !== targetInitializer && (sourceInitializer !== source || targetInitializer !== target)) {
                         mergeSymbol(targetInitializer, sourceInitializer);
                     }
                 }


### PR DESCRIPTION
This just cuts off the infinite merging; it doesn't address the underlying bug which is probably in bindPropertyAssignment.

Note that we're still waiting on a repro. Currently it looks like there is more than one library that fails.