### PR TITLE
Add support for the 'messsageerror' Event to MessagePort type definition

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -9162,10 +9162,12 @@ declare var MessageEvent: {
 
 interface MessagePortEventMap {
     "message": MessageEvent;
+    "messageerror": MessageEvent;
 }
 
 interface MessagePort extends EventTarget {
     onmessage: ((this: MessagePort, ev: MessageEvent) => any) | null;
+    onmessageerror: ((this: MessagePort, ev: MessageEvent) => any) | null;
     close(): void;
     postMessage(message?: any, transfer?: any[]): void;
     start(): void;


### PR DESCRIPTION
The MessagePort spec says that the event handler types that must be supported
by any implementation of MessagePort are 'message' and 'messageerror'.
The MessagePort type definition needs to have the 'messageerror' event type
added since it is missing.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #24059
