### PR TITLE
Dump XML test results in VSTS

### DIFF
--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -127,6 +127,7 @@ namespace Harness.Parallel.Host {
         let passingFiles = 0;
         let failingFiles = 0;
         let errorResults: ErrorInfo[] = [];
+        let passingResults: { name: string[] }[] = [];
         let totalPassing = 0;
         const startTime = Date.now();
 
@@ -198,9 +199,11 @@ namespace Harness.Parallel.Host {
                         totalPassing += data.payload.passing;
                         if (data.payload.errors.length) {
                             errorResults = errorResults.concat(data.payload.errors);
+                            passingResults = passingResults.concat(data.payload.passes);
                             failingFiles++;
                         }
                         else {
+                            passingResults = passingResults.concat(data.payload.passes);
                             passingFiles++;
                         }
                         newPerfData[hashName(data.payload.runner, data.payload.file)] = data.payload.duration;
@@ -367,21 +370,55 @@ namespace Harness.Parallel.Host {
 
             IO.writeFile(perfdataFileName(configOption), JSON.stringify(newPerfData, null, 4)); // tslint:disable-line:no-null-keyword
 
-            process.exit(errorResults.length);
+            if (Utils.getExecutionEnvironment() !== Utils.ExecutionEnvironment.Browser && process.env.CI === "true") {
+                const xunitReport = new xunit({ on: ts.noop, once: ts.noop }, { reporterOptions: { output: "./TEST-results.xml" } });
+                xunitReport.stats = reporter.stats;
+                xunitReport.failures = reporter.failures;
+                const rootAttrs: {[index: string]: any} = {
+                    name: "Tests",
+                    tests: stats.tests,
+                    failures: stats.failures,
+                    errors: stats.failures,
+                    skipped: stats.tests - stats.failures - stats.passes,
+                    timestamp: (new Date()).toUTCString(),
+                    time: (stats.duration / 1000) || 0
+                };
+                xunitReport.write(`<?xml version="1.0" encoding="UTF-8"?>` + "\n");
+                xunitReport.write(`<testsuite ${Object.keys(rootAttrs).map(k => `${k}="${escape("" + rootAttrs[k])}"`).join(" ")}>`);
+                [...failures, ...ts.map(passingResults, makeMochaTest)].forEach(t => {
+                    xunitReport.test(t);
+                });
+                xunitReport.write("</testsuite>");
+                xunitReport.done(failures, (f: any[]) => {
+                    process.exit(f.length);
+                });
+            }
+            else {
+                process.exit(failures.length);
+            }
+
         }
 
-        function makeMochaTest(test: ErrorInfo) {
+        function makeMochaTest(test: ErrorInfo | TestInfo) {
             return {
+                state: (test as ErrorInfo).error ? "failed" : "passed",
+                parent: {
+                    fullTitle: () => {
+                        return test.name.slice(0, test.name.length - 1).join(" ");
+                    }
+                },
+                title: test.name[test.name.length - 1],
                 fullTitle: () => {
                     return test.name.join(" ");
                 },
                 titlePath: () => {
                     return test.name;
                 },
-                err: {
-                    message: test.error,
-                    stack: test.stack
-                }
+                isPending: () => false,
+                err: (test as ErrorInfo).error ? {
+                    message: (test as ErrorInfo).error,
+                    stack: (test as ErrorInfo).stack
+                } : undefined
             };
         }
 
@@ -392,6 +429,7 @@ namespace Harness.Parallel.Host {
 
     let mocha: any;
     let base: any;
+    let xunit: any;
     let color: any;
     let cursor: any;
     let readline: any;
@@ -434,6 +472,7 @@ namespace Harness.Parallel.Host {
     function initializeProgressBarsDependencies() {
         mocha = require("mocha");
         base = mocha.reporters.Base;
+        xunit = mocha.reporters.xunit;
         color = base.color;
         cursor = base.cursor;
         readline = require("readline");

--- a/src/harness/parallel/shared.ts
+++ b/src/harness/parallel/shared.ts
@@ -7,8 +7,9 @@ namespace Harness.Parallel {
     export type ParallelHostMessage = ParallelTestMessage | ParallelCloseMessage | ParallelBatchMessage;
 
     export type ParallelErrorMessage = { type: "error", payload: { error: string, stack: string, name?: string[] } } | never;
-    export type ErrorInfo = ParallelErrorMessage["payload"] & { name: string[] };
-    export type ParallelResultMessage = { type: "result", payload: { passing: number, errors: ErrorInfo[], duration: number, runner: TestRunnerKind | "unittest", file: string } } | never;
+    export type TestInfo = { name: string[] } | never;
+    export type ErrorInfo = ParallelErrorMessage["payload"] & TestInfo;
+    export type ParallelResultMessage = { type: "result", payload: { passing: number, errors: ErrorInfo[], passes: TestInfo[], duration: number, runner: TestRunnerKind | "unittest", file: string } } | never;
     export type ParallelBatchProgressMessage = { type: "progress", payload: ParallelResultMessage["payload"] } | never;
     export type ParallelTimeoutChangeMessage = { type: "timeout", payload: { duration: number | "reset" } } | never;
     export type ParallelClientMessage = ParallelErrorMessage | ParallelResultMessage | ParallelBatchProgressMessage | ParallelTimeoutChangeMessage;

--- a/src/harness/parallel/worker.ts
+++ b/src/harness/parallel/worker.ts
@@ -1,5 +1,6 @@
 namespace Harness.Parallel.Worker {
     let errors: ErrorInfo[] = [];
+    let passes: TestInfo[] = [];
     let passing = 0;
 
     type MochaCallback = (this: Mocha.ISuiteCallbackContext, done: MochaDone) => void;
@@ -9,12 +10,13 @@ namespace Harness.Parallel.Worker {
 
     function resetShimHarnessAndExecute(runner: RunnerBase) {
         errors = [];
+        passes = [];
         passing = 0;
         testList.length = 0;
         const start = +(new Date());
         runner.initializeTests();
         testList.forEach(({ name, callback, kind }) => executeCallback(name, callback, kind));
-        return { errors, passing, duration: +(new Date()) - start };
+        return { errors, passes, passing, duration: +(new Date()) - start };
     }
 
 
@@ -152,6 +154,7 @@ namespace Harness.Parallel.Worker {
             try {
                 // TODO: If we ever start using async test completions, polyfill promise return handling
                 callback.call(fakeContext);
+                passes.push({ name: [...namestack] });
             }
             catch (error) {
                 errors.push({ error: error.message, stack: error.stack, name: [...namestack] });
@@ -178,6 +181,7 @@ namespace Harness.Parallel.Worker {
                         errors.push({ error: err.toString(), stack: "", name: [...namestack] });
                     }
                     else {
+                        passes.push({ name: [...namestack] });
                         passing++;
                     }
                     completed = true;
@@ -294,11 +298,12 @@ namespace Harness.Parallel.Worker {
         }
         if (unitTests[name]) {
             errors = [];
+            passes = [];
             passing = 0;
             const start = +(new Date());
             executeSuiteCallback(name, unitTests[name]);
             delete unitTests[name];
-            return { file: name, runner: unittest, errors, passing, duration: +(new Date()) - start };
+            return { file: name, runner: unittest, errors, passes, passing, duration: +(new Date()) - start };
         }
         throw new Error(`Unit test with name "${name}" was asked to be run, but such a test does not exist!`);
     }


### PR DESCRIPTION
This should populate the `tests` panel in VSTS (with both passes and fails); I've already modified the task in VSTS, so this PR should demonstrate it.

The benefit here is that the output should be a little easier to search/filter/inspect in the VSTS interface compared with the normal log output (which will also still be present).