### PR TITLE
Return mapped locations in alternate fields

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -700,6 +700,13 @@ namespace ts.server {
             return definitions.map(def => this.toFileSpan(def.fileName, def.textSpan, project));
         }
 
+        /*
+         * When we map a .d.ts location to .ts, Visual Studio gets confused because there's no associated Roslyn Document in
+         * the same project which corresponds to the file. VS Code has no problem with this, and luckily we have two protocols.
+         * This retains the existing behavior for the "simplified" (VS Code) protocol but stores the .d.ts location in a
+         * set of additional fields, and does the reverse for VS (store the .d.ts location where
+         * it used to be and stores the .ts location in the additional fields).
+        */
         private static mapToOriginalLocation<T extends DocumentSpan>(def: T): T {
             if (def.originalFileName) {
                 Debug.assert(def.originalTextSpan !== undefined, "originalTextSpan should be present if originalFileName is");

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1600,10 +1600,10 @@ namespace ts {
 
         function makeGetTargetOfMappedPosition<TIn>(
             extract: (original: TIn) => sourcemaps.SourceMappableLocation,
-            create: (result: sourcemaps.SourceMappableLocation, original: TIn) => TIn
+            create: (result: sourcemaps.SourceMappableLocation, original: TIn, firstOriginal: TIn) => TIn
         ) {
             return getTargetOfMappedPosition;
-            function getTargetOfMappedPosition(input: TIn): TIn {
+            function getTargetOfMappedPosition(input: TIn, firstOriginal = input): TIn {
                 const info = extract(input);
                 if (endsWith(info.fileName, Extension.Dts)) {
                     let file: SourceFileLike = program.getSourceFile(info.fileName);
@@ -1617,7 +1617,7 @@ namespace ts {
                     const mapper = getSourceMapper(info.fileName, file);
                     const newLoc = mapper.getOriginalPosition(info);
                     if (newLoc === info) return input;
-                    return getTargetOfMappedPosition(create(newLoc, input));
+                    return getTargetOfMappedPosition(create(newLoc, input, firstOriginal), firstOriginal);
                 }
                 return input;
             }
@@ -1625,7 +1625,7 @@ namespace ts {
 
         const getTargetOfMappedDeclarationInfo = makeGetTargetOfMappedPosition(
             (info: DefinitionInfo) => ({ fileName: info.fileName, position: info.textSpan.start }),
-            (newLoc, info) => ({
+            (newLoc, info, firstOriginal) => ({
                 containerKind: info.containerKind,
                 containerName: info.containerName,
                 fileName: newLoc.fileName,
@@ -1635,13 +1635,13 @@ namespace ts {
                     start: newLoc.position,
                     length: info.textSpan.length
                 },
-                originalFileName: info.fileName,
-                originalTextSpan: info.textSpan
+                originalFileName: firstOriginal.fileName,
+                originalTextSpan: firstOriginal.textSpan
             })
         );
 
         function getTargetOfMappedDeclarationFiles(infos: ReadonlyArray<DefinitionInfo>): DefinitionInfo[] {
-            return map(infos, getTargetOfMappedDeclarationInfo);
+            return map(infos, d => getTargetOfMappedDeclarationInfo(d));
         }
 
         /// Goto definition
@@ -1687,7 +1687,7 @@ namespace ts {
         );
 
         function getTargetOfMappedImplementationLocations(infos: ReadonlyArray<ImplementationLocation>): ImplementationLocation[] {
-            return map(infos, getTargetOfMappedImplementationLocation);
+            return map(infos, d => getTargetOfMappedImplementationLocation(d));
         }
 
         function getImplementationAtPosition(fileName: string, position: number): ImplementationLocation[] {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1600,10 +1600,10 @@ namespace ts {
 
         function makeGetTargetOfMappedPosition<TIn>(
             extract: (original: TIn) => sourcemaps.SourceMappableLocation,
-            create: (result: sourcemaps.SourceMappableLocation, original: TIn, firstOriginal: TIn) => TIn
+            create: (result: sourcemaps.SourceMappableLocation, unmapped: TIn, original: TIn) => TIn
         ) {
             return getTargetOfMappedPosition;
-            function getTargetOfMappedPosition(input: TIn, firstOriginal = input): TIn {
+            function getTargetOfMappedPosition(input: TIn, original = input): TIn {
                 const info = extract(input);
                 if (endsWith(info.fileName, Extension.Dts)) {
                     let file: SourceFileLike = program.getSourceFile(info.fileName);
@@ -1617,7 +1617,7 @@ namespace ts {
                     const mapper = getSourceMapper(info.fileName, file);
                     const newLoc = mapper.getOriginalPosition(info);
                     if (newLoc === info) return input;
-                    return getTargetOfMappedPosition(create(newLoc, input, firstOriginal), firstOriginal);
+                    return getTargetOfMappedPosition(create(newLoc, input, original), original);
                 }
                 return input;
             }
@@ -1625,7 +1625,7 @@ namespace ts {
 
         const getTargetOfMappedDeclarationInfo = makeGetTargetOfMappedPosition(
             (info: DefinitionInfo) => ({ fileName: info.fileName, position: info.textSpan.start }),
-            (newLoc, info, firstOriginal) => ({
+            (newLoc, info, original) => ({
                 containerKind: info.containerKind,
                 containerName: info.containerName,
                 fileName: newLoc.fileName,
@@ -1635,8 +1635,8 @@ namespace ts {
                     start: newLoc.position,
                     length: info.textSpan.length
                 },
-                originalFileName: firstOriginal.fileName,
-                originalTextSpan: firstOriginal.textSpan
+                originalFileName: original.fileName,
+                originalTextSpan: original.textSpan
             })
         );
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1634,7 +1634,9 @@ namespace ts {
                 textSpan: {
                     start: newLoc.position,
                     length: info.textSpan.length
-                }
+                },
+                originalFileName: info.fileName,
+                originalTextSpan: info.textSpan
             })
         );
 
@@ -1678,7 +1680,9 @@ namespace ts {
                 textSpan: {
                     start: newLoc.position,
                     length: info.textSpan.length
-                }
+                },
+                originalFileName: info.fileName,
+                originalTextSpan: info.textSpan
             })
         );
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -542,6 +542,13 @@ namespace ts {
     export interface DocumentSpan {
         textSpan: TextSpan;
         fileName: string;
+
+        /**
+         * If the span represents a location that was remapped (e.g. via a .d.ts.map file),
+         * then the original filename and span will be specified here
+         */
+        originalTextSpan?: TextSpan;
+        originalFileName?: string;
     }
 
     export interface RenameLocation extends DocumentSpan {
@@ -654,9 +661,7 @@ namespace ts {
         indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
     }
 
-    export interface DefinitionInfo {
-        fileName: string;
-        textSpan: TextSpan;
+    export interface DefinitionInfo extends DocumentSpan {
         kind: ScriptElementKind;
         name: string;
         containerKind: ScriptElementKind;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4701,6 +4701,12 @@ declare namespace ts {
     interface DocumentSpan {
         textSpan: TextSpan;
         fileName: string;
+        /**
+         * If the span represents a location that was remapped (e.g. via a .d.ts.map file),
+         * then the original filename and span will be specified here
+         */
+        originalTextSpan?: TextSpan;
+        originalFileName?: string;
     }
     interface RenameLocation extends DocumentSpan {
     }
@@ -4798,9 +4804,7 @@ declare namespace ts {
         insertSpaceBeforeTypeAnnotation?: boolean;
         indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
     }
-    interface DefinitionInfo {
-        fileName: string;
-        textSpan: TextSpan;
+    interface DefinitionInfo extends DocumentSpan {
         kind: ScriptElementKind;
         name: string;
         containerKind: ScriptElementKind;
@@ -8410,6 +8414,7 @@ declare namespace ts.server {
         private getDefinition;
         private getDefinitionAndBoundSpan;
         private mapDefinitionInfo;
+        private static mapToOriginalLocation;
         private toFileSpan;
         private getTypeDefinition;
         private getImplementation;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4701,6 +4701,12 @@ declare namespace ts {
     interface DocumentSpan {
         textSpan: TextSpan;
         fileName: string;
+        /**
+         * If the span represents a location that was remapped (e.g. via a .d.ts.map file),
+         * then the original filename and span will be specified here
+         */
+        originalTextSpan?: TextSpan;
+        originalFileName?: string;
     }
     interface RenameLocation extends DocumentSpan {
     }
@@ -4798,9 +4804,7 @@ declare namespace ts {
         insertSpaceBeforeTypeAnnotation?: boolean;
         indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
     }
-    interface DefinitionInfo {
-        fileName: string;
-        textSpan: TextSpan;
+    interface DefinitionInfo extends DocumentSpan {
         kind: ScriptElementKind;
         name: string;
         containerKind: ScriptElementKind;


### PR DESCRIPTION
When we map a `.d.ts` location to `.ts`, Visual Studio gets confused because there's no associated Roslyn `Document` in the same project which corresponds to the file. VS Code has no problem with this, and luckily we have two protocols.

This retains the existing behavior for the "simplified" (VS Code) protocol but stores the `.d.ts` location in a set of additional fields, and does the reverse for VS (store the `.d.ts` location where it used to be and stores the `.ts` location in the additional fields).

This gives both editors maximum flexibility in terms of how they treat go-to-def requests which land in sourcemapped .d.ts files.

I have a separate PR on the managed side to consume these fields when they are present.