### PR TITLE
"gulp" -> "jake"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,29 +61,29 @@ Change to the TypeScript directory:
 cd TypeScript
 ```
 
-Install Gulp tools and dev dependencies:
+Install Jake tools and dev dependencies:
 
 ```bash
-npm install -g gulp
+npm install -g jake
 npm install
 ```
 
 Use one of the following to build and test:
 
 ```
-gulp local            # Build the compiler into built/local 
-gulp clean            # Delete the built compiler 
-gulp LKG              # Replace the last known good with the built one.
+jake local            # Build the compiler into built/local 
+jake clean            # Delete the built compiler 
+jake LKG              # Replace the last known good with the built one.
                       # Bootstrapping step to be executed when the built compiler reaches a stable state.
-gulp tests            # Build the test infrastructure using the built compiler. 
-gulp runtests         # Run tests using the built compiler and test infrastructure. 
+jake tests            # Build the test infrastructure using the built compiler. 
+jake runtests         # Run tests using the built compiler and test infrastructure. 
                       # You can override the host or specify a test for this command. 
                       # Use host=<hostName> or tests=<testPath>. 
-gulp runtests-browser # Runs the tests using the built run.js file. Syntax is gulp runtests. Optional
+jake runtests-browser # Runs the tests using the built run.js file. Syntax is jake runtests. Optional
                         parameters 'host=', 'tests=[regex], reporter=[list|spec|json|<more>]'.
-gulp baseline-accept  # This replaces the baseline test results with the results obtained from gulp runtests.
-gulp lint             # Runs tslint on the TypeScript source.
-gulp help             # List the above commands. 
+jake baseline-accept  # This replaces the baseline test results with the results obtained from jake runtests.
+jake lint             # Runs tslint on the TypeScript source.
+jake help             # List the above commands. 
 ```
 
 


### PR DESCRIPTION
On branch `release-2.8`, `gulp` produces a build error.  In practice, `jake` is our supported build tool.