### PR TITLE
VSTS prefers to pass secrets as command line params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ scripts/buildProtocol.js
 scripts/ior.js
 scripts/authors.js
 scripts/configurePrerelease.js
+scripts/open-user-pr.js
 scripts/processDiagnosticMessages.d.ts
 scripts/processDiagnosticMessages.js
 scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.js

--- a/scripts/open-user-pr.ts
+++ b/scripts/open-user-pr.ts
@@ -33,7 +33,7 @@ runSequence([
 const gh = new Octokit();
 gh.authenticate({
     type: "token",
-    token: process.env.GH_TOKEN
+    token: process.argv[2]
 });
 gh.pullRequests.create({
     owner: process.env.TARGET_FORK,


### PR DESCRIPTION
Also add the built version of the script to the gitignore, so the build task doesn't need to use ts-node, which we no longer actually depend on.
