### PR TITLE
Support '/' as a trigger character in path completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2218,7 +2218,9 @@ namespace ts.Completions {
                 // Opening JSX tag
                 return contextToken.kind === SyntaxKind.LessThanToken && contextToken.parent.kind !== SyntaxKind.BinaryExpression;
             case "/":
-                return isJsxClosingElement(contextToken.parent);
+                return isStringLiteralLike(contextToken)
+                    ? !!tryGetImportFromModuleSpecifier(contextToken)
+                    : contextToken.kind === SyntaxKind.SlashToken && isJsxClosingElement(contextToken.parent);
             default:
                 return Debug.assertNever(triggerCharacter);
         }

--- a/tests/cases/fourslash/completionsTriggerCharacter.ts
+++ b/tests/cases/fourslash/completionsTriggerCharacter.ts
@@ -9,6 +9,9 @@
 
 ////// "/*quoteInComment*/ </*lessInComment*/
 
+// @Filename: /foo/importMe.ts
+////whatever
+
 // @Filename: /a.tsx
 ////declare namespace JSX {
 ////    interface Element {}
@@ -16,9 +19,10 @@
 ////        div: {};
 ////    }
 ////}
-////const ctr = </*openTag*/
-////const less = 1 </*lessThan*/
-////const closeTag = <div> foo <//*closeTag*/
+////const ctr = </*openTag*/;
+////const less = 1 </*lessThan*/;
+////const closeTag = <div> foo <//*closeTag*/;
+////import something from "./foo//*path*/";
 ////const divide = 1 //*divide*/
 
 verify.completions(
@@ -37,5 +41,6 @@ verify.completions(
     { marker: "openTag", includes: "div", triggerCharacter: "<" },
     { marker: "lessThan", exact: undefined, triggerCharacter: "<" },
     { marker: "closeTag", exact: "div", triggerCharacter: "/" },
+    { marker: "path", exact: "importMe", triggerCharacter: "/", isNewIdentifierLocation: true },
     { marker: "divide", exact: undefined, triggerCharacter: "/" },
 );


### PR DESCRIPTION
Sequel to #24038

Treat `/` as a trigger character in `import foo from "./foo/"` (but not in `const aStringLiteral = "foo/"`).