### PR TITLE
Don't count '/' in division as a completions trigger

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2207,7 +2207,6 @@ namespace ts.Completions {
     function isValidTrigger(sourceFile: SourceFile, triggerCharacter: CompletionsTriggerCharacter, contextToken: Node, position: number): boolean {
         switch (triggerCharacter) {
             case ".":
-            case "/":
             case "@":
                 return true;
             case '"':
@@ -2218,6 +2217,8 @@ namespace ts.Completions {
             case "<":
                 // Opening JSX tag
                 return contextToken.kind === SyntaxKind.LessThanToken && contextToken.parent.kind !== SyntaxKind.BinaryExpression;
+            case "/":
+                return isJsxClosingElement(contextToken.parent);
             default:
                 return Debug.assertNever(triggerCharacter);
         }

--- a/tests/cases/fourslash/completionsTriggerCharacter.ts
+++ b/tests/cases/fourslash/completionsTriggerCharacter.ts
@@ -18,6 +18,8 @@
 ////}
 ////const ctr = </*openTag*/
 ////const less = 1 </*lessThan*/
+////const closeTag = <div> foo <//*closeTag*/
+////const divide = 1 //*divide*/
 
 verify.completions(
     { marker: "openQuote", exact: ["a", "b"], triggerCharacter: '"' },
@@ -34,4 +36,6 @@ verify.completions(
 
     { marker: "openTag", includes: "div", triggerCharacter: "<" },
     { marker: "lessThan", exact: undefined, triggerCharacter: "<" },
+    { marker: "closeTag", exact: "div", triggerCharacter: "/" },
+    { marker: "divide", exact: undefined, triggerCharacter: "/" },
 );


### PR DESCRIPTION
@mjbvz Currently vscode doesn't seem to trigger at all on '/', but maybe it should as in `<div> foo </` completing with `div`.