### PR TITLE
Simplify conditionals if both branches are independent of instantiation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8828,6 +8828,19 @@ namespace ts {
             return type.flags & TypeFlags.Substitution ? (<SubstitutionType>type).typeVariable : type;
         }
 
+        function createConditionalWildcardMapper(root: ConditionalRoot): TypeMapper {
+            if (root.isDistributive && root.inferTypeParameters) {
+                return combineTypeMappers(makeUnaryTypeMapper(root.checkType, wildcardType), createTypeMapper(root.inferTypeParameters, map(root.inferTypeParameters, _ => wildcardType)));
+            }
+            else if (root.isDistributive) {
+                return makeUnaryTypeMapper(root.checkType, wildcardType);
+            }
+            else if (root.inferTypeParameters) {
+                return createTypeMapper(root.inferTypeParameters, map(root.inferTypeParameters, _ => wildcardType));
+            }
+            return identityMapper;
+        }
+
         function getConditionalType(root: ConditionalRoot, mapper: TypeMapper): Type {
             const checkType = instantiateType(root.checkType, mapper);
             const extendsType = instantiateType(root.extendsType, mapper);
@@ -8837,7 +8850,10 @@ namespace ts {
             // If this is a distributive conditional type and the check type is generic we need to defer
             // resolution of the conditional type such that a later instantiation will properly distribute
             // over union types.
-            const isDeferred = root.isDistributive && maybeTypeOfKind(checkType, TypeFlags.Instantiable);
+            // If the true and false branches of the conditional aren't affected by any infer param or check type instantiation, then we can and should try to simplify the type
+            const conditionalMapper = createConditionalWildcardMapper(root);
+            const independent = conditionalMapper !== identityMapper && instantiateType(root.trueType, conditionalMapper) === root.trueType && instantiateType(root.falseType, conditionalMapper) === root.falseType;
+            const isDeferred = !independent && root.isDistributive && maybeTypeOfKind(checkType, TypeFlags.Instantiable);
             let combinedMapper: TypeMapper;
             if (root.inferTypeParameters) {
                 const context = createInferenceContext(root.inferTypeParameters, /*signature*/ undefined, InferenceFlags.None);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8852,7 +8852,7 @@ namespace ts {
             // over union types.
             // If the true and false branches of the conditional aren't affected by any infer param or check type instantiation, then we can and should try to simplify the type
             const conditionalMapper = createConditionalWildcardMapper(root);
-            const independent = conditionalMapper !== identityMapper && instantiateType(root.trueType, conditionalMapper) === root.trueType && instantiateType(root.falseType, conditionalMapper) === root.falseType;
+            const independent = conditionalMapper === identityMapper || (instantiateType(root.trueType, conditionalMapper) === root.trueType && instantiateType(root.falseType, conditionalMapper) === root.falseType);
             const isDeferred = !independent && root.isDistributive && maybeTypeOfKind(checkType, TypeFlags.Instantiable);
             let combinedMapper: TypeMapper;
             if (root.inferTypeParameters) {

--- a/tests/baselines/reference/complexTypeExampleNoHang.errors.txt
+++ b/tests/baselines/reference/complexTypeExampleNoHang.errors.txt
@@ -1,0 +1,61 @@
+tests/cases/compiler/complexTypeExampleNoHang.ts(8,6): error TS2456: Type alias 'KeysRec' circularly references itself.
+tests/cases/compiler/complexTypeExampleNoHang.ts(9,7): error TS2502: '"1"' is referenced directly or indirectly in its own type annotation.
+tests/cases/compiler/complexTypeExampleNoHang.ts(9,12): error TS2315: Type 'HKeys' is not generic.
+tests/cases/compiler/complexTypeExampleNoHang.ts(9,46): error TS2304: Cannot find name 'Whatever'.
+tests/cases/compiler/complexTypeExampleNoHang.ts(11,6): error TS2456: Type alias 'HKeys' circularly references itself.
+tests/cases/compiler/complexTypeExampleNoHang.ts(11,17): error TS2315: Type 'KeysRec' is not generic.
+tests/cases/compiler/complexTypeExampleNoHang.ts(13,6): error TS2456: Type alias 'Normalize' circularly references itself.
+tests/cases/compiler/complexTypeExampleNoHang.ts(14,7): error TS2502: '"1"' is referenced directly or indirectly in its own type annotation.
+tests/cases/compiler/complexTypeExampleNoHang.ts(14,12): error TS2315: Type 'Normalize' is not generic.
+tests/cases/compiler/complexTypeExampleNoHang.ts(14,31): error TS2304: Cannot find name 'Shabadoo'.
+tests/cases/compiler/complexTypeExampleNoHang.ts(14,52): error TS2304: Cannot find name 'Whatever'.
+tests/cases/compiler/complexTypeExampleNoHang.ts(19,27): error TS2315: Type 'Normalize' is not generic.
+tests/cases/compiler/complexTypeExampleNoHang.ts(19,37): error TS2315: Type 'HKeys' is not generic.
+
+
+==== tests/cases/compiler/complexTypeExampleNoHang.ts (13 errors) ====
+    interface HCons<Next> {
+        readonly next: Next;
+    }
+    
+    type Unionize<T> = keyof T extends infer K
+      ? K extends string & keyof T ? Record<K, T[K]> : never
+      : never;
+    type KeysRec<T> = T extends Record<any, infer V>
+         ~~~~~~~
+!!! error TS2456: Type alias 'KeysRec' circularly references itself.
+      ? { "1": HKeys<V>, "0": number }[V extends Whatever ? '1' : '0']
+          ~~~
+!!! error TS2502: '"1"' is referenced directly or indirectly in its own type annotation.
+               ~~~~~~~~
+!!! error TS2315: Type 'HKeys' is not generic.
+                                                 ~~~~~~~~
+!!! error TS2304: Cannot find name 'Whatever'.
+      : never;
+    type HKeys<T> = KeysRec<Unionize<T>>;
+         ~~~~~
+!!! error TS2456: Type alias 'HKeys' circularly references itself.
+                    ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2315: Type 'KeysRec' is not generic.
+    
+    type Normalize<T> = T extends HCons<infer N>
+         ~~~~~~~~~
+!!! error TS2456: Type alias 'Normalize' circularly references itself.
+      ? { "1": Normalize<N>, "0": Shabadoo }[N extends Whatever ? '1' : '0']
+          ~~~
+!!! error TS2502: '"1"' is referenced directly or indirectly in its own type annotation.
+               ~~~~~~~~~~~~
+!!! error TS2315: Type 'Normalize' is not generic.
+                                  ~~~~~~~~
+!!! error TS2304: Cannot find name 'Shabadoo'.
+                                                       ~~~~~~~~
+!!! error TS2304: Cannot find name 'Whatever'.
+      : never;
+    
+    type JustNumber<H extends HCons<any>> = number;
+    
+    type Keys<T> = JustNumber<Normalize<HKeys<T>>>;
+                              ~~~~~~~~~~~~~~~~~~~
+!!! error TS2315: Type 'Normalize' is not generic.
+                                        ~~~~~~~~
+!!! error TS2315: Type 'HKeys' is not generic.

--- a/tests/baselines/reference/complexTypeExampleNoHang.js
+++ b/tests/baselines/reference/complexTypeExampleNoHang.js
@@ -1,0 +1,22 @@
+//// [complexTypeExampleNoHang.ts]
+interface HCons<Next> {
+    readonly next: Next;
+}
+
+type Unionize<T> = keyof T extends infer K
+  ? K extends string & keyof T ? Record<K, T[K]> : never
+  : never;
+type KeysRec<T> = T extends Record<any, infer V>
+  ? { "1": HKeys<V>, "0": number }[V extends Whatever ? '1' : '0']
+  : never;
+type HKeys<T> = KeysRec<Unionize<T>>;
+
+type Normalize<T> = T extends HCons<infer N>
+  ? { "1": Normalize<N>, "0": Shabadoo }[N extends Whatever ? '1' : '0']
+  : never;
+
+type JustNumber<H extends HCons<any>> = number;
+
+type Keys<T> = JustNumber<Normalize<HKeys<T>>>;
+
+//// [complexTypeExampleNoHang.js]

--- a/tests/baselines/reference/complexTypeExampleNoHang.symbols
+++ b/tests/baselines/reference/complexTypeExampleNoHang.symbols
@@ -1,0 +1,76 @@
+=== tests/cases/compiler/complexTypeExampleNoHang.ts ===
+interface HCons<Next> {
+>HCons : Symbol(HCons, Decl(complexTypeExampleNoHang.ts, 0, 0))
+>Next : Symbol(Next, Decl(complexTypeExampleNoHang.ts, 0, 16))
+
+    readonly next: Next;
+>next : Symbol(HCons.next, Decl(complexTypeExampleNoHang.ts, 0, 23))
+>Next : Symbol(Next, Decl(complexTypeExampleNoHang.ts, 0, 16))
+}
+
+type Unionize<T> = keyof T extends infer K
+>Unionize : Symbol(Unionize, Decl(complexTypeExampleNoHang.ts, 2, 1))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 4, 14))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 4, 14))
+>K : Symbol(K, Decl(complexTypeExampleNoHang.ts, 4, 40))
+
+  ? K extends string & keyof T ? Record<K, T[K]> : never
+>K : Symbol(K, Decl(complexTypeExampleNoHang.ts, 4, 40))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 4, 14))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>K : Symbol(K, Decl(complexTypeExampleNoHang.ts, 4, 40))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 4, 14))
+>K : Symbol(K, Decl(complexTypeExampleNoHang.ts, 4, 40))
+
+  : never;
+type KeysRec<T> = T extends Record<any, infer V>
+>KeysRec : Symbol(KeysRec, Decl(complexTypeExampleNoHang.ts, 6, 10))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 7, 13))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 7, 13))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>V : Symbol(V, Decl(complexTypeExampleNoHang.ts, 7, 45))
+
+  ? { "1": HKeys<V>, "0": number }[V extends Whatever ? '1' : '0']
+>"1" : Symbol("1", Decl(complexTypeExampleNoHang.ts, 8, 5))
+>HKeys : Symbol(HKeys, Decl(complexTypeExampleNoHang.ts, 9, 10))
+>V : Symbol(V, Decl(complexTypeExampleNoHang.ts, 7, 45))
+>"0" : Symbol("0", Decl(complexTypeExampleNoHang.ts, 8, 20))
+>V : Symbol(V, Decl(complexTypeExampleNoHang.ts, 7, 45))
+
+  : never;
+type HKeys<T> = KeysRec<Unionize<T>>;
+>HKeys : Symbol(HKeys, Decl(complexTypeExampleNoHang.ts, 9, 10))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 10, 11))
+>KeysRec : Symbol(KeysRec, Decl(complexTypeExampleNoHang.ts, 6, 10))
+>Unionize : Symbol(Unionize, Decl(complexTypeExampleNoHang.ts, 2, 1))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 10, 11))
+
+type Normalize<T> = T extends HCons<infer N>
+>Normalize : Symbol(Normalize, Decl(complexTypeExampleNoHang.ts, 10, 37))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 12, 15))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 12, 15))
+>HCons : Symbol(HCons, Decl(complexTypeExampleNoHang.ts, 0, 0))
+>N : Symbol(N, Decl(complexTypeExampleNoHang.ts, 12, 41))
+
+  ? { "1": Normalize<N>, "0": Shabadoo }[N extends Whatever ? '1' : '0']
+>"1" : Symbol("1", Decl(complexTypeExampleNoHang.ts, 13, 5))
+>Normalize : Symbol(Normalize, Decl(complexTypeExampleNoHang.ts, 10, 37))
+>N : Symbol(N, Decl(complexTypeExampleNoHang.ts, 12, 41))
+>"0" : Symbol("0", Decl(complexTypeExampleNoHang.ts, 13, 24))
+>N : Symbol(N, Decl(complexTypeExampleNoHang.ts, 12, 41))
+
+  : never;
+
+type JustNumber<H extends HCons<any>> = number;
+>JustNumber : Symbol(JustNumber, Decl(complexTypeExampleNoHang.ts, 14, 10))
+>H : Symbol(H, Decl(complexTypeExampleNoHang.ts, 16, 16))
+>HCons : Symbol(HCons, Decl(complexTypeExampleNoHang.ts, 0, 0))
+
+type Keys<T> = JustNumber<Normalize<HKeys<T>>>;
+>Keys : Symbol(Keys, Decl(complexTypeExampleNoHang.ts, 16, 47))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 18, 10))
+>JustNumber : Symbol(JustNumber, Decl(complexTypeExampleNoHang.ts, 14, 10))
+>Normalize : Symbol(Normalize, Decl(complexTypeExampleNoHang.ts, 10, 37))
+>HKeys : Symbol(HKeys, Decl(complexTypeExampleNoHang.ts, 9, 10))
+>T : Symbol(T, Decl(complexTypeExampleNoHang.ts, 18, 10))
+

--- a/tests/baselines/reference/complexTypeExampleNoHang.types
+++ b/tests/baselines/reference/complexTypeExampleNoHang.types
@@ -1,0 +1,79 @@
+=== tests/cases/compiler/complexTypeExampleNoHang.ts ===
+interface HCons<Next> {
+>HCons : HCons<Next>
+>Next : Next
+
+    readonly next: Next;
+>next : Next
+>Next : Next
+}
+
+type Unionize<T> = keyof T extends infer K
+>Unionize : keyof T extends string & keyof T ? Record<keyof T, T[keyof T]> : never
+>T : T
+>T : T
+>K : K
+
+  ? K extends string & keyof T ? Record<K, T[K]> : never
+>K : K
+>T : T
+>Record : Record<K, T>
+>K : K
+>T : T
+>K : K
+
+  : never;
+type KeysRec<T> = T extends Record<any, infer V>
+>KeysRec : any
+>T : T
+>T : T
+>Record : Record<K, T>
+>V : V
+
+  ? { "1": HKeys<V>, "0": number }[V extends Whatever ? '1' : '0']
+>"1" : any
+>HKeys : any
+>V : V
+>"0" : number
+>V : V
+>Whatever : No type information available!
+
+  : never;
+type HKeys<T> = KeysRec<Unionize<T>>;
+>HKeys : any
+>T : T
+>KeysRec : any
+>Unionize : keyof T extends string & keyof T ? Record<keyof T, T[keyof T]> : never
+>T : T
+
+type Normalize<T> = T extends HCons<infer N>
+>Normalize : any
+>T : T
+>T : T
+>HCons : HCons<Next>
+>N : N
+
+  ? { "1": Normalize<N>, "0": Shabadoo }[N extends Whatever ? '1' : '0']
+>"1" : any
+>Normalize : any
+>N : N
+>"0" : any
+>Shabadoo : No type information available!
+>N : N
+>Whatever : No type information available!
+
+  : never;
+
+type JustNumber<H extends HCons<any>> = number;
+>JustNumber : number
+>H : H
+>HCons : HCons<Next>
+
+type Keys<T> = JustNumber<Normalize<HKeys<T>>>;
+>Keys : number
+>T : T
+>JustNumber : number
+>Normalize : any
+>HKeys : any
+>T : T
+

--- a/tests/baselines/reference/complextypeExampleNoOOM.errors.txt
+++ b/tests/baselines/reference/complextypeExampleNoOOM.errors.txt
@@ -1,0 +1,113 @@
+tests/cases/compiler/complextypeExampleNoOOM.ts(29,8): error TS2456: Type alias 'KeysRec' circularly references itself.
+tests/cases/compiler/complextypeExampleNoOOM.ts(31,9): error TS2502: '"1"' is referenced directly or indirectly in its own type annotation.
+tests/cases/compiler/complextypeExampleNoOOM.ts(31,44): error TS2315: Type 'HKeys' is not generic.
+tests/cases/compiler/complextypeExampleNoOOM.ts(35,8): error TS2456: Type alias 'HKeys' circularly references itself.
+tests/cases/compiler/complextypeExampleNoOOM.ts(35,19): error TS2315: Type 'KeysRec' is not generic.
+tests/cases/compiler/complextypeExampleNoOOM.ts(82,30): error TS2315: Type 'HKeys' is not generic.
+tests/cases/compiler/complextypeExampleNoOOM.ts(85,32): error TS2344: Type 'HNil | HCons<{}, HNil>' does not satisfy the constraint 'HCons<any, any>'.
+  Type 'HNil' is not assignable to type 'HCons<any, any>'.
+    Property 'value' is missing in type 'HNil'.
+
+
+==== tests/cases/compiler/complextypeExampleNoOOM.ts (7 errors) ====
+    class HList {
+        static hnil(): HNil {
+          return HNil.instance;
+        }
+        static hcons<V, Next extends HList>(value: V, next: Next) {
+          return new HCons<V, Next>(value, next);
+        }
+      }
+      class HNil extends HList {
+        static readonly instance = new HNil();
+        private readonly __hnil = 0;
+      }
+      class HCons<Value, Next extends HList> extends HList {
+        constructor(readonly value: Value, readonly next: Next) {
+          super();
+        }
+      }
+      
+      type IsHNil<H extends HList> = H extends HNil ? '1' : '0';
+      type IsHCons<H extends HList> = H extends HCons<any, any> ? '1' : '0';
+      type GetValue<H extends HList> = H extends HCons<infer V, any> ? V : never;
+      type GetNext<H extends HList> = H extends HCons<any, infer N> ? N : never;
+      
+      // Keys
+      type JsObject = { [key: string]: any };
+      type Unionize<T> = keyof T extends infer K
+        ? K extends string & keyof T ? Record<K, T[K]> : never
+        : never;
+      type KeysRec<T> = T extends Record<infer K, infer V>
+           ~~~~~~~
+!!! error TS2456: Type alias 'KeysRec' circularly references itself.
+        ? {
+            "1": V extends JsObject ? HCons<K, HKeys<V>> : HCons<K, HNil>;
+            ~~~
+!!! error TS2502: '"1"' is referenced directly or indirectly in its own type annotation.
+                                               ~~~~~~~~
+!!! error TS2315: Type 'HKeys' is not generic.
+            "0": HCons<K, HNil>;
+          }[V extends JsObject ? '1' : '0']
+        : HNil;
+      type HKeys<T> = KeysRec<Unionize<T>>;
+           ~~~~~
+!!! error TS2456: Type alias 'HKeys' circularly references itself.
+                      ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2315: Type 'KeysRec' is not generic.
+      
+      type DistriHelper<T, V> = T extends infer U ? HCons<V, U> : never;
+      
+      type Normalize<T extends HList> = T extends HCons<infer V, infer N>
+        ? {
+            "1": DistriHelper<Normalize<N>, V>;
+            "0": HCons<V, HNil>;
+          }[IsHCons<N>]
+        : HNil;
+      
+      type HListToArray<H extends HCons<any, any>> = H extends HCons<infer V1, HNil>
+        ? [V1]
+        : (H extends HCons<infer V1, HCons<infer V2, HNil>>
+            ? [V1, V2]
+            : (H extends HCons<infer V1, HCons<infer V2, HCons<infer V3, HNil>>>
+                ? [V1, V2, V3]
+                : (H extends HCons<
+                    infer V1,
+                    HCons<infer V2, HCons<infer V3, HCons<infer V4, HNil>>>
+                  >
+                    ? [V1, V2, V3, V4]
+                    : (H extends HCons<
+                        infer V1,
+                        HCons<
+                          infer V2,
+                          HCons<infer V3, HCons<infer V4, HCons<infer V5, HNil>>>
+                        >
+                      >
+                        ? [V1, V2, V3, V4, V5]
+                        : never))));
+      
+      type HListToArray2<H extends HCons<any, any>> = H extends HCons<
+        infer V1,
+        infer N
+      >
+        ? (N extends HCons<infer V2, infer N>
+            ? (N extends HCons<infer V3, infer N>
+                ? (N extends HCons<infer V4, infer N>
+                    ? (N extends HCons<infer V5, infer N>
+                        ? [V1, V2, V3, V4, V5]
+                        : [V1, V2, V3, V4])
+                    : [V1, V2, V3])
+                : [V1, V2])
+            : [V1])
+        : HNil;
+      
+      type NHKeys<T> = Normalize<HKeys<T>>;
+                                 ~~~~~~~~
+!!! error TS2315: Type 'HKeys' is not generic.
+      
+      // ADDING THIS LINE WOULD HANG THE COMPILER
+      type Keys<T> = HListToArray2<NHKeys<T>>;
+                                   ~~~~~~~~~
+!!! error TS2344: Type 'HNil | HCons<{}, HNil>' does not satisfy the constraint 'HCons<any, any>'.
+!!! error TS2344:   Type 'HNil' is not assignable to type 'HCons<any, any>'.
+!!! error TS2344:     Property 'value' is missing in type 'HNil'.

--- a/tests/baselines/reference/complextypeExampleNoOOM.js
+++ b/tests/baselines/reference/complextypeExampleNoOOM.js
@@ -1,0 +1,129 @@
+//// [complextypeExampleNoOOM.ts]
+class HList {
+    static hnil(): HNil {
+      return HNil.instance;
+    }
+    static hcons<V, Next extends HList>(value: V, next: Next) {
+      return new HCons<V, Next>(value, next);
+    }
+  }
+  class HNil extends HList {
+    static readonly instance = new HNil();
+    private readonly __hnil = 0;
+  }
+  class HCons<Value, Next extends HList> extends HList {
+    constructor(readonly value: Value, readonly next: Next) {
+      super();
+    }
+  }
+  
+  type IsHNil<H extends HList> = H extends HNil ? '1' : '0';
+  type IsHCons<H extends HList> = H extends HCons<any, any> ? '1' : '0';
+  type GetValue<H extends HList> = H extends HCons<infer V, any> ? V : never;
+  type GetNext<H extends HList> = H extends HCons<any, infer N> ? N : never;
+  
+  // Keys
+  type JsObject = { [key: string]: any };
+  type Unionize<T> = keyof T extends infer K
+    ? K extends string & keyof T ? Record<K, T[K]> : never
+    : never;
+  type KeysRec<T> = T extends Record<infer K, infer V>
+    ? {
+        "1": V extends JsObject ? HCons<K, HKeys<V>> : HCons<K, HNil>;
+        "0": HCons<K, HNil>;
+      }[V extends JsObject ? '1' : '0']
+    : HNil;
+  type HKeys<T> = KeysRec<Unionize<T>>;
+  
+  type DistriHelper<T, V> = T extends infer U ? HCons<V, U> : never;
+  
+  type Normalize<T extends HList> = T extends HCons<infer V, infer N>
+    ? {
+        "1": DistriHelper<Normalize<N>, V>;
+        "0": HCons<V, HNil>;
+      }[IsHCons<N>]
+    : HNil;
+  
+  type HListToArray<H extends HCons<any, any>> = H extends HCons<infer V1, HNil>
+    ? [V1]
+    : (H extends HCons<infer V1, HCons<infer V2, HNil>>
+        ? [V1, V2]
+        : (H extends HCons<infer V1, HCons<infer V2, HCons<infer V3, HNil>>>
+            ? [V1, V2, V3]
+            : (H extends HCons<
+                infer V1,
+                HCons<infer V2, HCons<infer V3, HCons<infer V4, HNil>>>
+              >
+                ? [V1, V2, V3, V4]
+                : (H extends HCons<
+                    infer V1,
+                    HCons<
+                      infer V2,
+                      HCons<infer V3, HCons<infer V4, HCons<infer V5, HNil>>>
+                    >
+                  >
+                    ? [V1, V2, V3, V4, V5]
+                    : never))));
+  
+  type HListToArray2<H extends HCons<any, any>> = H extends HCons<
+    infer V1,
+    infer N
+  >
+    ? (N extends HCons<infer V2, infer N>
+        ? (N extends HCons<infer V3, infer N>
+            ? (N extends HCons<infer V4, infer N>
+                ? (N extends HCons<infer V5, infer N>
+                    ? [V1, V2, V3, V4, V5]
+                    : [V1, V2, V3, V4])
+                : [V1, V2, V3])
+            : [V1, V2])
+        : [V1])
+    : HNil;
+  
+  type NHKeys<T> = Normalize<HKeys<T>>;
+  
+  // ADDING THIS LINE WOULD HANG THE COMPILER
+  type Keys<T> = HListToArray2<NHKeys<T>>;
+
+//// [complextypeExampleNoOOM.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var HList = /** @class */ (function () {
+    function HList() {
+    }
+    HList.hnil = function () {
+        return HNil.instance;
+    };
+    HList.hcons = function (value, next) {
+        return new HCons(value, next);
+    };
+    return HList;
+}());
+var HNil = /** @class */ (function (_super) {
+    __extends(HNil, _super);
+    function HNil() {
+        var _this = _super !== null && _super.apply(this, arguments) || this;
+        _this.__hnil = 0;
+        return _this;
+    }
+    HNil.instance = new HNil();
+    return HNil;
+}(HList));
+var HCons = /** @class */ (function (_super) {
+    __extends(HCons, _super);
+    function HCons(value, next) {
+        var _this = _super.call(this) || this;
+        _this.value = value;
+        _this.next = next;
+        return _this;
+    }
+    return HCons;
+}(HList));

--- a/tests/baselines/reference/complextypeExampleNoOOM.symbols
+++ b/tests/baselines/reference/complextypeExampleNoOOM.symbols
@@ -1,0 +1,369 @@
+=== tests/cases/compiler/complextypeExampleNoOOM.ts ===
+class HList {
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+
+    static hnil(): HNil {
+>hnil : Symbol(HList.hnil, Decl(complextypeExampleNoOOM.ts, 0, 13))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+      return HNil.instance;
+>HNil.instance : Symbol(HNil.instance, Decl(complextypeExampleNoOOM.ts, 8, 28))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+>instance : Symbol(HNil.instance, Decl(complextypeExampleNoOOM.ts, 8, 28))
+    }
+    static hcons<V, Next extends HList>(value: V, next: Next) {
+>hcons : Symbol(HList.hcons, Decl(complextypeExampleNoOOM.ts, 3, 5))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 4, 17))
+>Next : Symbol(Next, Decl(complextypeExampleNoOOM.ts, 4, 19))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+>value : Symbol(value, Decl(complextypeExampleNoOOM.ts, 4, 40))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 4, 17))
+>next : Symbol(next, Decl(complextypeExampleNoOOM.ts, 4, 49))
+>Next : Symbol(Next, Decl(complextypeExampleNoOOM.ts, 4, 19))
+
+      return new HCons<V, Next>(value, next);
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 4, 17))
+>Next : Symbol(Next, Decl(complextypeExampleNoOOM.ts, 4, 19))
+>value : Symbol(value, Decl(complextypeExampleNoOOM.ts, 4, 40))
+>next : Symbol(next, Decl(complextypeExampleNoOOM.ts, 4, 49))
+    }
+  }
+  class HNil extends HList {
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+
+    static readonly instance = new HNil();
+>instance : Symbol(HNil.instance, Decl(complextypeExampleNoOOM.ts, 8, 28))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+    private readonly __hnil = 0;
+>__hnil : Symbol(HNil.__hnil, Decl(complextypeExampleNoOOM.ts, 9, 42))
+  }
+  class HCons<Value, Next extends HList> extends HList {
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>Value : Symbol(Value, Decl(complextypeExampleNoOOM.ts, 12, 14))
+>Next : Symbol(Next, Decl(complextypeExampleNoOOM.ts, 12, 20))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+
+    constructor(readonly value: Value, readonly next: Next) {
+>value : Symbol(HCons.value, Decl(complextypeExampleNoOOM.ts, 13, 16))
+>Value : Symbol(Value, Decl(complextypeExampleNoOOM.ts, 12, 14))
+>next : Symbol(HCons.next, Decl(complextypeExampleNoOOM.ts, 13, 38))
+>Next : Symbol(Next, Decl(complextypeExampleNoOOM.ts, 12, 20))
+
+      super();
+>super : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+    }
+  }
+  
+  type IsHNil<H extends HList> = H extends HNil ? '1' : '0';
+>IsHNil : Symbol(IsHNil, Decl(complextypeExampleNoOOM.ts, 16, 3))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 18, 14))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 18, 14))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+  type IsHCons<H extends HList> = H extends HCons<any, any> ? '1' : '0';
+>IsHCons : Symbol(IsHCons, Decl(complextypeExampleNoOOM.ts, 18, 60))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 19, 15))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 19, 15))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+
+  type GetValue<H extends HList> = H extends HCons<infer V, any> ? V : never;
+>GetValue : Symbol(GetValue, Decl(complextypeExampleNoOOM.ts, 19, 72))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 20, 16))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 20, 16))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 20, 56))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 20, 56))
+
+  type GetNext<H extends HList> = H extends HCons<any, infer N> ? N : never;
+>GetNext : Symbol(GetNext, Decl(complextypeExampleNoOOM.ts, 20, 77))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 21, 15))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 21, 15))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 21, 60))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 21, 60))
+  
+  // Keys
+  type JsObject = { [key: string]: any };
+>JsObject : Symbol(JsObject, Decl(complextypeExampleNoOOM.ts, 21, 76))
+>key : Symbol(key, Decl(complextypeExampleNoOOM.ts, 24, 21))
+
+  type Unionize<T> = keyof T extends infer K
+>Unionize : Symbol(Unionize, Decl(complextypeExampleNoOOM.ts, 24, 41))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 25, 16))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 25, 16))
+>K : Symbol(K, Decl(complextypeExampleNoOOM.ts, 25, 42))
+
+    ? K extends string & keyof T ? Record<K, T[K]> : never
+>K : Symbol(K, Decl(complextypeExampleNoOOM.ts, 25, 42))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 25, 16))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>K : Symbol(K, Decl(complextypeExampleNoOOM.ts, 25, 42))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 25, 16))
+>K : Symbol(K, Decl(complextypeExampleNoOOM.ts, 25, 42))
+
+    : never;
+  type KeysRec<T> = T extends Record<infer K, infer V>
+>KeysRec : Symbol(KeysRec, Decl(complextypeExampleNoOOM.ts, 27, 12))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 28, 15))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 28, 15))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>K : Symbol(K, Decl(complextypeExampleNoOOM.ts, 28, 42))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 28, 51))
+
+    ? {
+        "1": V extends JsObject ? HCons<K, HKeys<V>> : HCons<K, HNil>;
+>"1" : Symbol("1", Decl(complextypeExampleNoOOM.ts, 29, 7))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 28, 51))
+>JsObject : Symbol(JsObject, Decl(complextypeExampleNoOOM.ts, 21, 76))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>K : Symbol(K, Decl(complextypeExampleNoOOM.ts, 28, 42))
+>HKeys : Symbol(HKeys, Decl(complextypeExampleNoOOM.ts, 33, 11))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 28, 51))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>K : Symbol(K, Decl(complextypeExampleNoOOM.ts, 28, 42))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+        "0": HCons<K, HNil>;
+>"0" : Symbol("0", Decl(complextypeExampleNoOOM.ts, 30, 70))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>K : Symbol(K, Decl(complextypeExampleNoOOM.ts, 28, 42))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+      }[V extends JsObject ? '1' : '0']
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 28, 51))
+>JsObject : Symbol(JsObject, Decl(complextypeExampleNoOOM.ts, 21, 76))
+
+    : HNil;
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+  type HKeys<T> = KeysRec<Unionize<T>>;
+>HKeys : Symbol(HKeys, Decl(complextypeExampleNoOOM.ts, 33, 11))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 34, 13))
+>KeysRec : Symbol(KeysRec, Decl(complextypeExampleNoOOM.ts, 27, 12))
+>Unionize : Symbol(Unionize, Decl(complextypeExampleNoOOM.ts, 24, 41))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 34, 13))
+  
+  type DistriHelper<T, V> = T extends infer U ? HCons<V, U> : never;
+>DistriHelper : Symbol(DistriHelper, Decl(complextypeExampleNoOOM.ts, 34, 39))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 36, 20))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 36, 22))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 36, 20))
+>U : Symbol(U, Decl(complextypeExampleNoOOM.ts, 36, 43))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 36, 22))
+>U : Symbol(U, Decl(complextypeExampleNoOOM.ts, 36, 43))
+  
+  type Normalize<T extends HList> = T extends HCons<infer V, infer N>
+>Normalize : Symbol(Normalize, Decl(complextypeExampleNoOOM.ts, 36, 68))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 38, 17))
+>HList : Symbol(HList, Decl(complextypeExampleNoOOM.ts, 0, 0))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 38, 17))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 38, 57))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 38, 66))
+
+    ? {
+        "1": DistriHelper<Normalize<N>, V>;
+>"1" : Symbol("1", Decl(complextypeExampleNoOOM.ts, 39, 7))
+>DistriHelper : Symbol(DistriHelper, Decl(complextypeExampleNoOOM.ts, 34, 39))
+>Normalize : Symbol(Normalize, Decl(complextypeExampleNoOOM.ts, 36, 68))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 38, 66))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 38, 57))
+
+        "0": HCons<V, HNil>;
+>"0" : Symbol("0", Decl(complextypeExampleNoOOM.ts, 40, 43))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V : Symbol(V, Decl(complextypeExampleNoOOM.ts, 38, 57))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+      }[IsHCons<N>]
+>IsHCons : Symbol(IsHCons, Decl(complextypeExampleNoOOM.ts, 18, 60))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 38, 66))
+
+    : HNil;
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+  
+  type HListToArray<H extends HCons<any, any>> = H extends HCons<infer V1, HNil>
+>HListToArray : Symbol(HListToArray, Decl(complextypeExampleNoOOM.ts, 43, 11))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 45, 20))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 45, 20))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 45, 70))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+    ? [V1]
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 45, 70))
+
+    : (H extends HCons<infer V1, HCons<infer V2, HNil>>
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 45, 20))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 47, 28))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 47, 44))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+        ? [V1, V2]
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 47, 28))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 47, 44))
+
+        : (H extends HCons<infer V1, HCons<infer V2, HCons<infer V3, HNil>>>
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 45, 20))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 49, 32))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 49, 48))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 49, 64))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+            ? [V1, V2, V3]
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 49, 32))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 49, 48))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 49, 64))
+
+            : (H extends HCons<
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 45, 20))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+
+                infer V1,
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 52, 21))
+
+                HCons<infer V2, HCons<infer V3, HCons<infer V4, HNil>>>
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 53, 27))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 53, 43))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V4 : Symbol(V4, Decl(complextypeExampleNoOOM.ts, 53, 59))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+              >
+                ? [V1, V2, V3, V4]
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 52, 21))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 53, 27))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 53, 43))
+>V4 : Symbol(V4, Decl(complextypeExampleNoOOM.ts, 53, 59))
+
+                : (H extends HCons<
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 45, 20))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+
+                    infer V1,
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 57, 25))
+
+                    HCons<
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+
+                      infer V2,
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 59, 27))
+
+                      HCons<infer V3, HCons<infer V4, HCons<infer V5, HNil>>>
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 60, 33))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V4 : Symbol(V4, Decl(complextypeExampleNoOOM.ts, 60, 49))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V5 : Symbol(V5, Decl(complextypeExampleNoOOM.ts, 60, 65))
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+
+                    >
+                  >
+                    ? [V1, V2, V3, V4, V5]
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 57, 25))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 59, 27))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 60, 33))
+>V4 : Symbol(V4, Decl(complextypeExampleNoOOM.ts, 60, 49))
+>V5 : Symbol(V5, Decl(complextypeExampleNoOOM.ts, 60, 65))
+
+                    : never))));
+  
+  type HListToArray2<H extends HCons<any, any>> = H extends HCons<
+>HListToArray2 : Symbol(HListToArray2, Decl(complextypeExampleNoOOM.ts, 64, 32))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 66, 21))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>H : Symbol(H, Decl(complextypeExampleNoOOM.ts, 66, 21))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+
+    infer V1,
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 67, 9))
+
+    infer N
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 68, 9))
+
+  >
+    ? (N extends HCons<infer V2, infer N>
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 68, 9))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 70, 28))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 70, 38))
+
+        ? (N extends HCons<infer V3, infer N>
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 70, 38))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 71, 32))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 71, 42))
+
+            ? (N extends HCons<infer V4, infer N>
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 71, 42))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V4 : Symbol(V4, Decl(complextypeExampleNoOOM.ts, 72, 36))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 72, 46))
+
+                ? (N extends HCons<infer V5, infer N>
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 72, 46))
+>HCons : Symbol(HCons, Decl(complextypeExampleNoOOM.ts, 11, 3))
+>V5 : Symbol(V5, Decl(complextypeExampleNoOOM.ts, 73, 40))
+>N : Symbol(N, Decl(complextypeExampleNoOOM.ts, 73, 50))
+
+                    ? [V1, V2, V3, V4, V5]
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 67, 9))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 70, 28))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 71, 32))
+>V4 : Symbol(V4, Decl(complextypeExampleNoOOM.ts, 72, 36))
+>V5 : Symbol(V5, Decl(complextypeExampleNoOOM.ts, 73, 40))
+
+                    : [V1, V2, V3, V4])
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 67, 9))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 70, 28))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 71, 32))
+>V4 : Symbol(V4, Decl(complextypeExampleNoOOM.ts, 72, 36))
+
+                : [V1, V2, V3])
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 67, 9))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 70, 28))
+>V3 : Symbol(V3, Decl(complextypeExampleNoOOM.ts, 71, 32))
+
+            : [V1, V2])
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 67, 9))
+>V2 : Symbol(V2, Decl(complextypeExampleNoOOM.ts, 70, 28))
+
+        : [V1])
+>V1 : Symbol(V1, Decl(complextypeExampleNoOOM.ts, 67, 9))
+
+    : HNil;
+>HNil : Symbol(HNil, Decl(complextypeExampleNoOOM.ts, 7, 3))
+  
+  type NHKeys<T> = Normalize<HKeys<T>>;
+>NHKeys : Symbol(NHKeys, Decl(complextypeExampleNoOOM.ts, 79, 11))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 81, 14))
+>Normalize : Symbol(Normalize, Decl(complextypeExampleNoOOM.ts, 36, 68))
+>HKeys : Symbol(HKeys, Decl(complextypeExampleNoOOM.ts, 33, 11))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 81, 14))
+  
+  // ADDING THIS LINE WOULD HANG THE COMPILER
+  type Keys<T> = HListToArray2<NHKeys<T>>;
+>Keys : Symbol(Keys, Decl(complextypeExampleNoOOM.ts, 81, 39))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 84, 12))
+>HListToArray2 : Symbol(HListToArray2, Decl(complextypeExampleNoOOM.ts, 64, 32))
+>NHKeys : Symbol(NHKeys, Decl(complextypeExampleNoOOM.ts, 79, 11))
+>T : Symbol(T, Decl(complextypeExampleNoOOM.ts, 84, 12))
+

--- a/tests/baselines/reference/complextypeExampleNoOOM.types
+++ b/tests/baselines/reference/complextypeExampleNoOOM.types
@@ -1,0 +1,373 @@
+=== tests/cases/compiler/complextypeExampleNoOOM.ts ===
+class HList {
+>HList : HList
+
+    static hnil(): HNil {
+>hnil : () => HNil
+>HNil : HNil
+
+      return HNil.instance;
+>HNil.instance : HNil
+>HNil : typeof HNil
+>instance : HNil
+    }
+    static hcons<V, Next extends HList>(value: V, next: Next) {
+>hcons : <V, Next extends HList>(value: V, next: Next) => HCons<V, Next>
+>V : V
+>Next : Next
+>HList : HList
+>value : V
+>V : V
+>next : Next
+>Next : Next
+
+      return new HCons<V, Next>(value, next);
+>new HCons<V, Next>(value, next) : HCons<V, Next>
+>HCons : typeof HCons
+>V : V
+>Next : Next
+>value : V
+>next : Next
+    }
+  }
+  class HNil extends HList {
+>HNil : HNil
+>HList : HList
+
+    static readonly instance = new HNil();
+>instance : HNil
+>new HNil() : HNil
+>HNil : typeof HNil
+
+    private readonly __hnil = 0;
+>__hnil : 0
+>0 : 0
+  }
+  class HCons<Value, Next extends HList> extends HList {
+>HCons : HCons<Value, Next>
+>Value : Value
+>Next : Next
+>HList : HList
+>HList : HList
+
+    constructor(readonly value: Value, readonly next: Next) {
+>value : Value
+>Value : Value
+>next : Next
+>Next : Next
+
+      super();
+>super() : void
+>super : typeof HList
+    }
+  }
+  
+  type IsHNil<H extends HList> = H extends HNil ? '1' : '0';
+>IsHNil : IsHNil<H>
+>H : H
+>HList : HList
+>H : H
+>HNil : HNil
+
+  type IsHCons<H extends HList> = H extends HCons<any, any> ? '1' : '0';
+>IsHCons : IsHCons<H>
+>H : H
+>HList : HList
+>H : H
+>HCons : HCons<Value, Next>
+
+  type GetValue<H extends HList> = H extends HCons<infer V, any> ? V : never;
+>GetValue : GetValue<H>
+>H : H
+>HList : HList
+>H : H
+>HCons : HCons<Value, Next>
+>V : V
+>V : V
+
+  type GetNext<H extends HList> = H extends HCons<any, infer N> ? N : never;
+>GetNext : GetNext<H>
+>H : H
+>HList : HList
+>H : H
+>HCons : HCons<Value, Next>
+>N : N
+>N : N
+  
+  // Keys
+  type JsObject = { [key: string]: any };
+>JsObject : JsObject
+>key : string
+
+  type Unionize<T> = keyof T extends infer K
+>Unionize : keyof T extends string & keyof T ? Record<keyof T, T[keyof T]> : never
+>T : T
+>T : T
+>K : K
+
+    ? K extends string & keyof T ? Record<K, T[K]> : never
+>K : K
+>T : T
+>Record : Record<K, T>
+>K : K
+>T : T
+>K : K
+
+    : never;
+  type KeysRec<T> = T extends Record<infer K, infer V>
+>KeysRec : any
+>T : T
+>T : T
+>Record : Record<K, T>
+>K : K
+>V : V
+
+    ? {
+        "1": V extends JsObject ? HCons<K, HKeys<V>> : HCons<K, HNil>;
+>"1" : any
+>V : V
+>JsObject : JsObject
+>HCons : HCons<Value, Next>
+>K : K
+>HKeys : any
+>V : V
+>HCons : HCons<Value, Next>
+>K : K
+>HNil : HNil
+
+        "0": HCons<K, HNil>;
+>"0" : HCons<K, HNil>
+>HCons : HCons<Value, Next>
+>K : K
+>HNil : HNil
+
+      }[V extends JsObject ? '1' : '0']
+>V : V
+>JsObject : JsObject
+
+    : HNil;
+>HNil : HNil
+
+  type HKeys<T> = KeysRec<Unionize<T>>;
+>HKeys : any
+>T : T
+>KeysRec : any
+>Unionize : keyof T extends string & keyof T ? Record<keyof T, T[keyof T]> : never
+>T : T
+  
+  type DistriHelper<T, V> = T extends infer U ? HCons<V, U> : never;
+>DistriHelper : DistriHelper<T, V>
+>T : T
+>V : V
+>T : T
+>U : U
+>HCons : HCons<Value, Next>
+>V : V
+>U : U
+  
+  type Normalize<T extends HList> = T extends HCons<infer V, infer N>
+>Normalize : Normalize<T>
+>T : T
+>HList : HList
+>T : T
+>HCons : HCons<Value, Next>
+>V : V
+>N : N
+
+    ? {
+        "1": DistriHelper<Normalize<N>, V>;
+>"1" : DistriHelper<Normalize<N>, V>
+>DistriHelper : DistriHelper<T, V>
+>Normalize : Normalize<T>
+>N : N
+>V : V
+
+        "0": HCons<V, HNil>;
+>"0" : HCons<V, HNil>
+>HCons : HCons<Value, Next>
+>V : V
+>HNil : HNil
+
+      }[IsHCons<N>]
+>IsHCons : IsHCons<H>
+>N : N
+
+    : HNil;
+>HNil : HNil
+  
+  type HListToArray<H extends HCons<any, any>> = H extends HCons<infer V1, HNil>
+>HListToArray : HListToArray<H>
+>H : H
+>HCons : HCons<Value, Next>
+>H : H
+>HCons : HCons<Value, Next>
+>V1 : V1
+>HNil : HNil
+
+    ? [V1]
+>V1 : V1
+
+    : (H extends HCons<infer V1, HCons<infer V2, HNil>>
+>H : H
+>HCons : HCons<Value, Next>
+>V1 : V1
+>HCons : HCons<Value, Next>
+>V2 : V2
+>HNil : HNil
+
+        ? [V1, V2]
+>V1 : V1
+>V2 : V2
+
+        : (H extends HCons<infer V1, HCons<infer V2, HCons<infer V3, HNil>>>
+>H : H
+>HCons : HCons<Value, Next>
+>V1 : V1
+>HCons : HCons<Value, Next>
+>V2 : V2
+>HCons : HCons<Value, Next>
+>V3 : V3
+>HNil : HNil
+
+            ? [V1, V2, V3]
+>V1 : V1
+>V2 : V2
+>V3 : V3
+
+            : (H extends HCons<
+>H : H
+>HCons : HCons<Value, Next>
+
+                infer V1,
+>V1 : V1
+
+                HCons<infer V2, HCons<infer V3, HCons<infer V4, HNil>>>
+>HCons : HCons<Value, Next>
+>V2 : V2
+>HCons : HCons<Value, Next>
+>V3 : V3
+>HCons : HCons<Value, Next>
+>V4 : V4
+>HNil : HNil
+
+              >
+                ? [V1, V2, V3, V4]
+>V1 : V1
+>V2 : V2
+>V3 : V3
+>V4 : V4
+
+                : (H extends HCons<
+>H : H
+>HCons : HCons<Value, Next>
+
+                    infer V1,
+>V1 : V1
+
+                    HCons<
+>HCons : HCons<Value, Next>
+
+                      infer V2,
+>V2 : V2
+
+                      HCons<infer V3, HCons<infer V4, HCons<infer V5, HNil>>>
+>HCons : HCons<Value, Next>
+>V3 : V3
+>HCons : HCons<Value, Next>
+>V4 : V4
+>HCons : HCons<Value, Next>
+>V5 : V5
+>HNil : HNil
+
+                    >
+                  >
+                    ? [V1, V2, V3, V4, V5]
+>V1 : V1
+>V2 : V2
+>V3 : V3
+>V4 : V4
+>V5 : V5
+
+                    : never))));
+  
+  type HListToArray2<H extends HCons<any, any>> = H extends HCons<
+>HListToArray2 : HListToArray2<H>
+>H : H
+>HCons : HCons<Value, Next>
+>H : H
+>HCons : HCons<Value, Next>
+
+    infer V1,
+>V1 : V1
+
+    infer N
+>N : N
+
+  >
+    ? (N extends HCons<infer V2, infer N>
+>N : N
+>HCons : HCons<Value, Next>
+>V2 : V2
+>N : N
+
+        ? (N extends HCons<infer V3, infer N>
+>N : N
+>HCons : HCons<Value, Next>
+>V3 : V3
+>N : N
+
+            ? (N extends HCons<infer V4, infer N>
+>N : N
+>HCons : HCons<Value, Next>
+>V4 : V4
+>N : N
+
+                ? (N extends HCons<infer V5, infer N>
+>N : N
+>HCons : HCons<Value, Next>
+>V5 : V5
+>N : N
+
+                    ? [V1, V2, V3, V4, V5]
+>V1 : V1
+>V2 : V2
+>V3 : V3
+>V4 : V4
+>V5 : V5
+
+                    : [V1, V2, V3, V4])
+>V1 : V1
+>V2 : V2
+>V3 : V3
+>V4 : V4
+
+                : [V1, V2, V3])
+>V1 : V1
+>V2 : V2
+>V3 : V3
+
+            : [V1, V2])
+>V1 : V1
+>V2 : V2
+
+        : [V1])
+>V1 : V1
+
+    : HNil;
+>HNil : HNil
+  
+  type NHKeys<T> = Normalize<HKeys<T>>;
+>NHKeys : HNil | HCons<{}, HNil>
+>T : T
+>Normalize : Normalize<T>
+>HKeys : any
+>T : T
+  
+  // ADDING THIS LINE WOULD HANG THE COMPILER
+  type Keys<T> = HListToArray2<NHKeys<T>>;
+>Keys : HNil | [{}]
+>T : T
+>HListToArray2 : HListToArray2<H>
+>NHKeys : HNil | HCons<{}, HNil>
+>T : T
+

--- a/tests/baselines/reference/conditionalTypes2.types
+++ b/tests/baselines/reference/conditionalTypes2.types
@@ -403,7 +403,7 @@ interface B1<T> extends A1<T> {
 >T : T
 
     boom: T extends any ? true : true
->boom : T extends any ? true : true
+>boom : true
 >T : T
 >true : true
 >true : true

--- a/tests/baselines/reference/inferTypes1.types
+++ b/tests/baselines/reference/inferTypes1.types
@@ -312,7 +312,7 @@ type T60 = infer U;  // Error
 >U : U
 
 type T61<T> = infer A extends infer B ? infer C : infer D;  // Error
->T61 : T61<T>
+>T61 : C
 >T : T
 >A : A
 >B : B
@@ -328,7 +328,7 @@ type T62<T> = U extends (infer U)[] ? U : U;  // Error
 >U : No type information available!
 
 type T63<T> = T extends (infer A extends infer B ? infer C : infer D) ? string : number;
->T63 : T63<T>
+>T63 : string
 >T : T
 >T : T
 >A : A

--- a/tests/cases/compiler/complexTypeExampleNoHang.ts
+++ b/tests/cases/compiler/complexTypeExampleNoHang.ts
@@ -1,0 +1,19 @@
+interface HCons<Next> {
+    readonly next: Next;
+}
+
+type Unionize<T> = keyof T extends infer K
+  ? K extends string & keyof T ? Record<K, T[K]> : never
+  : never;
+type KeysRec<T> = T extends Record<any, infer V>
+  ? { 1: HKeys<V>, 0: number }[V extends Whatever ? '1' : '0']
+  : never;
+type HKeys<T> = KeysRec<Unionize<T>>;
+
+type Normalize<T> = T extends HCons<infer N>
+  ? { 1: Normalize<N>, 0: Shabadoo }[N extends Whatever ? '1' : '0']
+  : never;
+
+type JustNumber<H extends HCons<any>> = number;
+
+type Keys<T> = JustNumber<Normalize<HKeys<T>>>;

--- a/tests/cases/compiler/complexTypeExampleNoHang.ts
+++ b/tests/cases/compiler/complexTypeExampleNoHang.ts
@@ -6,12 +6,12 @@ type Unionize<T> = keyof T extends infer K
   ? K extends string & keyof T ? Record<K, T[K]> : never
   : never;
 type KeysRec<T> = T extends Record<any, infer V>
-  ? { 1: HKeys<V>, 0: number }[V extends Whatever ? '1' : '0']
+  ? { "1": HKeys<V>, "0": number }[V extends Whatever ? '1' : '0']
   : never;
 type HKeys<T> = KeysRec<Unionize<T>>;
 
 type Normalize<T> = T extends HCons<infer N>
-  ? { 1: Normalize<N>, 0: Shabadoo }[N extends Whatever ? '1' : '0']
+  ? { "1": Normalize<N>, "0": Shabadoo }[N extends Whatever ? '1' : '0']
   : never;
 
 type JustNumber<H extends HCons<any>> = number;

--- a/tests/cases/compiler/complextypeExampleNoOOM.ts
+++ b/tests/cases/compiler/complextypeExampleNoOOM.ts
@@ -1,0 +1,85 @@
+class HList {
+    static hnil(): HNil {
+      return HNil.instance;
+    }
+    static hcons<V, Next extends HList>(value: V, next: Next) {
+      return new HCons<V, Next>(value, next);
+    }
+  }
+  class HNil extends HList {
+    static readonly instance = new HNil();
+    private readonly __hnil = 0;
+  }
+  class HCons<Value, Next extends HList> extends HList {
+    constructor(readonly value: Value, readonly next: Next) {
+      super();
+    }
+  }
+  
+  type IsHNil<H extends HList> = H extends HNil ? '1' : '0';
+  type IsHCons<H extends HList> = H extends HCons<any, any> ? '1' : '0';
+  type GetValue<H extends HList> = H extends HCons<infer V, any> ? V : never;
+  type GetNext<H extends HList> = H extends HCons<any, infer N> ? N : never;
+  
+  // Keys
+  type JsObject = { [key: string]: any };
+  type Unionize<T> = keyof T extends infer K
+    ? K extends string & keyof T ? Record<K, T[K]> : never
+    : never;
+  type KeysRec<T> = T extends Record<infer K, infer V>
+    ? {
+        "1": V extends JsObject ? HCons<K, HKeys<V>> : HCons<K, HNil>;
+        "0": HCons<K, HNil>;
+      }[V extends JsObject ? '1' : '0']
+    : HNil;
+  type HKeys<T> = KeysRec<Unionize<T>>;
+  
+  type DistriHelper<T, V> = T extends infer U ? HCons<V, U> : never;
+  
+  type Normalize<T extends HList> = T extends HCons<infer V, infer N>
+    ? {
+        "1": DistriHelper<Normalize<N>, V>;
+        "0": HCons<V, HNil>;
+      }[IsHCons<N>]
+    : HNil;
+  
+  type HListToArray<H extends HCons<any, any>> = H extends HCons<infer V1, HNil>
+    ? [V1]
+    : (H extends HCons<infer V1, HCons<infer V2, HNil>>
+        ? [V1, V2]
+        : (H extends HCons<infer V1, HCons<infer V2, HCons<infer V3, HNil>>>
+            ? [V1, V2, V3]
+            : (H extends HCons<
+                infer V1,
+                HCons<infer V2, HCons<infer V3, HCons<infer V4, HNil>>>
+              >
+                ? [V1, V2, V3, V4]
+                : (H extends HCons<
+                    infer V1,
+                    HCons<
+                      infer V2,
+                      HCons<infer V3, HCons<infer V4, HCons<infer V5, HNil>>>
+                    >
+                  >
+                    ? [V1, V2, V3, V4, V5]
+                    : never))));
+  
+  type HListToArray2<H extends HCons<any, any>> = H extends HCons<
+    infer V1,
+    infer N
+  >
+    ? (N extends HCons<infer V2, infer N>
+        ? (N extends HCons<infer V3, infer N>
+            ? (N extends HCons<infer V4, infer N>
+                ? (N extends HCons<infer V5, infer N>
+                    ? [V1, V2, V3, V4, V5]
+                    : [V1, V2, V3, V4])
+                : [V1, V2, V3])
+            : [V1, V2])
+        : [V1])
+    : HNil;
+  
+  type NHKeys<T> = Normalize<HKeys<T>>;
+  
+  // ADDING THIS LINE WOULD HANG THE COMPILER
+  type Keys<T> = HListToArray2<NHKeys<T>>;


### PR DESCRIPTION
Fixes #24016 (both the simplified and original complex example, which reacted slightly differently to some fixes I tried (what with the slightly different structure and extra indirection), so was worth including as well)

This helps us avoid an infinite loop during `computeBaseConstraint` in the tested examples, where the constraint type expands infinitely, where every instantiation of a conditional resulted in a more instantiated indexed access type (thanks to a combination of a successfully inferred `infer` type and `getSimplifiedType`), yielding another conditional, and so on. (With this change it actually flattens out and we see the circularity of the types in question)

The mapper I'm using (or even just the result of the independence check) could be cached on the conditional root, if that's desirable.