### PR TITLE
Reduce aggression of parenthesis removal in ts transform

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2534,6 +2534,11 @@ namespace ts {
                 // we can safely elide the parentheses here, as a new synthetic
                 // ParenthesizedExpression will be inserted if we remove parentheses too
                 // aggressively.
+                // HOWEVER - if there are leading comments on the expression itself, to handle ASI
+                // correctly for return and throw, we must keep the parenthesis
+                if (length(getLeadingCommentRangesOfNode(expression, currentSourceFile))) {
+                    return updateParen(node, expression);
+                }
                 return createPartiallyEmittedExpression(expression, node);
             }
 

--- a/tests/baselines/reference/parenthesizedArrowExpressionASI.js
+++ b/tests/baselines/reference/parenthesizedArrowExpressionASI.js
@@ -1,0 +1,11 @@
+//// [parenthesizedArrowExpressionASI.ts]
+const x = (a: any[]) => (
+    // comment
+    undefined as number
+);
+
+
+//// [parenthesizedArrowExpressionASI.js]
+var x = function (a) { return (
+// comment
+undefined); };

--- a/tests/baselines/reference/parenthesizedArrowExpressionASI.symbols
+++ b/tests/baselines/reference/parenthesizedArrowExpressionASI.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/parenthesizedArrowExpressionASI.ts ===
+const x = (a: any[]) => (
+>x : Symbol(x, Decl(parenthesizedArrowExpressionASI.ts, 0, 5))
+>a : Symbol(a, Decl(parenthesizedArrowExpressionASI.ts, 0, 11))
+
+    // comment
+    undefined as number
+>undefined : Symbol(undefined)
+
+);
+

--- a/tests/baselines/reference/parenthesizedArrowExpressionASI.types
+++ b/tests/baselines/reference/parenthesizedArrowExpressionASI.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/parenthesizedArrowExpressionASI.ts ===
+const x = (a: any[]) => (
+>x : (a: any[]) => number
+>(a: any[]) => (    // comment    undefined as number) : (a: any[]) => number
+>a : any[]
+>(    // comment    undefined as number) : number
+
+    // comment
+    undefined as number
+>undefined as number : number
+>undefined : undefined
+
+);
+

--- a/tests/cases/compiler/parenthesizedArrowExpressionASI.ts
+++ b/tests/cases/compiler/parenthesizedArrowExpressionASI.ts
@@ -1,0 +1,4 @@
+const x = (a: any[]) => (
+    // comment
+    undefined as number
+);


### PR DESCRIPTION
Fixes #24021

Since comments are the only way we introduce a line terminator (as we do not preserve input whitespace in general), simply checking for the presence of a leading comment is sufficient for checking if we need to preserve the parens when removing the parens around a cast or not.