### PR TITLE
Fix comment

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -538,7 +538,7 @@ namespace ts {
         Abstract =           1 << 7,  // Class/Method/ConstructSignature
         Async =              1 << 8,  // Property/Method/Function
         Default =            1 << 9,  // Function/Class (export default declaration)
-        Const =              1 << 11, // Variable declaration
+        Const =              1 << 11, // Const enum
         HasComputedFlags =   1 << 29, // Modifier flags have been computed
 
         AccessibilityModifier = Public | Private | Protected,


### PR DESCRIPTION
It looks like the `const` keyword in `const x = 0;` isn't parsed as a modifier, so this will only apply to enums. There's no `ModifierFlags.Let` or `ModifierFlags.Var`.