### PR TITLE
Fix RWC test case sensitivity

### DIFF
--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -126,7 +126,7 @@ namespace RWC {
                 compilerResult = Harness.Compiler.compileFiles(
                     inputFiles,
                     otherFiles,
-                    /* harnessOptions */ undefined,
+                    {useCaseSensitiveFileNames: ""+(ioLog.useCaseSensitiveFileNames || false)},
                     opts.options,
                     // Since each RWC json file specifies its current directory in its json file, we need
                     // to pass this information in explicitly instead of acquiring it from the process.


### PR DESCRIPTION
There's still another pair of RWC changes that were caused by the VFS change that we should _probably_ just take baseline updates for - reordered input files (now matches what a real fs does) causing sourcemap and error baseline adjustments, and more reported input dupes from inconsistent casing (since there's no longer a pre-compile dedupe stage in the rwc runner); additionally JS baselines that previous had inconsistently slashed/cased paths logged at the top are now consistent.

Other RWC changes we have out (beyond the glimmer timeout) look to mostly be from renamed temp vars (from our recent generated name change) and some error span changes from property changes, though there's also a handful of new errors along the lines of `Type 'T' is not assignable to type 'object'`, which are somewhat concerning.