### PR TITLE
Inspector to modules

### DIFF
--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -32,12 +32,43 @@ namespace ts.JsTyping {
 
     /* @internal */
     export const nodeCoreModuleList: ReadonlyArray<string> = [
-        "buffer", "querystring", "events", "http", "cluster",
-        "zlib", "os", "https", "punycode", "repl", "readline",
-        "vm", "child_process", "url", "dns", "net",
-        "dgram", "fs", "path", "string_decoder", "tls",
-        "crypto", "stream", "util", "assert", "tty", "domain",
-        "constants", "process", "v8", "timers", "console", "inspector"];
+        "assert",
+        "async_hooks",
+        "buffer",
+        "child_process",
+        "cluster",
+        "console",
+        "constants",
+        "crypto",
+        "dgram",
+        "dns",
+        "domain",
+        "events",
+        "fs",
+        "http",
+        "https",
+        "http2",
+        "inspector",
+        "net",
+        "os",
+        "path",
+        "perf_hooks",
+        "process",
+        "punycode",
+        "querystring",
+        "readline",
+        "repl",
+        "stream",
+        "string_decoder",
+        "timers",
+        "tls",
+        "tty",
+        "url",
+        "util",
+        "v8",
+        "vm",
+        "zlib"
+    ];
 
     /* @internal */
     export const nodeCoreModules = arrayToSet(nodeCoreModuleList);

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -37,7 +37,7 @@ namespace ts.JsTyping {
         "vm", "child_process", "url", "dns", "net",
         "dgram", "fs", "path", "string_decoder", "tls",
         "crypto", "stream", "util", "assert", "tty", "domain",
-        "constants", "process", "v8", "timers", "console"];
+        "constants", "process", "v8", "timers", "console", "inspector"];
 
     /* @internal */
     export const nodeCoreModules = arrayToSet(nodeCoreModuleList);


### PR DESCRIPTION
Adds a few missing core node modules:
* [`"inspector"`](https://nodejs.org/api/inspector.html)
* [`"http2"`](https://nodejs.org/api/http2.html)
* [`"async_hooks"`](https://nodejs.org/api/async_hooks.html)
* [`"perf_hooks"`](https://nodejs.org/api/perf_hooks.html)
