### PR TITLE
Fix verify.goToDefinition with "" as marker name

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1250,7 +1250,7 @@ namespace ts {
         for (let { value: pair, done } = iterator.next(); !done; { value: pair, done } = iterator.next()) {
             const [key, value] = pair;
             const result = callback(value, key as (string & __String));
-            if (result) {
+            if (result !== undefined && result !== false as any) {
                 return result;
             }
         }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -649,7 +649,7 @@ namespace FourSlash {
         }
 
         private verifyGoToX(arg0: any, endMarkerNames: ArrayOrSingle<string> | undefined, getDefs: () => ts.DefinitionInfo[] | ts.DefinitionInfoAndBoundSpan | undefined) {
-            if (endMarkerNames) {
+            if (endMarkerNames !== undefined) {
                 this.verifyGoToXPlain(arg0, endMarkerNames, getDefs);
             }
             else if (ts.isArray(arg0)) {

--- a/tests/cases/fourslash/findAllRefsForDefaultExport.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport.ts
@@ -5,7 +5,7 @@
 
 // @Filename: b.ts
 ////import [|{| "isWriteAccess": true, "isDefinition": true |}g|] from "./a";
-////[|/*ref*/g|]();
+////[|/**/g|]();
 
 // @Filename: c.ts
 ////import { f } from "./a";
@@ -18,4 +18,4 @@ verify.referenceGroups(r0, [
 ]);
 verify.singleReferenceGroup("(alias) function g(): void\nimport g", [r1, r2]);
 
-verify.goToDefinition("ref", "def");
+verify.goToDefinition("", "def");


### PR DESCRIPTION
`markerName` in `fourslash.ts` called `forEachEntry` which used a truthy test, making it fail for `""`.
